### PR TITLE
KAZOO-4409: hangup both legs on hold properly by tracking call events

### DIFF
--- a/applications/konami/src/module/konami_hold.erl
+++ b/applications/konami/src/module/konami_hold.erl
@@ -3,9 +3,7 @@
 %%% @doc
 %%% Put the call on hold
 %%% Data = {
-%%%   "moh_aleg":"media_id"
-%%%   ,"moh_bleg":"media_id"
-%%%   ,"unhold_key":"DTMF"
+%%%   "moh":"media_id"
 %%% }
 %%% @end
 %%% @contributors
@@ -14,39 +12,61 @@
 %%%-------------------------------------------------------------------
 -module(konami_hold).
 
+-behaviour(gen_server).
+
 -export([handle/2
          ,number_builder/1
+        ]).
+-export([init/1
+         ,handle_call/3
+         ,handle_cast/2
+         ,handle_info/2
+         ,terminate/2
+         ,code_change/3
         ]).
 
 -include("../konami.hrl").
 
--spec handle(wh_json:object(), whapps_call:call()) ->
-                    {'continue', whapps_call:call()}.
+-record(state, {call :: whapps_call:call()
+                ,requesting_leg :: ne_binary()
+                ,hold_leg :: ne_binary()}).
+-type state() :: #state{}.
+
+-define(HOLD_CALL_EVENTS, [<<"CHANNEL_BRIDGE">> ,<<"CHANNEL_DESTROY">>]).
+-define(HOLD_TIMEOUT, 3600 * 1000).
+
+-spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
-    AMOH = wh_json:get_value(<<"moh_aleg">>, Data),
-    AMOHToPlay = wh_media_util:media_path(AMOH, Call),
-
-    BMOH = wh_json:get_value(<<"moh_bleg">>, Data, AMOH),
-    BMOHToPlay = wh_media_util:media_path(BMOH, Call),
-
-    Unholdkey = wh_json:get_value(<<"unhold_key">>, Data, <<"1">>),
+    whapps_call:put_callid(Call),
+    MOH = wh_json:get_value(<<"moh">>, Data),
 
     RequestingLeg = wh_json:get_value(<<"dtmf_leg">>, Data),
+    HoldLeg = hold_leg(Call, RequestingLeg),
 
-    HoldCommand = whapps_call_command:soft_hold_command(RequestingLeg, Unholdkey, AMOHToPlay, BMOHToPlay),
+    lager:debug("first, we need to receive call events for our two legs"),
+    konami_event_listener:add_call_binding(RequestingLeg, ?HOLD_CALL_EVENTS),
+    konami_event_listener:add_call_binding(HoldLeg, ?HOLD_CALL_EVENTS),
 
-    lager:debug("leg ~s is putting ~s on hold", [RequestingLeg, hold_leg(Call, RequestingLeg)]),
+    lager:debug("then unbridging the call"),
+    whapps_call_command:unbridge(Call),
 
-    whapps_call_command:send_command(props:set_value(<<"Insert-At">>, <<"now">>, HoldCommand)
-                                     ,Call
-                                    ),
-    {'continue', Call}.
+    HoldCommand = whapps_call_command:hold_command(MOH, HoldLeg),
+    whapps_call_command:send_command(
+      wh_json:set_value(<<"Insert-At">>, <<"now">>, HoldCommand)
+      ,Call
+     ),
+    lager:debug("leg ~s is putting ~s on hold", [RequestingLeg, HoldLeg]),
 
--spec hold_leg(whapps_call:call(), ne_binary()) -> ne_binary().
-hold_leg(Call, RequestingLeg) ->
-    case whapps_call:call_id(Call) of
-        RequestingLeg -> whapps_call:other_leg_call_id(Call);
-        HoldLeg -> HoldLeg
+    try gen_server:enter_loop(?MODULE, [], #state{call = Call
+                                                  ,requesting_leg = RequestingLeg
+                                                  ,hold_leg = HoldLeg}, ?HOLD_TIMEOUT)
+    of
+        _ -> 'ok'
+    catch
+        'exit':'normal' -> 'ok';
+        _E:_R ->
+            ST = erlang:get_stacktrace(),
+            wh_util:log_stacktrace(ST)
     end.
 
 -spec number_builder(wh_json:object()) -> wh_json:object().
