### PR TITLE
KAZOO-3234 - set default broker

### DIFF
--- a/applications/doodle/src/doodle_inbound_listener.erl
+++ b/applications/doodle/src/doodle_inbound_listener.erl
@@ -26,7 +26,7 @@
 -define(DEFAULT_EXCHANGE, <<"sms">>).
 -define(DEFAULT_EXCHANGE_TYPE, <<"topic">>).
 -define(DEFAULT_EXCHANGE_OPTIONS, [{'passive', 'true'}]).
--define(DEFAULT_BROKER, <<"amqp://user:pass@server.com:5672/babble">>).
+-define(DEFAULT_BROKER, wh_amqp_connections:primary_broker()).
 -define(QUEUE_NAME, <<"smsc_inbound_queue_", (?DOODLE_INBOUND_EXCHANGE)/binary>>).
 
 -define(DOODLE_INBOUND_QUEUE, whapps_config:get_ne_binary(?CONFIG_CAT, <<"inbound_queue_name">>, ?QUEUE_NAME)).


### PR DESCRIPTION
set wh_amqp_connections:primary_broker() as default broker