### PR TITLE
KAZOO-883: GWT API client running on Chrome can't make crossbar API calls

### DIFF
--- a/whistle_apps/apps/crossbar/src/v1_util.erl
+++ b/whistle_apps/apps/crossbar/src/v1_util.erl
@@ -106,7 +106,7 @@ add_cors_headers(Req0, #cb_context{allow_methods=Ms}=Context) ->
 get_cors_headers(#cb_context{allow_methods=Allow}) ->
     [{<<"Access-Control-Allow-Origin">>, <<"*">>}
      ,{<<"Access-Control-Allow-Methods">>, wh_util:join_binary(Allow, <<", ">>)}
-     ,{<<"Access-Control-Allow-Headers">>, <<"Content-Type, Depth, User-Agent, X-File-Size, X-Requested-With, If-Modified-Since, X-File-Name, Cache-Control, X-Auth-Token, If-Match">>}
+     ,{<<"Access-Control-Allow-Headers">>, <<"Content-Type, Depth, User-Agent, X-Http-Method-Override, X-File-Size, X-Requested-With, If-Modified-Since, X-File-Name, Cache-Control, X-Auth-Token, If-Match">>}
      ,{<<"Access-Control-Expose-Headers">>, <<"Content-Type, X-Auth-Token, X-Request-ID, Location, Etag, ETag">>}
      ,{<<"Access-Control-Max-Age">>, wh_util:to_binary(?SECONDS_IN_DAY)}
     ].


### PR DESCRIPTION
due to SOP violation

I just hardcoded another header there. Works well for me but it might worth to consider more intelligent solution.
