### PR TITLE
HELP-19461 clarify usage of stepswitch resource properties

### DIFF
--- a/applications/jonny5/src/j5_request.erl
+++ b/applications/jonny5/src/j5_request.erl
@@ -134,7 +134,10 @@ from_ccvs(#request{request_ccvs=ReqCCVs
 
 -spec request_number(ne_binary(), wh_json:object()) -> ne_binary().
 request_number(Number, CCVs) ->
-    case wh_json:get_value(<<"Original-Number">>, CCVs) of
+    case wh_json:get_first_defined([<<"E164-Destination">>
+                                    ,<<"Original-Number">>
+                                   ], CCVs
+                                  ) of
         'undefined' -> Number;
         Original ->
             lager:debug("using original number ~s instead of ~s", [Original, Number]),

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -405,6 +405,7 @@ maybe_resource_to_endpoints(#resrc{id=Id
             CCVUpdates = [{<<"Global-Resource">>, wh_util:to_binary(Global)}
                           ,{<<"Resource-ID">>, Id}
                           ,{<<"E164-Destination">>, Number}
+                          ,{<<"Original-Number">>, wapi_offnet_resource:to_did(OffnetJObj)}
                          ],
             Updates = [{<<"Name">>, Name}
                        ,{<<"Weight">>, Weight}
@@ -563,7 +564,7 @@ gateway_to_endpoint(Number
                    ) ->
     CCVs = props:filter_empty(
              [{<<"Emergency-Resource">>, gateway_emergency_resource(Gateway)}
-              ,{<<"Original-Number">>, Number}
+              ,{<<"Matched-Number">>, Number}
               | gateway_from_uri_settings(Gateway)
              ]),
     wh_json:from_list(

--- a/core/kazoo_documents-1.0.0/src/kzd_freeswitch.erl
+++ b/core/kazoo_documents-1.0.0/src/kzd_freeswitch.erl
@@ -152,7 +152,8 @@ reseller_billing(Props) ->
 
 -spec to_did(wh_proplist()) -> api_binary().
 to_did(Props) ->
-    props:get_first_defined([?CCV(<<"Original-Number">>)
+    props:get_first_defined([?CCV(<<"E164-Destination">>)
+                             ,?CCV(<<"Original-Number">>)
                              ,<<"Caller-Destination-Number">>
                             ]
                             ,Props


### PR DESCRIPTION
E164-Destination precedence for authz/rating
Original-Number is set from Original Request
Add Matched-Number (value taken from former Original-Number)
