### PR TITLE
KAZOO-2144 Typo in cb_faxes.erl

### DIFF
--- a/applications/crossbar/src/modules/cb_faxes.erl
+++ b/applications/crossbar/src/modules/cb_faxes.erl
@@ -287,7 +287,7 @@ on_successful_validation('undefined', Context) ->
     AccountDb = wh_util:format_account_id(AccountId, 'encoded'),
     AuthDoc = cb_context:auth_doc(Context),
     OwnerId = wh_json:get_value(<<"owner_id">>, AuthDoc),
-    Timezone = crossbar_util:get_account_timezone(AccountId, OwnerId),
+    Timezone = crossbar_util:get_user_timezone(AccountId, OwnerId),
 			
     cb_context:set_doc(Context
                        ,wh_json:set_values([{<<"pvt_type">>, <<"fax">>}


### PR DESCRIPTION
Line 290: 
Timezone = crossbar_util:get_account_timezone(AccountId, OwnerId), 

There is no crossbar_util:get_account_timezone/2 

As a result request fails: 

{"auth_token":"++++++++++++++++++","request_id":"f91e5e8f5c3f2f26839de90a06dc6b88","status":"error","message":"init failed","error":"500"} 

Besides that, common logic says it should be crossbar_util:get_user_timezone(AccountId, OwnerId), 
