### PR TITLE
KAZOO-2904: Make rate responce mandatory for call (per_minute).

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_authz.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_authz.erl
@@ -242,8 +242,8 @@ rate_channel(Props, Node) ->
         {'error', _R} ->
             lager:debug("rate request lookup failed: ~p", [_R]),
             %%  Disconnect only per_minute channels
-            AccountBilling = props:get_binary_value(<<"variable_ecallmgr_Account-Billing">>,Props),
-            ResellerBilling = props:get_binary_value(<<"variable_ecallmgr_Reseller-Billing">>,Props),
+            AccountBilling = props:get_binary_value(?GET_CCV(<<"Account-Billing">>),Props),
+            ResellerBilling = props:get_binary_value(?GET_CCV(<<"Reseller-Billing">>),Props),
             case AccountBilling =:= <<"per_minute">> orelse ResellerBilling =:= <<"per_minute">> of 
                 'true' -> maybe_kill_unrated_channel(Props, Node);
                 _ -> 'ok'


### PR DESCRIPTION
Add 4 options inbound_rate_required/outbound_rate_required (default false) and inbound_rate_resp_timeout/outbound_rate_resp_timeoutto (default 10000) to system_config/ecallmgr database.
When *_rate_required set to true then call after authz ecallmgr wait for *_rate_resp_timeout and if no rate responce received then this channel killed.
