### PR TITLE
Added support to callflow modules and pivot to utilize custom KVS

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -57,6 +57,7 @@
          ,check_value_of_fields/4
          ,get_timezone/2, account_timezone/1
         ]).
+-export([maybe_use_variable/2]).
 
 -export([wait_for_noop/2]).
 -export([start_task/3]).
@@ -929,6 +930,18 @@ account_timezone(Call) ->
             kz_account:timezone(AccountJObj, ?DEFAULT_TIMEZONE);
         {'error', _E} ->
             whapps_config:get(<<"accounts">>, <<"timezone">>, ?DEFAULT_TIMEZONE)
+    end.
+
+-spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
+maybe_use_variable(Data, Call) ->
+    case wh_json:get_value(<<"var">>, Data) of
+        'undefined' -> wh_doc:id(Data);
+        Variable ->
+            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
+            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
+                {'ok', _} -> Value;
+                _ -> wh_doc:id(Data)
+            end
     end.
 
 -spec start_task(fun(), list(), whapps_call:call()) -> 'ok'.

--- a/applications/callflow/src/module/cf_acdc_member.erl
+++ b/applications/callflow/src/module/cf_acdc_member.erl
@@ -36,7 +36,7 @@
 %%--------------------------------------------------------------------
 -spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
-    QueueId = maybe_use_variable(Data, Call),
+    QueueId = cf_util:maybe_use_variable(Data, Call),
     lager:info("sending call to queue ~s", [QueueId]),
 
     Priority = lookup_priority(Data, Call),
@@ -68,19 +68,6 @@ handle(Data, Call) ->
                                   }
                       ,is_queue_full(MaxQueueSize, CurrQueueSize)
                      ).
-
--spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
-maybe_use_variable(Data, Call) ->
-    case wh_json:get_value(<<"var">>, Data) of
-        'undefined' ->
-            wh_json:get_value(<<"id">>, Data);
-        Variable ->
-            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
-            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
-                {'ok', _} -> Value;
-                _ -> wh_json:get_value(<<"id">>, Data)
-            end
-    end.
 
 -spec lookup_priority(wh_json:object(), whapps_call:call()) -> api_binary().
 lookup_priority(Data, Call) ->

--- a/applications/callflow/src/module/cf_callflow.erl
+++ b/applications/callflow/src/module/cf_callflow.erl
@@ -30,26 +30,13 @@ handle(Data, Call) ->
 
 -spec maybe_branch_callflow(wh_json:object(), whapps_call:call()) -> 'ok'.
 maybe_branch_callflow(Data, Call) ->
-    Id = maybe_use_variable(Data, Call),
+    Id = cf_util:maybe_use_variable(Data, Call),
     case couch_mgr:open_doc(whapps_call:account_db(Call), Id) of
         {'error', R} ->
             lager:info("could not branch to callflow ~s, ~p", [Id, R]),
             cf_exe:continue(Call);
         {'ok', JObj} ->
             continue_if_still_active(Call, JObj)
-    end.
-
--spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
-maybe_use_variable(Data, Call) ->
-    case wh_json:get_value(<<"var">>, Data) of
-        'undefined' ->
-            wh_json:get_value(<<"id">>, Data);
-        Variable ->
-            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
-            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
-                {'ok', _} -> Value;
-                _ -> wh_json:get_value(<<"id">>, Data)
-            end
     end.
 
 -spec continue_if_still_active(whapps_call:call(), wh_json:object()) -> 'ok'.

--- a/applications/callflow/src/module/cf_device.erl
+++ b/applications/callflow/src/module/cf_device.erl
@@ -50,7 +50,7 @@ maybe_handle_bridge_failure(Reason, Call) ->
 -spec bridge_to_endpoints(wh_json:object(), whapps_call:call()) ->
                                  cf_api_bridge_return().
 bridge_to_endpoints(Data, Call) ->
-    EndpointId = maybe_use_variable(Data, Call),
+    EndpointId = cf_util:maybe_use_variable(Data, Call),
     Params = wh_json:set_value(<<"source">>, ?MODULE, Data),
     case cf_endpoint:build(EndpointId, Params, Call) of
         {'error', _}=E -> E;
@@ -58,17 +58,4 @@ bridge_to_endpoints(Data, Call) ->
             Timeout = wh_json:get_integer_value(<<"timeout">>, Data, ?DEFAULT_TIMEOUT_S),
             IgnoreEarlyMedia = cf_util:ignore_early_media(Endpoints),
             whapps_call_command:b_bridge(Endpoints, Timeout, <<"simultaneous">>, IgnoreEarlyMedia, Call)