@@ -102,3 +122,86 @@ moh_data("n") ->
     wh_json:new();
 moh_data(MOH) ->
     wh_json:from_list([{<<"moh">>, wh_util:to_binary(MOH)}]).
+
+%% ------------------------------------------------------------------
+%% gen_server callback functions
+%% ------------------------------------------------------------------
+init(Args) ->
+    {'ok', Args}.
+
+handle_call(_Request, _From, State) ->
+    {'reply', 'ok', State}.
+
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+handle_info({'amqp_msg', JObj}, State) ->
+    handle_call_event(wh_json:get_first_defined([<<"Call-ID">>
+                                                 ,<<"Outbound-Call-ID">>
+                                                ], JObj)
+                      ,wh_json:get_value(<<"Event-Name">>, JObj)
+                      ,State);
+handle_info('timeout', #state{call = Call
+                              ,requesting_leg = RequestingLeg
+                              ,hold_leg = HoldLeg} = State) ->
+    hangup_leg(Call, RequestingLeg),
+    hangup_leg(Call, HoldLeg),
+    lager:debug("timeout, hangup both ~s and ~s", [RequestingLeg, HoldLeg]),
+    {'stop', 'timeout', State}.
+
+-spec handle_call_event(ne_binary(), ne_binary(), state()) ->
+    {'noreply', state(), ?HOLD_TIMEOUT} | {'stop', term(), state()}.
+handle_call_event(CallId, <<"CHANNEL_BRIDGE">>
+                  ,#state{requesting_leg = CallId
+                          ,hold_leg = HoldLeg} = State) ->
+    lager:debug("~s and ~s are reconnected", [CallId, HoldLeg]),
+    {'stop', 'normal', State};
+handle_call_event(CallId, <<"CHANNEL_BRIDGE">>
+                  ,#state{requesting_leg = RequestingLeg
+                          ,hold_leg = CallId} = State) ->
+    lager:debug("~s and ~s are reconnected", [RequestingLeg, CallId]),
+    {'stop', 'normal', State};
+handle_call_event(CallId, <<"CHANNEL_DESTROY">>
+                  ,#state{call = Call
+                          ,requesting_leg = CallId
+                          ,hold_leg = HoldLeg} = State) ->
+    hangup_leg(Call, HoldLeg),
+    lager:debug("leg ~s are destroy, handup ~s too", [CallId, HoldLeg]),
+    {'stop', 'normal', State};
+handle_call_event(CallId, <<"CHANNEL_DESTROY">>
+                  ,#state{call = Call
+                          ,requesting_leg = RequestingLeg
+                          ,hold_leg = CallId} = State) ->
+    hangup_leg(Call, RequestingLeg),
+    lager:debug("leg ~s are destroy, handup ~s too", [CallId, RequestingLeg]),
+    {'stop', 'normal', State};
+handle_call_event(_, _, State) ->
+    lager:debug("ignore other event"),
+    {'noreply', State, ?HOLD_TIMEOUT}.
+
+terminate(_Reason, #state{requesting_leg = RequestingLeg
+                        ,hold_leg = HoldLeg}) ->
+    konami_event_listener:rm_call_binding(RequestingLeg, ?HOLD_CALL_EVENTS),
+    konami_event_listener:rm_call_binding(HoldLeg, ?HOLD_CALL_EVENTS),
+    'ok'.
+
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%% ------------------------------------------------------------------
+%% internal helper functions
+%% ------------------------------------------------------------------
+-spec hold_leg(whapps_call:call(), ne_binary()) -> ne_binary().
+hold_leg(Call, RequestingLeg) ->
+    case whapps_call:call_id(Call) of
+        RequestingLeg -> whapps_call:other_leg_call_id(Call);
+        HoldLeg -> HoldLeg
+    end.
+
+-spec hangup_leg(whapps_call:call(), ne_binary()) -> 'ok'.
+hangup_leg(Call, CallId) ->
+    Command = [{<<"Application-Name">>, <<"hangup">>}
+               ,{<<"Call-ID">>, CallId}
+               ,{<<"Insert-At">>, <<"now">>}
+              ],
+    whapps_call_command:send_command(Command, Call).


### PR DESCRIPTION
I believe the soft_hold method implemented by siplab is more elegant then the one proposed in this pull request. This pull request is created just  for someone may need to use metaflow_req to resume from hold like us.