### PR TITLE
"authz_local_resources" .. support for node specific configuration

### DIFF
--- a/applications/jonny5/src/j5_authz_req.erl
+++ b/applications/jonny5/src/j5_authz_req.erl
@@ -43,9 +43,12 @@ determine_account_id(Request) ->
 
 -spec maybe_local_resource(ne_binary(), wh_proplist(), j5_request:request()) -> 'ok'.
 maybe_local_resource(AccountId, Props, Request) ->
-    %% TODO: we need to check system_config to determine if we authz local
-    case wh_number_properties:is_local_number(Props) of
+    Node = j5_request:node(Request),
+    case wh_number_properties:is_local_number(Props) 
+       andalso whapps_config:get_is_false(<<"ecallmgr">>, 'authz_local_resources', 'false', Node) 
+    of
         'false' ->
+            lager:debug("authz_local_resources enabled, applying limits for local numbers"),
             maybe_account_limited(
               j5_request:set_account_id(AccountId, Request)
              );

--- a/applications/jonny5/src/j5_request.erl
+++ b/applications/jonny5/src/j5_request.erl
@@ -44,6 +44,7 @@
 -export([timestamp/1]).
 -export([message_id/1]).
 -export([server_id/1]).
+-export([node/1]).
 -export([classification/1]).
 -export([number/1]).
 -export([per_minute_cost/1]).
@@ -66,6 +67,7 @@
                   ,sip_request :: api_binary()
                   ,message_id :: api_binary()
                   ,server_id :: api_binary()
+                  ,node :: api_binary()                  
                   ,classification :: api_binary()
                   ,number :: api_binary()
                   ,billing_seconds = 0 :: non_neg_integer()
@@ -102,6 +104,7 @@ from_jobj(JObj) ->
              ,sip_request = Request
              ,message_id = wh_json:get_value(<<"Msg-ID">>, JObj)
              ,server_id = wh_json:get_value(<<"Server-ID">>, JObj)
+             ,node = wh_json:get_value(<<"Node">>, JObj)             
              ,billing_seconds = wh_json:get_integer_value(<<"Billing-Seconds">>, JObj, 0)
              ,answered_time = wh_json:get_integer_value(<<"Answered-Seconds">>, JObj, 0)
              ,timestamp = wh_json:get_integer_value(<<"Timestamp">>, JObj, wh_util:current_tstamp())
@@ -385,6 +388,15 @@ message_id(#request{message_id=MessageId}) -> MessageId.
 %%--------------------------------------------------------------------
 -spec server_id(request()) -> api_binary().
 server_id(#request{server_id=ServerId}) -> ServerId.
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec node(request()) -> api_binary().
+node(#request{node=NodeId}) -> NodeId.
 
 %%--------------------------------------------------------------------
 %% @public


### PR DESCRIPTION
Currently even with authz_local_resources set to true, calls placed to local number resources do not  consume an inbound trunk.  This commit addresses this issue. With "authz_local_resources" will now be checked,  if true (for individual node or default) AND the number is local, authz will process the call for authorization.

This commit is an enhancement to "https://github.com/2600hz/kazoo/pull/502" since it now validates the configuration parameters on a per node basis.