### PR TITLE
This is not a final official fix but I'd like to create this PR to raise...

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -208,7 +208,7 @@ find_allowed_methods(Req0, Context) ->
     Event = api_util:create_event_name(Context, <<"allowed_methods">>),
     Responses = crossbar_bindings:map(<<Event/binary, ".", Mod/binary>>, Params),
     {Method, Req1} = cowboy_req:method(Req0),
-    AllowMethods = api_util:allow_methods(Responses
+    AllowMethods = api_util:allow_methods([lists:flatten(Responses)]
                                           ,cb_context:allowed_methods(Context)
                                           ,cb_context:req_verb(Context)
                                           ,wh_util:to_binary(Method)


### PR DESCRIPTION
... a bug that needs a bigger solution.

The implemented fix submitted is what we're using as a temporary fix until you guys figure this out :)

Here's the simplified version of the issue:

We want to support PATCH for vmboxes.
We created our custom cb_grid_vmboxes module that supports PATCH
For cb_grid_vmboxes.allow_methods we want to return the verbs we support
Without flattering the list, we don't get PATCH as supported (some other weird list of allow_methods verbs seems to be used -- we haven't looked into it)

Main reason solution needs help:
With flattening the list, crossbar_bindings will still attemp to call PATCH for cb_vmboxes which is undefined.  This generates an error in the logs, but since it's done in another process - yay for crossbar_bindings - this doesn't "break" anything.
