### PR TITLE
KAZOO-3377

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -525,9 +525,7 @@ send_default_response(Cause, Call) ->
     case cf_exe:wildcard_is_empty(Call) of
         'false' -> 'ok';
         'true' ->
-            CallId = cf_exe:callid(Call),
-            CtrlQ = cf_exe:control_queue(Call),
-            case wh_call_response:send_default(CallId, CtrlQ, Cause) of
+            case wh_call_response:send_default(Call, Cause) of
                 {'error', 'no_response'} -> 'ok';
                 {'ok', NoopId} ->
                     _ = whapps_call_command:wait_for_noop(Call, NoopId),

--- a/core/whistle-1.0.0/src/wh_call_response.erl
+++ b/core/whistle-1.0.0/src/wh_call_response.erl
@@ -12,11 +12,16 @@
 -export([send_default/2]).
 -export([get_response/2]).
 -export([default_response/2]).
+-export([config_doc_id/0]).
 
 -include_lib("whistle/include/wh_types.hrl").
 -include_lib("whistle/include/wh_log.hrl").
 
 -define(CALL_RESPONSE_CONF, <<"call_response">>).
+
+-spec config_doc_id() -> ne_binary().
+config_doc_id() ->
+    ?CALL_RESPONSE_CONF.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/whistle-1.0.0/src/wh_call_response.erl
+++ b/core/whistle-1.0.0/src/wh_call_response.erl
@@ -9,9 +9,9 @@
 -module(wh_call_response).
 
 -export([send/3, send/4, send/5]).
--export([send_default/3]).
--export([get_response/1]).
--export([default_response/1]).
+-export([send_default/2]).
+-export([get_response/2]).
+-export([default_response/2]).
 
 -include_lib("whistle/include/wh_types.hrl").
 -include_lib("whistle/include/wh_log.hrl").
@@ -28,7 +28,7 @@
 -spec send(ne_binary(), ne_binary(), api_binary()) ->
                         {'ok', ne_binary()} |
                         {'error', 'no_response'}.
--spec send(ne_binary(), ne_binary(), api_binary(), 'undefined' | binary()) ->
+-spec send(ne_binary() | whapps_call:call(), ne_binary(), api_binary(), 'undefined' | binary()) ->
                         {'ok', ne_binary()} |
                         {'error', 'no_response'}.
 -spec send(ne_binary(), ne_binary(), api_binary(), 'undefined' | binary(), 'undefined' | binary()) ->
@@ -38,8 +38,14 @@
 send(CallId, CtrlQ, Code) ->
     send(CallId, CtrlQ, Code, 'undefined').
 
-send(CallId, CtrlQ, Code, Cause) ->
-    send(CallId, CtrlQ, Code, Cause, 'undefined').
+send(CallId, CtrlQ, Code, Cause)
+  when is_binary(CallId) ->
+    send(CallId, CtrlQ, Code, Cause, 'undefined');
+
+send(Call, Code, Cause, Media) ->
+    CallId = whapps_call:call_id(Call),
+    CtrlQ  = whapps_call:control_queue(Call),
+    send(CallId, CtrlQ, Code, Cause, Media).
 
 send(_, _, 'undefined', 'undefined', 'undefined') ->
     {'error', 'no_response'};
@@ -116,18 +122,19 @@ do_send(CallId, CtrlQ, Commands) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec send_default(ne_binary(), ne_binary(), api_binary()) ->
+-spec send_default(whapps_call:call(), api_binary()) ->
                           {'ok', ne_binary()} |
                           {'error', 'no_response'}.
-send_default(_, _, 'undefined') ->
+send_default(_Call, 'undefined') ->
     {'error', 'no_response'};
-send_default(CallId, CtrlQ, Cause) ->
+send_default(Call, Cause) ->
     lager:debug("attempting to send default response for ~s", [Cause]),
-    Response = get_response(Cause),
-    send(CallId, CtrlQ
-         ,wh_json:get_value(<<"Code">>, Response)
-         ,wh_json:get_value(<<"Message">>, Response)
-         ,wh_json:get_value(<<"Media">>, Response)).
+    Response = get_response(Cause, Call),
+    send(whapps_call:call_id(Call)
+        ,whapps_call:control_queue(Call)
+        ,wh_json:get_value(<<"Code">>, Response)
+        ,wh_json:get_value(<<"Message">>, Response)
+        ,wh_json:get_value(<<"Media">>, Response)).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -135,9 +142,9 @@ send_default(CallId, CtrlQ, Cause) ->
 %% returns the configured response proplist
 %% @end
 %%--------------------------------------------------------------------
