### PR TITLE
KAZOO-4108: fetch logs from notifications, consistently to the fax smtplog API

### DIFF
--- a/applications/crossbar/doc/notifications.md
+++ b/applications/crossbar/doc/notifications.md
@@ -20,7 +20,7 @@ Example:
          ]
      }
      ,"from": "peter@email.com"
-     ,"subject": "Hello {{user.first_name}}, you recieved a new voicemail!"
+     ,"subject": "Hello {{user.first_name}}, you received a new voicemail!"
      ,"enabled": true
      ,"template_charset": "utf-8"
      ,"macros": {
@@ -241,7 +241,7 @@ Similar to the PUT, POST will update an existing config:
 
 Omit `/accounts/{ACCOUNT_ID}` to update the system's version.
 
-#### Delete - remove a notification template
+#### DELETE - remove a notification template
 
     curl -X DELETE -H "X-Auth-Token: {AUTH_TOKEN}" -H "Content-Type:application/json" http://server:8000/v2/accounts/{ACCOUNT_ID}/notifications/{NOTIFICATION_ID}
 
@@ -293,8 +293,8 @@ All accounts will continue to be processed by the `notify` app until the Crossba
 
 ## Logs
 
-* GET - Gets the notification(s) smtp log.
+* GET - Gets the notification(s) SMTP log.
 
 ```
-curl  -H "X-Auth-Token:{AUTH_TOKEN}" -H "Content-Type:text/plain"  http://server:8000/v2/accounts/{ACCOUNT_ID}/notifications/logs
+curl -H 'X-Auth-Token: {AUTH_TOKEN}' -H 'Content-Type: text/plain'  http://server:8000/v2/accounts/{ACCOUNT_ID}/notifications/smtplog
 ```

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -590,7 +590,7 @@ remove_qs_keys(Context) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec load_cdr(ne_binary(), cb_context:context()) -> cb_context:context().
-load_cdr(<<Year:4/binary, Month:2/binary, "-", _/binary>> = CDRId, Context) ->
+load_cdr(?MATCH_MODB_PREFIX(Year,Month,_) = CDRId, Context) ->
     AccountId = cb_context:account_id(Context),
     AcctDb = kazoo_modb:get_modb(AccountId, wh_util:to_integer(Year), wh_util:to_integer(Month)),
     Context1 = cb_context:set_account_db(Context, AcctDb),

--- a/applications/crossbar/src/modules/cb_faxes.erl
+++ b/applications/crossbar/src/modules/cb_faxes.erl
@@ -72,7 +72,7 @@ init() ->
     _ = crossbar_bindings:bind(<<"*.execute.put.faxes">>, ?MODULE, 'put'),
     _ = crossbar_bindings:bind(<<"*.execute.post.faxes">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"*.execute.patch.faxes">>, ?MODULE, 'patch'),
-    crossbar_bindings:bind(<<"*.execute.delete.faxes">>, ?MODULE, 'delete').
+    _ = crossbar_bindings:bind(<<"*.execute.delete.faxes">>, ?MODULE, 'delete').
 
 %%--------------------------------------------------------------------
 %% @public
@@ -133,11 +133,10 @@ resource_exists(?OUTGOING, _Id) -> 'true'.
 resource_exists(?INCOMING, _Id, ?ATTACHMENT) -> 'true'.
 
 -spec content_types_accepted(cb_context:context()) -> cb_context:context().
+-spec content_types_accepted(cb_context:context(), path_token()) -> cb_context:context().
 content_types_accepted(Context) ->
     maybe_add_types_accepted(Context, cb_context:req_verb(Context)).
 
--spec content_types_accepted(cb_context:context(), path_token()) ->
-                                    cb_context:context().
 content_types_accepted(Context, ?OUTGOING) ->
     maybe_add_types_accepted(Context, cb_context:req_verb(Context));
 content_types_accepted(Context, _) -> Context.
@@ -156,8 +155,10 @@ maybe_add_types_accepted(Context, _) -> Context.
 %%--------------------------------------------------------------------
 -spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token()) ->
                                     cb_context:context().
-content_types_provided(Context, ?INCOMING, <<Year:4/binary, Month:2/binary, "-", _/binary>> = FaxId, ?ATTACHMENT) ->
-    Ctx = cb_context:set_account_modb(Context, wh_util:to_integer(Year), wh_util:to_integer(Month)),
+content_types_provided(Context, ?INCOMING, <<YYYY:4/binary, MM:2/binary, "-", _/binary>> = FaxId, ?ATTACHMENT) ->
+    Year  = wh_util:to_integer(YYYY),
+    Month = wh_util:to_integer(MM),
+    Ctx = cb_context:set_account_modb(Context, Year, Month),
     content_types_provided_for_fax(Ctx, FaxId, cb_context:req_verb(Context));
 content_types_provided(Context, ?INCOMING, FaxId, ?ATTACHMENT) ->
     content_types_provided_for_fax(Context, FaxId, cb_context:req_verb(Context));
@@ -209,7 +210,7 @@ validate(Context, ?OUTGOING) ->
 validate(Context, ?INCOMING) ->
     incoming_summary(Context);
 validate(Context, ?SMTP_LOG) ->
