### PR TITLE
Restore work allotments/consumed

### DIFF
--- a/applications/crossbar/src/modules/cb_allotments.erl
+++ b/applications/crossbar/src/modules/cb_allotments.erl
@@ -127,14 +127,6 @@ load_consumed(Context) ->
 -spec foldl_consumed(api_binary(), wh_json:object(), CMA) -> CMA when
       CMA :: {cb_context:context(), mode(), wh_json:objects()}.
 foldl_consumed(Classification, Value, {Context, Mode, Acc}) ->
-    case cb_context:resp_status(Context) of
-        'success' -> consume_allotment(Classification, Value, {Context,Mode,Acc});
-        _Error -> {Context, Mode, Acc}
-    end.
-
--spec consume_allotment(api_binary(), wh_json:object(), CMA) -> CMA when
-      CMA :: {cb_context:context(), mode(), wh_json:objects()}.
-consume_allotment(Classification, Value, {Context,Mode,Acc}) ->
     case create_viewoptions(Context, Classification, Value, Mode) of
         {Cycle, ViewOptions} ->
             [_, From] = props:get_value('startkey', ViewOptions),


### PR DESCRIPTION
After 64ac39b01c3a307ce1ebc9da76981ddda6fbac15 always get 500 error on `allotments/consumed`