### PR TITLE
wh_cache flush entry on DB create/delete

### DIFF
--- a/core/whistle-1.0.0/src/api/wapi_conf.erl
+++ b/core/whistle-1.0.0/src/api/wapi_conf.erl
@@ -18,6 +18,8 @@
          ,publish_doc_update/5, publish_doc_update/6
          ,publish_doc_type_update/1, publish_doc_type_update/2
 
+         ,publish_db_update/3, publish_db_update/4
+
          ,get_account_id/1, get_account_db/1
          ,get_type/1, get_doc/1, get_id/1
          ,get_action/1, get_is_soft_deleted/1
@@ -29,8 +31,8 @@
 -include_lib("whistle/include/wh_api.hrl").
 -include_lib("whistle/include/wh_log.hrl").
 
--define(CONF_DOC_UPDATE_HEADERS, [<<"ID">>, <<"Rev">>, <<"Database">>]).
--define(OPTIONAL_CONF_DOC_UPDATE_HEADERS, [<<"Account-ID">>, <<"Type">>, <<"Version">>
+-define(CONF_DOC_UPDATE_HEADERS, [<<"ID">>, <<"Database">>]).
+-define(OPTIONAL_CONF_DOC_UPDATE_HEADERS, [<<"Rev">>, <<"Account-ID">>, <<"Type">>, <<"Version">>
                                            ,<<"Date-Modified">>, <<"Date-Created">>
                                            ,<<"Doc">>, <<"Is-Soft-Deleted">>
                                           ]).
@@ -262,6 +264,14 @@ publish_doc_update(Action, Db, Type, Id, JObj) ->
 publish_doc_update(Action, Db, Type, Id, Change, ContentType) ->
     {'ok', Payload} = wh_api:prepare_api_payload(Change, ?CONF_DOC_UPDATE_VALUES, fun ?MODULE:doc_update/1),
     amqp_util:document_change_publish(Action, Db, Type, Id, Payload, ContentType).
+
+-spec publish_db_update(action(), ne_binary(), api_terms()) -> 'ok'.
+-spec publish_db_update(action(), ne_binary(), api_terms(), ne_binary()) -> 'ok'.
+publish_db_update(Action, Db, JObj) ->
+    publish_db_update(Action, Db, JObj, ?DEFAULT_CONTENT_TYPE).
+publish_db_update(Action, Db, Change, ContentType) ->
+    {'ok', Payload} = wh_api:prepare_api_payload(Change, ?CONF_DOC_UPDATE_VALUES, fun ?MODULE:doc_update/1),
+    amqp_util:document_change_publish(Action, Db, <<"database">>, Db, Payload, ContentType).
 
 -spec publish_doc_type_update(api_terms()) -> 'ok'.
 -spec publish_doc_type_update(api_terms(), ne_binary()) -> 'ok'.

--- a/core/whistle-1.0.0/src/api/wapi_conf.erl
+++ b/core/whistle-1.0.0/src/api/wapi_conf.erl
@@ -38,6 +38,8 @@
                                  ,{<<"Event-Name">>, [<<"doc_edited">>
                                                       ,<<"doc_created">>
                                                       ,<<"doc_deleted">>
+                                                      ,<<"db_created">>
+                                                      ,<<"db_deleted">>
                                                      ]}
                                 ]).
 -define(CONF_DOC_UPDATE_TYPES, [{<<"ID">>, fun is_binary/1}

--- a/core/whistle-1.0.0/src/wh_cache.erl
+++ b/core/whistle-1.0.0/src/wh_cache.erl
@@ -144,13 +144,17 @@ start_link(Name, ExpirePeriod, Props) ->
     end.
 
 -spec build_bindings(wh_proplist()) -> wh_proplist().
-build_bindings([[]]) -> [{'conf', ['federate']}];
+build_bindings([[]]) -> document_bindings([[]]);
 build_bindings(BindingProps) ->
-     add_database_binding([{'conf', ['federate'|P]} || P <- BindingProps]).
+    [database_binding() | document_bindings(BindingProps)].
 
--spec add_database_binding(wh_proplist()) -> wh_proplist().
-add_database_binding(Bindings) ->
-    [{'conf', ['federate', {'type', <<"database">>}]} | Bindings].
+-spec document_bindings(wh_proplist()) -> wh_proplist().
+document_bindings(BindingProps) ->
+     [{'conf', ['federate'|P]} || P <- BindingProps].
+
+-spec database_binding() -> wh_proplist().
+database_binding() ->
+    {'conf', ['federate', {'type', <<"database">>}]}.
 
 -spec store(term(), term()) -> 'ok'.
 -spec store(term(), term(), wh_proplist()) -> 'ok'.

--- a/core/whistle-1.0.0/src/wh_cache.erl
+++ b/core/whistle-1.0.0/src/wh_cache.erl
@@ -132,8 +132,10 @@ start_link(Name, ExpirePeriod, Props) ->
             lager:debug("started new cache process (gen_server): ~s", [Name]),
             gen_server:start_link({'local', Name}, ?MODULE, [Name, ExpirePeriod, Props], []);
         BindingProps ->
+            lager:debug("DEBUG BindingProps: ~p",[BindingProps]),
             lager:debug("started new cache process (gen_listener): ~s", [Name]),
             Bindings = [{'conf', ['federate' | P]} || P <- maybe_add_db_binding(BindingProps)],
+            lager:debug("DEBUG Bindings: ~p",[Bindings]),
             gen_listener:start_link({'local', Name}, ?MODULE
                                     ,[{'bindings', Bindings}
                                       ,{'responders', ?RESPONDERS}
@@ -146,6 +148,7 @@ start_link(Name, ExpirePeriod, Props) ->
     end.
 
 -spec maybe_add_db_binding(wh_proplists()) -> wh_proplists().
+maybe_add_db_binding([]) -> [];
 maybe_add_db_binding([[]]) -> [[]];
 maybe_add_db_binding(BindingProps) ->
     [?DATABASE_BINDING | BindingProps].

--- a/core/whistle-1.0.0/src/wh_cache.erl
+++ b/core/whistle-1.0.0/src/wh_cache.erl
@@ -132,10 +132,8 @@ start_link(Name, ExpirePeriod, Props) ->
             lager:debug("started new cache process (gen_server): ~s", [Name]),
             gen_server:start_link({'local', Name}, ?MODULE, [Name, ExpirePeriod, Props], []);
         BindingProps ->
-            lager:debug("DEBUG BindingProps: ~p",[BindingProps]),
             lager:debug("started new cache process (gen_listener): ~s", [Name]),
             Bindings = [{'conf', ['federate' | P]} || P <- maybe_add_db_binding(BindingProps)],
-            lager:debug("DEBUG Bindings: ~p",[Bindings]),
             gen_listener:start_link({'local', Name}, ?MODULE
                                     ,[{'bindings', Bindings}
                                       ,{'responders', ?RESPONDERS}

--- a/core/whistle-1.0.0/src/wh_cache.erl
+++ b/core/whistle-1.0.0/src/wh_cache.erl
@@ -152,7 +152,7 @@ build_bindings(BindingProps) ->
 document_bindings(BindingProps) ->
      [{'conf', ['federate'|P]} || P <- BindingProps].
 
--spec database_binding() -> wh_proplist().
+-spec database_binding() -> tuple().
 database_binding() ->
     {'conf', ['federate', {'type', <<"database">>}]}.
 

--- a/core/whistle_amqp-1.0.0/src/amqp_util.erl
+++ b/core/whistle_amqp-1.0.0/src/amqp_util.erl
@@ -263,8 +263,20 @@ document_routing_key(<<"*">>, Db, Type, Id) ->
                     ,".", wh_util:to_binary(Type)
                     ,".", encode(wh_util:to_binary(Id))
                    ]);
+document_routing_key(<<"db_", _/binary>> = Action, Db, Type, Id) ->
+    list_to_binary([Action
+                    ,".", wh_util:to_binary(Db)
+                    ,".", wh_util:to_binary(Type)
+                    ,".", encode(wh_util:to_binary(Id))
+                   ]);
 document_routing_key(<<"doc_", _/binary>> = Action, Db, Type, Id) ->
     list_to_binary([Action
+                    ,".", wh_util:to_binary(Db)
+                    ,".", wh_util:to_binary(Type)
+                    ,".", encode(wh_util:to_binary(Id))
+                   ]);
+document_routing_key(Action, Db, 'database'=Type, Id) ->
+    list_to_binary(["db_", wh_util:to_list(Action)
                     ,".", wh_util:to_binary(Db)
                     ,".", wh_util:to_binary(Type)
                     ,".", encode(wh_util:to_binary(Id))

--- a/core/whistle_amqp-1.0.0/src/amqp_util.erl
+++ b/core/whistle_amqp-1.0.0/src/amqp_util.erl
@@ -275,7 +275,7 @@ document_routing_key(<<"doc_", _/binary>> = Action, Db, Type, Id) ->
                     ,".", wh_util:to_binary(Type)
                     ,".", encode(wh_util:to_binary(Id))
                    ]);
-document_routing_key(Action, Db, 'database'=Type, Id) ->
+document_routing_key(Action, Db, <<"database">>=Type, Id) ->
     list_to_binary(["db_", wh_util:to_list(Action)
                     ,".", wh_util:to_binary(Db)
                     ,".", wh_util:to_binary(Type)

--- a/core/whistle_couch-1.0.0/src/couch_util.erl
+++ b/core/whistle_couch-1.0.0/src/couch_util.erl
@@ -1036,11 +1036,9 @@ publish_doc(#db{name=DbName}, Doc, JObj) ->
 
 -spec publish_db(couchbeam_db(), atom()) -> 'ok'.
 publish_db(Db, Action) ->
-    Type = 'database',
     Props =
         [{<<"Type">>, 'database'}
          ,{<<"ID">>, Db}
-         ,{<<"Rev">>, <<"0">>}
          ,{<<"Database">>, Db}
          | wh_api:default_headers(<<"configuration">>
                                   ,<<"db_", (wh_util:to_binary(Action))/binary>>
@@ -1048,7 +1046,7 @@ publish_db(Db, Action) ->
                                   ,<<"1.0.0">>
                                  )
         ],
-    Fun = fun(P) -> wapi_conf:publish_doc_update(Action, Db, Type, Db, P) end,
+    Fun = fun(P) -> wapi_conf:publish_db_update(Action, Db, P) end,
     whapps_util:amqp_pool_send(Props, Fun).
 
 -spec publish_fields(wh_json:object()) -> wh_proplist().

--- a/core/whistle_couch-1.0.0/src/couch_util.erl
+++ b/core/whistle_couch-1.0.0/src/couch_util.erl
@@ -307,7 +307,7 @@ db_create(#server{}=Conn, DbName) ->
 db_create(#server{}=Conn, DbName, Options) ->
     case couchbeam:create_db(Conn, wh_util:to_list(DbName), [], Options) of
         {'error', _} -> 'false';
-        {'ok', _} -> 
+        {'ok', _} ->
             _ = maybe_publish_db(DbName, 'created'),
             'true'
     end.
@@ -316,7 +316,7 @@ db_create(#server{}=Conn, DbName, Options) ->
 db_delete(#server{}=Conn, DbName) ->
     case couchbeam:delete_db(Conn, wh_util:to_list(DbName)) of
         {'error', _} -> 'false';
-        {'ok', _} -> 
+        {'ok', _} ->
             _ = maybe_publish_db(DbName, 'deleted'),
             'true'
     end.


### PR DESCRIPTION
Notification on DB create/delete.
wh_cache binding for database create/delete notififcations.
wh_cache auto-add origins for DB.
Flush cache entry on dtabase create/delete.