-    end.
-
--spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
-maybe_use_variable(Data, Call) ->
-    case wh_json:get_value(<<"var">>, Data) of
-        'undefined' ->
-            wh_json:get_value(<<"id">>, Data);
-        Variable ->
-            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
-            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
-                {'ok', _} -> Value;
-                _ -> wh_json:get_value(<<"id">>, Data)
-            end
     end.

--- a/applications/callflow/src/module/cf_device.erl
+++ b/applications/callflow/src/module/cf_device.erl
@@ -50,7 +50,7 @@ maybe_handle_bridge_failure(Reason, Call) ->
 -spec bridge_to_endpoints(wh_json:object(), whapps_call:call()) ->
                                  cf_api_bridge_return().
 bridge_to_endpoints(Data, Call) ->
-    EndpointId = wh_json:get_value(<<"id">>, Data),
+    EndpointId = maybe_use_variable(Data, Call),
     Params = wh_json:set_value(<<"source">>, ?MODULE, Data),
     case cf_endpoint:build(EndpointId, Params, Call) of
         {'error', _}=E -> E;
@@ -58,4 +58,17 @@ bridge_to_endpoints(Data, Call) ->
             Timeout = wh_json:get_integer_value(<<"timeout">>, Data, ?DEFAULT_TIMEOUT_S),
             IgnoreEarlyMedia = cf_util:ignore_early_media(Endpoints),
             whapps_call_command:b_bridge(Endpoints, Timeout, <<"simultaneous">>, IgnoreEarlyMedia, Call)
+    end.
+
+-spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
+maybe_use_variable(Data, Call) ->
+    case wh_json:get_value(<<"var">>, Data) of
+        'undefined' ->
+            wh_json:get_value(<<"id">>, Data);
+        Variable ->
+            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
+            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
+                {'ok', _} -> Value;
+                _ -> wh_json:get_value(<<"id">>, Data)
+            end
     end.

