### PR TITLE
KAZOO-3993: if configured include a cluster_id in the request

### DIFF
--- a/applications/crossbar/src/modules/provisioner_v5.erl
+++ b/applications/crossbar/src/modules/provisioner_v5.erl
@@ -540,8 +540,13 @@ req_headers(Token) ->
     props:filter_undefined(
         [{"Content-Type", "application/json"}
          ,{"X-Auth-Token", wh_util:to_list(Token)}
+         ,{"X-Kazoo-Cluster-ID", get_cluster_id()}
          ,{"User-Agent", wh_util:to_list(erlang:node())}
         ]).
+
+-spec get_cluster_id() -> 'undefined' | string().
+get_cluster_id() ->
+    whapps_config:get_string(?MOD_CONFIG_CAT, <<"cluster_id">>).
 
 %%--------------------------------------------------------------------
 %% @private


### PR DESCRIPTION
This will need to be backported to 3.19+