### PR TITLE
KAZOO-3293: update eavesdrop to current state

### DIFF
--- a/applications/callflow/src/module/cf_eavesdrop.erl
+++ b/applications/callflow/src/module/cf_eavesdrop.erl
@@ -73,28 +73,26 @@ eavesdrop_a_channel(Channels, Call) ->
 
     lager:debug("looking for channels on my node ~s that aren't me", [MyMediaServer]),
 
-    {_, _, Chans} = lists:foldl(fun chan_sort/2, {MyUUID, MyMediaServer, {[], []}}, Channels),
+    {_, _, SortedChannels} = lists:foldl(fun channels_sort/2, {MyUUID, MyMediaServer, {[], []}}, Channels),
 
-    case Chans of
+    case SortedChannels of
         {[], []} ->
             lager:debug("no channels available to eavesdrop"),
             no_channels(Call);
-        {[], [RemoteChan | _Remote]} ->
-            lager:info("no calls on my media server, trying ~s", [wh_json:get_value(<<"uuid">>, RemoteChan)]),
-
+        {[], [RemoteChannel | _Remote]} ->
+            lager:info("no calls on my media server, trying redirect to ~s", [wh_json:get_value(<<"node">>, RemoteChannel)]),
             Contact = erlang:iolist_to_binary(["sip:", whapps_call:request(Call)]),
-            whapps_call_command:redirect(Contact, wh_json:get_value(<<"node">>, RemoteChan), Call),
-            eavesdrop_call(RemoteChan, Call);
-        {[LocalChan | _Cs], _} ->
-            lager:info("found a call (~s) on my media server", [wh_json:get_value(<<"uuid">>, LocalChan)]),
-            eavesdrop_call(LocalChan, Call)
+            whapps_call_command:redirect_to_node(Contact, wh_json:get_value(<<"node">>, RemoteChannel), Call);
+        {[LocalChannel | _Cs], _} ->
+            lager:info("found a call (~s) on my media server", [wh_json:get_value(<<"uuid">>, LocalChannel)]),
+            eavesdrop_call(LocalChannel, Call)
     end.
 
--type chans() :: {wh_json:objects(), wh_json:objects()}.
--type chan_sort_acc() :: {ne_binary(), ne_binary(), chans()}.
+-type channels() :: {wh_json:objects(), wh_json:objects()}.
+-type channel_sort_acc() :: {ne_binary(), ne_binary(), channels()}.
 
