### PR TITLE
Fix double prepend

### DIFF
--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -250,7 +250,8 @@ update_ccvs(Call) ->
                ,{<<"Caller-ID-Number">>, CIDNumber}
                | get_incoming_security(Call)
               ]),
-    whapps_call:set_custom_channel_vars(Props, Call).
+    Call1 = whapps_call:kvs_erase(['prepend_cid_name', 'prepend_cid_number'], Call),
+    whapps_call:set_custom_channel_vars(Props, Call1).
 
 -spec maybe_start_metaflow(whapps_call:call()) -> whapps_call:call().
 maybe_start_metaflow(Call) ->


### PR DESCRIPTION
If phone number have "prepend" attribute - this prepend apllied in "cf_route_win" and "cf_endpoint" (each time it call cf_attributes:caller_id/2).