### PR TITLE
KAZOO-3774: get list_entries vcard

### DIFF
--- a/applications/callflow/src/module/cf_cidlistmatch.erl
+++ b/applications/callflow/src/module/cf_cidlistmatch.erl
@@ -30,15 +30,54 @@
 -spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
     CallerIdNumber = whapps_call:caller_id_number(Call),
-    ListEntries = get_list_entries(Data, Call),
-    lager:debug("comparing caller id ~s with match list entries", [CallerIdNumber]),
-    case match_one_of(ListEntries, CallerIdNumber) of
-        {'match', Entry} ->
-            lager:info("matched list ~s entry", [wh_doc:id(Entry)]),
-            handle_match(Call);
-        'nomatch' ->
-            handle_no_match(Call)
+    ListId = wh_doc:id(Data),
+    AccountDb = whapps_call:account_db(Call),
+    lager:debug("comparing caller id ~s with match list ~s entries in ~s", [CallerIdNumber, ListId, AccountDb]),
+    case is_matching_prefix(AccountDb, ListId, CallerIdNumber)
+         orelse is_matching_regexp(AccountDb, ListId, CallerIdNumber)
+    of
+        'true' -> handle_match(Call);
+        'false' -> handle_no_match(Call)
     end.
+
+-spec is_matching_prefix(ne_binary(), ne_binary(), ne_binary()) -> boolean().
+is_matching_prefix(AccountDb, ListId, Number) ->
+    NumberPrefixes = build_keys(Number),
+    Keys = [[ListId, X] || X <- NumberPrefixes],
+    case couch_mgr:get_results(AccountDb, <<"lists/match_prefix_in_list">>, [{'keys', Keys}]) of
+        {'ok', [_ | _]} -> 'true';
+        _ -> 'false'
+    end.
+
+-spec is_matching_regexp(ne_binary(), ne_binary(), ne_binary()) -> boolean().
+is_matching_regexp(AccountDb, ListId, Number) ->
+    case couch_mgr:get_results(AccountDb, <<"lists/regexps_in_list">>, [{'key', ListId}]) of
+        {'ok', Regexps} ->
+            Patterns = [wh_json:get_value(<<"value">>, X) || X <- Regexps],
+            match_regexps(Patterns, Number);
+        _ ->
+            'false'
+    end.
+
+-spec match_regexps(binaries(), ne_binary()) -> boolean().
+match_regexps([Pattern | Rest], Number) ->
+    case re:run(Number, Pattern) of
+        {'match', _} -> 'true';
+        'nomatch' -> match_regexps(Rest, Number)
+    end;
+match_regexps([], _Number) -> 'false'.
+
+%% TODO: this function from hon_util, may be place it somewhere in library?
+-spec build_keys(binary()) -> binaries().
+build_keys(<<"+", E164/binary>>) ->
+    build_keys(E164);
+build_keys(<<D:1/binary, Rest/binary>>) ->
+    build_keys(Rest, D, [D]).
+
+-spec build_keys(binary(), binary(), binaries()) -> binaries().
+build_keys(<<D:1/binary, Rest/binary>>, Prefix, Acc) ->
+    build_keys(Rest, <<Prefix/binary, D/binary>>, [<<Prefix/binary, D/binary>> | Acc]);
+build_keys(<<>>, _, Acc) -> Acc.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -83,38 +122,3 @@ is_callflow_child(Name, Call) ->
             lager:debug("failed to find callflow child"),
             'false'
     end.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Check if caller id matches list entry pattern.
-%% @end
-%%--------------------------------------------------------------------
--spec match_one_of(wh_json:objects(), ne_binary()) ->
-                          {'match', wh_json:object()} |
-                          'nomatch'.
-match_one_of([], _CallerIdNumber) -> 'nomatch';
-match_one_of([Entry|Rest], CallerIdNumber) ->
-    Pattern = wh_json:get_value(<<"pattern">>, Entry),
-    case re:run(CallerIdNumber, Pattern) of
-        {'match', _} -> {'match', Entry};
-        'nomatch' -> match_one_of(Rest, CallerIdNumber)
-    end.
-
--spec get_list_entries(wh_json:object(), whapps_call:call()) -> wh_json:objects().
-get_list_entries(Data, Call) ->
-    ListId = wh_doc:id(Data),
-    AccountDb = whapps_call:account_db(Call),
-    case couch_mgr:open_cache_doc(AccountDb, ListId) of
-        {'ok', ListJObj} ->
-            lager:info("match list loaded: ~s", [ListId]),
-            JObj = wh_json:get_ne_value(<<"entries">>, ListJObj),
-            lists:map(fun get_list_entries_map/1, wh_json:to_proplist(JObj));
-        {'error', Reason} ->
-            lager:info("failed to load match list box ~s, ~p", [ListId, Reason]),
-            []
-    end.
-
--spec get_list_entries_map({ne_binary(), wh_json:object()}) -> wh_json:object().
-get_list_entries_map({K, V}) ->
-    wh_json:set_value(<<"id">>, K, V).

