### PR TITLE
Added support to callflow modules and pivot to utilize custom KVS

### DIFF
--- a/applications/callflow/src/module/cf_acdc_member.erl
+++ b/applications/callflow/src/module/cf_acdc_member.erl
@@ -36,7 +36,7 @@
 %%--------------------------------------------------------------------
 -spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
-    QueueId = wh_doc:id(Data),
+    QueueId = cf_util:maybe_use_variable(Data, Call),
     lager:info("sending call to queue ~s", [QueueId]),
 
     Priority = lookup_priority(Data, Call),

--- a/applications/callflow/src/module/cf_callflow.erl
+++ b/applications/callflow/src/module/cf_callflow.erl
@@ -30,7 +30,7 @@ handle(Data, Call) ->
 
 -spec maybe_branch_callflow(wh_json:object(), whapps_call:call()) -> 'ok'.
 maybe_branch_callflow(Data, Call) ->
-    Id = wh_doc:id(Data),
+    Id = cf_util:maybe_use_variable(Data, Call),
     case couch_mgr:open_doc(whapps_call:account_db(Call), Id) of
         {'error', R} ->
             lager:info("could not branch to callflow ~s, ~p", [Id, R]),

--- a/applications/callflow/src/module/cf_device.erl
+++ b/applications/callflow/src/module/cf_device.erl
@@ -50,7 +50,7 @@ maybe_handle_bridge_failure(Reason, Call) ->
 -spec bridge_to_endpoints(wh_json:object(), whapps_call:call()) ->
                                  cf_api_bridge_return().
 bridge_to_endpoints(Data, Call) ->
-    EndpointId = wh_doc:id(Data),
+    EndpointId = cf_util:maybe_use_variable(Data, Call),
     Params = wh_json:set_value(<<"source">>, ?MODULE, Data),
     case cf_endpoint:build(EndpointId, Params, Call) of
         {'error', _}=E -> E;

--- a/applications/callflow/src/module/cf_kvs_set.erl
+++ b/applications/callflow/src/module/cf_kvs_set.erl
@@ -1,0 +1,91 @@
+%%%-------------------------------------------------------------------
+
+%%%-------------------------------------------------------------------
+-module(cf_kvs_set).
+
+-export([handle/2]).
+-export([get_kv/2, get_kv/3]).
+-export([kvs_to_props/1]).
+
+-include("../callflow.hrl").
+
+-define(KVS_DB, <<"kvs_collections">>).
+-define(COLLECTION_KVS, <<"Custom-KVS">>).
+-define(COLLECTION_MODE, <<"KVS-Mode">>).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
+handle(Data, Call) ->
+    Call2 = set_kvs(Data, Call),
+    cf_exe:set_call(Call2),
+    cf_exe:continue(Call2).
+
+get_kv(Key, Call) ->
+    get_kv(?COLLECTION_KVS, Key, Call).
+
+get_kv(Collection, Key, Call) ->
+    wh_json:get_value(Key, get_collection(Collection, Call)).
+    
+set_kvs(Data, Call) ->
+    Call2 = set_kvs_mode(wh_json:get_value(<<"kvs_mode">>, Data, 'undefined'), Call),
+    Data2 = wh_json:delete_key(<<"kvs_mode">>, Data),
+    Keys = wh_json:get_keys(Data2),
+    fold_set_kvs(Call2, Data2, Keys).
+
+fold_set_kvs(Call, _, []) ->
+    Call;
+fold_set_kvs(Call, Data, [Key|Keys]) ->
+    Call2 = set_kvs_collection(Key, evaluate(wh_json:get_value(Key, Data), Call), Call),
+    fold_set_kvs(Call2, Data, Keys).
+    
+set_kvs_mode('undefined', Call) -> set_collection(?COLLECTION_MODE, <<"kvs_mode">>, 'undefined', Call);
+set_kvs_mode(Mode, Call) -> set_collection(?COLLECTION_MODE, <<"kvs_mode">>, Mode, Call).
+
+evaluate(<<"$", Key/binary>>, Call) ->
+    get_kv(Key, Call);
+evaluate(Value, Call) ->
+    case wh_json:is_json_object(Value) of
+        'true' -> evaluate_ui(wh_json:get_keys(Value), Value, Call);
+        'false' -> Value
+    end.
+
+evaluate_ui([<<"type">>, <<"value">>], Value, _Call) ->
+    %evaluate(wh_json:get_value(<<"value">>, Value), Call);
+    Value;
+evaluate_ui(_, Value, _) ->
+    Value.
+
+-spec get_kvs_collection(whapps_call:call()) -> api_binary().
+get_kvs_collection(Call) ->
+    get_collection(?COLLECTION_KVS, Call).
+
+get_collection(Collection, Call) ->
+    wh_json:get_value(Collection, whapps_call:kvs_fetch(?KVS_DB, wh_json:new(), Call), wh_json:new()).
+
+-spec set_kvs_collection(ne_binary(), ne_binary(), whapps_call:call()) -> whapps_call:call().
+set_kvs_collection(Key, Value, Call) ->
+    set_collection(?COLLECTION_KVS, Key, Value, Call).
+    
+set_collection(Collection, Key, Value, Call) ->
+    Collections = whapps_call:kvs_fetch(?KVS_DB, wh_json:new(), Call),
+    OldCollection = get_collection(Collection, Call),
+    NewCollection = wh_json:set_value(Key, Value, OldCollection),
+    whapps_call:kvs_store(
+    	?KVS_DB,
+        wh_json:set_value(Collection, NewCollection, Collections),
+        Call
+    ).
+    
+kvs_to_props(Call) ->
+    case wh_json:get_value(<<"kvs_mode">>, get_collection(?COLLECTION_MODE, Call), 'undefined') of
+        <<"json">> ->
+            Collection = get_kvs_collection(Call),
+            Keys = wh_json:get_keys(Collection),
+            [{Key, wh_json:encode(wh_json:get_value(Key, Collection))} || Key <- Keys];
+        _ ->
+            [{<<"Custom-KVS">>, get_kvs_collection(Call)}]
+    end.