-    smtp_summary(Context).
+    load_smtp_log(Context).
 
 validate_outgoing_fax(Context, ?HTTP_GET) ->
     outgoing_summary(cb_context:set_account_db(Context, ?WH_FAXES_DB));
@@ -320,8 +321,10 @@ create(Context) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec read(ne_binary(), cb_context:context()) -> cb_context:context().
-read(<<Year:4/binary, Month:2/binary, "-", _/binary>> = Id, Context) ->
-    crossbar_doc:load(Id, cb_context:set_account_modb(Context, wh_util:to_integer(Year), wh_util:to_integer(Month)));
+read(<<YYYY:4/binary, MM:2/binary, "-", _/binary>> = Id, Context) ->
+    Year  = wh_util:to_integer(YYYY),
+    Month = wh_util:to_integer(MM),
+    crossbar_doc:load(Id, cb_context:set_account_modb(Context, Year, Month));
 read(Id, Context) ->
     crossbar_doc:load(Id, Context).
 
@@ -486,8 +489,8 @@ get_incoming_view_and_filter(JObj) ->
         _Else -> {?CB_LIST_ALL, 'undefined', [wh_json:new()]}
     end.
 
--spec smtp_summary(cb_context:context()) -> cb_context:context().
-smtp_summary(Context) ->
+-spec load_smtp_log(cb_context:context()) -> cb_context:context().
+load_smtp_log(Context) ->
     case cb_modules_util:range_modb_view_options(Context) of
         {'ok', ViewOptions} ->
             crossbar_doc:load_view(?CB_LIST_SMTP_LOG

--- a/applications/crossbar/src/modules/cb_faxes.erl
+++ b/applications/crossbar/src/modules/cb_faxes.erl
@@ -155,7 +155,7 @@ maybe_add_types_accepted(Context, _) -> Context.
 %%--------------------------------------------------------------------
 -spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token()) ->
                                     cb_context:context().
-content_types_provided(Context, ?INCOMING, <<YYYY:4/binary, MM:2/binary, "-", _/binary>> = FaxId, ?ATTACHMENT) ->
+content_types_provided(Context, ?INCOMING, ?MATCH_MODB_PREFIX(YYYY,MM,_) = FaxId, ?ATTACHMENT) ->
     Year  = wh_util:to_integer(YYYY),
     Month = wh_util:to_integer(MM),
     Ctx = cb_context:set_account_modb(Context, Year, Month),
@@ -321,7 +321,7 @@ create(Context) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec read(ne_binary(), cb_context:context()) -> cb_context:context().
-read(<<YYYY:4/binary, MM:2/binary, "-", _/binary>> = Id, Context) ->
+read(?MATCH_MODB_PREFIX(YYYY,MM,_) = Id, Context) ->
     Year  = wh_util:to_integer(YYYY),
     Month = wh_util:to_integer(MM),
     crossbar_doc:load(Id, cb_context:set_account_modb(Context, Year, Month));
@@ -508,7 +508,7 @@ load_smtp_log(Context) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec load_fax_binary(path_token(), cb_context:context()) -> cb_context:context().
-load_fax_binary(<<Year:4/binary, Month:2/binary, "-", _/binary>> = FaxId, Context) ->
+load_fax_binary(?MATCH_MODB_PREFIX(Year,Month,_) = FaxId, Context) ->
     do_load_fax_binary(FaxId, cb_context:set_account_modb(Context, wh_util:to_integer(Year), wh_util:to_integer(Month)));
 load_fax_binary(FaxId, Context) ->
     do_load_fax_binary(FaxId, Context).

--- a/applications/crossbar/src/modules/cb_jobs_listener.erl
+++ b/applications/crossbar/src/modules/cb_jobs_listener.erl
@@ -394,9 +394,9 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 -spec job_modb(ne_binary(), ne_binary()) -> ne_binary().
-job_modb(AccountId, <<Year:4/binary, Month:2/binary, "-", _/binary>>) ->
+job_modb(AccountId, ?MATCH_MODB_PREFIX(Year,Month,_)) ->
     wh_util:format_account_mod_id(AccountId, wh_util:to_integer(Year), wh_util:to_integer(Month));
-job_modb(AccountId, <<Year:4/binary, Month:1/binary, "-", _/binary>>) ->
+job_modb(AccountId, ?MATCH_MODB_PREFIX_M1(Year,Month,_)) ->
     wh_util:format_account_mod_id(AccountId, wh_util:to_integer(Year), wh_util:to_integer(Month)).
 
 -spec start_timer() -> reference().

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -458,7 +458,7 @@ maybe_delete_template(Context, Id, ContentType, TemplateJObj) ->
         'undefined' ->
             lager:debug("failed to find attachment ~s", [AttachmentName]),
             JObj = wh_json:from_list([{<<"cause">>, ContentType}]),
-            cb_context:add_system_error('bad_identifier', JObj, ContentType);
+            cb_context:add_system_error('bad_identifier', JObj, Context);
         _Attachment ->
             lager:debug("attempting to delete attachment ~s", [AttachmentName]),
             crossbar_doc:delete_attachment(kz_notification:db_id(Id), AttachmentName, Context)

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -982,8 +982,9 @@ normalize_available_port(Value, Acc, Context) ->
 %% @end
 %%--------------------------------------------------------------------
 