--- a/applications/crossbar/doc/lists.md
+++ b/applications/crossbar/doc/lists.md
@@ -1,0 +1,80 @@
+/*
+Section: Crossbar
+Title: Lists
+Language: en-US
+*/
+
+# Lists
+
+## cURL examples
+
+### Get all lists (doesn't return entries)
+    curl -v -X GET -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists
+
+### Get list properties (doesn't return entries)
+    curl -v -X GET -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}
+
+### Add new list (beware: no entries)
+    curl -v -X PUT -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists -d '{"data": {"name": "list name"}}'
+
+### Replacing list (without entries)
+    curl -v -X POST -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists -d '{"data": {"name": "new list name"}}'
+
+### Updating list (without entries)
+    curl -v -X PATCH -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists -d '{"data": {"description": "desc"}}'
+
+### Delete list and its entries
+    curl -v -X DELETE -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}}
+
+### Delete all entries from list
+    curl -v -X DELETE -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}}/entries
+
+### Add an entry to a list
+    curl -v -X PUT -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}}/entries -d '{"data": {"number": "0123", "displayname" : "List Entry"}}'
+
+### List entry properties
+    curl -v -X GET -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}}/entries/{ENTRY_ID}
+
+### Replace list entry
+    curl -v -X POST -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}}/entries/{ENTRY_ID} -d '{"data": {"number": "0123", "displayname" : "New List Entry"}}'
+
+### Update list entry
+    curl -v -X PATCH -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}}/entries/{ENTRY_ID} -d '{"data": {"firstname" : "First name"}}'
+
+### Delete entry from the list
+    curl -v -X DELETE -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}}/entries/{ENTRY_ID}
+
+### List entry vcard
+    curl -v -X GET -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}}/entries/{ENTRY_ID}/vcard
+
+### Add photo to List entry
+    curl -v -X POST -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}}/entries/{ENTRY_ID}/photo
+
+## v1 examples.
+
+### Get lists and their entries
+    curl -v -X GET -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v1/accounts/{ACCOUNT_ID}/lists
+
+### Create new list
+    curl -v -X PUT -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v1/accounts/{ACCOUNT_ID}/lists -d '{"data": {"name": "List name"}}'
+
+### Get list with LIST_ID
+    curl -v -X GET -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v1/accounts/{ACCOUNT_ID}/lists/{LIST_ID}
+
+### Add new entry to list
+    curl -v -X PUT -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v1/accounts/{ACCOUNT_ID}/lists/{LIST_ID} -d '{"data": {"pattern": "345"}}'
+
+### Rewrite list
+    curl -v -X POST -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v1/accounts/{ACCOUNT_ID}/lists/{LIST_ID} -d '{"data": {"name": "New List name"}}'
+
+### Delete list
+    curl -v -X DELETE -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v1/accounts/{ACCOUNT_ID}/lists/{LIST_ID}
+
+### Get entry {ENTRY_ID} from list {LIST_ID}
+    curl -v -X GET -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v1/accounts/{ACCOUNT_ID}/lists/{LIST_ID}/{ENTRY_ID}
+
+### Rewrite entry {ENTRY_ID} in list {LIST_ID}
+    curl -v -X POST -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v1/accounts/{ACCOUNT_ID}/lists/{LIST_ID}/{ENTRY_ID} -d "{"data": {"132", "321"}}"
+
+### Delete entry from list
+    curl -v -X DELETE -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v1/accounts/{ACCOUNT_ID}/lists/{LIST_ID}/{ENTRY_ID}

