### PR TITLE
KAZOO-3386: push device to provisioner iff its MAC belongs to no one

### DIFF
--- a/applications/crossbar/src/modules/provisioner_util.erl
+++ b/applications/crossbar/src/modules/provisioner_util.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2012-2013, 2600Hz INC
+%%% @copyright (C) 2012-2015, 2600Hz INC
 %%% @doc
 %%%
 %%% Common functions for the provisioner modules

--- a/applications/crossbar/src/modules/provisioner_v5.erl
+++ b/applications/crossbar/src/modules/provisioner_v5.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2012-2014, 2600Hz INC
+%%% @copyright (C) 2012-2015, 2600Hz INC
 %%% @doc
 %%%
 %%% Common functions for the provisioner modules
@@ -127,11 +127,9 @@ check_MAC(MacAddress, AuthToken) ->
     HTTPOptions = [],
     UrlString = req_uri('devices', MacAddress),
     lager:debug("pre-provisioning via ~s", [UrlString]),
-    Resp = ibrowse:send_req(UrlString, Headers, 'get', [], HTTPOptions),
-    case Resp of
-        {'ok', "200", _RespHeaders, JSONStr} ->
-            JObj = wh_json:decode(JSONStr),
-            wh_json:get_value([<<"data">>, <<"account_id">>], JObj);
+    case ibrowse:send_req(UrlString, Headers, 'get', [], HTTPOptions) of
+        {'ok', "200", _RespHeaders, JSON} ->
+            wh_json:get_value([<<"data">>, <<"account_id">>], wh_json:decode(JSON));
         _AnythingElse -> 'false'
     end.
 
@@ -172,7 +170,7 @@ set_owner(JObj) ->
 %%--------------------------------------------------------------------
 -spec get_owner(api_binary(), ne_binary()) ->
                        {'ok', wh_json:object()} |
-                       {'error', any()}.
+                       {'error', _}.
 get_owner('undefined', _) -> {'error', 'undefined'};
 get_owner(OwnerId, AccountId) ->
     AccountDb = wh_util:format_account_id(AccountId, 'encoded'),
@@ -325,7 +323,6 @@ set_audio([], _, JObj) -> JObj;
 set_audio([Codec|Codecs], [Key|Keys], JObj) ->
     set_audio(Codecs, Keys, wh_json:set_value(Key, Codec, JObj)).
 
-
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
@@ -396,7 +393,7 @@ send_req('accounts_update', JObj, AuthToken, AccountId, _) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec handle_resp(any()) -> 'ok'.
+-spec handle_resp(ibrowse_ret()) -> 'ok'.
 handle_resp({'ok', "200", _, Resp}) ->
     lager:debug("provisioning success ~p", [Resp]);
 handle_resp({'ok', Code, _, Resp}) ->
@@ -413,10 +410,10 @@ handle_resp(_Error) ->
 -spec req_headers(ne_binary()) -> wh_proplist().
 req_headers(Token) ->
     props:filter_undefined(
-        [{"Content-Type", "application/json"}
-         ,{"X-Auth-Token", wh_util:to_list(Token)}
-         ,{"User-Agent", wh_util:to_list(erlang:node())}
-    ]).
+      [{"Content-Type", "application/json"}
+       ,{"X-Auth-Token", wh_util:to_list(Token)}
+       ,{"User-Agent", wh_util:to_list(erlang:node())}
+      ]).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/modules/provisioner_v5.erl
+++ b/applications/crossbar/src/modules/provisioner_v5.erl
@@ -15,6 +15,7 @@
 -export([delete/2]).
 -export([delete_account/2]).
 -export([update_account/3]).
+-export([check_MAC/2]).
 
 -include_lib("whistle/include/wh_types.hrl").
 -include_lib("whistle/include/wh_amqp.hrl").
@@ -112,6 +113,27 @@ update_account(AccountId, JObj, AuthToken) ->
              ,AccountId
              ,'none'
             ).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Use before a POST or PUT to a device.