--spec system_config_notification_doc(ne_binary()) -> {'ok', wh_json:object()} |
-                                                     {'error', any()}.
+-spec system_config_notification_doc(ne_binary()) ->
+                                            {'ok', wh_json:object()} |
+                                            {'error', any()}.
 system_config_notification_doc(DocId) ->
     couch_mgr:open_cache_doc(?WH_CONFIG_DB, DocId).
 
@@ -1114,7 +1115,6 @@ load_smtp_log(Context) ->
 -spec normalize_view_results(wh_json:object(), wh_json:objects()) -> wh_json:objects().
 normalize_view_results(JObj, Acc) ->
     [wh_json:get_value(<<"doc">>, JObj)|Acc].
-
 
 -spec maybe_update_db(cb_context:context()) -> cb_context:context().
 maybe_update_db(Context) ->

--- a/applications/crossbar/src/modules/cb_resources.erl
+++ b/applications/crossbar/src/modules/cb_resources.erl
@@ -387,10 +387,10 @@ read(Id, Context) ->
     crossbar_doc:load(Id, Context).
 
 -spec read_job(cb_context:context(), ne_binary()) -> cb_context:context().
-read_job(Context, <<Year:4/binary, Month:2/binary, "-", _/binary>> = JobId) ->
+read_job(Context, ?MATCH_MODB_PREFIX(Year,Month,_) = JobId) ->
     Modb = cb_context:account_modb(Context, wh_util:to_integer(Year), wh_util:to_integer(Month)),
     leak_job_fields(crossbar_doc:load(JobId, cb_context:set_account_db(Context, Modb)));
-read_job(Context, <<Year:4/binary, Month:1/binary, "-", _/binary>> = JobId) ->
+read_job(Context, ?MATCH_MODB_PREFIX_M1(Year,Month,_) = JobId) ->
     Modb = cb_context:account_modb(Context, wh_util:to_integer(Year), wh_util:to_integer(Month)),
     leak_job_fields(crossbar_doc:load(JobId, cb_context:set_account_db(Context, Modb)));
 read_job(Context, JobId) ->

--- a/applications/crossbar/src/modules/cb_sms.erl
+++ b/applications/crossbar/src/modules/cb_sms.erl
@@ -148,8 +148,9 @@ create(Context) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec read(ne_binary(), cb_context:context()) -> cb_context:context().
-read(<<Year:4/binary, Month:2/binary, "-", _/binary>> = Id, Context) ->
-    crossbar_doc:load(Id, cb_context:set_account_modb(Context, wh_util:to_integer(Year), wh_util:to_integer(Month)));
+read(?MATCH_MODB_PREFIX(Year,Month,_) = Id, Context) ->
+    Context1 = cb_context:set_account_modb(Context, wh_util:to_integer(Year), wh_util:to_integer(Month)),
+    crossbar_doc:load(Id, Context1);
 read(Id, Context) ->
     crossbar_doc:load(Id, Context).
 

--- a/applications/doodle/src/doodle_doc_handler.erl
+++ b/applications/doodle/src/doodle_doc_handler.erl
@@ -25,8 +25,8 @@ handle_req(JObj, _Props) ->
 -spec handle_doc(api_binary(), api_binary(), api_binary(), api_binary()) -> 'ok'.
 handle_doc(?DOC_CREATED, <<"sms">>, Db, Id) ->
     doodle_api:handle_api_sms(Db, Id);
-handle_doc(_, <<"device">>, <<_:32/binary>>=AccountId, Id) ->
+handle_doc(_, <<"device">>, ?MATCH_ACCOUNT_RAW(AccountId), Id) ->
     doodle_maintenance:check_sms_by_device_id(AccountId, Id);
-handle_doc(_, <<"user">>, <<_:32/binary>>=AccountId, Id) ->
+handle_doc(_, <<"user">>, ?MATCH_ACCOUNT_RAW(AccountId), Id) ->
     doodle_maintenance:check_sms_by_owner_id(AccountId, Id);
 handle_doc(_, _, _, _) -> 'ok'.

--- a/applications/doodle/src/doodle_maintenance.erl
+++ b/applications/doodle/src/doodle_maintenance.erl
@@ -99,9 +99,8 @@ replay_queue_sms(AccountId, JObjs) ->
 -spec spawn_handler(ne_binary(), wh_json:object()) -> 'ok'.
 spawn_handler(AccountId, JObj) ->
     DocId = wh_doc:id(JObj),
-    <<Year:4/binary, Month:2/binary, "-", _/binary>> = DocId,
+    ?MATCH_MODB_PREFIX(Year,Month,_) = DocId,
     AccountDb = kazoo_modb:get_modb(AccountId, Year, Month),
-
     _ = wh_util:spawn('doodle_api', 'handle_api_sms', [AccountDb, DocId]),
     timer:sleep(200).
 

--- a/applications/doodle/src/doodle_util.erl
+++ b/applications/doodle/src/doodle_util.erl
@@ -124,13 +124,13 @@ save_sms(JObj, 'undefined', Call) ->
     save_sms(JObj, SmsDocId, Doc, UpdatedCall);
 save_sms(JObj, DocId, Call) ->
     AccountId = whapps_call:account_id(Call),
-    <<Year:4/binary, Month:2/binary, "-", _/binary>> = DocId,
+    ?MATCH_MODB_PREFIX(Year,Month,_) = DocId,
     {'ok', Doc} = kazoo_modb:open_doc(AccountId, DocId, Year, Month),
     save_sms(JObj, DocId, Doc, Call).
 
