### PR TITLE
KAZOO-2146: use quoted-printable transfer encoding for voicemail notific...

### DIFF
--- a/applications/notify/src/notify_vm.erl
+++ b/applications/notify/src/notify_vm.erl
@@ -188,7 +188,9 @@ build_and_send_email(TxtBody, HTMLBody, Subject, To, Props, {RespQ, MsgId}) ->
              ,ContentTypeParams
              ,[{<<"multipart">>, <<"alternative">>, [], []
                 ,[{<<"text">>, <<"plain">>, [{<<"Content-Type">>, iolist_to_binary([<<"text/plain">>,CharsetString])}], [], iolist_to_binary(TxtBody)}
-                  ,{<<"text">>, <<"html">>, [{<<"Content-Type">>, iolist_to_binary([<<"text/html">>,CharsetString])}], [], iolist_to_binary(HTMLBody)}
+                  ,{<<"text">>, <<"html">>, [{<<"Content-Type">>, iolist_to_binary([<<"text/html">>,CharsetString])}
+                                             ,{<<"Content-Transfer-Encoding">>, <<"quoted-printable">>}
+                                            ], [], iolist_to_binary(HTMLBody)}
                  ]
                }
                ,{<<"audio">>, <<"mpeg">>


### PR DESCRIPTION
...ation email

Note: I only updated notify_vm.erl since I'm hoping for some guidance on the best approach for a more general solution.  Should this same change be applied to all email notifications?  Does it need to be configurable in some way?  If it does need to be configurable, what would be the best way to control it?
