### PR TITLE
Shortcut code: app.json is already known to exist

### DIFF
--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -905,19 +905,9 @@ read_icon(Path, File) ->
 
 -spec find_metadata(ne_binary()) -> {'ok', wh_json:object()} | {'invalid_data', wh_proplist()}.
 find_metadata(AppPath) ->
-    {'ok', Dirs} = file:list_dir(AppPath),
-    case lists:member("app.json", Dirs) of
-        'true' -> read_metadata(AppPath);
-        'false' -> read_metadata(filename:join([AppPath, <<"metadata">>]))
-    end.
-
--spec read_metadata(ne_binary()) -> {'ok', wh_json:object()} | {'invalid_data', wh_proplist()}.
-read_metadata(MetadataPath) ->
-    {'ok', JSON} = file:read_file(filename:join([MetadataPath, <<"app.json">>])),
-    validate_metadata(wh_json:decode(JSON)).
-
--spec validate_metadata(wh_json:object()) -> {'ok', wh_json:object()} | {'invalid_data', wh_proplist()}.
-validate_metadata(JObj) ->
+    AppJSONPath = filename:join([AppPath, <<"metadata">>, <<"app.json">>]),
+    {'ok', JSON} = file:read_file(AppJSONPath),
+    JObj = wh_json:decode(JSON),
     {'ok', Schema} = wh_json_schema:load(<<"app">>),
     case jesse:validate_with_schema(Schema, wh_json:public_fields(JObj)) of
         {'ok', _}=OK -> OK;


### PR DESCRIPTION
Found this while looking for a reason for a bug I had (turned out I needed to refresh the schemas).
These changes follow those I made in https://github.com/2600hz/kazoo/pull/831