### PR TITLE
Fix recording

### DIFF
--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -47,13 +47,15 @@ handle(Data, Call, <<"start">>) ->
         'false' ->
             Url = wh_json:get_value(<<"url">>, Data),
             case wh_media_recording:should_store_recording(Url) of
+                {'true', 'other', 'third_party'} ->
+                    lager:debug("call will be stored to 3rd party CouchDB", [l]),
+                    record_call(Data, Call);
                 {'true', 'other', Url} ->
                     lager:debug("call will be stored to 3rd party url '~s'", [Url]),
                     record_call(Data, Call);
                 'false' ->
-                    lager:error("misconfigured call record (missing url)"),
-                    wh_notify:system_alert("misconfigured call record (missing url in ~p)", [Call]),
-                    start_wh_media_recording(Data, Call);
+                    lager:error("misconfigured call record (missing url and disabled store_recordings)"),
+                    wh_notify:system_alert("misconfigured call record (missing url in ~p)", [Call]);
                 {'true', 'local'} ->
                     lager:debug("call will be store to account"),
                     start_wh_media_recording(Data, Call)

--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -48,7 +48,7 @@ handle(Data, Call, <<"start">>) ->
             Url = wh_json:get_value(<<"url">>, Data),
             case wh_media_recording:should_store_recording(Url) of
                 {'true', 'other', 'third_party'} ->
-                    lager:debug("call will be stored to 3rd party CouchDB", [l]),
+                    lager:debug("call will be stored to 3rd party CouchDB", []),
                     record_call(Data, Call);
                 {'true', 'other', Url} ->
                     lager:debug("call will be stored to 3rd party url '~s'", [Url]),

--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -49,7 +49,7 @@ handle(Data, Call, <<"start">>) ->
             case wh_media_recording:should_store_recording(Url) of
                 {'true', 'other', 'third_party'} ->
                     lager:debug("call will be stored to 3rd party CouchDB", []),
-                    record_call(Data, Call);
+                    start_wh_media_recording(Data, Call);
                 {'true', 'other', Url} ->
                     lager:debug("call will be stored to 3rd party url '~s'", [Url]),
                     record_call(Data, Call);

--- a/core/whistle_media-1.0.0/src/wh_media_recording.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_recording.erl
@@ -508,10 +508,10 @@ save_recording(Call, MediaName, Format, {'true', 'local'}) ->
     lager:info("stored meta: ~p", [MediaJObj]),
     StoreUrl = store_url(Call, MediaJObj),
     lager:info("store local url: ~s", [StoreUrl]),
-    store_recording(MediaName, StoreUrl, Call);
+    store_recording(MediaName, StoreUrl, Call, 'local');
 save_recording(Call, MediaName, _Format, {'true', 'other', Url}) ->
     lager:info("store remote url: ~s", [Url]),
-    store_recording(MediaName, Url, Call).
+    store_recording(MediaName, Url, Call, 'other').
 
 -spec store_recording_to_third_party_bigcouch(whapps_call:call(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 store_recording_to_third_party_bigcouch(Call, MediaName, Format, BCHost) ->
@@ -547,10 +547,13 @@ store_recording_to_third_party_bigcouch(Call, MediaName, Format, BCHost) ->
     lager:info("store to third-party modb url: ~s", [StoreUrl]),
     'ok' = whapps_call_command:store(MediaName, StoreUrl, Call).
 
--spec store_recording(ne_binary(), ne_binary(), whapps_call:call()) -> 'ok'.
-store_recording(MediaName, Url, Call) ->
+-spec store_recording(ne_binary(), ne_binary(), whapps_call:call(), ne_binary()) -> 'ok'.
+store_recording(MediaName, Url, Call, 'other') ->
     StoreUrl = append_path(Url, MediaName),
     lager:debug("appending filename to url: ~s", [StoreUrl]),
+    'ok' = whapps_call_command:store(MediaName, StoreUrl, Call);
+
+store_recording(MediaName, StoreUrl, Call, 'local') ->
     'ok' = whapps_call_command:store(MediaName, StoreUrl, Call).
 
 -spec append_path(ne_binary(), ne_binary()) -> ne_binary().

--- a/core/whistle_media-1.0.0/src/wh_media_recording.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_recording.erl
@@ -256,7 +256,11 @@ handle_cast('maybe_start_recording_on_answer', #state{is_recording='false'
 handle_cast('stop_call', #state{store_attempted='true'}=State) ->
     lager:debug("we've already sent a store attempt, waiting to hear back"),
     {'noreply', State};
-handle_cast('stop_call', #state{media_name=MediaName
+handle_cast('stop_call', #state{is_recording='false'}=State) ->
+    lager:debug("recv stop_call event, but recording is not started, ignoring event"),
+    {'noreply', State};
+handle_cast('stop_call', #state{is_recording='true'
+                                ,media_name=MediaName
                                 ,format=Format
                                 ,call=Call
                                 ,should_store=Store

--- a/core/whistle_media-1.0.0/src/wh_media_recording.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_recording.erl
@@ -525,7 +525,7 @@ save_recording(Call, MediaName, _Format, {'true', 'other', Url}) ->
 
 -spec store_recording_to_third_party_bigcouch(whapps_call:call(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 store_recording_to_third_party_bigcouch(Call, MediaName, Format, BCHost) ->
-    BCPort = whapps_config:get_integer(?CONFIG_CAT, <<"third_party_bigcouch_port">>, <<"5984">>),
+    BCPort = whapps_config:get(?CONFIG_CAT, <<"third_party_bigcouch_port">>, <<"5984">>),
     lager:info("storing to third-party bigcouch ~s:~p", [BCHost, BCPort]),
     AcctMODb = wh_util:format_account_id(kazoo_modb:get_modb(whapps_call:account_db(Call)),'encoded'),
     CallId = whapps_call:call_id(Call),

--- a/core/whistle_media-1.0.0/src/wh_media_recording.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_recording.erl
@@ -504,13 +504,11 @@ should_store_recording(Url) ->
 
 -spec save_recording(whapps_call:call(), ne_binary(), ne_binary(), store_url()) -> 'ok'.
 save_recording(_Call, MediaName, _Format, 'false') ->
-    lager:info("not configured to store recording ~s", [MediaName]),
-    'ok';
+    lager:info("not configured to store recording ~s", [MediaName]);
 save_recording(Call, MediaName, Format, {'true', 'other', 'third_party'}) ->
     case whapps_config:get_ne_binary(?CONFIG_CAT, <<"third_party_bigcouch_host">>) of
         'undefined' -> 
-            lager:error("no URL for call recording provided, third_party_bigcouch_host undefined"),
-            'ok';
+            lager:error("no URL for call recording provided, third_party_bigcouch_host undefined");
         BCHost -> store_recording_to_third_party_bigcouch(Call, MediaName, Format, BCHost)
     end;
 save_recording(Call, MediaName, Format, {'true', 'local'}) ->


### PR DESCRIPTION
1. Store recording file on call stop, only if we started recording early.
2. When store file to 'local' DB dont append filename to Url (its already here).
3. Store to third_party only when enabled store_recordings and set third_party_bigcouch_host