### PR TITLE
KAZOO-4384: resource's cid_rules option should honor Diversions if ex…

### DIFF
--- a/applications/stepswitch/src/stepswitch.hrl
+++ b/applications/stepswitch/src/stepswitch.hrl
@@ -29,5 +29,9 @@
         ,wh_json:from_list([{'passive', 'true'}])
        ).
 
+-define(RULES_HONOR_DIVERSION
+        ,whapps_config:get_is_true(?SS_CONFIG_CAT, <<"cid_rules_honor_diversions">>, 'true')
+       ).
+
 -define(STEPSWITCH_HRL, 'true').
 -endif.

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -397,7 +397,10 @@ maybe_resource_to_endpoints(#resrc{id=Id
                             ,OffnetJObj
                             ,Endpoints
                            ) ->
-    CallerIdNumber = wapi_offnet_resource:outbound_caller_id_number(OffnetJObj),
+    CallerIdNumber = case whapps_config:get_is_true(?SS_CONFIG_CAT, <<"cid_rules_honor_diversions">>, 'true') of
+        'false' -> wapi_offnet_resource:outbound_caller_id_number(OffnetJObj);
+        'true' -> check_diversion_fields(OffnetJObj)
+    end,
     case filter_resource_by_rules(Id, Number, Rules, CallerIdNumber, CallerIdRules) of
         {'error','no_match'} -> Endpoints;
         {'ok', NumberMatch} ->
@@ -414,6 +417,16 @@ maybe_resource_to_endpoints(#resrc{id=Id
                             || Endpoint <- gateways_to_endpoints(NumberMatch, Gateways, OffnetJObj, [])
                            ],
             maybe_add_proxies(EndpointList, Proxies, Endpoints)
+    end.
+
+-spec check_diversion_fields(wapi_offnet_resource:req()) -> ne_binary(). 
+check_diversion_fields(OffnetJObj) ->
+    case wh_json:get_value([<<"Custom-SIP-Headers">>,<<"Diversions">>], OffnetJObj) of
+        'undefined' ->
+            wapi_offnet_resource:outbound_caller_id_number(OffnetJObj);
+        [Diversion|_] ->
+            [_,_,CallerIdNumber,_] = re:split(Diversion,"(:)(\\d*)(@.*)",[{return,binary},{parts,0}]),
+            CallerIdNumber
     end.
 
 -spec update_endpoint(wh_json:object(), wh_proplist(), wh_proplist(), wapi_offnet_resource:req()) -> wh_json:object().

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -397,10 +397,10 @@ maybe_resource_to_endpoints(#resrc{id=Id
                             ,OffnetJObj
                             ,Endpoints
                            ) ->
-    CallerIdNumber = case whapps_config:get_is_true(?SS_CONFIG_CAT, <<"cid_rules_honor_diversions">>, 'true') of
-        'false' -> wapi_offnet_resource:outbound_caller_id_number(OffnetJObj);
-        'true' -> check_diversion_fields(OffnetJObj)
-    end,
+    CallerIdNumber = case ?RULES_HONOR_DIVERSION of
+                         'false' -> wapi_offnet_resource:outbound_caller_id_number(OffnetJObj);
+                         'true' -> check_diversion_fields(OffnetJObj)
+                     end,
     case filter_resource_by_rules(Id, Number, Rules, CallerIdNumber, CallerIdRules) of
         {'error','no_match'} -> Endpoints;
         {'ok', NumberMatch} ->
@@ -422,11 +422,11 @@ maybe_resource_to_endpoints(#resrc{id=Id
 -spec check_diversion_fields(wapi_offnet_resource:req()) -> ne_binary(). 
 check_diversion_fields(OffnetJObj) ->
     case wh_json:get_value([<<"Custom-SIP-Headers">>,<<"Diversions">>], OffnetJObj) of
-        'undefined' ->
-            wapi_offnet_resource:outbound_caller_id_number(OffnetJObj);
         [Diversion|_] ->
-            [_,_,CallerIdNumber,_] = re:split(Diversion,"(:)(\\d*)(@.*)",[{return,binary},{parts,0}]),
-            CallerIdNumber
+            [_,CallerIdNumber,_] = binary:split(Diversion, [<<":">>,<<"@">>], ['global']),
+            CallerIdNumber;
+        _ ->
+            wapi_offnet_resource:outbound_caller_id_number(OffnetJObj)
     end.
 
 -spec update_endpoint(wh_json:object(), wh_proplist(), wh_proplist(), wapi_offnet_resource:req()) -> wh_json:object().

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -419,7 +419,7 @@ maybe_resource_to_endpoints(#resrc{id=Id
             maybe_add_proxies(EndpointList, Proxies, Endpoints)
     end.
 
--spec check_diversion_fields(wapi_offnet_resource:req()) -> ne_binary(). 
+-spec check_diversion_fields(wapi_offnet_resource:req()) -> ne_binary().
 check_diversion_fields(OffnetJObj) ->
     case wh_json:get_value([<<"Custom-SIP-Headers">>,<<"Diversions">>], OffnetJObj) of
         [Diversion|_] ->


### PR DESCRIPTION
…ists
While using stepswitch's cid_rules field for CID-based outbound routing, it looks like we need to check if diversions fields exists and use it to make routing decision based on account's number, but not someone's else.
