### PR TITLE
Fixes to schema.

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/users.json
+++ b/applications/crossbar/priv/couchdb/schemas/users.json
@@ -500,6 +500,13 @@
             "description": "User's profile data",
             "$ref":"profile",
             "default": {}
+        },
+        "presence_id": {
+            "type": "string",
+            "required": false,
+            "name": "Presence ID",
+            "description": "User's presence ID"
         }
+
     }
 }

--- a/applications/crossbar/priv/couchdb/schemas/webhook_attempts.json
+++ b/applications/crossbar/priv/couchdb/schemas/webhook_attempts.json
@@ -4,7 +4,7 @@
     "type": "object",
     "required": true,
     "name": "Webhook Attempt",
-    "description": "Log of an attempt to send a webhook to a third-party server"
+    "description": "Log of an attempt to send a webhook to a third-party server",
     "properties": {
         "hook_id": {
             "type": "string",


### PR DESCRIPTION
Add presence_id to users schema. If this value set to integer (monster-ui do it at some circumstances) then `cf_attributes:presence_id/2` is crashed wen try `binary:match(PresenceId, <<"@">>)`.
Add missing coma in webhooks_attemps schema.