--- a/applications/callflow/src/module/cf_kvs_set.erl
+++ b/applications/callflow/src/module/cf_kvs_set.erl
@@ -1,0 +1,143 @@
+%%%-------------------------------------------------------------------
+
+%%%-------------------------------------------------------------------
+-module(cf_kvs_set).
+
+-export([handle/2]).
+-export([get_kv/2, get_kv/3]).
+-export([kvs_to_props/1]).
+-export([format_json/1]).
+
+-include("../callflow.hrl").
+
+-define(KVS_DB, <<"kvs_collections">>).
+-define(COLLECTION_KVS, <<"Custom-KVS">>).
+-define(COLLECTION_MODE, <<"KVS-Mode">>).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
+handle(Data, Call) ->
+    Call2 = set_kvs(Data, Call),
+    cf_exe:set_call(Call2),
+    cf_exe:continue(Call2).
+
+get_kv(Key, Call) ->
+    get_kv(?COLLECTION_KVS, Key, Call).
+
+get_kv(Collection, Key, Call) ->
+    wh_json:get_value(Key, get_collection(Collection, Call)).
+    
+set_kvs(Data, Call) ->
+    Call2 = set_kvs_mode(wh_json:get_value(<<"kvs_mode">>, Data, undefined), Call),
+    Data2 = wh_json:delete_key(<<"kvs_mode">>, Data),
+    Keys = wh_json:get_keys(Data2),
+    lists:foldl(fun(Key, Call3) ->
+        set_kvs_collection(Key, evaluate(wh_json:get_value(Key, Data2), Call3), Call3) end,
+        Call2,
+        Keys
+    ).
+    
+set_kvs_mode('undefined', Call) -> set_collection(?COLLECTION_MODE, <<"kvs_mode">>, 'undefined', Call);
+set_kvs_mode(Mode, Call) -> set_collection(?COLLECTION_MODE, <<"kvs_mode">>, Mode, Call).
+
+evaluate(<<"$", Key/binary>>, Call) ->
+    get_kv(Key, Call);
+evaluate(Value, Call) ->
+    case wh_json:is_json_object(Value) of
+        'true' -> evaluate_ui(wh_json:get_keys(Value), Value, Call);
+        'false' -> Value
+    end.
+
+evaluate_ui([<<"type">>, <<"value">>], Value, _Call) ->
+    %evaluate(wh_json:get_value(<<"value">>, Value), Call);
+    Value;
+evaluate_ui(_, Value, _) ->
+    Value.
+
+-spec get_kvs_collection(whapps_call:call()) -> api_binary().
+get_kvs_collection(Call) ->
+    get_collection(?COLLECTION_KVS, Call).
+
+get_collection(Collection, Call) ->
+    wh_json:get_value(Collection, whapps_call:kvs_fetch(?KVS_DB, wh_json:new(), Call), wh_json:new()).
+
+-spec set_kvs_collection(ne_binary(), ne_binary(), whapps_call:call()) -> whapps_call:call().
+set_kvs_collection(Key, Value, Call) ->
+    set_collection(?COLLECTION_KVS, Key, Value, Call).
+    
+set_collection(Collection, Key, Value, Call) ->
+    Collections = whapps_call:kvs_fetch(?KVS_DB, wh_json:new(), Call),
+    OldCollection = get_collection(Collection, Call),
+    NewCollection = wh_json:set_value(Key, Value, OldCollection),
+    whapps_call:kvs_store(
+    	?KVS_DB,
+        wh_json:set_value(Collection, NewCollection, Collections),
+        Call
+    ).
+    
+kvs_to_props(Call) ->
+    case wh_json:get_value(<<"kvs_mode">>, get_collection(?COLLECTION_MODE, Call), undefined) of
+        <<"json">> ->
+            Collection = get_kvs_collection(Call),
+            Keys = wh_json:get_keys(Collection),
+            
+            lists:foldl(fun(Key, Props) ->
+                [{Key, list_to_binary(format_json(wh_json:get_value(Key, Collection)))}] ++ Props
+                end, [], Keys);
+        _ ->
+            [{<<"Custom-KVS">>, get_kvs_collection(Call)}]
+    end.
+    
+format_json(Data) ->
+    Proplist = case wh_json:is_json_object(Data) of
+        true ->
+            wh_json:to_proplist(Data);
+        _ ->
+            Data
+    end,
+    
+    format_json_rec(Proplist).
+    
+format_json_rec(Proplist) ->
+    format_json_rec(Proplist, []).
+    
+format_json_rec([{K,V}], []) ->
+    "{" ++ format_json_rec({K, V}) ++ "}";
+    
+format_json_rec([{K,V}], _) ->
+    format_json_rec({K, V}) ++ "}";
+    
+format_json_rec([{K,V}=KV|Others], []) ->
+    "{" ++ format_json_rec({K, V}) ++ "," ++ format_json_rec(Others, [KV]);
+    
+format_json_rec([{K,V}=KV|Others], Done) ->
+    format_json_rec({K, V}) ++ "," ++ format_json_rec(Others, [KV] ++ Done);
+    
+format_json_rec({K, V}, _) ->
+    "\"" ++ binary_to_list(K) ++ "\":" ++ format_json_rec(V, []);
+    
+format_json_rec([Prim], []) ->
+    "[" ++ format_type(Prim) ++ "]";
+    
+format_json_rec([Prim], _) ->
+    format_type(Prim) ++ "]";
+    
+format_json_rec([Prim|Others], []) ->
+    "[" ++ format_type(Prim) ++ "," ++ format_json_rec(Others, [Prim]);
+    
+format_json_rec([Prim|Others], _) ->
+    format_type(Prim) ++ "," ++ format_json_rec(Others, [Prim]);
+
+format_json_rec(V, _) ->
+    "\"" ++ wh_util:to_list(V) ++ "\"".
+    
+format_type(Data) when not is_binary(Data) ->
+    wh_util:to_list(Data);
+    
+format_type(<<Data/binary>>) ->
+    "\"" ++ binary_to_list(Data) ++ "\"".
+ 

--- a/applications/callflow/src/module/cf_menu.erl
+++ b/applications/callflow/src/module/cf_menu.erl
@@ -507,7 +507,7 @@ update_doc(Updates, Id, Call) ->
 %%--------------------------------------------------------------------
 -spec get_menu_profile(wh_json:object(), whapps_call:call()) -> menu().
 get_menu_profile(Data, Call) ->
-    Id = maybe_use_variable(Data, Call),
+    Id = cf_util:maybe_use_variable(Data, Call),
     AccountDb = whapps_call:account_db(Call),
     case couch_mgr:open_doc(AccountDb, Id) of
         {'ok', JObj} ->
@@ -553,17 +553,4 @@ get_menu_profile(Data, Call) ->
         {'error', R} ->
             lager:info("failed to load menu route ~s, ~w", [Id, R]),
             #cf_menu_data{}
-    end.
-
--spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
-maybe_use_variable(Data, Call) ->
-    case wh_json:get_value(<<"var">>, Data) of
-        'undefined' ->
-            wh_json:get_value(<<"id">>, Data);
-        Variable ->
-            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
-            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
-                {'ok', _} -> Value;
-                _ -> wh_json:get_value(<<"id">>, Data)
-            end
     end.