+%% Return the account id a MAC address belongs to, `false' otherwise.
+%% @end
+%%--------------------------------------------------------------------
+-spec check_MAC(ne_binary(), ne_binary()) -> ne_binary() | 'false'.
+check_MAC(MacAddress, AuthToken) ->
+    Headers = req_headers(AuthToken),
+    HTTPOptions = [],
+    UrlString = req_uri('devices', MacAddress),
+    lager:debug("pre-provisioning via ~s", [UrlString]),
+    Resp = ibrowse:send_req(UrlString, Headers, 'get', [], HTTPOptions),
+    case Resp of
+        {'ok', "200", _RespHeaders, JSONStr} ->
+            JObj = wh_json:decode(JSONStr),
+            wh_json:get_value([<<"data">>, <<"account_id">>], JObj);
+        _AnythingElse -> 'false'
+    end.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -402,21 +424,27 @@ req_headers(Token) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec req_uri(atom()) -> iolist().
+-spec req_uri('files') -> iolist().
+-spec req_uri('accounts' | 'devices', ne_binary()) -> iolist().
+-spec req_uri('devices', ne_binary(), ne_binary()) -> iolist().
+
 req_uri('files') ->
-    Url = whapps_config:get_binary(?MOD_CONFIG_CAT, <<"provisioning_url">>),
-    Uri = wh_util:uri(Url, [<<"files/generate">>]),
-    binary:bin_to_list(Uri).
+    provisioning_uri([<<"files/generate">>]).
 
 req_uri('accounts', AccountId) ->
-    Url = whapps_config:get_binary(?MOD_CONFIG_CAT, <<"provisioning_url">>),
-    Uri = wh_util:uri(Url, [<<"accounts">>, AccountId]),
-    binary:bin_to_list(Uri).
+    provisioning_uri([<<"accounts">>, AccountId]);
+req_uri('devices', MacAddress) ->
+    provisioning_uri([<<"devices">>, MacAddress]).
 
 req_uri('devices', AccountId, MACAddress) ->
-    Url = whapps_config:get_binary(?MOD_CONFIG_CAT, <<"provisioning_url">>),
     EncodedAddress = binary:replace(MACAddress, <<":">>, <<>>, ['global']),
-    Uri = wh_util:uri(Url, [<<"devices">>, AccountId, EncodedAddress]),
+    provisioning_uri([<<"devices">>, AccountId, EncodedAddress]).
+
+%% @private
+-spec provisioning_uri(iolist()) -> iolist().
+provisioning_uri(ExplodedPath) ->
+    Url = whapps_config:get_binary(?MOD_CONFIG_CAT, <<"provisioning_url">>),
+    Uri = wh_util:uri(Url, ExplodedPath),
     binary:bin_to_list(Uri).
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules_v1/cb_devices_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_devices_v1.erl
@@ -268,25 +268,25 @@ changed_mac_address(Context) ->
     case NewAddress =:= OldAddress of
         'true' -> 'true';
         'false' ->
-            unique_mac_address(NewAddress, cb_context:account_db(Context))
+            unique_mac_address(NewAddress, Context)
     end.
 
 -spec check_mac_address(api_binary(), cb_context:context()) -> cb_context:context().
 check_mac_address(DeviceId, Context) ->
-    case unique_mac_address(cb_context:req_value(Context, <<"mac_address">>)
-                            ,cb_context:account_db(Context)
-                           )
-    of
+    MacAddress = cb_context:req_value(Context, <<"mac_address">>),
+    case unique_mac_address(MacAddress, Context) of
         'true' ->
             prepare_outbound_flags(DeviceId, Context);
         'false' ->
            error_used_mac_address(Context)
     end.
 
--spec unique_mac_address(api_binary(), ne_binary()) -> boolean().
-unique_mac_address('undefined', _) -> 'true';
-unique_mac_address(MacAddress, DbName) ->
-    not(lists:member(MacAddress, get_mac_addresses(DbName))).
+-spec unique_mac_address(api_binary(), cb_context:context()) -> boolean().
+unique_mac_address('undefined', _Context) -> 'true';
+unique_mac_address(MacAddress, Context) ->
+    DbName = cb_context:account_db(Context),
+    not lists:member(MacAddress, get_mac_addresses(DbName))
+        andalso not cb_provisioner_util:is_mac_address_in_use(Context, MacAddress).
 
 -spec error_used_mac_address(cb_context:context()) -> cb_context:context().
 error_used_mac_address(Context) ->

--- a/applications/crossbar/src/modules_v2/cb_devices_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_devices_v2.erl
@@ -294,14 +294,13 @@ changed_mac_address(Context) ->
     case NewAddress =:= OldAddress of
         'true' -> 'true';
         'false' ->
-            unique_mac_address(NewAddress, cb_context:account_db(Context))
+            unique_mac_address(NewAddress, Context)
     end.
 
 -spec check_mac_address(api_binary(), cb_context:context()) -> cb_context:context().
 check_mac_address(DeviceId, Context) ->
-    case unique_mac_address(cb_context:req_value(Context, <<"mac_address">>)
-                            ,cb_context:account_db(Context)
-                           )
+    MacAddress = cb_context:req_value(Context, <<"mac_address">>),
+    case unique_mac_address(MacAddress, Context)
     of
         'true' ->
             prepare_outbound_flags(DeviceId, Context);
@@ -309,10 +308,12 @@ check_mac_address(DeviceId, Context) ->
             error_used_mac_address(Context)
     end.
 
--spec unique_mac_address(api_binary(), ne_binary()) -> boolean().
-unique_mac_address('undefined', _) -> 'true';
-unique_mac_address(MacAddress, DbName) ->
-    not(lists:member(MacAddress, get_mac_addresses(DbName))).
+-spec unique_mac_address(api_binary(), cb_context:context()) -> boolean().
+unique_mac_address('undefined', _Context) -> 'true';
+unique_mac_address(MacAddress, Context) ->
+    DbName = cb_context:account_db(Context),
+    not lists:member(MacAddress, get_mac_addresses(DbName))
+        andalso not cb_provisioner_util:is_mac_address_in_use(Context, MacAddress).
 
 -spec error_used_mac_address(cb_context:context()) -> cb_context:context().
 error_used_mac_address(Context) ->


### PR DESCRIPTION
* If needs be, do a REST request to see to whom a MAC address may belong to
* Check and context modification happens in `cb_devices*`
* REST request is implemented in provisioner_v5
* cb_provisioner_util handles API compatibility

Note: this is paired with https://github.com/2600hz/provisioner/commit/356bf0dc71b982b56404f640b40f91bf2669a21d