### PR TITLE
Fetch more data for incomplete unicode characters

### DIFF
--- a/deps/couchbeam-0.8.0/src/couchbeam_json_stream.erl
+++ b/deps/couchbeam-0.8.0/src/couchbeam_json_stream.erl
@@ -333,6 +333,10 @@ toke_string(DF, <<$\\, $u, A, B, C, D, Rest/binary>>, Acc)
             toke_string(DF, Rest, lists:reverse(Chars) ++ Acc);
         _ -> toke_string(DF, Rest, [<<16#fffd/utf8>>] ++ Acc)
     end;
+toke_string(DF, <<$\\, $u, Rest/binary>>, Acc)
+        when byte_size(Rest) < 4 ->
+    {Data, DF2} = must_df(DF, bad_escape_utf8_character_cdoe),
+    toke_string(DF2, <<$\\, $u, Rest/binary, Data/binary>>, Acc);
 toke_string(DF, <<$\\>>, Acc) ->
     {Data, DF2} = must_df(DF, unterminated_string),
     toke_string(DF2, <<$\\,Data/binary>>, Acc);

--- a/deps/couchbeam-0.8.0/src/couchbeam_json_stream.erl
+++ b/deps/couchbeam-0.8.0/src/couchbeam_json_stream.erl
@@ -335,7 +335,7 @@ toke_string(DF, <<$\\, $u, A, B, C, D, Rest/binary>>, Acc)
     end;
 toke_string(DF, <<$\\, $u, Rest/binary>>, Acc)
         when byte_size(Rest) < 4 ->
-    {Data, DF2} = must_df(DF, bad_escape_utf8_character_cdoe),
+    {Data, DF2} = must_df(DF, bad_escape_utf8_character_code),
     toke_string(DF2, <<$\\, $u, Rest/binary, Data/binary>>, Acc);
 toke_string(DF, <<$\\>>, Acc) ->
     {Data, DF2} = must_df(DF, unterminated_string),


### PR DESCRIPTION
After https://github.com/2600hz/kazoo/commit/90b035c8a32065e7197e31be28120ec2a78847c6 broken fetch UTF-data when chnuks not alligned to border of UTF-character.
For example if this UTF-data
**"\u041e\u0441\u043d\u043e\u0432\u043d\u0430\u044f"**
splitted in 2 chunks
**"\u041e\u0441\u04"** and **"3d\u043e\u0432\u043d\u0430\u044f"**
we got error
couch_util:445 (<0.23294.0>) unformatted error: {parse_error,bad_escape}
