### PR TITLE
CCCP update2

### DIFF
--- a/applications/cccp/src/cccp_callback_listener.erl
+++ b/applications/cccp/src/cccp_callback_listener.erl
@@ -60,16 +60,16 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec start_link([term()]) -> startlink_ret().
-start_link(Args) ->
+start_link(JObj) ->
     gen_listener:start_link(?MODULE, [{'responders', ?RESPONDERS}
                                       ,{'bindings', ?BINDINGS}
                                       ,{'queue_name', ?QUEUE_NAME}
                                       ,{'queue_options', ?QUEUE_OPTIONS}
                                       ,{'consume_options', ?CONSUME_OPTIONS}
-                                     ], Args).
+                                     ], [JObj]).
 
 -spec init(wh_json:object()) -> {'ok', state()}.
-init(JObj) ->
+init([JObj]) ->
     CustomerNumber = wh_json:get_value(<<"Number">>, JObj),
     AccountId = wh_json:get_value(<<"Account-ID">>, JObj),
     OutboundCID = wh_json:get_value(<<"Outbound-Caller-ID-Number">>, JObj),

--- a/applications/cccp/src/cccp_platform_listener.erl
+++ b/applications/cccp/src/cccp_platform_listener.erl
@@ -61,7 +61,7 @@ start_link(Call) ->
                                       ,{'queue_name', ?QUEUE_NAME}       % optional to include
                                       ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                                       ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
-                                     ], Call).
+                                     ], [Call]).
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -79,7 +79,7 @@ start_link(Call) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec init(whapps_call:call()) -> {'ok', state()}.
-init(Call) ->
+init([Call]) ->
     process_flag('trap_exit', 'true'),
     CallId = whapps_call:call_id(Call),
     put('callid', CallId),


### PR DESCRIPTION
Small corrections to be able to pass gen_listener:start_link/3,4,5 guards introduced in "KAZOO-3249: added more types for gen_server" (1f642b639f33daa4d09a2e62067f58d3cc981a3e)

Please backport it to 3.19 since gen_listener changes were also backported