--spec get_response(ne_binary()) -> wh_proplist() | 'undefined'.
-get_response(Cause) ->
-    case default_response(Cause) of
+-spec get_response(ne_binary(), whapps_call:call()) -> wh_proplist() | 'undefined'.
+get_response(Cause, Call) ->
+    case default_response(Call, Cause) of
         'undefined' -> whapps_config:get(?CALL_RESPONSE_CONF, Cause);
         Else -> whapps_config:get(?CALL_RESPONSE_CONF, Cause, wh_json:from_list(Else))
     end.
@@ -148,191 +155,191 @@ get_response(Cause) ->
 %% returns the default action given the error
 %% @end
 %%--------------------------------------------------------------------
--spec default_response(ne_binary()) -> 'undefined' | wh_proplist().
-default_response(<<"RESPONSE_TO_STATUS_ENQUIRY">>) -> 'undefined';
-default_response(<<"FACILITY_NOT_SUBSCRIBED">>) -> 'undefined';
-default_response(<<"INVALID_MSG_UNSPECIFIED">>) -> 'undefined';
+-spec default_response(whapps_call:call(), ne_binary()) -> 'undefined' | wh_proplist().
+default_response(_Call, <<"RESPONSE_TO_STATUS_ENQUIRY">>) -> 'undefined';
+default_response(_Call, <<"FACILITY_NOT_SUBSCRIBED">>) -> 'undefined';
+default_response(_Call, <<"INVALID_MSG_UNSPECIFIED">>) -> 'undefined';
 
-default_response(<<"INVALID_CALL_REFERENCE">>) -> 'undefined';
-default_response(<<"CALL_AWARDED_DELIVERED">>) -> 'undefined';
-default_response(<<"ACCESS_INFO_DISCARDED">>) -> 'undefined';
-default_response(<<"MESSAGE_TYPE_NONEXIST">>) -> 'undefined';
-default_response(<<"CHANNEL_UNACCEPTABLE">>) -> 'undefined';
-default_response(<<"CHAN_NOT_IMPLEMENTED">>) -> 'undefined';
+default_response(_Call, <<"INVALID_CALL_REFERENCE">>) -> 'undefined';
+default_response(_Call, <<"CALL_AWARDED_DELIVERED">>) -> 'undefined';
+default_response(_Call, <<"ACCESS_INFO_DISCARDED">>) -> 'undefined';
+default_response(_Call, <<"MESSAGE_TYPE_NONEXIST">>) -> 'undefined';
+default_response(_Call, <<"CHANNEL_UNACCEPTABLE">>) -> 'undefined';
+default_response(_Call, <<"CHAN_NOT_IMPLEMENTED">>) -> 'undefined';
 
-default_response(<<"INVALID_IE_CONTENTS">>) -> 'undefined';
-default_response(<<"USER_NOT_REGISTERED">>) -> 'undefined';
-default_response(<<"SERVICE_UNAVAILABLE">>) -> 'undefined';
+default_response(_Call, <<"INVALID_IE_CONTENTS">>) -> 'undefined';
+default_response(_Call, <<"USER_NOT_REGISTERED">>) -> 'undefined';
+default_response(_Call, <<"SERVICE_UNAVAILABLE">>) -> 'undefined';
 
-default_response(<<"ATTENDED_TRANSFER">>) -> 'undefined';
-default_response(<<"ALLOTTED_TIMEOUT">>) -> 'undefined';
-default_response(<<"WRONG_CALL_STATE">>) -> 'undefined';
-default_response(<<"MANAGER_REQUEST">>) -> 'undefined';
-default_response(<<"SYSTEM_SHUTDOWN">>) -> 'undefined';
+default_response(_Call, <<"ATTENDED_TRANSFER">>) -> 'undefined';
+default_response(_Call, <<"ALLOTTED_TIMEOUT">>) -> 'undefined';
+default_response(_Call, <<"WRONG_CALL_STATE">>) -> 'undefined';
+default_response(_Call, <<"MANAGER_REQUEST">>) -> 'undefined';
+default_response(_Call, <<"SYSTEM_SHUTDOWN">>) -> 'undefined';
 
