### PR TITLE
Error is logged when no balance is found for an account.  Filed a suppor...

### DIFF
--- a/core/whistle_transactions-1.0.0/src/wht_util.erl
+++ b/core/whistle_transactions-1.0.0/src/wht_util.erl
@@ -156,7 +156,7 @@ get_balance_from_previous(Account, ViewOptions, Retry) when Retry >= 0 ->
     lager:warning("could not find current balance trying previous month: ~p", [VOptions]),
     get_balance(Account, VOptions);
 get_balance_from_previous(Account, ViewOptions, _) ->
-    lager:error("3 attempt to find balance in previous modb getting from account", []),
+    lager:warning("3 attempt to find balance in previous modb getting from account", []),
     get_balance_from_account(Account, ViewOptions).
 
 -spec maybe_rollup(ne_binary(), wh_proplist(), integer()) -> integer().


### PR DESCRIPTION
...t ticket and was told to ignore this error since a balance is not required for an account and seeing this log is ok.

If this is the case, then this log should be not logged at the error level.