### PR TITLE
KAZOO-3543: account promotion failing due to invalid context

### DIFF
--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -392,8 +392,8 @@ create_account(AccountName, Realm, Username, Password) ->
         {'ok', C3} = validate_user(User, C2),
         {'ok', _} = create_user(C3),
 
-        AccountDb = cb_context:account_db(C1),
-        AccountId = cb_context:account_id(C1),
+        AccountDb = cb_context:account_db(C3),
+        AccountId = cb_context:account_id(C3),
 
         case whapps_util:get_all_accounts() of
             [AccountDb] ->


### PR DESCRIPTION
Modified the context from C1 to C3.