### PR TITLE
Auth-By-IP fix for authz and add sup cmd

### DIFF
--- a/applications/registrar/src/reg.hrl
+++ b/applications/registrar/src/reg.hrl
@@ -8,6 +8,8 @@
 
 -define(CONFIG_CAT, <<"registrar">>).
 
+-define(REG_CACHE, 'registrar_cache').
+
 -record(auth_user, {realm :: ne_binary()
                     ,username :: ne_binary()
                     ,password :: api_binary()

--- a/applications/registrar/src/reg_authz_req.erl
+++ b/applications/registrar/src/reg_authz_req.erl
@@ -1,0 +1,43 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2011-2013, 2600Hz INC
+%%% @doc
+%%% Handle authz_req messages
+%%% @end
+%%% @contributors
+%%%   David Singer (cando)
+%%%-------------------------------------------------------------------
+-module(reg_authz_req).
+
+-export([init/0
+	, handle_req/2
+	]).
+
+-include("reg.hrl").
+
+init() -> 'ok'.
+
+-spec handle_req(wh_json:object(), wh_proplist()) -> 'ok'.
+handle_req(JObj, _Props) ->
+    'true' = wapi_authz:authz_req_v(JObj),
+    CCVs = wh_json:get_value(<<"Custom-Channel-Vars">>, JObj, wh_json:new()),
+    AccId = wh_json:get_ne_value(<<"Account-ID">>, CCVs),
+    lager:debug("Account-ID ~p from CCVs: ~p, req: ~p", [AccId, CCVs, JObj]),
+    case AccId of
+	'undefined' ->
+	    wh_util:put_callid(JObj),
+	    IP = wh_json:get_value(<<"From-Network-Addr">>, JObj),
+	    lager:debug("Missing Account-ID, trying to authenticate with auth-by-IP ~s.", [IP]),
+	    case reg_authn_req:lookup_account_by_ip(IP) of
+	        {'ok', AccProps} ->
+		    lager:debug("replaying authz_req with auth by IP account CCVs: ~p", [AccProps]),
+		    wapi_authz:publish_authz_req(
+			wh_json:set_value(
+			    <<"Custom-Channel-Vars">>
+			    , wh_json:set_values(AccProps, CCVs)
+			    , JObj)
+		    );
+		_Err -> _Err
+	    end;
+	_ ->
+	    'ok'
+    end.

--- a/applications/registrar/src/reg_route_req.erl
+++ b/applications/registrar/src/reg_route_req.erl
@@ -19,40 +19,22 @@ handle_route_req(JObj, _Props) ->
     'true' = wapi_route:req_v(JObj),
     CCVs = wh_json:get_value(<<"Custom-Channel-Vars">>, JObj, wh_json:new()),
     case wh_json:get_ne_value(<<"Account-ID">>, CCVs) of
-        'undefined' ->  maybe_replay_route_req(JObj);
+        'undefined' ->
+	    case wh_json:get_value(<<"From-Network-Addr">>, JObj) of
+		'undefined' -> 'ok';
+		IP ->
+		    lager:debug("trying to see if this route req is an auth-by-ip'd device: ~s", [IP]),
+		    case reg_authn_req:lookup_account_by_ip(IP) of
+			{'ok', AccProps} ->
+			    lager:debug("replaying route_req with auth by IP account CCVs: ~p", [AccProps]),
+			    wapi_route:publish_req(
+				wh_json:set_value(
+				    <<"Custom-Channel-Vars">>
+				    , wh_json:set_values(AccProps, CCVs)
+				    , JObj)
+			    );
+			_E -> _E
+		    end
+	    end;
         _AccountId -> 'ok'
     end.
-
--spec maybe_replay_route_req(wh_json:object()) -> any().
-maybe_replay_route_req(JObj) ->
-    case wh_json:get_value(<<"From-Network-Addr">>, JObj) of
-        'undefined' -> 'ok';
-        IP -> maybe_replay_route_req(JObj, IP)
-    end.
-
--spec maybe_replay_route_req(wh_json:object(), api_binary()) -> any().
-maybe_replay_route_req(JObj, IP) ->
-    lager:debug("trying to see if this route req is an auth-by-ip'd device: ~s", [IP]),
-    ViewOptions = [{'key', IP}],
-    case couch_mgr:get_results(?WH_SIP_DB, <<"credentials/lookup_by_ip">>, ViewOptions) of
-        {'ok', []} -> lager:debug("no entry in ~s for IP ~s", [?WH_SIP_DB, IP]);
-        {'ok', [Doc|_]} -> replay_route_req(JObj, Doc);
-        {'error', _E} -> lager:debug("failed to lookup by ip: ~s: ~p", [IP, _E])
-    end.
-
--spec replay_route_req(wh_json:object(), wh_json:object()) -> any().
-replay_route_req(JObj, Doc) ->
-    AccountID = wh_json:get_value([<<"value">>,  <<"account_id">>], Doc),
-    OwnerID = wh_json:get_value([<<"value">>, <<"owner_id">>], Doc),
-    AuthType = wh_json:get_value([<<"value">>, <<"authorizing_type">>], Doc, <<"anonymous">>),
-    lager:debug("adding account ~s and owner ~s to ccvs", [AccountID, OwnerID]),
-    CCVs = wh_json:set_values(
-             props:filter_undefined(
-               [{<<"Account-ID">>, AccountID}
-                ,{<<"Owner-ID">>, OwnerID}
-                ,{<<"Authorizing-ID">>, wh_json:get_value(<<"id">>, Doc)}
-                ,{<<"Authorizing-Type">>, AuthType}
-               ])
-             ,wh_json:get_value(<<"Custom-Channel-Vars">>, JObj, wh_json:new())),
-    lager:debug("replaying route_req"),
-    wapi_route:publish_req(wh_json:set_value(<<"Custom-Channel-Vars">>, CCVs, JObj)).

--- a/applications/registrar/src/registrar_maintenance.erl
+++ b/applications/registrar/src/registrar_maintenance.erl
@@ -10,6 +10,7 @@
 
 -export([local_summary/0, local_summary/1, local_summary/2
          ,flush_realm_registrations/1
+	 ,dev_by_ip/1
         ]).
 
 -include("reg.hrl").
@@ -96,3 +97,20 @@ print_details(Registration) when is_list(Registration) ->
     [io:format("~s: ~s~n", [K, wh_util:to_list(V)]) || {K, V} <- Registration];
 print_details(Registration) ->
     print_details(wh_json:to_proplist(Registration)).
+
+-spec dev_by_ip(text()) -> 'ok'.
+dev_by_ip(IP) when not is_binary(IP) ->
+    dev_by_ip(wh_util:to_binary(IP));
+dev_by_ip(IP) ->
+    io:format("Looking up IP: ~s~n", [IP]),
+    case reg_authn_req:lookup_account_by_ip(IP) of
+	{'ok', AccProps} ->
+	    pretty_print_dev_by_ip(AccProps);
+	{'error', _E} ->
+	    io:format("Not found: ~p~n", [_E])
+    end.
+
+pretty_print_dev_by_ip([]) -> 'ok';
+pretty_print_dev_by_ip([{Key, Value}|Props]) ->
+    io:format("~-39s: ~s~n", [Key, wh_util:to_binary(Value)]),
+    pretty_print_dev_by_ip(Props).

--- a/applications/registrar/src/registrar_shared_listener.erl
+++ b/applications/registrar/src/registrar_shared_listener.erl
@@ -25,11 +25,15 @@
 -define(RESPONDERS, [{'reg_authn_req'
                       ,[{<<"directory">>, <<"authn_req">>}]
                      }
+                     ,{'reg_authz_req'
+                      ,[{<<"authz">>, <<"authz_req">>}]
+                     }
                      ,{{'reg_route_req', 'handle_route_req'}
                        ,[{<<"dialplan">>, <<"route_req">>}]
                       }
                     ]).
 -define(BINDINGS, [{'authn', []}
+                   ,{'authz', []}
                    ,{'route', []}
                    ,{'self', []}
                   ]).

--- a/applications/registrar/src/registrar_sup.erl
+++ b/applications/registrar/src/registrar_sup.erl
@@ -14,7 +14,9 @@
 -export([start_link/0]).
 -export([init/1]).
 
--define(CHILDREN, [?WORKER('registrar_shared_listener')]).
+-define(CHILDREN, [?CACHE(?REG_CACHE)
+                   ,?WORKER('registrar_shared_listener')
+                  ]).
 
 %% ===================================================================
 %% API functions


### PR DESCRIPTION
Authz relied on vars normally set when call is challenged and FS dynamically requests directory from ecallmgr. So the vars were set when channel create event kicks off authz. But for auth-by-IP FS never does directory request because of trusted ACL.

Moved the auth-by-IP lookup from reg_route_req.erl to reg_authn_req.erl. Added caching.
Created reg_authz_req.erl to listen for authz requests and if account info is missing try auth-by-IP lookup.
Added sup command registrar_maintenance dev-by-ip <IP of device>
