### PR TITLE
KAZOO-1190: fix the caller-id merge so partial data can be retrieved fro...

### DIFF
--- a/applications/callflow/src/cf_attributes.erl
+++ b/applications/callflow/src/cf_attributes.erl
@@ -117,7 +117,7 @@ maybe_prefix_cid_number(Number, Name, Validate, Attribute, Call) ->
             Prefixed = <<(wh_util:to_binary(Prefix))/binary, Number/binary>>,
             maybe_prefix_cid_name(Prefixed, Name, Validate, Attribute, Call)
     end.
-
+ 
 -spec maybe_prefix_cid_name(ne_binary(), ne_binary(), boolean(), ne_binary(), whapps_call:call()) ->
                                    {api_binary(), api_binary()}.
 maybe_prefix_cid_name(Number, Name, Validate, Attribute, Call) ->
@@ -135,7 +135,7 @@ maybe_ensure_cid_valid(Number, Name, 'true', <<"external">>, Call) ->
         'true' -> ensure_valid_caller_id(Number, Name, Call);
         'false' ->
             lager:info("external caller id <~s> ~s", [Name, Number]),
-            {Number, Name}
+            maybe_cid_privacy(Number, Name, Call)
     end;
 maybe_ensure_cid_valid(Number, Name, 'true', <<"emergency">>, Call) ->
     case whapps_config:get_is_true(<<"callflow">>, <<"ensure_valid_emergency_number">>, 'false') of
@@ -144,9 +144,18 @@ maybe_ensure_cid_valid(Number, Name, 'true', <<"emergency">>, Call) ->
             lager:info("emergency caller id <~s> ~s", [Name, Number]),
             {Number, Name}
     end;
-maybe_ensure_cid_valid(Number, Name, _, Attribute, _) ->
+maybe_ensure_cid_valid(Number, Name, _, Attribute, Call) ->
     lager:info("~s caller id <~s> ~s", [Attribute, Name, Number]),
-    {Number, Name}.
+    maybe_cid_privacy(Number, Name, Call).
+
+maybe_cid_privacy(Number, Name, Call) ->
+    case wh_util:is_true(whapps_call:kvs_fetch('cf_privacy', Call)) of
+        'true' ->
+            lager:info("overriding caller id to maintain privacy"),
+            {whapps_config:get_non_empty(<<"callflow">>, <<"privacy_number">>, <<"0000000000">>)
+            ,whapps_config:get_non_empty(<<"callflow">>, <<"privacy_name">>, <<"anonymous">>)};
+        'false' -> {Number, Name}
+    end.
 
 -spec ensure_valid_emergency_number(ne_binary(), api_binary(), whapps_call:call()) ->
                                            {api_binary(), api_binary()}.
@@ -463,6 +472,13 @@ default_cid_name(Endpoint) ->
     end.
 
 -spec get_cid_or_default(ne_binary(), ne_binary(), wh_json:object()) -> api_binary().
+get_cid_or_default(<<"emergency">>, Property, Endpoint) ->
+    case wh_json:get_first_defined([[<<"caller_id">>, <<"emergency">>, Property]
+                                    ,[<<"caller_id">>, <<"external">>, Property]
+                                   ], Endpoint) of
+        'undefined' -> wh_json:get_ne_value([<<"default">>, Property], Endpoint);
+        Value -> Value
+    end;
 get_cid_or_default(Attribute, Property, Endpoint) ->
     case wh_json:get_ne_value([<<"caller_id">>, Attribute, Property], Endpoint) of
         'undefined' -> wh_json:get_ne_value([<<"default">>, Property], Endpoint);

--- a/applications/callflow/src/module/cf_privacy.erl
+++ b/applications/callflow/src/module/cf_privacy.erl
@@ -14,21 +14,35 @@
 handle(Data, Call) ->
     CaptureGroup = whapps_call:kvs_fetch('cf_capture_group', Call),
     AccountId = whapps_call:account_id(Call),
-    io:format("~p~n", [CaptureGroup]),
     case cf_util:lookup_callflow(CaptureGroup, AccountId) of
         {'ok', CallFlow, _} ->
             Mode = wh_json:get_value(<<"mode">>, Data),
             whapps_call_command:privacy(Mode, Call),
