### PR TITLE
KAZOO-3532: use a device's getters and setters instead of less clear code

### DIFF
--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -1501,7 +1501,7 @@ missed_reason(Reason) -> Reason.
 
 -spec find_username(wh_json:object()) -> api_binary().
 find_username(EP) ->
-    find_sip_username(EP, wh_json:get_value([<<"sip">>, <<"username">>], EP)).
+    find_sip_username(EP, kz_device:sip_username(EP)).
 
 -spec find_sip_username(wh_json:object(), api_binary()) -> api_binary().
 find_sip_username(EP, 'undefined') -> wh_json:get_value(<<"To-User">>, EP);

--- a/applications/callflow/src/cf_attributes.erl
+++ b/applications/callflow/src/cf_attributes.erl
@@ -433,13 +433,12 @@ presence_id(EndpointId, Call) when is_binary(EndpointId) ->
         {'error', _} -> 'undefined'
     end;
 presence_id(Endpoint, Call) ->
+    Username = case kz_device:sip_username(Endpoint) of
+                   'undefined' -> whapps_call:request_user(Call);
+                   Name -> Name
+               end,
     PresenceId = case wh_json:get_ne_value(<<"presence_id">>, Endpoint) of
-                     'undefined' ->
-                         wh_json:get_binary_value(
-                           [<<"sip">>, <<"username">>]
-                           ,Endpoint
-                           ,whapps_call:request_user(Call)
-                          );
+                     'undefined' -> Username;
                      Else -> Else
                  end,
     case binary:match(PresenceId, <<"@">>) of

