### PR TITLE
log client IP in crossbar

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -75,7 +75,10 @@ rest_init(Req0, Opts) ->
     {Method, Req5} = cowboy_req:method(Req4),
     {{Peer, _PeerPort}, Req6} = cowboy_req:peer(Req5),
     {Version, Req7} = cowboy_req:binding('version', Req6),
-    ClientIP = wh_network_utils:iptuple_to_binary(Peer),
+    ClientIP = case cowboy_req:header(<<"x-forwarded-for">>, Req7) of
+                {'undefined', _} -> wh_network_utils:iptuple_to_binary(Peer);
+                {ForwardIP, _} -> wh_util:to_binary(ForwardIP)
+            end,
     Context0 = #cb_context{
                   req_id = ReqId
                   ,raw_host = wh_util:to_binary(Host)


### PR DESCRIPTION
if we have two or more whapps servers and want to use haproxy to balance crossbar requests we will always get the IP of haproxy server not the IP from the client making the request.
we can use "option forwardfor" and "option http-server-close" on haproxy to have the clients IP forward as a header (x-forwarded-for) to whapps servers.
"option http-server-close" is needed to forward the ip on all requests, without it you get OPTIONS request with client IP and GET request with haproxy IP.