-            update_request(CaptureGroup
+            update_call(CaptureGroup
                            ,cf_exe:get_call(Call)),
             cf_exe:branch(wh_json:get_value(<<"flow">>, CallFlow), Call);
         {'error', _} ->
             cf_exe:stop(Call)
     end.
 
--spec update_request(ne_binary(), {'ok', whapps_call:call()}) -> 'ok'.
-update_request(CaptureGroup, {'ok', Call}) ->
-    Request = <<CaptureGroup/binary, "@"
-                ,(whapps_call:request_realm(Call))/binary>>,
-    cf_exe:set_call(whapps_call:set_request(Request, Call)).
+-spec update_call(ne_binary(), {'ok', whapps_call:call()}) -> 'ok'.
+update_call(CaptureGroup, {'ok', Call}) ->
+    Routines = [fun(C) ->
+                        Request = <<CaptureGroup/binary, "@"
+                                    ,(whapps_call:request_realm(C))/binary>>,
+                        whapps_call:set_request(Request, C)
+                end
+                ,fun(C) ->
+                         whapps_call:kvs_store('cf_privacy', 'true', C)
+                 end
+                ,fun(C) ->
+                         Name = whapps_config:get_non_empty(<<"callflow">>, <<"privacy_name">>, <<"anonymous">>),
+                         whapps_call:set_caller_id_name(Name, C)
+                 end
+                ,fun(C) ->
+                         Number = whapps_config:get_non_empty(<<"callflow">>, <<"privacy_number">>, <<"0000000000">>),
+                         whapps_call:set_caller_id_number(Number, C)
+                 end
+               ],
+    cf_exe:set_call(lists:foldl(fun(F, C) -> F(C) end, Call, Routines)).
 

--- a/core/whistle-1.0.0/src/wh_json.erl
+++ b/core/whistle-1.0.0/src/wh_json.erl
@@ -28,13 +28,21 @@
 -export([get_json_value/2, get_json_value/3]).
 -export([is_true/2, is_true/3, is_false/2, is_false/3, is_empty/1]).
 
--export([filter/2, filter/3, map/2, foldl/3, find/2, find/3, foreach/2]).
+-export([filter/2, filter/3
+         ,map/2
+         ,foldl/3
+         ,find/2, find/3
+         ,foreach/2
+        ]).
 -export([get_ne_value/2, get_ne_value/3]).
 -export([get_value/2, get_value/3, get_values/1]).
 -export([get_keys/1, get_keys/2]).
 -export([set_value/3, set_values/2, new/0]).
 -export([delete_key/2, delete_key/3, delete_keys/2]).
--export([merge_recursive/2]).
+-export([merge_recursive/1
+         ,merge_recursive/2
+         ,merge_recursive/3
+        ]).
 
 -export([from_list/1, merge_jobjs/2]).
 
@@ -180,18 +188,37 @@ merge_jobjs(?JSON_WRAPPER(Props1)=_JObj1, ?JSON_WRAPPER(_)=JObj2) ->
                         set_value(K, V, JObj2Acc)
                 end, JObj2, Props1).
 
-%% inserts values from JObj2 into JObj1
--spec merge_recursive(object(), object()) -> object().
--spec merge_recursive(object(), object() | json_term(), json_strings()) -> object().
-merge_recursive(JObj1, JObj2) ->
-    merge_recursive(JObj1, JObj2, []).
+-type merge_pred() :: fun(({json_term(), json_term()}) -> boolean()).
 
