### PR TITLE
KAZOO-3170: add a master capture group to phone number regexes

### DIFF
--- a/applications/crossbar/doc/internationalization/numbers.md
+++ b/applications/crossbar/doc/internationalization/numbers.md
@@ -83,33 +83,33 @@ This is a set of regexes to group numbers by type and are not used for routing. 
 
     "classifiers":{
         "tollfree_us":{
-            "regex":"^\\+1(800|888|877|866|855)\\d{7}$",
+            "regex":"^\\+1((?:800|888|877|866|855)\\d{7})$",
             "friendly_name":"US TollFree"
         },
         "toll_us":{
-            "regex":"^\\+1900\\d{7}$",
+            "regex":"^\\+1(900\\d{7})$",
             "friendly_name":"US Toll"
         },
         "emergency":{
-            "regex":"^911$",
+            "regex":"^(911)$",
             "friendly_name":"Emergency Dispatcher"
         },
         "caribbean":{
-            "regex":"^\\+?1(684|264|268|242|246|441|284|345|767|809|829|849|473|671|876|664|670|787|939|869|758|784|721|868|649|340)\\d{7}$",
+            "regex":"^\\+?1((?:684|264|268|242|246|441|284|345|767|809|829|849|473|671|876|664|670|787|939|869|758|784|721|868|649|340)\\d{7})$",
             "friendly_name":"Caribbean"
         },
         "did_us":{
-            "regex":"^\\+?1?[2-9][0-9]{2}[2-9][0-9]{6}$",
+            "regex":"^\\+?1?([2-9][0-9]{2}[2-9][0-9]{6})$",
             "friendly_name":"US DID",
             "pretty_print":"SS(###) ### - ####"
         },
         "international":{
-            "regex":"^011\\d*$|^00\\d*$",
+            "regex":"^(011\\d*)$|^(00\\d*)$",
             "friendly_name":"International",
             "pretty_print":"SSS011*"
         },
         "unknown":{
-            "regex":"^.*$",
+            "regex":"^(.*)$",
             "friendly_name":"Unknown"
         }
     }

--- a/core/whistle_number_manager-1.0.0/src/wnm_util.erl
+++ b/core/whistle_number_manager-1.0.0/src/wnm_util.erl
@@ -36,18 +36,18 @@
 -include("wnm.hrl").
 
 -define(SERVER, ?MODULE).
--define(DEFAULT_CLASSIFIERS, [{<<"tollfree_us">>, wh_json:from_list([{<<"regex">>, <<"^\\+1(800|888|877|866|855)\\d{7}$">>}
+-define(DEFAULT_CLASSIFIERS, [{<<"tollfree_us">>, wh_json:from_list([{<<"regex">>, <<"^\\+1((?:800|888|877|866|855)\\d{7})$">>}
                                                                      ,{<<"friendly_name">>, <<"US TollFree">>}
                                                                      ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
                                                                     ])}
-                              ,{<<"toll_us">>, wh_json:from_list([{<<"regex">>, <<"^\\+1900\\d{7}$">>}
+                              ,{<<"toll_us">>, wh_json:from_list([{<<"regex">>, <<"^\\+1(900\\d{7})$">>}
                                                                   ,{<<"friendly_name">>, <<"US Toll">>}
                                                                   ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
                                                                  ])}
-                              ,{<<"emergency">>, wh_json:from_list([{<<"regex">>, <<"^911$">>}
+                              ,{<<"emergency">>, wh_json:from_list([{<<"regex">>, <<"^(911)$">>}
                                                                     ,{<<"friendly_name">>, <<"Emergency Dispatcher">>}
                                                                    ])}
-                              ,{<<"caribbean">>, wh_json:from_list([{<<"regex">>, <<"^\\+?1(684|264|268|242|246|441|284|345|767|809|829|849|473|671|876|664|670|787|939|869|758|784|721|868|649|340)\\d{7}$">>}
+                              ,{<<"caribbean">>, wh_json:from_list([{<<"regex">>, <<"^\\+?1((?:684|264|268|242|246|441|284|345|767|809|829|849|473|671|876|664|670|787|939|869|758|784|721|868|649|340)\\d{7})$">>}
                                                                     ,{<<"friendly_name">>, <<"Caribbean">>}
                                                                     ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
                                                                    ])}
@@ -55,10 +55,10 @@
                                                                  ,{<<"friendly_name">>, <<"US DID">>}
                                                                  ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
                                                                 ])}
-                              ,{<<"international">>, wh_json:from_list([{<<"regex">>, <<"^011\\d*$|^00\\d*$">>}
+                              ,{<<"international">>, wh_json:from_list([{<<"regex">>, <<"^(011\\d*)$|^(00\\d*)$">>}
                                                                         ,{<<"friendly_name">>, <<"International">>}
                                                                        ])}
-                              ,{<<"unknown">>, wh_json:from_list([{<<"regex">>, <<"^.*$">>}
+                              ,{<<"unknown">>, wh_json:from_list([{<<"regex">>, <<"^(.*)$">>}
                                                                   ,{<<"friendly_name">>, <<"Unknown">>}
                                                                  ])}
                              ]).


### PR DESCRIPTION
It appears the defaults stored in whapps_config are automatically updated, so no need to flush the defaults in ETS.
