### PR TITLE
Fixed KAZOO-2661, bypass_e164 option in callflow doesn't work for quickc...

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -438,7 +438,7 @@ get_originate_action(<<"transfer">>, JObj) ->
         Route ->
             Context = ?DEFAULT_FREESWITCH_CONTEXT,
             list_to_binary(["'m:^:", get_unset_vars(JObj)
-                            ,"transfer:", wnm_util:to_e164(Route)
+                            ,"transfer:", Route
                             ," XML ", Context, "' inline"
                            ])
     end;

--- a/core/whistle_apps-1.0.0/src/whapps_call.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_call.erl
@@ -195,7 +195,7 @@ from_route_req(RouteReq, #whapps_call{call_id=OldCallId
 
     Call#whapps_call{call_id=CallId
                      ,request=Request
-                     ,request_user=wnm_util:to_e164(RequestUser)
+                     ,request_user=RequestUser
                      ,request_realm=RequestRealm
                      ,from=From
                      ,from_user=FromUser
@@ -510,7 +510,7 @@ callee_id_number(#whapps_call{callee_id_number=CIDNumber}) ->
 set_request(Request, #whapps_call{}=Call) when is_binary(Request) ->
     [RequestUser, RequestRealm] = binary:split(Request, <<"@">>),
     Call#whapps_call{request=Request
-                     ,request_user=wnm_util:to_e164(RequestUser)
+                     ,request_user=RequestUser
                      ,request_realm=RequestRealm
                     }.
 


### PR DESCRIPTION
This patch fixes KAZOO-2661 to make bypass_e164 option works for quickcall.
Hope it doesn't affect other feature.
