### PR TITLE
Added webhook for CHANNEL_BRIDGE

### DIFF
--- a/applications/webhooks/src/modules/webhooks_channel_bridge.erl
+++ b/applications/webhooks/src/modules/webhooks_channel_bridge.erl
@@ -1,0 +1,44 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2015, 2600Hz INC
+%%%
+%%% @contributors
+%%%-------------------------------------------------------------------
+
+-module(webhooks_channel_bridge).
+
+-export([init/0
+         ,bindings_and_responders/0
+        ]).
+
+-include("../webhooks.hrl").
+
+-define(ID, wh_util:to_binary(?MODULE)).
+-define(NAME, <<"channel_bridge">>).
+-define(DESC, <<"Events when channel is bridged">>).
+-define(METADATA
+        ,wh_json:from_list([{<<"_id">>, ?ID}
+                            ,{<<"name">>, ?NAME}
+                            ,{<<"description">>, ?DESC}
+                           ])
+       ).
+
+-spec init() -> 'ok'.
+init() ->
+    webhooks_util:init_metadata(?ID, ?METADATA).
+
+-spec bindings_and_responders() ->
+                                  {gen_listener:bindings()
+                                   ,gen_listener:responders()
+                                  }.
+bindings_and_responders() ->
+    {[{'call', [{'restrict_to', ['CHANNEL_BRIDGE']}
+                ,'federate'
+               ]
+      }
+     ]
+     ,[{{'webhooks_channel_util', 'handle_event'}
+        ,[{<<"call_event">>, <<"CHANNEL_BRIDGE">>}]
+       }
+      ]
+    }.
+

--- a/applications/webhooks/src/webhooks_channel_util.erl
+++ b/applications/webhooks/src/webhooks_channel_util.erl
@@ -46,6 +46,14 @@ format_event(JObj, AccountId, <<"CHANNEL_ANSWER">>) ->
     wh_json:set_value(<<"hook_event">>, <<"channel_answer">>
                       ,base_hook_event(JObj, AccountId)
                      );
+format_event(JObj, AccountId, <<"CHANNEL_BRIDGE">>) ->
+    base_hook_event(JObj
+		     ,AccountId
+		     ,[{<<"hook_event">>, <<"channel_bridge">>}
+		       ,{<<"original_number">>, ccv(JObj, <<"Original-Number">>)}
+		       ,{<<"other_leg_destination_number">>, wh_json:get_value(<<"Other-Leg-Destination-Number">>, JObj)}
+		      ]
+		     );	
 format_event(JObj, AccountId, <<"CHANNEL_DESTROY">>) ->
     base_hook_event(JObj
                     ,AccountId

--- a/applications/webhooks/src/webhooks_channel_util.erl
+++ b/applications/webhooks/src/webhooks_channel_util.erl
@@ -53,7 +53,7 @@ format_event(JObj, AccountId, <<"CHANNEL_BRIDGE">>) ->
 		       ,{<<"original_number">>, ccv(JObj, <<"Original-Number">>)}
 		       ,{<<"other_leg_destination_number">>, wh_json:get_value(<<"Other-Leg-Destination-Number">>, JObj)}
 		      ]
-		     );	
+		     );
 format_event(JObj, AccountId, <<"CHANNEL_DESTROY">>) ->
     base_hook_event(JObj
                     ,AccountId

--- a/applications/webhooks/src/webhooks_util.erl
+++ b/applications/webhooks/src/webhooks_util.erl
@@ -349,6 +349,7 @@ hook_event(Bin) -> hook_event_lowered(wh_util:to_lower_binary(Bin)).
 hook_event_lowered(<<"channel_create">>) -> <<"CHANNEL_CREATE">>;
 hook_event_lowered(<<"channel_answer">>) -> <<"CHANNEL_ANSWER">>;
 hook_event_lowered(<<"channel_destroy">>) -> <<"CHANNEL_DESTROY">>;
+hook_event_lowered(<<"channel_bridge">>) -> <<"CHANNEL_BRIDGE">>;
 hook_event_lowered(<<"all">>) -> <<"all">>;
 hook_event_lowered(Event) ->
     'true' = lists:member(Event, available_events()),

--- a/core/whistle_apps-1.0.0/src/wh_hooks_listener.erl
+++ b/core/whistle_apps-1.0.0/src/wh_hooks_listener.erl
@@ -28,6 +28,7 @@
 -define(ALL_EVENTS, [<<"CHANNEL_CREATE">>
                      ,<<"CHANNEL_ANSWER">>
                      ,<<"CHANNEL_DESTROY">>
+		     ,<<"CHANNEL_BRIDGE">>
                     ]).
 -define(CALL_BINDING(Events), {'call', [{'restrict_to', Events}
                                         ,'federate'

--- a/core/whistle_apps-1.0.0/src/wh_hooks_shared_listener.erl
+++ b/core/whistle_apps-1.0.0/src/wh_hooks_shared_listener.erl
@@ -28,6 +28,7 @@
 -define(ALL_EVENTS, [<<"CHANNEL_CREATE">>
                      ,<<"CHANNEL_ANSWER">>
                      ,<<"CHANNEL_DESTROY">>
+		     ,<<"CHANNEL_BRIDGE">>
                     ]).
 -define(CALL_BINDING(Events), {'call', [{'restrict_to', Events}
                                         ,'federate'


### PR DESCRIPTION
Hi,

I created a webhook for the CHANNEL_BRIDGE callevt, and customized some variables in the webhook in order to track call transfers (to see what the original called number was).

other_leg_destination_number: shows the destination of a call transfer
original_number: shows the number on the other end of the bridge