-merge_recursive(JObj1, ?JSON_WRAPPER(Prop2), Keys) ->
+-spec merge_recursive(objects()) -> object().
+merge_recursive(JObjs) ->
+    merge_recursive(JObjs, fun(_, _) -> 'true' end).
+
+-spec merge_recursive(objects(), merge_pred()) -> object();
+                     (object(), object()) -> object().
+merge_recursive([J|JObjs], Pred) when is_function(Pred, 2) ->
+    lists:foldl(fun(JObj2, JObj1) ->
+                        merge_recursive(JObj1, JObj2, Pred)
+                end, J, JObjs);
+merge_recursive(JObj1, JObj2) ->
+    merge_recursive(JObj1, JObj2, fun(_, _) -> 'true' end).
+
+-spec merge_recursive(object(), object(), merge_pred()) -> object().
+merge_recursive(JObj1, JObj2, Pred) ->
+    merge_recursive(JObj1, JObj2, Pred, []).
+
+%% inserts values from JObj2 into JObj1
+-spec merge_recursive(object(), object() | json_term(), merge_pred(), json_strings()) -> object().
+merge_recursive(JObj1, ?JSON_WRAPPER(Prop2), Pred, Keys) ->
     lists:foldr(fun(Key, J) ->
-                        merge_recursive(J, props:get_value(Key, Prop2), [Key|Keys])
+                        merge_recursive(J, props:get_value(Key, Prop2), Pred, [Key|Keys])
                 end, JObj1, props:get_keys(Prop2));
-merge_recursive(JObj1, Value, Keys) ->
-    set_value(lists:reverse(Keys), Value, JObj1).
+merge_recursive(JObj1, Value, Pred, Keys) ->
+    Syek = lists:reverse(Keys),
+    case Pred(get_value(Syek, JObj1), Value) of
+        'false' -> JObj1;
+        'true' -> set_value(Syek, Value, JObj1)
+    end.
 
 -spec to_proplist(object() | objects()) -> json_proplist() | [json_proplist(),...].
 -spec to_proplist(key(), object() | objects()) -> json_proplist() | [json_proplist(),...].

--- a/core/whistle-1.0.0/src/wh_util.erl
+++ b/core/whistle-1.0.0/src/wh_util.erl
@@ -32,7 +32,8 @@
         ]).
 -export([to_boolean/1, is_boolean/1
          ,is_true/1, is_false/1
-         ,is_empty/1, is_proplist/1
+         ,is_empty/1, is_not_empty/1
+         ,is_proplist/1
         ]).
 -export([to_lower_binary/1, to_upper_binary/1
          ,to_lower_string/1, to_upper_string/1
@@ -631,6 +632,9 @@ is_empty(MaybeJObj) ->
         'false' -> 'false'; %% if not a json object, its not empty
         'true' -> wh_json:is_empty(MaybeJObj)
     end.
+
+-spec is_not_empty(term()) -> boolean().
+is_not_empty(Term) -> (not is_empty(Term)).
 
 -spec is_proplist(any()) -> boolean().
 is_proplist(Term) when is_list(Term) ->

--- a/core/whistle_apps-1.0.0/src/whapps_call.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_call.erl
@@ -428,7 +428,10 @@ set_caller_id_name(CIDName, #whapps_call{}=Call) when is_binary(CIDName) ->
 
 -spec caller_id_name(call()) -> binary().
 caller_id_name(#whapps_call{caller_id_name=CIDName}) ->
-    CIDName.
+    case wh_util:is_empty(CIDName) of
+        'true' -> <<>>;
+        'false' -> CIDName
+    end.
 
 -spec set_caller_id_number(ne_binary(), call()) -> call().
 set_caller_id_number(CIDNumber, #whapps_call{}=Call) when is_binary(CIDNumber) ->
@@ -437,7 +440,10 @@ set_caller_id_number(CIDNumber, #whapps_call{}=Call) when is_binary(CIDNumber) -
 
 -spec caller_id_number(call()) -> binary().
 caller_id_number(#whapps_call{caller_id_number=CIDNumber}) ->
-    CIDNumber.
+    case  wh_util:is_empty(CIDNumber) of
+        'true' -> <<>>;
+        'false' -> CIDNumber
+    end.
 
 -spec set_callee_id_name(ne_binary(), call()) -> call().
 set_callee_id_name(CIDName, #whapps_call{}=Call) when is_binary(CIDName) ->


### PR DESCRIPTION
...m the hiearchy, allow a list of json_objects for merge_recursive, added a debug command to fetch a merged endpoint (for inspection), honor privacy internally for devices that do not support the proper SIP headers.  Together these address the underlying issues of the ticket.