-default_response(<<"PROTOCOL_ERROR">>) -> 'undefined';
-default_response(<<"USER_CHALLENGE">>) -> 'undefined';
-default_response(<<"BLIND_TRANSFER">>) -> 'undefined';
-default_response(<<"WRONG_MESSAGE">>) -> 'undefined';
-default_response(<<"INTERWORKING">>) -> 'undefined';
-default_response(<<"UNSPECIFIED">>) -> 'undefined';
-default_response(<<"IE_NONEXIST">>) -> 'undefined';
-default_response(<<"PICKED_OFF">>) -> 'undefined';
-default_response(<<"PRE_EMPTED">>) -> 'undefined';
-default_response(<<"LOSE_RACE">>) -> 'undefined';
-default_response(<<"CRASH">>) -> 'undefined';
+default_response(_Call, <<"PROTOCOL_ERROR">>) -> 'undefined';
+default_response(_Call, <<"USER_CHALLENGE">>) -> 'undefined';
+default_response(_Call, <<"BLIND_TRANSFER">>) -> 'undefined';
+default_response(_Call, <<"WRONG_MESSAGE">>) -> 'undefined';
+default_response(_Call, <<"INTERWORKING">>) -> 'undefined';
+default_response(_Call, <<"UNSPECIFIED">>) -> 'undefined';
+default_response(_Call, <<"IE_NONEXIST">>) -> 'undefined';
+default_response(_Call, <<"PICKED_OFF">>) -> 'undefined';
+default_response(_Call, <<"PRE_EMPTED">>) -> 'undefined';
+default_response(_Call, <<"LOSE_RACE">>) -> 'undefined';
+default_response(_Call, <<"CRASH">>) -> 'undefined';
 
-default_response(<<"UNALLOCATED_NUMBER">>) ->
+default_response(Call, <<"UNALLOCATED_NUMBER">>) ->
     [{<<"Code">>, <<"404">>}
      ,{<<"Message">>, <<"No route to destination">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_as_dialed">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_as_dialed">>,Call)}
     ];
-default_response(<<"NO_ROUTE_TRANSIT_NET">>) ->
+default_response(_Call, <<"NO_ROUTE_TRANSIT_NET">>) ->
     [{<<"Code">>, <<"404">>}
      ,{<<"Message">>, <<"Invalid number">>}
     ];
-default_response(<<"NO_ROUTE_DESTINATION">>) ->
+default_response(Call, <<"NO_ROUTE_DESTINATION">>) ->
     [{<<"Code">>, <<"404">>}
      ,{<<"Message">>, <<"No route to destination">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_as_dialed">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_as_dialed">>,Call)}
     ];
-default_response(<<"NORMAL_CLEARING">>) ->
+default_response(_Call, <<"NORMAL_CLEARING">>) ->
     [{<<"Media">>, <<"tone_stream://%(500,500,480,620);loops=25">>}];
-default_response(<<"USER_BUSY">>) ->
+default_response(_Call, <<"USER_BUSY">>) ->
     [{<<"Code">>, <<"486">>}
      ,{<<"Message">>, <<"Number busy">>}
      ,{<<"Media">>, <<"tone_stream://%(500,500,480,620);loops=25">>}
     ];
-default_response(<<"NO_USER_RESPONSE">>) ->
+default_response(_Call, <<"NO_USER_RESPONSE">>) ->
     [{<<"Code">>, <<"408">>}
      ,{<<"Message">>, <<"No response">>}
      ,{<<"Media">>, <<"tone_stream://%(250,250,480,620);loops=25">>}
     ];
-default_response(<<"NO_ANSWER">>) ->
+default_response(_Call, <<"NO_ANSWER">>) ->
     [{<<"Code">>, <<"480">>}
      ,{<<"Message">>, <<"No answer">>}
     ];
-default_response(<<"SUBSCRIBER_ABSENT">>) ->
+default_response(_Call, <<"SUBSCRIBER_ABSENT">>) ->
     [{<<"Code">>, <<"480">>}
      ,{<<"Message">>, <<"Subscriber absent">>}
     ];
-default_response(<<"CALL_REJECTED">>) ->
+default_response(_Call, <<"CALL_REJECTED">>) ->
     [{<<"Code">>, <<"603">>}
      ,{<<"Message">>, <<"Call Rejected">>}
      ,{<<"Media">>, <<"tone_stream://%(250,250,480,620);loops=25">>}
     ];
-default_response(<<"NUMBER_CHANGED">>) ->
+default_response(_Call, <<"NUMBER_CHANGED">>) ->
     [{<<"Code">>, <<"410">>}
      ,{<<"Message">>, <<"Number changed">>}
     ];
-default_response(<<"REDIRECTION_TO_NEW_DESTINATION">>) ->
+default_response(_Call, <<"REDIRECTION_TO_NEW_DESTINATION">>) ->
     [{<<"Code">>, <<"410">>}
      ,{<<"Message">>, <<"Redirection to new destination">>}
     ];
