### PR TITLE
KAZOO-3229 - ecallmgr_maintenance registrar_summary show not all registrations

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_registrar.erl
+++ b/applications/ecallmgr/src/ecallmgr_registrar.erl
@@ -66,7 +66,7 @@
 -define(REG_QUEUE_NAME, <<>>).
 -define(REG_QUEUE_OPTIONS, []).
 -define(REG_CONSUME_OPTIONS, []).
--define(SUMMARY_REGEX, <<"^.*?:.*@([0-9.:]*)(?:;transport=udp|tcp|tls)(?:;fs_path=.*?:([0-9.:]*);)*">>).
+-define(SUMMARY_REGEX, <<"^.*?:.*@([0-9.:]*)(?:;transport=(?:udp|tls|tcp))?(?:;ob)?(?:;rinstance=.{16})?(?:;fs_path=.*?:([0-9.:]*);)*">>).
 
 -record(state, {started = wh_util:current_tstamp()}).
 
@@ -997,7 +997,7 @@ print_summary({[#registration{username=Username
               ,Count) ->
     User = <<Username/binary, "@", Realm/binary>>,
     Remaining = (LastRegistration + Expires) - wh_util:current_tstamp(),
-    _ = case re:run(Contact, ?SUMMARY_REGEX, [{'capture', 'all_but_first', 'binary'}]) of
+    _ = case re:run(Contact, ?SUMMARY_REGEX, [{'capture', 'all_but_first', 'binary'}, caseless]) of
             {'match', [Host, Path]} ->
                 io:format("| ~-45s | ~-22s | ~-22s | ~-32s | ~-4B |~n"
                           ,[User, Host, Path, CallId, Remaining]);


### PR DESCRIPTION
To continue conversation https://groups.google.com/forum/#!topic/2600hz-dev/SBu5fGmUSpM

Here are some 'unusual' registration strings found in my registrations table:

Bria iOS 3.2.1:

<sip:5519@2.2.2.2:55061;transport=TLS;ob;fs_path=<sip:1.1.1.1:5061;lr;received='sip:1.1.1.1:55061;transport=tls'>>

<sip:User_2pnrza@3.3.3.3:64967;ob;fs_path=<sip:1.1.1.1:5060;lr;received='sip:3.3.3.3:64967;transport=udp'>>

Zoiper r28827:

<sip:5520@4.4.4.4:26070;transport=TLS;rinstance=e6b1e5bda0fcfd30;fs_path=<sip:1.1.1.1:5061;lr;received='sip:4.4.4.4:26070;transport=tls'>>


We could see here a couple of additional fields - "ob" and  "rinstance=e6b1e5bda0fcfd30"

Besides that re:run should be case insensitive because transport protocol name could be in both cases (TLS/tls)

So finally, regex string, which totally satisfied my humble 400 registrations look like this:

-define(SUMMARY_REGEX, <<"^.*?:.*@([0-9.:]*)(?:;transport=(?:udp|tls|tcp))?(?:;ob)?(?:;rinstance=.{16})?(?:;fs_path=.*?:([0-9.:]*);)*">>). 


Regards,
Kirill
