### PR TITLE
Call restriction no longer missing when using ts_from_onnet

### DIFF
--- a/applications/trunkstore/src/ts_util.erl
+++ b/applications/trunkstore/src/ts_util.erl
@@ -198,11 +198,8 @@ lookup_user_flags(Name, Realm, AccountId, _) ->
                     JObj = wh_json:set_value(<<"id">>, wh_doc:id(User), ValJObj),
 
                     {'ok', AccountJObj} = kz_account:fetch(AccountId),
-                    FlagsJObj = wh_json:from_list(
-                                    [{<<"server">>, wh_json:get_value(<<"server">>, JObj, wh_json:new())}
-                                     ,{<<"account">>, wh_json:get_value(<<"account">>, JObj, wh_json:new())}
-                                     ,{<<"call_restriction">>, wh_json:get_value(<<"call_restriction">>, AccountJObj, wh_json:new())}
-                                    ]),
+                    Restriction = wh_json:get_value(<<"call_restriction">>, AccountJObj, wh_json:new()),
+                    FlagsJObj = wh_json:set_value(<<"call_restriction">>, Restriction, JObj),
                     wh_cache:store_local(?TRUNKSTORE_CACHE
                                          ,{'lookup_user_flags', Realm, Name, AccountId}
                                          ,FlagsJObj

--- a/applications/trunkstore/src/ts_util.erl
+++ b/applications/trunkstore/src/ts_util.erl
@@ -196,11 +196,18 @@ lookup_user_flags(Name, Realm, AccountId, _) ->
                     lager:info("cache miss, found view result for ~s@~s with id ~s", [Name, Realm, wh_doc:id(User)]),
                     ValJObj = wh_json:get_value(<<"value">>, User),
                     JObj = wh_json:set_value(<<"id">>, wh_doc:id(User), ValJObj),
+
+                    {'ok', AccountJObj} = kz_account:fetch(AccountId),
+                    FlagsJObj = wh_json:from_list(
+                                    [{<<"server">>, wh_json:get_value(<<"server">>, JObj, wh_json:new())}
+                                     ,{<<"account">>, wh_json:get_value(<<"account">>, JObj, wh_json:new())}
+                                     ,{<<"call_restriction">>, wh_json:get_value(<<"call_restriction">>, AccountJObj, wh_json:new())}
+                                    ]),
                     wh_cache:store_local(?TRUNKSTORE_CACHE
                                          ,{'lookup_user_flags', Realm, Name, AccountId}
-                                         ,JObj
+                                         ,FlagsJObj
                                         ),
-                    {'ok', JObj}
+                    {'ok', FlagsJObj}
             end
     end.
 


### PR DESCRIPTION
#1256 against master

Conflicts:

	applications/trunkstore/src/ts_util.erl