### PR TITLE
Added extra property to user document schema called 'opaque'. This prope...

### DIFF
--- a/applications/callflow/src/cf_endpoint.erl
+++ b/applications/callflow/src/cf_endpoint.erl
@@ -110,6 +110,7 @@ maybe_cached_hotdesk_ids(Props, JObj, AccountDb) ->
 -spec merge_attributes(wh_json:object()) -> wh_json:object().
 merge_attributes(Endpoint) ->
     Keys = [<<"name">>
+            ,<<"opaque">>
             ,<<"call_restriction">>
             ,<<"music_on_hold">>
             ,<<"ringtones">>

--- a/applications/crossbar/priv/couchdb/schemas/users.json
+++ b/applications/crossbar/priv/couchdb/schemas/users.json
@@ -6,6 +6,13 @@
     "name": "User",
     "description": "Schema for a user",
     "properties": {
+        "opaque": {
+            "type": "object",
+            "required": false,
+            "name": "Opaque",
+            "description": "A black box in which other developers can store their custom user properties",
+            "additionalProperties": true
+        },
         "enabled": {
             "type": "boolean",
             "required": false,


### PR DESCRIPTION
...rty is to allow custom data to be stored in the user document. Modified cf_endpoint in the callflow application to access that opaque data and merge it into the endpoint with the other merged in user properties.
