### PR TITLE
KAZOO-4137 KAZOO-4138

### DIFF
--- a/applications/omnipresence/src/omnip_subscriptions.erl
+++ b/applications/omnipresence/src/omnip_subscriptions.erl
@@ -354,13 +354,13 @@ subscribe_notify(#omnip_subscription{event=Package
 %% @end
 %%--------------------------------------------------------------------
 -spec distribute_subscribe(integer(), wh_json:object()) -> 'ok'.
-distribute_subscribe(Count, JObj) 
+distribute_subscribe(Count, JObj)
   when Count > 1 ->
     whapps_util:amqp_pool_send(
       wh_json:delete_key(<<"Node">>, JObj)
       ,fun wapi_presence:publish_subscribe/1
      );
-distribute_subscribe(_Count, _JObj) -> 'ok'. 
+distribute_subscribe(_Count, _JObj) -> 'ok'.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/omnipresence/src/omnip_sup.erl
+++ b/applications/omnipresence/src/omnip_sup.erl
@@ -17,10 +17,10 @@
 
 
 %% Helper macro for declaring children of supervisor
--define(CHILDREN, [?WORKER('omnip_dialog')
-                   ,?WORKER('omnip_message_summary')
-                   ,?WORKER('omnip_presence')
-                  ]).
+-define(DEFAULT_MODULES, [<<"omnip_dialog">>
+                          ,<<"omnip_message_summary">>
+                          ,<<"omnip_presence">>
+                         ]).
 
 %% ===================================================================
 %% API functions
@@ -63,4 +63,8 @@ init([]) ->
 
     SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
 
-    {'ok', {SupFlags, ?CHILDREN}}.
+    Children = [ ?WORKER(wh_util:to_atom(H, 'true'))
+                 || H <- whapps_config:get(?CONFIG_CAT, <<"modules">>, ?DEFAULT_MODULES)
+               ],
+
+    {'ok', {SupFlags, Children}}.

--- a/applications/omnipresence/src/wapi_omnipresence.erl
+++ b/applications/omnipresence/src/wapi_omnipresence.erl
@@ -181,7 +181,7 @@ notify_v(JObj) -> notify_v(wh_json:to_proplist(JObj)).
 publish_notify(JObj) -> publish_notify(JObj, ?DEFAULT_CONTENT_TYPE).
 publish_notify(Req, ContentType) ->
     {'ok', Payload} = wh_api:prepare_api_payload(Req, ?NOTIFY_VALUES, fun ?MODULE:notify/1),
-    amqp_util:basic_publish(?DIALOGINFO_SUBS_EXCHANGE, <<>>, Payload, ContentType).
+    amqp_util:basic_publish(?OMNIPRESENCE_EXCHANGE, <<>>, Payload, ContentType).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -292,7 +292,7 @@ bind_q(Queue, 'undefined', Props) ->
                                 ),
     amqp_util:bind_q_to_exchange(Queue
                                  ,?NOTIFY_RK(Props)
-                                 ,?DIALOGINFO_SUBS_EXCHANGE
+                                 ,?OMNIPRESENCE_EXCHANGE
                                 );
 bind_q(Queue, ['subscribe'|Restrict], Props) ->
     amqp_util:bind_q_to_exchange(Queue
@@ -309,7 +309,7 @@ bind_q(Queue, ['update'|Restrict], Props) ->
 bind_q(Queue, ['notify'|Restrict], Props) ->
     amqp_util:bind_q_to_exchange(Queue
                                  ,?NOTIFY_RK(Props)
-                                 ,?DIALOGINFO_SUBS_EXCHANGE
+                                 ,?OMNIPRESENCE_EXCHANGE
                                 ),
     bind_q(Queue, Restrict, Props);
 bind_q(Queue, [_|Restrict], Props) ->
@@ -332,7 +332,7 @@ unbind_q(Queue, 'undefined', Props) ->
                                     ),
     amqp_util:unbind_q_from_exchange(Queue
                                      ,?NOTIFY_RK(Props)
-                                     ,?DIALOGINFO_SUBS_EXCHANGE
+                                     ,?OMNIPRESENCE_EXCHANGE
                                     );
 unbind_q(Queue, ['subscribe'|Restrict], Props) ->
     amqp_util:unbind_q_from_exchange(Queue
@@ -349,7 +349,7 @@ unbind_q(Queue, ['update'|Restrict], Props) ->
 unbind_q(Queue, ['notify'|Restrict], Props) ->
     amqp_util:unbind_q_from_exchange(Queue
                                      ,?NOTIFY_RK(Props)
-                                     ,?DIALOGINFO_SUBS_EXCHANGE
+                                     ,?OMNIPRESENCE_EXCHANGE
                                     ),
     unbind_q(Queue, Restrict, Props);
 unbind_q(Queue, [_|Restrict], Props) ->


### PR DESCRIPTION
load omnipresence modules from configuration so we can disable omnip_presence
KAZOO-4138 - fixes notify exchange
do not publish internal subscribe if there is only one omnipresence server