### PR TITLE
Webhooks dedup events

### DIFF
--- a/applications/webhooks/src/webhooks.hrl
+++ b/applications/webhooks/src/webhooks.hrl
@@ -22,10 +22,4 @@
 -type webhook() :: #webhook{}.
 -type webhooks() :: [webhook(),...] | [].
 
--record(webhook_event, {
-          id :: ne_binary() | '$1' | '_'
-          ,received :: pos_integer() | '$1' | '_'
-         }).
--type webhook_event() :: #webhook_event{}.
-
 -endif.


### PR DESCRIPTION
Because multiple ecallmgrs could produce the same event, webhooks needs a small cache to know whether the event+call_id has been recently seen, where recently is in the last 5 seconds, up to one minute (the cache is cleared of "old" events every minute).