--spec save_sms(wh_json:object(), api_binary(), wh_json:object(), whapps_call:call()) -> whapps_call:call().
-save_sms(JObj, DocId, Doc, Call) ->
-    <<Year:4/binary, Month:2/binary, "-", _/binary>> = DocId,
+-spec save_sms(wh_json:object(), api_binary(), wh_json:object(), whapps_call:call()) ->
+                      whapps_call:call().
+save_sms(JObj, ?MATCH_MODB_PREFIX(Year,Month,_) = DocId, Doc, Call) ->
     AccountId = whapps_call:account_id(Call),
     AccountDb = kazoo_modb:get_modb(AccountId, Year, Month),
     OwnerId = whapps_call:owner_id(Call),

--- a/applications/fax/src/fax_request.erl
+++ b/applications/fax/src/fax_request.erl
@@ -559,7 +559,7 @@ create_fax_doc(JObj, #state{owner_id = OwnerId
                            ," " , wh_util:to_binary(H), ":", wh_util:to_binary(I), ":", wh_util:to_binary(S)
                            ," UTC"
                           ]),
-    <<Year:4/binary, Month:2/binary, "-", _/binary>> = FaxDocId,
+    ?MATCH_MODB_PREFIX(Year,Month,_) = FaxDocId,
     CdrId = <<(wh_util:to_binary(Year))/binary
               ,(wh_util:pad_month(Month))/binary
               ,"-"

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -191,8 +191,8 @@ handle_other(<<"PROXY">>, Args, State) ->
     {State};
 handle_other(Verb, Args, State) ->
     %% You can implement other SMTP verbs here, if you need to
-    lager:debug("500 Error: command not recognized : ~p / ~p",[Verb,Args]),
-    {["500 Error: command not recognized : '", wh_util:to_list(Verb), "'"], State}.
+    lager:debug("500 Error: command not recognized : '~s ~s'",[Verb,Args]),
+    {["500 Error: command not recognized : '", Verb, "'"], State}.
 
 -spec handle_AUTH('login' | 'plain' | 'cram-md5', binary(), binary() | {binary(), binary()}, state()) ->
                          'error'.

--- a/applications/fax/src/fax_util.erl
+++ b/applications/fax/src/fax_util.erl
@@ -144,12 +144,12 @@ save_fax_docs([Doc|Docs], FileContents, CT) ->
                                  {'ok', wh_json:object()} |
                                  {'error', ne_binary()}.
 save_fax_attachment(JObj, FileContents, CT) ->
-    save_fax_attachment(JObj, FileContents, CT, whapps_config:get_integer(?CONFIG_CAT, <<"max_storage_retry">>, 5)).
+    MaxStorageRetry = whapps_config:get_integer(?CONFIG_CAT, <<"max_storage_retry">>, 5),
+    save_fax_attachment(JObj, FileContents, CT, MaxStorageRetry).
 
 save_fax_attachment(JObj, _FileContents, _CT, 0) ->
     DocId = wh_doc:id(JObj),
-    Rev = wh_doc:revision(JObj),
-    lager:debug("max retry saving attachment on fax id ~s rev ~s",[DocId, Rev]),
+    lager:debug("max retry saving attachment on fax id ~s rev ~s",[DocId, wh_doc:revision(JObj)]),
     {'error', <<"max retry saving attachment">>};
 save_fax_attachment(JObj, FileContents, CT, Count) ->
     DocId = wh_doc:id(JObj),

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -96,7 +96,7 @@ log_smtp(Emails, Subject, RenderedTemplates, Receipt, Error, AccountId) ->
     Doc = props:filter_undefined(
             [{<<"rendered_templates">>, wh_json:from_list(RenderedTemplates)}
              ,{<<"subject">>, Subject}
-             ,{<<"emails">>, wh_json:from_list(Emails)}
+             ,{<<"emails">>, wh_json:from_list(props:filter_undefined(Emails))}
              ,{<<"receipt">>, Receipt}
              ,{<<"error">>, Error}
              ,{<<"pvt_type">>, <<"notify_smtp_log">>}

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -106,8 +106,9 @@ log_smtp(Emails, Subject, RenderedTemplates, Receipt, Error, AccountId) ->
              ,{<<"template_id">>, get('template_id')}
              ,{<<"template_account_id">>, get('template_account_id')}
             ]),
+    lager:debug("attempting to save notify smtp log"),
     _ = kazoo_modb:save_doc(AccountDb, wh_json:from_list(Doc)),
-    lager:debug("saved notify smtp log").
+    'ok'.
 
 -spec email_body(rendered_templates()) -> mimemail:mimetuple().
 email_body(RenderedTemplates) ->

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -105,10 +105,15 @@ log_smtp(Emails, Subject, RenderedTemplates, Receipt, Error, AccountId) ->
              ,{<<"pvt_created">>, wh_util:current_tstamp()}
              ,{<<"template_id">>, get('template_id')}
              ,{<<"template_account_id">>, get('template_account_id')}
+             ,{<<"_id">>, make_smtplog_id(AccountDb)}
             ]),
     lager:debug("attempting to save notify smtp log"),
     _ = kazoo_modb:save_doc(AccountDb, wh_json:from_list(Doc)),
     'ok'.
