### PR TITLE
Callflows no longer continue if channel is hung up (related to KAZOO-3250)

### DIFF
--- a/applications/callflow/src/cf_exe.erl
+++ b/applications/callflow/src/cf_exe.erl
@@ -513,10 +513,6 @@ handle_event(JObj, #state{cf_module_pid=PidRef
                                ,{'cf_event_pids', Others}
                               ]}
             end;
-        {{<<"call_event">>, <<"CHANNEL_DESTROY">>}, CallId} ->
-            {'reply', [{'cf_module_pid', get_pid(PidRef)}
-                       ,{'cf_event_pids', Others}
-                      ]};
         {{<<"call_event">>, <<"usurp_control">>}, CallId} ->
             _ = case whapps_call:custom_channel_var(<<"Fetch-ID">>, Call)
                     =:= wh_json:get_value(<<"Fetch-ID">>, JObj)
@@ -687,7 +683,7 @@ spawn_cf_module(CFModule, Data, Call) ->
 send_amqp_message(API, PubFun, Q) ->
     PubFun(add_server_id(API, Q)).
 
--spec maybe_flag_destroyed(pid(), {api_binary(), api_binary()}) -> any().
+-spec maybe_flag_destroyed(pid(), {api_binary(), api_binary()}) -> 'ok'.
 maybe_flag_destroyed(Srv, {<<"call_event">>, <<"CHANNEL_DESTROY">>}) ->
     gen_listener:cast(Srv, 'flag_destroyed');
 maybe_flag_destroyed(_, _) ->

--- a/applications/callflow/src/cf_exe.erl
+++ b/applications/callflow/src/cf_exe.erl
@@ -17,7 +17,6 @@
 -export([queue_name/1]).
 -export([control_queue/1, control_queue/2]).
 -export([continue/1, continue/2]).
--export([force_continue/2]).
 -export([continue_with_flow/2]).
 -export([branch/2]).
 -export([stop/1]).
@@ -59,6 +58,7 @@
                 ,status = <<"sane">> :: ne_binary()
                 ,queue :: api_binary()
                 ,self = self()
+                ,destroyed = 'false' :: boolean()
                }).
 -type state() :: #state{}.
 
@@ -107,13 +107,6 @@ continue(Key, Srv) when is_pid(Srv) ->
 continue(Key, Call) ->
     Srv = whapps_call:kvs_fetch('consumer_pid', Call),
     continue(Key, Srv).
-
--spec force_continue(ne_binary(), whapps_call:call() | pid()) -> 'ok'.
-force_continue(Key, Srv) when is_pid(Srv) ->
-	gen_listener:cast(Srv, {'force_continue', Key});
-force_continue(Key, Call) ->
-	Srv = whapps_call:kvs_fetch('consumer_pid', Call),
-	force_continue(Key, Srv).
 
 -spec continue_with_flow(wh_json:object(), whapps_call:call() | pid()) -> 'ok'.
 continue_with_flow(Flow, Srv) when is_pid(Srv) ->
@@ -240,7 +233,8 @@ relay_amqp(JObj, Props) ->
                P when is_pid(P) -> [P | props:get_value('cf_event_pids', Props, [])];
                _ -> props:get_value('cf_event_pids', Props, [])
            end,
-    [whapps_call_command:relay_event(Pid, JObj) || Pid <- Pids, is_pid(Pid)].
+    [whapps_call_command:relay_event(Pid, JObj) || Pid <- Pids, is_pid(Pid)],
+    maybe_flag_destroyed(props:get_value('server', Props), wh_util:get_event_type(JObj)).
 
 -spec send_amqp(pid() | whapps_call:call(), api_terms(), wh_amqp_worker:publish_fun()) -> 'ok'.
 send_amqp(Srv, API, PubFun) when is_pid(Srv), is_function(PubFun, 1) ->
