### PR TITLE
KAZOO-938: Crossbar module list needs to be updated

### DIFF
--- a/whistle_apps/apps/crossbar/priv/crossbar.config
+++ b/whistle_apps/apps/crossbar/priv/crossbar.config
@@ -1,10 +1,16 @@
-{autoload_modules, [cb_user_auth, cb_simple_authz, cb_vmboxes, cb_schemas, cb_connectivity, cb_temporal_rules
-                    , cb_webhooks, cb_global_provisioner_templates, cb_shared_auth, cb_users, cb_global_resources
-                    , cb_phone_numbers, cb_templates, cb_signup, cb_accounts, cb_limits, cb_local_provisioner_templates
-                    , cb_callflows, cb_local_resources, cb_faxes, cb_configs, cb_api_auth, cb_braintree, cb_whitelabel
-                    , cb_onboard, cb_conferences, cb_directories, cb_registrations, cb_token_auth, cb_clicktocall
-                    , cb_media, cb_menus, cb_cdrs, cb_servers, cb_devices, #cb_queues, cb_rates, cb_contact_list
-                    , cb_groups, cb_bulk]}.
+{autoload_modules, [cb_user_auth, cb_simple_authz, cb_vmboxes, cb_schemas
+                    ,cb_connectivity, cb_temporal_rules, cb_webhooks
+                    ,cb_global_provisioner_templates, cb_shared_auth
+                    ,cb_users, cb_global_resources, cb_phone_numbers
+                    ,cb_templates, cb_signup, cb_accounts, cb_limits
+                    ,cb_local_provisioner_templates, cb_callflows
+                    ,cb_local_resources, cb_faxes, cb_configs
+                    ,cb_api_auth, cb_braintree, cb_whitelabel
+                    ,cb_onboard, cb_conferences, cb_directories
+                    ,cb_registrations, cb_token_auth, cb_clicktocall
+                    ,cb_media, cb_menus, cb_cdrs, cb_servers
+                    ,cb_devices, cb_queues, cb_rates, cb_contact_list
+                    ,cb_groups, cb_bulk]}.
 {ip, <<"0.0.0.0">>}.
 {port, <<"8000">>}.
 {name, <<"crossbar">>}.


### PR DESCRIPTION
The list of crossbar module in whistle_apps/apps/crossbar/priv/crossbar.config hasn't been updated in some time, so people have to manually edit it when deploying a new cluster.

This updated list should fix this issue.
