### PR TITLE
KAZOO-3872

### DIFF
--- a/applications/crossbar/priv/couchdb/account/users.json
+++ b/applications/crossbar/priv/couchdb/account/users.json
@@ -6,10 +6,10 @@
     "language": "javascript",
     "views": {
         "creds_by_md5": {
-            "map": "function(doc) { if(!doc.pvt_md5_auth || (doc.pvt_type != 'user' || doc.pvt_deleted)) return; emit( doc.pvt_md5_auth, {'owner_id': doc._id, 'account_id': doc.pvt_account_id} ); }"
+            "map": "function(doc) { if(!doc.pvt_md5_auth || (doc.pvt_type != 'user' || doc.pvt_deleted || !doc.enabled)) return; emit( doc.pvt_md5_auth, {'owner_id': doc._id, 'account_id': doc.pvt_account_id} ); }"
         },
         "creds_by_sha": {
-            "map": "function(doc) { if(!doc.pvt_sha1_auth || (doc.pvt_type != 'user' || doc.pvt_deleted)) return; emit( doc.pvt_sha1_auth, {'owner_id': doc._id, 'account_id': doc.pvt_account_id} ); }"
+            "map": "function(doc) { if(!doc.pvt_sha1_auth || (doc.pvt_type != 'user' || doc.pvt_deleted || !doc.enabled)) return; emit( doc.pvt_sha1_auth, {'owner_id': doc._id, 'account_id': doc.pvt_account_id} ); }"
         },
         "crossbar_listing": {
             "map": "function(doc) {if (doc.pvt_type != 'user' || doc.pvt_deleted) return;var features = [];if (doc.smartpbx) {for (var feature in doc.smartpbx) {if (doc.smartpbx[feature].enabled) {features.push(feature);}}}if (doc.hotdesk && doc.hotdesk.enabled) {features.push('hotdesk');}if (doc.call_forward && doc.call_forward.enabled) {features.push('call_forward');}if (doc.caller_id && doc.caller_id.external && doc.caller_id.external.number) {features.push('caller_id');}if (doc.vm_to_email_enabled) {features.push('vm_to_email');}if (doc.music_on_hold && doc.music_on_hold.media_id) {features.push('music_on_hold');}emit(doc.last_name + \" \" + doc.first_name, {'id': doc._id,'features': features,'username': doc.username,'email': doc.email,'first_name': doc.first_name,'last_name': doc.last_name,'priv_level': doc.priv_level, 'presence_id': doc.presence_id,'timezone':doc.timezone});}"


### PR DESCRIPTION
Setting enabled field to 'false' in user's doc prevents user associated devices from outbound calling which is great :) 
But still user can authenticate through crossbar's user_auth. 
There could be some reasons for such a behavior which I just can't see, but from the very first look web/api access should also be restricted for blocked user. 

Please consider to accept if it make sense

Regards,