### PR TITLE
Support for serializing registrations to and from file

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_maintenance.erl
+++ b/applications/ecallmgr/src/ecallmgr_maintenance.erl
@@ -88,6 +88,7 @@
          ,enable_authz/0, enable_local_resource_authz/0
          ,disable_authz/0, disable_local_resource_authz/0
         ]).
+-export([export_registrations/1,import_registrations/1]).
 
 -export([show_channels/0]).
 -export([show_calls/0]).
@@ -696,3 +697,15 @@ hangup_long_running_channels(MaxAge) ->
     io:format("hanging up channels older than ~p seconds~n", [MaxAge]),
     N = ecallmgr_fs_channels:cleanup_old_channels(wh_util:to_integer(MaxAge)),
     io:format("hungup ~p channels~n", [N]).
+
+-spec export_registrations(ne_binary()) -> integer().
+export_registrations(Filename) ->
+    Exported = ecallmgr_registrar:export_registrations(Filename),
+    io:format("exported ~p registrations", [Exported]),
+    Exported.
+
+-spec import_registrations(ne_binary()) -> integer().
+import_registrations(Filename) ->
+    Imported = ecallmgr_registrar:import_registrations(Filename),
+    io:format("imported ~p registrations", [Imported]),
+    Imported.

--- a/applications/ecallmgr/src/ecallmgr_registrar.erl
+++ b/applications/ecallmgr/src/ecallmgr_registrar.erl
@@ -1280,7 +1280,7 @@ get_contact_hostport(Uri) ->
         _Else -> Uri
     end.
 
--spec write_terms(list(), list()) -> 'ok' | {'error', posix()}.
+-spec write_terms(list(), list()) -> 'ok' | {'error', atom()}.
 write_terms(Filename, List) ->
     Text = lists:map(fun(Term) -> io_lib:format("~p.~n", [Term]) end, List),
     file:write_file(Filename, Text).

--- a/applications/ecallmgr/src/ecallmgr_registrar.erl
+++ b/applications/ecallmgr/src/ecallmgr_registrar.erl
@@ -1280,7 +1280,7 @@ get_contact_hostport(Uri) ->
         _Else -> Uri
     end.
 
--spec write_terms(list(), list()) -> 'ok'|{'error', term()}.
+-spec write_terms(list(), list()) -> 'ok' | {'error', posix()}.
 write_terms(Filename, List) ->
     Text = lists:map(fun(Term) -> io_lib:format("~p.~n", [Term]) end, List),
     file:write_file(Filename, Text).
@@ -1288,8 +1288,10 @@ write_terms(Filename, List) ->
 -spec export_registrations_to_file(ne_binary()) -> integer().
 export_registrations_to_file(Filename) ->
     RegList = ets:tab2list(?MODULE),
-    write_terms(binary_to_list(Filename), RegList),
-    length(RegList).
+    case write_terms(binary_to_list(Filename), RegList) of
+        'ok' -> length(RegList);
+        _ -> 0
+    end.
 
 -spec import_registrations_from_file(ne_binary()) -> integer().
 import_registrations_from_file(Filename) ->


### PR DESCRIPTION
You may be interested in this. Useful to save your ecallmgr registrations to some temp file before restart and then reload them after restart with no downtime. It won't overwrite new registrations and is safe for production. Especially good for single machine installs. It is also useful if you want to manipulate registrations manually for tests since the file is editable text. If you want this feature I will update the docs properly in another pull request.