### PR TITLE
For "system_media" use default_prompt_language()

### DIFF
--- a/core/whistle_media-1.0.0/src/wh_media_util.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_util.erl
@@ -411,6 +411,7 @@ default_prompt_language(Default) ->
      ).
 
 -spec prompt_language(api_binary()) -> ne_binary().
+prompt_language(?WH_MEDIA_DB) -> default_prompt_language();
 prompt_language(AccountId) ->
     prompt_language(AccountId, default_prompt_language()).
 


### PR DESCRIPTION
Little fix.
For wh_media_util:prompt_language(<<"system_meida">>) dont try <<"system_meida">> as account ID and always use default_prompt_language() for it.