--- a/applications/crossbar/priv/couchdb/account/lists.json
+++ b/applications/crossbar/priv/couchdb/account/lists.json
@@ -6,7 +6,23 @@
     "language": "javascript",
     "views": {
         "crossbar_listing": {
-            "map": "function(doc) { if (doc.pvt_type == 'list' && !doc.pvt_deleted) emit(doc._id, {'id': doc._id, 'name': doc.name, 'entries': doc.entries}) };"
+            "map": "function(doc) {if (doc.pvt_deleted) return; doc.id = doc._id; if (doc.pvt_type == 'list_entry') emit(doc.list_id, {id: doc._id, pattern: doc.pattern, displayname: doc.displayname, firstname: doc.firstname, lastname: doc.lastname}); if (doc.pvt_type == 'list') emit(doc._id, doc);}",
+            "reduce": "function(keys, values, rereduce) {var a = {entries: {}}; var i = 0; var l = values.length; for (i; i < l; i++) {if (values[i].pvt_type == 'list') {if (!values[i].entries) values[i].entries = {}; for (j in a.entries) {values[i].entries[j] = a.entries[j]}; a = values[i];} else {if (values[i].id) a.entries[values[i].id] = values[i]; else {for (j in values[i].entries) a.entries[j] = values[i].entries[j];}}} return a;}"
+        },
+        "crossbar_listing_v2": {
+            "map": "function(doc) {if ((doc.pvt_type != 'list') || doc.pvt_deleted) return; emit(doc._id, {'id': doc._id, 'name': doc.name, 'description': doc.description});}"
+        },
+        "entries": {
+            "map": "function(doc) {if ((doc.pvt_type != 'list_entry') || doc.pvt_deleted) return; emit(doc.list_id, doc);}"
+        },
+        "match_prefix": {
+            "map": "function(doc) {if ((doc.pvt_type != 'list_entry') || doc.pvt_deleted || (doc.number == null && doc.prefix == null)) return; emit(doc.number ? doc.number : doc.prefix, null);}"
+        },
+        "match_prefix_in_list": {
+            "map": "function(doc) {if ((doc.pvt_type != 'list_entry') || doc.pvt_deleted || (doc.number == null && doc.prefix == null)) return; emit([doc.list_id, doc.number ? doc.number : doc.prefix], null);}"
+        },
+        "regexps_in_list": {
+            "map": "function(doc) {if ((doc.pvt_type != 'list_entry') || doc.pvt_deleted || !doc.regexp) return; emit(doc.list_id, doc.regexp);}"
         }
     }
 }

--- a/applications/crossbar/priv/couchdb/schemas/list_entries.json
+++ b/applications/crossbar/priv/couchdb/schemas/list_entries.json
@@ -27,11 +27,30 @@
             "required": false,
             "type": "string"
         },
