### PR TITLE
Large SMS messages are sent as fragments and reassembled by Babble befor...

### DIFF
--- a/applications/doodle/src/doodle_util.erl
+++ b/applications/doodle/src/doodle_util.erl
@@ -120,6 +120,7 @@ save_sms(JObj, DocId, Doc, Call) ->
     AuthType = whapps_call:authorizing_type(Call),
     AuthId = whapps_call:authorizing_id(Call),
     Body = get_sms_body(Call),
+    Bits = bit_size(Body),
     To = whapps_call:to(Call),
     From = whapps_call:from(Call),
     Request = whapps_call:request(Call),
@@ -155,6 +156,7 @@ save_sms(JObj, DocId, Doc, Call) ->
                ,{<<"request_user">>, RequestUser }
                ,{<<"request_realm">>, RequestRealm }
                ,{<<"body">>, Body }
+               ,{<<"bits">>, Bits }
                ,{<<"message_id">>, MessageId}
                ,{<<"pvt_created">>, Created}
                ,{<<"pvt_modified">>, Modified}


### PR DESCRIPTION
...e they enter Kazoo.  When they leave Kazoo, Babble refragments them.

Fragmentation is dependent on number of bits in the SMS.  For billing and other purposes, its necessary to know how many SMS messages flowed through the network.  Number of bits in the message as a whole seems our only insight into that.  See below for why bits is preferred over bytes.

Notes:
A single-segment sms can be 160 7-bit characters, 140 8-bit characters, or 70 16-bit characters.

In a multi-segment sms, some space in each segment is used to store fragmentation information, so each segment can be (approximately) 153 7-bit characters, 134 8-bit characters, or 67 16-bit characters.

If there are any extended, foreign, or emoji characters in a message, that will force the use of 16 bit characters.
- Source: http://8s.ms/sms-segment-length