### PR TITLE
cb_sms was not added to the system_config crossbar document as a default...

### DIFF
--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -72,6 +72,7 @@
                           ,'cb_user_auth', 'cb_users'
                           ,'cb_vmboxes'
                           ,'cb_webhooks', 'cb_whitelabel'
+                          ,'cb_sms'
                          ]).
 
 -define(DEPRECATED_MODULES, ['cb_local_resources', 'cb_global_resources']).


### PR DESCRIPTION
... module.  Consequently, it did not start.