### PR TITLE
Update indonesia.md

### DIFF
--- a/applications/crossbar/doc/internationalization/numbers/indonesia.md
+++ b/applications/crossbar/doc/internationalization/numbers/indonesia.md
@@ -22,7 +22,7 @@ optionally, since we know E.164 is 15 max digits (including country code), it ca
     "^0(\\d{8,})$": {
         "prefix": "+62"
     },
-    "^+62(\\d{8,})$": {
+    "^\\+62(\\d{8,})$": {
         "prefix": "+62"
     }
 ```


### PR DESCRIPTION
leaving \\ in front of +62  (ex. "\\+62(\d{8,})$") will cause number schema error when adding callflow.
