### PR TITLE
KAZOO-3216 

### DIFF
--- a/applications/stepswitch/src/stepswitch_bridge.erl
+++ b/applications/stepswitch/src/stepswitch_bridge.erl
@@ -536,12 +536,12 @@ get_sip_headers(JObj) ->
     case get_diversions(JObj) of
         'undefined' ->
             wh_json:delete_key(<<"Diversion">>
-                               ,wh_json:get_value(<<"Custom-SIP-Headers">>, JObj)
+                               ,wh_json:get_value(<<"Custom-SIP-Headers">>, JObj, wh_json:new())
                               );
         Diversion ->
             wh_json:set_value(<<"Diversion">>
                               ,Diversion
-                              ,wh_json:get_value(<<"Custom-SIP-Headers">>, JObj)
+                              ,wh_json:get_value(<<"Custom-SIP-Headers">>, JObj, wh_json:new())
                              )
     end.
 


### PR DESCRIPTION
stepswitch_bridge:get_sip_headers/1 throws error if <<"Custom-SIP-Headers">> are absent
