### PR TITLE
Refactor: call wh_doc:is_soft_deleted/1

### DIFF
--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -907,7 +907,7 @@ handle_json_success(JObj, Context) ->
 handle_json_success([_|_]=JObjs, Context, ?HTTP_PUT) ->
     RespData = [wh_json:public_fields(JObj)
                 || JObj <- JObjs,
-                   wh_json:is_false(<<"pvt_deleted">>, JObj, 'true')
+                   not wh_doc:is_soft_deleted(JObj)
                ],
     RespHeaders = [{<<"Location">>, wh_json:get_value(<<"_id">>, JObj)}
                    || JObj <- JObjs
@@ -922,7 +922,7 @@ handle_json_success([_|_]=JObjs, Context, ?HTTP_PUT) ->
 handle_json_success([_|_]=JObjs, Context, _Verb) ->
     RespData = [wh_json:public_fields(JObj)
                 || JObj <- JObjs,
-                   wh_json:is_false(<<"pvt_deleted">>, JObj, 'true')
+                   not wh_doc:is_soft_deleted(JObj)
                ],
     cb_context:setters(Context
                        ,[{fun cb_context:set_doc/2, JObjs}

--- a/applications/crossbar/src/modules_v1/cb_users_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_users_v1.erl
@@ -138,7 +138,7 @@ validate_user_id(UserId, Context) ->
     end.
 
 validate_user_id(UserId, Context, Doc) ->
-    case wh_json:is_true(<<"pvt_deleted">>, Doc) of
+    case wh_doc:is_soft_deleted(Doc) of
         'true' ->
             cb_context:add_system_error(
                 'bad_identifier'

--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -176,7 +176,7 @@ validate_user_id(UserId, Context) ->
     end.
 
 validate_user_id(UserId, Context, Doc) ->
-    case wh_json:is_true(<<"pvt_deleted">>, Doc) of
+    case wh_doc:is_soft_deleted(Doc) of
         'true' ->
             cb_context:add_system_error(
                 'bad_identifier'

--- a/applications/notify/src/notify_account_crawler.erl
+++ b/applications/notify/src/notify_account_crawler.erl
@@ -148,9 +148,8 @@ handle_info(_Info, State) ->
 
 -spec check_then_process_account(ne_binary(), {'ok', wh_json:object()} | {'error',_}) -> 'ok'.
 check_then_process_account(AccountId, {'ok', JObj}) ->
-    case wh_json:is_true(<<"pvt_deleted">>, JObj) of
+    case wh_doc:is_soft_deleted(JObj) of
         'true' ->
-            %% Account has actually been soft-destroyed
             lager:debug("not processing account ~p (soft-destroyed)", [AccountId]);
         'false' ->
             AccountDb = wh_json:get_value(<<"pvt_account_db">>, JObj),

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -434,7 +434,7 @@ create_template(MasterAccountDb, DocId, Params) ->
 
 -spec maybe_update_template(ne_binary(), wh_json:object(), init_params()) -> 'ok'.
 maybe_update_template(MasterAccountDb, TemplateJObj, Params) ->
-    case wh_json:is_true(<<"pvt_deleted">>, TemplateJObj) of
+    case wh_doc:is_soft_deleted(TemplateJObj) of
         'true' -> lager:debug("template is currently soft-deleted");
         'false' ->
             case update_template(MasterAccountDb, TemplateJObj, Params) of

--- a/core/whistle_couch-1.0.0/src/couch_util.erl
+++ b/core/whistle_couch-1.0.0/src/couch_util.erl
@@ -876,7 +876,7 @@ should_publish_doc(Doc) ->
 
 -spec publish_doc(couchbeam_db(), wh_json:object(), wh_json:object()) -> 'ok'.
 publish_doc(#db{name=DbName}, Doc, JObj) ->
-    case wh_json:is_true(<<"pvt_deleted">>, Doc)
+    case wh_doc:is_soft_deleted(Doc)
         orelse wh_json:is_true(<<"_deleted">>, Doc)
     of
         'true' -> publish('deleted', wh_util:to_binary(DbName), Doc);

--- a/core/whistle_media-1.0.0/src/wh_media_util.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_util.erl
@@ -338,7 +338,7 @@ lookup_prompt(Db, Id) ->
                               {'ok', wh_json:object()} |
                               {'error', 'not_found'}.
 prompt_is_usable(Doc) ->
-    case wh_json:is_true(<<"pvt_deleted">>, Doc, 'false') of
+    case wh_doc:is_soft_deleted(Doc) of
         'true' -> {'error', 'not_found'};
         'false' -> {'ok', Doc}
     end.

--- a/core/whistle_services-1.0.0/src/wh_service_sync.erl
+++ b/core/whistle_services-1.0.0/src/wh_service_sync.erl
@@ -359,7 +359,7 @@ maybe_update_billing_id(BillingId, AccountId, ServiceJObj) ->
             lager:debug("billing id ~s on ~s does not exist anymore, updating to bill self", [BillingId, AccountId]),
             couch_mgr:save_doc(?WH_SERVICES_DB, wh_json:set_value(<<"billing_id">>, AccountId, ServiceJObj));
         {'ok', JObj} ->
-            case wh_json:is_true(<<"pvt_deleted">>, JObj) of
+            case wh_doc:is_soft_deleted(JObj) of
                 'false' -> wh_services:reconcile(BillingId);
                 'true' ->
                     lager:debug("billing id ~s on ~s was deleted, updating to bill self", [BillingId, AccountId]),

--- a/core/whistle_services-1.0.0/src/wh_services.erl
+++ b/core/whistle_services-1.0.0/src/wh_services.erl
@@ -121,7 +121,7 @@ new(AccountId) ->
                  ,dirty='true'
                  ,billing_id=BillingId
                  ,current_billing_id=BillingId
-                 ,deleted=wh_json:is_true(<<"pvt_deleted">>, Account)
+                 ,deleted=wh_doc:is_soft_deleted(Account)
                 }.
 
 %%--------------------------------------------------------------------
@@ -141,7 +141,7 @@ from_service_json(JObj) ->
                  ,status=wh_json:get_ne_value(<<"pvt_status">>, JObj, <<"good_standing">>)
                  ,billing_id=BillingId
                  ,current_billing_id=BillingId
-                 ,deleted=wh_json:is_true(<<"pvt_deleted">>, JObj)
+                 ,deleted=wh_doc:is_soft_deleted(JObj)
                 }.
 
 %%--------------------------------------------------------------------
@@ -173,7 +173,7 @@ handle_fetch_result(AccountId, JObj) ->
                  ,status=wh_json:get_ne_value(<<"pvt_status">>, JObj, <<"good_standing">>)
                  ,billing_id=BillingId
                  ,current_billing_id=BillingId
-                 ,deleted=wh_json:is_true(<<"pvt_deleted">>, JObj)
+                 ,deleted=wh_doc:is_soft_deleted(JObj)
                  ,dirty=wh_json:is_true(<<"pvt_dirty">>, JObj)
                 }.
 
@@ -226,7 +226,7 @@ save_as_dirty(#wh_services{jobj=JObj
             lager:debug("marked services as dirty for account ~s", [AccountId]),
             Services#wh_services{jobj=JObj
                                  ,status=wh_json:get_ne_value(<<"pvt_status">>, SavedJObj, <<"good_standing">>)
-                                 ,deleted=wh_json:is_true(<<"pvt_deleted">>, SavedJObj)
+                                 ,deleted=wh_doc:is_soft_deleted(SavedJObj)
                                  ,dirty='true'
                                 };
         {'error', 'not_found'} ->
@@ -279,7 +279,7 @@ save(#wh_services{jobj=JObj
                                  ,status=wh_json:get_ne_value(<<"pvt_status">>, NewJObj, <<"good_stainding">>)
                                  ,billing_id=BillingId
                                  ,current_billing_id=BillingId
-                                 ,deleted=wh_json:is_true(<<"pvt_deleted">>, NewJObj)
+                                 ,deleted=wh_doc:is_soft_deleted(NewJObj)
                                 };
         {'error', 'not_found'} ->
             lager:debug("service database does not exist, attempting to create"),


### PR DESCRIPTION
During "code roaming" I noticed a function `wh_doc:is_soft_deleted/1` I could have used on my very first PR to this project.

I found out it was only called once, while making code easier to read. (yes, by hiding stuff out…)
So I pulled this together quickly to see what you guys thought.

There are a couple cases left. I'm not patching those lines as I'm getting too tired and not sure I get the logic:
```erlang
applications/crossbar/src/crossbar_doc.erl:910:                   wh_json:is_false(<<"pvt_deleted">>, JObj, 'true')
applications/crossbar/src/crossbar_doc.erl:925:                   wh_json:is_false(<<"pvt_deleted">>, JObj, 'true')
```

Here is how I found what to patch:
```shell
git grep -n '<<"pvt_deleted">>'
```