+
+-spec make_smtplog_id(ne_binary()) -> ne_binary().
+make_smtplog_id(?MATCH_MODB_SUFFIX_ENCODED(_Account, Year, Month)) ->
+    ?MATCH_MODB_PREFIX(Year, Month, wh_util:rand_hex_binary(16)).
 
 -spec email_body(rendered_templates()) -> mimemail:mimetuple().
 email_body(RenderedTemplates) ->

--- a/core/kazoo_modb-1.0.0/priv/couchdb/views/faxes.json
+++ b/core/kazoo_modb-1.0.0/priv/couchdb/views/faxes.json
@@ -12,7 +12,7 @@
             "map": "function(doc) { if (doc.pvt_type != 'fax' || doc.pvt_deleted || !doc.owner_id) return; emit([doc.owner_id, doc.pvt_created], {'id': doc._id, 'status': doc.pvt_job_status, 'to': doc.to_number, 'from': doc.from_number, 'created': doc.pvt_created}); }"
         },
         "smtp_log": {
-            "map": "function(doc) { if (doc.pvt_deleted || doc.pvt_type != 'fax_smtp_log') return; emit(doc.pvt_created, {'id': doc._id, 'from' : doc.from, 'to' : doc.to, 'error' : doc.errors[0], 'created': doc.pvt_created}); }"
+            "map": "function(doc) { if (doc.pvt_deleted || doc.pvt_type != 'fax_smtp_log') return; emit(doc.pvt_created, {'id': doc._id, 'from': doc.from, 'to': doc.to, 'error': doc.errors[0], 'created': doc.pvt_created}); }"
         }
     }
 }

--- a/core/kazoo_modb-1.0.0/priv/couchdb/views/faxes.json
+++ b/core/kazoo_modb-1.0.0/priv/couchdb/views/faxes.json
@@ -12,7 +12,7 @@
             "map": "function(doc) { if (doc.pvt_type != 'fax' || doc.pvt_deleted || !doc.owner_id) return; emit([doc.owner_id, doc.pvt_created], {'id': doc._id, 'status': doc.pvt_job_status, 'to': doc.to_number, 'from': doc.from_number, 'created': doc.pvt_created}); }"
         },
         "smtp_log": {
-            "map": "function(doc) { if (doc.pvt_type != 'fax_smtp_log' || doc.pvt_deleted) return; emit(doc.pvt_created, {'id': doc._id, 'from' : doc.from, 'to' : doc.to, 'error' : doc.errors[0], 'created': doc.pvt_created}); }"
+            "map": "function(doc) { if (doc.pvt_deleted || doc.pvt_type != 'fax_smtp_log') return; emit(doc.pvt_created, {'id': doc._id, 'from' : doc.from, 'to' : doc.to, 'error' : doc.errors[0], 'created': doc.pvt_created}); }"
         }
     }
 }

--- a/core/kazoo_modb-1.0.0/priv/couchdb/views/notifications.json
+++ b/core/kazoo_modb-1.0.0/priv/couchdb/views/notifications.json
@@ -3,7 +3,7 @@
     "language": "javascript",
     "views": {
         "smtp_log": {
-            "map": "function(doc) { if (doc.pvt_deleted || doc.pvt_type != 'notify_smtp_log') return; emit(doc.pvt_created, {'id': doc._id, 'from': doc.from, 'to': doc.to, 'created': doc.pvt_created}); }"
+            "map": "function(doc) { if (doc.pvt_deleted || doc.pvt_type != 'notify_smtp_log') return; emit(doc.pvt_created, {'id': doc._id, 'from': doc.from, 'to': doc.to, 'error': doc.error, 'created': doc.pvt_created}); }"
         }
     }
 }

--- a/core/kazoo_modb-1.0.0/priv/couchdb/views/notifications.json
+++ b/core/kazoo_modb-1.0.0/priv/couchdb/views/notifications.json
@@ -3,7 +3,7 @@
     "language": "javascript",
     "views": {
         "smtp_log": {
-            "map": "function(doc) {if (doc.pvt_deleted || doc.pvt_type != 'notify_smtp_log') return; emit(doc.pvt_created); }"
+            "map": "function(doc) { if (doc.pvt_deleted || doc.pvt_type != 'notify_smtp_log') return; emit(doc.pvt_created, {'id': doc._id, 'from': doc.from, 'to': doc.to, 'created': doc.pvt_created}); }"
         }
     }
 }

--- a/core/kazoo_modb-1.0.0/priv/couchdb/views/notifications.json
+++ b/core/kazoo_modb-1.0.0/priv/couchdb/views/notifications.json
@@ -3,7 +3,7 @@
     "language": "javascript",
     "views": {
         "smtp_log": {
-            "map": "function(doc) {if (doc.pvt_deleted || doc.pvt_type != 'notify_smtp_log') return; emit(doc.pvt_created);} ;"
+            "map": "function(doc) {if (doc.pvt_deleted || doc.pvt_type != 'notify_smtp_log') return; emit(doc.pvt_created); }"
         }
     }
 }

