### PR TITLE
Timestamp has no place in the DB name. It produces errors like this Dec ...

### DIFF
--- a/applications/cdr/src/cdr_listener.erl
+++ b/applications/cdr/src/cdr_listener.erl
@@ -181,7 +181,7 @@ update_pvt_parameters('undefined', _, JObj) ->
             ],
     wh_doc:update_pvt_parameters(JObj, ?WH_ANONYMOUS_CDR_DB, Props);
 update_pvt_parameters(AccountId, Timestamp, JObj) ->
-    AccountMODb = wh_util:format_account_id(AccountId, Timestamp),    
+    AccountMODb = wh_util:format_account_id(AccountId, 'encoded'),    
     Props = [{'type', 'cdr'}
              ,{'crossbar_doc_vsn', 2}
             ],


### PR DESCRIPTION
Edit: Now I realize that the timestamped DB names must exist. So this pull request is invalid.

I think this could be an easy fix. When you add the timestamp to the DB name it will produce names such as /accounts/sfgs/43t5/3/tag35yga3g-TIMESTAMP_HERE. Which later is being used in the request to store the CDR PUT http://COUCH/account/7f/0f/3474fbe2c9262b730e371669458b-201312/201312-MGE4YTVhOWZhZThjMjJjMmY5MTYwNWRlNjg0YjI4NDA.

Ultimately CouchDB return 404 due to non-existent database and CDR fails with a message like this:
Dec 27 01:52:57 kz01-local 2600hz[20523]: |MGZkYmEwNjdkYWYwMzNhZmE0ZGZiN2FmMzk1ODA0Zjc.|cdr_listener:221 (<0.25092.0>) write fail: account%2F7f%2F0f%2F3474fbe2c9262b730e371669458b-201312

I think there are no places in the code that require a timestamp in the DB name, so it should be safe.
