### PR TITLE
Changed some twiml/pivot log levels to info

### DIFF
--- a/applications/pivot/src/pivot_call.erl
+++ b/applications/pivot/src/pivot_call.erl
@@ -282,7 +282,7 @@ handle_info({'ibrowse_async_response', ReqId, Chunk}
             ,#state{request_id=ReqId
                     ,response_body=RespBody
                    }=State) ->
-    lager:debug("adding response chunk: '~s'", [Chunk]),
+    lager:info("adding response chunk: '~s'", [Chunk]),
     {'noreply', State#state{response_body = <<RespBody/binary, Chunk/binary>>}};
 
 handle_info({'ibrowse_async_response_end', ReqId}, #state{request_id=ReqId

--- a/core/kazoo_translator-1.0.0/src/convertors/kzt_twiml.erl
+++ b/core/kazoo_translator-1.0.0/src/convertors/kzt_twiml.erl
@@ -280,7 +280,7 @@ redirect(Call, XmlText, Attrs) ->
 
 -spec exec_gather_els(pid(), whapps_call:call(), list()) -> 'ok'.
 exec_gather_els(_Parent, _Call, []) ->
-    lager:debug("finished gather sub elements");
+    lager:info("finished gather sub elements");
 exec_gather_els(Parent, Call, [SubAction|SubActions]) ->
     whapps_call:put_callid(Call),
 

--- a/core/kazoo_translator-1.0.0/src/kzt_receiver.erl
+++ b/core/kazoo_translator-1.0.0/src/kzt_receiver.erl
@@ -73,7 +73,7 @@ collect_dtmfs(Call, FinishKey, Timeout, N, OnFirstFun, Collected) ->
         {'other', {'DOWN', Ref, 'process', Pid, _Reason}} ->
             case kzt_util:get_gather_pidref(Call) of
                 {Pid, Ref} when is_pid(Pid), is_reference(Ref) ->
-                    lager:debug("subactions are done, timer can start"),
+                    lager:info("subactions are done, timer can start"),
                     collect_dtmfs(kzt_util:set_gather_pidref('undefined', Call)
                                   ,FinishKey, collect_decr_timeout(Call, Timeout, Start), N, OnFirstFun, Collected
                                  );


### PR DESCRIPTION
I think these would be nice in log level info:
1. "adding response chunk" <-- tells me that the twiml app is sending what I think it's sending
2. "finish gather sub elements" <--tells me when kazoo thinks it's finished all the nested actions
3. "sub actions are done, timer can start" <-- tells me all the nested actions finished before user input; this is important to know if the user has interrupted the prompts

Please please please pretty please :)?
