### PR TITLE
sup command to list all account's call_restriction flags

### DIFF
--- a/applications/callflow/src/callflow_maintenance.erl
+++ b/applications/callflow/src/callflow_maintenance.erl
@@ -426,10 +426,10 @@ print_users_level_call_restrictions(DbName) ->
         {'ok', JObj} ->
             io:format("\n\nUser level classifiers:\n"),
             lists:foreach(fun(UserObj) ->
-                             io:format("\nUsername: ~s\n\n", [wh_json:get_value(<<"username">>,props:get_value(<<"value">>,UserObj))]),
-                             print_call_restrictions(DbName, props:get_value(<<"id">>,UserObj)) 
+                             io:format("\nUsername: ~s\n\n", [wh_json:get_value([<<"value">>,<<"username">>],UserObj)]),
+                             print_call_restrictions(DbName, wh_json:get_value(<<"id">>,UserObj)) 
                           end,
-                          wh_json:to_proplist(JObj));
+                          JObj);
         {'error', E} ->
             io:format("An error occurred: ~p", [E])
     end.
@@ -440,10 +440,10 @@ print_devices_level_call_restrictions(DbName) ->
         {'ok', JObj} ->
             io:format("\n\nDevice level classifiers:\n"),
             lists:foreach(fun(UserObj) ->
-                             io:format("\nDevice: ~s\n\n", [wh_json:get_value(<<"name">>,props:get_value(<<"value">>,UserObj))]),
-                             print_call_restrictions(DbName, props:get_value(<<"id">>,UserObj)) 
+                             io:format("\nDevice: ~s\n\n", [wh_json:get_value([<<"value">>,<<"name">>],UserObj)]),
+                             print_call_restrictions(DbName, wh_json:get_value(<<"id">>,UserObj)) 
                           end,
-                          wh_json:to_proplist(JObj));
+                          JObj);
         {'error', E} ->
             io:format("An error occurred: ~p", [E])
     end.
@@ -454,10 +454,10 @@ print_trunkstore_call_restrictions(DbName) ->
         {'ok', JObj} ->
             io:format("\n\nTrunkstore classifiers:\n\n"),
             lists:foreach(fun(UserObj) ->
-                             io:format("Trunk: ~s@~s\n\n", lists:reverse(props:get_value(<<"key">>,UserObj))),
-                             print_call_restrictions(DbName, props:get_value(<<"id">>,UserObj)) 
+                             io:format("Trunk: ~s@~s\n\n", lists:reverse(wh_json:get_value(<<"key">>,UserObj))),
+                             print_call_restrictions(DbName, wh_json:get_value(<<"id">>,UserObj)) 
                           end,
-                          wh_json:to_proplist(JObj));
+                          JObj);
         {'error', E} ->
             io:format("An error occurred: ~p", [E])
     end.


### PR DESCRIPTION
An alternative to digging CouchDB or UI

Output sample:

[root@host kazoo]# sup callflow_maintenance list_account_restrictions "my office"

Account level classifiers:

Classifier <<"local_spb">>:      action <<"allow">>
Classifier <<"national">>:       action <<"allow">>
Classifier <<"international">>:      action <<"deny">>
Classifier <<"dangerous">>:      action <<"deny">>

User level classifiers:

Username: admin

Classifier <<"closed_groups">>:      action <<"inherit">>
Classifier <<"local_spb">>:      action <<"inherit">>
Classifier <<"national">>:       action <<"inherit">>
Classifier <<"dangerous">>:      action <<"inherit">>
Classifier <<"international">>:      action <<"deny">>

Username: user1

Classifier <<"closed_groups">>:      action <<"inherit">>
Classifier <<"local_spb">>:      action <<"inherit">>
Classifier <<"national">>:       action <<"inherit">>
Classifier <<"dangerous">>:      action <<"inherit">>
Classifier <<"international">>:      action <<"inherit">>

Device level classifiers:

Device: spa525

Classifier <<"closed_groups">>:      action <<"inherit">>
Classifier <<"local_spb">>:      action <<"inherit">>
Classifier <<"national">>:       action <<"inherit">>
Classifier <<"dangerous">>:      action <<"deny">>
Classifier <<"international">>:      action <<"inherit">>

Device: spa922

Classifier <<"closed_groups">>:      action <<"inherit">>
Classifier <<"local_spb">>:      action <<"inherit">>
Classifier <<"national">>:       action <<"deny">>
Classifier <<"international">>:      action <<"deny">>

Trunkstore classifiers:

Trunk: pbx_single@domain.tld

Classifier <<"local_spb">>:      action <<"allow">>
Classifier <<"national">>:       action <<"allow">>
Classifier <<"international">>:      action <<"deny">>
Classifier <<"dangerous">>:      action <<"deny">>
ok
