### PR TITLE
KAZOO-4224 allow cf_park to continue when callback is not answered

### DIFF
--- a/applications/callflow/src/module/cf_park.erl
+++ b/applications/callflow/src/module/cf_park.erl
@@ -616,18 +616,22 @@ wait_for_pickup(SlotNumber, Slot, Call) ->
             cf_exe:transfer(Call)
     end.
 
+-spec ringback_timeout(ne_binary(), integer()) -> integer().
 ringback_timeout(AccountId, SlotNumber) ->
     JObj = slot_configuration(AccountId, SlotNumber),
-    wh_json:get_value(<<"ringback_time">>, JObj, ?ACCOUNT_RINGBACK_TM(AccountId)).
+    wh_json:get_integer_value(<<"ringback_time">>, JObj, ?ACCOUNT_RINGBACK_TM(AccountId)).
 
+-spec unanswered_action(integer(), wh_json:object(), whapps_call:call()) -> 'ok'.
 unanswered_action(SlotNumber, Slot, Call) ->
     JObj = slot_configuration(whapps_call:account_id(Call), SlotNumber),
     unanswered_action(SlotNumber, Slot, Call, JObj).
 
+-spec unanswered_action(integer(), wh_json:object(), whapps_call:call(), wh_json:object()) -> 'ok'.
 unanswered_action(SlotNumber, Slot, Call, JObj) ->
     Action = wh_json:get_string_value(<<"type">>, JObj, <<"repark">>),
     unanswered_action(Action, SlotNumber, Slot, Call, JObj).
 
+-spec unanswered_action(ne_binary(), integer(), wh_json:object(), whapps_call:call(), wh_json:object()) -> 'ok'.
 unanswered_action(<<"repark">>, SlotNumber, Slot, Call, _JObj) ->
     lager:info("ringback was not answered, continuing to hold parked call"),
     wait_for_pickup(SlotNumber, Slot, Call);
@@ -649,9 +653,11 @@ get_flow(Id, AccountId) ->
         _ -> 'undefined'
     end.
 
+-spec slots_configuration(ne_binary()) -> wh_json:object().
 slots_configuration(AccountId) ->
     whapps_account_config:get(AccountId, ?MOD_CONFIG_CAT, <<"slots">>, wh_json:new()).
 
+-spec slot_configuration(ne_binary(), integer()) -> wh_json:object().
 slot_configuration(AccountId, SlotNumber) ->
     wh_json:get_value(SlotNumber, slots_configuration(AccountId), wh_json:new()).
 

--- a/applications/callflow/src/module/cf_park.erl
+++ b/applications/callflow/src/module/cf_park.erl
@@ -629,7 +629,7 @@ unanswered_action(SlotNumber, Slot, Data, Call) ->
         'undefined' -> wait_for_pickup(SlotNumber, Slot, Data, Call);
         _ ->
             _ = publish_abandoned(Call, SlotNumber),
-            _ = cleanup_slot(SlotNumber, cf_exe:callid(Call), whapps_call:account_db(Call)),            
+            _ = cleanup_slot(SlotNumber, cf_exe:callid(Call), whapps_call:account_db(Call)),
             cf_exe:continue(SlotNumber, Call)
     end.
 
@@ -666,7 +666,7 @@ get_endpoint_id(Username, Call) ->
                              'answered' | 'failed' | 'channel_hungup'.
 ringback_parker('undefined', _, _, _, _) -> 'failed';
 ringback_parker(EndpointId, SlotNumber, TmpCID, Data, Call) ->
-    Timeout = callback_timeout(Data, SlotNumber),    
+    Timeout = callback_timeout(Data, SlotNumber),
     case cf_endpoint:build(EndpointId, wh_json:from_list([{<<"can_call_self">>, 'true'}]), Call) of
         {'ok', Endpoints} ->
             lager:info("attempting to ringback endpoint ~s", [EndpointId]),


### PR DESCRIPTION
define children with SlotNumber to allow callflow continuation per slot
or define wildcard "_" to allow for all slots
