### PR TITLE
Fix problem of deleting/re-adding numbers

### DIFF
--- a/lib/whistle_number_manager-1.0.0/src/wh_number_manager.erl
+++ b/lib/whistle_number_manager-1.0.0/src/wh_number_manager.erl
@@ -169,7 +169,13 @@ create_number(Number, AssignTo, AuthBy, PublicFields) ->
                                  wnm_number:error_unauthorized(N)
                          end;
                     ({_, #number{}}=E) -> E;
-                    (#number{}=N) -> wnm_number:error_number_exists(N)
+                    (#number{}=N) -> 
+                        case N#number.current_state of
+                            <<"available">> ->
+                                N;
+                            _ ->
+                                wnm_number:error_number_exists(N)
+                        end
                  end
                 ,fun({_, #number{}}=E) -> E;
                     (#number{}=N) -> wnm_number:reserved(N#number{assign_to=AssignTo, auth_by=AuthBy})


### PR DESCRIPTION
Add code to check the current status of the number. If the status is "available", don't return "Number is already is use" error. 
