### PR TITLE
KAZOO-4470: Run start_dtmf in case of "101 telephone-event" absence

### DIFF
--- a/applications/callflow/src/cf_route_req.erl
+++ b/applications/callflow/src/cf_route_req.erl
@@ -240,10 +240,11 @@ get_ringback_media(Flow, JObj) ->
 pre_park_action(Call,JObj) ->
     case whapps_config:get_is_true(<<"callflow">>, <<"ring_ready_offnet">>, 'true')
         andalso whapps_call:inception(Call) =/= 'undefined'
-        andalso (whapps_call:authorizing_type(Call) =:= 'undefined' orelse whapps_call:authorizing_type(Call) =:= <<"resource">>)
+        andalso (whapps_call:authorizing_type(Call) =:= 'undefined'
+                 orelse whapps_call:authorizing_type(Call) =:= <<"resource">>)
     of
         'false' -> <<"none">>;
-        'true' -> check_dtmf_type(wh_json:get_value(<<"Remote-SDP">>, JObj, <<"101 telephone-event">>)) 
+        'true' -> check_dtmf_type(wh_json:get_value(<<"Remote-SDP">>, JObj, <<"101 telephone-event">>))
     end.
 
 -spec check_dtmf_type(ne_binary()) -> ne_binary().

--- a/applications/callflow/src/cf_route_req.erl
+++ b/applications/callflow/src/cf_route_req.erl
@@ -243,7 +243,7 @@ pre_park_action(Call,JObj) ->
         andalso whapps_call:authorizing_type(Call) =:= 'undefined'
     of
         'false' -> <<"none">>;
-        'true' -> check_dtmf_type(JObj) 
+        'true' -> check_dtmf_type(JObj)
     end.
 
 -spec check_dtmf_type(wh_json:object()) -> ne_binary().

--- a/applications/ecallmgr/src/ecallmgr_fs_route.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_route.erl
@@ -402,6 +402,7 @@ route_req(CallId, FetchId, Props, Node) ->
      ,{<<"Resource-Type">>, kzd_freeswitch:resource_type(Props, <<"audio">>)}
      ,{<<"To-Tag">>, props:get_value(<<"variable_sip_to_tag">>, Props)}
      ,{<<"From-Tag">>, props:get_value(<<"variable_sip_from_tag">>, Props)}
+     ,{<<"Remote-SDP">>, props:get_value(<<"variable_switch_r_sdp">>, Props)}
      | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -401,6 +401,7 @@ route_resp_pre_park_action(JObj) ->
     case wh_json:get_value(<<"Pre-Park">>, JObj) of
         <<"ring_ready">> -> action_el(<<"ring_ready">>);
         <<"answer">> -> action_el(<<"answer">>);
+        <<"start_dtmf">> -> action_el(<<"start_dtmf">>);
         _Else -> 'undefined'
     end.
 

--- a/core/whistle-1.0.0/src/api/wapi_route.erl
+++ b/core/whistle-1.0.0/src/api/wapi_route.erl
@@ -56,6 +56,7 @@
                                      ,<<"Body">>
                                      ,<<"From-Tag">>, <<"To-Tag">>
                                      ,<<"Prepend-CID-Name">>
+                                     ,<<"Remote-SDP">>
                                     ]).
 -define(ROUTE_REQ_VALUES, [{<<"Event-Category">>, ?EVENT_CATEGORY}
                            ,{<<"Event-Name">>, ?ROUTE_REQ_EVENT_NAME}
@@ -123,7 +124,7 @@ has_cost_parameters(JObj) ->
 -define(ROUTE_RESP_VALUES, [{<<"Event-Category">>, ?EVENT_CATEGORY}
                             ,{<<"Event-Name">>, <<"route_resp">>}
                             ,{<<"Method">>, [<<"bridge">>, <<"park">>, <<"error">>, <<"sms">>]}
-                            ,{<<"Pre-Park">>, [<<"none">>, <<"ring_ready">>, <<"answer">>]}
+                            ,{<<"Pre-Park">>, [<<"none">>, <<"ring_ready">>, <<"answer">>, <<"start_dtmf">>]}
                            ]).
 -define(ROUTE_RESP_TYPES, [{<<"Route-Error-Code">>, fun is_binary/1}
                            ,{<<"Route-Error-Message">>, fun is_binary/1}


### PR DESCRIPTION
<<"One gateway that is connecting to Kazoo is using inband DTMF (changing to RFC2833 or INFO is not possible for them). On a standard freeswitch server, this is solved by using <action application="start_dtmf"> in the extension . Is the equivalent possible with Kazoo?">> 

Please check 2600-dev for details 

https://groups.google.com/forum/#!searchin/2600hz-dev/kiril/2600hz-dev/jV7UWPnMyKc/2qbM4nKmAwAJ 
