### PR TITLE
Handle DTMF digits properly after TTS module

### DIFF
--- a/applications/callflow/src/module/cf_collect_dtmf.erl
+++ b/applications/callflow/src/module/cf_collect_dtmf.erl
@@ -9,7 +9,6 @@
 %%%   ,"terminators":["#","*"] // what DTMFs stop collection (and aren't included)
 %%%   ,"interdigit_timeout":2000 // milliseconds, how long to wait for the next DTMF
 %%%   ,"collection_name":"your_name_here" // name the collection for later processing
-%%%   ,"reset_collection":"true" // already collected DTMF in the collection are purged if this is set to true
 %%% }
 %%% @end
 %%% @contributors

--- a/applications/callflow/src/module/cf_collect_dtmf.erl
+++ b/applications/callflow/src/module/cf_collect_dtmf.erl
@@ -9,6 +9,7 @@
 %%%   ,"terminators":["#","*"] // what DTMFs stop collection (and aren't included)
 %%%   ,"interdigit_timeout":2000 // milliseconds, how long to wait for the next DTMF
 %%%   ,"collection_name":"your_name_here" // name the collection for later processing
+%%%   ,"reset_collection":"true" // already collected DTMF in the collection are purged if this is set to true
 %%% }
 %%% @end
 %%% @contributors
@@ -29,23 +30,42 @@
 handle(Data, Call) ->
     whapps_call_command:answer(Call),
 
-    AlreadyCollected =
-        case whapps_call:get_dtmf_collection(Call) of
-            'undefined' -> <<>>;
-            <<_/binary>> = D ->
-                _ = cf_exe:set_call(whapps_call:set_dtmf_collection('undefined', Call)),
-                D
-        end,
+    AlreadyCollected = case whapps_call:get_dtmf_collection(Call) of
+        'undefined' -> <<>>;
+        <<_/binary>> = D ->
+            _ = cf_exe:set_call(whapps_call:set_dtmf_collection('undefined', Call)),
+            D
+    end,
 
-    _ = case whapps_call_command:collect_digits(max_digits(Data)
-                                                ,collect_timeout(Data)
-                                                ,interdigit(Data)
-                                                ,'undefined'
-                                                ,terminators(Data)
-                                                ,Call
-                                               )
-        of
-            {'ok', Ds} ->
+    maybe_collect_more_digits(Data, Call, AlreadyCollected).
+
+-spec maybe_collect_more_digits(wh_json:object(), whapps_call:call(), binary()) -> 'ok'.
+maybe_collect_more_digits(Data, Call, AlreadyCollected) ->
+	AlreadyCollectedSize = byte_size(AlreadyCollected),
+	MaxDigits = max_digits(Data),
+
+	if AlreadyCollectedSize >= MaxDigits ->
+		lager:debug("early DTMF met collection criteria, not collecting any more digits"),
+		<<Head:MaxDigits/binary, _/binary>> = AlreadyCollected,
+		CollectionName = collection_name(Data),
+
+		cf_exe:set_call(whapps_call:set_dtmf_collection(Head, CollectionName, Call));
+	'true' ->
+		collect_more_digits(Data, Call, AlreadyCollected, MaxDigits-AlreadyCollectedSize)
+	end,
+	cf_exe:continue(Call).
+
+-spec collect_more_digits(wh_json:object(), whapps_call:call(), pos_integer(), binary()) -> 'ok'.
+collect_more_digits(Data, Call, AlreadyCollected, MaxDigits) ->
+	case whapps_call_command:collect_digits(MaxDigits
+											,collect_timeout(Data)
+											,interdigit(Data)
+											,'undefined'
+											,terminators(Data)
+											,Call
+										   )
+		of
+			{'ok', Ds} ->
                 CollectionName = collection_name(Data),
                 lager:debug("collected ~s~s for ~s", [AlreadyCollected, Ds, CollectionName]),
 
@@ -54,8 +74,7 @@ handle(Data, Call) ->
                  );
             {'error', _E} ->
                 lager:debug("failed to collect DTMF: ~p", [_E])
-        end,
-    cf_exe:continue(Call).
+        end.
 
 -spec collection_name(wh_json:object()) -> ne_binary().
 collection_name(Data) ->


### PR DESCRIPTION
If DTMF is entered prior to the noop being sent to the cf_tts module, they are put into a collection that is read at the start of cf_collect_dtmf. However, it did not consider that the user may have already entered MaxDigits and that the execution should not go into whapps_call_command:collect_digits. If it did, it would await a noop that would cause the default timeout to be 1 day. Thus, even if MaxDigits was entered, they would still be waiting for DTMF timeout.