### PR TITLE
doodle_exec should also utilize it's gen_listener behavior implementatio...

### DIFF
--- a/applications/doodle/src/doodle_exe.erl
+++ b/applications/doodle/src/doodle_exe.erl
@@ -253,7 +253,7 @@ init([Call]) ->
     process_flag('trap_exit', 'true'),
     CallId = whapps_call:call_id(Call),
     put('callid', CallId),
-    self() ! 'initialize',
+    gen_listener:cast(self(), 'initialize'),
     {'ok', #state{call=Call}}.
 
 %%--------------------------------------------------------------------
@@ -385,6 +385,17 @@ handle_cast({'add_event_listener', {M, A}}, #state{call=Call}=State) ->
             lager:info("failed to spawn ~s:~s: ~p", [M, _R]),
             {'noreply', State}
     end;
+handle_cast('initialize', #state{call=Call}) ->
+    log_call_information(Call),
+    Flow = whapps_call:kvs_fetch('cf_flow', Call),
+    Updaters = [fun(C) -> whapps_call:kvs_store('consumer_pid', self(), C) end
+                ,fun(C) -> whapps_call:call_id_helper(fun doodle_exe:callid/2, C) end
+                ,fun(C) -> whapps_call:control_queue_helper(fun doodle_exe:control_queue/2, C) end
+               ],
+    CallWithHelpers = lists:foldr(fun(F, C) -> F(C) end, Call, Updaters),
+    {'noreply', #state{call=CallWithHelpers
+                       ,flow=Flow
+                      }};
 handle_cast({'gen_listener', {'created_queue', Q}}, #state{call=Call}=State) ->
     {'noreply', launch_cf_module(State#state{queue=Q
                                              ,call=whapps_call:set_controller_queue(Q, Call)
@@ -411,17 +422,6 @@ event_listener_name(Call, Module) ->
 %%                                   {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
-handle_info('initialize', #state{call=Call}) ->
-    log_call_information(Call),
-    Flow = whapps_call:kvs_fetch('cf_flow', Call),
-    Updaters = [fun(C) -> whapps_call:kvs_store('consumer_pid', self(), C) end
-                ,fun(C) -> whapps_call:call_id_helper(fun doodle_exe:callid/2, C) end
-                ,fun(C) -> whapps_call:control_queue_helper(fun doodle_exe:control_queue/2, C) end
-               ],
-    CallWithHelpers = lists:foldr(fun(F, C) -> F(C) end, Call, Updaters),
-    {'noreply', #state{call=CallWithHelpers
-                       ,flow=Flow
-                      }};
 handle_info({'DOWN', Ref, 'process', Pid, 'normal'}, #state{cf_module_pid={Pid, Ref}
                                                             ,call=Call
                                                            }=State) ->


### PR DESCRIPTION
...n, no?

Analogous to cf_exe.erl..

I see that the 'initialize' is caught in `doodle_exec:handle_info` vs `handle_cast` and not quite the same then ensures, but this seems like a good place to ask why.  Why doesn't the flow match callflow?