### PR TITLE
PATCH support to modify users from HTTP

### DIFF
--- a/applications/crossbar/src/modules_v1/cb_users_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_users_v1.erl
@@ -23,6 +23,7 @@
          ,put/1
          ,post/2
          ,delete/2
+		 ,patch/2
         ]).
 
 -include("../crossbar.hrl").
@@ -55,7 +56,8 @@ init() ->
     _ = crossbar_bindings:bind(<<"v1_resource.validate.users">>, ?MODULE, 'validate'),
     _ = crossbar_bindings:bind(<<"v1_resource.execute.put.users">>, ?MODULE, 'put'),
     _ = crossbar_bindings:bind(<<"v1_resource.execute.post.users">>, ?MODULE, 'post'),
-    _ = crossbar_bindings:bind(<<"v1_resource.execute.delete.users">>, ?MODULE, 'delete').
+    _ = crossbar_bindings:bind(<<"v1_resource.execute.delete.users">>, ?MODULE, 'delete'),
+    _ = crossbar_bindings:bind(<<"v1_resource.execute.patch.users">>, ?MODULE, 'patch').
 
 %%--------------------------------------------------------------------
 %% @public
@@ -74,7 +76,7 @@ allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
 
 allowed_methods(_) ->
-    [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
+    [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE, ?HTTP_PATCH].
 
 allowed_methods(_, ?CHANNELS) ->
     [?HTTP_GET].
@@ -171,6 +173,8 @@ validate_user(Context, UserId, ?HTTP_GET) ->
 validate_user(Context, UserId, ?HTTP_POST) ->
     validate_request(UserId, Context);
 validate_user(Context, UserId, ?HTTP_DELETE) ->
+    load_user(UserId, Context);
+validate_user(Context, UserId, ?HTTP_PATCH) ->
     load_user(UserId, Context).
 
 validate(Context, UserId, ?CHANNELS) ->
@@ -203,6 +207,11 @@ put(Context) ->
 -spec delete(cb_context:context(), path_token()) -> cb_context:context().
 delete(Context, _) ->
     crossbar_doc:delete(Context).
+
+-spec patch(cb_context:context(), path_token()) -> cb_context:context().
+patch(Context, _) -> 
+	crossbar_doc:patch(Context).
+
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -23,6 +23,7 @@
          ,put/1
          ,post/2
          ,delete/2
+		 ,patch/2
         ]).
 
 -include("../crossbar.hrl").
@@ -56,6 +57,7 @@ init() ->
     _ = crossbar_bindings:bind(<<"v2_resource.execute.put.users">>, ?MODULE, 'put'),
     _ = crossbar_bindings:bind(<<"v2_resource.execute.post.users">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"v2_resource.execute.delete.users">>, ?MODULE, 'delete').
+    _ = crossbar_bindings:bind(<<"v2_resource.execute.patch.users">>, ?MODULE, 'patch').
 
 %%--------------------------------------------------------------------
 %% @public
@@ -171,6 +173,8 @@ validate_user(Context, UserId, ?HTTP_GET) ->
 validate_user(Context, UserId, ?HTTP_POST) ->
     validate_request(UserId, Context);
 validate_user(Context, UserId, ?HTTP_DELETE) ->
+    load_user(UserId, Context);
+validate_user(Context, UserId, ?HTTP_PATCH) ->
     load_user(UserId, Context).
 
 validate(Context, UserId, ?CHANNELS) ->
@@ -237,6 +241,11 @@ dry_run(Context) ->
 -spec delete(cb_context:context(), path_token()) -> cb_context:context().
 delete(Context, _) ->
     crossbar_doc:delete(Context).
+
+-spec patch(cb_context:context(), path_token()) -> cb_context:context().
+patch(Context, _) -> 
+	crossbar_doc:patch(Context).
+
 
 %%--------------------------------------------------------------------
 %% @private


### PR DESCRIPTION
Nothing complicated here, but we find it very convenient to be able to update just one property of a user document, instead of having to send it completely via a POST request.
