### PR TITLE
KAZOO-2143: load db_doc to fix bulk edit

### DIFF
--- a/applications/crossbar/src/modules_v1/cb_devices_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_devices_v1.erl
@@ -177,7 +177,7 @@ validate(Context, DeviceId, ?QUICKCALL_PATH_TOKEN, _) ->
 
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
 post(Context, DeviceId) ->
-    case changed_mac_address(Context) of
+    case changed_mac_address(crossbar_doc:load_merge(DeviceId, Context)) of
         'true' ->
             _ = crossbar_util:maybe_refresh_fs_xml('device', Context),
             Context1 = crossbar_doc:save(Context),


### PR DESCRIPTION
1. ~~I'm not sure I should patch `v2`, but did it anyway (bulk edit is only on kazoo-ui AFAICT, and kazoo-ui uses v1)~~
2. ~~Should I put code shared by `cb_devices_v1` and `cb_devices_v2` in `cb_devices_utils`?~~