### PR TITLE
fix: stale cache while updating objects

### DIFF
--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -264,6 +264,8 @@ save(#cb_context{db_name=Db, doc=[_|_]=JObjs}=Context, Options) ->
             IDs = [wh_json:get_value(<<"_id">>, J) || J <- JObjs],
             handle_couch_mgr_errors(Error, IDs, Context);
         {'ok', JObj1} ->
+            IDs = [wh_json:get_value(<<"_id">>, J) || J <- JObjs],
+            lists:map(fun(DocId) -> couch_mgr:flush_cache_doc(Db, DocId) end, IDs),
             Context1 = handle_couch_mgr_success(JObj1, Context),
             provisioner_util:maybe_send_contact_list(Context1)
     end;
@@ -274,6 +276,8 @@ save(#cb_context{db_name=Db, doc=JObj}=Context, Options) ->
             DocId = wh_json:get_value(<<"_id">>, JObj0),
             handle_couch_mgr_errors(Error, DocId, Context);
         {'ok', JObj1} ->
+            DocId = wh_json:get_value(<<"_id">>, JObj1),
+            couch_mgr:flush_cache_doc(Db, DocId),
             Context1 = handle_couch_mgr_success(JObj1, Context),
             provisioner_util:maybe_send_contact_list(Context1)
     end.


### PR DESCRIPTION
> When I send a POST update the parameters of queue I recieve:
> {"auth_token":"502b392f9a4eb160323330fa9ba78bb8","request_id":"f41894441304285898df11e9a42d2a50","status":"error","message":"conflicting documents","error":"409","data":{}} 
> 
> Interesting that it appears only for newly created queues, for queues that were created earlier I don't receive this error.

https://groups.google.com/forum/?hl=ru#!topic/2600hz-dev/M7gdOeiYLEQ

This issue is caused by obsolete revision number, stored in cache by the first call of couch_mgr:open_cache_doc function. New revisions does not fall into the cache while updating the entries, as the cache is not synchronized with couch db. So the easiest way is to clear the cache manually after the data update. It will be refilled after the first data access.
