### PR TITLE
KAZOO-3426: fix Cowboy sending duplicate headers

### DIFF
--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -313,8 +313,8 @@ set_resp_header_fold({K, V}, Hs) -> lists:keystore(K, 1, Hs, {K, V}).
 add_resp_headers(#cb_context{resp_headers=RespHeaders}=Context, Headers) ->
     Context#cb_context{resp_headers=lists:foldl(fun add_resp_headers_fold/2, RespHeaders, Headers)}.
 add_resp_header(#cb_context{resp_headers=RespHeaders}=Context, K, V) ->
-    Context#cb_context{resp_headers=[{K, V} | RespHeaders]}.
-add_resp_headers_fold({K, V}, Hs) -> [{K, V} | Hs].
+    Context#cb_context{resp_headers=[{wh_util:to_lower_binary(K), V} | RespHeaders]}.
+add_resp_headers_fold({K, V}, Hs) -> [{wh_util:to_lower_binary(K), V} | Hs].
 
 set_validation_errors(#cb_context{}=Context, Errors) -> Context#cb_context{validation_errors=Errors}.
 


### PR DESCRIPTION
The fix actually relies on setting headers to lower case. But for future additions I'd say just lowercasing header names here is the best.