### PR TITLE
Record min sec

### DIFF
--- a/applications/callflow/doc/record_call.md
+++ b/applications/callflow/doc/record_call.md
@@ -7,6 +7,19 @@ Version: 3.20
 
 The `record_call` callflow enables you to record the audio of the call.
 
+## Mandatory fields
+
+**action** - Must be set to `start` or `stop`.
+
+## Optional fields
+
+**time_limit** - Limit, in seconds, of how long to record the call. If ommited get value from `system_config/media/max_recording_time_limit`. Default `3600`.  
+**format** - Format to write the recording. Set `mp3` or `wav`. If ommited get value from `system_config/media/call_recording/extension`. Default `mp3`.  
+**record_on_answer** - Whether to delay starting the recording until the call is answered. Default `false`.  
+**record_sample_rate** - Sampling rate of the recording, in Hz. If ommited get value from `system_config/ecallmgr/record_sample_rate`. Default `8000`.  
+**record_min_sec** - Minimal record time, in seconds, to store recordings. If the recording time is less than this value, FreeSwitch will discard recorded file. If ommited get value from `system_config/media/record_min_sec`. Default `0`.  
+**url** - See **Storage of recordings** section.
+
 ## Storage of recordings
 
 If you supply a URL in the `data` portion of the callflow, Kazoo will send an HTTP PUT with the recording to the URL when the recording has finished.
@@ -18,3 +31,5 @@ If you omit the URL, there are a couple options for storage:
     * If `true`, check `system_config/media` for `third_party_bigcouch_host`
         * If `undefined`, store to the Kazoo BigCouch cluster
         * If defined, send the recording to the configured URL
+
+

--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -86,6 +86,7 @@ record_call(Data, Call) ->
              ,{<<"Additional-Headers">>, wh_json:get_value(<<"additional_headers">>, Data)}
              ,{<<"Time-Limit">>, wh_json:get_value(<<"time_limit">>, Data)}
              ,{<<"Record-Sample-Rate">>, wh_json:get_integer_value(<<"record_sample_rate">>, Data)}
+             ,{<<"Record-Min-Sec">>, wh_json:get_integer_value(<<"record_min_sec">>, Data)}
             ],
     _ = whapps_call_command:record_call(props:filter_undefined(Props), <<"start">>, Call),
     lager:debug("auto handling call recording").

--- a/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
@@ -43,6 +43,13 @@
             "required":false,
             "name":"Sample Rate",
             "description":"Sampling rate of the recording, in Hz"
+        },
+        "record_min_sec":{
+            "type":"integer",
+            "required":false,
+            "name":"Recording minmum seconds",
+            "description":"Minimal record time, in seconds, to store recordings",
+            "minimum":0
         }
     }
 }

--- a/applications/ecallmgr/src/ecallmgr.hrl
+++ b/applications/ecallmgr/src/ecallmgr.hrl
@@ -226,6 +226,7 @@
                                ,{<<"Record-Sample-Rate">>, <<"record_sample_rate">>}
                                ,{<<"recording_follow_transfer">>, <<"recording_follow_transfer">>}
                                ,{<<"recording_follow_attxfer">>, <<"recording_follow_attxfer">>}
+                               ,{<<"Record-Min-Sec">>, <<"record_min_sec">>}
                                ,{<<"enable_file_write_buffering">>, <<"enable_file_write_buffering">>}
                                ,{<<"RECORD_APPEND">>, <<"RECORD_APPEND">>}
                                ,{<<"fax_enable_t38_request">>, <<"fax_enable_t38_request">>}

--- a/applications/ecallmgr/src/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_command.erl
@@ -1275,7 +1275,7 @@ maybe_get_terminators(Acc, JObj) ->
 -spec start_record_call_args(atom(), ne_binary(), wh_json:object(), ne_binary()) -> ne_binary().
 start_record_call_args(Node, UUID, JObj, RecordingName) ->
     FollowTransfer = wh_json:get_binary_boolean(<<"Follow-Transfer">>, JObj, <<"true">>),
