### PR TITLE
Resolved issue with agent origination continuing after queue timeout

### DIFF
--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -579,9 +579,17 @@ connecting({'timeout', ConnRef, ?CONNECTION_TIMEOUT_MESSAGE}, #state{queue_proc=
                                                                      ,account_id=AccountId
                                                                      ,queue_id=QueueId
                                                                      ,member_call=Call
+                                                                     ,member_call_winner=Winner
                                                                     }=State) ->
     lager:debug("connection timeout occurred, bounce the caller out of the queue"),
-    acdc_queue_listener:timeout_member_call(Srv),
+
+    case Winner of
+    	undefined ->
+    		acdc_queue_listener:timeout_member_call(Srv);
+    	_ ->
+    		acdc_queue_listener:timeout_member_call(Srv, Winner)
+    end,
+
     acdc_stats:call_abandoned(AccountId, QueueId, whapps_call:call_id(Call), ?ABANDON_TIMEOUT),
 
     webseq:evt(?WSD_ID, self(), whapps_call:call_id(Call), <<"member call finish - timeout">>),

--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -139,10 +139,10 @@ timeout_agent(Srv, RespJObj) ->
 
 -spec timeout_member_call(pid()) -> 'ok'.
 timeout_member_call(Srv) ->
-    timeout_member_call(Srv, undefined).
--spec timeout_member_call(pid(), wh_json:object()) -> ok.
+    timeout_member_call(Srv, 'undefined').
+-spec timeout_member_call(pid(), api_object()) -> 'ok'.
 timeout_member_call(Srv, JObj) ->
-	gen_listener:cast(Srv, {timeout_member_call, JObj}).
+	gen_listener:cast(Srv, {'timeout_member_call', JObj}).
 
 exit_member_call(Srv) ->
     gen_listener:cast(Srv, {'exit_member_call'}).
@@ -344,26 +344,20 @@ handle_cast({'timeout_agent', RespJObj}, #state{queue_id=QueueId
     send_agent_timeout(RespJObj, Call, QueueId),
     {'noreply', State#state{agent_id='undefined'}, 'hibernate'};
 handle_cast({'timeout_member_call', JObj}, #state{delivery=Delivery
-                                            ,call=Call
-                                            ,shared_pid=Pid
-                                            ,member_call_queue=Q
-                                            ,acct_id=AcctId
-                                            ,queue_id=QueueId
-                                            ,my_id=MyId
-                                            ,agent_id=AgentId
-                                           }=State) ->
+                                                  ,call=Call
+                                                  ,shared_pid=Pid
+                                                  ,member_call_queue=Q
+                                                  ,acct_id=AcctId
+                                                  ,queue_id=QueueId
+                                                  ,my_id=MyId
+                                                  ,agent_id=AgentId
+                                                 }=State) ->
     lager:debug("member call has timed out, we're done"),
 
     acdc_util:unbind_from_call_events(Call),
     lager:debug("unbound from call events for ~s", [whapps_call:call_id(Call)]),
 
-    case AgentId of
-    	undefined ->
-    		ok;
-    	_ ->
-    		lager:debug("timing out winning agent because they should not be able to pick up after the queue timeout"),
-    		send_agent_timeout(JObj, Call, QueueId)
-    end,
+    maybe_timeout_agent(AgentId, QueueId, Call, JObj),
 
     acdc_queue_shared:ack(Pid, Delivery),
     send_member_call_failure(Q, AcctId, QueueId, whapps_call:call_id(Call), MyId, AgentId),
@@ -524,6 +518,13 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+-spec maybe_timeout_agent(api_object(), ne_binary(), whapps_call:call(), wh_json:object()) -> 'ok'.
+maybe_timeout_agent('undefined', _QueueId, _Call, _JObj) ->
+    'ok';
+maybe_timeout_agent(_AgentId, QueueId, Call, JObj) ->
+    lager:debug("timing out winning agent because they should not be able to pick up after the queue timeout"),
+    send_agent_timeout(JObj, Call, QueueId).
+
 -spec send_member_connect_req(ne_binary(), ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 send_member_connect_req(CallId, AcctId, QueueId, MyQ, MyId) ->
     Req = props:filter_undefined(


### PR DESCRIPTION
If an agent's ring timer was not timed out but the queue's timeout gets hit, there is a chance that the agent can answer their phone after the queue timed out. This would cause odd bridging issues and stuck calls in the kazoo-ui (stats module)