@@ -337,19 +331,16 @@ handle_call(_Request, _From, State) ->
 %%--------------------------------------------------------------------
 handle_cast({'set_call', Call}, State) ->
     {'noreply', State#state{call=Call}};
-handle_cast({'continue', Key}, #state{cf_module_pid=OldPidRef
-									  ,call=Call
+handle_cast({'continue', _}, #state{destroyed='true'}=State) ->
+    lager:info("channel no longer active, not continuing"),
+    ?MODULE:hard_stop(self()),
+    {'noreply', State};
+handle_cast({'continue', Key}, #state{flow=Flow
+                                      ,cf_module_pid=OldPidRef
                                      }=State) ->
     lager:info("continuing to child '~s'", [Key]),
     maybe_stop_caring(OldPidRef),
 
-    spawn(
-      fun() ->
-          continue_if_still_active(Key, Call)
-      end),
-    {'noreply', State};
-handle_cast({'force_continue', Key}, #state{flow=Flow
-										   }=State) ->
 	case wh_json:get_value([<<"children">>, Key], Flow) of
         'undefined' when Key =:= <<"_">> ->
             lager:info("wildcard child does not exist, we are lost...hanging up"),
@@ -377,6 +368,8 @@ handle_cast('transfer', State) ->
     {'stop', {'shutdown', 'transfer'}, State};
 handle_cast('control_usurped', State) ->
     {'stop', {'shutdown', 'control_usurped'}, State};
+handle_cast('flag_destroyed', State) ->
+    {'noreply', State#state{destroyed='true'}};
 handle_cast({'continue_with_flow', NewFlow}, State) ->
     lager:info("callflow has been reset"),
     {'noreply', launch_cf_module(State#state{flow=NewFlow})};
@@ -434,16 +427,6 @@ handle_cast({'gen_listener', {'is_consuming', 'true'}}
 handle_cast(_Msg, State) ->
     lager:debug("unhandled cast: ~p", [_Msg]),
     {'noreply', State}.
-
--spec continue_if_still_active(ne_binary(), whapps_call:call()) -> 'ok'.
-continue_if_still_active(Key, Call) ->
-    case whapps_call_command:b_channel_status(Call) of
-        {'error', E} ->
-            lager:info("channel no longer active (~p), not continuing", [E]),
-            ?MODULE:hard_stop(Call);
-        {'ok', _} ->
-            ?MODULE:force_continue(Key, Call)
-    end.
 
 -spec event_listener_name(whapps_call:call(), atom() | ne_binary()) -> ne_binary().
 event_listener_name(Call, Module) ->
@@ -525,6 +508,8 @@ handle_event(JObj, #state{cf_module_pid=PidRef
                                ,{'cf_event_pids', Others}
                               ]}
             end;
+        {{<<"call_event">>, <<"CHANNEL_DESTROY">>}, CallId} ->
+            {'reply', []};
         {{<<"call_event">>, <<"usurp_control">>}, CallId} ->
             _ = case whapps_call:custom_channel_var(<<"Fetch-ID">>, Call)
                     =:= wh_json:get_value(<<"Fetch-ID">>, JObj)
@@ -694,6 +679,12 @@ spawn_cf_module(CFModule, Data, Call) ->
 -spec send_amqp_message(api_terms(), wh_amqp_worker:publish_fun(), ne_binary()) -> 'ok'.
 send_amqp_message(API, PubFun, Q) ->
     PubFun(add_server_id(API, Q)).
+
+-spec maybe_flag_destroyed(pid(), {api_binary(), api_binary()}) -> any().
+maybe_flag_destroyed(Srv, {<<"call_event">>, <<"CHANNEL_DESTROY">>}) ->
+    gen_listener:cast(Srv, 'flag_destroyed');
+maybe_flag_destroyed(_, _) ->
+    'ok'.
 
 -spec send_command(wh_proplist(), api_binary(), api_binary()) -> 'ok'.
 send_command(_, 'undefined', _) -> lager:debug("no control queue to send command to");

--- a/applications/callflow/src/cf_exe.erl
+++ b/applications/callflow/src/cf_exe.erl
@@ -514,7 +514,9 @@ handle_event(JObj, #state{cf_module_pid=PidRef
                               ]}
             end;
         {{<<"call_event">>, <<"CHANNEL_DESTROY">>}, CallId} ->
-            {'reply', []};
+            {'reply', [{'cf_module_pid', get_pid(PidRef)}
+                       ,{'cf_event_pids', Others}
+                      ]};
         {{<<"call_event">>, <<"usurp_control">>}, CallId} ->
             _ = case whapps_call:custom_channel_var(<<"Fetch-ID">>, Call)
                     =:= wh_json:get_value(<<"Fetch-ID">>, JObj)


### PR DESCRIPTION
Similar to the fix for KAZOO-3250, callflows should not continue if the a-leg is destroyed during the cf_* module. See https://groups.google.com/forum/#!topic/2600hz-dev/--DJFztGF_Q for discussion