### PR TITLE
KAZOO-4130: as a fax user i want more control and log of processing faxes

### DIFF
--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -36,7 +36,7 @@
           options = [] :: list()
           ,from :: binary()
           ,to :: binary()
-          ,docs = [] :: wh_json:objects()
+          ,doc :: api_object()
           ,filename :: api_binary()
           ,content_type :: binary()
           ,peer_ip :: peer()
@@ -48,6 +48,7 @@
           ,original_number :: api_binary()
           ,number :: api_binary()
           ,account_id :: api_binary()
+          ,session_id :: api_binary()
          }).
 
 -type state() :: #state{}.
@@ -64,7 +65,9 @@ init(Hostname, SessionCount, Address, Options) ->
             Banner = [Hostname, " Kazoo Email to Fax Server"],
             State = #state{options = Options
                            ,peer_ip = Address
+                           ,session_id = wh_util:rand_hex_binary(16)
                           },
+            wh_util:put_callid(State#state.session_id),
             {'ok', Banner, State};
         'true' ->
             lager:warning("connection limit exceeded ~p", [Address]),
@@ -225,7 +228,7 @@ terminate(Reason, State) ->
 -spec handle_message(state()) -> 'ok'.
 handle_message(#state{errors=[_Error | _Errors]}=State) ->
     maybe_faxbox_log(State);
-handle_message(#state{docs=[]}=State) ->
+handle_message(#state{doc='undefined'}=State) ->
     maybe_faxbox_log(State#state{errors=[<<"no fax documents to save">>]});
 handle_message(#state{filename='undefined'}=State) ->
     maybe_faxbox_log(State#state{errors=[<<"no fax attachment to save">>]});
@@ -233,13 +236,16 @@ handle_message(#state{errors=[], faxbox='undefined'}=State) ->
     maybe_faxbox_log(State#state{errors=[<<"no previous errors but no faxbox doc">>]});
 handle_message(#state{filename=Filename
                          ,content_type=CT
-                         ,docs=Docs
+                         ,doc=Doc
                          ,errors=[]
                         }=State) ->
+    lager:debug("checking file ~s", [Filename]),
     case file:read_file(Filename) of
         {'ok', FileContents} ->
-            case fax_util:save_fax_docs(Docs, FileContents, CT) of
-                'ok' -> wh_util:delete_file(Filename);
+            case fax_util:save_fax_docs([Doc], FileContents, CT) of
+                'ok' ->
+                    lager:debug("smtp fax document saved"),
+                    wh_util:delete_file(Filename);
                 {'error', Error} -> maybe_faxbox_log(State#state{errors=[Error]})
             end;
         _Else ->
@@ -581,11 +587,12 @@ maybe_faxbox_by_rules([JObj | JObjs], #state{from=From}=State) ->
 -spec add_fax_document(state()) ->
                               {'ok', state()} |
                               {'error', string(), state()}.
-add_fax_document(#state{docs=Docs
+add_fax_document(#state{doc='undefined'
                         ,from=From
                         ,owner_email=OwnerEmail
                         ,number=FaxNumber
                         ,faxbox=FaxBoxDoc
+                        ,session_id=Id
                        }=State) ->
     FaxBoxId = wh_doc:id(FaxBoxDoc),
     AccountId = wh_doc:account_id(FaxBoxDoc),
@@ -620,6 +627,7 @@ add_fax_document(#state{docs=Docs
                ,{<<"notifications">>, Notify}
                ,{<<"faxbox_id">>, FaxBoxId}
                ,{<<"folder">>, <<"outbox">>}
+               ,{<<"_id">>, Id}
               ]),
 
     Doc = wh_json:set_values([{<<"pvt_type">>, <<"fax">>}
@@ -632,7 +640,12 @@ add_fax_document(#state{docs=Docs
                              ]
                              ,wh_json_schema:add_defaults(wh_json:from_list(Props), <<"faxes">>)
                             ),
-    {'ok', State#state{docs=[Doc | Docs]}}.
+    lager:debug("added fax document from smtp : ~p", [Doc]),
+    {'ok', State#state{doc=Doc}};
+add_fax_document(#state{doc=Doc}=State) ->
+    lager:debug("add fax document called but already has a doc : ~p", [Doc]),
+    {'ok', State}.
+    
 
 %% ====================================================================
 %% Internal functions

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -645,7 +645,7 @@ add_fax_document(#state{doc='undefined'
 add_fax_document(#state{doc=Doc}=State) ->
     lager:debug("add fax document called but already has a doc : ~p", [Doc]),
     {'ok', State}.
-    
+
 
 %% ====================================================================
 %% Internal functions


### PR DESCRIPTION
the sup maintenance commands that already exist are.
```
sup fax_maintenance restart_job JobId
sup fax_maintenance update_job JobIs State
sup fax_maintenance account_jobs AccountId
sup fax_maintenance account_jobs AccountId State
sup fax_maintenance faxbox_jobs FaxboxId
sup fax_maintenance faxbox_jobs FaxboxId State
sup fax_maintenance pending_jobs
sup fax_maintenance active_jobs
```
@k-anderson 
@dschreiber what other tools may we need ?
