### PR TITLE
Add systemwide token restrictions.

### DIFF
--- a/applications/crossbar/doc/token_restrictions.md
+++ b/applications/crossbar/doc/token_restrictions.md
@@ -1,0 +1,301 @@
+/*
+Section: Crossbar
+Title: Token restrictions
+Language: en-US
+*/
+
+# Token restrictions
+Module `cb_token_restrictions`.
+
+## What is it?
+Token restrictions - set of rules saved in auth token document. This rules grant access to API URI-s.  
+**If token document dont have any set of rules - then this module dont apply any restrictions to request.**  
+This rules created when the system create auth token.
+Rules can be loaded from system template or account template.
+System template located in `system_config/crossbar.token_restrictions`.
+Account template located in `{AccountDB}/token_restrictions`.
+
+## How it works?
+When you make request to Crossbar (API), the system load rules from token, which used for authentitcation, and try apply this rules to URI (`/v1/accounts/1234...xyz/devices/123...xyz/`).  
+More information about URI structure you can find [here](basics.md).  
+If system not found match for all parameters (endpoint name, account id, endpoint arguments, HTTP method), then it halt this request and return 403 error.
+
+## Template structure
+Each template can have differnet rules for different authentication method and user privelege level.
+```JSON
+{
+        "AUTH_METHOD_1": {
+        "PRIV_LEVEL_1": {
+                "RULES"
+        },
+        "PRIV_LEVEL_2": {
+                "RULES"
+        },
+        ...
+    },
+    "AUTH_METHOD_2": {
+        "PRIV_LEVEL_1":{
+                "RULES
+        }
+    },
+    ...
+}
+```
+`AUTH_METHOD_#` - name of used authentication method (`cb_api_auth`, `cb_user_auth`, etc) which created this auth token.  
+`PRIV_LEVEL_#` - name of privilege level of authenticated user (`admin`, `user`, etc). This level set in `priv_level` property of user document. If authentication method dont have usern id (such as `cb_api_auth`) then select `admin` set of rules.  
+`RULES` - set of rules which will be saved in auth token document.  
+Auth method and priv level can be matched with "catch all" term - `"_"`. If no exact match for auth method or priv level, then system try use "catch all" rules.  
+This search made at moment when token is created and result of this search will be saved in token document and applied to any further reqest, authenticated by this token.
+
+Example template:
+```JSON
+{
+        "cb_user_auth": {
+        "admin": {
+                "RULES_FOR_ADMIN"
+        },
+        "user": {
+                "RULES_FOR_USER"
+        },
+        ...
+    },
+    "_": {
+        "admin": {
+                "RULES_FOR_ADMIN"
+        },
+        "_": {
+                "CATCH_ALL_RULES"
+        }
+    }
+}
+```
+
+## Rules structure (saved in token document)
+```JSON
+{
+        "ENDPOINT_1": [
+                {
+                "allowed_accounts": [
+                "ACCOUNT_ID_1",
+                "ACCOUNT_ID_2
+            ],
+            "rules": {
+                "ARG_1": [
+                        "VERB_1",
+                    "VERB_2"
+                ],
+                "ARG_2": [
+                        "VERB_3"
+                ],
+                ...
+            }
+        },
+                {
+                "allowed_accounts": [
+                "ACCOUNT_ID_3"
+            ],
+            "rules": {
+                "ARG_1": [
+                        "VERB_1"
+                ],
+                ...
+            }
+        }
+        ],
+        "ENDPOINT_2": [
+                {
+                "rules": {
+                "ARG_1":[
+                        "_"
+                ]
+            }
+        }
+        ].
+    ...
+}
+```
+`ENDPOINT_#` - any appropriate name of endpoint (`"devices"`, `"users"`, `"callflows"`, etc)  
+`ACCOUNT_ID_#` - any appropriate account ID  
+`ARG_#` - arguments for endpoint separated by `/`
+`VERB_#` - any appropriate HTTP method (`"GET"`, `"PUT"`, etc)
+
+
+## Match order
+
+### Endpoint match
+At this step module compare resource from URI with resource names in token restrictions. 
+If URI is `/v1/accounts/1234...890/users/abc/xyz/` then endpoint will be `users`, and `abc`, `xyz` is arguments of this endpoint.  
+Rules applied to the last endpoint in URI.  
+You can use "catch all" (`"_"`) endpoint name. First try found exact endpoint name, then try search for "catch all" name.
+
+```JSON
+{
+        "account": [
+                { ... },
+                { ... }
+        ],
+        "users": [
+                { ... },
+                { ... }
+        ],
+        "_": [
+                { ... }
+        ]
+}
+```
+If not found match for endpoint- this request is halted and returned 403 error.  
+Each endpoint contain list of objects with rules. Appropriate object select by `"allowed_account"` parameter.  
+
+### Account match
+After system found endpoint it try match account ID for this request.
+```JSON
+{
+        "devices": [
+        {
+                "allowed_accounts": [
+                        "90b771808407e7079bfc206d5e3c1a8a",
+                "83a5cb95ac8ce8bc79d6f9b148004cf4",
+                "{AUTH_ACCOUNT_ID}"
+                ],
+            "rules": {
+                        ...
+                }
+                },
+        {
+                "allowed_accounts": [
+                "{DESCENDANT_ACCOUNT_ID}"
+            ],
+            "rules": {
+                ...
+            }
+        }
+    ]
+}
+```
+ List of account IDs set in parameter `"allowed_accounts"`. You can write axact IDs or one of special macroses.  
+ `"{AUTH_ACCOUNT_ID}"` - match account which created auth token.  
+ `"{DESCENDANT_ACCOUNT_ID}"` - match any descendats accounts.  
+ `"_"` - match any account.  
+ **If object dont have parameter `"allowed_accounts"` then it match any account (equal to `"_"`).**  
+ 
+ ### Endpoint arguments match
+ Endpoint argumnets matched with parameter `"rules"`.
+ ```JSON
+{
+        "devices": [
+        {
+                "allowed_accounts": [
+                "90b771808407e7079bfc206d5e3c1a8a"
+                        ],
+                "rules": {
+                        "/": [ ... ],
+                "1f6d4b82b4baafc74ba83186ee04b3d5": [ ... ],
+                "*": [ ... ]
+                }
+                }
+        ]
+}
+```
+The search is performed in the order in which they appear in the rules for first match. No more search after that.
+
+`/` - match empty argument list (catch `/v1/accounts/90b771808407e7079bfc206d5e3c1a8a/devices`).
+
+`*` - match any non empty argument (catch `.../devices/f61dd570039038eb97d7c656fe57ed9c`, but not `.../devices/f61dd570039038eb97d7c656fe57ed9c/sync`).
+
+`#` - match any argument list, empty to (catch `.../devices`, `.../devices/f61dd570039038eb97d7c656fe57ed9c`, `.../devices/f61dd570039038eb97d7c656fe57ed9c/sync`, etc). Single `#` work as "catch all" rule.
+
+`1f6d4b82b4baafc74ba83186ee04b3d5` - exact match (catch only `.../devices/1f6d4b82b4baafc74ba83186ee04b3d5`)
+
+If you have more than one argumnets, write them in one string, seprate with `/`.You can mix the with special characters, from above.
+
+`*/*/*` - match eactly three arguments (catch `.../devices/1f6d4b82b4baafc74ba83186ee04b3d5/quickcall/+1234567890`).
+
+`f61dd570039038eb97d7c656fe57ed9c/#` - match `.../devices/1f6d4b82b4baafc74ba83186ee04b3d5`, `.../devices/1f6d4b82b4baafc74ba83186ee04b3d5/sync`, `.../devices/1f6d4b82b4baafc74ba83186ee04b3d5/quickcall/+1234567890`, etc.
+
+### HTTP method match
+After matching endpoint arguments, system try match HTTP method, used in this request.
+ ```JSON
+{
+        "devices": [
+        {
+                "allowed_accounts": [
+                "90b771808407e7079bfc206d5e3c1a8a"
+                        ],
+                "rules": {
+                        "/": [
+                        "GET",
+                    "PUT"
+                                ],
+                "1f6d4b82b4baafc74ba83186ee04b3d5": [
+                        "_"
+                ],
+                "#": [
+                        "GET"
+                ]
+                }
+                }
+        ]
+}
+```
+List can contain any valid HTTP method ("GET", "PUT", "POST", "PATCH", "DELETE") or "allow any" method - `"_"`.
+
+## Manage accounts templates
+### Get current account template
+`GET /v1/accounts/{ACCOUNT_ID}/token_restrictions` return JSON like this:  
+```JSON
+{
+  "data": {
+    "restrictions": {
+      "_": {
+        "_": {
+          "about": [
+            {
+              "allowed_accounts": [
+                "_"
+              ],
+              "rules": {
+                "/": [
+                  "GET"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+If account dont have token restrictions template - return 404 error.
+
+### Create/update account template
+`POST /v1/accounts/{ACCOUNT_ID}/token_restrictions` 
+```JSON
+{
+  "data": {
+    "restrictions": {
+      "_": {
+        "_": {
+          "about": [
+            {
+              "allowed_accounts": [
+                "_"
+              ],
+              "rules": {
+                "/": [
+                  "GET"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Delete account template
+`DELETE /v1/accounts/{ACCOUNT_ID}/token_restrictions`
+
+

--- a/applications/crossbar/doc/token_restrictions.md
+++ b/applications/crossbar/doc/token_restrictions.md
@@ -24,21 +24,21 @@ If system not found match for all parameters (endpoint name, account id, endpoin
 Each template can have differnet rules for different authentication method and user privelege level.
 ```JSON
 {
-        "AUTH_METHOD_1": {
-        "PRIV_LEVEL_1": {
-                "RULES"
-        },
-        "PRIV_LEVEL_2": {
-                "RULES"
-        },
-        ...
+  "AUTH_METHOD_1": {
+    "PRIV_LEVEL_1": {
+      "RULES"
     },
-    "AUTH_METHOD_2": {
-        "PRIV_LEVEL_1":{
-                "RULES
-        }
+    "PRIV_LEVEL_2": {
+      "RULES"
     },
     ...
+  },
+  "AUTH_METHOD_2": {
+    "PRIV_LEVEL_1": {
+      "RULES"
+    }
+  },
+  ...
 }
 ```
 `AUTH_METHOD_#` - name of used authentication method (`cb_api_auth`, `cb_user_auth`, etc) which created this auth token.  
@@ -50,68 +50,67 @@ This search made at moment when token is created and result of this search will 
 Example template:
 ```JSON
 {
-        "cb_user_auth": {
-        "admin": {
-                "RULES_FOR_ADMIN"
-        },
-        "user": {
-                "RULES_FOR_USER"
-        },
-        ...
+  "cb_user_auth": {
+    "admin": {
+      "RULES_FOR_ADMIN"
+    },
+    "user": {
+      "RULES_FOR_USER"
+    }
+  },
+  "_": {
+    "admin": {
+      "RULES_FOR_ADMIN"
     },
     "_": {
-        "admin": {
-                "RULES_FOR_ADMIN"
-        },
-        "_": {
-                "CATCH_ALL_RULES"
-        }
+      "CATCH_ALL_RULES"
     }
+  }
 }
 ```
 
 ## Rules structure (saved in token document)
 ```JSON
 {
-        "ENDPOINT_1": [
-                {
-                "allowed_accounts": [
-                "ACCOUNT_ID_1",
-                "ACCOUNT_ID_2
-            ],
-            "rules": {
-                "ARG_1": [
-                        "VERB_1",
-                    "VERB_2"
-                ],
-                "ARG_2": [
-                        "VERB_3"
-                ],
-                ...
-            }
-        },
-                {
-                "allowed_accounts": [
-                "ACCOUNT_ID_3"
-            ],
-            "rules": {
-                "ARG_1": [
-                        "VERB_1"
-                ],
-                ...
-            }
-        }
+  "ENDPOINT_1": [
+    {
+      "allowed_accounts": [
+        "ACCOUNT_ID_1",
+        "ACCOUNT_ID_2"
+      ],
+      "rules": {
+        "ARG_1": [
+          "VERB_1",
+          "VERB_2"
         ],
-        "ENDPOINT_2": [
-                {
-                "rules": {
-                "ARG_1":[
-                        "_"
-                ]
-            }
-        }
-        ].
-    ...
+        "ARG_2": [
+          "VERB_3"
+        ]
+        ...
+      }
+    },
+    {
+      "allowed_accounts": [
+        "ACCOUNT_ID_3"
+      ],
+      "rules": {
+        "ARG_1": [
+          "VERB_1"
+        ],
+        ...
+      }
+    }
+  ],
+  "ENDPOINT_2": [
+    {
+      "rules": {
+        "ARG_1": [
+          "_"
+        ]
+      }
+    }
+  ],
+  ...
 }
 ```
 `ENDPOINT_#` - any appropriate name of endpoint (`"devices"`, `"users"`, `"callflows"`, etc)  
@@ -130,17 +129,17 @@ You can use "catch all" (`"_"`) endpoint name. First try found exact endpoint na
 
 ```JSON
 {
-        "account": [
-                { ... },
-                { ... }
-        ],
-        "users": [
-                { ... },
-                { ... }
-        ],
-        "_": [
-                { ... }
-        ]
+  "account": [
+    { ... },
+    { ... }
+  ],
+  "users": [
+    { ... },
+    { ... }
+  ],
+  "_": [
+    { ... }
+  ]
 }
 ```
 If not found match for endpoint- this request is halted and returned 403 error.  
@@ -150,26 +149,26 @@ Each endpoint contain list of objects with rules. Appropriate object select by `
 After system found endpoint it try match account ID for this request.
 ```JSON
 {
-        "devices": [
-        {
-                "allowed_accounts": [
-                        "90b771808407e7079bfc206d5e3c1a8a",
-                "83a5cb95ac8ce8bc79d6f9b148004cf4",
-                "{AUTH_ACCOUNT_ID}"
-                ],
-            "rules": {
-                        ...
-                }
-                },
-        {
-                "allowed_accounts": [
-                "{DESCENDANT_ACCOUNT_ID}"
-            ],
-            "rules": {
-                ...
-            }
-        }
-    ]
+  "devices": [
+    {
+      "allowed_accounts": [
+        "90b771808407e7079bfc206d5e3c1a8a",
+        "83a5cb95ac8ce8bc79d6f9b148004cf4",
+        "{AUTH_ACCOUNT_ID}"
+      ],
+      "rules": {
+        ...
+      }
+    },
+    {
+      "allowed_accounts": [
+        "{DESCENDANT_ACCOUNT_ID}"
+      ],
+      "rules": {
+        ...
+      }
+    }
+  ]
 }
 ```
  List of account IDs set in parameter `"allowed_accounts"`. You can write axact IDs or one of special macroses.  
@@ -182,18 +181,18 @@ After system found endpoint it try match account ID for this request.
  Endpoint argumnets matched with parameter `"rules"`.
  ```JSON
 {
-        "devices": [
-        {
-                "allowed_accounts": [
-                "90b771808407e7079bfc206d5e3c1a8a"
-                        ],
-                "rules": {
-                        "/": [ ... ],
-                "1f6d4b82b4baafc74ba83186ee04b3d5": [ ... ],
-                "*": [ ... ]
-                }
-                }
-        ]
+  "devices": [
+    {
+      "allowed_accounts": [
+        "90b771808407e7079bfc206d5e3c1a8a"
+      ],
+      "rules": {
+        "/": [ ... ],
+        "1f6d4b82b4baafc74ba83186ee04b3d5": [ ... ],
+        "*": [ ... ]
+      }
+    }
+  ]
 }
 ```
 The search is performed in the order in which they appear in the rules for first match. No more search after that.
@@ -216,25 +215,25 @@ If you have more than one argumnets, write them in one string, seprate with `/`.
 After matching endpoint arguments, system try match HTTP method, used in this request.
  ```JSON
 {
-        "devices": [
-        {
-                "allowed_accounts": [
-                "90b771808407e7079bfc206d5e3c1a8a"
-                        ],
-                "rules": {
-                        "/": [
-                        "GET",
-                    "PUT"
-                                ],
-                "1f6d4b82b4baafc74ba83186ee04b3d5": [
-                        "_"
-                ],
-                "#": [
-                        "GET"
-                ]
-                }
-                }
+  "devices": [
+    {
+      "allowed_accounts": [
+        "90b771808407e7079bfc206d5e3c1a8a"
+      ],
+      "rules": {
+        "/": [
+          "GET",
+          "PUT"
+        ],
+        "1f6d4b82b4baafc74ba83186ee04b3d5": [
+          "_"
+        ],
+        "#": [
+          "GET"
         ]
+      }
+    }
+  ]
 }
 ```
 List can contain any valid HTTP method ("GET", "PUT", "POST", "PATCH", "DELETE") or "allow any" method - `"_"`.
@@ -297,5 +296,4 @@ If account dont have token restrictions template - return 404 error.
 
 ### Delete account template
 `DELETE /v1/accounts/{ACCOUNT_ID}/token_restrictions`
-
 

--- a/applications/crossbar/priv/couchdb/schemas/token_restrictions.json
+++ b/applications/crossbar/priv/couchdb/schemas/token_restrictions.json
@@ -1,0 +1,79 @@
+{
+    "_id": "token_restrictions",
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "required": true,
+    "name": "Token restrictions",
+    "description": "Schema for token restrictions",
+    "properties": {
+        "restrictions": {
+            "type": "object",
+            "patternProperties": {
+                "^\\w+$": {
+                    "type": "object",
+                    "required": true,
+                    "name": "Auth method",
+                    "description": "Name of athentication metod used when creating token. \"_\" for match any auth method",
+                    "patternProperties": {
+                        "^\\w+$": {
+                            "type": "object",
+                            "required": true,
+                            "name": "User priv level",
+                            "description": "User privelege level. \"_\" for match any priv level",
+                            "patternProperties": {
+                                "^\\w+$":{
+                                    "type": "array",
+                                    "required": true,
+                                    "items": {
+                                        "type": "object",
+                                        "name": "Endpoint",
+                                        "required": false,
+                                        "description": "Endpoint (first path token) to wich apply restrictions. \"_\" for match any endpoint",
+                                        "properties": {
+                                            "allowed_accounts":{
+                                                "type": "array",
+                                                "required": false,
+                                                "name" : "Allowed accounts",
+                                                "description": "Account allowed to match this item",
+                                                "uniqueItems": true,
+                                                "items":{
+                                                    "type": "string",
+                                                    "required": false
+                                                }
+                                            },
+                                            "rules": {
+                                                "type": "object",
+                                                "requred": false,
+                                                "name": "Rules",
+                                                "description": "Rules applied to endpoint parameters",
+                                                "patternProperties": {
+                                                    "^[\\w/#*]+$": {
+                                                        "type": "array",
+                                                        "requred": false,
+                                                        "name": "verbs",
+                                                        "uniqueItems": true,
+                                                        "items":{
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "GET",
+                                                                "PUT",
+                                                                "POST",
+                                                                "PATCH",
+                                                                "DELETE",
+                                                                "_"
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -28,6 +28,8 @@
 
 -define(CROSSBAR_DEFAULT_CONTENT_TYPE, {<<"application">>, <<"json">>, []}).
 
+-define(CB_ACCOUNT_TOKEN_RESTRICTIONS, <<"token_restrictions">>).
+
 -define(CONTENT_PROVIDED, [{'to_json', ?JSON_CONTENT_TYPES}]).
 -define(CONTENT_ACCEPTED, [{'from_json', ?JSON_CONTENT_TYPES}
                            ,{'from_form', ?MULTIPART_CONTENT_TYPES}

--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -75,6 +75,7 @@
                           ,'cb_schemas', 'cb_service_plans', 'cb_services'
                           ,'cb_simple_authz', 'cb_sms'
                           ,'cb_temporal_rules', 'cb_token_auth', 'cb_transactions'
+                          ,'cb_token_restrictions'
                           ,'cb_user_auth', 'cb_users'
                           ,'cb_vmboxes'
                           ,'cb_webhooks', 'cb_whitelabel'

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -875,17 +875,12 @@ create_auth_token(Context, Method, JObj) ->
     AccountId = wh_json:get_value(<<"account_id">>, JObj),
     OwnerId = wh_json:get_value(<<"owner_id">>, JObj),
 
-    Restrictions = case get_forced_restrictions(Method, AccountId, OwnerId) of
-        'undefined' -> wh_json:get_ne_value(<<"restrictions">>, Data);
-        MethodRestrictions -> MethodRestrictions
-    end,
-    
     Token = props:filter_undefined(
               [{<<"account_id">>, AccountId}
                ,{<<"owner_id">>, OwnerId}
                ,{<<"as">>, wh_json:get_value(<<"as">>, Data)}
                ,{<<"api_key">>, wh_json:get_value(<<"api_key">>, Data)}
-               ,{<<"restrictions">>, Restrictions}
+               ,{<<"restrictions">>, get_token_restrictions(Method, AccountId, OwnerId)}
                ,{<<"method">>, wh_util:to_binary(Method)}
               ]),
     JObjToken = wh_doc:update_pvt_parameters(wh_json:from_list(Token)
@@ -909,30 +904,43 @@ create_auth_token(Context, Method, JObj) ->
             cb_context:add_system_error('invalid_credentials', Context)
     end.
 
--spec get_forced_restrictions(atom(), ne_binary(), ne_binary()) -> api_object().
-get_forced_restrictions(Method, AccountId, OwnerId) -> 
-    PrivLevel = get_priv_level(AccountId, OwnerId, Method),
-    case get_default_restrictions(wh_util:to_binary(Method)) of
-        'undefined' -> 'undefined';
-        Restrictions -> get_priv_level_restrictions(Restrictions, PrivLevel)
-    end.
+-spec get_token_restrictions(ne_binary(), ne_binary(), ne_binary()) -> wh_json:object().
+get_token_restrictions(Method, AccountId, OwnerId) ->
+    Restrictions = case get_account_token_restrictions(AccountId, Method) of
+        'undefined' -> get_system_token_restrictions(Method);
+        AccountRestrictions -> AccountRestrictions
+    end,
+    PrivLevel = get_priv_level(AccountId, OwnerId),
+    get_priv_level_restrictions(Restrictions, PrivLevel).
 
--spec get_priv_level(ne_binary(), ne_binary(), atom()) -> ne_binary().
+-spec get_priv_level(ne_binary(), ne_binary()) -> ne_binary().
 %%
 %% for api_auth tokens we force "admin" priv_level
 %%
-get_priv_level(_AccountId, 'undefined', 'cb_api_auth') -> <<"admin">>;
+get_priv_level(_AccountId, 'undefined') -> <<"admin">>;
 
-get_priv_level(AccountId, OwnerId, _Method) ->
+get_priv_level(AccountId, OwnerId) ->
     AccountDB = wh_util:format_account_db(AccountId),
     {'ok', Doc} = couch_mgr:open_cache_doc(AccountDB, OwnerId),
     wh_json:get_ne_value(<<"priv_level">>, Doc).
 
--spec get_default_restrictions(ne_binary()) -> api_object().
-get_default_restrictions(Method) -> 
+-spec get_system_token_restrictions(ne_binary()) -> api_object().
+get_system_token_restrictions(Method) -> 
     case whapps_config:get(<<(?CONFIG_CAT)/binary, ".token_restrictions">>, Method) of
         'undefined' ->  whapps_config:get(<<(?CONFIG_CAT)/binary, ".token_restrictions">>, <<"_">>);
         MethodRestrictions -> MethodRestrictions
+    end.
+
+-spec get_account_token_restrictions(ne_binary(), ne_binary()) -> api_object().
+get_account_token_restrictions(AccountId, Method) -> 
+    AccountDB = wh_util:format_account_db(AccountId),
+    case couch_mgr:open_cache_doc(AccountDB, ?CB_ACCOUNT_TOKEN_RESTRICTIONS) of
+        {'ok', RestrictionsDoc} -> wh_json:get_first_defined(
+                                     [[<<"pvt_restrictions">>, wh_util:to_binary(Method)] 
+                                      ,[<<"pvt_restrictions">>, <<"_">>]
+                                     ], 
+                                     RestrictionsDoc);
+        {'error', _} -> 'undefined'
     end.
 
 -spec get_priv_level_restrictions(api_object(), ne_binary()) -> api_object().

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -949,6 +949,8 @@ get_account_token_restrictions(AccountId, Method) ->
     end.
 
 -spec get_priv_level_restrictions(api_object(), ne_binary()) -> api_object().
+get_priv_level_restrictions('undefined', _PrivLevel) -> 'undefined';
+get_priv_level_restrictions(_Restrictions, 'undefined') -> 'undefined';
 get_priv_level_restrictions(Restrictions, PrivLevel) ->
     RestrictionLevels = wh_json:get_keys(Restrictions),
     case lists:member(PrivLevel, RestrictionLevels) of

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -941,8 +941,8 @@ get_account_token_restrictions(AccountId, Method) ->
     AccountDB = wh_util:format_account_db(AccountId),
     case couch_mgr:open_cache_doc(AccountDB, ?CB_ACCOUNT_TOKEN_RESTRICTIONS) of
         {'ok', RestrictionsDoc} -> wh_json:get_first_defined(
-                                     [[<<"pvt_restrictions">>, wh_util:to_binary(Method)] 
-                                      ,[<<"pvt_restrictions">>, <<"_">>]
+                                     [[<<"restrictions">>, wh_util:to_binary(Method)] 
+                                      ,[<<"restrictions">>, <<"_">>]
                                      ], 
                                      RestrictionsDoc);
         {'error', _} -> 'undefined'

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -906,12 +906,17 @@ create_auth_token(Context, Method, JObj) ->
 
 -spec get_token_restrictions(ne_binary(), ne_binary(), ne_binary()) -> wh_json:object().
 get_token_restrictions(Method, AccountId, OwnerId) ->
-    Restrictions = case get_account_token_restrictions(AccountId, Method) of
-        'undefined' -> get_system_token_restrictions(Method);
-        AccountRestrictions -> AccountRestrictions
-    end,
-    PrivLevel = get_priv_level(AccountId, OwnerId),
-    get_priv_level_restrictions(Restrictions, PrivLevel).
+    %% dont restrict SuperAdmin
+    case wh_util:is_system_admin(AccountId) of
+        'true' -> 'undefined';
+        'false' ->
+            Restrictions = case get_account_token_restrictions(AccountId, Method) of
+                'undefined' -> get_system_token_restrictions(Method);
+                AccountRestrictions -> AccountRestrictions
+            end,
+            PrivLevel = get_priv_level(AccountId, OwnerId),
+            get_priv_level_restrictions(Restrictions, PrivLevel)
+    end.
 
 -spec get_priv_level(ne_binary(), ne_binary()) -> ne_binary().
 %%

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -876,11 +876,7 @@ create_auth_token(Context, Method, JObj) ->
     OwnerId = wh_json:get_value(<<"owner_id">>, JObj),
 
     Restrictions = case get_forced_restrictions(Method, AccountId, OwnerId) of
-        'undefined' ->
-            case wh_json:get_ne_value(<<"restrictions">>, Data) of
-                'undefined' -> 'undefined';
-                ReqRestrictions -> ReqRestrictions
-            end;
+        'undefined' -> wh_json:get_ne_value(<<"restrictions">>, Data);
         MethodRestrictions -> MethodRestrictions
     end,
     

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -938,9 +938,8 @@ get_priv_level(AccountId, OwnerId, _Method) ->
 
 -spec get_default_restrictions(ne_binary()) -> api_object().
 get_default_restrictions(Method) -> 
-    Key = <<Method/binary, "_restrictions">>,
-    case whapps_config:get(<<(?CONFIG_CAT)/binary, ".token_restrictions">>, Key) of
-        'undefined' ->  whapps_config:get(<<(?CONFIG_CAT)/binary, ".token_restrictions">>, <<"restrictions">>);
+    case whapps_config:get(<<(?CONFIG_CAT)/binary, ".token_restrictions">>, Method) of
+        'undefined' ->  whapps_config:get(<<(?CONFIG_CAT)/binary, ".token_restrictions">>, <<"_">>);
         MethodRestrictions -> MethodRestrictions
     end.
 

--- a/applications/crossbar/src/modules/cb_token_auth.erl
+++ b/applications/crossbar/src/modules/cb_token_auth.erl
@@ -19,7 +19,6 @@
          ,validate/1
          ,delete/1
          ,authenticate/1
-         ,authorize/1
          ,finish_request/1
          ,clean_expired/0, clean_expired/1
         ]).
@@ -44,7 +43,6 @@ init() ->
     crossbar_bindings:bind(crossbar_cleanup:binding_hour(), ?MODULE, 'clean_expired'),
 
     _ = crossbar_bindings:bind(<<"*.authenticate">>, ?MODULE, 'authenticate'),
-    _ = crossbar_bindings:bind(<<"*.authorize">>, ?MODULE, 'authorize'),
     _ = crossbar_bindings:bind(<<"*.allowed_methods.token_auth">>, ?MODULE, 'allowed_methods'),
     _ = crossbar_bindings:bind(<<"*.resource_exists.token_auth">>, ?MODULE, 'resource_exists'),
     _ = crossbar_bindings:bind(<<"*.validate.token_auth">>, ?MODULE, 'validate'),
@@ -207,160 +205,6 @@ disable_account(AccountId) ->
     case crossbar_maintenance:disable_account(AccountId) of
         'ok' -> lager:info("account ~s disabled because expired", [AccountId]);
         'failed' -> lager:error("falied to disable account ~s", [AccountId])
-    end.
-%%
-%%--------------------------------------------------------------------
-%% @public
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
--spec authorize(cb_context:context()) ->
-                          'false' |
-                          {'true' | 'halt', cb_context:context()}.
-authorize(Context) ->
-    case maybe_deny_access(Context) of
-        'false' -> 
-            %%---------------------------------------------------------
-            %% We dont halt this request, let someone else authorize it
-            %%---------------------------------------------------------
-            'false';
-        'true' -> 
-            lager:info("deny access"),
-            Cause = wh_json:from_list([{<<"cause">>, <<"access denied by token restrictions">>}]),
-            {'halt', cb_context:add_system_error('forbidden', Cause, Context)}
-    end.
-
--spec maybe_deny_access(cb_context:context()) -> boolean().
-maybe_deny_access(Context) ->
-    AuthDoc = cb_context:auth_doc(Context),
-    case wh_json:get_ne_value(<<"restrictions">>, AuthDoc) of
-        'undefined' ->
-            lager:debug("no restrictions"),
-            'false';
-        Rs ->
-            maybe_deny_access(Context, Rs)
-    end.
-
--spec maybe_deny_access(cb_context:context(), wh_json:objects()) -> boolean().
-maybe_deny_access(Context, Rs) ->
-    MatchFuns = [fun match_endpoint/2
-                ,fun match_account/2
-                ,fun match_param/2
-                ,fun match_verb/2
-                ],
-    Result = lists:foldl(fun(F, R) -> 
-                             case wh_util:is_empty(R) of
-                                 'false' -> F(Context, R);
-                                 'true' -> 'undefined'
-                             end
-                     end, 
-                     Rs,
-                     MatchFuns
-                    ),
-    wh_util:is_empty(Result).
-
--spec match_endpoint(cb_context:context(), wh_json:object() | 'undefined') -> wh_json:objects() | 'undefined'.
-match_endpoint(Context, Rs) -> 
-    [{ReqEndpoint, _}|_] = cb_context:req_nouns(Context),
-    case wh_json:get_value(ReqEndpoint, Rs) of
-        'undefined' -> 
-            case wh_json:get_value(<<"_">>, Rs) of
-                'undefined' ->
-                    lager:info("no match endpoint for: ~p", [ReqEndpoint]),
-                    'undefined';
-                R ->
-                    lager:debug("match endpoint \"_\""),
-                    R
-            end;
-        R -> 
-            lager:debug("match endpoint ~p",[ReqEndpoint]),
-            R
-    end.
-
--spec match_account(cb_context:context(), wh_json:objects()) -> wh_json:objects() | 'undefined'.
-match_account(Context, Rs) -> 
-    AllowedAccounts = allowed_accounts(Context),
-    filter_by_account(AllowedAccounts, Rs).
-
-filter_by_account(Accounts, []) -> 
-    lager:info("no match account for: ~p",[Accounts]),
-    'undefined';
-filter_by_account(AllowedAccounts, [R|Rs]) ->
-    case wh_json:get_value(<<"allowed_accounts">>, R) of
-        'undefined' -> 
-            lager:debug("no \"allowed_accounts\" parameter in rule, match any account"),
-            wh_json:get_value(<<"rules">>, R);
-        RsAccounts -> 
-            SetsAllowedAccounts = sets:from_list(AllowedAccounts),
-            SetsRsAccounts = sets:from_list(RsAccounts),
-            SetsMatch = sets:intersection(SetsAllowedAccounts, SetsRsAccounts),
-            case sets:to_list(SetsMatch) of
-                [] -> filter_by_account(AllowedAccounts, Rs);
-                Match ->
-                    lager:debug("match account: ~p",[Match]),
-                    wh_json:get_value(<<"rules">>, R)
-            end
-    end.
-
--spec allowed_accounts(cb_context:context()) -> ne_binaries().
-allowed_accounts(Context) ->
-    AuthAccountId = cb_context:auth_account_id(Context),
-    AccountId = cb_context:account_id(Context),
-    %% 
-    %% #cb_context.account_id not always contain AccountId, try found it from req_nouns
-    %%
-%%    AccountId = case cb_context:account_id(Context) of
-%%        'undefined' -> 
-%%            Nouns = cb_context:req_nouns(Context),
-%%            case props:get_value(?WH_ACCOUNTS_DB, Nouns) of
-%%                'undefined' -> 'undefined';
-%%                [] -> 'undefined';
-%%                [A|_] -> A
-%%            end;
-%%        A -> A
-%%    end,
-    case AccountId =:= AuthAccountId of
-        'true' -> [ <<"_">>, AuthAccountId, <<"{AUTH_ACCOUNT_ID}">> ];
-        'false' ->
-            case wh_util:is_in_account_hierarchy(AuthAccountId, AccountId) of
-                'true' -> [ <<"_">>, AccountId, <<"{DESCENDANT_ACCOUNT_ID}">> ];
-                'false' when AccountId =:= 'undefined' -> [ <<"_">> ];
-                'false' when AuthAccountId =:= 'undefined' -> [ <<"_">> ];
-                'false' -> [ <<"_">>, AccountId ]
-            end
-    end.
-
--spec match_param(cb_context:context(), wh_json:objects()) -> wh_json:object() | 'undefined'.
-match_param(Context, R) -> 
-    [{_, ReqParam}|_] = cb_context:req_nouns(Context),
-    Rules = wh_json:get_keys(R),
-    case match_rules(ReqParam, Rules) of
-        'undefined' -> 
-            lager:info("no match rule for: ~p",[ReqParam]),
-                'undefined';
-        MatchRule -> 
-            lager:debug("match rule: ~p",[MatchRule]),
-            wh_json:get_value(MatchRule, R)
-    end.
-
-match_rules(_ReqParam, []) -> 'undefined';
-match_rules(ReqParam, [R|Rules]) ->
-    Rule = binary:split(R, <<"/">>, [global, trim]),
-    case kazoo_bindings:matches(Rule, ReqParam) of
-        'true' -> R;
-        'false' -> match_rules(ReqParam, Rules)
-    end.
-
--spec match_verb(cb_context:context(), list()) -> boolean().
-match_verb(Context, Verbs) ->
-    Verb = cb_context:req_verb(Context),
-    case lists:member(Verb, Verbs) orelse lists:member(<<"_">>, Verbs) of
-        'true' ->
-            lager:debug("match verb: ~p", [Verb]),
-            [Verb];
-        'false' ->
-            lager:info("no match verb for: ~p", [Verb]),
-            'undefined'
     end.
 
 -spec check_as(cb_context:context(), wh_json:object()) ->

--- a/applications/crossbar/src/modules/cb_token_auth.erl
+++ b/applications/crossbar/src/modules/cb_token_auth.erl
@@ -226,7 +226,7 @@ authorize(Context) ->
             'false';
         'true' -> 
             lager:info("deny access"),
-            Cause = wh_json:from_list([{<<"cause">>, <<"access denied">>}]),
+            Cause = wh_json:from_list([{<<"cause">>, <<"access denied by token restrictions">>}]),
             {'halt', cb_context:add_system_error('forbidden', Cause, Context)}
     end.
 

--- a/applications/crossbar/src/modules/cb_token_restrictions.erl
+++ b/applications/crossbar/src/modules/cb_token_restrictions.erl
@@ -1,0 +1,185 @@
+
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2011-2015, 2600Hz INC
+%%% @doc
+%%% Token auth module
+%%%
+%%% This is a simple auth mechanism, once the user has aquired an
+%%% auth token this module will allow access.  This module should be
+%%% updated to be FAR more robust.
+%%% @end
+%%% @contributors
+%%%   Karl Anderson
+%%%   James Aimonetti
+%%%-------------------------------------------------------------------
+-module(cb_token_restrictions).
+
+-export([init/0
+         ,authorize/1
+        ]).
+
+-include("../crossbar.hrl").
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+init() ->
+    couch_mgr:db_create(?KZ_TOKEN_DB),
+
+    _ = couch_mgr:revise_doc_from_file(?KZ_TOKEN_DB, 'crossbar', "views/token_auth.json"),
+
+    _ = crossbar_bindings:bind(<<"*.authorize">>, ?MODULE, 'authorize').
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec authorize(cb_context:context()) ->
+                          'false' |
+                          {'true' | 'halt', cb_context:context()}.
+authorize(Context) ->
+    case maybe_deny_access(Context) of
+        'false' -> 
+            %%---------------------------------------------------------
+            %% We dont halt this request, let someone else authorize it
+            %%---------------------------------------------------------
+            'false';
+        'true' -> 
+            lager:info("deny access"),
+            Cause = wh_json:from_list([{<<"cause">>, <<"access denied by token restrictions">>}]),
+            {'halt', cb_context:add_system_error('forbidden', Cause, Context)}
+    end.
+
+-spec maybe_deny_access(cb_context:context()) -> boolean().
+maybe_deny_access(Context) ->
+    AuthDoc = cb_context:auth_doc(Context),
+    case wh_json:get_ne_value(<<"restrictions">>, AuthDoc) of
+        'undefined' ->
+            lager:debug("no restrictions"),
+            'false';
+        Rs ->
+            maybe_deny_access(Context, Rs)
+    end.
+
+-spec maybe_deny_access(cb_context:context(), wh_json:objects()) -> boolean().
+maybe_deny_access(Context, Rs) ->
+    MatchFuns = [fun match_endpoint/2
+                ,fun match_account/2
+                ,fun match_param/2
+                ,fun match_verb/2
+                ],
+    Result = lists:foldl(fun(F, R) -> 
+                             case wh_util:is_empty(R) of
+                                 'false' -> F(Context, R);
+                                 'true' -> 'undefined'
+                             end
+                     end, 
+                     Rs,
+                     MatchFuns
+                    ),
+    wh_util:is_empty(Result).
+
+-spec match_endpoint(cb_context:context(), wh_json:object() | 'undefined') -> wh_json:objects() | 'undefined'.
+match_endpoint(Context, Rs) -> 
+    [{ReqEndpoint, _}|_] = cb_context:req_nouns(Context),
+    case wh_json:get_value(ReqEndpoint, Rs) of
+        'undefined' -> 
+            case wh_json:get_value(<<"_">>, Rs) of
+                'undefined' ->
+                    lager:info("no match endpoint for: ~p", [ReqEndpoint]),
+                    'undefined';
+                R ->
+                    lager:debug("match endpoint \"_\""),
+                    R
+            end;
+        R -> 
+            lager:debug("match endpoint ~p",[ReqEndpoint]),
+            R
+    end.
+
+-spec match_account(cb_context:context(), wh_json:objects()) -> wh_json:objects() | 'undefined'.
+match_account(Context, Rs) -> 
+    AllowedAccounts = allowed_accounts(Context),
+    filter_by_account(AllowedAccounts, Rs).
+
+filter_by_account(Accounts, []) -> 
+    lager:info("no match account for: ~p",[Accounts]),
+    'undefined';
+filter_by_account(AllowedAccounts, [R|Rs]) ->
+    case wh_json:get_value(<<"allowed_accounts">>, R) of
+        'undefined' -> 
+            lager:debug("no \"allowed_accounts\" parameter in rule, match any account"),
+            wh_json:get_value(<<"rules">>, R);
+        RsAccounts -> 
+            SetsAllowedAccounts = sets:from_list(AllowedAccounts),
+            SetsRsAccounts = sets:from_list(RsAccounts),
+            SetsMatch = sets:intersection(SetsAllowedAccounts, SetsRsAccounts),
+            case sets:to_list(SetsMatch) of
+                [] -> filter_by_account(AllowedAccounts, Rs);
+                Match ->
+                    lager:debug("match account: ~p",[Match]),
+                    wh_json:get_value(<<"rules">>, R)
+            end
+    end.
+
+-spec allowed_accounts(cb_context:context()) -> ne_binaries().
+allowed_accounts(Context) ->
+    AuthAccountId = cb_context:auth_account_id(Context),
+    AccountId = cb_context:account_id(Context),
+    %% 
+    %% #cb_context.account_id not always contain AccountId, try found it from req_nouns
+    %%
+%%    AccountId = case cb_context:account_id(Context) of
+%%        'undefined' -> 
+%%            Nouns = cb_context:req_nouns(Context),
+%%            case props:get_value(?WH_ACCOUNTS_DB, Nouns) of
+%%                'undefined' -> 'undefined';
+%%                [] -> 'undefined';
+%%                [A|_] -> A
+%%            end;
+%%        A -> A
+%%    end,
+    case AccountId =:= AuthAccountId of
+        'true' -> [ <<"_">>, AuthAccountId, <<"{AUTH_ACCOUNT_ID}">> ];
+        'false' ->
+            case wh_util:is_in_account_hierarchy(AuthAccountId, AccountId) of
+                'true' -> [ <<"_">>, AccountId, <<"{DESCENDANT_ACCOUNT_ID}">> ];
+                'false' when AccountId =:= 'undefined' -> [ <<"_">> ];
+                'false' when AuthAccountId =:= 'undefined' -> [ <<"_">> ];
+                'false' -> [ <<"_">>, AccountId ]
+            end
+    end.
+
+-spec match_param(cb_context:context(), wh_json:objects()) -> wh_json:object() | 'undefined'.
+match_param(Context, R) -> 
+    [{_, ReqParam}|_] = cb_context:req_nouns(Context),
+    Rules = wh_json:get_keys(R),
+    case match_rules(ReqParam, Rules) of
+        'undefined' -> 
+            lager:info("no match rule for: ~p",[ReqParam]),
+                'undefined';
+        MatchRule -> 
+            lager:debug("match rule: ~p",[MatchRule]),
+            wh_json:get_value(MatchRule, R)
+    end.
+
+match_rules(_ReqParam, []) -> 'undefined';
+match_rules(ReqParam, [R|Rules]) ->
+    Rule = binary:split(R, <<"/">>, [global, trim]),
+    case kazoo_bindings:matches(Rule, ReqParam) of
+        'true' -> R;
+        'false' -> match_rules(ReqParam, Rules)
+    end.
+
+-spec match_verb(cb_context:context(), list()) -> boolean().
+match_verb(Context, Verbs) ->
+    Verb = cb_context:req_verb(Context),
+    case lists:member(Verb, Verbs) orelse lists:member(<<"_">>, Verbs) of
+        'true' ->
+            lager:debug("match verb: ~p", [Verb]),
+            [Verb];
+        'false' ->
+            lager:info("no match verb for: ~p", [Verb]),
+            'undefined'
+    end.


### PR DESCRIPTION
Each auth type method have own restrictions and one default restriction.
"cb_api_auth_restrictions", "cb_user_auth_restrictions", ... - for each auth method.
"restrictions" - default restrictions if no match auth method.

Macroses {ACCOUNT_ID} and {USER_ID} replaced with <<"account_id">> and <<"owner_id">> from cb_context:doc(Context) when creating auth_token.

Each priv_level have own template for restrictions.
You can create as many priv_level as you wish ("operator" - wich can modify users, but cant modify account).

Example token_restrictions template
system_config / crossbar.token_restrictions
``` JSON
{
   "_id": "crossbar.token_restrictions",
   "_rev": "5-c4955b161980d140cd49ec60c3e3575d",
   "default": {
       "restrictions": {
           "*": {
               "*": [
                   "#"
               ]
           }
       },
       "cb_user_auth_restrictions": {
           "*": {
               "get": [
                   "#"
               ],
               "post": [
                   "accounts/{ACCOUNT_ID}/users/{USER_ID}",
                   "accounts/{ACCOUNT_ID}/users/{USER_ID}/*"
               ]
           },
           "admin": {
               "get": [
                   "accounts/{ACCOUNT_ID}/users",
                   "accounts/{ACCOUNT_ID}/users/*",
                   "accounts/{ACCOUNT_ID}/users/*/*"
               ],
               "put": [
                   "accounts/{ACCOUNT_ID}/users"
               ],
               "post": [
                   "accounts/{ACCOUNT_ID}/users/*"
               ],
               "delete": [
                   "accounts/{ACCOUNT_ID}/users/*"
               ]
           }
       },
       "cb_api_auth_restrictions": {
           "admin": {
               "get": [
                   "accounts/{ACCOUNT_ID}/users",
                   "accounts/{ACCOUNT_ID}/users/*",
                   "accounts/{ACCOUNT_ID}/users/*/*"
               ],
               "put": [
                   "accounts/{ACCOUNT_ID}/users"
               ],
               "post": [
                   "accounts/{ACCOUNT_ID}/users/*"
               ],
               "delete": [
                   "accounts/{ACCOUNT_ID}/users/*"
               ]
           },
           "user": {
               "get": [
                   "accounts/{ACCOUNT_ID}/#"
               ]
           },
           "*": {
           }
       }
   }
}
```

On next step i want add per account token_restriction template.
Create cb_token_restriction module and separte document in AccountDB (<<"token_restrictions">>).