### PR TITLE
KAZOO-3504: Not loading skel/system notifications for non system admins

### DIFF
--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -922,7 +922,7 @@ normalize_available_admin(JObj, Acc) ->
 
 normalize_available_non_admin(JObj, Acc) ->
     Value = wh_json:get_value(<<"value">>, JObj),
-    case wh_json:get_value(<<"category">>, Value) of
+    case kz_notification:category(Value) of
         <<"system">> -> Acc;
         <<"skel">> -> Acc;
         _Category -> [Value | Acc]


### PR DESCRIPTION
I know using process dictionary is not the best way but as I dont have access to the context. The only solution would be after loading the view which would mean that I have to re-do the resp breaking the paginations and stuff ...