### PR TITLE
KAZOO-3235: POST hangups JSON data to a URI.

### DIFF
--- a/applications/hangups/doc/index.md
+++ b/applications/hangups/doc/index.md
@@ -5,8 +5,8 @@ Language: en-US
 */
 
 # Hangups
-Abnormal hangup cause logging
 
+Abnormal hangup cause logging
 
 ## Two ways of logging hangups
 
@@ -30,6 +30,7 @@ In case this string is causing issues, `hangups` will log the complaint and the 
 picked up will be *email*.
 
 The JSON sent has the following fields:
+
 * "details"
 * "hangup_cause"
 * "source"
@@ -38,11 +39,18 @@ The JSON sent has the following fields:
 * "realm"
 * "account_id"
 
-Example:
+### Setting the system up
+
+#### Via Erlang
 ```erlang
-{ok, _NewConf} = whapps_config:set(<<"hangups">>, <<"enable_email_alerts">>, false).
+{ok, _NewConf} = whapps_config:set_default(<<"hangups">>, <<"enable_email_alerts">>, false).
 URL = <<"http://yourserver.com/your/api/receiving/hangups/data">>.
-{ok, _} = whapps_config:set(<<"hangups">>, <<"subscriber_url">>, URL).
+{ok, _} = whapps_config:set_default(<<"hangups">>, <<"subscriber_url">>, URL).
 ```
 
 Note that URL needs to be a binary, that is, not a list.
+
+#### Via SUP
+
+    sup whapps_config set_default hangups enable_email_alerts false
+    sup whapps_config set_default hangups subscriber_url 'http://my.alerts.platform.com/hangups.php'

--- a/applications/hangups/doc/index.md
+++ b/applications/hangups/doc/index.md
@@ -6,3 +6,43 @@ Language: en-US
 
 # Hangups
 Abnormal hangup cause logging
+
+
+## Two ways of logging hangups
+
+Since KAZOO-3235, one can receive alerts via:
+
+* Email
+* JSON sent as POST to a URL
+* Or both
+
+Mind that if POSTing JSON fails for whatever reason, an email will be sent instead.
+
+### Configuration
+
+`hangups` configuration is filed under `system_config`.
+
+Receiving email can be turned on/off by setting `enable_email_alerts` to `true`/`false` (respectively).
+
+The URL through which to receive JSON is ruled by the `subscriber_url` field.
+It takes a string representing a valid URL pointing to a valid server.
+In case this string is causing issues, `hangups` will log the complaint and the method
+picked up will be *email*.
+
+The JSON sent has the following fields:
+* "details"
+* "hangup_cause"
+* "source"
+* "destination"
+* "direction"
+* "realm"
+* "account_id"
+
+Example:
+```erlang
+{ok, _NewConf} = whapps_config:set(<<"hangups">>, <<"enable_email_alerts">>, false).
+URL = <<"http://yourserver.com/your/api/receiving/hangups/data">>.
+{ok, _} = whapps_config:set(<<"hangups">>, <<"subscriber_url">>, URL).
+```
+
+Note that URL needs to be a binary, that is, not a list.

--- a/applications/hangups/src/hangups_channel_destroy.erl
+++ b/applications/hangups/src/hangups_channel_destroy.erl
@@ -32,27 +32,57 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec handle_req(wh_json:object(), wh_proplist()) -> any().
-handle_req(JObj, _Props) ->    
+-spec handle_req(wh_json:object(), wh_proplist()) -> 'ok'.
+handle_req(JObj, _Props) ->
     'true' = wapi_call:event_v(JObj),
     HangupCause = wh_json:get_value(<<"Hangup-Cause">>, JObj, <<"unknown">>),
     case lists:member(HangupCause, ?IGNORE) of
         'true' -> 'ok';
         'false' ->
