### PR TITLE
Check previous modb when determining initial agent status

### DIFF
--- a/applications/acdc/src/acdc_agent_util.erl
+++ b/applications/acdc/src/acdc_agent_util.erl
@@ -96,6 +96,10 @@ most_recent_db_status(AccountId, AgentId) ->
 -spec prev_month_recent_db_status(ne_binary(), ne_binary()) ->
                                          {'ok', ne_binary()}.
 prev_month_recent_db_status(AccountId, AgentId) ->
+    Opts = [{'startkey', [AgentId, wh_util:current_tstamp()]}
+            ,{'limit', 1}
+            ,'descending'
+           ],
     case couch_mgr:get_results(kazoo_modb_util:prev_year_month_mod(acdc_stats_util:db_name(AccountId)), <<"agent_stats/status_log">>, Opts) of
         {'ok', [StatusJObj]} -> {'ok', wh_json:get_value(<<"value">>, StatusJObj)};
         {'ok', []} -> {'ok', <<"unknown">>};
@@ -105,7 +109,7 @@ prev_month_recent_db_status(AccountId, AgentId) ->
         {'error', _E} ->
             lager:debug("error querying view: ~p", [_E]),
             {'ok', <<"unknown">>}
-    end;
+    end.
 
 -type statuses_return() :: {'ok', wh_json:object()}.
 -spec most_recent_statuses(ne_binary()) ->

--- a/applications/acdc/src/acdc_agent_util.erl
+++ b/applications/acdc/src/acdc_agent_util.erl
@@ -96,7 +96,7 @@ most_recent_db_status(AccountId, AgentId) ->
 -spec prev_month_recent_db_status(ne_binary(), ne_binary()) ->
                                          {'ok', ne_binary()}.
 prev_month_recent_db_status(AccountId, AgentId) ->
-    case couch_mgr:get_results(acdc_stats_util:prev_modb(AccountId), <<"agent_stats/status_log">>, Opts) of
+    case couch_mgr:get_results(kazoo_modb_util:prev_year_month_mod(acdc_stats_util:db_name(AccountId)), <<"agent_stats/status_log">>, Opts) of
         {'ok', [StatusJObj]} -> {'ok', wh_json:get_value(<<"value">>, StatusJObj)};
         {'ok', []} -> {'ok', <<"unknown">>};
         {'error', 'not_found'} ->

--- a/applications/acdc/src/acdc_agent_util.erl
+++ b/applications/acdc/src/acdc_agent_util.erl
@@ -82,17 +82,8 @@ most_recent_db_status(AccountId, AgentId) ->
     case couch_mgr:get_results(acdc_stats_util:db_name(AccountId), <<"agent_stats/status_log">>, Opts) of
         {'ok', [StatusJObj]} -> {'ok', wh_json:get_value(<<"value">>, StatusJObj)};
         {'ok', []} ->
-        	lager:debug("Could not find a recent status for agent ~p, checking previous modb", [AgentId]),
-        	case couch_mgr:get_results(acdc_stats_util:prev_modb(AccountId), <<"agent_stats/status_log">>, Opts) of
-        		{'ok', [StatusJObj2]} -> {'ok', wh_json:get_value(<<"value">>, StatusJObj2)};
-        		{'ok', []} -> {'ok', <<"unknown">>};
-			{'error', 'not_found'} ->
-				lager:debug("No previous modb found, returning unknown status"),
-				{'ok', <<"unknown">>};
-		        {'error', _E} ->
-		            lager:debug("error querying view: ~p", [_E]),
-		            {'ok', <<"unknown">>}
-		    end;
+        	lager:debug("could not find a recent status for agent ~s, checking previous modb", [AgentId]),
+        	prev_month_recent_db_status(AccountId, AgentId);
         {'error', 'not_found'} ->
             acdc_maintenance:refresh_account(AccountId),
             timer:sleep(150),
@@ -101,6 +92,20 @@ most_recent_db_status(AccountId, AgentId) ->
             lager:debug("error querying view: ~p", [_E]),
             {'ok', <<"unknown">>}
     end.
+
+-spec prev_month_recent_db_status(ne_binary(), ne_binary()) ->
+                                         {'ok', ne_binary()}.
+prev_month_recent_db_status(AccountId, AgentId) ->
+    case couch_mgr:get_results(acdc_stats_util:prev_modb(AccountId), <<"agent_stats/status_log">>, Opts) of
+        {'ok', [StatusJObj]} -> {'ok', wh_json:get_value(<<"value">>, StatusJObj)};
+        {'ok', []} -> {'ok', <<"unknown">>};
+        {'error', 'not_found'} ->
+            lager:debug("no previous modb found, returning unknown status"),
+            {'ok', <<"unknown">>};
+        {'error', _E} ->
+            lager:debug("error querying view: ~p", [_E]),
+            {'ok', <<"unknown">>}
+    end;
 
 -type statuses_return() :: {'ok', wh_json:object()}.
 -spec most_recent_statuses(ne_binary()) ->

--- a/applications/acdc/src/acdc_stats_util.erl
+++ b/applications/acdc/src/acdc_stats_util.erl
@@ -15,7 +15,6 @@
 
          ,get_query_limit/1
          ,db_name/1
-         ,prev_modb/1
         ]).
 
 -include("acdc.hrl").
@@ -51,14 +50,3 @@ get_query_limit(JObj) ->
 -spec db_name(ne_binary()) -> ne_binary().
 db_name(Account) ->
     wh_util:format_account_mod_id(Account).
-
--spec prev_modb(ne_binary()) -> ne_binary().
-prev_modb(Account) ->
-	{{Year, Month, _}, _} = calendar:now_to_universal_time(os:timestamp()),
-	prev_modb(Account, Year, Month-1).
-
--spec prev_modb(ne_binary(), calendar:year(), integer()) -> ne_binary().
-prev_modb(Account, Year, 0) ->
-	prev_modb(Account, Year-1, 12);
-prev_modb(Account, Year, Month) ->
-	wh_util:format_account_id(Account, Year, Month).

--- a/applications/acdc/src/acdc_stats_util.erl
+++ b/applications/acdc/src/acdc_stats_util.erl
@@ -15,6 +15,7 @@
 
          ,get_query_limit/1
          ,db_name/1
+         ,prev_modb/1
         ]).
 
 -include("acdc.hrl").
@@ -50,3 +51,14 @@ get_query_limit(JObj) ->
 -spec db_name(ne_binary()) -> ne_binary().
 db_name(Account) ->
     wh_util:format_account_mod_id(Account).
+
+-spec prev_modb(ne_binary()) -> ne_binary().
+prev_modb(Account) ->
+	{{Year, Month, _}, _} = calendar:now_to_universal_time(os:timestamp()),
+	prev_modb(Account, Year, Month-1).
+
+-spec prev_modb(ne_binary(), calendar:year(), integer()) -> ne_binary().
+prev_modb(Account, Year, 0) ->
+	prev_modb(Account, Year-1, 12);
+prev_modb(Account, Year, Month) ->
+	wh_util:format_account_id(Account, Year, Month).


### PR DESCRIPTION
If the agent did not have a status update for the month, stored in the modb, the lookup would return an empty list and the agent would default to "ready" state. Search now includes the previous modb if it exists, fails to old default (ready state)