### PR TITLE
Kazoo 3003: Allow superduper admins to edit port requests in protected states

### DIFF
--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -650,7 +650,7 @@ can_update_port_request(_Context, ?PORT_WAITING) ->
 can_update_port_request(_Context, ?PORT_REJECT) ->
     'true';
 can_update_port_request(Context, _) ->
-    cb_modules_util:is_superduper_admin(cb_context:account_id(Context)).
+    cb_modules_util:is_superduper_admin(cb_context:auth_account_id(Context)).
 
 -spec successful_validation(api_binary(), cb_context:context()) -> cb_context:context().
 successful_validation('undefined', Context) ->


### PR DESCRIPTION
Superduper admins are unable to edit a port request in any state only the have access to (e.g.submitted/scheduled). See issue [KAZOO-3003](https://2600hz.atlassian.net/browse/KAZOO-3003).

In addition, according to wh_port_request it is possible to resubmit a rejected port. It makes sense then that a user should be able to edit their port request before resubmitting it.
