### PR TITLE
KAZOO-3382: trunkstore: skip route requests for bridged calls

### DIFF
--- a/applications/trunkstore/src/ts_callflow.erl
+++ b/applications/trunkstore/src/ts_callflow.erl
@@ -40,11 +40,18 @@
 
 -type ts_state() :: #ts_callflow_state{}.
 
+-spec is_bridged(wh_json:object()) -> boolean().
+is_bridged(JObj) ->
+    case wh_json:get_value([<<"Custom-Channel-Vars">>, <<"Bridge-ID">>], JObj) of
+        'undefined' -> 'false';
+        _BridgeId -> 'true'
+    end.
+
 -spec init(wh_json:object()) -> ts_state() | {'error', 'not_ts_account'}.
 init(RouteReqJObj) ->
     CallID = wh_json:get_value(<<"Call-ID">>, RouteReqJObj),
     put('callid', CallID),
-    case is_trunkstore_acct(RouteReqJObj) of
+    case is_trunkstore_acct(RouteReqJObj) andalso not is_bridged(RouteReqJObj) of
         'false' ->
             lager:info("request is not for a trunkstore account"),
             {'error', 'not_ts_account'};

--- a/applications/trunkstore/src/ts_callflow.erl
+++ b/applications/trunkstore/src/ts_callflow.erl
@@ -5,6 +5,8 @@
 %%% @end
 %%% @contributors
 %%%   James Aimonetti
+%%%
+%%% Fix KAZOO-3382 sponsored by Conversant, Ltd. Implemented by SIPLABS, LLC.
 %%%-------------------------------------------------------------------
 -module(ts_callflow).
 

--- a/applications/trunkstore/src/ts_callflow.erl
+++ b/applications/trunkstore/src/ts_callflow.erl
@@ -42,10 +42,7 @@
 
 -spec is_bridged(wh_json:object()) -> boolean().
 is_bridged(JObj) ->
-    case wh_json:get_value([<<"Custom-Channel-Vars">>, <<"Bridge-ID">>], JObj) of
-        'undefined' -> 'false';
-        _BridgeId -> 'true'
-    end.
+    wh_json:get_value([<<"Custom-Channel-Vars">>, <<"Bridge-ID">>], JObj) =/= 'undefined'.
 
 -spec init(wh_json:object()) -> ts_state() | {'error', 'not_ts_account'}.
 init(RouteReqJObj) ->


### PR DESCRIPTION
Trunksore sometimes steal call processing from callflow. Example: REFER-ed calls.