### PR TITLE
Update hon_util.erl to fix priorities

### DIFF
--- a/applications/hotornot/src/hon_util.erl
+++ b/applications/hotornot/src/hon_util.erl
@@ -119,7 +119,7 @@ sort_rate(RateA, RateB) ->
 
     case PrefixA =:= PrefixB of
         'true' ->
-            wh_json:get_integer_value(<<"weight">>, RateA, 100) >
+            wh_json:get_integer_value(<<"weight">>, RateA, 100) <
                 wh_json:get_integer_value(<<"weight">>, RateB, 100);
         'false' ->
             PrefixA > PrefixB


### PR DESCRIPTION
I believe what was there before was wrong, but I'm not certain - I have a really hard time getting my head around comparison functions.
In rates.json the description field says that lower weights are preferred over higher ones, but this implies otherwise.