### PR TITLE
KAZOO-3085: conditionally add HEARTBEAT to all FS event streams

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_event_stream.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_event_stream.erl
@@ -28,8 +28,7 @@
                 ,ip :: inet:ip_address()
                 ,port :: inet:port_number()
                 ,socket :: inet:socket()
-                ,idle_alert = 'infinity' :: non_neg_integer() | 'infinity'
-               }).
+                ,idle_alert = 'infinity' :: wh_timeout()
 -type state() :: #state{}.
 
 %%%===================================================================


### PR DESCRIPTION
Also add corresponding gen_server timeout events when connected so we can emit a log line if it becomes idle.
