### PR TITLE
KAZOO-3125: Fixed /usr/bin/dirname error in kz_whistle_apps and kz_ecallmgr init scripts. 

### DIFF
--- a/scripts/kz-generic.init
+++ b/scripts/kz-generic.init
@@ -38,7 +38,7 @@ start() {
     export ERL_CRASH_DUMP=$(date +%s)_${KZ_APP}_erl_crash.dump
     export ERL_LIBS=${KZ_DIR}/deps:${KZ_DIR}/core
     ensure_cookie
-    daemon --user=${USER} "erl -name ${KZ_APP} -args_file /etc/kazoo/vm.args -pa ${KZ_DIR}/applications/*/ebin -pa ${KZ_DIR}/core/*/ebin -pa ${KZ_DIR}/deps/*/ebin -pa ${KZ_DIR}/applications/*/lib/*/ebin -detached -s ${KZ_APP} >/dev/null &"
+    daemon --user=${USER} --pidfile="nofile" "erl -name ${KZ_APP} -args_file /etc/kazoo/vm.args -pa ${KZ_DIR}/applications/*/ebin -pa ${KZ_DIR}/core/*/ebin -pa ${KZ_DIR}/deps/*/ebin -pa ${KZ_DIR}/applications/*/lib/*/ebin -detached -s ${KZ_APP} >/dev/null &"
     RETVAL=$?
     echo
     [ $RETVAL -eq 0 ] && touch ${LOCKFILE}


### PR DESCRIPTION
initscripts.9.03.46 and above (centos 6.6 and 6.5 with updated init version) introduced error in kz-whistle_apps and kz-ecallmgr start due to change in __pids_var_run in /etc/init.d/functions (centos common init script functions). Added dummy --pidfile argument to daemon args in kz-generic.init to prevent error from occurring.