### PR TITLE
KAZOO-4403: use lists:keyreplace/4 in props.erl

### DIFF
--- a/core/whistle-1.0.0/src/props.erl
+++ b/core/whistle-1.0.0/src/props.erl
@@ -47,7 +47,7 @@ set_values([{K, V}|KVs], Props) ->
 -spec set_value(wh_proplist_key(), wh_proplist_value(), wh_proplist()) ->
                        wh_proplist().
 set_value(K, V, Props) ->
-    [{K, V} | [KV || {Key, _}=KV <- Props, K =/= Key]].
+    lists:keyreplace(K, 1, Props, {K,V}).
 
 -spec insert_value({wh_proplist_key(), wh_proplist_value()} | wh_proplist_key(), wh_proplist()) ->
                           wh_proplist().


### PR DESCRIPTION
And I just saw that lists:keyreplace/4 was already used by wh_json to set_value/3