### PR TITLE
Remove potential macro clash in media CONFIG_CAT

### DIFF
--- a/core/whistle_media-1.0.0/src/wh_media_recording.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_recording.erl
@@ -420,7 +420,7 @@ get_timelimit(TL) ->
     end.
 
 -spec get_format(api_binary()) -> ne_binary().
-get_format('undefined') -> whapps_config:get(?WHS_CONFIG_CAT, [<<"call_recording">>, <<"extension">>], <<"mp3">>);
+get_format('undefined') -> whapps_config:get(?WHM_CONFIG_CAT, [<<"call_recording">>, <<"extension">>], <<"mp3">>);
 get_format(<<"mp3">> = MP3) -> MP3;
 get_format(<<"wav">> = WAV) -> WAV;
 get_format(_) -> get_format('undefined').

--- a/core/whistle_media-1.0.0/src/wh_media_util.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_util.erl
@@ -116,7 +116,7 @@ recording_url(CallId, Data) ->
 
 -spec max_recording_time_limit() -> ?SECONDS_IN_HOUR.
 max_recording_time_limit() ->
-    whapps_config:get_integer(?WHS_CONFIG_CAT, <<"max_recording_time_limit">>, ?SECONDS_IN_HOUR).
+    whapps_config:get_integer(?WHM_CONFIG_CAT, <<"max_recording_time_limit">>, ?SECONDS_IN_HOUR).
 
 base_url(Host) ->
     Port = wh_couch_connections:get_port(),
@@ -389,7 +389,7 @@ default_prompt_language() ->
     default_prompt_language(<<"en-us">>).
 default_prompt_language(Default) ->
     wh_util:to_lower_binary(
-      whapps_config:get(?WHS_CONFIG_CAT, ?PROMPT_LANGUAGE_KEY, Default)
+      whapps_config:get(?WHM_CONFIG_CAT, ?PROMPT_LANGUAGE_KEY, Default)
      ).
 
 -spec prompt_language(api_binary()) -> ne_binary().
@@ -406,6 +406,6 @@ prompt_language(<<_/binary>> = AccountId, Default) ->
         'false' -> default_prompt_language();
         'true' ->
             wh_util:to_lower_binary(
-              whapps_account_config:get(AccountId, ?WHS_CONFIG_CAT, ?PROMPT_LANGUAGE_KEY, wh_util:to_lower_binary(Default))
+              whapps_account_config:get(AccountId, ?WHM_CONFIG_CAT, ?PROMPT_LANGUAGE_KEY, wh_util:to_lower_binary(Default))
              )
     end.

--- a/core/whistle_media-1.0.0/src/whistle_media.hrl
+++ b/core/whistle_media-1.0.0/src/whistle_media.hrl
@@ -5,7 +5,7 @@
 -include_lib("whistle/include/wh_databases.hrl").
 -include_lib("whistle/include/wh_log.hrl").
 
--define(WHS_CONFIG_CAT, <<"media">>).
+-define(WHM_CONFIG_CAT, <<"media">>).
 
 -define(APP_NAME, <<"media_srv">>).
 -define(APP_VERSION, <<"0.2.0">>).
@@ -20,7 +20,7 @@
 -define(MAX_RESERVED_PORTS, 10).
 -define(MAX_WAIT_FOR_LISTENERS, 600000). %% 600 secs = 10 minutes
 
--define(CONFIG_CAT, ?WHS_CONFIG_CAT).
+-define(CONFIG_CAT, ?WHM_CONFIG_CAT).
 
 -define(PROMPT_LANGUAGE_KEY, <<"default_language">>).
 

--- a/core/whistle_media-1.0.0/src/whistle_media_maintenance.erl
+++ b/core/whistle_media-1.0.0/src/whistle_media_maintenance.erl
@@ -19,11 +19,11 @@
 
 -spec migrate() -> 'no_return'.
 migrate() ->
-    io:format("migrating relevant settings from system_config/callflow to system_config/~s~n", [?WHS_CONFIG_CAT]),
+    io:format("migrating relevant settings from system_config/callflow to system_config/~s~n", [?WHM_CONFIG_CAT]),
 
     maybe_migrate_system_config(<<"callflow">>),
 
-    io:format("migrating relevant settings from system_config/media_mgr to system_config/~s~n", [?WHS_CONFIG_CAT]),
+    io:format("migrating relevant settings from system_config/media_mgr to system_config/~s~n", [?WHM_CONFIG_CAT]),
     maybe_migrate_system_config(<<"media_mgr">>),
 
     'no_return'.
@@ -39,7 +39,7 @@ set_account_language(Account, Language) ->
     OldLang = wh_media_util:prompt_language(AccountId),
 
     try whapps_account_config:set(AccountId
-                                  ,?WHS_CONFIG_CAT
+                                  ,?WHM_CONFIG_CAT
                                   ,?PROMPT_LANGUAGE_KEY
                                   ,wh_util:to_lower_binary(Language)
                                  )
@@ -224,9 +224,9 @@ migrate_system_config(ConfigJObj) ->
 
 -spec get_media_config_doc() -> {'ok', wh_json:object()}.
 get_media_config_doc() ->
-    case couch_mgr:open_doc(?WH_CONFIG_DB, ?WHS_CONFIG_CAT) of
+    case couch_mgr:open_doc(?WH_CONFIG_DB, ?WHM_CONFIG_CAT) of
         {'ok', _MediaJObj}=OK -> OK;
-        {'error', 'not_found'} -> {'ok', wh_json:from_list([{<<"_id">>, ?WHS_CONFIG_CAT}])}
+        {'error', 'not_found'} -> {'ok', wh_json:from_list([{<<"_id">>, ?WHM_CONFIG_CAT}])}
     end.
 
 -spec migrate_system_config_fold(ne_binary(), wh_json:json_term(), wh_json:object()) -> wh_json:object().


### PR DESCRIPTION
`WHS_CONFIG_CAT` was set both in `whistle_media.hrl` and `whistle_services.hrl`, to different values.
`WHM_CONFIG_CAT` was not taken.


```
# for x in $(git grep whistle_media.hrl | cut -d: -f 1); do grep whistle_services.hrl $x; done
# echo $?
1
```
(hence the *potential*)