-    RecordMinSec = wh_json:get_value(<<"Record-Min-Sec">>, JObj),
+    RecordMinSec = wh_json:get_binary_value(<<"Record-Min-Sec">>, JObj),
     SampleRate = get_sample_rate(JObj),
 
     _ = ecallmgr_util:set(Node, UUID, [{<<"recording_follow_transfer">>, FollowTransfer}

--- a/applications/ecallmgr/src/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_command.erl
@@ -1275,10 +1275,12 @@ maybe_get_terminators(Acc, JObj) ->
 -spec start_record_call_args(atom(), ne_binary(), wh_json:object(), ne_binary()) -> ne_binary().
 start_record_call_args(Node, UUID, JObj, RecordingName) ->
     FollowTransfer = wh_json:get_binary_boolean(<<"Follow-Transfer">>, JObj, <<"true">>),
+    RecordMinSec = wh_json:get_value(<<"Record-Min-Sec">>, JObj),
     SampleRate = get_sample_rate(JObj),
 
     _ = ecallmgr_util:set(Node, UUID, [{<<"recording_follow_transfer">>, FollowTransfer}
                                        ,{<<"recording_follow_attxfer">>, FollowTransfer}
+                                       ,{<<"Record-Min-Sec">>, RecordMinSec}
                                        ,{<<"record_sample_rate">>, wh_util:to_binary(SampleRate)}
                                       ]),
     _ = ecallmgr_util:export(

--- a/core/whistle-1.0.0/src/api/wapi_dialplan.hrl
+++ b/core/whistle-1.0.0/src/api/wapi_dialplan.hrl
@@ -490,6 +490,7 @@
 -define(OPTIONAL_RECORD_CALL_REQ_HEADERS, [<<"Time-Limit">>, <<"Insert-At">>, <<"Follow-Transfer">>
                                            ,<<"Media-Transfer-Method">> ,<<"Media-Transfer-Destination">>
                                            ,<<"Additional-Headers">>, <<"Record-Sample-Rate">>
+                                           ,<<"Record-Min-Sec">>
                                           ]).
 -define(RECORD_CALL_REQ_VALUES, [{<<"Event-Category">>, <<"call">>}
                                  ,{<<"Event-Name">>, <<"command">>}

--- a/core/whistle_apps-1.0.0/src/whapps_call_command.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_call_command.erl
@@ -1380,6 +1380,7 @@ record_call(Media, Action, TimeLimit, Terminators, Call) ->
     Headers = props:get_value(<<"Additional-Headers">>, Media),
     Limit = props:get_value(<<"Time-Limit">>, Media, wh_util:to_binary(TimeLimit)),
     SampleRate = props:get_value(<<"Record-Sample-Rate">>, Media),
+    RecordMinSec = props:get_value(<<"Record-Min-Sec">>, Media),
 
     Command = props:filter_undefined(
                 [{<<"Application-Name">>, <<"record_call">>}
@@ -1392,6 +1393,7 @@ record_call(Media, Action, TimeLimit, Terminators, Call) ->
                  ,{<<"Media-Transfer-Destination">>, Destination}
                  ,{<<"Additional-Headers">>, Headers}
                  ,{<<"Record-Sample-Rate">>, SampleRate}
+                 ,{<<"Record-Min-Sec">>, RecordMinSec}
                 ]),
     send_command(Command, Call).
 

--- a/core/whistle_media-1.0.0/src/wh_media_recording.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_recording.erl
@@ -50,6 +50,7 @@
                 ,record_on_answer          :: boolean()
                 ,should_store              :: store_url()
                 ,time_limit                :: pos_integer()
+                ,record_min_sec            :: pos_integer()
                 ,store_attempted = 'false' :: boolean()
                 ,is_recording = 'false'    :: boolean()
                 ,channel_status_ref        :: reference() | 'undefined'
@@ -144,6 +145,7 @@ init([Call, Data]) ->
     TimeLimit = get_timelimit(wh_json:get_integer_value(<<"time_limit">>, Data)),
     RecordOnAnswer = wh_json:is_true(<<"record_on_answer">>, Data, 'false'),
     SampleRate = wh_json:get_integer_value(<<"record_sample_rate">>, Data),
+    RecordMinSec = wh_json:get_integer_value(<<"record_min_sec">>, Data,  whapps_config:get_integer(?WHM_CONFIG_CAT, <<"record_min_sec">>, 0)),
 
     Url = get_url(Data),
 
@@ -155,6 +157,7 @@ init([Call, Data]) ->
                   ,record_on_answer=RecordOnAnswer
                   ,should_store=should_store_recording(Url)
                   ,sample_rate = SampleRate
+                  ,record_min_sec = RecordMinSec
                  }}.
 
 %%--------------------------------------------------------------------
@@ -199,8 +202,9 @@ handle_cast('maybe_start_recording', #state{is_recording='false'
                                             ,time_limit=TimeLimit
                                             ,should_store={'true', 'other', _}
                                             ,sample_rate = SampleRate
+                                            ,record_min_sec = RecordMinSec
                                            }=State) ->
-    start_recording(Call, MediaName, TimeLimit, SampleRate),
+    start_recording(Call, MediaName, TimeLimit, SampleRate, RecordMinSec),
     lager:debug("statred recording shutting down"),
     {'stop', 'normal', State};
 handle_cast('maybe_start_recording', #state{is_recording='false'
@@ -209,8 +213,9 @@ handle_cast('maybe_start_recording', #state{is_recording='false'
                                             ,media_name=MediaName
                                             ,time_limit=TimeLimit
                                             ,sample_rate = SampleRate
+                                            ,record_min_sec = RecordMinSec
                                            }=State) ->
-    start_recording(Call, MediaName, TimeLimit, <<"wh_media_recording">>, SampleRate),
+    start_recording(Call, MediaName, TimeLimit, <<"wh_media_recording">>, SampleRate, RecordMinSec),
     {'noreply', State#state{
                   channel_status_ref=start_check_call_timer()
                   ,time_limit_ref=start_time_limit_timer(TimeLimit)
@@ -223,8 +228,9 @@ handle_cast('maybe_start_recording', #state{is_recording='false'
                                             ,time_limit=TimeLimit
                                             ,should_store={'true', 'other', _}
                                             ,sample_rate = SampleRate
+                                            ,record_min_sec = RecordMinSec
                                            }=State) ->
-    start_recording(Call, MediaName, TimeLimit, SampleRate),
+    start_recording(Call, MediaName, TimeLimit, SampleRate, RecordMinSec),
     {'stop', 'normal', State};
 handle_cast('maybe_start_recording_on_answer', #state{is_recording='true'}=State) ->
     lager:debug("we've already starting a recording for this call"),
@@ -236,8 +242,9 @@ handle_cast('maybe_start_recording_on_answer', #state{is_recording='false'
                                                       ,time_limit=TimeLimit
                                                       ,should_store={'true', 'other', _}
                                                       ,sample_rate = SampleRate
+                                                      ,record_min_sec = RecordMinSec
                                                      }=State) ->
-    start_recording(Call, MediaName, TimeLimit, SampleRate),
+    start_recording(Call, MediaName, TimeLimit, SampleRate, RecordMinSec),
     lager:debug("statred recording on answer shutting down"),
     {'stop', 'normal', State};
 handle_cast('maybe_start_recording_on_answer', #state{is_recording='false'
@@ -246,8 +253,9 @@ handle_cast('maybe_start_recording_on_answer', #state{is_recording='false'
                                                       ,media_name=MediaName
                                                       ,time_limit=TimeLimit
                                                       ,sample_rate = SampleRate
+                                                      ,record_min_sec = RecordMinSec
                                                      }=State) ->
-    start_recording(Call, MediaName, TimeLimit, <<"wh_media_recording">>, SampleRate),
+    start_recording(Call, MediaName, TimeLimit, <<"wh_media_recording">>, SampleRate, RecordMinSec),
     {'noreply', State#state{
                   channel_status_ref=start_check_call_timer()
                   ,time_limit_ref=start_time_limit_timer(TimeLimit)
@@ -318,8 +326,9 @@ handle_cast({'gen_listener',{'is_consuming', 'true'}}, #state{record_on_answer='
                                                               ,media_name=MediaName
                                                               ,time_limit=TimeLimit
                                                               ,sample_rate = SampleRate
+                                                              ,record_min_sec = RecordMinSec
                                                              }=State) ->
-    start_recording(Call, MediaName, TimeLimit, <<"wh_media_recording">>, SampleRate),
+    start_recording(Call, MediaName, TimeLimit, <<"wh_media_recording">>, SampleRate, RecordMinSec),
     lager:debug("started the recording"),
     {'noreply', State};
 
@@ -581,18 +590,20 @@ append_path(Url, MediaName) ->
         _ -> <<Url/binary, "/", Encoded/binary>>
     end.
 
--spec start_recording(whapps_call:call(), ne_binary(), pos_integer(), ne_binary(), api_integer()) -> 'ok'.
--spec start_recording(whapps_call:call(), ne_binary(), pos_integer(), api_integer()) -> 'ok'.
-start_recording(Call, MediaName, TimeLimit, SampleRate) ->
+-spec start_recording(whapps_call:call(), ne_binary(), pos_integer(), ne_binary(), api_integer(), api_integer()) -> 'ok'.
+-spec start_recording(whapps_call:call(), ne_binary(), pos_integer(), api_integer(), api_integer()) -> 'ok'.
+start_recording(Call, MediaName, TimeLimit, SampleRate, RecordMinSec) ->
     lager:debug("starting recording of ~s", [MediaName]),
     Props = [{<<"Media-Name">>, MediaName}
              ,{<<"Record-Sample-Rate">>, SampleRate}
+             ,{<<"Record-Min-Sec">>, wh_util:to_binary(RecordMinSec)}
             ],
     whapps_call_command:start_record_call(Props, TimeLimit, Call).
-start_recording(Call, MediaName, TimeLimit, MediaRecorder, SampleRate) ->
+start_recording(Call, MediaName, TimeLimit, MediaRecorder, SampleRate, RecordMinSec) ->
     lager:debug("starting recording of ~s", [MediaName]),
     Call1 = whapps_call:set_custom_channel_var(<<"Media-Recorder">>, MediaRecorder, Call),
     Props = [{<<"Media-Name">>, MediaName}
              ,{<<"Record-Sample-Rate">>, SampleRate}
+             ,{<<"Record-Min-Sec">>, wh_util:to_binary(RecordMinSec)}
             ],
     whapps_call_command:start_record_call(Props, TimeLimit, Call1).

--- a/core/whistle_media-1.0.0/src/whistle_media.hrl
+++ b/core/whistle_media-1.0.0/src/whistle_media.hrl
@@ -50,6 +50,7 @@
                      ,{<<"ssl_key">>, 'undefined'}
                      ,{<<"ssl_port">>, 'undefined'}
                      ,{<<"ssl_password">>, 'undefined'}
+                     ,{<<"record_min_sec">>, 0}
                     ]).
 
 -define(WH_MEDIA_HRL, 'true').


### PR DESCRIPTION
FS by default drop record files shorten than 3 seconds. https://wiki.freeswitch.org/wiki/Variable_record_min_sec.
I add `record_min_sec` option for `record_call` module to set minmum recording time.