### PR TITLE
check system_config to determine if auth local

### DIFF
--- a/applications/jonny5/src/j5_authz_req.erl
+++ b/applications/jonny5/src/j5_authz_req.erl
@@ -43,8 +43,9 @@ determine_account_id(Request) ->
 
 -spec maybe_local_resource(ne_binary(), wh_proplist(), j5_request:request()) -> 'ok'.
 maybe_local_resource(AccountId, Props, Request) ->
-    %% TODO: we need to check system_config to determine if we authz local
-    case wh_number_properties:is_local_number(Props) of
+    case wh_number_properties:is_local_number(Props) 
+        andalso whapps_config:get_is_false(<<"ecallmgr">>, 'authz_local_resources','false')
+    of
         'false' ->
             maybe_account_limited(
               j5_request:set_account_id(AccountId, Request)


### PR DESCRIPTION
With authz_local_resources set to true, calls placed to local resources will now consume an inbound trunk.

Noted that this was set %%TODO.
