### PR TITLE
Kazoo 3396 - move number to deleted state

### DIFF
--- a/applications/callflow/src/cf_attributes.erl
+++ b/applications/callflow/src/cf_attributes.erl
@@ -265,7 +265,7 @@ maybe_get_assigned_number(_, Name, Call) ->
                        || Num <- wh_json:get_keys(PublicJObj)
                               ,Num =/= <<"id">>
                               ,(not wh_json:is_true([Num, <<"on_subaccount">>], JObj))
-                              ,(wh_json:get_value([Num, <<"state">>], JObj) =:= <<"in_service">>)
+                              ,(wh_json:get_value([Num, <<"state">>], JObj) =:= ?NUMBER_STATE_AVAILABLE)
                       ],
             maybe_get_assigned_numbers(Numbers, Name, Call)
     end.

--- a/applications/crossbar/doc/phone_numbers.md
+++ b/applications/crossbar/doc/phone_numbers.md
@@ -65,7 +65,6 @@ This API check if the numbers are still available for purchase.
 
 ## Fix Phone Numbers
 
-
 ### Request
 
 - Verb: `POST`
@@ -80,3 +79,8 @@ This API check if the numbers are still available for purchase.
     "status": "success"
 }
 ```
+
+## Activate a new phone number
+
+    curl -X PUT -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://server:8000/v2/accounts/{ACCOUNT_ID}/phone_numbers/{NUMBER}/activate -d '{}'

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -918,6 +918,8 @@ add_system_error(Error, Props, Context) when is_list(Props) ->
 add_system_error('bad_identifier'=Error, JObj, Context) ->
     J = wh_json:set_value(<<"message">>, <<"bad identifier">>, JObj),
     build_system_error(404, Error, J, Context);
+add_system_error('not_found', JObj, Context) ->
+    add_system_error('bad_identifier', JObj, Context);
 add_system_error('invalid_bulk_type'=Error, JObj, Context) ->
     %% TODO: JObj is expected to have a type key!!
     Type = wh_json:get_value(<<"type">>, JObj),

--- a/applications/crossbar/src/crossbar_freeswitch.erl
+++ b/applications/crossbar/src/crossbar_freeswitch.erl
@@ -327,7 +327,7 @@ maybe_export_numbers(Db, [Number|Numbers]) ->
     _ = case couch_mgr:open_doc(Db, Number) of
             {'ok', JObj} ->
                 maybe_export_number(Number
-                                    ,wh_json:get_value(<<"pvt_number_state">>, JObj)
+                                    ,wh_json:get_value(?PVT_NUMBER_STATE, JObj)
                                     ,wh_json:get_value(<<"pvt_assigned_to">>, JObj)
                                    );
             {'error', _R} ->
@@ -338,7 +338,7 @@ maybe_export_numbers(Db, [Number|Numbers]) ->
     maybe_export_numbers(Db, Numbers).
 
 -spec maybe_export_number(ne_binary(), api_binary(), api_binary()) -> 'ok'.
-maybe_export_number(Number, <<"in_service">>, AccountId) ->
+maybe_export_number(Number, ?NUMBER_STATE_IN_SERVICE, AccountId) ->
     AccountDb = wh_util:format_account_id(AccountId, 'encoded'),
     ViewOptions = [{'key', Number}
                    ,'include_docs'

--- a/applications/crossbar/src/modules/cb_api_auth.erl
+++ b/applications/crossbar/src/modules/cb_api_auth.erl
@@ -154,6 +154,8 @@ validate_by_api_key(Context, ApiKey, []) ->
                 ,[ApiKey]
                ),
     crossbar_util:response_bad_identifier(ApiKey, Context);
+validate_by_api_key(Context, ApiKey, [Doc]) ->
+    validate_by_api_key(Context, ApiKey, Doc);
 validate_by_api_key(Context, ApiKey, [Doc|_]) ->
     lager:debug("found multiple accounts with api key '~s', using '~s'"
                 ,[ApiKey, wh_json:get_value(<<"id">>, Doc)]
@@ -176,5 +178,6 @@ consume_tokens(Context) ->
     of
         'true' -> cb_context:set_resp_status(Context, 'success');
         'false' ->
+            lager:debug("client has no tokens left"),
             cb_context:add_system_error('too_many_requests', Context)
     end.

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -1224,7 +1224,7 @@ add_to_phone_numbers_doc(Context, JObj) ->
 -spec build_number_properties(ne_binary(), gregorian_seconds()) -> wh_json:object().
 build_number_properties(AccountId, Now) ->
     wh_json:from_list(
-      [{<<"state">>, <<"port_in">>}
+      [{<<"state">>, ?NUMBER_STATE_PORT_IN}
        ,{<<"features">>, []}
        ,{<<"assigned_to">>, AccountId}
        ,{<<"used_by">>, <<>>}

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -79,7 +79,6 @@ init() ->
     _ = crossbar_bindings:bind(<<"v2_resource.execute.post.phone_numbers">>, ?MODULE, 'post'),
     crossbar_bindings:bind(<<"v2_resource.execute.delete.phone_numbers">>, ?MODULE, 'delete').
 
-
 %%--------------------------------------------------------------------
 %% @public
 %% @doc

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -49,8 +49,10 @@
                      ,{<<"application">>, <<"base64">>}
                      ,{<<"application">>, <<"x-base64">>}
                     ]).
+
 -define(PHONE_NUMBERS_CONFIG_CAT, <<"crossbar.phone_numbers">>).
 -define(FIND_NUMBER_SCHEMA, "{\"$schema\": \"http://json-schema.org/draft-03/schema#\", \"id\": \"http://json-schema.org/draft-03/schema#\", \"properties\": {\"prefix\": {\"required\": \"true\", \"type\": \"string\", \"minLength\": 3, \"maxLength\": 10}, \"quantity\": {\"default\": 1, \"type\": \"integer\", \"minimum\": 1}}}").
+
 -define(DEFAULT_COUNTRY, <<"US">>).
 -define(FREE_URL, <<"phonebook_url">>).
 -define(PAYED_URL, <<"phonebook_url_premium">>).

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2011-2014, 2600Hz INC
+%%% @copyright (C) 2011-2015, 2600Hz INC
 %%% @doc
 %%%
 %%% Handle client requests for phone_number documents
@@ -35,6 +35,7 @@
 -define(PORT, <<"port">>).
 -define(ACTIVATE, <<"activate">>).
 -define(RESERVE, <<"reserve">>).
+
 -define(CLASSIFIERS, <<"classifiers">>).
 -define(IDENTIFY, <<"identify">>).
 -define(COLLECTION, <<"collection">>).

--- a/core/whistle_number_manager-1.0.0/doc/number_states.md
+++ b/core/whistle_number_manager-1.0.0/doc/number_states.md
@@ -7,7 +7,7 @@ Version: 3.20
 
 Numbers travel through a variety of states within Kazoo during their lifecycle.
 
-Let's first enumerate those states and then see how they fit together!
+Let's enumerate those states and then see how they fit together!
 
 ## Number States
 
@@ -30,3 +30,59 @@ When an account initiates a port request via the APIs, the number is created in 
 * Any account can create a `port_in` number if the number doesn't yet exist in the system
 * The public fields can be managed by the assigned account or its ancestors.
 * `port_in` numbers can only transition to `in_service` (on first call) or `deleted` (if the port is canceled).
+
+### Available
+
+A number that is routing to the cluster but not yet assigned to an account.
+
+* Any account can transition `available` numbers to `reserved` or `in_service` if the account is in good standing
+* `available` numbers do not participate in number hunts
+
+### Reserved
+
+A number assigned to an account but not yet in use (be it a by a callflow, trunkstore, etc).
+
+* `reserved` numbers do not participate in number hunts
+* If the number is coming from the `discovery` state, the carrier module associated (`wnm_local`, `wnm_bandwidth`, etc) will attempt to acquire the number.
+* `reserved` numbers can be put in service if requested by:
+    * The requesting account is the same as the number's assigned account
+    * The requesting account is an ancestor of the number's assigned account
+    * The requesting account is a descendent of the number's assigned account
+* Accounts can reserve a number if:
+    * The requesting account is an ancestor of the number's assigned account
+    * The requesting account is a descendent of the number's assigned account
+* When a number is `reserved`, the new assignment is added to the number's history of assignments
+* An account with the flag `pvt_wnm_allow_additions` set to true can create numbers into the `available` state. These numbers can then be `reserved` by the account or its sub-accounts.
+* E911 and other features follow the number into `reserved`
+* Public fields on the number can be managed by the assigned account or its ancestors
+
+### In Service
+
+A number assigned to an account and in use by an application such as callflows, trunkstore, etc.
+
+* `in_service` numbers participate in number hunts
+* Can transition to `reserved` by the assigned account or an ancestor
+* E911 and other features follow the number into `in_service`
+* Public fields on the number can be managed by the assigned account or its ancestors
+
+## Released
+
+A temporary state between `reserved` and `in_service` before placing the number back into the `available` pool (by default, see the `system_config/number_manager` doc for the `released_state` attribute to change which state the number transitions into).
+
+* `released` does not participate in number hunts
+* When a `reserved` or `in_service` number is released:
+    * If the reserve history is empty, the number will either be disconnected, or disconnected and marked for deletion (controllabe with the `should_permanently_delete` flag in `system_config/number_manager`).
+    * If the reserve history is not empty, the number is re-assigned to the previously assigned account
+* E911 and other features are turned off
+
+### Port Out
+
+An internal state for releasing numbers. Works similarly to `port_in` except that inbound requests do not move to `in_service`.
+
+### Disconnected
+
+An internal state marking the number as archivable.
+
+### Deleted
+
+An internal state marking the number as hard-deletable. A crawler will walk the number databases and remove these entries after an aging period.

--- a/core/whistle_number_manager-1.0.0/doc/number_states.md
+++ b/core/whistle_number_manager-1.0.0/doc/number_states.md
@@ -1,0 +1,32 @@
+/*
+Section: Whistle Number Manager
+Title: Number States
+Language: en-US
+Version: 3.20
+*/
+
+Numbers travel through a variety of states within Kazoo during their lifecycle.
+
+Let's first enumerate those states and then see how they fit together!
+
+## Number States
+
+### Discovery
+
+An internal number state used to temporarily hold numbers that are available for users to acquire from the system.
+
+* Populated by API requests to activate numbers for an account that don't yet exist in the system
+* Numbers in `discovery` do not participate in number hunting
+* No number can transition from another state to `discovery`
+* There are no public fields for `discovery` numbers
+
+### Port In
+
+When an account initiates a port request via the APIs, the number is created in the `port_in` state.
+
+* Numbers in `port_in` will automatically transition to `in_service` the first time a call is received from a carrier to that number (the number hunt process)
+* Only used for internal number hunting within an account; calls to the number from another account will be routed upstream
+* No number can transition from another state to `port_in`
+* Any account can create a `port_in` number if the number doesn't yet exist in the system
+* The public fields can be managed by the assigned account or its ancestors.
+* `port_in` numbers can only transition to `in_service` (on first call) or `deleted` (if the port is canceled).

--- a/core/whistle_number_manager-1.0.0/include/wh_number_manager.hrl
+++ b/core/whistle_number_manager-1.0.0/include/wh_number_manager.hrl
@@ -3,10 +3,33 @@
 -include_lib("whistle/include/wh_log.hrl").
 -include_lib("whistle/include/wh_types.hrl").
 
+-define(NUMBER_STATE_PORT_IN, <<"port_in">>).
+-define(NUMBER_STATE_PORT_OUT, <<"port_out">>).
+-define(NUMBER_STATE_DISCOVERY, <<"discovery">>).
+-define(NUMBER_STATE_IN_SERVICE, <<"in_service">>).
+-define(NUMBER_STATE_RELEASED, <<"released">>).
+-define(NUMBER_STATE_RESERVED, <<"reserved">>).
+-define(NUMBER_STATE_AVAILABLE, <<"available">>).
+-define(NUMBER_STATE_DISCONNECTED, <<"disconnected">>).
+-define(NUMBER_STATE_DELETED, <<"deleted">>).
+
+-define(PVT_NUMBER_STATE, <<"pvt_number_state">>).
+
+-define(WNM_NUMBER_STATUS, [?NUMBER_STATE_AVAILABLE
+                            ,?NUMBER_STATE_DELETED, ?NUMBER_STATE_DISCONNECTED, ?NUMBER_STATE_DISCOVERY
+                            ,?NUMBER_STATE_IN_SERVICE
+                            ,?NUMBER_STATE_PORT_IN, ?NUMBER_STATE_PORT_OUT
+                            ,?NUMBER_STATE_RELEASED, ?NUMBER_STATE_RESERVED
+                           ]).
+-define(WNM_AVALIABLE_STATES, [?NUMBER_STATE_DISCOVERY, ?NUMBER_STATE_AVAILABLE]).
+-define(WNM_UNAVAILABLE_STATES, [?NUMBER_STATE_RESERVED, ?NUMBER_STATE_IN_SERVICE
+                                 ,?NUMBER_STATE_PORT_IN, ?NUMBER_STATE_PORT_OUT
+                                ]).
+
 -record(number, {number :: api_binary()
                  ,number_db :: api_binary()
-                 ,state = <<"discovery">> :: ne_binary()
-                 ,current_state = <<"discovery">> :: ne_binary()
+                 ,state = ?NUMBER_STATE_DISCOVERY :: ne_binary()
+                 ,current_state = ?NUMBER_STATE_DISCOVERY :: ne_binary()
                  ,reserve_history = ordsets:new() :: ordsets:ordset(ne_binary())
                  ,assign_to :: api_binary()
                  ,assigned_to :: api_binary()
@@ -44,14 +67,6 @@
                            {'account_id', api_binary()} |
                            {'prepend', 'false' | api_binary()}.
 -type number_properties() :: [number_property(),...] | [].
-
--define(WNM_NUMBER_STATUS, [<<"discovery">>, <<"available">>, <<"reserved">>, <<"released">>
-                                ,<<"port_in">> ,<<"in_service">>, <<"disconnected">>, <<"port_out">>
-                           ]).
--define(WNM_AVALIABLE_STATES, [<<"discovery">>, <<"available">>]).
--define(WNM_UNAVAILABLE_STATES, [<<"reserved">>, <<"in_service">>
-                                     ,<<"port_in">>, <<"port_out">>
-                                ]).
 
 -define(WNM_DEAFULT_CARRIER_MODULES, [<<"wnm_local">>]).
 -define(WNM_DEAFULT_PROVIDER_MODULES, [<<"cnam_notifier">>, <<"port_notifier">>
@@ -97,6 +112,8 @@
 %%%                it will be moved to avaliable or cancled with the carrier.
 %%% disconnected - Number is being ported or cancelled
 %%% cancelled    - Number has been cancelled with the carrier and will be removed from the system
+%%% deleted      - Number has been permanently deleted (and will be removed from
+%%%                the system after the number has been aged properly
 
 -define(WH_NUMBER_MANAGER_HRL, 'true').
 -endif.

--- a/core/whistle_number_manager-1.0.0/src/carriers/wnm_bandwidth.erl
+++ b/core/whistle_number_manager-1.0.0/src/carriers/wnm_bandwidth.erl
@@ -117,10 +117,13 @@ is_number_billable(_Number) -> 'true'.
 -spec acquire_number/1 :: (wnm_number()) -> wnm_number().
 
 acquire_number(#number{dry_run='true'}=Number) -> Number;
-acquire_number(#number{auth_by=AuthBy, assigned_to=AssignedTo, module_data=Data}=N) ->
-    Debug = whapps_config:get_is_true(?WNM_BW_CONFIG_CAT, <<"sandbox_provisioning">>, true),
-    case whapps_config:get_is_true(?WNM_BW_CONFIG_CAT, <<"enable_provisioning">>, true) of
-        false when Debug ->
+acquire_number(#number{auth_by=AuthBy
+                       ,assigned_to=AssignedTo
+                       ,module_data=Data
+                      }=N) ->
+    Debug = whapps_config:get_is_true(?WNM_BW_CONFIG_CAT, <<"sandbox_provisioning">>, 'true'),
+    case whapps_config:get_is_true(?WNM_BW_CONFIG_CAT, <<"enable_provisioning">>, 'true') of
+        'false' when Debug ->
             lager:debug("allowing sandbox provisioning", []),
             N;
         'false' ->

--- a/core/whistle_number_manager-1.0.0/src/carriers/wnm_inum.erl
+++ b/core/whistle_number_manager-1.0.0/src/carriers/wnm_inum.erl
@@ -45,8 +45,8 @@ find_numbers(Number, Quantity, Opts) ->
     find_numbers(<<"+",Number/binary>>, Quantity,Opts).
 
 find_numbers_in_account(Number, Quantity,AccountId) ->
-    ViewOptions = [{'startkey', [AccountId, <<"available">>, Number]}
-                   ,{'endkey', [AccountId, <<"available">>, <<Number/binary, "\ufff0">>]}
+    ViewOptions = [{'startkey', [AccountId, ?NUMBER_STATE_AVAILABLE, Number]}
+                   ,{'endkey', [AccountId, ?NUMBER_STATE_AVAILABLE, <<Number/binary, "\ufff0">>]}
                    ,{'limit', Quantity}
                    ,'include_docs'
                   ],
@@ -91,7 +91,7 @@ acquire_number(#number{number=Number
                        ,state=State
                       }=N) ->
     lager:debug("inum acquiring number ~p",[Number]),
-    _ = update_doc(Number,[{<<"pvt_number_state">>, State}
+    _ = update_doc(Number,[{?PVT_NUMBER_STATE, State}
                            ,{<<"pvt_assigned_to">>,AssignTo}
                           ]),
     N.
@@ -106,11 +106,11 @@ acquire_number(#number{number=Number
 -spec disconnect_number(wnm_number()) -> wnm_number().
 disconnect_number(#number{number=Number}=N) ->
     lager:debug("inum disconnect number ~p",[Number]),
-    update_doc(Number, [{<<"pvt_number_state">>, <<"available">>}
+    update_doc(Number, [{?PVT_NUMBER_STATE, ?NUMBER_STATE_AVAILABLE}
                         ,{<<"pvt_assigned_to">>,<<>>}
                        ]),
 
-    N#number{state = <<"released">>
+    N#number{state = ?NUMBER_STATE_RELEASED
              ,reserve_history=ordsets:new()
              ,hard_delete='true'
             }.
@@ -124,7 +124,7 @@ gen_numbers(AccountId, Number, Quantity) when Quantity > 0
                                               andalso is_integer(Quantity) ->
     JObj = wh_json:from_list([{<<"_id">>,<<"+",(wh_util:to_binary(Number))/binary>>}
                               ,{<<"pvt_account_id">>, AccountId}
-                              ,{<<"pvt_number_state">>, <<"available">>}
+                              ,{?PVT_NUMBER_STATE, ?NUMBER_STATE_AVAILABLE}
                               ,{<<"pvt_type">>, <<"number">>}
                              ]),
     _R = save_doc(JObj),

--- a/core/whistle_number_manager-1.0.0/src/carriers/wnm_local.erl
+++ b/core/whistle_number_manager-1.0.0/src/carriers/wnm_local.erl
@@ -44,7 +44,7 @@ is_number_billable(_Number) -> 'false'.
 %% Acquire a given number from the carrier
 %% @end
 %%--------------------------------------------------------------------
--spec acquire_number/1 :: (wnm_number()) -> wnm_number().
+-spec acquire_number(wnm_number()) -> wnm_number().
 acquire_number(#number{dry_run='true'}=Number) -> Number;
 acquire_number(Number) -> Number.
 
@@ -57,7 +57,9 @@ acquire_number(Number) -> Number.
 
 -spec disconnect_number(wnm_number()) -> wnm_number().
 disconnect_number(Number) ->
-        Number#number{state = <<"released">>, hard_delete='true'}.
+        Number#number{state = ?NUMBER_STATE_RELEASED
+                      ,hard_delete='true'
+                     }.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/core/whistle_number_manager-1.0.0/src/providers/wnm_cnam_notifier.erl
+++ b/core/whistle_number_manager-1.0.0/src/providers/wnm_cnam_notifier.erl
@@ -24,11 +24,11 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec save(wnm_number()) -> wnm_number().
-save(#number{state = <<"reserved">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_RESERVED} = Number) ->
     update_cnam_features(Number);
-save(#number{state = <<"in_service">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_IN_SERVICE} = Number) ->
     update_cnam_features(Number);
-save(#number{state = <<"port_in">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_PORT_IN} = Number) ->
     update_cnam_features(Number);
 save(Number) -> Number.
 

--- a/core/whistle_number_manager-1.0.0/src/providers/wnm_dash_e911.erl
+++ b/core/whistle_number_manager-1.0.0/src/providers/wnm_dash_e911.erl
@@ -38,11 +38,11 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec save(wnm_number()) -> wnm_number().
-save(#number{state = <<"port_in">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_PORT_IN} = Number) ->
     maybe_update_dash_e911(Number);
-save(#number{state = <<"reserved">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_RESERVED} = Number) ->
     maybe_update_dash_e911(Number);
-save(#number{state = <<"in_service">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_IN_SERVICE} = Number) ->
     maybe_update_dash_e911(Number);
 save(Number) -> delete(Number).
 

--- a/core/whistle_number_manager-1.0.0/src/providers/wnm_failover.erl
+++ b/core/whistle_number_manager-1.0.0/src/providers/wnm_failover.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2012, VoIP INC
+%%% @copyright (C) 2012-2015, 2600Hz INC
 %%% @doc
 %%% Handle failover provisioning
 %%% @end
@@ -23,8 +23,8 @@
 %% add the failover route (for in service numbers only)
 %% @end
 %%--------------------------------------------------------------------
--spec save/1 :: (wnm_number()) -> wnm_number().
-save(#number{state = <<"in_service">>} = Number) ->
+-spec save(wnm_number()) -> wnm_number().
+save(#number{state = ?NUMBER_STATE_IN_SERVICE} = Number) ->
     maybe_update_failover(Number);
 save(Number) ->
     delete(Number).
@@ -36,20 +36,20 @@ save(Number) ->
 %% remove the failover route
 %% @end
 %%--------------------------------------------------------------------
--spec delete/1 :: (wnm_number()) -> wnm_number().
+-spec delete(wnm_number()) -> wnm_number().
 delete(#number{features=Features
                ,current_number_doc=CurrentDoc
                ,number_doc=Doc
               }=Number) ->
     case wh_json:get_ne_value(?FAILOVER_KEY, CurrentDoc) of
-        undefined -> Number;
+        'undefined' -> Number;
         _Else ->
             Number#number{features=sets:del_element(?FAILOVER_KEY, Features)
                           ,number_doc=wh_json:delete_key(?FAILOVER_KEY, Doc)
                          }
     end.
 
--spec maybe_update_failover/1 :: (wnm_number()) -> wnm_number().
+-spec maybe_update_failover(wnm_number()) -> wnm_number().
 maybe_update_failover(#number{current_number_doc=CurrentJObj
                               ,number_doc=JObj
                               ,features=Features
@@ -59,9 +59,9 @@ maybe_update_failover(#number{current_number_doc=CurrentJObj
     NotChanged = wnm_util:are_jobjs_identical(CurrentFailover, Failover),
 
     case wh_util:is_empty(Failover) of
-        true ->
+        'true' ->
             N#number{features=sets:del_element(?FAILOVER_KEY, Features)};
-        false when NotChanged  -> N#number{features=sets:add_element(?FAILOVER_KEY, Features)};
-        false ->
+        'false' when NotChanged  -> N#number{features=sets:add_element(?FAILOVER_KEY, Features)};
+        'false' ->
             wnm_number:activate_feature(?FAILOVER_KEY, N)
     end.

--- a/core/whistle_number_manager-1.0.0/src/providers/wnm_port_notifier.erl
+++ b/core/whistle_number_manager-1.0.0/src/providers/wnm_port_notifier.erl
@@ -25,14 +25,14 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec save(wnm_number()) -> wnm_number().
-save(#number{current_state = <<"port_in">>
-             ,state = <<"in_service">>
+save(#number{current_state = ?NUMBER_STATE_PORT_IN
+             ,state = ?NUMBER_STATE_IN_SERVICE
              ,number_doc=JObj
             }=Number) ->
     Port = wh_json:get_ne_value(<<"port">>, JObj, wh_json:new()),
     _ = publish_ported(Port, Number),
     Number;
-save(#number{state = <<"port_in">>}=Number) ->
+save(#number{state = ?NUMBER_STATE_PORT_IN}=Number) ->
     Routines = [fun maybe_port_feature/1
                 ,fun maybe_activate_feature/1
                ],

--- a/core/whistle_number_manager-1.0.0/src/providers/wnm_prepend.erl
+++ b/core/whistle_number_manager-1.0.0/src/providers/wnm_prepend.erl
@@ -24,7 +24,7 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec save(wnm_number()) -> wnm_number().
-save(#number{state = <<"in_service">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_IN_SERVICE} = Number) ->
     maybe_update_prepend(Number);
 save(Number) ->
     delete(Number).
@@ -71,8 +71,3 @@ maybe_update_prepend(#number{current_number_doc=CurrentJObj
                     wnm_number:activate_feature(?PREPEND_KEY, N)
             end
     end.
-
-
-
-
-

--- a/core/whistle_number_manager-1.0.0/src/providers/wnm_vitelity_cnam.erl
+++ b/core/whistle_number_manager-1.0.0/src/providers/wnm_vitelity_cnam.erl
@@ -25,11 +25,11 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec save(wnm_number()) -> wnm_number().
-save(#number{state = <<"reserved">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_RESERVED} = Number) ->
     update_cnam_features(Number);
-save(#number{state = <<"in_service">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_IN_SERVICE} = Number) ->
     update_cnam_features(Number);
-save(#number{state = <<"port_in">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_PORT_IN} = Number) ->
     update_cnam_features(Number);
 save(Number) -> Number.
 

--- a/core/whistle_number_manager-1.0.0/src/providers/wnm_vitelity_e911.erl
+++ b/core/whistle_number_manager-1.0.0/src/providers/wnm_vitelity_e911.erl
@@ -26,11 +26,11 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec save(wnm_number()) -> wnm_number().
-save(#number{state = <<"port_in">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_PORT_IN} = Number) ->
     maybe_update_e911(Number);
-save(#number{state = <<"reserved">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_RESERVED} = Number) ->
     maybe_update_e911(Number);
-save(#number{state = <<"in_service">>} = Number) ->
+save(#number{state = ?NUMBER_STATE_IN_SERVICE} = Number) ->
     maybe_update_e911(Number);
 save(Number) -> delete(Number).
 

--- a/core/whistle_number_manager-1.0.0/src/wh_number_fix.erl
+++ b/core/whistle_number_manager-1.0.0/src/wh_number_fix.erl
@@ -259,7 +259,7 @@ remove_number(AccountId, Number) ->
 -spec maybe_remove_non_porting(ne_binary(), ne_binary(), ne_binary(), wh_json:object()) -> 'stop' | 'ok'.
 maybe_remove_non_porting(AccountId, Number, AccountDb, JObj) ->
     case wh_json:get_value([Number, <<"state">>], JObj) of
-        <<"port_in">> ->
+        ?NUMBER_STATE_PORT_IN ->
             io:format("[~s] will not be removed as it is in 'port_in' state~n", [Number]);
         _Else ->
             remove_number(AccountId, Number, AccountDb, JObj)

--- a/core/whistle_number_manager-1.0.0/src/wh_number_manager.erl
+++ b/core/whistle_number_manager-1.0.0/src/wh_number_manager.erl
@@ -60,13 +60,15 @@ find(Number, Quantity, Opts) ->
     AccountId = props:get_value(<<"Account-ID">>, Opts),
     Num = wnm_util:normalize_number(Number),
     lager:info("attempting to find ~p numbers with prefix '~s' for account ~p"
-              ,[Quantity, Number, AccountId]),
+               ,[Quantity, Number, AccountId]
+              ),
+
     Results = [{Module, catch(Module:find_numbers(Num, Quantity, Opts))}
                || Module <- wnm_util:list_carrier_modules()
               ],
     NewOpts = [{<<"classification">>, wnm_util:classify_number(Num)}
-              ,{<<"account-id">>, AccountId}
-              ,{<<"services">>, maybe_get_services(AccountId)}
+               ,{<<"account-id">>, AccountId}
+               ,{<<"services">>, maybe_get_services(AccountId)}
                | Opts
               ],
     prepare_find_results(Results, [], NewOpts).

--- a/core/whistle_number_manager-1.0.0/src/wnm.hrl
+++ b/core/whistle_number_manager-1.0.0/src/wnm.hrl
@@ -7,13 +7,5 @@
 -define(APP_VERSION, <<"1.0.0">>).
 -define(APP_NAME, <<"whistle_number_manager">>).
 
--define(NUMBER_STATE_PORT_IN, <<"port_in">>).
--define(NUMBER_STATE_PORT_OUT, <<"port_out">>).
--define(NUMBER_STATE_DISCOVERY, <<"discovery">>).
--define(NUMBER_STATE_IN_SERVICE, <<"in_service">>).
--define(NUMBER_STATE_RELEASED, <<"released">>).
--define(NUMBER_STATE_RESERVED, <<"reserved">>).
--define(NUMBER_STATE_AVAILABLE, <<"available">>).
-
 -define(WNM_HRL, 'true').
 -endif.

--- a/core/whistle_number_manager-1.0.0/src/wnm_number.erl
+++ b/core/whistle_number_manager-1.0.0/src/wnm_number.erl
@@ -31,6 +31,7 @@
 -export([released/1]).
 -export([port_out/1]).
 -export([disconnected/1]).
+-export([deleted/1]).
 
 -export([used_by/2]).
 
@@ -67,7 +68,7 @@ create_discovery(#number{number=Number
     Updates = [{<<"_id">>, Num}
                ,{<<"pvt_module_name">>, ModuleName}
                ,{<<"pvt_module_data">>, ModuleData}
-               ,{<<"pvt_number_state">>, ?NUMBER_STATE_DISCOVERY}
+               ,{?PVT_NUMBER_STATE, ?NUMBER_STATE_DISCOVERY}
                ,{<<"pvt_ported_in">>, 'false'}
                ,{<<"pvt_db_name">>, wnm_util:number_to_db_name(Num)}
                ,{<<"pvt_created">>, wh_util:current_tstamp()}
@@ -94,7 +95,7 @@ create_available(#number{number=Number
     Updates = [{<<"_id">>, Num}
                ,{<<"pvt_module_name">>, ModuleName}
                ,{<<"pvt_module_data">>, wh_json:new()}
-               ,{<<"pvt_number_state">>, ?NUMBER_STATE_AVAILABLE}
+               ,{?PVT_NUMBER_STATE, ?NUMBER_STATE_AVAILABLE}
                ,{<<"pvt_db_name">>, wnm_util:number_to_db_name(Num)}
                ,{<<"pvt_created">>, wh_util:current_tstamp()}
                ,{<<"pvt_authorizing_account">>, AuthBy}
@@ -126,7 +127,7 @@ create_port_in(#number{number=Number
     Updates = [{<<"_id">>, Num}
                ,{<<"pvt_module_name">>, ModuleName}
                ,{<<"pvt_module_data">>, wh_json:new()}
-               ,{<<"pvt_number_state">>, ?NUMBER_STATE_PORT_IN}
+               ,{?PVT_NUMBER_STATE, ?NUMBER_STATE_PORT_IN}
                ,{<<"pvt_ported_in">>, 'true'}
                ,{<<"pvt_db_name">>, wnm_util:number_to_db_name(Num)}
                ,{<<"pvt_created">>, wh_util:current_tstamp()}
@@ -549,18 +550,31 @@ reserved(Number) ->
 %%--------------------------------------------------------------------
 -spec in_service(wnm_number()) -> wnm_number().
 in_service(#number{state = ?NUMBER_STATE_DISCOVERY}=Number) ->
-    Routines = [fun(#number{assign_to=AssignTo, auth_by=AuthBy}=N) ->
+    Routines = [fun(#number{assign_to=AssignTo
+                            ,auth_by=AuthBy
+                           }=N) ->
                         case AuthBy =:= 'system' orelse wh_util:is_in_account_hierarchy(AuthBy, AssignTo, 'true') of
                             'false' -> error_unauthorized(N);
                             'true' -> N
                         end
                 end
-                ,fun(#number{assigned_to='undefined', assign_to=AssignTo}=N) ->
-                         N#number{state = ?NUMBER_STATE_IN_SERVICE, assigned_to=AssignTo};
-                    (#number{assigned_to=AssignedTo, assign_to=AssignedTo}=N) ->
+                ,fun(#number{assigned_to='undefined'
+                             ,assign_to=AssignTo
+                            }=N) ->
+                         N#number{state = ?NUMBER_STATE_IN_SERVICE
+                                  ,assigned_to=AssignTo
+                                 };
+                    (#number{assigned_to=AssignedTo
+                             ,assign_to=AssignedTo
+                            }=N) ->
                          N#number{state = ?NUMBER_STATE_IN_SERVICE};
-                    (#number{assigned_to=AssignedTo, assign_to=AssignTo}=N) ->
-                         N#number{state = ?NUMBER_STATE_IN_SERVICE, assigned_to=AssignTo, prev_assigned_to=AssignedTo}
+                    (#number{assigned_to=AssignedTo
+                             ,assign_to=AssignTo
+                            }=N) ->
+                         N#number{state = ?NUMBER_STATE_IN_SERVICE
+                                  ,assigned_to=AssignTo
+                                  ,prev_assigned_to=AssignedTo
+                                 }
                  end
                 ,fun(#number{}=N) -> activate_phone_number(N) end
                 ,fun(#number{module_name='undefined'}=N) ->
@@ -572,7 +586,9 @@ in_service(#number{state = ?NUMBER_STATE_DISCOVERY}=Number) ->
                ],
     lists:foldl(fun(F, J) -> F(J) end, Number, Routines);
 in_service(#number{state = ?NUMBER_STATE_PORT_IN}=Number) ->
-    Routines = [fun(#number{assigned_to=AssignedTo, auth_by=AuthBy}=N) ->
+    Routines = [fun(#number{assigned_to=AssignedTo
+                            ,auth_by=AuthBy
+                           }=N) ->
                         case wh_util:is_in_account_hierarchy(AuthBy, AssignedTo, 'true') of
                             'false' -> error_unauthorized(N);
                             'true' -> N#number{state = ?NUMBER_STATE_IN_SERVICE}
@@ -581,56 +597,99 @@ in_service(#number{state = ?NUMBER_STATE_PORT_IN}=Number) ->
                ],
     lists:foldl(fun(F, J) -> F(J) end, Number, Routines);
 in_service(#number{state = ?NUMBER_STATE_AVAILABLE}=Number) ->
-    Routines = [fun(#number{assign_to=AssignTo, auth_by=AuthBy}=N) ->
+    Routines = [fun(#number{assign_to=AssignTo
+                            ,auth_by=AuthBy
+                           }=N) ->
                         case AuthBy =:= 'system' orelse wh_util:is_in_account_hierarchy(AuthBy, AssignTo, 'true') of
                             'false' -> error_unauthorized(N);
                             'true' -> N
                         end
                 end
-                ,fun(#number{assigned_to='undefined', assign_to=AssignTo}=N) ->
-                         N#number{state = ?NUMBER_STATE_IN_SERVICE, assigned_to=AssignTo};
-                    (#number{assigned_to=AssignedTo, assign_to=AssignedTo}=N) ->
+                ,fun(#number{assigned_to='undefined'
+                             ,assign_to=AssignTo
+                            }=N) ->
+                         N#number{state = ?NUMBER_STATE_IN_SERVICE
+                                  ,assigned_to=AssignTo
+                                 };
+                    (#number{assigned_to=AssignedTo
+                             ,assign_to=AssignedTo
+                            }=N) ->
                          N#number{state = ?NUMBER_STATE_IN_SERVICE};
-                    (#number{assigned_to=AssignedTo, assign_to=AssignTo}=N) ->
-                         N#number{state = ?NUMBER_STATE_IN_SERVICE, assigned_to=AssignTo, prev_assigned_to=AssignedTo}
+                    (#number{assigned_to=AssignedTo
+                             ,assign_to=AssignTo
+                            }=N) ->
+                         N#number{state = ?NUMBER_STATE_IN_SERVICE
+                                  ,assigned_to=AssignTo
+                                  ,prev_assigned_to=AssignedTo
+                                 }
                  end
                 ,fun(#number{}=N) -> activate_phone_number(N) end
                ],
     lists:foldl(fun(F, J) -> F(J) end, Number, Routines);
 in_service(#number{state = ?NUMBER_STATE_RESERVED}=Number) ->
-    Routines = [fun(#number{assign_to=AssignTo, auth_by=AuthBy, assigned_to=AssignedTo}=N) ->
+    Routines = [fun(#number{assign_to=AssignTo
+                            ,auth_by=AuthBy
+                            ,assigned_to=AssignedTo
+                           }=N) ->
                         case (wh_util:is_in_account_hierarchy(AssignedTo, AuthBy, 'true')
-                              orelse wh_util:is_in_account_hierarchy(AuthBy, AssignedTo))
+                              orelse wh_util:is_in_account_hierarchy(AuthBy, AssignedTo)
+                             )
                             andalso wh_util:is_in_account_hierarchy(AssignedTo, AssignTo, 'true')
                         of
                             'false' -> error_unauthorized(N);
                             'true' -> N
                         end
                 end
-                ,fun(#number{assigned_to='undefined', assign_to=AssignTo}=N) ->
-                         N#number{state = ?NUMBER_STATE_IN_SERVICE, assigned_to=AssignTo};
-                    (#number{assigned_to=AssignedTo, assign_to=AssignedTo}=N) ->
+                ,fun(#number{assigned_to='undefined'
+                             ,assign_to=AssignTo
+                            }=N) ->
+                         N#number{state = ?NUMBER_STATE_IN_SERVICE
+                                  ,assigned_to=AssignTo
+                                 };
+                    (#number{assigned_to=AssignedTo
+                             ,assign_to=AssignedTo
+                            }=N) ->
                          N#number{state = ?NUMBER_STATE_IN_SERVICE};
-                    (#number{assigned_to=AssignedTo, assign_to=AssignTo}=N) ->
-                         N#number{state = ?NUMBER_STATE_IN_SERVICE, assigned_to=AssignTo, prev_assigned_to=AssignedTo}
+                    (#number{assigned_to=AssignedTo
+                             ,assign_to=AssignTo
+                            }=N) ->
+                         N#number{state = ?NUMBER_STATE_IN_SERVICE
+                                  ,assigned_to=AssignTo
+                                  ,prev_assigned_to=AssignedTo
+                                 }
                  end
                ],
     lists:foldl(fun(F, J) -> F(J) end, Number, Routines);
-in_service(#number{state = ?NUMBER_STATE_IN_SERVICE, assigned_to=AssignedTo, assign_to=AssignedTo}=Number) ->
+in_service(#number{state = ?NUMBER_STATE_IN_SERVICE
+                   ,assigned_to=AssignedTo
+                   ,assign_to=AssignedTo
+                  }=Number) ->
     error_no_change_required(?NUMBER_STATE_IN_SERVICE, Number);
 in_service(#number{state = ?NUMBER_STATE_IN_SERVICE}=Number) ->
-    Routines = [fun(#number{assign_to=AssignTo, auth_by=AuthBy}=N) ->
+    Routines = [fun(#number{assign_to=AssignTo
+                            ,auth_by=AuthBy
+                           }=N) ->
                         case (wh_util:is_in_account_hierarchy(AssignTo, AuthBy, 'true')
-                              orelse wh_util:is_in_account_hierarchy(AuthBy, AssignTo))
+                              orelse wh_util:is_in_account_hierarchy(AuthBy, AssignTo)
+                             )
                         of
                             'false' -> error_unauthorized(N);
                             'true' -> N
                         end
                 end
-                ,fun(#number{assigned_to=undefined, assign_to=AssignTo}=N) ->
-                         N#number{state = ?NUMBER_STATE_IN_SERVICE, assigned_to=AssignTo};
-                    (#number{assigned_to=AssignedTo, assign_to=AssignTo}=N) ->
-                         N#number{state = ?NUMBER_STATE_IN_SERVICE, assigned_to=AssignTo, prev_assigned_to=AssignedTo}
+                ,fun(#number{assigned_to='undefined'
+                             ,assign_to=AssignTo
+                            }=N) ->
+                         N#number{state = ?NUMBER_STATE_IN_SERVICE
+                                  ,assigned_to=AssignTo
+                                 };
+                    (#number{assigned_to=AssignedTo
+                             ,assign_to=AssignTo
+                            }=N) ->
+                         N#number{state = ?NUMBER_STATE_IN_SERVICE
+                                  ,assigned_to=AssignTo
+                                  ,prev_assigned_to=AssignedTo
+                                 }
                  end
                ],
     lists:foldl(fun(F, J) -> F(J) end, Number, Routines);
@@ -648,7 +707,8 @@ released(#number{state = ?NUMBER_STATE_RESERVED}=Number) ->
     NewState = whapps_config:get_binary(?WNM_CONFIG_CAT, <<"released_state">>, ?NUMBER_STATE_AVAILABLE),
     Routines = [fun(#number{assigned_to=AssignedTo
                             ,auth_by=AuthBy
-                            ,number_doc=JObj}=N) ->
+                            ,number_doc=JObj
+                           }=N) ->
                         case wh_util:is_in_account_hierarchy(AuthBy, AssignedTo, 'true') of
                             'false' -> error_unauthorized(N);
                             'true' -> N#number{features=sets:new()
@@ -659,21 +719,24 @@ released(#number{state = ?NUMBER_STATE_RESERVED}=Number) ->
                 ,fun(#number{assigned_to=AssignedTo}=N) ->
                          N#number{state=NewState
                                   ,assigned_to='undefined'
-                                  ,prev_assigned_to=AssignedTo}
+                                  ,prev_assigned_to=AssignedTo
+                                 }
                  end
                 ,fun(#number{prev_assigned_to=AssignedTo
-                             ,reserve_history=ReserveHistory}=N) ->
-                    History = ordsets:del_element(AssignedTo, ReserveHistory),
-                    case ordsets:to_list(History) of
-                        [] -> attempt_discconect_number(N);
-                        [PrevReservation|_] ->
-                            lager:debug("unwinding reservation history, reserving on account ~s"
-                                        ,[PrevReservation]),
-                            N#number{reserve_history=History
-                                     ,assigned_to=PrevReservation
-                                     ,state = ?NUMBER_STATE_RESERVED
-                                    }
-                    end
+                             ,reserve_history=ReserveHistory
+                            }=N) ->
+                         History = ordsets:del_element(AssignedTo, ReserveHistory),
+                         case ordsets:to_list(History) of
+                             [] -> attempt_discconect_number(N);
+                             [PrevReservation|_] ->
+                                 lager:debug("unwinding reservation history, reserving on account ~s"
+                                             ,[PrevReservation]
+                                            ),
+                                 N#number{reserve_history=History
+                                          ,assigned_to=PrevReservation
+                                          ,state = ?NUMBER_STATE_RESERVED
+                                         }
+                         end
                  end
                ],
     lists:foldl(fun(F, J) -> F(J) end, Number, Routines);
@@ -681,7 +744,8 @@ released(#number{state = ?NUMBER_STATE_IN_SERVICE}=Number) ->
     NewState = whapps_config:get_binary(?WNM_CONFIG_CAT, <<"released_state">>, ?NUMBER_STATE_AVAILABLE),
     Routines = [fun(#number{assigned_to=AssignedTo
                             ,auth_by=AuthBy
-                            ,number_doc=JObj}=N) ->
+                            ,number_doc=JObj
+                           }=N) ->
                         case wh_util:is_in_account_hierarchy(AuthBy, AssignedTo, 'true') of
                             'false' -> error_unauthorized(N);
                             'true' -> N#number{features=sets:new()
@@ -692,16 +756,19 @@ released(#number{state = ?NUMBER_STATE_IN_SERVICE}=Number) ->
                 ,fun(#number{assigned_to=AssignedTo}=N) ->
                          N#number{state=NewState
                                   ,assigned_to='undefined'
-                                  ,prev_assigned_to=AssignedTo}
+                                  ,prev_assigned_to=AssignedTo
+                                 }
                  end
                 ,fun(#number{prev_assigned_to=AssignedTo
-                             ,reserve_history=ReserveHistory}=N) ->
+                             ,reserve_history=ReserveHistory
+                            }=N) ->
                          History = ordsets:del_element(AssignedTo, ReserveHistory),
                          case ordsets:to_list(History) of
                              [] -> attempt_discconect_number(N);
                              [PrevReservation|_] ->
                                  lager:debug("unwinding reservation history, reserving on account ~s"
-                                             ,[PrevReservation]),
+                                             ,[PrevReservation]
+                                            ),
                                  N#number{reserve_history=History
                                           ,assigned_to=PrevReservation
                                           ,state = ?NUMBER_STATE_RESERVED
@@ -731,7 +798,7 @@ attempt_discconect_number(#number{module_name=ModuleName}=Number) ->
 %%--------------------------------------------------------------------
 -spec port_out(wnm_number()) -> no_return().
 port_out(Number) ->
-    error_invalid_state_transition(<<"port_out">>, Number).
+    error_invalid_state_transition(?NUMBER_STATE_PORT_OUT, Number).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -741,7 +808,17 @@ port_out(Number) ->
 %%--------------------------------------------------------------------
 -spec disconnected(wnm_number()) -> no_return().
 disconnected(Number) ->
-    error_invalid_state_transition(<<"disconnected">>, Number).
+    error_invalid_state_transition(?NUMBER_STATE_DISCONNECTED, Number).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec deleted(wnm_number()) -> no_return().
+deleted(Number) ->
+    error_invalid_state_transition(?NUMBER_STATE_DELETED, Number).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -760,11 +837,13 @@ used_by(PhoneNumber, UsedBy) ->
                 Number ->
                     _ = save(Number#number{used_by=UsedBy}),
                     lager:debug("updating number '~s' used_by from '~s' field to: '~s'"
-                                ,[PhoneNumber, Number#number.used_by, UsedBy])
+                                ,[PhoneNumber, Number#number.used_by, UsedBy]
+                               )
             catch
                 _E:_R ->
                     lager:notice("~s getting '~s' for used_by update to ~s: ~p"
-                                ,[_E, PhoneNumber, UsedBy, _R])
+                                 ,[_E, PhoneNumber, UsedBy, _R]
+                                )
             end
     end.
 
@@ -781,12 +860,14 @@ json_to_record(JObj, #number{}=Number) ->
 json_to_record(JObj, IsNew) when is_boolean(IsNew) ->
     json_to_record(JObj, IsNew, #number{}).
 
-json_to_record(JObj, IsNew, #number{number=Num, number_db=Db}=Number) ->
+json_to_record(JObj, IsNew, #number{number=Num
+                                    ,number_db=Db
+                                   }=Number) ->
     Number#number{
       number=wh_json:get_value(<<"_id">>, JObj, Num)
       ,number_db=wh_json:get_value(<<"pvt_db_name">>, JObj, Db)
-      ,state=wh_json:get_ne_value(<<"pvt_number_state">>, JObj)
-      ,current_state=wh_json:get_ne_value(<<"pvt_number_state">>, JObj)
+      ,state=wh_json:get_ne_value(?PVT_NUMBER_STATE, JObj)
+      ,current_state=wh_json:get_ne_value(?PVT_NUMBER_STATE, JObj)
       ,reserve_history=ordsets:from_list(wh_json:get_ne_value(<<"pvt_reserve_history">>, JObj, []))
       ,assigned_to=wh_json:get_ne_value(<<"pvt_assigned_to">>, JObj)
       ,prev_assigned_to=wh_json:get_ne_value(<<"pvt_previously_assigned_to">>, JObj)
@@ -819,7 +900,7 @@ number_from_port_doc(#number{number=N}=Number, JObj) ->
 -spec record_to_json(wnm_number()) -> wh_json:object().
 record_to_json(#number{number_doc=JObj}=N) ->
     Updates = [{<<"_id">>, N#number.number}
-               ,{<<"pvt_number_state">>, N#number.state}
+               ,{?PVT_NUMBER_STATE, N#number.state}
                ,{<<"pvt_reserve_history">>, ordsets:to_list(N#number.reserve_history)}
                ,{<<"pvt_assigned_to">>, N#number.assigned_to}
                ,{<<"pvt_previously_assigned_to">>, N#number.prev_assigned_to}
@@ -1058,7 +1139,8 @@ get_updated_phone_number_docs(#number{state=State}=Number) ->
     Unavailable = lists:member(State, ?WNM_UNAVAILABLE_STATES),
     Routines = [fun(#number{prev_assigned_to='undefined'}=N) -> N;
                    (#number{prev_assigned_to=PrevAssigned
-                            ,assigned_to=PrevAssigned}=N) -> N;
+                            ,assigned_to=PrevAssigned
+                           }=N) -> N;
                    (#number{prev_assigned_to=PrevAssigned}=N) ->
                         remove_from_phone_number_doc(PrevAssigned, N)
                 end
@@ -1081,7 +1163,9 @@ get_updated_phone_number_docs(#number{state=State}=Number) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec remove_from_phone_number_doc(ne_binary(), wnm_number()) -> wnm_number().
-remove_from_phone_number_doc(Account, #number{number=Num, phone_number_docs=PhoneNumberDocs}=Number) ->
+remove_from_phone_number_doc(Account, #number{number=Num
+                                              ,phone_number_docs=PhoneNumberDocs
+                                             }=Number) ->
     case get_phone_number_doc(Account, Number) of
         {'error', _} -> Number;
         {'ok', JObj} ->
@@ -1102,7 +1186,9 @@ remove_from_phone_number_doc(Account, #number{number=Num, phone_number_docs=Phon
 %% @end
 %%--------------------------------------------------------------------
 -spec update_phone_number_doc(ne_binary(), wnm_number()) -> wnm_number().
-update_phone_number_doc(Account, #number{number=Num, phone_number_docs=PhoneNumberDocs}=Number) ->
+update_phone_number_doc(Account, #number{number=Num
+                                         ,phone_number_docs=PhoneNumberDocs
+                                        }=Number) ->
     case get_phone_number_doc(Account, Number) of
         {'error', _} -> Number;
         {'ok', JObj} ->
@@ -1127,7 +1213,8 @@ update_phone_number_doc(Account, #number{number=Num, phone_number_docs=PhoneNumb
                                   {'ok', wh_json:object()} |
                                   {'error', _}.
 get_phone_number_doc(Account, #number{phone_number_docs=Docs
-                                      ,dry_run=DryRun}) ->
+                                      ,dry_run=DryRun
+                                     }) ->
     case dict:find(Account, Docs) of
         'error' -> load_phone_number_doc(Account, DryRun);
         {'ok', _}=Ok -> Ok
@@ -1309,11 +1396,17 @@ activate_feature(Feature, Units, #number{feature_activation_charges=Charges
 %%--------------------------------------------------------------------
 -spec activate_phone_number(wnm_number()) -> wnm_number().
 
-activate_phone_number(#number{billing_id='undefined', assigned_to=Account}=N) ->
+activate_phone_number(#number{billing_id='undefined'
+                              ,assigned_to=Account
+                             }=N) ->
     activate_phone_number(N#number{billing_id=wh_services:get_billing_id(Account)});
-activate_phone_number(#number{services='undefined', billing_id=Account}=N) ->
+activate_phone_number(#number{services='undefined'
+                              ,billing_id=Account
+                             }=N) ->
     activate_phone_number(N#number{services=wh_services:fetch(Account)});
-activate_phone_number(#number{services=Services, number=Number}=N) ->
+activate_phone_number(#number{services=Services
+                              ,number=Number
+                             }=N) ->
     Units = wh_service_phone_numbers:phone_number_activation_charge(Number, Services),
     activate_phone_number(Units, N).
 

--- a/core/whistle_number_manager-1.0.0/src/wnm_number.erl
+++ b/core/whistle_number_manager-1.0.0/src/wnm_number.erl
@@ -622,7 +622,7 @@ released_maybe_disconnect(#number{prev_assigned_to=AssignedTo
                                  }=N) ->
     History = ordsets:del_element(AssignedTo, ReserveHistory),
     case ordsets:to_list(History) of
-        [] -> attempt_disconnect_number(N);
+        [] -> disconnect_or_delete(N);
         [PrevReservation|_] ->
             lager:debug("unwinding reservation history, reserving on account ~s"
                         ,[PrevReservation]
@@ -631,6 +631,28 @@ released_maybe_disconnect(#number{prev_assigned_to=AssignedTo
                      ,assigned_to=PrevReservation
                      ,state = ?NUMBER_STATE_RESERVED
                     }
+    end.
+
+-spec disconnect_or_delete(wnm_number()) -> wnm_number().
+-spec disconnect_or_delete(wnm_number(), boolean()) -> wnm_number().
+disconnect_or_delete(N) ->
+    disconnect_or_delete(N
+                         ,whapps_config:get_is_true(?WNM_CONFIG_CAT, <<"should_permanently_delete">>, 'false')
+                        ).
+
+disconnect_or_delete(N, 'false') ->
+    attempt_disconnect_number(N);
+disconnect_or_delete(N, 'true') ->
+    move_state(N, ?NUMBER_STATE_DELETED).
+
+-spec attempt_disconnect_number(wnm_number()) -> wnm_number().
+attempt_disconnect_number(#number{module_name=ModuleName}=Number) ->
+    try ModuleName:disconnect_number(Number) of
+        #number{}=N -> N#number{reserve_history=ordsets:new()}
+    catch
+        _E:_R ->
+            lager:debug("failed to disconnect via ~s: ~s: ~p", [ModuleName, _E, _R]),
+            error_carrier_fault(<<"Failed to disconnect number">>, Number)
     end.
 
 -spec released(wnm_number()) -> wnm_number().
@@ -652,16 +674,6 @@ released(#number{state = ?NUMBER_STATE_RELEASED}=Number) ->
     error_no_change_required(?NUMBER_STATE_RELEASED, Number);
 released(Number) ->
     error_invalid_state_transition(?NUMBER_STATE_RELEASED, Number).
-
--spec attempt_disconnect_number(wnm_number()) -> wnm_number().
-attempt_disconnect_number(#number{module_name=ModuleName}=Number) ->
-    try ModuleName:disconnect_number(Number) of
-        #number{}=N -> N#number{reserve_history=ordsets:new()}
-    catch
-        _E:_R ->
-            lager:debug("failed to disconnect via ~s: ~s: ~p", [ModuleName, _E, _R]),
-            error_carrier_fault(<<"Failed to disconnect number">>, Number)
-    end.
 
 %%--------------------------------------------------------------------
 %% @public
@@ -1343,16 +1355,24 @@ append_feature_debit(Feature, Units, #number{billing_id=Ledger
                 end
                 ,fun(T) -> wh_transaction:set_feature(Feature, T) end
                 ,fun(T) -> wh_transaction:set_number(Number, T) end
-                ,fun(T) ->
-                         wh_transaction:set_description(<<"number feature activation for "
-                                                          ,(wh_util:to_binary(Feature))/binary
-                                                        >>
-                                                        ,T)
-                 end
+                ,fun(T) -> set_feature_description(T, wh_util:to_binary(Feature)) end
                ],
     lager:debug("staging feature '~s' activation charge $~p for ~s via billing account ~s"
-                ,[Feature, wht_util:units_to_dollars(Units), AccountId, LedgerId]),
-    [lists:foldl(fun(F, T) -> F(T) end, wh_transaction:debit(Ledger, Units), Routines)|Activations].
+                ,[Feature, wht_util:units_to_dollars(Units), AccountId, LedgerId]
+               ),
+
+    [lists:foldl(fun(F, T) -> F(T) end
+                 ,wh_transaction:debit(Ledger, Units)
+                 ,Routines
+                )
+     |Activations
+    ].
+
+-spec set_feature_description(wh_transaction:transaction(), ne_binary()) ->
+                                     wh_transaction:transaction().
+set_feature_description(T, Feature) ->
+    Description = <<"number feature activation for ", Feature/binary>>,
+    wh_transaction:set_description(Description, T).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -1377,11 +1397,14 @@ append_phone_number_debit(Units, #number{billing_id=Ledger
                         end
                 end
                 ,fun(T) -> wh_transaction:set_number(Number, T) end
-                ,fun(T) ->
-                         wh_transaction:set_description(<<"number activation for "
-                                                          ,(wh_util:to_binary(Number))/binary>>, T)
-                 end
+                ,fun(T) -> set_number_description(T, wh_util:to_binary(Number)) end
                ],
     lager:debug("staging number activation charge $~p for ~s via billing account ~s"
                 ,[wht_util:units_to_dollars(Units), AccountId, LedgerId]),
     [lists:foldl(fun(F, T) -> F(T) end, wh_transaction:debit(Ledger, Units), Routines)|Activations].
+
+-spec set_number_description(wh_transaction:transaction(), ne_binary()) ->
+                                    wh_transaction:transaction().
+set_number_description(T, Number) ->
+    Description = <<"number activation for ", Number/binary>>,
+    wh_transaction:set_description(Description, T).

--- a/core/whistle_number_manager-1.0.0/src/wnm_number.erl
+++ b/core/whistle_number_manager-1.0.0/src/wnm_number.erl
@@ -634,15 +634,15 @@ released_maybe_disconnect(#number{prev_assigned_to=AssignedTo
     end.
 
 -spec disconnect_or_delete(wnm_number()) -> wnm_number().
--spec disconnect_or_delete(wnm_number(), boolean()) -> wnm_number().
+-spec should_permanently_delete(wnm_number(), boolean()) -> wnm_number().
 disconnect_or_delete(N) ->
-    disconnect_or_delete(N
-                         ,whapps_config:get_is_true(?WNM_CONFIG_CAT, <<"should_permanently_delete">>, 'false')
-                        ).
+    should_permanently_delete(N
+                              ,whapps_config:get_is_true(?WNM_CONFIG_CAT, <<"should_permanently_delete">>, 'false')
+                             ).
 
-disconnect_or_delete(N, 'false') ->
+should_permanently_delete(N, 'false') ->
     attempt_disconnect_number(N);
-disconnect_or_delete(N, 'true') ->
+should_permanently_delete(N, 'true') ->
     try attempt_disconnect_number(N) of
         N1 -> move_state(N1, ?NUMBER_STATE_DELETED)
     catch


### PR DESCRIPTION
If the system is configured to do so, instead of moving a number to 'disconnected' move it to 'deleted' for subsequent hard-removal from the system.