--- a/core/kazoo_modb-1.0.0/src/kazoo_modb.erl
+++ b/core/kazoo_modb-1.0.0/src/kazoo_modb.erl
@@ -85,7 +85,7 @@ get_results_missing_db(Account, View, ViewOptions, Retry) ->
 -spec open_doc(ne_binary(), ne_binary(), wh_year() | ne_binary(), wh_month() | ne_binary()) ->
                       {'ok', wh_json:object()} |
                       {'error', atom()}.
-open_doc(Account, <<Year:4/binary, Month:2/binary, "-", _/binary>> = DocId) ->
+open_doc(Account, ?MATCH_MODB_PREFIX(Year,Month,_) = DocId) ->
     AccountMODb = get_modb(Account, wh_util:to_integer(Year), wh_util:to_integer(Month)),
     couch_open(AccountMODb, DocId);
 open_doc(Account, DocId) ->
@@ -168,13 +168,13 @@ couch_save(AccountMODb, Doc, Retry) ->
                       ne_binary().
 -spec get_modb(ne_binary(), wh_year() | ne_binary(), wh_month() | ne_binary()) ->
                       ne_binary().
-get_modb(<<_:32/binary, "-", _:4/binary, _:2/binary>>=AccountMODb) ->
+get_modb(?MATCH_MODB_SUFFIX_RAW(_,_,_) = AccountMODb) ->
     AccountMODb;
 get_modb(Account) ->
     {Year, Month, _} = erlang:date(),
     get_modb(Account, Year, Month).
 
