### PR TITLE
Added dependency to the Travis configuration: xsltproc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,7 @@ otp_release:
   - R15B02
   - R15B01
   - R15B
+before_install:
+    - sudo apt-get install -qq xsltproc
 script: "make compile"
 after script: "make eunit"


### PR DESCRIPTION
Travis builds are currently failing because the default environment is missing the package "xsltproc", which is needed for RabbitMQ. Added the package to the Travis configuration file to resolve this issue.