--- a/applications/callflow/src/module/cf_menu.erl
+++ b/applications/callflow/src/module/cf_menu.erl
@@ -507,7 +507,7 @@ update_doc(Updates, Id, Call) ->
 %%--------------------------------------------------------------------
 -spec get_menu_profile(wh_json:object(), whapps_call:call()) -> menu().
 get_menu_profile(Data, Call) ->
-    Id = wh_json:get_value(<<"id">>, Data),
+    Id = maybe_use_variable(Data, Call),
     AccountDb = whapps_call:account_db(Call),
     case couch_mgr:open_doc(AccountDb, Id) of
         {'ok', JObj} ->
@@ -553,4 +553,17 @@ get_menu_profile(Data, Call) ->
         {'error', R} ->
             lager:info("failed to load menu route ~s, ~w", [Id, R]),
             #cf_menu_data{}
+    end.
+
+-spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
+maybe_use_variable(Data, Call) ->
+    case wh_json:get_value(<<"var">>, Data) of
+        'undefined' ->
+            wh_json:get_value(<<"id">>, Data);
+        Variable ->
+            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
+            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
+                {'ok', _} -> Value;
+                _ -> wh_json:get_value(<<"id">>, Data)
+            end
     end.

--- a/applications/callflow/src/module/cf_play.erl
+++ b/applications/callflow/src/module/cf_play.erl
@@ -24,7 +24,7 @@
 handle(Data, Call) ->
     AccountId = whapps_call:account_id(Call),
 
-    Path = maybe_use_variable(Data, Call),
+    Path = cf_util:maybe_use_variable(Data, Call),
     case wh_media_util:media_path(Path, AccountId) of
         'undefined' ->
             lager:info("invalid data in the play callflow"),
@@ -32,19 +32,6 @@ handle(Data, Call) ->
         Media ->
             NoopId = play(Data, Call, Media),
             handle_noop_recv(Call, cf_util:wait_for_noop(Call, NoopId))
-    end.
-
--spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
-maybe_use_variable(Data, Call) ->
-    case wh_json:get_value(<<"var">>, Data) of
-        'undefined' ->
-            wh_json:get_value(<<"id">>, Data);
-        Variable ->
-            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
-            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
-                {'ok', _} -> Value;
-                _ -> wh_json:get_value(<<"id">>, Data)
-            end
     end.
 
 -spec handle_noop_recv(whapps_call:call(), {'ok', whapps_call:call()} | {'error', _}) -> 'ok'.

--- a/applications/callflow/src/module/cf_play.erl
+++ b/applications/callflow/src/module/cf_play.erl
@@ -23,7 +23,8 @@
 -spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
     AccountId = whapps_call:account_id(Call),
-    Path = wh_json:get_value(<<"id">>, Data),
+
+    Path = maybe_use_variable(Data, Call),
     case wh_media_util:media_path(Path, AccountId) of
         'undefined' ->
             lager:info("invalid data in the play callflow"),
@@ -31,6 +32,19 @@ handle(Data, Call) ->
         Media ->
             NoopId = play(Data, Call, Media),
             handle_noop_recv(Call, cf_util:wait_for_noop(Call, NoopId))
+    end.
+
+-spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
+maybe_use_variable(Data, Call) ->
+    case wh_json:get_value(<<"var">>, Data) of
+        'undefined' ->
+            wh_json:get_value(<<"id">>, Data);
+        Variable ->
+            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
+            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
+                {'ok', _} -> Value;
+                _ -> wh_json:get_value(<<"id">>, Data)
+            end
     end.
 
 -spec handle_noop_recv(whapps_call:call(), {'ok', whapps_call:call()} | {'error', _}) -> 'ok'.

--- a/applications/callflow/src/module/cf_user.erl
+++ b/applications/callflow/src/module/cf_user.erl
@@ -24,7 +24,7 @@
 %%--------------------------------------------------------------------
 -spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
-    UserId = maybe_use_variable(Data, Call),
+    UserId = cf_util:maybe_use_variable(Data, Call),
     Endpoints = get_endpoints(UserId, Data, Call),
     Timeout = wh_json:get_integer_value(<<"timeout">>, Data, ?DEFAULT_TIMEOUT_S),
     Strategy = wh_json:get_binary_value(<<"strategy">>, Data, <<"simultaneous">>),