+        "list_id": {
+            "description": "List id",
+            "name": "List id",
+            "required": true,
+            "type": "string"
+        },
+        "number": {
+            "description": "Phone number",
+            "name": "Number",
+            "required": false,
+            "type": "string"
+        },
         "pattern": {
             "description": "Match pattern",
             "name": "Pattern",
-            "required": true,
+            "required": false,
             "type": "string"
+        },
+        "profile": {
+            "$ref": "profile",
+            "default": {},
+            "description": "Profile data",
+            "required": false,
+            "type": "object"
         },
         "type": {
             "maxLength": 128,

--- a/applications/crossbar/priv/couchdb/schemas/lists.json
+++ b/applications/crossbar/priv/couchdb/schemas/lists.json
@@ -3,12 +3,13 @@
     "_id": "lists",
     "description": "Schema for a match list",
     "properties": {
-        "entries": {
-            "default": {},
-            "description": "Patterns used by match list",
-            "name": "Patterns",
+        "description": {
+            "description": "A friendly list description",
+            "maxLength": 128,
+            "minLength": 1,
+            "name": "Description",
             "required": false,
-            "type": "object"
+            "type": "string"
         },
         "name": {
             "description": "A friendly match list name",
@@ -16,6 +17,12 @@
             "minLength": 1,
             "name": "Name",
             "required": true,
+            "type": "string"
+        },
+        "org": {
+            "description": "Full legal name of the organization",
+            "name": "Organizational name",
+            "required": false,
             "type": "string"
         }
     },

--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -92,6 +92,7 @@ migrate_account_data(Account) ->
     _ = cb_clicktocall:maybe_migrate_history(Account),
     _ = migrate_ring_group_callflow(Account),
     _ = cb_vmboxes:migrate(Account),
+    _ = cb_lists_v2:maybe_migrate(Account),
     'no_return'.
 
 -spec add_missing_modules(atoms(), atoms()) -> 'no_return'.

--- a/applications/crossbar/src/modules_v2/cb_lists_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_lists_v2.erl
@@ -1,0 +1,265 @@
+%%%----------------------------------------------------------------------------
+%%% @copyright (C) 2011-2015, 2600Hz INC
+%%% @doc
+%%% Match list module
+%%%
+%%% Handle client requests for match list documents, api v2
+%%%
+%%% @end
+%%% @contributors
+%%%   SIPLABS, LLC (Ilya Ashchepkov)
+%%%----------------------------------------------------------------------------
+-module(cb_lists_v2).
+
+-export([maybe_migrate/1]).
+-export([init/0
+         ,allowed_methods/0, allowed_methods/1, allowed_methods/2, allowed_methods/3, allowed_methods/4
+         ,resource_exists/0, resource_exists/1, resource_exists/2, resource_exists/3, resource_exists/4
+         ,content_types_provided/1, content_types_provided/2, content_types_provided/3, content_types_provided/4, content_types_provided/5
+         ,validate/1, validate/2, validate/3, validate/4, validate/5
+         ,delete/2, delete/3, delete/4
+         ,save/1, save/2, save/3, save/4, save/5
+        ]).
+
+-include("../crossbar.hrl").
+
+-define(ENTRIES, <<"entries">>).
+-define(VCARD, <<"vcard">>).
+-define(PHOTO, <<"photo">>).
+%%%===================================================================
+%%% API
+%%%===================================================================
+-spec maybe_migrate(ne_binary()) -> 'ok'.
+maybe_migrate(Account) ->
+    AccountDb = wh_util:format_account_id(Account, 'encoded'),
+    case couch_mgr:get_results(AccountDb, <<"lists/crossbar_listing_v2">>, ['include_docs']) of
+        {'ok', []} -> 'ok';
+        {'ok', Lists} -> migrate(AccountDb, Lists);
+        {'error', _} -> 'ok'
+    end.
+
+-spec migrate(ne_binary(), wh_json:objects()) -> 'ok'.
+migrate(AccountDb, [List | Lists]) ->
+    DocId = wh_json:get_value(<<"id">>, List),
+    Entries = wh_json:to_proplist(wh_json:get_value([<<"doc">>, <<"entries">>], List, wh_json:new())),
+
+    %% NOTE: this function will rewrite existing entry with the same id.
+    %% If in lists will be entry with same id only last will be saved.
+    MigrateEntryFun = fun({Id, Entry}) ->
+                              wh_json:set_values([{<<"pvt_type">>, <<"list_entry">>}
+                                                  ,{<<"_id">>, Id}
+                                                  ,{<<"list_id">>, DocId}]
+                                                 ,Entry)
+                      end,
+    Entries1 = lists:map(MigrateEntryFun, Entries),
+    couch_mgr:save_doc(AccountDb, Entries1),
+    Doc = wh_json:delete_key(<<"entries">>, wh_json:get_value(<<"doc">>, List)),
+    couch_mgr:save_doc(AccountDb, Doc),
+    migrate(AccountDb, Lists);
+migrate(_AccountDb, []) ->
+    'ok'.
+
+-spec init() -> any().
+init() ->
+    [crossbar_bindings:bind(Binding, ?MODULE, F)
+     || {Binding, F} <- [{<<"v2_resource.allowed_methods.lists">>, 'allowed_methods'}
+                         ,{<<"v2_resource.resource_exists.lists">>, 'resource_exists'}
+                         ,{<<"v2_resource.content_types_provided.lists">>, 'content_types_provided'}
+                         ,{<<"v2_resource.validate.lists">>, 'validate'}
+                         ,{<<"v2_resource.execute.put.lists">>, 'save'}
+                         ,{<<"v2_resource.execute.post.lists">>, 'save'}
+                         ,{<<"v2_resource.execute.patch.lists">>, 'save'}
+                         ,{<<"v2_resource.execute.delete.lists">>, 'delete'}
+                        ]
+    ].
+
+-spec allowed_methods() -> http_methods().
+-spec allowed_methods(path_token()) -> http_methods().
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
+-spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
+allowed_methods() ->
+    [?HTTP_GET, ?HTTP_PUT].
+allowed_methods(_ListId) ->
+    [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
+allowed_methods(_ListId, ?ENTRIES) ->
+    [?HTTP_GET, ?HTTP_PUT, ?HTTP_DELETE].
+allowed_methods(_List, ?ENTRIES, _EntryId) ->
+    [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
+allowed_methods(_List, ?ENTRIES, _EntryId, ?VCARD) ->
+    [?HTTP_GET];
+allowed_methods(_List, ?ENTRIES, _EntryId, ?PHOTO) ->
+    [?HTTP_POST].
+
+-spec resource_exists() -> 'true'.
+-spec resource_exists(path_token()) -> 'true'.
+-spec resource_exists(path_token(), path_token()) -> 'true'.
+-spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
+-spec resource_exists(path_token(), path_token(), path_token(), path_token()) -> 'true'.
+resource_exists() -> 'true'.
+resource_exists(_ListId) -> 'true'.
+resource_exists(_ListId, ?ENTRIES) -> 'true'.
+resource_exists(_ListId, ?ENTRIES, _EntryId) -> 'true'.
+resource_exists(_ListId, ?ENTRIES, _EntryId, ?VCARD) -> 'true'.
+
+-spec content_types_provided(cb_context:context()) ->
+                                    cb_context:context().
+-spec content_types_provided(cb_context:context(), path_token()) ->
+                                    cb_context:context().
+-spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
+                                    cb_context:context().
+-spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token()) ->
+                                    cb_context:context().
+content_types_provided(Context) ->
+    Context.
+content_types_provided(Context, _) ->
+    Context.
+content_types_provided(Context, _, _) ->
+    Context.
+content_types_provided(Context, _, _, _) ->
+    Context.
+content_types_provided(Context, _, ?ENTRIES, _, ?VCARD) ->
+    cb_context:set_content_types_provided(Context, [{'to_binary', [{<<"text">>, <<"x-vcard">>}
+                                                                   ,{<<"text">>, <<"directory">>}]}]).
+
+-spec validate(cb_context:context()) -> cb_context:context().
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
+-spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
+-spec validate(cb_context:context(), path_token(), path_token(), path_token(), path_token()) -> cb_context:context().
+validate(Context) ->
+    validate_req(cb_context:req_verb(Context), Context, []).
+validate(Context, ListId) ->
+    validate_req(cb_context:req_verb(Context), Context, [ListId]).
+validate(Context, ListId, ?ENTRIES) ->
+    validate_req(cb_context:req_verb(Context), Context, [ListId, ?ENTRIES]).
+validate(Context, ListId, ?ENTRIES, EntryId) ->
+    validate_req(cb_context:req_verb(Context), Context, [ListId, ?ENTRIES, EntryId]).
+validate(Context, ListId, ?ENTRIES, EntryId, ?VCARD) ->
+    validate_req(cb_context:req_verb(Context), Context, [ListId, ?ENTRIES, EntryId, ?VCARD]).
+
+-spec validate_req(http_method(), cb_context:context(), path_tokens()) -> cb_context:context().
+validate_req(?HTTP_GET, Context, []) ->
+    crossbar_doc:load_view(<<"lists/crossbar_listing_v2">>, [], Context, fun normalize_list/2);
+validate_req(?HTTP_PUT, Context, []) ->
+    validate_doc('undefined', <<"list">>, Context);
+
+validate_req(?HTTP_GET, Context, [ListId]) ->
+    crossbar_doc:load(ListId, Context);
+validate_req(?HTTP_DELETE, Context, [ListId]) ->
+    crossbar_doc:load_view(<<"lists/entries">>, [{'key', ListId}], Context);
+validate_req(?HTTP_POST, Context, [ListId]) ->
+    validate_doc(ListId, <<"list">>, Context);
+validate_req(?HTTP_PATCH, Context, [ListId] = Path) ->
+    crossbar_doc:patch_and_validate(ListId, Context, fun(_Id, C) -> validate_req(?HTTP_POST, C, Path) end);
+
+validate_req(?HTTP_GET, Context, [ListId, ?ENTRIES]) ->
+    crossbar_doc:load_view(<<"lists/entries">>, [{'key', ListId}], Context);
+validate_req(?HTTP_PUT, Context, [ListId, ?ENTRIES]) ->
+    ReqData = wh_json:set_values([{<<"list_id">>, ListId}], cb_context:req_data(Context)),
+    validate_doc('undefined', <<"list_entry">>, cb_context:set_req_data(Context, ReqData));
+validate_req(?HTTP_DELETE, Context, [ListId, ?ENTRIES]) ->
+    crossbar_doc:load_view(<<"lists/entries">>, [{'key', ListId}], Context);
+
+validate_req(?HTTP_GET, Context, [_ListId, ?ENTRIES, EntryId]) ->
+    crossbar_doc:load(EntryId, Context);
+validate_req(?HTTP_DELETE, Context, [_ListId, ?ENTRIES, EntryId]) ->
+    crossbar_doc:load(EntryId, Context);
+validate_req(?HTTP_POST, Context, [_ListId, ?ENTRIES, EntryId]) ->
+    validate_doc(EntryId, <<"list_entry">>, Context);
+validate_req(?HTTP_PATCH, Context, [_ListId, ?ENTRIES, EntryId] = Path) ->
+    crossbar_doc:patch_and_validate(EntryId, Context, fun(_Id, C) -> validate_req(?HTTP_POST, C, Path) end);
+
+validate_req(?HTTP_GET, Context, [_ListId, ?ENTRIES, EntryId, ?VCARD]) ->
+    Context1 = crossbar_doc:load(EntryId, Context),
+    JObj = cb_context:doc(Context1),
+    JProfile = wh_json:get_value(<<"profile">>, JObj),
+    JObj1 = wh_json:merge_jobjs(JObj, JProfile),
+    JObj2 = wh_json:set_values(
+              props:filter_empty(
+                [{<<"first_name">>, wh_json:get_value(<<"firstname">>, JObj1)}
+                 ,{<<"last_name">>, wh_json:get_value(<<"lastname">>, JObj1)}
+                 ,{<<"middle_name">>, wh_json:get_value(<<"middlename">>, JObj1)}
+                 ,{<<"nicknames">>, [wh_json:get_value(<<"displayname">>, JObj1)]}])
+              ,JObj1),
+    JObj3 = set_org(JObj2, Context1),
+    JObj4 = set_photo(JObj3, Context1),
+    RespData = kzd_user:to_vcard(JObj4),
+    cb_context:set_resp_data(Context1, [RespData, "\n"]).
+
+-spec validate_doc(api_binary(), ne_binary(), cb_context:context()) -> cb_context:context().
+validate_doc(Id, Type, Context) ->
+    OnSuccess = fun(C) -> on_successfull_validation(Id, Type, C) end,
+    cb_context:validate_request_data(type_schema_name(Type), Context, OnSuccess).
+
+-spec delete(cb_context:context(), path_token()) -> cb_context:context().
+-spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
+-spec delete(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
+delete(Context, ListId) ->
+    delete(Context, ListId, ?ENTRIES),
+    Context1 = crossbar_doc:load(ListId, Context),
+    crossbar_doc:delete(Context1).
+delete(Context, _ListId, ?ENTRIES) ->
+    Docs = [wh_json:get_value(<<"id">>, Entry) || Entry <- cb_context:doc(Context)],
+    AccountDb = wh_util:format_account_id(cb_context:account_db(Context), 'encoded'),
+    %% do we need 'soft' delete as in crossbar_doc?
+    couch_mgr:del_docs(AccountDb, Docs),
+    Context.
+delete(Context, _ListId, ?ENTRIES, _EntryId) ->
+    crossbar_doc:delete(Context).
+
+-spec save(cb_context:context()) -> cb_context:context().
+-spec save(cb_context:context(), path_token(), path_token()) -> cb_context:context().
+save(Context) ->
+    crossbar_doc:save(Context).
+save(Context, _) ->
+    save(Context).
+save(Context, _, ?ENTRIES) ->
+    save(Context).
+save(Context, _, ?ENTRIES, _) ->
+    save(Context).
+save(Context, _, ?ENTRIES, EntryId, ?PHOTO) ->
+    %% May be move code from cb_users_v2 to crossbar_doc?
+    cb_users_v2:post(Context, EntryId, ?PHOTO).
+
+-spec type_schema_name(ne_binary()) -> ne_binary().
+type_schema_name(<<"list">>) -> <<"lists">>;
+type_schema_name(<<"list_entry">>) -> <<"list_entries">>.
+
+-spec on_successfull_validation(api_binary(), ne_binary(), cb_context:context()) -> cb_context:context().
+on_successfull_validation('undefined', Type, Context) ->
+    Doc = wh_json:set_values([{<<"pvt_type">>, Type}], cb_context:doc(Context)),
+    cb_context:set_doc(Context, Doc);
+on_successfull_validation(Id, _Type, Context) ->
+    crossbar_doc:load_merge(Id, Context).
+
+-spec set_org(wh_json:object(), cb_context:context()) -> wh_json:object().
+set_org(JObj, Context) ->
+    Context1 = crossbar_doc:load(wh_json:get_value(<<"list_id">>, JObj), Context),
+    set_org(JObj, Context1, cb_context:resp_status(Context1)).
+
+-spec set_org(wh_json:object(), cb_context:context(), crossbar_status()) -> wh_json:object().
+set_org(JObj, Context, 'success') ->
+    case wh_json:get_value(<<"org">>, cb_context:doc(Context)) of
+        'undefined' -> JObj;
+        Val -> wh_json:set_value(<<"org">>, Val, JObj)
+    end;
+set_org(JObj, Context, _) ->
+    lager:debug("failed to load list ~p while loading list entry ~p", [crossbar_doc:doc_id(Context), wh_json:get_value(<<"id">>, JObj)]),
+    JObj.
+
+-spec set_photo(wh_json:object(), cb_context:context()) -> wh_json:object().
+set_photo(JObj, Context) ->
+    %% This code is copied from cb_users_v2. May be move it to crossbar_doc?
+    DocId = wh_json:get_value(<<"_id">>, cb_context:doc(Context)),
+    Attach = crossbar_doc:load_attachment(DocId, ?PHOTO, Context),
+    case cb_context:resp_status(Attach) of
+        'error' -> JObj;
+        'success' ->
+            Data = cb_context:resp_data(Attach),
+            CT = wh_doc:attachment_content_type(cb_context:doc(Context), ?PHOTO),
+            wh_json:set_value(?PHOTO, wh_json:from_list([{CT, Data}]), JObj)
+    end.
+
+-spec normalize_list(wh_json:object(), wh_json:objects()) -> wh_json:objects().
+normalize_list(JObj, Acc) ->
+    [wh_json:get_value(<<"value">>, JObj) | Acc].

--- a/core/kazoo_documents-1.0.0/test/kzd_user_test.erl
+++ b/core/kazoo_documents-1.0.0/test/kzd_user_test.erl
@@ -1,0 +1,37 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2015, 2600Hz
+%%% @doc
+%%% User document: tests
+%%% @end
+%%% @contributors
+%%%   SIPLABS, LLS (Ilya Ashchepkov)
+%%%-------------------------------------------------------------------
+-module(kzd_user_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DOC, wh_json:set_values([{<<"first_name">>, "F"}
+                                 ,{<<"last_name">>, "L"}
+                                 ,{<<"email">>, <<"email@example.com">>}
+                                 ,{<<"vm_to_email_enabled">>, 'true'}]
+                                , wh_json:new())).
+-define(EMPTY, wh_json:new()).
+
+email_test() ->
+    ?assertEqual(<<"email@example.com">>,   kzd_user:email(?DOC)),
+    ?assertEqual('undefined',               kzd_user:email(?EMPTY)),
+    ?assertEqual(<<"email@example.com">>,   kzd_user:email(?EMPTY, <<"email@example.com">>)).
+
+voicemail_notification_enabled_test() ->
+    ?assertEqual('true',    kzd_user:voicemail_notification_enabled(?DOC)),
+    ?assertEqual('false',   kzd_user:voicemail_notification_enabled(?EMPTY)),
+    ?assertEqual('true',    kzd_user:voicemail_notification_enabled(?EMPTY, 'true')).
+
+to_vcard_test() ->
+    ?assertEqual(<<"BEGIN:VCARD\n"
+                   "VERSION:3.0\n"
+                   "FN:F L\n"
+                   "N:L;F\n"
+                   "EMAIL:email@example.com\n"
+                   "END:VCARD">>
+                 , kzd_user:to_vcard(?DOC)).


### PR DESCRIPTION
I added tests for `kzd_users.erl` to this commit.

For using `lists/crossbar_listing` couchdb view (this means "v1 API") you should add
```ini
[query_server_config]
reduce_limit = false
```
to `/etc/kazoo/bigcouch/local.ini`

And this commit brokes v1 API compatibility:
It was allowed to add/update `lists` with `enries` and their IDs in old API.
This ability allowed to have different `entries` with same IDs in different `lists`.
Now `list entry` is separate document, so I wanted prevent ability to rewrite `list entries` when updating `list`.