-default_response(<<"EXCHANGE_ROUTING_ERROR">>) ->
+default_response(Call, <<"EXCHANGE_ROUTING_ERROR">>) ->
     [{<<"Code">>, <<"483">>}
      ,{<<"Message">>, <<"Exchange routing error">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>,Call)}
     ];
-default_response(<<"DESTINATION_OUT_OF_ORDER">>) ->
+default_response(Call, <<"DESTINATION_OUT_OF_ORDER">>) ->
     [{<<"Code">>, <<"502">>}
      ,{<<"Message">>, <<"Destination out of order">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_as_dialed">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_as_dialed">>,Call)}
     ];
-default_response(<<"INVALID_NUMBER_FORMAT">>) ->
+default_response(Call, <<"INVALID_NUMBER_FORMAT">>) ->
     [{<<"Code">>, <<"484">>}
      ,{<<"Message">>, <<"Invalid number format">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_as_dialed">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_as_dialed">>,Call)}
     ];
-default_response(<<"FACILITY_REJECTED">>) ->
+default_response(_Call, <<"FACILITY_REJECTED">>) ->
     [{<<"Code">>, <<"510">>}
      ,{<<"Message">>, <<"Facility rejected">>}
     ];
-default_response(<<"NORMAL_UNSPECIFIED">>) ->
+default_response(_Call, <<"NORMAL_UNSPECIFIED">>) ->
     [{<<"Code">>, <<"480">>}
      ,{<<"Message">>, <<"Normal unspecified">>}
     ];
-default_response(<<"NORMAL_CIRCUIT_CONGESTION">>) ->
+default_response(_Call, <<"NORMAL_CIRCUIT_CONGESTION">>) ->
     [{<<"Code">>, <<"503">>}
      ,{<<"Message">>, <<"Normal circuit congestion">>}
     ];
-default_response(<<"NETWORK_OUT_OF_ORDER">>) ->
+default_response(_Call, <<"NETWORK_OUT_OF_ORDER">>) ->
     [{<<"Code">>, <<"503">>}
      ,{<<"Message">>, <<"Network out of order">>}
     ];
-default_response(<<"NORMAL_TEMPORARY_FAILURE">>) ->
+default_response(Call, <<"NORMAL_TEMPORARY_FAILURE">>) ->
     [{<<"Code">>, <<"503">>}
      ,{<<"Message">>, <<"Normal temporary failure">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_at_this_time">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_at_this_time">>,Call)}
     ];
-default_response(<<"SWITCH_CONGESTION">>) ->
+default_response(_Call, <<"SWITCH_CONGESTION">>) ->
     [{<<"Code">>, <<"503">>}
      ,{<<"Message">>, <<"Switch congestion">>}
     ];
-default_response(<<"REQUESTED_CHAN_UNAVAIL">>) ->
+default_response(_Call, <<"REQUESTED_CHAN_UNAVAIL">>) ->
     [{<<"Code">>, <<"503">>}
      ,{<<"Message">>, <<"Requested channel unavailable">>}
     ];
-default_response(<<"OUTGOING_CALL_BARRED">>) ->
+default_response(_Call, <<"OUTGOING_CALL_BARRED">>) ->
     [{<<"Code">>, <<"403">>}
      ,{<<"Message">>, <<"Outgoing call barred">>}
     ];
-default_response(<<"INCOMING_CALL_BARRED">>) ->
+default_response(_Call, <<"INCOMING_CALL_BARRED">>) ->
     [{<<"Code">>, <<"403">>}
      ,{<<"Message">>, <<"Incoming call barred">>}
     ];
-default_response(<<"BEARERCAPABILITY_NOTAUTH">>) ->
+default_response(_Call, <<"BEARERCAPABILITY_NOTAUTH">>) ->
     [{<<"Code">>, <<"403">>}
      ,{<<"Message">>, <<"Bearer capability not authorized">>}
     ];
-default_response(<<"BEARERCAPABILITY_NOTAVAIL">>) ->
+default_response(_Call, <<"BEARERCAPABILITY_NOTAVAIL">>) ->
     [{<<"Code">>, <<"403">>}
      ,{<<"Message">>, <<"Bearer capability not presently available">>}
     ];
-default_response(<<"BEARERCAPABILITY_NOTIMPL">>) ->
+default_response(_Call, <<"BEARERCAPABILITY_NOTIMPL">>) ->
     [{<<"Code">>, <<"488">>}
      ,{<<"Message">>, <<"Bearer capability not implemented">>}
     ];