--spec chan_sort(wh_json:object(), chan_sort_acc()) -> chan_sort_acc().
-chan_sort(Channel, {MyUUID, MyMediaServer, {Local, Remote}} = Acc) ->
+-spec channels_sort(wh_json:object(), channel_sort_acc()) -> channel_sort_acc().
+channels_sort(Channel, {MyUUID, MyMediaServer, {Local, Remote}} = Acc) ->
     lager:debug("channel: c: ~s a: ~s n: ~s oleg: ~s", [wh_json:get_value(<<"uuid">>, Channel)
                                                         ,wh_json:is_true(<<"answered">>, Channel)
                                                         ,wh_json:get_value(<<"node">>, Channel)

--- a/applications/ecallmgr/src/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_command.erl
@@ -517,22 +517,8 @@ get_fs_app(Node, UUID, JObj, <<"redirect">>) ->
     case wapi_dialplan:redirect_v(JObj) of
         'false' -> {'error', <<"redirect failed to execute as JObj did not validate">>};
         'true' ->
-            RedirectServer = case wh_json:get_value(<<"Redirect-Server">>, JObj) of
-                                 'undefined' ->
-                                     case wh_json:get_value(<<"Redirect-Node">>, JObj) of
-                                         'undefined' -> 'undefined';
-                                         RedirectNode ->
-                                             SipUrl = ecallmgr_fs_node:sip_url(RedirectNode),
-                                             binary:replace(SipUrl, <<"mod_sofia@">>, <<>>)
-                                     end;
-                                 Server -> Server
-                             end,
-            case RedirectServer of
-                'undefined' -> 'ok';
-                _Else ->
-                    lager:debug("Set X-Redirect-Server to ~s", [RedirectServer]),
-                    ecallmgr_util:set(Node, UUID, [{<<"sip_rh_X-Redirect-Server">>, RedirectServer}])
-            end,
+            RedirectServer = lookup_redirect_server(JObj) ,
+            maybe_add_redirect_header(Node, UUID, RedirectServer),
 
             {<<"redirect">>, wh_json:get_value(<<"Redirect-Contact">>, JObj, <<>>)}
     end;
@@ -570,6 +556,34 @@ get_fs_app(_Node, _UUID, JObj, <<"fax_detection">>) ->
 get_fs_app(_Node, _UUID, _JObj, _App) ->
     lager:debug("unknown application ~s", [_App]),
     {'error', <<"application unknown">>}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Redirect command helpers
+%% @end
+%%--------------------------------------------------------------------
+
+-spec lookup_redirect_server(wh_json:object()) -> api_binary().
+lookup_redirect_server(JObj) ->
+    case wh_json:get_value(<<"Redirect-Server">>, JObj) of
+        'undefined' -> fixup_redirect_node(wh_json:get_value(<<"Redirect-Node">>, JObj));
+        Server -> Server
+    end.
+
+-spec fixup_redirect_node(api_binary()) -> api_binary().
+fixup_redirect_node('undefined') ->
+    'undefined';
+fixup_redirect_node(Node) ->
+    SipUrl = ecallmgr_fs_node:sip_url(Node),
+    binary:replace(SipUrl, <<"mod_sofia@">>, <<>>).
+
+-spec maybe_add_redirect_header(ne_binary(), ne_binary(), api_binary()) -> 'ok'.
+maybe_add_redirect_header(_, _, 'undefined') ->
+    'ok';
+maybe_add_redirect_header(Node, UUID, RedirectServer) ->
+    lager:debug("Set X-Redirect-Server to ~s", [RedirectServer]),
+    ecallmgr_util:set(Node, UUID, [{<<"sip_rh_X-Redirect-Server">>, RedirectServer}]).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/core/whistle-1.0.0/src/api/wapi_dialplan.hrl
+++ b/core/whistle-1.0.0/src/api/wapi_dialplan.hrl
@@ -555,7 +555,7 @@
 
 %% Redirect
 -define(REDIRECT_REQ_HEADERS, [<<"Application-Name">>, <<"Call-ID">>, <<"Redirect-Contact">>]).
--define(OPTIONAL_REDIRECT_REQ_HEADERS, [<<"Insert-At">>, <<"Redirect-Server">>]).
+-define(OPTIONAL_REDIRECT_REQ_HEADERS, [<<"Insert-At">>, <<"Redirect-Server">>, <<"Redirect-Node">>]).
 -define(REDIRECT_REQ_VALUES, [{<<"Event-Category">>, <<"call">>}
                               ,{<<"Event-Name">>, <<"command">>}
                               ,{<<"Application-Name">>, <<"redirect">>}
@@ -563,6 +563,7 @@
                              ]).
 -define(REDIRECT_REQ_TYPES, [{<<"Redirect-Contact">>, fun is_binary/1}
                              ,{<<"Redirect-Server">>, fun is_binary/1}
+                             ,{<<"Redirect-Node">>, fun is_binary/1}
                             ]).
 
 %% Execute_Extension

--- a/core/whistle_apps-1.0.0/src/whapps_call_command.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_call_command.erl
@@ -35,6 +35,7 @@
         ]).
 -export([redirect/2
          ,redirect/3
+         ,redirect_to_node/3
         ]).
 -export([answer/1, answer_now/1
          ,hangup/1, hangup/2
@@ -607,6 +608,23 @@ redirect(Contact, Server, Call) ->
     lager:debug("redirect to ~s on ~s", [Contact, Server]),
     Command = [{<<"Redirect-Contact">>, Contact}
                ,{<<"Redirect-Server">>, Server}
+               ,{<<"Application-Name">>, <<"redirect">>}
+              ],
+    send_command(Command, Call),
+    timer:sleep(2000),
+    'ok'.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Create a redirect request to Node
+%% @end
+%%--------------------------------------------------------------------
+-spec redirect_to_node(ne_binary(), api_binary(), whapps_call:call()) -> 'ok'.
+redirect_to_node(Contact, Node, Call) ->
+    lager:debug("redirect ~s to ~s", [Contact, Node]),
+    Command = [{<<"Redirect-Contact">>, Contact}
+               ,{<<"Redirect-Node">>, Node}
                ,{<<"Application-Name">>, <<"redirect">>}
               ],
     send_command(Command, Call),


### PR DESCRIPTION
Hello @jamesaimonetti,

By some unknown reason (UFO invasion probably) our version of eavesdrop callflow modules and one we've contributed differs significantly. We had to fix ecallmgr a bit to make it possible for calls to be routed to some specific FS node.
As always - you feedback is greatly awaited and appreciated.
Thanks!
