### PR TITLE
KAZOO-3565: acdc attended transfer

### DIFF
--- a/applications/acdc/src/acdc_util.erl
+++ b/applications/acdc/src/acdc_util.erl
@@ -113,7 +113,7 @@ bind_to_call_events(Call) ->
 bind_to_call_events('undefined', _) -> 'ok';
 bind_to_call_events(?NE_BINARY = CallId, Pid) ->
     gen_listener:add_binding(Pid, 'call', [{'callid', CallId}
-                                           ,{'restrict_to', ?CALL_EVENT_RESTRICTIONS}
+%                                           ,{'restrict_to', ?CALL_EVENT_RESTRICTIONS}
                                           ]);
 bind_to_call_events({CallId, _}, Pid) -> bind_to_call_events(CallId, Pid);
 bind_to_call_events(Call, Pid) -> bind_to_call_events(whapps_call:call_id(Call), Pid).
@@ -126,7 +126,7 @@ unbind_from_call_events(Call) ->
 unbind_from_call_events('undefined', _Pid) -> 'ok';
 unbind_from_call_events(?NE_BINARY = CallId, Pid) ->
     gen_listener:rm_binding(Pid, 'call', [{'callid', CallId}
-                                          ,{'restrict_to', ?CALL_EVENT_RESTRICTIONS}
+%                                          ,{'restrict_to', ?CALL_EVENT_RESTRICTIONS}
                                          ]);
 unbind_from_call_events({CallId, _}, Pid) -> unbind_from_call_events(CallId, Pid);
 unbind_from_call_events(Call, Pid) -> unbind_from_call_events(whapps_call:call_id(Call), Pid).


### PR DESCRIPTION
Hello,

We are trying to make it possible to transfer ACDC-managed calls (e.g. transfer to another queue). It works but demonstrates wierd behaviour at rare cases: when first transfer to another queue works ok as does the second one, but the third one fails. The agent FSM acts in wrong way and the state is wrong. Probably we are not unsubscribing from AMQP or something like that.... we have a little trouble here due to lack of deep knowledge of ACDC guts. Can you suggest something?

Logs attached to JIRA ticket.