-default_response(<<"FACILITY_NOT_IMPLEMENTED">>) ->
+default_response(_Call, <<"FACILITY_NOT_IMPLEMENTED">>) ->
     [{<<"Code">>, <<"501">>}
      ,{<<"Message">>, <<"Facility not implemented">>}
     ];
-default_response(<<"SERVICE_NOT_IMPLEMENTED">>) ->
+default_response(Call, <<"SERVICE_NOT_IMPLEMENTED">>) ->
     [{<<"Code">>, <<"501">>}
      ,{<<"Message">>, <<"Service not implemented">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>,Call)}
     ];
-default_response(<<"INCOMPATIBLE_DESTINATION">>) ->
+default_response(Call, <<"INCOMPATIBLE_DESTINATION">>) ->
     [{<<"Code">>, <<"488">>}
      ,{<<"Message">>, <<"Incompatible destination">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>,Call)}
     ];
-default_response(<<"MANDATORY_IE_MISSING">>) ->
+default_response(Call, <<"MANDATORY_IE_MISSING">>) ->
     [{<<"Code">>, <<"400">>}
      ,{<<"Message">>, <<"Mandatory informatin missing">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>,Call)}
     ];
-default_response(<<"RECOVERY_ON_TIMER_EXPIRE">>) ->
+default_response(_Call, <<"RECOVERY_ON_TIMER_EXPIRE">>) ->
     [{<<"Code">>, <<"504">>}
      ,{<<"Message">>, <<"Recovery on timer expire">>}
      ,{<<"Media">>, <<"tone_stream://%(250,250,480,620);loops=25">>}
     ];
-default_response(<<"MANDATORY_IE_LENGTH_ERROR">>) ->
+default_response(Call, <<"MANDATORY_IE_LENGTH_ERROR">>) ->
     [{<<"Code">>, <<"400">>}
      ,{<<"Message">>, <<"Mandatory informatin missing">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-facility_trouble">>,Call)}
     ];
-default_response(<<"ORIGINATOR_CANCEL">>) ->
+default_response(_Call, <<"ORIGINATOR_CANCEL">>) ->
     [{<<"Code">>, <<"487">>}
      ,{<<"Message">>, <<"Originator cancel">>}
     ];
-default_response(<<"MEDIA_TIMEOUT">>) ->
+default_response(_Call, <<"MEDIA_TIMEOUT">>) ->
     [{<<"Code">>, <<"504">>}
      ,{<<"Message">>, <<"Media timeout">>}
      ,{<<"Media">>, <<"tone_stream://%(250,250,480,620);loops=25">>}
     ];
-default_response(<<"PROGRESS_TIMEOUT">>) ->
+default_response(Call, <<"PROGRESS_TIMEOUT">>) ->
     [{<<"Code">>, <<"486">>}
      ,{<<"Message">>, <<"Progress timeout">>}
-     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_at_this_time">>)}
+     ,{<<"Media">>, wh_media_util:get_prompt(<<"fault-can_not_be_completed_at_this_time">>,Call)}
     ].

--- a/core/whistle_apps-1.0.0/src/whapps_call_command.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_call_command.erl
@@ -439,9 +439,7 @@ response(Code, Call) ->
 response(Code, Cause, Call) ->
     response(Code, Cause, 'undefined', Call).
 response(Code, Cause, Media, Call) ->
-    CallId = whapps_call:call_id(Call),
-    CtrlQ = whapps_call:control_queue(Call),
-    wh_call_response:send(CallId, CtrlQ, Code, Cause, Media).
+    wh_call_response:send(Call, Code, Cause, Media).
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/whistle_media-1.0.0/src/wh_media_util.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_util.erl
@@ -229,10 +229,8 @@ get_prompt(Name, 'undefined') ->
 get_prompt(Name, <<_/binary>> = Lang) ->
     get_prompt(Name, Lang, 'undefined');
 get_prompt(Name, Call) ->
-    get_prompt(Name
-               ,whapps_call:language(Call)
-               ,Call
-              ).
+    Lang = whapps_call:language(Call),
+    get_prompt(Name, Lang, Call).
 
 get_prompt(<<"/system_media/", Name/binary>>, Lang, Call) ->
     get_prompt(Name, Lang, Call);


### PR DESCRIPTION
After conversing with @jamesaimonetti I resolved to cleanup `system_media` lines that could be found on older systems [as per this code](https://github.com/2600hz/kazoo/commit/3ca29dbc7a2ac0f806de92949d33c87cf56dd3aa)

After conversing with @k-anderson I made it so `wh_call_response:send*` accepts a `whapps_call` while providing the old interface to `trunkstore` functions.