### PR TITLE
Don't overwrite voicemail greeting media if it was shared media file upl...

### DIFF
--- a/applications/callflow/src/module/cf_ring_group.erl
+++ b/applications/callflow/src/module/cf_ring_group.erl
@@ -45,6 +45,14 @@ attempt_endpoints(Endpoints, Data, Call) ->
                 'ok' -> lager:debug("bridge failure handled");
                 'not_found' -> cf_exe:continue(Call)
             end;
+        {'error', 'timeout'} ->
+            case Strategy of 
+                <<"simultaneous">> -> 
+                    lager:debug("Ignore this timeout"); 
+                _ -> 
+                    lager:debug("Timeout for one-by-one continues normally"),
+                    cf_exe:continue(Call) 
+            end;
         {'error', _R} ->
             lager:info("error bridging to ring group: ~p"
                        ,[wh_json:get_value(<<"Error-Message">>, _R)]

--- a/applications/callflow/src/module/cf_ring_group.erl
+++ b/applications/callflow/src/module/cf_ring_group.erl
@@ -46,13 +46,8 @@ attempt_endpoints(Endpoints, Data, Call) ->
                 'not_found' -> cf_exe:continue(Call)
             end;
         {'error', 'timeout'} ->
-            case Strategy of 
-                <<"simultaneous">> -> 
-                    lager:debug("Ignore this timeout"); 
-                _ -> 
-                    lager:debug("Timeout for one-by-one continues normally"),
-                    cf_exe:continue(Call) 
-            end;
+            lager:debug("bridge timed out waiting for someone to answer"),
+            cf_exe:continue(Call);
         {'error', _R} ->
             lager:info("error bridging to ring group: ~p"
                        ,[wh_json:get_value(<<"Error-Message">>, _R)]

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -819,7 +819,22 @@ record_unavailable_greeting(AttachmentName, #mailbox{unavailable_media_id='undef
     MediaId = recording_media_doc(<<"unavailable greeting">>, Box, Call),
     record_unavailable_greeting(AttachmentName, Box#mailbox{unavailable_media_id=MediaId}, Call);
 record_unavailable_greeting(AttachmentName, #mailbox{unavailable_media_id=MediaId}=Box, Call) ->
-    lager:info("recording unavailable greeting  as ~s", [AttachmentName]),
+    case couch_mgr:open_doc(whapps_call:account_db(Call), MediaId) of
+        {'ok', JObj} ->
+            case wh_json:get_value(<<"media_source">>, JObj) of
+                <<"upload">> ->
+                    lager:debug("The voicemail media is a web upload, let's not touch it,"
+                      ++ " it may be in use in some other maibox and create new media document"),
+                    record_unavailable_greeting(AttachmentName, Box#mailbox{unavailable_media_id='undefined'}, Call);
+                _ -> 
+                    overwrite_unavailable_greeting(AttachmentName, Box, Call)
+            end;
+        _ -> overwrite_unavailable_greeting(AttachmentName, Box, Call)
+    end.
+-spec overwrite_unavailable_greeting(ne_binary(), mailbox(), whapps_call:call()) ->
+                                         'ok' | mailbox().
+overwrite_unavailable_greeting(AttachmentName, #mailbox{unavailable_media_id=MediaId}=Box, Call) ->
+   lager:info("overwriting unavailable greeting  as ~s", [AttachmentName]),
     Tone = wh_json:from_list([{<<"Frequencies">>, [<<"440">>]}
                               ,{<<"Duration-ON">>, <<"500">>}
                               ,{<<"Duration-OFF">>, <<"100">>}

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -819,12 +819,12 @@ record_unavailable_greeting(AttachmentName, #mailbox{unavailable_media_id='undef
     MediaId = recording_media_doc(<<"unavailable greeting">>, Box, Call),
     record_unavailable_greeting(AttachmentName, Box#mailbox{unavailable_media_id=MediaId}, Call);
 record_unavailable_greeting(AttachmentName, #mailbox{unavailable_media_id=MediaId}=Box, Call) ->
-    case couch_mgr:open_doc(whapps_call:account_db(Call), MediaId) of
+    case couch_mgr:open_cache_doc(whapps_call:account_db(Call), MediaId) of
         {'ok', JObj} ->
             case wh_json:get_value(<<"media_source">>, JObj) of
                 <<"upload">> ->
-                    lager:debug("The voicemail media is a web upload, let's not touch it,"
-                      ++ " it may be in use in some other maibox and create new media document"),
+                    lager:debug("The voicemail greeting media is a web upload, let's not touch it,"
+                      ++ " it may be in use in some other maibox. We create new media document."),
                     record_unavailable_greeting(AttachmentName, Box#mailbox{unavailable_media_id='undefined'}, Call);
                 _ -> 
                     overwrite_unavailable_greeting(AttachmentName, Box, Call)


### PR DESCRIPTION
...oaded from the Web UI

When setting up a mailbox from the Web UI you can use any media file on the account, including shared media files. If somebody with such shared greeting file re-records their voicemail greeting from the phone it will overwrite the shared file (everybody else's greeting as well). This patch checks if the greeting was uploaded from the UI and creates a new media file as opposed to overwriting it when that's the case.