### PR TITLE
KAZOO-4451 - check_bookkeeper incorrect

### DIFF
--- a/core/whistle_services-1.0.0/src/wh_services.erl
+++ b/core/whistle_services-1.0.0/src/wh_services.erl
@@ -503,7 +503,7 @@ check_bookkeeper(BillingId, Amount) ->
     case select_bookkeeper(BillingId) of
         'wh_bookkeeper_local' ->
             Balance = wht_util:current_balance(BillingId),
-            Balance - Amount =< 0;
+            Balance - Amount => 0;
         Bookkeeper -> Bookkeeper:is_good_standing(BillingId)
     end.
 

--- a/core/whistle_services-1.0.0/src/wh_services.erl
+++ b/core/whistle_services-1.0.0/src/wh_services.erl
@@ -503,7 +503,7 @@ check_bookkeeper(BillingId, Amount) ->
     case select_bookkeeper(BillingId) of
         'wh_bookkeeper_local' ->
             Balance = wht_util:current_balance(BillingId),
-            Balance - Amount => 0;
+            Balance - Amount >= 0;
         Bookkeeper -> Bookkeeper:is_good_standing(BillingId)
     end.
 


### PR DESCRIPTION
Correctly typo in previous pull request.

Should be
Balance - Amount >= 0;

Now the function will return true when deducting the charge from the balance and the resulting balance is greater than or equal to zero