--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -228,7 +228,7 @@ unsolicited_owner_mwi_update(AccountDb, OwnerId) ->
             lists:foreach(
               fun(JObj) ->
                       J = wh_json:get_value(<<"doc">>, JObj),
-                      Username = wh_json:get_value([<<"sip">>, <<"username">>], J),
+                      Username = kz_device:sip_username(J),
                       Realm = get_sip_realm(J, AccountId),
                       OwnerId = get_endpoint_owner(J),
                       case wh_json:get_value([<<"sip">>, <<"method">>], J) =:= <<"password">>
@@ -263,7 +263,7 @@ unsolicited_endpoint_mwi_update(AccountDb, EndpointId) ->
                                             'ok' | {'error', 'not_appropriate'}.
 maybe_send_endpoint_mwi_update(JObj, AccountDb) ->
     AccountId = wh_util:format_account_id(AccountDb, 'raw'),
-    Username = wh_json:get_value([<<"sip">>, <<"username">>], JObj),
+    Username = kz_device:sip_username(JObj),
     Realm = get_sip_realm(JObj, AccountId),
     OwnerId = get_endpoint_owner(JObj),
     case wh_json:get_value([<<"sip">>, <<"method">>], JObj) =:= <<"password">>
@@ -865,7 +865,7 @@ sip_user_from_device_id(EndpointId, Call) ->
     case cf_endpoint:get(EndpointId, Call) of
         {'error', _} -> 'undefined';
         {'ok', Endpoint} ->
-            wh_json:get_value([<<"sip">>, <<"username">>], Endpoint)
+            kz_device:sip_username(Endpoint)
     end.
 
 -spec wait_for_noop(whapps_call:call(), ne_binary()) ->

--- a/applications/callflow/src/module/cf_camping_feature.erl
+++ b/applications/callflow/src/module/cf_camping_feature.erl
@@ -170,7 +170,7 @@ get_sip_usernames_for_target(TargetId, TargetType, Call) ->
 -spec get_device_sip_username(ne_binary(), ne_binary()) -> api_binary().
 get_device_sip_username(AccountDb, DeviceId) ->
     {'ok', JObj} = couch_mgr:open_cache_doc(AccountDb, DeviceId),
-    wh_json:get_value([<<"sip">>, <<"username">>], JObj).
+    kz_device:sip_username(JObj).
 
 -spec no_channels(state(), whapps_call:call()) -> maybe('accepted') |
                                                   maybe('connected').

--- a/applications/callflow/src/module/cf_eavesdrop.erl
+++ b/applications/callflow/src/module/cf_eavesdrop.erl
@@ -177,7 +177,7 @@ sip_user_of_endpoint(EndpointId, Call) ->
     case cf_endpoint:get(EndpointId, Call) of
         {'error', _} -> 'undefined';
         {'ok', Endpoint} ->
-            wh_json:get_value([<<"sip">>, <<"username">>], Endpoint)
+            kz_device:sip_username(Endpoint)
     end.
 
 -spec no_users(whapps_call:call()) -> any().

--- a/applications/crossbar/src/crossbar_freeswitch.erl
+++ b/applications/crossbar/src/crossbar_freeswitch.erl
@@ -426,7 +426,7 @@ process_callflow(_, _, _, _) -> 'ok'.
 process_device(Number, AccountId, JObj) ->
     AccountRealm = wh_util:get_account_realm(AccountId),
     Realm = wh_json:get_value([<<"sip">>,<<"realm">>], JObj, AccountRealm),
-    Username = wh_json:get_value([<<"sip">>,<<"username">>], JObj),
+    Username = kz_device:sip_username(JObj),
     case query_registrar(Realm, Username) of
         {'ok', Auth} ->
             Props = props_for_rendering(Number, Username, Realm, Auth),

--- a/applications/crossbar/src/modules/cb_onboard.erl
+++ b/applications/crossbar/src/modules/cb_onboard.erl
@@ -319,21 +319,19 @@ create_device(JObj, Iteration, Context, {Pass, Fail}) ->
                            end
                    end
                   ,fun(J) ->
-                           case wh_json:get_ne_value([<<"sip">>, <<"username">>], J) of
+                           case kz_device:sip_username(J) of
                                'undefined' ->
                                    Strength = whapps_config:get_integer(?OB_CONFIG_CAT, <<"device_username_strength">>, 3),
-                                   wh_json:set_value([<<"sip">>, <<"username">>]
-                                                     ,list_to_binary(["user_", wh_util:rand_hex_binary(Strength)]), J);
+                                   kz_device:set_sip_username(J, list_to_binary(["user_", wh_util:rand_hex_binary(Strength)]), J);
                                _ ->
                                    J
                            end
                    end
                   ,fun(J) ->
-                           case wh_json:get_ne_value([<<"sip">>, <<"password">>], J) of
+                           case kz_device:sip_password(J) of
                                'undefined' ->
                                    Strength = whapps_config:get_integer(?OB_CONFIG_CAT, <<"device_pwd_strength">>, 6),
-                                   wh_json:set_value([<<"sip">>, <<"password">>]
-                                                     ,wh_util:rand_hex_binary(Strength), J);
+                                   kz_device:set_sip_password(J, wh_util:rand_hex_binary(Strength));
                                _ ->
                                    J
                            end

--- a/applications/crossbar/src/modules/cb_rate_limits.erl
+++ b/applications/crossbar/src/modules/cb_rate_limits.erl
@@ -220,7 +220,7 @@ set_pvt_fields(Context) ->
 query_name(<<"account">>, JObj) ->
     wh_json:get_value(<<"realm">>, JObj);
 query_name(<<"device">>, JObj) ->
-    wh_json:get_value([<<"sip">>, <<"username">>], JObj).
+    kz_device:sip_username(JObj).
 
 %%--------------------------------------------------------------------
 %% @public

--- a/applications/crossbar/src/modules/provisioner_util.erl
+++ b/applications/crossbar/src/modules/provisioner_util.erl
@@ -349,8 +349,8 @@ do_simple_provision(MACAddress, Context) ->
             Body = [{"device[mac]", MACAddress}
                     ,{"device[label]", wh_json:get_string_value(<<"name">>, JObj)}
                     ,{"sip[realm]", wh_json:get_string_value([<<"sip">>, <<"realm">>], JObj, AccountRealm)}
-                    ,{"sip[username]", wh_json:get_string_value([<<"sip">>, <<"username">>], JObj)}
-                    ,{"sip[password]", wh_json:get_string_value([<<"sip">>, <<"password">>], JObj)}
+                    ,{"sip[username]", kz_device:sip_username(JObj)}
+                    ,{"sip[password]", kz_device:sip_password(JObj)}
                     ,{"submit", "true"}
                    ],
             Encoded = mochiweb_util:urlencode(Body),
@@ -638,19 +638,19 @@ set_account_line_defaults(Context) ->
 set_device_line_defaults(Context) ->
     Device = cb_context:doc(Context),
     [fun(J) ->
-             case wh_json:get_ne_value([<<"sip">>, <<"username">>], Device) of
+             case kz_device:sip_username(Device) of
                  'undefined' -> J;
                  Value -> wh_json:set_value([<<"authname">>, <<"value">>], Value, J)
              end
      end
      ,fun(J) ->
-              case wh_json:get_ne_value([<<"sip">>, <<"username">>], Device) of
+              case kz_device:sip_username(Device) of
                   'undefined' -> J;
                   Value -> wh_json:set_value([<<"username">>, <<"value">>], Value, J)
               end
       end
      ,fun(J) ->
-              case wh_json:get_ne_value([<<"sip">>, <<"password">>], Device) of
+              case kz_device:sip_password(Device) of
                   'undefined' -> J;
                   Value -> wh_json:set_value([<<"secret">>, <<"value">>], Value, J)
               end

--- a/applications/crossbar/src/modules/provisioner_v5.erl
+++ b/applications/crossbar/src/modules/provisioner_v5.erl
@@ -296,9 +296,9 @@ settings_sip(JObj) ->
               ], JObj
              ),
     Props = props:filter_undefined(
-              [{<<"username">>, wh_json:get_value([<<"sip">>, <<"username">>], JObj)},
-               {<<"password">>, wh_json:get_value([<<"sip">>, <<"password">>], JObj)},
-               {<<"realm">>, Realm}
+              [{<<"username">>, kz_device:sip_username(JObj)}
+               ,{<<"password">>, kz_device:sip_password(JObj)}
+               ,{<<"realm">>, Realm}
               ]
              ),
     wh_json:from_list(Props).


### PR DESCRIPTION
Found the culprits with:
$ cd /opt/kazoo/
$ git grep -InE '<<"(username|password)">>' | grep '<<"sip">>'