### PR TITLE
attachment_name fix

### DIFF
--- a/applications/crossbar/src/modules/cb_whitelabel.erl
+++ b/applications/crossbar/src/modules/cb_whitelabel.erl
@@ -403,7 +403,7 @@ attachment_name(Filename, CT) ->
                            end
                    end
                  ],
-    lists:foldr(fun(F, A) -> F(A) end, Filename, Generators).
+    lists:foldl(fun(F, A) -> F(A) end, Filename, Generators).
 
 %%--------------------------------------------------------------------
 %% @private


### PR DESCRIPTION
foldr should be foldl or else wh_util:is_empty(A) is always false