-            AccountId = wh_json:get_value([<<"Custom-Channel-Vars">>, <<"Account-ID">>], JObj),
-            lager:debug("abnormal call termination: ~s", [HangupCause]),
-            wh_notify:system_alert("~s ~s to ~s (~s) on ~s(~s)"
-                                   ,[wh_util:to_lower_binary(HangupCause)
-                                     ,find_source(JObj)
-                                     ,find_destination(JObj)
-                                     ,find_direction(JObj)
-                                     ,find_realm(JObj, AccountId)
-                                     ,AccountId
-                                    ]
-                                   ,maybe_add_hangup_specific(HangupCause, JObj)
-                                  ),
-            add_to_meters(AccountId, HangupCause)
+            alert_about_hangup(HangupCause, JObj)
     end.
+
+
+-spec alert_about_hangup(ne_binary(), wh_json:object()) -> 'ok'.
+alert_about_hangup(HangupCause, JObj) ->
+    lager:debug("abnormal call termination: ~s", [HangupCause]),
+    UseEmail = whapps_config:get_is_true(?APP_NAME, <<"enable_email_alerts">>, 'true'),
+    SUBUrl   = whapps_config:get_string(?APP_NAME, <<"subscriber_url">>),
+    AccountId = wh_json:get_value([<<"Custom-Channel-Vars">>, <<"Account-ID">>], JObj),
+    DataDetails = maybe_add_hangup_specific(HangupCause, JObj),
+    Data = [{<<"hangup_cause">>, wh_util:to_lower_binary(HangupCause)}
+           ,{<<"source">>,       find_source(JObj)}
+           ,{<<"destination">>,  find_destination(JObj)}
+           ,{<<"direction">>,    find_direction(JObj)}
+           ,{<<"realm">>,        find_realm(JObj, AccountId)}
+           ,{<<"account_id">>,   AccountId}
+           ],
+    alert_about_hangup__email(UseEmail, Data, DataDetails),
+    alert_about_hangup__POST(SUBUrl,    Data, DataDetails, UseEmail),
+    add_to_meters(AccountId, HangupCause).
+
+-type ne_binary_proplist() :: [{ne_binary(), ne_binary()}].
+
+-spec alert_about_hangup__POST(string() | 'undefined', ne_binary_proplist(), wh_proplist(), boolean()) -> 'ok'.
+alert_about_hangup__POST(SUBUrl, Data, Details0, EmailUsed) ->
+    Details = {<<"details">>, {Details0}},
+    Headers = [{"Content-Type", "application/json"}],
+    Encoded = wh_json:encode({[Details] ++ Data}),
+    case ibrowse:send_req(SUBUrl, Headers, 'post', Encoded) of
+        {'ok', "200", _ResponseHeaders, _ResponseBody} ->
+            lager:debug("hangup JSON data successfully POSTed to ~p", [SUBUrl]);
+        Error ->
+            lager:debug("failed to POST hangup JSON data to ~p for reason: ~p", [SUBUrl,Error]),
+            alert_about_hangup__email(not EmailUsed, Data, Details0)
+    end.
+
+-spec alert_about_hangup__email(boolean(), ne_binary_proplist(), wh_proplist()) -> 'ok'.
+alert_about_hangup__email('false', _Data, _Details) -> 'ok';
+alert_about_hangup__email('true', Data, Details) ->
+    {_Lhs, DataRhs} = lists:unzip(Data),
+    wh_notify:system_alert("~s ~s to ~s (~s) on ~s(~s)", DataRhs, Details),
+    lager:debug("hangup JSON data successfully emailed").
+
 
 %%--------------------------------------------------------------------
 %% @private


### PR DESCRIPTION
2 new fields are added to hangups' system_config:
* `enable_email_alerts` :: `boolean()`: `true` means receiving emails
on hangups alerts (this is the legacy behaviour).
* `subscriber_url` :: `string()`: when non-empty will be used to send
hangups alerts as JSON in a HTTP POST request.

When both alert methods are deactivated, email is used.