### PR TITLE
KAZOO-3334 - [ERR] switch_core_file.c:149 Invalid file format [prompt]

### DIFF
--- a/core/whistle_media-1.0.0/src/wh_media_map.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_map.erl
@@ -362,7 +362,10 @@ get_map(?WH_MEDIA_DB = Db, PromptId) ->
             #media_map{id=MapId
                        ,account_id=Db
                        ,prompt_id=PromptId
-                       ,languages=wh_json:new()
+                       ,languages=wh_json:set_value(wh_media_util:default_prompt_language()
+                                                    ,<<"/", ?WH_MEDIA_DB/binary, "/", (wh_media_util:default_prompt_language())/binary, "%2F", PromptId/binary>>
+                                                    , wh_json:new()
+                                                   )
                       }
     end;
 get_map(AccountId, PromptId) ->


### PR DESCRIPTION
Looks like default prompts are acceptable only if they reside in cache.
This is what solved this problem to me.
Please take a look if it could be helpfull.
Sorry if it is just a problem of my local misconfuguration.

Regards,
Kirill 