### PR TITLE
KAZOO-3385: don't crash when missing url in misconfigured call record

### DIFF
--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -49,6 +49,10 @@ handle(Data, Call, <<"start">>) ->
             case wh_media_recording:should_store_recording(Url) of
                 {'true', 'other', Url} ->
                     record_call(Data, Call);
+                'false' ->
+                    lager:error("misconfigured call record (missing url)"),
+                    wh_notify:system_alert("misconfigured call record (missing url in ~p)", [Call]),
+                    start_wh_media_recording(Data, Call);
                 _ ->
                     start_wh_media_recording(Data, Call)
             end

--- a/applications/callflow/src/module/cf_record_caller.erl
+++ b/applications/callflow/src/module/cf_record_caller.erl
@@ -25,10 +25,6 @@
 %%--------------------------------------------------------------------
 -spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
-    maybe_start_recording(Data, Call).
-
--spec maybe_start_recording(wh_json:object(), whapps_call:call()) -> 'ok'.
-maybe_start_recording(Data, Call) ->
     Url = wh_json:get_value(<<"url">>, Data),
     case wh_media_recording:should_store_recording(Url) of
         'false' ->

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -1060,9 +1060,10 @@ usurp_other_publishers(#state{node=Node
                              [ecallmgr_util:send_cmd_ret(),...].
 store_recording(Props, CallId, Node) ->
     MediaName = props:get_value(?GET_CCV(<<"Media-Name">>), Props),
-    case props:get_value(?GET_CCV(<<"Media-Transfer-Destination">>), Props) of
-        'undefined' -> 'ok';
-        Destination ->
+    Destination = props:get_value(?GET_CCV(<<"Media-Transfer-Destination">>), Props),
+    case wh_util:is_empty(Destination) of
+        'true' -> 'ok';
+        'false' ->
             %% TODO: if you change this logic be sure it matches wh_media_util as well!
             Url = wh_util:strip_right_binary(Destination, $/),
             JObj = wh_json:from_list(


### PR DESCRIPTION
* Already handled in `ecallmgr_call_events`
    * commit 2466cef0ab4c655c0abdd8943a47fab52257a96d
* Now handle it prior in `cf_record_call`
    * Log it as an error
    * Let callflow execution continue
    * Send a system_alert