### PR TITLE
    Commit of partial work (this commit will be amended) to share with J...

### DIFF
--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -802,26 +802,44 @@ does_resource_exist(_Context, _ReqNouns) ->
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
-%% This function gives each noun a chance to determine if
+%% This function gives each {Mod, Params} pair a chance to determine if
 %% it is valid and returns the status, and any errors
+%%
+%% validate_resource for each {Mod, Params} pair
+%% validate for LAST {Mod, Params} pair
+%%
 %% @end
 %%--------------------------------------------------------------------
 -spec validate(cb_context:context()) -> cb_context:context().
-validate(Context0) ->
-    Context1 =
-        cb_context:import_errors(
-          lists:foldr(fun({Mod, Params}, ContextAcc) ->
-                              Event = api_util:create_event_name(Context0, <<"validate.", Mod/binary>>),
-                              Payload = [cb_context:set_resp_status(ContextAcc, 'fatal') | Params],
-                              crossbar_bindings:fold(Event, Payload)
-                      end
-                      ,Context0
-                      ,cb_context:req_nouns(Context0)
-                     )),
-    case succeeded(Context1) of
-        'true' -> process_billing(Context1);
-        'false' -> Context1
+-spec validate(cb_context:context(), list()) -> cb_context:context().
+validate(Context) ->
+    validate(Context, cb_context:req_nouns(Context)).
+
+validate(Context, ReqNouns) ->
+    Context1 = validate_resources(Context, ReqNouns),
+    Context2 = validate_data(Context1, ReqNouns),
+    case succeeded(Context2) of
+        'true' -> process_billing(Context2);
+        'false' -> Context2
     end.
+
+-spec validate_data(cb_context:context(), list()) -> cb_context:context().
+validate_data(Context, [{Mod, Params}|_]) ->
+    Event = api_util:create_event_name(Context, <<"validate.", Mod/binary>>),
+    Payload = [cb_context:set_resp_status(Context, 'fatal') | Params],
+    cb_context:import_errors(crossbar_bindings:fold(Event, Payload)).
+
+-spec validate_data(cb_context:context(), list()) -> cb_context:context().
+validate_resources(Context, ReqNouns) ->
+    cb_context:import_errors(
+        lists:foldr(fun({Mod, Params}, ContextAcc) ->
+            Event = api_util:create_event_name(Context, <<"validate_resource.", Mod/binary>>),
+            Payload = [cb_context:set_resp_status(ContextAcc, 'fatal') | Params],
+            crossbar_bindings:fold(Event, Payload)
+        end
+        ,Context
+        ,ReqNouns
+    )).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -28,6 +28,7 @@
 
          ,account_id/1, set_account_id/2
          ,account_db/1, set_account_db/2
+         ,user_id/1, set_user_id/2
          ,account_modb/1, account_modb/2, account_modb/3
          ,set_account_modb/3, set_account_modb/4
          ,reseller_id/1, set_reseller_id/2
@@ -108,6 +109,7 @@ req_value(#cb_context{req_data=ReqData, query_json=QS}, Key, Default) ->
 %% Accessors
 -spec account_id(context()) -> api_binary().
 -spec account_db(context()) -> api_binary().
+-spec user_id(context()) -> api_binary().
 -spec account_modb(context()) -> api_binary().
 -spec account_modb(context(), wh_now() | wh_timeout()) -> api_binary().
 -spec account_modb(context(), wh_year(), wh_month()) -> api_binary().
@@ -115,6 +117,7 @@ req_value(#cb_context{req_data=ReqData, query_json=QS}, Key, Default) ->
 -spec account_doc(context()) -> api_object().
 
 account_id(#cb_context{account_id=AcctId}) -> AcctId.
+user_id(#cb_context{user_id=UserId}) -> UserId.
 reseller_id(#cb_context{reseller_id=AcctId}) -> AcctId.
 account_db(#cb_context{db_name=AcctDb}) -> AcctDb.
 
@@ -192,6 +195,7 @@ setters_fold({F, K, V}, C) -> F(C, K, V).
 
 -spec set_account_id(context(), ne_binary()) -> context().
 -spec set_account_db(context(), ne_binary()) -> context().
+-spec set_user_id(context(), ne_binary()) -> context().
 -spec set_auth_token(context(), ne_binary()) -> context().
 -spec set_auth_doc(context(), wh_json:object()) -> context().
 -spec set_auth_account_id(context(), ne_binary()) -> context().
@@ -229,6 +233,7 @@ setters_fold({F, K, V}, C) -> F(C, K, V).
 -spec set_validation_errors(context(), wh_json:object()) -> context().
 
 set_account_id(#cb_context{}=Context, AcctId) -> Context#cb_context{account_id=AcctId}.
+set_user_id(#cb_context{}=Context, UserId) -> Context#cb_context{user_id=UserId}.
 set_reseller_id(#cb_context{}=Context, AcctId) -> Context#cb_context{reseller_id=AcctId}.
 set_account_db(#cb_context{}=Context, AcctDb) -> Context#cb_context{db_name=AcctDb}.
 set_account_modb(#cb_context{}=Context, Year, Month) ->

--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -111,6 +111,7 @@
           ,req_headers = [] :: cowboy:http_headers()
           ,query_json = wh_json:new() :: wh_json:object()
           ,account_id :: api_binary()
+          ,user_id :: api_binary()   % Will be loaded in validate stage for endpoints such as /accounts/{acct-id}/users/{user-id}/*
           ,reseller_id :: api_binary()
           ,db_name :: api_binary() | ne_binaries()
           ,doc :: api_object() | wh_json:objects()


### PR DESCRIPTION
...ames

```
    - during validation stage:
        Event 1: resource_valid
            - run on each Module in URL path
            - Does this event need a better name, like validate_resource ?

            - binders:
                - cb_users_*
                    - load user_id into context
                - cb_accounts
                    - load account_db/accout_id into context

        Event 2: validate
            - only run on last Module, like resource_exists

    If only resource_exists() method took Context as parameter, could fold o
```
