### PR TITLE
Allow "X-Forward-For" only from allowed proxies

### DIFF
--- a/applications/crossbar/doc/reverse_proxy.md
+++ b/applications/crossbar/doc/reverse_proxy.md
@@ -8,7 +8,7 @@ Version: 3.18
 # Working with reverse proxies (HAProxy, Nginx, etc)
 
 ## Configuring list allowed proxies
-Set list in `system_config/crossbar`, key `reverse_proxies`.  
+Set list in `system_config/crossbar`, key `reverse_proxies`.
 Values can be:
 - single ip address ("192.168.0.1");
 - single ip address in CIDR notation ("192.168.0.1/32")

--- a/applications/crossbar/doc/reverse_proxy.md
+++ b/applications/crossbar/doc/reverse_proxy.md
@@ -1,0 +1,21 @@
+/*
+Section: Crossbar
+Title: Reverse proxy
+Language: en-US
+Version: 3.18
+*/
+
+# Working with reverse proxies (HAProxy, Nginx, etc)
+
+## Configuring list allowed proxies
+Set list in `system_config/crossbar`, key `reverse_proxies`.  
+Values can be:
+- single ip address ("192.168.0.1");
+- single ip address in CIDR notation ("192.168.0.1/32")
+- network in CIDR notation ("192.168.0.0/24")
+
+## Configuration reverse proxy
+Reverse proxy must set "X-Forwarded-For" header.
+- [HAProxy](https://cbonte.github.io/haproxy-dconv/configuration-1.6.html#4-option%20forwardfor)
+- [Nginx](https://www.nginx.com/resources/admin-guide/reverse-proxy/) + add `proxy_set_header X-Forwarded-For $remote_addr;`
+- [Apache 2.2](https://httpd.apache.org/docs/2.2/mod/mod_proxy.html)

--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -75,7 +75,7 @@ rest_init(Req0, Opts) ->
 
     ClientIP = case cowboy_req:header(<<"x-forwarded-for">>, Req7) of
                 {'undefined', _} -> wh_network_utils:iptuple_to_binary(Peer);
-                {ForwardIP, _} -> wh_util:to_binary(ForwardIP)
+                {ForwardIP, _} -> maybe_allow_proxy_req(wh_network_utils:iptuple_to_binary(Peer), ForwardIP)
             end,
 
     {Headers, _} = cowboy_req:headers(Req7),
@@ -122,6 +122,26 @@ find_version(Path) ->
         [Path] -> ?VERSION_1;
         [<<>>, Ver | _] -> to_version(Ver);
         [Ver | _] -> to_version(Ver)
+    end.
+
+maybe_allow_proxy_req(Peer, ForwardIP) ->
+    case is_proxied(Peer) of
+        true -> wh_util:to_binary(ForwardIP);
+        false ->
+            lager:warning("request with \"X-Forwarded-For: ~s\" header, but peer (~s) is not allowed as proxy", [ForwardIP, Peer]),
+            Peer
+    end.
+
+is_proxied(Peer) ->
+    Proxies = whapps_config:get_non_empty(?APP_NAME, <<"reverse_proxies">>, []),
+    is_proxied(Peer, Proxies).
+is_proxied(_Peer, []) -> false;
+is_proxied(Peer, [Proxy|Rest]) ->
+    case wh_network_utils:verify_cidr(Peer, wh_network_utils:to_cidr(Proxy)) of
+        'true' -> 
+            lager:info("request from reverse proxy: ~s", [Proxy]),
+            'true';
+        'false' -> is_proxied(Peer, Rest)
     end.
 
 to_version(<<"v", Int/binary>>=Version) ->

--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -138,7 +138,7 @@ is_proxied(Peer) ->
 is_proxied(_Peer, []) -> false;
 is_proxied(Peer, [Proxy|Rest]) ->
     case wh_network_utils:verify_cidr(Peer, wh_network_utils:to_cidr(Proxy)) of
-        'true' -> 
+        'true' ->
             lager:info("request from reverse proxy: ~s", [Proxy]),
             'true';
         'false' -> is_proxied(Peer, Rest)


### PR DESCRIPTION
Any client can set "X-Forward-For" header, and Crossbar accept this request, and set #context.client_ip to value of this header.
This allow avoiding token buckets and authenticate with cb_ip_auth from any address.