### PR TITLE
No longer sets language again during pivot callflow exec

### DIFF
--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -214,14 +214,18 @@ store_owner_id(Call) ->
 -spec set_language(whapps_call:call()) -> whapps_call:call().
 set_language(Call) ->
     Default = wh_media_util:prompt_language(whapps_call:account_id(Call)),
-    case cf_endpoint:get(Call) of
-        {'ok', Endpoint} ->
-            Language = kz_device:language(Endpoint, Default),
-            lager:debug("setting language '~s' for this call", [Language]),
-            whapps_call:set_language(wh_util:to_lower_binary(Language), Call);
-        {'error', _E} ->
-            lager:debug("no source endpoint for this call, setting language to default ~s", [Default]),
-            whapps_call:set_language(Default, Call)
+    case whapps_call:language(Call) of
+        Default ->
+            case cf_endpoint:get(Call) of
+                {'ok', Endpoint} ->
+                    Language = kz_device:language(Endpoint, Default),
+                    lager:debug("setting language '~s' for this call", [Language]),
+                    whapps_call:set_language(wh_util:to_lower_binary(Language), Call);
+                {'error', _E} ->
+                    lager:debug("no source endpoint for this call, setting language to default ~s", [Default]),
+                    whapps_call:set_language(Default, Call)
+            end;
+        _ -> Call
     end.
 
 %%-----------------------------------------------------------------------------


### PR DESCRIPTION
If the call language has been changed from the default defined for the calling endpoint, and a pivot script executes, the resulting callflow will overwrite any "Set Language" modules that were called in the previous one. This patch ensures that they are not overwritten.