### PR TITLE
KAZOO-4292: blackhole clear_subscriptions event

### DIFF
--- a/applications/blackhole/doc/index.md
+++ b/applications/blackhole/doc/index.md
@@ -33,10 +33,10 @@ From here, you can write your own Javascript callbacks, triggered everytime a re
   <body>
     <script>
       var socket = io.connect('http://{BLACKHOLE_IP_ADDRESS}:5555');
-      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: {AUTH_TOKEN}, binding: 'call.CHANNEL_CREATE.*' });
-      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: {AUTH_TOKEN}, binding: 'call.CHANNEL_ANSWER.*' });
-      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: {AUTH_TOKEN}, binding: 'call.CHANNEL_DESTROY.*' });
-      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: {AUTH_TOKEN}, binding: 'conference.event.*' });
+      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: '{AUTH_TOKEN}', binding: 'call.CHANNEL_CREATE.*' });
+      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: '{AUTH_TOKEN}', binding: 'call.CHANNEL_ANSWER.*' });
+      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: '{AUTH_TOKEN}', binding: 'call.CHANNEL_DESTROY.*' });
+      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: '{AUTH_TOKEN}', binding: 'conference.event.*' });
 
       socket.on('participants_event', function (data) {
         console.log(data);

--- a/applications/blackhole/doc/index.md
+++ b/applications/blackhole/doc/index.md
@@ -60,7 +60,23 @@ From here, you can write your own Javascript callbacks, triggered everytime a re
     </script>
   </body>
 </html>
+
+
 ```
+To remove unnecessary bindings use 'unsubscribe' event:
+For particular subscription:
+```
+socket.emit('unsubscribe', { account_id: '4b8c6fec4b2597882c0390202d195419', auth_token: AuthToken, binding: 'call.CHANNEL_CREATE.*'});
+```
+For all previous subscriptions:
+```
+socket.emit('unsubscribe', {});
+```
+or just
+```
+socket.emit('unsubscribe');
+```
+
 
 ### The EventJObj data structure
 

--- a/applications/blackhole/doc/index.md
+++ b/applications/blackhole/doc/index.md
@@ -13,9 +13,9 @@ Language: en-US
 1. Find your Account ID (e.g. `4b31dd1d32ce6d249897c06332375d65`)
 1. [Obtain an Auth Token](https://2600hz.atlassian.net/wiki/display/APIs/Generating+an+Authentication+Token) (e.g. `7b70f69a2a4976d80bfa0382894d1553`)
 1. Copy the **Example Client** code into an HTML file (named e.g. `kazoo_example_ws_client.html`)
-    1. Replace `192.168.56.111` with your Kazoo server's IP address
+    1. Replace `{BLACKHOLE_IP_ADDRESS}` with your Kazoo server's IP address
     1. Replace default `5555` with the port number you can configure in **sysconfig > blackhole > port** (integer)
-    1. Replace the `account_id` and `auth_token` fields with your data
+    1. Replace the `{ACCOUNT_ID}` and `{AUTH_TOKEN}` fields with your data
 1. You're all set!
 
 Now access `kazoo_example_ws_client.html` with your favourite Web browser and open the Javascript console.
@@ -32,12 +32,11 @@ From here, you can write your own Javascript callbacks, triggered everytime a re
   </head>
   <body>
     <script>
-      var socket = io.connect('http://192.168.25.216:5555');
-      var AuthToken = '53d0af4ae87bee5e5896ca3c98fd2497';
-      socket.emit('subscribe', { account_id: '4b8c6fec4b2597882c0390202d195419', auth_token: AuthToken, binding: 'call.CHANNEL_CREATE.*'});
-      socket.emit('subscribe', { account_id: '4b8c6fec4b2597882c0390202d195419', auth_token: Authtoken, binding: 'call.CHANNEL_ANSWER.*'});
-      socket.emit('subscribe', { account_id: '4b8c6fec4b2597882c0390202d195419', auth_token: Authtoken, binding: 'call.CHANNEL_DESTROY.*'});
-      socket.emit('subscribe', { account_id: '4b8c6fec4b2597882c0390202d195419', auth_token: Authtoken, binding: 'conference.event.*'});
+      var socket = io.connect('http://{BLACKHOLE_IP_ADDRESS}:5555');
+      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: {AUTH_TOKEN}, binding: 'call.CHANNEL_CREATE.*' });
+      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: {AUTH_TOKEN}, binding: 'call.CHANNEL_ANSWER.*' });
+      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: {AUTH_TOKEN}, binding: 'call.CHANNEL_DESTROY.*' });
+      socket.emit('subscribe', { account_id: '{ACCOUNT_ID}', auth_token: {AUTH_TOKEN}, binding: 'conference.event.*' });
 
       socket.on('participants_event', function (data) {
         console.log(data);
@@ -67,15 +66,11 @@ To remove unnecessary bindings use 'unsubscribe' event:
 
 For particular subscription:
 ```
-socket.emit('unsubscribe', { account_id: '4b8c6fec4b2597882c0390202d195419', auth_token: AuthToken, binding: 'call.CHANNEL_CREATE.*'});
+socket.emit('unsubscribe', { account_id: '{ACCOUNT_ID}', auth_token: '{AUTH_TOKEN}', binding: 'call.CHANNEL_CREATE.*' });
 ```
 For all previous subscriptions:
 ```
-socket.emit('unsubscribe', {});
-```
-or just
-```
-socket.emit('unsubscribe');
+socket.emit('unsubscribe', { auth_token: '{AUTH_TOKEN}' });
 ```
 
 

--- a/applications/blackhole/doc/index.md
+++ b/applications/blackhole/doc/index.md
@@ -64,6 +64,7 @@ From here, you can write your own Javascript callbacks, triggered everytime a re
 
 ```
 To remove unnecessary bindings use 'unsubscribe' event:
+
 For particular subscription:
 ```
 socket.emit('unsubscribe', { account_id: '4b8c6fec4b2597882c0390202d195419', auth_token: AuthToken, binding: 'call.CHANNEL_CREATE.*'});

--- a/applications/blackhole/src/blackhole_socket_callback.erl
+++ b/applications/blackhole/src/blackhole_socket_callback.erl
@@ -39,23 +39,25 @@ recv(_SessionPid, _SessionId, {'event', _Ignore, <<"subscribe">>, SubscriptionJO
     end,
     {'ok', Context1};
 
-recv(SessionPid, SessionId, {'event', _Ignore, <<"unsubscribe">>, {[]}}, Context) ->
-    lager:debug("remove all bindings for session: ~p", [SessionId]),
-    Filter = fun (_1, _2, _3, _4) -> filter_bindings(SessionPid, _1, _2, _3, _4) end,
-    blackhole_bindings:filter(Filter),
-    {'ok', Context};
-
-recv(_SessionPid, SessionId, {'event', _Ignore, <<"unsubscribe">>, SubscriptionJObj}, Context) ->
-    lager:debug("Remove binding for session: ~p. Data: ~p", [SessionId, SubscriptionJObj]),
+recv(SessionPid, SessionId, {'event', _Ignore, <<"unsubscribe">>, SubscriptionJObj}, Context) ->
+    lager:debug("maybe remove binding for session: ~p. Data: ~p", [SessionId, SubscriptionJObj]),
     Context1 = bh_context:from_subscription(Context, SubscriptionJObj),
     case blackhole_util:is_authorized(Context1) of
         'true' ->
-            Binding = bh_context:binding(Context1),
-            case blackhole_util:get_callback_module(Binding) of
-                'undefined' -> blackhole_util:respond_with_error(Context1);
-                Module ->
-                    blackhole_bindings:unbind(Binding, Module, 'handle_event', Context1),
-                    blackhole_util:maybe_rm_binding_from_listener(Module, Binding, Context1)
+            case wh_json:get_value(<<"account_id">>, SubscriptionJObj) of
+                'undefined' ->
+                    lager:debug("remove all bindings for session: ~p", [SessionId]),
+                    Filter = fun (A, B, C, D) -> filter_bindings(SessionPid, A, B, C, D) end,
+                    blackhole_bindings:filter(Filter);
+                AccountId ->
+                    Binding = bh_context:binding(Context1),
+                    case blackhole_util:get_callback_module(Binding) of
+                        'undefined' -> blackhole_util:respond_with_error(Context1);
+                        Module ->
+                            lager:debug("remove binding for account_id: ~p", [AccountId]),
+                            blackhole_bindings:unbind(Binding, Module, 'handle_event', Context1),
+                            blackhole_util:maybe_rm_binding_from_listener(Module, Binding, Context1)
+                    end
             end;
         'false' ->
             blackhole_util:respond_with_authn_failure(Context1)
@@ -71,7 +73,7 @@ recv(_SessionPid, SessionId, Message, Context) ->
 
 close(SessionPid, SessionId, _Context) ->
     lager:debug("closing socket ~p", [SessionId]),
-    Filter = fun (_1, _2, _3, _4) -> filter_bindings(SessionPid, _1, _2, _3, _4) end,
+    Filter = fun (A, B, C, D) -> filter_bindings(SessionPid, A, B, C, D) end,
     blackhole_bindings:filter(Filter),
     'ok'.
 

--- a/applications/blackhole/src/blackhole_socket_callback.erl
+++ b/applications/blackhole/src/blackhole_socket_callback.erl
@@ -39,11 +39,28 @@ recv(_SessionPid, _SessionId, {'event', _Ignore, <<"subscribe">>, SubscriptionJO
     end,
     {'ok', Context1};
 
-recv(SessionPid, SessionId, {'event', _Ignore, <<"clear_subscriptions">>, _Data}, Context) ->
+recv(SessionPid, SessionId, {'event', _Ignore, <<"unsubscribe">>, {[]}}, Context) ->
     lager:debug("remove all bindings for session: ~p", [SessionId]),
     Filter = fun (_1, _2, _3, _4) -> filter_bindings(SessionPid, _1, _2, _3, _4) end,
     blackhole_bindings:filter(Filter),
     {'ok', Context};
+
+recv(_SessionPid, SessionId, {'event', _Ignore, <<"unsubscribe">>, SubscriptionJObj}, Context) ->
+    lager:debug("Remove binding for session: ~p. Data: ~p", [SessionId, SubscriptionJObj]),
+    Context1 = bh_context:from_subscription(Context, SubscriptionJObj),
+    case blackhole_util:is_authorized(Context1) of
+        'true' ->
+            Binding = bh_context:binding(Context1),
+            case blackhole_util:get_callback_module(Binding) of
+                'undefined' -> blackhole_util:respond_with_error(Context1);
+                Module ->
+                    blackhole_bindings:unbind(Binding, Module, 'handle_event', Context1),
+                    blackhole_util:maybe_rm_binding_from_listener(Module, Binding, Context1)
+            end;
+        'false' ->
+            blackhole_util:respond_with_authn_failure(Context1)
+    end,
+    {'ok', Context1};
 
 recv(_SessionPid, _SessionId, {'event', _Ignore, _Event, _Data}, Context) ->
     lager:debug("received event: ~p on socket ~p with data payload", [_Event, _SessionId]),

--- a/applications/blackhole/src/blackhole_socket_callback.erl
+++ b/applications/blackhole/src/blackhole_socket_callback.erl
@@ -39,6 +39,12 @@ recv(_SessionPid, _SessionId, {'event', _Ignore, <<"subscribe">>, SubscriptionJO
     end,
     {'ok', Context1};
 
+recv(SessionPid, SessionId, {'event', _Ignore, <<"clear_subscriptions">>, _Data}, Context) ->
+    lager:debug("remove all bindings for session: ~p", [SessionId]),
+    Filter = fun (_1, _2, _3, _4) -> filter_bindings(SessionPid, _1, _2, _3, _4) end,
+    blackhole_bindings:filter(Filter),
+    {'ok', Context};
+
 recv(_SessionPid, _SessionId, {'event', _Ignore, _Event, _Data}, Context) ->
     lager:debug("received event: ~p on socket ~p with data payload", [_Event, _SessionId]),
     {'ok', Context};


### PR DESCRIPTION
As a reseller I would like to monitor accounts' calls with blackhole. 
When I am choosing one account after another I need to remove bindings used to listen for previous account's events 