### PR TITLE
Gateway dst/src port

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/resources.json
+++ b/applications/crossbar/priv/couchdb/schemas/resources.json
@@ -199,6 +199,13 @@
                         "minLength": 1,
                         "maxLength": 64
                     },
+                    "port": {
+                        "type": "integer",
+                        "required": false,
+                        "name": "Port",
+                        "description": "This resource gateway port",
+                        "default": 5060
+                    },
                     "realm": {
                         "type": "string",
                         "required": false,
@@ -389,6 +396,13 @@
                         "required": false,
                         "name": "Is Emergency?",
                         "description": "Determines if the resource gateway represents emergency services",
+                        "default": false
+                    },
+                    "force_port": {
+                        "type": "boolean"m
+                        "required": false,
+                        "name": "Force port",
+                        "description": "Receive only from this port",
                         "default": false
                     }
                 },

--- a/applications/crossbar/priv/couchdb/schemas/resources.json
+++ b/applications/crossbar/priv/couchdb/schemas/resources.json
@@ -399,10 +399,10 @@
                         "default": false
                     },
                     "force_port": {
-                        "type": "boolean"m
+                        "type": "boolean",
                         "required": false,
                         "name": "Force port",
-                        "description": "Receive only from this port",
+                        "description": "Allow request only from this port",
                         "default": false
                     }
                 },

--- a/applications/ecallmgr/src/ecallmgr_fs_authn.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_authn.erl
@@ -255,6 +255,7 @@ query_registrar(Realm, Username, Node, Id, Method, Props) ->
            ,{<<"To">>, ecallmgr_util:get_sip_to(Props)}
            ,{<<"From">>, ecallmgr_util:get_sip_from(Props)}
            ,{<<"Orig-IP">>, ecallmgr_util:get_orig_ip(Props)}
+           ,{<<"Orig-Port">>, ecallmgr_util:get_orig_port(Props)}
            ,{<<"Method">>, Method}
            ,{<<"Auth-User">>, Username}
            ,{<<"Auth-Realm">>, Realm}

--- a/applications/ecallmgr/src/ecallmgr_fs_route.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_route.erl
@@ -362,6 +362,9 @@ route_req(CallId, FetchId, Props, Node) ->
      ,{<<"From-Network-Addr">>, props:get_first_defined([<<"variable_sip_h_X-AUTH-IP">>
                                                          ,<<"variable_sip_received_ip">>
                                                         ], Props)}
+     ,{<<"From-Network-Port">>, props:get_first_defined([<<"variable_sip_h_X-AUTH-PORT">>
+                                                         ,<<"variable_sip_received_port">>
+                                                        ], Props)}
      ,{<<"User-Agent">>, props:get_first_defined([<<"variable_sip_user_agent">>
                                                   ,<<"sip_user_agent">>
                                                  ], Props)}

--- a/applications/ecallmgr/src/ecallmgr_registrar.erl
+++ b/applications/ecallmgr/src/ecallmgr_registrar.erl
@@ -897,6 +897,7 @@ query_authn(#registration{username=Username
                           ,from_user=FromUser
                           ,from_host=FromHost
                           ,network_ip=NetworkIP
+                          ,network_port=NetworkPort
                           ,registrar_node=Node
                           ,call_id=CallId
                          }=Reg) ->
