### PR TITLE
Fix queue initialization in pivot_call module

### DIFF
--- a/whistle_apps/apps/pivot/src/pivot_call.erl
+++ b/whistle_apps/apps/pivot/src/pivot_call.erl
@@ -109,7 +109,7 @@ handle_call_event(JObj, Props) ->
 init([Call, JObj]) ->
     put(callid, whapps_call:call_id(Call)),
 
-    get_my_queue(),
+    gen_listener:cast(?MODULE, {controller_queue, <<>>}),
 
     Method = kzt_util:http_method(wh_json:get_value(<<"HTTP-Method">>, JObj, get)),
     VoiceUri = wh_json:get_value(<<"Voice-URI">>, JObj),


### PR DESCRIPTION
There is a race condition when pivot_call will not get queue name thus it crashes. gen_listener runs init_amqp after gen_listener:init is done. 