@@ -44,19 +44,6 @@ handle(Data, Call) ->
         {'error', _R} ->
             lager:info("error bridging to user: ~p", [_R]),
             cf_exe:continue(Call)
-    end.
-
--spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
-maybe_use_variable(Data, Call) ->
-    case wh_json:get_value(<<"var">>, Data) of
-        'undefined' ->
-            wh_json:get_value(<<"id">>, Data);
-        Variable ->
-            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
-            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
-                {'ok', _} -> Value;
-                _ -> wh_json:get_value(<<"id">>, Data)
-            end
     end.
 
 -spec maybe_handle_bridge_failure(_, whapps_call:call()) -> 'ok'.

--- a/applications/callflow/src/module/cf_user.erl
+++ b/applications/callflow/src/module/cf_user.erl
@@ -24,7 +24,7 @@
 %%--------------------------------------------------------------------
 -spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
-    UserId = wh_json:get_ne_value(<<"id">>, Data),
+    UserId = maybe_use_variable(Data, Call),
     Endpoints = get_endpoints(UserId, Data, Call),
     Timeout = wh_json:get_integer_value(<<"timeout">>, Data, ?DEFAULT_TIMEOUT_S),
     Strategy = wh_json:get_binary_value(<<"strategy">>, Data, <<"simultaneous">>),
@@ -44,6 +44,19 @@ handle(Data, Call) ->
         {'error', _R} ->
             lager:info("error bridging to user: ~p", [_R]),
             cf_exe:continue(Call)
+    end.
+
+-spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
+maybe_use_variable(Data, Call) ->
+    case wh_json:get_value(<<"var">>, Data) of
+        'undefined' ->
+            wh_json:get_value(<<"id">>, Data);
+        Variable ->
+            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
+            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
+                {'ok', _} -> Value;
+                _ -> wh_json:get_value(<<"id">>, Data)
+            end
     end.
 
 -spec maybe_handle_bridge_failure(_, whapps_call:call()) -> 'ok'.

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -1513,7 +1513,7 @@ has_message_meta(NewMsgCallId, Messages) ->
 %%--------------------------------------------------------------------
 -spec get_mailbox_profile(wh_json:object(), whapps_call:call()) -> mailbox().
 get_mailbox_profile(Data, Call) ->
-    Id = maybe_use_variable(Data, Call),
+    Id = cf_util:maybe_use_variable(Data, Call),
     AccountDb = whapps_call:account_db(Call),
 
     case get_mailbox_doc(AccountDb, Id, Data, Call) of
@@ -1590,19 +1590,6 @@ get_mailbox_profile(Data, Call) ->
         {'error', R} ->
             lager:info("failed to load voicemail box ~s, ~p", [Id, R]),
             #mailbox{}
-    end.
-
--spec maybe_use_variable(wh_json:object(), whapps_call:call()) -> api_binary().
-maybe_use_variable(Data, Call) ->
-    case wh_json:get_value(<<"var">>, Data) of
-        'undefined' ->
-            wh_json:get_value(<<"id">>, Data);
-        Variable ->
-            Value = wh_json:get_value(<<"value">>, cf_kvs_set:get_kv(Variable, Call)),
-            case couch_mgr:open_cache_doc(whapps_call:account_db(Call), Value) of
-                {'ok', _} -> Value;
-                _ -> wh_json:get_value(<<"id">>, Data)
-            end
     end.
 
 -spec should_delete_after_notify(wh_json:object()) -> boolean().

--- a/core/kazoo_translator-1.0.0/src/convertors/kzt_kazoo.erl
+++ b/core/kazoo_translator-1.0.0/src/convertors/kzt_kazoo.erl
@@ -65,4 +65,5 @@ req_params(Call) ->
        ,{<<"Transcription-Text">>, kzt_util:get_transcription_text(Call)}
        ,{<<"Transcription-Status">>, kzt_util:get_transcription_status(Call)}
        ,{<<"Transcription-Url">>, kzt_util:get_transcription_url(Call)}
+       | cf_kvs_set:kvs_to_props(Call)
       ]).


### PR DESCRIPTION
cf_kvs_set supports setting arbitrary key-value pairs on a call, in an isolated key in the kvs_store db. These values can be used in the modified cf_ modules to connect to a queue, play a media file, use a vmbox, etc, dynamically, based on a key's current value. This enables a fully dynamic callflow, without the need for pivot scripts. A common main callflow structure can be defined to use variables, and a small setup callflow can be created for each of a handful of numbers/extensions that initialize the variables. This avoids the need to rebuild many callflows if the structure changes.
Finally, kzt_kazoo adds in the kvs set using this module to pivot requests, if needed.