### PR TITLE
Resolved DTMF ending up in default key when entered quickly

### DIFF
--- a/applications/callflow/src/module/cf_collect_dtmf.erl
+++ b/applications/callflow/src/module/cf_collect_dtmf.erl
@@ -32,17 +32,15 @@ handle(Data, Call) ->
     AlreadyCollected =
         case whapps_call:get_dtmf_collection(Call) of
             'undefined' -> <<>>;
-            <<_/binary>> = D ->
-                _ = cf_exe:set_call(whapps_call:set_dtmf_collection('undefined', Call)),
-                D
+            <<_/binary>> = D -> D
         end,
 
-    maybe_collect_more_digits(Data, Call, AlreadyCollected).
+    maybe_collect_more_digits(Data, whapps_call:set_dtmf_collection('undefined', Call), AlreadyCollected).
 
 -spec maybe_collect_more_digits(wh_json:object(), whapps_call:call(), binary()) -> 'ok'.
 maybe_collect_more_digits(Data, Call, AlreadyCollected) ->
-	AlreadyCollectedSize = byte_size(AlreadyCollected),
-	MaxDigits = max_digits(Data),
+    AlreadyCollectedSize = byte_size(AlreadyCollected),
+    MaxDigits = max_digits(Data),
 
     maybe_collect_more_digits(Data, Call, AlreadyCollected, AlreadyCollectedSize, MaxDigits),
     cf_exe:continue(Call).


### PR DESCRIPTION
We've previously encountered the issue described at:
https://groups.google.com/forum/#!topic/2600hz-dev/IVIk6Rt8Li4

The previous set of code for cf_collect_dtmf would utilize digits entered early, but not purge them so the next cf_collect_dtmf would be clean