### PR TITLE
Bug: When timeout error comes from gen_server, it comes as {error, {erro...

### DIFF
--- a/applications/stepswitch/src/stepswitch_sms.erl
+++ b/applications/stepswitch/src/stepswitch_sms.erl
@@ -270,7 +270,7 @@ send(<<"amqp">>, Endpoint, API) ->
             DeliveryProps = [{<<"Delivery-Result-Code">>, <<"sip:500">> }
                              ,{<<"Delivery-Failure">>, true}
                              ,{<<"Error-Code">>, 500}
-                             ,{<<"Error-Message">>, wh_util:to_binary(Reason)}
+                             ,{<<"Error-Message">>, wh_util:error_to_binary(Reason)}
                              ,{<<"Status">>, <<"Failed">>}
                              ,{<<"Message-ID">>, props:get_value(<<"Message-ID">>, API) }
                              ,{<<"Call-ID">>, CallId }

--- a/core/whistle-1.0.0/src/wh_util.erl
+++ b/core/whistle-1.0.0/src/wh_util.erl
@@ -34,6 +34,7 @@
          ,from_hex_binary/1, from_hex_string/1
          ,to_list/1, to_binary/1
          ,to_atom/1, to_atom/2
+         ,error_to_binary/1
         ]).
 -export([to_boolean/1, is_boolean/1
          ,is_true/1, is_false/1
@@ -784,6 +785,16 @@ to_boolean('true') -> 'true';
 to_boolean(<<"false">>) -> 'false';
 to_boolean("false") -> 'false';
 to_boolean('false') -> 'false'.
+
+-spec error_to_binary({'error', binary()} | binary()) -> binary().
+error_to_binary({'error', Reason}) ->
+    error_to_binary(Reason);
+error_to_binary(Reason) ->
+    try to_binary(Reason) of
+        Message -> Message
+    catch
+       _:_ -> <<"Unknown Error">>
+    end.
 
 -spec is_true(binary() | string() | atom()) -> boolean().
 is_true(<<"true">>) -> 'true';

--- a/core/whistle_apps-1.0.0/src/whapps_sms_command.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_sms_command.erl
@@ -135,7 +135,7 @@ send_and_wait(<<"amqp">>, API, Endpoint, _Timeout) ->
             DeliveryProps = [{<<"Delivery-Result-Code">>, <<"sip:500">> }
                              ,{<<"Delivery-Failure">>, true}
                              ,{<<"Error-Code">>, 500}
-                             ,{<<"Error-Message">>, wh_util:to_binary(Reason)}
+                             ,{<<"Error-Message">>, wh_util:error_to_binary(Reason)}
                              ,{<<"Status">>, <<"Failed">>}
                              ,{<<"Message-ID">>, props:get_value(<<"Message-ID">>, API) }
                              ,{<<"Call-ID">>, CallId }


### PR DESCRIPTION
...r, timeout}}.  Code before then tried to convert {error, timeout} to binary --> process dies.

Similar issues could occur when other errors are surfaced by gen_server.
Note: this gen_server is from beneath the gen_listener behavior.