-get_modb(<<_:32/binary, "-", _:4/binary, _:2/binary>>=AccountMODb, _) ->
+get_modb(?MATCH_MODB_SUFFIX_RAW(_,_,_) = AccountMODb, _) ->
     AccountMODb;
 get_modb(Account, Props) when is_list(Props) ->
     case {props:get_value('month', Props)
@@ -190,7 +190,7 @@ get_modb(Account, Props) when is_list(Props) ->
 get_modb(Account, Timestamp) ->
     wh_util:format_account_mod_id(Account, Timestamp).
 
-get_modb(<<_:32/binary, "-", _:4/binary, _:2/binary>>=AccountMODb, _Year, _Month) ->
+get_modb(?MATCH_MODB_SUFFIX_RAW(_,_,_) = AccountMODb, _Year, _Month) ->
     AccountMODb;
 get_modb(Account, Year, Month) ->
     wh_util:format_account_mod_id(Account, Year, Month).
@@ -202,7 +202,7 @@ get_modb(Account, Year, Month) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec maybe_create(ne_binary()) -> boolean().
-maybe_create(<<_:32/binary, "-", Year:4/binary, Month:2/binary>>=AccountMODb) ->
+maybe_create(?MATCH_MODB_SUFFIX_RAW(_,Year,Month) = AccountMODb) ->
     {Y, M, _} = erlang:date(),
     case {wh_util:to_binary(Y), wh_util:pad_month(M)} of
         {Year, Month} ->

--- a/core/kazoo_modb-1.0.0/src/kazoo_modb.erl
+++ b/core/kazoo_modb-1.0.0/src/kazoo_modb.erl
@@ -143,7 +143,8 @@ save_doc(Account, Doc, Year, Month) ->
                         {'ok', wh_json:object()} |
                         {'error', atom()}.
 couch_save(AccountMODb, _Doc, 0) ->
-    lager:error("failed to save doc in ~p", AccountMODb);
+    lager:error("failed to save doc in ~p", AccountMODb),
+    {'error', 'doc_save_failed'};
 couch_save(AccountMODb, Doc, Retry) ->
      EncodedMODb = wh_util:format_account_modb(AccountMODb, 'encoded'),
     case couch_mgr:save_doc(EncodedMODb, Doc) of

--- a/core/kazoo_modb-1.0.0/src/kazoo_modb_maintenance.erl
+++ b/core/kazoo_modb-1.0.0/src/kazoo_modb_maintenance.erl
@@ -62,9 +62,9 @@ should_delete(AccountModb, Months) ->
     ((ModYear * 12) + ModMonth) =< Months.
 
 -spec delete_modb(ne_binary()) -> 'ok'.
-delete_modb(<<_:42/binary, "-", _:4/binary, _:2/binary>> = AccountModb) ->
+delete_modb(?MATCH_MODB_SUFFIX_UNENCODED(_,_,_) = AccountModb) ->
     delete_modb(wh_util:format_account_db(AccountModb));
-delete_modb(<<_:48/binary, "-", _:4/binary, _:2/binary>> = AccountModb) ->
+delete_modb(?MATCH_MODB_SUFFIX_ENCODED(_,_,_) = AccountModb) ->
     'ok' = couch_util:archive(AccountModb),
     _Deleted = couch_mgr:db_delete(AccountModb),
     io:format("    deleted: ~p~n", [_Deleted]),

--- a/core/kazoo_modb-1.0.0/src/kazoo_modb_util.erl
+++ b/core/kazoo_modb-1.0.0/src/kazoo_modb_util.erl
@@ -31,17 +31,17 @@ prev_year_month_mod(AccountModb) ->
     wh_util:format_account_id(AccountId, PrevYear, PrevMonth).
 
 -spec split_account_mod(ne_binary()) -> {ne_binary(), wh_year(), wh_month()}.
-split_account_mod(<<Account:32/binary, "-", Year:4/binary, Month:2/binary>>) ->
+split_account_mod(?MATCH_MODB_SUFFIX_RAW(Account,Year,Month)) ->
     {wh_util:format_account_id(Account, 'raw')
      ,wh_util:to_integer(Year)
      ,wh_util:to_integer(Month)
     };
-split_account_mod(<<Account:42/binary, "-", Year:4/binary, Month:2/binary>>) ->
+split_account_mod(?MATCH_MODB_SUFFIX_UNENCODED(Account,Year,Month)) ->
     {wh_util:format_account_id(Account, 'raw')
      ,wh_util:to_integer(Year)
      ,wh_util:to_integer(Month)
     };
-split_account_mod(<<Account:48/binary, "-",  Year:4/binary, Month:2/binary>>) ->
+split_account_mod(?MATCH_MODB_SUFFIX_ENCODED(Account,Year,Month)) ->
     {wh_util:format_account_id(Account, 'raw')
      ,wh_util:to_integer(Year)
      ,wh_util:to_integer(Month)

--- a/core/whistle-1.0.0/include/wh_types.hrl
+++ b/core/whistle-1.0.0/include/wh_types.hrl
@@ -259,5 +259,73 @@
 -type xml_thing() :: xml_el() | xml_text().
 -type xml_things() :: xml_els() | xml_texts().
 
+
+-define(MATCH_ACCOUNT_RAW(Account),
+        <<(Account):32/binary>>
+       ).
+-define(MATCH_ACCOUNT_UNENCODED(Account),
+        <<"account/", (Account):34/binary>>
+       ).
+-define(MATCH_ACCOUNT_ENCODED(Account),
+        <<"account%2F", (Account):38/binary>>
+       ).
+-define(MATCH_ACCOUNT_encoded(Account),
+        <<"account%2f", (Account):38/binary>>
+       ).
+
+-define(MATCH_ACCOUNT_RAW(A, B, Rest),
+        <<(A):2/binary, (B):2/binary, (Rest)/binary>>
+       ).
+-define(MATCH_ACCOUNT_UNENCODED(A, B, Rest),
+        <<"account/", (A):2/binary, "/", (B):2/binary, "/", (Rest):28/binary>>
+       ).
+-define(MATCH_ACCOUNT_ENCODED(A, B, Rest),
+        <<"account%2F", (A):2/binary, "%2F", (B):2/binary, "%2F", (Rest):28/binary>>
+       ).
+-define(MATCH_ACCOUNT_encoded(A, B, Rest),
+        <<"account%2f", (A):2/binary, "%2f", (B):2/binary, "%2f", (Rest):28/binary>>
+       ).
+
+-define(MATCH_MODB_SUFFIX_RAW(A, B, Rest, Year, Month),
+        <<(A):2/binary, (B):2/binary, (Rest):28/binary
+          ,"-", (Year):4/binary, (Month):2/binary
+        >>
+       ).
+-define(MATCH_MODB_SUFFIX_UNENCODED(A, B, Rest, Year, Month),
+        <<"account/", (A):2/binary, "/", (B):2/binary, "/", (Rest):28/binary
+          ,"-", (Year):4/binary, (Month):2/binary
+        >>
+       ).
+-define(MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, Year, Month),
+        <<"account%2F", (A):2/binary, "%2F", (B):2/binary, "%2F", (Rest):28/binary
+          ,"-", (Year):4/binary, (Month):2/binary
+        >>
+       ).
+-define(MATCH_MODB_SUFFIX_encoded(A, B, Rest, Year, Month),
+        <<"account%2f", (A):2/binary, "%2f", (B):2/binary, "%2f", (Rest):28/binary
+          ,"-", (Year):4/binary, (Month):2/binary
+        >>
+       ).
+
+%% FIXME: replace these with the above ones, actually matching: "account..."
+%%   and then add MATCH_MODB_SUFFIX_encoded/3.
+-define(MATCH_MODB_SUFFIX_RAW(Account, Year, Month),
+        <<(Account):32/binary, "-", (Year):4/binary, (Month):2/binary>>
+       ).
+-define(MATCH_MODB_SUFFIX_UNENCODED(Account, Year, Month),
+        <<(Account):42/binary, "-", (Year):4/binary, (Month):2/binary>>
+       ).
+-define(MATCH_MODB_SUFFIX_ENCODED(Account, Year, Month),
+        <<(Account):48/binary, "-", (Year):4/binary, (Month):2/binary>>
+       ).
+
+-define(MATCH_MODB_PREFIX(Year, Month, Account),
+        <<(Year):4/binary, (Month):2/binary, "-", (Account)/binary>>
+       ).
+-define(MATCH_MODB_PREFIX_M1(Year, Month, Account),
+        <<(Year):4/binary, (Month):1/binary, "-", (Account)/binary>>
+       ).
+
+
 -define(WHISTLE_TYPES_INCLUDED, 'true').
 -endif.

--- a/core/whistle-1.0.0/include/wh_types.hrl
+++ b/core/whistle-1.0.0/include/wh_types.hrl
@@ -274,7 +274,7 @@
        ).
 
 -define(MATCH_ACCOUNT_RAW(A, B, Rest),
-        <<(A):2/binary, (B):2/binary, (Rest)/binary>>
+        <<(A):2/binary, (B):2/binary, (Rest)/binary>>  %% FIXME: add mising size
        ).
 -define(MATCH_ACCOUNT_UNENCODED(A, B, Rest),
         <<"account/", (A):2/binary, "/", (B):2/binary, "/", (Rest):28/binary>>
@@ -320,10 +320,10 @@
        ).
 
 -define(MATCH_MODB_PREFIX(Year, Month, Account),
-        <<(Year):4/binary, (Month):2/binary, "-", (Account)/binary>>
+        <<(Year):4/binary, (Month):2/binary, "-", (Account)/binary>>  %% FIXME: add mising size
        ).
 -define(MATCH_MODB_PREFIX_M1(Year, Month, Account),
-        <<(Year):4/binary, (Month):1/binary, "-", (Account)/binary>>
+        <<(Year):4/binary, (Month):1/binary, "-", (Account)/binary>>  %% FIXME: add mising size
        ).
 
 

