### PR TITLE
KAZOO-3115 cb_faxes GET incoming can't be validated if one of modbs doesn't exist

### DIFF
--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -237,7 +237,7 @@ load_view(View, Options, Context, StartKey, PageSize, FilterFun) ->
                                 ,start_key=StartKey
                                 ,page_size=PageSize
                                 ,filter_fun=FilterFun
-                                ,dbs=props:get_value('databases', Options, [cb_context:account_db(Context)])
+                                ,dbs=lists:filter(fun couch_mgr:db_exists/1, props:get_value('databases', Options, [cb_context:account_db(Context)]))
                                }).
 
 load_view(#load_view_params{dbs=[]

--- a/applications/crossbar/src/modules/cb_faxes.erl
+++ b/applications/crossbar/src/modules/cb_faxes.erl
@@ -501,6 +501,5 @@ get_modbs(Context, From, To) ->
     {{FromYear, FromMonth, _}, _} = calendar:gregorian_seconds_to_datetime(From),
     {{ToYear, ToMonth, _}, _} = calendar:gregorian_seconds_to_datetime(To),
     Range = crossbar_util:generate_year_month_sequence({FromYear, FromMonth}, {ToYear, ToMonth}, []),
-    FilterFun = fun couch_mgr:db_exists/1,
-    [{'databases', lists:filter(FilterFun, [wh_util:format_account_mod_id(AccountId, Year, Month) || {Year, Month} <- Range])}].
+    [{'databases', [ wh_util:format_account_mod_id(AccountId, Year, Month) || {Year, Month} <- Range]}].
 


### PR DESCRIPTION
If freshly created account tries to list incoming faxes it receives an error because crossbar tries to look at previous month modb which doesn't exists. 

Nonexistent DBs should be filtered from cb_faxes:incoming_summary
