### PR TITLE
Strip quotes from cookie variable

### DIFF
--- a/scripts/conn-to-apps.sh
+++ b/scripts/conn-to-apps.sh
@@ -24,5 +24,5 @@ fi
 
 ERL_COOKIE=`../utils/sup/sup erlang get_cookie`
 
-exec erl -setcookie $ERL_COOKIE -name ${SHELL_NAME} -remsh ${REMOTE_SHELL}
+exec erl -setcookie ${ERL_COOKIE//\'} -name ${SHELL_NAME} -remsh ${REMOTE_SHELL}
 

--- a/scripts/conn-to-ecallmgr.sh
+++ b/scripts/conn-to-ecallmgr.sh
@@ -24,4 +24,4 @@ fi
 
 ERL_COOKIE=`../utils/sup/sup erlang get_cookie -n ecallmgr`
 
-exec erl -setcookie $ERL_COOKIE -name ${SHELL_NAME} -remsh ${REMOTE_SHELL}
+exec erl -setcookie ${ERL_COOKIE//\'} -name ${SHELL_NAME} -remsh ${REMOTE_SHELL}


### PR DESCRIPTION
This forces troublesome shells to treat the variable properly; otherwise on some systems, script will fail to connect because the cookie, though valid, is not sent properly to erl.
