### PR TITLE
A better reply to an empty crossbar request

### DIFF
--- a/whistle_apps/apps/crossbar/src/crossbar_default_handler.erl
+++ b/whistle_apps/apps/crossbar/src/crossbar_default_handler.erl
@@ -22,7 +22,7 @@ init({_Any, 'http'}, Req, []) ->
 
 -spec handle(#http_req{}, State) -> {'ok', #http_req{}, State}.
 handle(Req, State) ->
-    {'ok', Req1} = cowboy_http_req:reply(200, [], <<"Howdy, new world!\n">>, Req),
+    {'ok', Req1} = cowboy_http_req:reply(200, [], <<"\x1b[32mHowdy, new world! \x1b[0m\n">>, Req),
     {'ok', Req1, State}.
 
 -spec terminate(#http_req{}, term()) -> 'ok'.


### PR DESCRIPTION
Currently, the reply to an empty crossbar request is lacking a newline, which is not very cool. see Fig.1

The added newline is fancy. see Fig. 2.

Some fancy ANSI coloring, now we're talking! see Fig.3

Figure 1: 
![crossbar broken](https://f.cloud.github.com/assets/1163438/230900/844aed2a-86db-11e2-9f4c-d5c45df8265e.png)

Figure 2: 
![crossbar better](https://f.cloud.github.com/assets/1163438/230902/ae861344-86db-11e2-86e7-1e239364ec4d.png)

Figure 3: 
![crossbar even better](https://f.cloud.github.com/assets/1163438/230907/ce4a3228-86db-11e2-834d-7c88512bed08.png)
