### PR TITLE
For request POST with verb=DELETE get real request method (POST) for setting content_types_accepted in #context.

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -309,7 +309,7 @@ valid_content_headers(Req, Context) ->
 -spec known_content_type(cowboy_req:req(), cb_context:context(), http_method()) ->
                                 {boolean(), cowboy_req:req(), cb_context:context()}.
 known_content_type(Req, Context) ->
-    known_content_type(Req, Context, cb_context:req_verb(Context)).
+    known_content_type(Req, Context, cb_context:method(Context)).
 
 known_content_type(Req, Context, ?HTTP_OPTIONS) ->
     {'true', Req, Context};

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -725,7 +725,7 @@ is_permitted_nouns(Req, Context0, _Nouns) ->
 -spec is_known_content_type(cowboy_req:req(), cb_context:context()) ->
                                    {boolean(), cowboy_req:req(), cb_context:context()}.
 is_known_content_type(Req, Context) ->
-    is_known_content_type(Req, Context, cb_context:req_verb(Context)).
+    is_known_content_type(Req, Context, cb_context:method(Context)).
 
 is_known_content_type(Req, Context, ?HTTP_OPTIONS) ->
     lager:debug("ignore content type for options"),


### PR DESCRIPTION
POST request with verb=DELETE stops after api_resources:content_types_accepted/2 since #context.content_types_accepted is empty.