### PR TITLE
Notify_util passes port as binary string to gen smtp client, it wants an...

### DIFF
--- a/applications/notify/src/notify_util.erl
+++ b/applications/notify/src/notify_util.erl
@@ -43,7 +43,7 @@ send_email(From, To, Email) ->
     Username = wh_util:to_list(whapps_config:get(<<"smtp_client">>, <<"username">>, <<"">>)),
     Password = wh_util:to_list(whapps_config:get(<<"smtp_client">>, <<"password">>, <<"">>)),
     Auth = wh_util:to_list(whapps_config:get(<<"smtp_client">>, <<"auth">>, <<"never">>)),
-    Port = wh_util:to_list(whapps_config:get(<<"smtp_client">>, <<"port">>, <<"25">>)),
+    Port = wh_util:to_integer(whapps_config:get(<<"smtp_client">>, <<"port">>, <<"25">>)),
 
     lager:debug("sending email to ~s from ~s via ~s", [To, From, Relay]),
     ReqId = get('callid'),


### PR DESCRIPTION
... int

Relavent Code in gen_smtp_client:489
https://github.com/2600hz/kazoo/blob/master/deps/gen_smtp-0.0.1/src/gen_smtp_client.erl#L489

``` erlang
    Port = case proplists:get_value(port, Options) of
        undefined when Proto =:= ssl ->
            465;
        OPort when is_integer(OPort) ->
            OPort;
        _ ->
            25
    end,
```
