### PR TITLE
KAZOO-3122: maintenance tool to update feature code patterns

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -632,7 +632,7 @@ is_digit(_) -> 'false'.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec lookup_callflow_patterns(ne_binary(), ne_binary()) ->
-                                      {'ok', {wh_json:object(), ne_binary()}} |
+                                      {'ok', {wh_json:object(), api_binary()}} |
                                       {'error', term()}.
 lookup_callflow_patterns(Number, Db) ->
     lager:info("lookup callflow patterns for ~s in ~s", [Number, Db]),
@@ -663,7 +663,6 @@ test_callflow_patterns([Pattern|T], Number, {_, Capture}=Result) ->
     Regex = wh_json:get_value(<<"key">>, Pattern),
     case re:run(Number, Regex) of
         {'match', [{Start,End}]} ->
-            Match = binary:part(Number, Start, End),
             Flow = wh_json:get_value(<<"doc">>, Pattern),
             case binary:part(Number, Start, End) of
                 <<>> when Capture =:= <<>> ->


### PR DESCRIPTION
When adding feature codes, kazoo-ui would send a too-greedy regex
(See featurecode.js, end of the last line).
If one cannot add feature code `*56` after `*5` is there, one has
to run `sup callflow_maintenance update_feature_codes {Account}`
then re-add `*56`.