### PR TITLE
Fix function clause on removing webhooks.

### DIFF
--- a/applications/webhooks/src/webhooks_listener.erl
+++ b/applications/webhooks/src/webhooks_listener.erl
@@ -279,8 +279,7 @@ maybe_remove_shared_bindings(Id) ->
     ets:delete(webhooks_util:table_id(), Id).
 
 -spec remove_shared_bindings(webhook()) -> 'ok'.
-remove_shared_bindings(#webhook{hook_event = <<"object">>
-                                ,account_id = AccountId
+remove_shared_bindings(#webhook{account_id = AccountId
                                 ,id = Id
                                }
                       ) ->


### PR DESCRIPTION
```
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|webhooks_listener:189 (<0.27433.2>) removing hook 0ee2d697cd6d7698cf9e0a3719fc0df5.700c8b2238fc1d52a53683797623b67a
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|gen_listener:993 (<0.27433.2>) handle_cast exception: error: function_clause
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|wh_util:140 (<0.27433.2>) stacktrace:
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|wh_util:149 (<0.27433.2>) st: webhooks_listener:remove_shared_bindings at 282
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|wh_util:150 (<0.27433.2>) args: {webhook,<<"0ee2d697cd6d7698cf9e0a3719fc0df5.700c8b2238fc1d52a53683797623b67a">>,<<"http://localhost:8100/test.php">>,get,<<"callflow">>,<<"700c8b2238fc1d52a53683797623b67a">>,1,<<"0ee2d697cd6d7698cf9e0a3719fc0df5">>,undefined,undefined}
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|wh_util:147 (<0.27433.2>) st: webhooks_listener:maybe_remove_shared_bindings/1 at (275) 
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|wh_util:147 (<0.27433.2>) st: webhooks_listener:handle_cast/2 at (190) 
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|wh_util:147 (<0.27433.2>) st: gen_listener:handle_module_cast/2 at (978) 
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|wh_util:147 (<0.27433.2>) st: gen_server:handle_msg/5 at (607) 
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|wh_util:147 (<0.27433.2>) st: proc_lib:wake_up/3 at (237) 
Oct  1 19:03:41 dev 2600hz[5506]: |webhooks_listener|webhooks_listener:248 (<0.27433.2>) listener terminating: function_clause
```