--- a/core/whistle-1.0.0/src/wh_util.erl
+++ b/core/whistle-1.0.0/src/wh_util.erl
@@ -269,11 +269,8 @@ format_account_id(AccountId, Year, Month) when not is_integer(Month) ->
     format_account_id(AccountId, Year, to_integer(Month));
 format_account_id(Account, Year, Month) when is_integer(Year),
                                              is_integer(Month) ->
-    AccountId = raw_account_id(Account),
-    ?MATCH_MODB_SUFFIX_ENCODED(format_account_id(AccountId, 'encoded')
-                               ,to_binary(Year)
-                               ,pad_month(Month)
-                              ).
+    ?MATCH_ACCOUNT_RAW(A,B,Rest) = raw_account_id(Account),
+    ?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, to_binary(Year), pad_month(Month)).
 
 -spec format_account_mod_id(ne_binary()) -> ne_binary().
 -spec format_account_mod_id(ne_binary(), gregorian_seconds() | wh_now()) -> ne_binary().

--- a/core/whistle_apps-1.0.0/src/whapps_util.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_util.erl
@@ -256,13 +256,13 @@ get_account_mods(AccountId, Encoding) ->
     ].
 
 -spec is_matched_account_mod(ne_binary(), ne_binary()) -> boolean().
-is_matched_account_mod(<<"account/", DbActId:34/binary, _/binary>>
-                       ,<<"account/", SearchId/binary>>
-                      ) when DbActId =:= SearchId ->
+is_matched_account_mod(?MATCH_MODB_SUFFIX_UNENCODED(A, B, Rest, _, _)  %% DbActId
+                       ,?MATCH_ACCOUNT_UNENCODED(A, B, Rest)  %% SearchId
+                      ) ->
     'true';
-is_matched_account_mod(<<"account%2F", DbActId:38/binary, _/binary>>
-                       ,<<"account%2F",SearchId/binary>>
-                      ) when DbActId =:= SearchId ->
+is_matched_account_mod(?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, _, _)  %% DbActId
+                       ,?MATCH_ACCOUNT_ENCODED(A, B, Rest)  %% SearchId
+                      ) ->
     'true';
 is_matched_account_mod(_, _) ->
     'false'.

--- a/core/whistle_couch-1.0.0/src/couch_util.erl
+++ b/core/whistle_couch-1.0.0/src/couch_util.erl
@@ -135,12 +135,12 @@ db_classification(?KZ_WEBHOOKS_DB) -> 'aggregate';
 db_classification(<<?WNM_DB_PREFIX_L, _Prefix:5/binary>>) -> 'numbers';
 db_classification(<<"numbers%2F", _Prefix:5/binary>>) -> 'numbers';
 db_classification(<<"numbers%2f", _Prefix:5/binary>>) -> 'numbers';
-db_classification(<<"account/", _AccountId:34/binary, "-", _Date:6/binary>>) -> 'modb';
-db_classification(<<"account%2F", _AccountId:38/binary, "-", _Date:6/binary>>) -> 'modb';
-db_classification(<<"account%2f", _AccountId:38/binary, "-", _Date:6/binary>>) -> 'modb';
-db_classification(<<"account/", _AccountId:34/binary>>) -> 'account';
-db_classification(<<"account%2f", _AccountId:38/binary>>) -> 'account';
-db_classification(<<"account%2F", _AccountId:38/binary>>) -> 'account';
+db_classification(?MATCH_MODB_SUFFIX_UNENCODED(_A,_B,_Rest,_Year,_Month)) -> 'modb';% these only need to match
+db_classification(?MATCH_MODB_SUFFIX_ENCODED(_A,_B,_Rest,_Year,_Month)) -> 'modb';%   "account..." then the
+db_classification(?MATCH_MODB_SUFFIX_encoded(_A,_B,_Rest,_Year,_Month)) -> 'modb';%   right size.
+db_classification(?MATCH_ACCOUNT_UNENCODED(_AccountId)) -> 'account';
+db_classification(?MATCH_ACCOUNT_encoded(_AccountId)) -> 'account';
+db_classification(?MATCH_ACCOUNT_ENCODED(_AccountId)) -> 'account';
 db_classification(?WH_RATES_DB) -> 'system';
 db_classification(?WH_OFFNET_DB) -> 'system';
 db_classification(?WH_ANONYMOUS_CDR_DB) -> 'system';


### PR DESCRIPTION
WIP

Also, in `cb_faxes` one can fetch `smtplog`s per-`Id`.
Should I implement the same API in `cb_notifications`?