### PR TITLE
log_stacktrack is a very useful function - but it logs at the debug leve...

### DIFF
--- a/core/whistle-1.0.0/src/wh_util.erl
+++ b/core/whistle-1.0.0/src/wh_util.erl
@@ -127,17 +127,17 @@ log_stacktrace() ->
     ST = erlang:get_stacktrace(),
     log_stacktrace(ST).
 log_stacktrace(ST) ->
-    lager:debug("stacktrace:"),
+    lager:info("stacktrace:"),
     _ = [log_stacktrace_mfa(M, F, A, Info)
          || {M, F, A, Info} <- ST
         ],
     'ok'.
 
 log_stacktrace_mfa(M, F, Arity, Info) when is_integer(Arity) ->
-    lager:debug("st: ~s:~s/~b at (~b)", [M, F, Arity, props:get_value('line', Info, 0)]);
+    lager:info("st: ~s:~s/~b at (~b)", [M, F, Arity, props:get_value('line', Info, 0)]);
 log_stacktrace_mfa(M, F, Args, Info) ->
-    lager:debug("st: ~s:~s at ~p", [M, F, props:get_value('line', Info, 0)]),
-    [lager:debug("args: ~p", [Arg]) || Arg <- Args],
+    lager:info("st: ~s:~s at ~p", [M, F, props:get_value('line', Info, 0)]),
+    [lager:info("args: ~p", [Arg]) || Arg <- Args],
     'ok'.
 
 -define(LOG_LEVELS, ['emergency'


### PR DESCRIPTION
...l.

Would like this to log at a higher level so that debug level messages can be suppressed from logs and stacktrace information can continue to come through.