### PR TITLE
Allow for queues to be created without TTL or MaxLength

### DIFF
--- a/core/whistle_amqp-1.0.0/src/amqp_util.erl
+++ b/core/whistle_amqp-1.0.0/src/amqp_util.erl
@@ -621,6 +621,7 @@ queue_arguments(Arguments) ->
 max_length(Args, Acc) ->
     case props:get_value(<<"x-max-length">>, Args) of
         'undefined' -> [{<<"x-max-length">>, 'short', 100}|Acc];
+        'infinity' -> props:delete(<<"x-max-length">>, Acc);
         Value ->
             Acc1 = props:delete(<<"x-max-length">>, Acc),
             [{<<"x-max-length">>, 'short', Value}|Acc1]
@@ -630,6 +631,7 @@ max_length(Args, Acc) ->
 message_ttl(Args, Acc) ->
     case props:get_value(<<"x-message-ttl">>, Args) of
         'undefined' -> [{<<"x-message-ttl">>, 'signedint', 60000}|Acc];
+        'infinity' -> props:delete(<<"x-message-ttl">>, Acc);
         Value ->
             Acc1 = props:delete(<<"x-message-ttl">>, Acc),
             [{<<"x-message-ttl">>, 'signedint', Value}|Acc1]


### PR DESCRIPTION
We are using gen_listener our queue workers and don't want to be limited by the message ttl or max length of the queue.  This pull request allows for 'infinity' to be specified for those values to eliminate them as queue creation args.

Example Usage:

``` erlang
-behaviour(gen_listener).
...
-define(MY_QUEUE_PROPERTIES, [
            {durable, true},
            {auto_delete, false},
            {arguments, [{<<"x-message-ttl">>, infinity}, {<<"x-max-length">>, infinity}]}
        ]).
...
start_link() ->
    gen_listener:start_link(?MODULE, [
         {responders, ?RESPONDERS}
        ,{bindings, ?BINDINGS}
        ,{queue_name, ?MY_QUEUE_NAME}
        ,{queue_options, ?MY_QUEUE_PROPERTIES}
        ,{consume_options, ?MY_QUEUE_CONSUME_OPTIONS}
    ], []).
```
