### PR TITLE
Support for call confirmation on non forwarded calls

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -488,6 +488,12 @@ get_channel_vars({<<"Forward-IP">>, V}, Vars) ->
 get_channel_vars({<<"Enable-T38-Gateway">>, Direction}, Vars) ->
     [<<"execute_on_answer='t38_gateway ", Direction/binary, "'">> | Vars];
 
+get_channel_vars({<<"Confirm-File">>, V}, Vars) ->
+    [list_to_binary(["group_confirm_file='"
+        ,wh_util:to_list(ecallmgr_util:media_path(V, 'extant', get('callid'), wh_json:new()))
+        ,"'"
+    ]) | Vars];
+
 get_channel_vars({AMQPHeader, V}, Vars) when not is_list(V) ->
     case lists:keyfind(AMQPHeader, 1, ?SPECIAL_CHANNEL_VARS) of
         'false' -> Vars;

--- a/core/whistle-1.0.0/src/api/wapi_dialplan.hrl
+++ b/core/whistle-1.0.0/src/api/wapi_dialplan.hrl
@@ -46,6 +46,9 @@
           ,<<"Callee-ID-Number">>
           ,<<"Caller-ID-Name">>
           ,<<"Caller-ID-Number">>
+          ,<<"Confirm-Key">>
+          ,<<"Confirm-Cancel-Timeout">>
+          ,<<"Confirm-File">>
           ,<<"Continue-On-Fail">>
           ,<<"Custom-Channel-Vars">>
           ,<<"Custom-SIP-Headers">>


### PR DESCRIPTION
Freeswitch requires group_* values to be in the global variables of the bridge to work.

Until now, these values were only in CCVS because it was for forwarded calls only. It worked because it uses a loopback.

If we want to be able to do it on regular bridges, this change is needed.