### PR TITLE
Fixing wh_util:whistle_version so crossbar's cb_about returns correct version

### DIFF
--- a/lib/whistle-1.0.0/src/wh_util.erl
+++ b/lib/whistle-1.0.0/src/wh_util.erl
@@ -719,10 +719,10 @@ whistle_version() ->
 
 -spec whistle_version(ne_binary() | nonempty_string()) -> ne_binary().
 whistle_version(FileName) ->
-    case file:consult(FileName) of
-        {'ok', [Version]} ->
+    case file:read_file(FileName) of
+        {'ok', Version} ->
             wh_cache:store(?WHISTLE_VERSION_CACHE_KEY, Version),
-            Version;
+            list_to_binary(string:strip(binary_to_list(Version), right, $\n));
         _ ->
             Version = <<"not available">>,
             wh_cache:store(?WHISTLE_VERSION_CACHE_KEY, Version),


### PR DESCRIPTION
While learning ErLang and Kazoo's internals I found that the module cb_about had a bug, so I decided to figure out why and fix it as a primary goal for my learning process, as it should be simple enough and harmless enough for a first contribution (as long as I don't break the whole wh_utils module ;) )

After enabling the cb_about in crossbar I saw that a request to /v1/about would always return "not available" for the whistle version.
Investigating why, I found out that this change: 
https://github.com/2600hz/kazoo/commit/a733c132845e2d48b5971c608ff1da18d2e2685b
required the VERSION file to have the contents in ErLang terms, so it could be read and returned by file:consult (not sure why it was done this way as it looks like it was nice enough before that).
Due to that requirement, a change in the VERSION file for version 1.51:
https://github.com/2600hz/kazoo/commit/e6a7c204ee044fda6fe1c174c124afb18e2cb8d8
broke the module, as ErLang would fail to parse the file contents.

So my fix is basically reversing to the original way it was done, but using a different method.
