### PR TITLE
Kazoo 3423

### DIFF
--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -109,7 +109,7 @@ get_from_uri_realm(Data, Call) ->
 -spec maybe_get_call_from_realm(whapps_call:call()) -> api_binary().
 maybe_get_call_from_realm(Call) ->
     case whapps_call:from_realm(Call) of
-        'undefined' -> get_account_realm(Call);
+        <<"norealm">> -> get_account_realm(Call);
         Realm -> Realm
     end.
 

--- a/applications/ecallmgr/src/ecallmgr_fs_authz.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_authz.erl
@@ -350,11 +350,10 @@ authz_req(Props) ->
 
 -spec rating_req(ne_binary(), wh_proplist()) -> wh_proplist().
 rating_req(CallId, Props) ->
-    AccountId = props:get_value(?GET_CCV(<<"Account-ID">>), Props),
     [{<<"To-DID">>, kzd_freeswitch:to_did(Props)}
      ,{<<"From-DID">>, kzd_freeswitch:caller_id_number(Props)}
      ,{<<"Call-ID">>, CallId}
-     ,{<<"Account-ID">>, AccountId}
+     ,{<<"Account-ID">>, kzd_freeswitch:account_id(Props)}
      ,{<<"Direction">>, kzd_freeswitch:call_direction(Props)}
      ,{<<"Send-Empty">>, 'true'}
      | wh_api:default_headers(?APP_NAME, ?APP_VERSION)

--- a/core/whistle-1.0.0/src/wh_call_response.erl
+++ b/core/whistle-1.0.0/src/wh_call_response.erl
@@ -11,7 +11,6 @@
 -export([send/3, send/4, send/5]).
 -export([send_default/2]).
 -export([get_response/2]).
--export([default_response/1]).
 -export([config_doc_id/0]).
 
 -include_lib("whistle/include/wh_types.hrl").
@@ -137,11 +136,12 @@ do_send(CallId, CtrlQ, Commands) ->
 send_default(_Call, 'undefined') ->
     {'error', 'no_response'};
 send_default(Call, Cause) ->
-    lager:debug("attempting to send default response for ~s", [Cause]),
     case get_response(Cause, Call) of
         'undefined' ->
+            lager:debug("no default response for '~s' found", [Cause]),
             {'error', 'no_response'};
         Response ->
+            lager:debug("sending default response for '~s': ~p", [Cause, Response]),
             send_default_response(Call, Response)
     end.
 

--- a/core/whistle_apps-1.0.0/src/whapps_call.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_call.erl
@@ -623,7 +623,10 @@ request_realm(#whapps_call{request_realm=RequestRealm}) ->
 -spec set_from(ne_binary(), call()) -> call().
 set_from(From, #whapps_call{}=Call) when is_binary(From) ->
     [FromUser, FromRealm] = binary:split(From, <<"@">>),
-    Call#whapps_call{from=From, from_user=FromUser, from_realm=FromRealm}.
+    Call#whapps_call{from=From
+                     ,from_user=FromUser
+                     ,from_realm=FromRealm
+                    }.
 
 -spec from(call()) -> ne_binary().
 from(#whapps_call{from=From}) ->
@@ -640,7 +643,10 @@ from_realm(#whapps_call{from_realm=FromRealm}) ->
 -spec set_to(ne_binary(), call()) -> call().
 set_to(To, #whapps_call{}=Call) when is_binary(To) ->
     [ToUser, ToRealm] = binary:split(To, <<"@">>),
-    Call#whapps_call{to=To, to_user=ToUser, to_realm=ToRealm}.
+    Call#whapps_call{to=To
+                     ,to_user=ToUser
+                     ,to_realm=ToRealm
+                    }.
 
 -spec to(call()) -> ne_binary().
 to(#whapps_call{to=To}) ->

--- a/core/whistle_media-1.0.0/src/wh_media_util.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_util.erl
@@ -232,6 +232,9 @@ get_prompt(Name, Call) ->
     Lang = whapps_call:language(Call),
     get_prompt(Name, Lang, Call).
 
+get_prompt(<<"prompt://", _/binary>> = PromptId, _Lang, _Call) ->
+    lager:debug("prompt is already encoded: ~s", [PromptId]),
+    PromptId;
 get_prompt(<<"/system_media/", Name/binary>>, Lang, Call) ->
     get_prompt(Name, Lang, Call);
 get_prompt(PromptId, Lang, 'undefined') ->
@@ -241,9 +244,14 @@ get_prompt(PromptId, Lang, <<_/binary>> = AccountId) ->
 get_prompt(PromptId, Lang, Call) ->
     get_prompt(PromptId, Lang, whapps_call:account_id(Call)).
 
+get_prompt(<<"prompt://", _/binary>> = PromptId, _Lang, _AccountId, _UseOverride) ->
+    lager:debug("prompt is already encoded: ~s", [PromptId]),
+    PromptId;
 get_prompt(PromptId, Lang, AccountId, 'true') ->
+    lager:debug("using account override for ~s in account ~s", [PromptId, AccountId]),
     wh_util:join_binary([<<"prompt:/">>, AccountId, PromptId, Lang], <<"/">>);
 get_prompt(PromptId, Lang, _AccountId, 'false') ->
+    lager:debug("account overrides not enabled; ignoring account prompt for ~s", [PromptId]),
     wh_util:join_binary([<<"prompt:/">>, ?WH_MEDIA_DB, PromptId, Lang], <<"/">>).
 
 -spec get_account_prompt(ne_binary(), api_binary(), whapps_call:call()) -> api_binary().


### PR DESCRIPTION
The main issue was already addressed and no longer an issue; however, there was an issue found accessing the prompt when playing failure-to-route prompts. This has been addressed (doesn't allow double-encoding).