### PR TITLE
Changes in KAZOO-3059 break ACDC

### DIFF
--- a/core/whistle_apps-1.0.0/src/whapps_call.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_call.erl
@@ -154,7 +154,7 @@
                       ,sip_headers = wh_json:new() :: wh_json:object()                   %% Custom SIP Headers
                       ,kvs = orddict:new() :: orddict:orddict()           %% allows callflows to set values that propogate to children
                       ,other_leg_call_id :: api_binary()
-                      ,resource_type :: api_binary()                      %% from route_req
+                      ,resource_type = <<"audio">> :: api_binary()        %% from route_req
                       ,to_tag :: api_binary()
                       ,from_tag :: api_binary()
                      }).


### PR DESCRIPTION
Adding overload for maybe_owner_called_self causes whapps_call:call()s with resource_type =:= 'undefined' to crash in cf_endpoint. Added default value for the resource_type