### PR TITLE
KAZOO-2900 Call limits .. Logic incorrect

### DIFF
--- a/applications/jonny5/src/j5_hard_limit.erl
+++ b/applications/jonny5/src/j5_hard_limit.erl
@@ -69,6 +69,6 @@ resource_consumption_at_limit(Limits) ->
 -spec should_deny(integer(), integer()) -> boolean().
 should_deny(-1, _) -> 'false';
 should_deny(0, _) -> 'true';
-should_deny(Limit, Used) -> Limit > Used.
+should_deny(Limit, Used) -> Used > Limit.
 
 


### PR DESCRIPTION
Logic incorrect. In order to deny the call the number of Used (active) calls must be greater than the limit defined.