--- a/applications/callflow/src/module/cf_menu.erl
+++ b/applications/callflow/src/module/cf_menu.erl
@@ -507,7 +507,7 @@ update_doc(Updates, Id, Call) ->
 %%--------------------------------------------------------------------
 -spec get_menu_profile(wh_json:object(), whapps_call:call()) -> menu().
 get_menu_profile(Data, Call) ->
-    Id = wh_doc:id(Data),
+    Id = cf_util:maybe_use_variable(Data, Call),
     AccountDb = whapps_call:account_db(Call),
     case couch_mgr:open_doc(AccountDb, Id) of
         {'ok', JObj} ->

--- a/applications/callflow/src/module/cf_play.erl
+++ b/applications/callflow/src/module/cf_play.erl
@@ -23,7 +23,8 @@
 -spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
     AccountId = whapps_call:account_id(Call),
-    Path = wh_doc:id(Data),
+
+    Path = cf_util:maybe_use_variable(Data, Call),
     case wh_media_util:media_path(Path, AccountId) of
         'undefined' ->
             lager:info("invalid data in the play callflow"),

--- a/applications/callflow/src/module/cf_user.erl
+++ b/applications/callflow/src/module/cf_user.erl
@@ -24,7 +24,7 @@
 %%--------------------------------------------------------------------
 -spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
-    UserId = wh_doc:id(Data),
+    UserId = cf_util:maybe_use_variable(Data, Call),
     Endpoints = get_endpoints(UserId, Data, Call),
     Timeout = wh_json:get_integer_value(<<"timeout">>, Data, ?DEFAULT_TIMEOUT_S),
     Strategy = wh_json:get_binary_value(<<"strategy">>, Data, <<"simultaneous">>),

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -1544,7 +1544,7 @@ has_message_meta(NewMsgCallId, Messages) ->
 %%--------------------------------------------------------------------
 -spec get_mailbox_profile(wh_json:object(), whapps_call:call()) -> mailbox().
 get_mailbox_profile(Data, Call) ->
-    Id = wh_doc:id(Data),
+    Id = cf_util:maybe_use_variable(Data, Call),
     AccountDb = whapps_call:account_db(Call),
 
     case get_mailbox_doc(AccountDb, Id, Data, Call) of

--- a/core/kazoo_translator-1.0.0/src/convertors/kzt_kazoo.erl
+++ b/core/kazoo_translator-1.0.0/src/convertors/kzt_kazoo.erl
@@ -65,4 +65,5 @@ req_params(Call) ->
        ,{<<"Transcription-Text">>, kzt_util:get_transcription_text(Call)}
        ,{<<"Transcription-Status">>, kzt_util:get_transcription_status(Call)}
        ,{<<"Transcription-Url">>, kzt_util:get_transcription_url(Call)}
+       | cf_kvs_set:kvs_to_props(Call)
       ]).


### PR DESCRIPTION
Continuation of #1255.
@lazedo In response to your idea to move away from changing the cf modules to use maybe_use_variable: do you have any suggestions for dealing with validation of doc existence? For example, any that are using cf_util:maybe_use_variable have the id value checked in couch. However, cf_pivot is the exception to this rule. cf_pivot just takes the voice_url value. Perhaps a third element of the tuple you suggested? ( {<<"TheElementIWant">>, {<<"kvs">>, <<"kv">>}, 'validate_exists'} )

Multiple fixes

Moved maybe_use_variable into cf_util
Formatting cleanup
Folding functions / list comps
Use wh_json:encode instead of format_json_rec