@@ -904,6 +905,7 @@ query_authn(#registration{username=Username
     Req = [{<<"To">>, <<ToUser/binary, "@", ToHost/binary>>}
            ,{<<"From">>, <<FromUser/binary, "@", FromHost/binary>>}
            ,{<<"Orig-IP">>, NetworkIP}
+           ,{<<"Orig-Port">>, NetworkPort}
            ,{<<"Auth-User">>, Username}
            ,{<<"Auth-Realm">>, Realm}
            ,{<<"Media-Server">>, wh_util:to_binary(Node)}

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -17,7 +17,7 @@
 -export([export/3, bridge_export/3]).
 -export([get_expires/1]).
 -export([get_interface_properties/1, get_interface_properties/2]).
--export([get_sip_to/1, get_sip_from/1, get_sip_request/1, get_orig_ip/1]).
+-export([get_sip_to/1, get_sip_from/1, get_sip_request/1, get_orig_ip/1, get_orig_port/1]).
 -export([custom_channel_vars/1, custom_channel_vars/2]).
 -export([eventstr_to_proplist/1, varstr_to_proplist/1, get_setting/1, get_setting/2]).
 -export([is_node_up/1, is_node_up/2]).
@@ -210,6 +210,10 @@ get_sip_request(Props) ->
 -spec get_orig_ip(wh_proplist()) -> api_binary().
 get_orig_ip(Prop) ->
     props:get_first_defined([<<"X-AUTH-IP">>, <<"ip">>], Prop).
+
+-spec get_orig_port(wh_proplist()) -> api_binary().
+get_orig_port(Prop) ->
+    props:get_first_defined([<<"X-AUTH-PORT">>, <<"port">>], Prop).
 
 %% Extract custom channel variables to include in the event
 -spec custom_channel_vars(wh_proplist()) -> wh_proplist().

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -211,9 +211,12 @@ get_sip_request(Props) ->
 get_orig_ip(Prop) ->
     props:get_first_defined([<<"X-AUTH-IP">>, <<"ip">>], Prop).
 
--spec get_orig_port(wh_proplist()) -> api_binary().
+-spec get_orig_port(wh_proplist()) -> api_integer().
 get_orig_port(Prop) ->
-    props:get_first_defined([<<"X-AUTH-PORT">>, <<"port">>], Prop).
+    case props:get_first_defined([<<"X-AUTH-PORT">>, <<"port">>], Prop) of
+        'undefined' -> 'undefined';
+        Port -> wh_util:to_integer(Port)
+    end.
 
 %% Extract custom channel variables to include in the event
 -spec custom_channel_vars(wh_proplist()) -> wh_proplist().

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -211,11 +211,12 @@ get_sip_request(Props) ->
 get_orig_ip(Prop) ->
     props:get_first_defined([<<"X-AUTH-IP">>, <<"ip">>], Prop).
 
--spec get_orig_port(wh_proplist()) -> api_integer().
+-spec get_orig_port(wh_proplist()) -> api_binary().
 get_orig_port(Prop) ->
     case props:get_first_defined([<<"X-AUTH-PORT">>, <<"port">>], Prop) of
-        'undefined' -> 'undefined';
-        Port -> wh_util:to_integer(Port)
+        <<>> -> 'undefined';
+        <<"0">> -> 'undefined';
+        Port -> Port
     end.
 
 %% Extract custom channel variables to include in the event

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -207,13 +207,9 @@ reverse_lookup(JObj) ->
 
 -spec find_port(wh_json:object()) -> api_integer().
 find_port(JObj) ->
-    case wh_json:get_first_defined([<<"From-Network-Port">>
+    wh_json:get_first_defined([<<"From-Network-Port">>
                                     ,<<"Orig-Port">>
-                                   ], JObj)
-    of
-        'undefined' -> 'undefined';
-        Port -> wh_util:to_integer(Port)
-    end.
+                                   ], JObj).
 
 -spec find_account_id(api_binary(), wh_json:object()) -> api_binary().
 find_account_id(Realm, JObj) ->
@@ -233,20 +229,20 @@ find_account_id(Realm) ->
         {'ok', AccountId} -> AccountId
     end.
 
--spec maybe_find_global(api_binary(), api_integer(), api_binary()) ->
+-spec maybe_find_global(api_binary(), api_binary(), api_binary()) ->
                                {'ok', wh_proplist()} |
                                {'error', 'not_found'}.
 maybe_find_global(IP, Port, Realm) ->
     search_resources(IP, Port, Realm, get()).
 
--spec maybe_find_local(api_binary(), api_integer(), api_binary(), api_binary()) ->
+-spec maybe_find_local(api_binary(), api_binary(), api_binary(), api_binary()) ->
                               {'ok', wh_proplist()} |
                               {'error', 'not_found'}.
 maybe_find_local(_, _, _, 'undefined') -> {'error', 'not_found'};
 maybe_find_local(IP, Port, Realm, AccountId) ->
     search_resources(IP, Port, Realm, get(AccountId)).
 
--spec search_resources(api_binary(), api_integer(), api_binary(), resources()) ->
+-spec search_resources(api_binary(), api_binary(), api_binary(), resources()) ->
                               {'ok', wh_proplist()} |
                               {'error', 'not_found'}.
 search_resources(_IP, _Port, _Realm, []) ->
@@ -272,7 +268,7 @@ search_resources(IP, Port, Realm, [#resrc{id=Id
             {'ok', Props}
     end.
 
--spec search_gateways(api_binary(), api_integer(), api_binary(), gateways()) ->
+-spec search_gateways(api_binary(), api_binary(), api_binary(), gateways()) ->
                              gateway() |
                              {'error', 'not_found'}.
 search_gateways(_, _, _, []) -> {'error', 'not_found'};
@@ -282,7 +278,7 @@ search_gateways(IP, Port, Realm, [Gateway | Gateways]) ->
         #gateway{}=Gateway -> Gateway
     end.
 
--spec search_gateway(api_binary(), api_integer(), api_binary(), gateway()) ->
+-spec search_gateway(api_binary(), api_binary(), api_binary(), gateway()) ->
                             gateway() |
                             {'error', 'not_found'}.
 search_gateway(IP, Port, _, #gateway{server=IP, port=Port, force_port='true'}=Gateway) when IP =/= 'undefined' andalso Port =/= 'undefined' -> Gateway;
@@ -857,7 +853,7 @@ gateway_from_jobj(JObj, #resrc{is_emergency=IsEmergency
     EndpointType = wh_json:get_ne_value(<<"endpoint_type">>, JObj, <<"sip">>),
     #gateway{endpoint_type=EndpointType
              ,server=wh_json:get_value(<<"server">>, JObj)
-             ,port=wh_json:get_integer_value(<<"port">>, JObj)
+             ,port=wh_json:get_binary_value(<<"port">>, JObj)
              ,realm=wh_json:get_value(<<"realm">>, JObj)
              ,username=wh_json:get_value(<<"username">>, JObj)
              ,password=wh_json:get_value(<<"password">>, JObj)

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -21,6 +21,7 @@
 
 -record(gateway, {
            server :: api_binary()
+           ,port :: api_binary()
            ,realm :: api_binary()
            ,username :: api_binary()
            ,password :: api_binary()
@@ -40,6 +41,7 @@
            ,format_from_uri = 'false' :: boolean()
            ,from_uri_realm :: api_binary()
            ,is_emergency = 'false' :: boolean()
+           ,force_port = 'false' :: boolean()
          }).
 
 -record(resrc, {
@@ -195,11 +197,14 @@ reverse_lookup(JObj) ->
     IP = wh_json:get_first_defined([<<"From-Network-Addr">>
                                     ,<<"Orig-IP">>
                                    ], JObj),
-    case maybe_find_global(IP, Realm) of
+    Port = wh_json:get_first_defined([<<"From-Network-Port">>
+                                    ,<<"Orig-Port">>
+                                   ], JObj),
+    case maybe_find_global(IP, Port, Realm) of
         {'ok', _}=Ok -> Ok;
         {'error', 'not_found'} ->
             AccountId = find_account_id(Realm, JObj),
-            maybe_find_local(IP, Realm, AccountId)
+            maybe_find_local(IP, Port, Realm, AccountId)
     end.
 
 -spec find_account_id(api_binary(), wh_json:object()) -> api_binary().
@@ -220,33 +225,33 @@ find_account_id(Realm) ->
         {'ok', AccountId} -> AccountId
     end.
 
--spec maybe_find_global(api_binary(), api_binary()) ->
+-spec maybe_find_global(api_binary(), api_binary(), api_binary()) ->
                                {'ok', wh_proplist()} |
                                {'error', 'not_found'}.
-maybe_find_global(IP, Realm) ->
-    search_resources(IP, Realm, get()).
+maybe_find_global(IP, Port, Realm) ->
+    search_resources(IP, Port, Realm, get()).
 
--spec maybe_find_local(api_binary(), api_binary(), api_binary()) ->
+-spec maybe_find_local(api_binary(), api_binary(), api_binary(), api_binary()) ->
                               {'ok', wh_proplist()} |
                               {'error', 'not_found'}.
-maybe_find_local(_, _, 'undefined') -> {'error', 'not_found'};
-maybe_find_local(IP, Realm, AccountId) ->
-    search_resources(IP, Realm, get(AccountId)).
+maybe_find_local(_, _, _, 'undefined') -> {'error', 'not_found'};
+maybe_find_local(IP, Port, Realm, AccountId) ->
+    search_resources(IP, Port, Realm, get(AccountId)).
 
--spec search_resources(api_binary(), api_binary(), resources()) ->
+-spec search_resources(api_binary(), api_binary(), api_binary(), resources()) ->
                               {'ok', wh_proplist()} |
                               {'error', 'not_found'}.
-search_resources(_IP, _Realm, []) ->
-    lager:debug("failed to find matching resource for ~s(~s)", [_IP, _Realm]),
+search_resources(_IP, _Port, _Realm, []) ->
+    lager:debug("failed to find matching resource for ~s:~s(~s)", [_IP, _Port, _Realm]),
     {'error', 'not_found'};
-search_resources(IP, Realm, [#resrc{id=Id
+search_resources(IP, Port, Realm, [#resrc{id=Id
                                     ,gateways=Gateways
                                     ,global=Global
                                    }
                              | Resources
                             ]) ->
-    case search_gateways(IP, Realm, Gateways) of
-        {'error', 'not_found'} -> search_resources(IP, Realm, Resources);
+    case search_gateways(IP, Port, Realm, Gateways) of
+        {'error', 'not_found'} -> search_resources(IP, Port, Realm, Resources);
         #gateway{}=Gateway ->
             Props = props:filter_undefined(
                       [{'resource_id', Id}
@@ -259,24 +264,25 @@ search_resources(IP, Realm, [#resrc{id=Id
             {'ok', Props}
     end.
 
--spec search_gateways(api_binary(), api_binary(), gateways()) ->
+-spec search_gateways(api_binary(), api_binary(), api_binary(), gateways()) ->
                              gateway() |
                              {'error', 'not_found'}.
-search_gateways(_, _, []) -> {'error', 'not_found'};
-search_gateways(IP, Realm, [Gateway | Gateways]) ->
-    case search_gateway(IP, Realm, Gateway) of
-        {'error', 'not_found'} -> search_gateways(IP, Realm, Gateways);
+search_gateways(_, _, _, []) -> {'error', 'not_found'};
+search_gateways(IP, Port, Realm, [Gateway | Gateways]) ->
+    case search_gateway(IP, Port, Realm, Gateway) of
+        {'error', 'not_found'} -> search_gateways(IP, Port, Realm, Gateways);
         #gateway{}=Gateway -> Gateway
     end.
 
--spec search_gateway(api_binary(), api_binary(), gateway()) ->
+-spec search_gateway(api_binary(), api_binary(), api_binary(), gateway()) ->
                             gateway() |
                             {'error', 'not_found'}.
-search_gateway(IP, _, #gateway{realm=IP}=Gateway) when IP =/= 'undefined' -> Gateway;
-search_gateway(IP, _, #gateway{server=IP}=Gateway) when IP =/= 'undefined' -> Gateway;
-search_gateway(_, Realm, #gateway{realm=Realm}=Gateway) when Realm =/= 'undefined' -> Gateway;
-search_gateway(_, Realm, #gateway{server=Realm}=Gateway) when Realm =/= 'undefined' -> Gateway;
-search_gateway(_, _, _) -> {'error', 'not_found'}.
+search_gateway(IP, Port, _, #gateway{server=IP, port=Port, force_port='true'}=Gateway) when IP =/= 'undefined' andalso Port =/= 'undefined' -> Gateway;
+search_gateway(IP, _, _, #gateway{server=IP, force_port='false'}=Gateway) when IP =/= 'undefined' -> Gateway;
+search_gateway(IP, _, _, #gateway{realm=IP, force_port='false'}=Gateway) when IP =/= 'undefined' -> Gateway;
+search_gateway(_, _, Realm, #gateway{realm=Realm, force_port='false'}=Gateway) when Realm =/= 'undefined' -> Gateway;
+search_gateway(_, _, Realm, #gateway{server=Realm, force_port='false'}=Gateway) when Realm =/= 'undefined' -> Gateway;
+search_gateway(_, _, _, _) -> {'error', 'not_found'}.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -843,7 +849,8 @@ gateway_from_jobj(JObj, #resrc{is_emergency=IsEmergency
     EndpointType = wh_json:get_ne_value(<<"endpoint_type">>, JObj, <<"sip">>),
     #gateway{endpoint_type=EndpointType
              ,server=wh_json:get_value(<<"server">>, JObj)
-             ,realm=wh_json:get_ne_value(<<"realm">>, JObj)
+             ,port=wh_json:get_value(<<"port">>, JObj)
+             ,realm=wh_json:get_value(<<"realm">>, JObj)
              ,username=wh_json:get_value(<<"username">>, JObj)
              ,password=wh_json:get_value(<<"password">>, JObj)
              ,sip_headers=wh_json:get_ne_value(<<"custom_sip_headers">>, JObj)
@@ -855,6 +862,7 @@ gateway_from_jobj(JObj, #resrc{is_emergency=IsEmergency
              ,fax_option=wh_json:is_true([<<"media">>, <<"fax_option">>], JObj, T38)
              ,codecs=wh_json:get_value(<<"codecs">>, JObj, Codecs)
              ,bypass_media=wh_json:is_true(<<"bypass_media">>, JObj, BypassMedia)
+             ,force_port=wh_json:get_value(<<"force_port">>, JObj, false)
              ,route=gateway_route(JObj)
              ,prefix=gateway_prefix(JObj)
              ,suffix=gateway_suffix(JObj)
@@ -932,13 +940,19 @@ gateway_dialstring(#gateway{route='undefined'
                             ,prefix=Prefix
                             ,suffix=Suffix
                             ,server=Server
+                            ,port=Port
                            }, Number) ->
+    DialStringPort = case wh_util:is_not_empty(Port) andalso Port =/= <<"5060">> of
+        'true' -> <<":", Port/binary>>;
+        'false' -> <<>>
+    end,
     Route = list_to_binary(["sip:"
                             ,wh_util:to_binary(Prefix)
                             ,Number
                             ,wh_util:to_binary(Suffix)
                             ,"@"
                             ,wh_util:to_binary(Server)
+                            ,DialStringPort
                            ]),
     lager:debug("created gateway route ~s", [Route]),
     Route;

--- a/core/whistle-1.0.0/src/api/wapi_authn.erl
+++ b/core/whistle-1.0.0/src/api/wapi_authn.erl
@@ -34,7 +34,7 @@
                             ,<<"Auth-User">>, <<"Auth-Realm">>
                            ]).
 -define(OPTIONAL_AUTHN_REQ_HEADERS, [<<"Method">>, <<"Switch-Hostname">>
-                                     ,<<"Orig-IP">>, <<"Call-ID">>
+                                     ,<<"Orig-IP">>, <<"Orig-Port">>, <<"Call-ID">>
                                      ,<<"Auth-Nonce">>, <<"Auth-Response">>
                                      ,<<"User-Agent">>, <<"Expires">>
                                      ,<<"Custom-SIP-Headers">>
@@ -45,6 +45,7 @@
 -define(AUTHN_REQ_TYPES, [{<<"To">>, fun is_binary/1}
                           ,{<<"From">>, fun is_binary/1}
                           ,{<<"Orig-IP">>, fun is_binary/1}
+                          ,{<<"Orig-Port">>, fun is_binary/1}
                           ,{<<"Auth-User">>, fun is_binary/1}
                           ,{<<"Auth-Realm">>, fun is_binary/1}
                           ,{<<"Custom-SIP-Headers">>, fun wh_json:is_json_object/1}

--- a/core/whistle-1.0.0/src/api/wapi_route.erl
+++ b/core/whistle-1.0.0/src/api/wapi_route.erl
@@ -36,12 +36,13 @@
 -define(ROUTE_REQ_HEADERS, [<<"To">>, <<"From">>, <<"Request">>, <<"Call-ID">>
                             ,<<"Caller-ID-Name">>, <<"Caller-ID-Number">>
                            ]).
--define(OPTIONAL_ROUTE_REQ_HEADERS, [<<"Geo-Location">>, <<"Orig-IP">>
+-define(OPTIONAL_ROUTE_REQ_HEADERS, [<<"Geo-Location">>, <<"Orig-IP">>, <<"Orig-Port">>
                                      ,<<"Max-Call-Length">>, <<"Media">>
                                      ,<<"Transcode">>, <<"Codecs">>
                                      ,<<"Custom-Channel-Vars">>, <<"Custom-SIP-Headers">>
                                      ,<<"Resource-Type">>, <<"Cost-Parameters">>
-                                     ,<<"From-Network-Addr">>, <<"User-Agent">>
+                                     ,<<"From-Network-Addr">>, <<"From-Network-Port">>
+                                     ,<<"User-Agent">>
                                      ,<<"Switch-Hostname">>, <<"Switch-Nodename">>
                                      ,<<"Switch-URL">>, <<"Switch-URI">>
                                      ,<<"Ringback-Media">>, <<"Transfer-Media">>

--- a/core/whistle-1.0.0/src/api/wapi_sms.erl
+++ b/core/whistle-1.0.0/src/api/wapi_sms.erl
@@ -81,7 +81,7 @@
 %% Delivery
 -define(DELIVERY_REQ_EVENT_NAME, <<"delivery">>).
 -define(DELIVERY_HEADERS, [<<"Call-ID">>, <<"Message-ID">>]).
--define(OPTIONAL_DELIVERY_HEADERS, [<<"Geo-Location">>, <<"Orig-IP">>
+-define(OPTIONAL_DELIVERY_HEADERS, [<<"Geo-Location">>, <<"Orig-IP">>, <<"Orig-Port">>
                                     ,<<"Custom-Channel-Vars">>, <<"Custom-SIP-Headers">>
                                     ,<<"From-Network-Addr">>
                                     ,<<"Switch-Hostname">>, <<"Switch-Nodename">>
@@ -121,7 +121,7 @@
 %% Inbound
 -define(INBOUND_REQ_EVENT_NAME, <<"inbound">>).
 -define(INBOUND_HEADERS, [<<"Message-ID">>]).
--define(OPTIONAL_INBOUND_HEADERS, [<<"Geo-Location">>, <<"Orig-IP">>
+-define(OPTIONAL_INBOUND_HEADERS, [<<"Geo-Location">>, <<"Orig-IP">>, <<"Orig-Port">>
                                    ,<<"Custom-Channel-Vars">>, <<"Custom-SIP-Headers">>
                                    ,<<"From-Network-Addr">>
                                    ,<<"Switch-Hostname">>, <<"Switch-Nodename">>
@@ -159,7 +159,7 @@
 %% Outbound
 -define(OUTBOUND_REQ_EVENT_NAME, <<"outbound">>).
 -define(OUTBOUND_HEADERS, [<<"Message-ID">>]).
--define(OPTIONAL_OUTBOUND_HEADERS, [<<"Geo-Location">>, <<"Orig-IP">>
+-define(OPTIONAL_OUTBOUND_HEADERS, [<<"Geo-Location">>, <<"Orig-IP">>, <<"Orig-Port">>
                                     ,<<"Custom-Channel-Vars">>, <<"Custom-SIP-Headers">>
                                     ,<<"From-Network-Addr">>
                                     ,<<"Switch-Hostname">>, <<"Switch-Nodename">>


### PR DESCRIPTION
Added fields "port" and "force_port" in the documents of resources.
At outgoing call field "port" is added to the SIP URI.
At incoming call (if "force_port" = true), the source port is compared with the field of "port".
This allows at one IP-address have multiple gateways separated on different ports.

To work correctly, also requires changes in the configuration file kamailio.
File "default.cfg":
```
route[EXTERNAL_TO_INTERNAL_RELAY]
...
    remove_hf_re("^X-.*");
    append_hf("X-AUTH-IP: $si\r\n");
    append_hf("X-AUTH-PORT: $sp\r\n"); <--- add this!!!

```