### PR TITLE
Why wasn't this previously a case?  My request failed for PUT /accounts/...

### DIFF
--- a/applications/crossbar/src/modules/cb_sms.erl
+++ b/applications/crossbar/src/modules/cb_sms.erl
@@ -176,7 +176,9 @@ on_successful_validation(Context) ->
             {UserId, 'undefined'} ->
                 {<<"user">>, UserId, UserId};
             {'undefined', UserAuth} ->
-                {<<"user">>, UserAuth, UserAuth}
+                {<<"user">>, UserAuth, UserAuth};
+            {UserId, _UserAuth} ->
+                {<<"user">>, UserId, UserId}
         end,
 
     ToUser = wh_json:get_value(<<"to">>, JObj),


### PR DESCRIPTION
...acct-id/users/user-id/sms without this