### PR TITLE
Bump queue callers out of the queue when empty

### DIFF
--- a/applications/acdc/src/acdc.hrl
+++ b/applications/acdc/src/acdc.hrl
@@ -13,6 +13,7 @@
 -define(ABANDON_TIMEOUT, 'member_timeout').
 -define(ABANDON_EXIT, 'member_exit').
 -define(ABANDON_HANGUP, 'member_hangup').
+-define(ABANDON_EMPTY, 'member_exit_empty').
 
 -define(PRESENCE_GREEN, <<"terminated">>).
 -define(PRESENCE_RED_FLASH, <<"early">>).

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -805,7 +805,9 @@ elapsed(Time) -> wh_util:elapsed_s(Time).
 %%                   queue_fsm_state()
 %% @end
 %%--------------------------------------------------------------------
--spec maybe_connect_re_req(pid(), pid(), queue_fsm_state()) -> queue_fsm_state().
+-spec maybe_connect_re_req(pid(), pid(), queue_fsm_state()) ->
+                                {'next_state', atom(), queue_fsm_state()}
+                                | {'next_state', atom(), queue_fsm_state(), 'hibernate'}.
 maybe_connect_re_req(MgrSrv, ListenerSrv, #state{account_id=AccountId
                                                  ,queue_id=QueueId
                                                  ,member_call=Call

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -339,10 +339,7 @@ connect_req({'timeout', Ref, ?COLLECT_RESP_MESSAGE}, #state{collect_ref=Ref
             acdc_queue_listener:finish_member_call(Srv),
             {'next_state', 'ready', State};
         'false' ->
-            lager:debug("done waiting, no agents responded, let's ask again"),
-            webseq:note(?WSD_ID, self(), 'right', <<"no agents responded, trying again">>),
-            acdc_queue_listener:member_connect_re_req(Srv),
-            {'next_state', 'connect_req', State#state{collect_ref=start_collect_timer()}}
+            maybe_connect_re_req(MgrSrv, Srv, State)
     end;
 
 connect_req({'timeout', Ref, ?COLLECT_RESP_MESSAGE}, #state{collect_ref=Ref}=State) ->
@@ -797,6 +794,35 @@ elapsed(Ref) when is_reference(Ref) ->
         Ms -> Ms div 1000
     end;
 elapsed(Time) -> wh_util:elapsed_s(Time).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Abort a queue call between connect_reqs if agents have left the
+%% building
+%%
+%% @spec maybe_connect_re_req(pid(), pid(), queue_fsm_state()) ->
+%%                   queue_fsm_state()
+%% @end
+%%--------------------------------------------------------------------
+-spec maybe_connect_re_req(pid(), pid(), queue_fsm_state()) -> queue_fsm_state().
+maybe_connect_re_req(MgrSrv, ListenerSrv, #state{account_id=AccountId
+                                                 ,queue_id=QueueId
+                                                 ,member_call=Call
+                                                }=State) ->
+    case acdc_queue_manager:are_agents_available(MgrSrv) of
+        'true' ->
+            lager:debug("done waiting, no agents responded, let's ask again"),
+            webseq:note(?WSD_ID, self(), 'right', <<"no agents responded, trying again">>),
+            acdc_queue_listener:member_connect_re_req(ListenerSrv),
+            {'next_state', 'connect_req', State#state{collect_ref=start_collect_timer()}};
+        'false' ->
+            lager:debug("all agents have left the queue, failing call"),
+            webseq:note(?WSD_ID, self(), 'right', <<"all agents have left the queue, failing call">>),
+            acdc_queue_listener:exit_member_call_empty(ListenerSrv),
+            acdc_stats:call_abandoned(AccountId, QueueId, whapps_call:call_id(Call), ?ABANDON_EMPTY),
+            {'next_state', 'ready', clear_member_call(State), 'hibernate'}
+    end.
 
 -spec accept_is_for_call(wh_json:object(), whapps_call:call()) -> boolean().
 accept_is_for_call(AcceptJObj, Call) ->

--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -395,7 +395,7 @@ handle_cast({'exit_member_call_empty'}, #state{delivery=Delivery
                                                ,call=Call
                                                ,shared_pid=Pid
                                                ,member_call_queue=Q
-                                               ,acct_id=AcctId
+                                               ,account_id=AccountId
                                                ,queue_id=QueueId
                                                ,my_id=MyId
                                                ,agent_id=AgentId
@@ -405,7 +405,7 @@ handle_cast({'exit_member_call_empty'}, #state{delivery=Delivery
     acdc_util:unbind_from_call_events(Call),
     lager:debug("unbound from call events for ~s", [whapps_call:call_id(Call)]),
     acdc_queue_shared:ack(Pid, Delivery),
-    send_member_call_failure(Q, AcctId, QueueId, whapps_call:call_id(Call), MyId, AgentId, <<"No agents left in queue">>),
+    send_member_call_failure(Q, AccountId, QueueId, whapps_call:call_id(Call), MyId, AgentId, <<"No agents left in queue">>),
 
     {'noreply', clear_call_state(State), 'hibernate'};
 handle_cast({'finish_member_call'}, #state{call='undefined'}=State) ->

--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -19,6 +19,7 @@
          ,handle_member_call/2
          ,handle_member_call_cancel/2
          ,handle_agent_change/2
+         ,are_agents_available/1
          ,handle_config_change/2
          ,should_ignore_member_call/3, should_ignore_member_call/4
          ,config/1
@@ -155,6 +156,10 @@ handle_member_call(JObj, Props) ->
         'true' ->
             start_queue_call(JObj, Props, Call)
     end.
+
+-spec are_agents_available(server_ref()) -> boolean().
+are_agents_available(Srv) ->
+    are_agents_available(Srv, gen_listener:call(Srv, 'enter_when_empty')).
 
 are_agents_available(Srv, EnterWhenEmpty) ->
     agents_available(Srv) > 0 orelse EnterWhenEmpty.
@@ -347,6 +352,9 @@ handle_call('agents_available', _, #state{strategy_state=[_|_]}=State) ->
     {'reply', 1, State};
 handle_call('agents_available', _, #state{strategy_state=SS}=State) ->
     {'reply', queue:len(SS), State};
+
+handle_call('enter_when_empty', _, #state{enter_when_empty=EnterWhenEmpty}=State) ->
+    {'reply', EnterWhenEmpty, State};
 
 handle_call('next_winner', _, #state{strategy='mi'}=State) ->
     {'reply', 'undefined', State};


### PR DESCRIPTION
If queue has enter_when_empty disabled, queue callers skip entering the queue in cf_acdc_member. However, if the caller enters the queue and all remaining agents subsequently leave the queue, the caller waits, potentially to the queue timeout. This pull request modifies the behaviour of the queue so that with enter_when_empty disabled, queue callers will abort the queue if all its agents log out.