### PR TITLE
Trim off extra quotes using sed

### DIFF
--- a/scripts/conn-to-apps.sh
+++ b/scripts/conn-to-apps.sh
@@ -22,7 +22,7 @@ if [[ ! "$REMOTE_SHELL" == *@*  ]]; then
     REMOTE_SHELL="${REMOTE_SHELL}@`hostname -f`"
 fi
 
-ERL_COOKIE=`../utils/sup/sup erlang get_cookie`
+ERL_COOKIE=`../utils/sup/sup erlang get_cookie | sed "s/'//g"`
 
 exec erl -setcookie $ERL_COOKIE -name ${SHELL_NAME} -remsh ${REMOTE_SHELL}
 

--- a/scripts/conn-to-ecallmgr.sh
+++ b/scripts/conn-to-ecallmgr.sh
@@ -22,6 +22,6 @@ if [[ ! "$REMOTE_SHELL" == *@*  ]]; then
     REMOTE_SHELL="${REMOTE_SHELL}@`hostname -f`"
 fi
 
-ERL_COOKIE=`../utils/sup/sup erlang get_cookie -n ecallmgr`
+ERL_COOKIE=`../utils/sup/sup erlang get_cookie -n ecallmgr | sed "s/'//g"`
 
 exec erl -setcookie $ERL_COOKIE -name ${SHELL_NAME} -remsh ${REMOTE_SHELL}


### PR DESCRIPTION
Some shells will fail to treat the cookie properly and will cause the conn-to-apps and conn-to-ecallmgr scripts to fail to connect. This attempts to strip out the extra single quotes that some systems insert. 
