### PR TITLE
J5 complex allotments

### DIFF
--- a/applications/jonny5/src/j5_allotments.erl
+++ b/applications/jonny5/src/j5_allotments.erl
@@ -126,9 +126,10 @@ reconcile_allotment(Seconds, Allotment, Request, Limits) ->
 %%--------------------------------------------------------------------
 -spec try_find_allotment(j5_request:request(), j5_limits:limits()) -> api_object().
 try_find_allotment(Request, Limits) ->
+    Direction = j5_request:call_direction(Request),
     case j5_request:classification(Request) of
         'undefined' -> 'undefined';
-        Classification -> try_find_allotment_classification(Classification, Limits)
+        Classification -> try_find_allotment_classification(<<Direction/binary, "_", Classification/binary>>, Limits)
     end.
 
 -spec try_find_allotment_classification(ne_binary(), j5_limits:limits()) -> api_object().

--- a/applications/jonny5/src/j5_allotments.erl
+++ b/applications/jonny5/src/j5_allotments.erl
@@ -62,7 +62,18 @@ maybe_reconcile_allotment(Request, Limits) ->
         'undefined' -> 'ok';
         Allotment ->
             BillingSeconds = j5_request:billing_seconds(Request),
-            reconcile_allotment(BillingSeconds, Allotment, Request, Limits)
+            AllotmentSeconds = get_allotment_seconds(BillingSeconds, Allotment),
+            reconcile_allotment(AllotmentSeconds, Allotment, Request, Limits)
+    end.
+
+-spec get_allotment_seconds(non_neg_integer(), wh_json:object()) -> non_neg_integer().
+get_allotment_seconds(BillingSeconds, Allotment) ->
+    NoConsumeTime = wh_json:get_integer_value(<<"no_consume_time">>, Allotment, 0),
+    Increment = wh_json:get_integer_value(<<"increment">>, Allotment, 1),
+    Minimum = wh_json:get_integer_value(<<"minimum">>, Allotment, 0),
+    case BillingSeconds > NoConsumeTime of
+        'true' -> ((BillingSeconds div Increment) * Increment) + Minimum;
+        'false' -> 0
     end.
 
 -spec reconcile_allotment(non_neg_integer(), wh_json:object(), j5_request:request(), j5_limits:limits()) ->


### PR DESCRIPTION
1) Consumed allotmens now have "increment", "minimum" and "no consume time" just like rates.
```json
      "outbound_rus_moscow": {
           "amount": 240,
           "cycle": "hourly",
           "increment": 60,
           "minimum": 60,
           "no_consume_time": 5
       }
```
Call consumed time rounded before store it to DB.
Call with duration 40 seconds will be count as 60 seconds.
70 seconds -> 120
5 seconds -> 0
6 seconds -> 60

2) Allotments consumption now separated by call direction.
If we have classifier with name "rus_moscow".
To set allotments for outbound calls we create rule with name "outbound_rus_moscow". For inbound calls - "inbound_rus_moscow".

3) When calculating already consumed allotments we can sum several classifiers.
Example:
```json
      "Class1": {
           "amount": 600,
           "group_consume": [
               "Class2"
           ]
       },
       "Class2": {
           "amount": 600,
           "group_consume": [
               "Class1"
           ]
       }
```
Here we have 2 classifiers which share same counter.
If Class1 already counsmed 400 seconds and Class2 consumed 150 seconds, next call with classifier Class2 (or Class1) will have 50 free seconds.

Little more complex example:
```json
      "Class1": {
           "amount": 600,
           "group_consume": [
               "Class2",
               "Class3"
           ]
       },
       "Class2": {
           "amount": 120,
           "group_consume": [
               "Class1"
           ]
       },
       "Class3": {
           "amount": 300,
           "group_consume": [
                "Class2"
           ]
       }
```
So if we already have counsumed calls:
Class1 - 300
Class2 - 60
Class3 - 180

As result next call wil have this free seconds:
Class1 - 60 (300 Class1 + 60 Class2 + 180 Class = 540, 600-540 = 60)
Class2 - 0 (60 Class2 + 300 Class1 = 360, 360 > 120)
Class3 - 60 (180 Class3 + 60 Class2 = 240, 300-240 = 60)
