### PR TITLE
KAZOO-4445: handling loopbacks in ecallmgr

### DIFF
--- a/applications/crossbar/src/modules/cb_clicktocall.erl
+++ b/applications/crossbar/src/modules/cb_clicktocall.erl
@@ -414,7 +414,7 @@ build_originate_req(Contact, Context) ->
     CalleeNumber = knm_converters:normalize(wh_json:get_binary_value(<<"outbound_callee_id_number">>, JObj, Exten)),
     FriendlyName = wh_json:get_ne_value(<<"name">>, JObj, <<>>),
     OutboundNumber = wh_json:get_value(<<"caller_id_number">>, JObj, Contact),
-    AutoAnswer = wh_json:is_true(<<"auto_answer">>, cb_context:query_string(Context), 'true'),
+    AutoAnswer = wh_json:is_true(<<"auto_answer">>, cb_context:query_string(Context), 'false'),
     {Caller, Callee} = get_caller_callee(wh_json:get_value(<<"dial_first">>, JObj, <<"extension">>)
                                          ,#contact{number = OutboundNumber
                                                    ,name = FriendlyName
@@ -462,7 +462,7 @@ build_originate_req(Contact, Context) ->
        ,{<<"Outbound-Caller-ID-Number">>, Caller#contact.number}
        ,{<<"Outbound-Call-ID">>, CallId}
        ,{<<"Ringback">>, wh_json:get_value(<<"ringback">>, JObj)}
-       ,{<<"Dial-Endpoint-Method">>, <<"single">>}
+       ,{<<"Loopback-Handler">>, <<"ecallmgr">>}
        ,{<<"Continue-On-Fail">>, 'true'}
        ,{<<"Custom-SIP-Headers">>, wh_json:get_value(<<"custom_sip_headers">>, JObj)}
        ,{<<"Custom-Channel-Vars">>, wh_json:from_list(CCVs)}

--- a/applications/ecallmgr/src/ecallmgr.hrl
+++ b/applications/ecallmgr/src/ecallmgr.hrl
@@ -9,6 +9,7 @@
 -define(ECALLMGR_AUTH_CACHE, 'ecallmgr_auth_cache').
 -define(ECALLMGR_CALL_CACHE, 'ecallmgr_call_cache').
 -define(ECALLMGR_INTERACTION_CACHE, 'ecallmgr_interaction_cache').
+-define(ECALLMGR_CMDS_CACHE, 'ecallmgr_loopback_commands').
 
 -define(CHANNELS_TBL, 'ecallmgr_channels').
 

--- a/applications/ecallmgr/src/ecallmgr_call_control.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_control.erl
@@ -255,9 +255,9 @@ handle_cast('init', #state{node=Node
     TRef = erlang:send_after(?SANITY_CHECK_PERIOD, self(), 'sanity_check'),
     {'noreply', State#state{sanity_check_tref=TRef}};
 handle_cast('check_commands', #state{call_id = CallId} = State) ->
-    case wh_cache:fetch_local(?ECALLMGR_CMDS_CACHE, CallId) of
+    case kz_cache:fetch_local(?ECALLMGR_CMDS_CACHE, CallId) of
         {'ok', Commands} ->
-            wh_cache:erase_local(?ECALLMGR_CMDS_CACHE, CallId),
+            kz_cache:erase_local(?ECALLMGR_CMDS_CACHE, CallId),
             NewState = lists:foldl(fun handle_dialplan/2, State, Commands),
             {'noreply', NewState};
         _ ->

--- a/applications/ecallmgr/src/ecallmgr_fs_event_stream.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_event_stream.erl
@@ -345,6 +345,7 @@ process_event(<<"CHANNEL_CREATE">>, UUID, Props, Node) ->
     wh_util:put_callid(UUID),
     _ = ecallmgr_fs_channel:new(Props, Node),
     _ = ecallmgr_fs_channel:maybe_update_interaction_id(Props, Node),
+    _ = ecallmgr_loopback_control:maybe_set_channel_id(UUID, Props),
     maybe_start_event_listener(Node, UUID);
 process_event(?CHANNEL_MOVE_RELEASED_EVENT_BIN, _, Props, Node) ->
     UUID = props:get_value(<<"old_node_channel_uuid">>, Props),

--- a/applications/ecallmgr/src/ecallmgr_loopback_control.erl
+++ b/applications/ecallmgr/src/ecallmgr_loopback_control.erl
@@ -1,0 +1,282 @@
+-module(ecallmgr_loopback_control).
+
+-behaviour(gen_server).
+
+%% API functions
+-export([start_link/4
+         ,get_endpoints/1
+         ,handle_call_command/2
+         ,maybe_set_channel_id/2
+        ]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         handle_event/2,
+         terminate/2,
+         code_change/3]).
+
+-define(RESPONDERS, [{{?MODULE, 'handle_call_command'}
+                      ,[{<<"call">>, <<"command">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<>>).
+-define(QUEUE_OPTIONS, []).
+-define(CONSUME_OPTIONS, []).
+
+-record(state, {call_id                         :: ne_binary()
+                ,loopback_id                    :: ne_binary()
+                ,resource_type = <<"audio">>    :: ne_binary()
+                ,endpoint                       :: wh_json:object()
+                ,self = self()                  :: pid()
+                ,control_q                      :: api_binary()
+                ,reply_to                       :: 'undefined' | {pid(), any()}
+                ,call_vars = []                 :: wh_json:objects()
+                ,channel_vars = []              :: wh_json:objects()
+                ,endpoints                      :: wh_json:object()
+                ,dial_method                    :: ne_binary()
+               }).
+
+-include("ecallmgr.hrl").
+
+-type state() :: #state{}.
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+%% @end
+%%--------------------------------------------------------------------
+-spec start_link(api_binary(), ne_binary(), ne_binary(), wh_json:object()) -> startlink_ret().
+start_link('undefined', ResourceType, LoopbackId, Endpoint) ->
+    CallId = <<"loopback-", (couch_mgr:get_uuid())/binary>>,
+    start_link(CallId, ResourceType, LoopbackId, Endpoint);
+start_link(<<"loopback-", _/binary>> = CallId, ResourceType, LoopbackId, Endpoint) ->
+    Bindings = [{'call', [{'callid', CallId}]}
+                ,{'dialplan', []}
+                ,{'self', []}
+               ],
+    gen_listener:start_link(?MODULE, [{'responders', ?RESPONDERS}
+                                      ,{'bindings', Bindings}
+                                      ,{'queue_name', ?QUEUE_NAME}
+                                      ,{'queue_options', ?QUEUE_OPTIONS}
+                                      ,{'consume_options', ?CONSUME_OPTIONS}
+                                     ]
+                            ,[CallId, LoopbackId, ResourceType, Endpoint]);
+start_link(CallId, LoopbackId, ResourceType, Endpoints) ->
+    start_link(<<"loopback-", CallId/binary, "-", (wh_util:rand_hex_binary(8))/binary>>, LoopbackId
+               ,ResourceType, Endpoints).
+
+-spec get_endpoints(pid()) -> {'ok', api_binary(), wh_json:objects()}.
+get_endpoints(Pid) ->
+    gen_server:call(Pid, 'get_endpoints').
+
+-spec handle_call_command(wh_json:object(), wh_proplist()) -> any().
+handle_call_command(JObj, Props) ->
+    Pid = props:get_value('server', Props),
+    LoopbackId = props:get_value('loopback_id', Props),
+    App = wh_json:get_value(<<"Application-Name">>, JObj),
+    handle_call_command(App, Pid, LoopbackId, JObj).
+
+-spec maybe_set_channel_id(ne_binary(), wh_proplist()) -> 'ok'.
+maybe_set_channel_id(UUID, Props) ->
+    case props:get_value(<<"variable_ecallmgr_Loopback-ID">>, Props) of
+        'undefined' -> 'ok';
+        LoopbackId ->
+            set_channel_id(LoopbackId, UUID)
+    end.
+
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%%
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%% @end
+%%--------------------------------------------------------------------
+-spec init(ne_binaries()) -> {'ok', state()}.
+init([CallId, LoopbackId, ResourceType, Endpoint]) ->
+    wh_util:put_callid(CallId),
+    {'ok', #state{call_id = CallId
+                  ,endpoint = Endpoint
+                  ,loopback_id = LoopbackId
+                  ,resource_type = ResourceType
+                 }}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%%
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_call('get_endpoints', From, State) ->
+    maybe_reply(State#state{reply_to = From});
+handle_call(_Request, _From, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%%
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_cast({'gen_listener', {'created_queue', CtrlQ}}, #state{call_id = CallId
+                                                               ,endpoint = E
+                                                               ,call_vars = CallVars
+                                                               ,channel_vars = CCVs
+                                                               ,resource_type = ResourceType
+                                                              } = State) ->
+    NewState = State#state{control_q = CtrlQ},
+    EndpointCCVs = wh_json:get_value(<<"Custom-Channel-Vars">>, E),
+    Realm = wh_json:get_value(<<"To-Realm">>, E),
+    Number = wh_json:get_value(<<"Route">>, E),
+    RouteReq = [{<<"From">>, <<"unknown@unknown">>}
+                ,{<<"To">>, <<"unknown@unknown">>}
+                ,{<<"Request">>, <<Number/binary, "@", Realm/binary>>}
+                ,{<<"Call-ID">>, CallId}
+                ,{<<"Caller-ID-Number">>, <<"0">>}
+                ,{<<"Caller-ID-Name">>, <<"Loopback">>}
+                ,{<<"Resource-Type">>, ResourceType}
+                ,{<<"Custom-Channel-Vars">>, EndpointCCVs}
+                | wh_api:default_headers(<<"dialplan">>, <<"route_req">>, ?APP_NAME, ?APP_VERSION)
+               ],
+    {'ok', Resp} = wh_amqp_worker:call(RouteReq
+                                       ,fun wapi_route:publish_req/1
+                                       ,fun wapi_route:is_actionable_resp/1
+                                       ,2000),
+    RespCCVs = wh_json:get_value(<<"Custom-Channel-Vars">>, Resp, wh_json:new()),
+    RespCallVars = wh_json:get_value(<<"Custom-Call-Vars">>, Resp, wh_json:new()),
+    ServerId = wh_json:get_value(<<"Server-ID">>, Resp),
+    RouteWin = [{<<"Call-ID">>, CallId}
+                ,{<<"Custom-Channel-Vars">>, CCVs}
+                ,{<<"Server-ID">>, ServerId}
+                ,{<<"Control-Queue">>, CtrlQ}
+                | wh_api:default_headers(<<"dialplan">>, <<"route_win">>
+                                         ,?APP_NAME, ?APP_VERSION)],
+    wh_amqp_worker:cast(RouteWin, fun(Payload) -> wapi_route:publish_win(ServerId, Payload) end),
+    {'noreply', NewState#state{channel_vars = [RespCCVs, EndpointCCVs | CCVs]
+                               ,call_vars = [RespCallVars | CallVars]
+                              }};
+handle_cast({'call_command', Data}, State) ->
+    Endpoints = wh_json:get_value(<<"Endpoints">>, Data, []),
+    DialMethod = wh_json:get_value(<<"Dial-Endpoint-Method">>, Data),
+    NewState = State#state{endpoints = Endpoints, dial_method = DialMethod},
+    maybe_reply(NewState);
+handle_cast({'gen_listener', {'is_consuming', 'true'}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @spec handle_event(Event, State) -> {reply, proplist()}
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_event(wh_json:object(), state()) -> {'reply', proplist()}.
+handle_event(_Event, #state{self = Self, loopback_id = LoopbackId} = _State) ->
+    {'reply', [{'server', Self}, {'loopback_id', LoopbackId}]}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+    %% TODO we should send 'call ended' here
+    'ok'.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+-spec maybe_reply(state()) -> {'noreply', state()}.
+maybe_reply(#state{reply_to = 'undefined'} = State) ->
+    {'noreply', State};
+maybe_reply(#state{endpoints = 'undefined'} = State) ->
+    {'noreply', State};
+maybe_reply(#state{reply_to = ReplyTo
+                   ,endpoints = Endpoints
+                   ,dial_method = DialMethod
+                  } = State) ->
+    gen_server:reply(ReplyTo, {'ok', DialMethod, Endpoints}),
+    {'noreply', State}.
+
+-spec handle_call_command(ne_binary(), pid(), ne_binary(), wh_json:object()) -> any().
+handle_call_command(<<"bridge">>, Pid, _, JObj) ->
+    gen_server:cast(Pid, {'call_command', JObj});
+handle_call_command(_, _, LoopbackId, JObj) ->
+    wh_cache:store_local(?ECALLMGR_CMDS_CACHE, LoopbackId, [JObj | stored_commands(LoopbackId)]).
+
+-spec stored_commands(ne_binary()) -> wh_json:objects().
+stored_commands(LoopbackId) ->
+    case wh_cache:fetch_local(?ECALLMGR_CMDS_CACHE, LoopbackId) of
+        {'error', 'not_found'} -> [];
+        {'ok', Commands} -> Commands
+    end.
+
+-spec set_channel_id(ne_binary(), ne_binary()) -> 'ok'.
+set_channel_id(LoopbackId, UUID) ->
+    case wh_cache:fetch_local(?ECALLMGR_CMDS_CACHE, LoopbackId) of
+        {'error', 'not_found'} -> 'ok';
+        {'ok', Commands} ->
+            wh_cache:store_local(?ECALLMGR_CMDS_CACHE, UUID, [wh_json:set_value(<<"Call-ID">>, UUID, Cmd) || Cmd <- lists:reverse(Commands)]),
+            wh_cache:erase_local(?ECALLMGR_CMDS_CACHE, LoopbackId),
+            'ok'
+    end.

--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -186,8 +186,27 @@ handle_call(_Request, _From, State) ->
 %%--------------------------------------------------------------------
 handle_cast({'gen_listener', {'created_queue', Q}}, State) ->
     lager:debug("starting originate request"),
-    gen_listener:cast(self(), {'get_originate_action'}),
-    {'noreply', State#state{queue=Q}};
+    Routines = [fun create_uuid/1
+                ,fun set_app/1
+                ,fun maybe_update_endpoints/1
+                ,fun build_originate_args/1
+                ,fun get_originate_action/1
+                ,fun update_dialstrings/1
+               ],
+    Return = lists:foldl(fun(F, #state{} = S) -> F(S);
+                            (_, {'break', #state{} = NState}) -> NState;
+                            (_, Ret) -> Ret
+                         end
+                         ,State#state{queue=Q}
+                         ,Routines),
+    case Return of
+        #state{} = NewState ->
+            {'noreply', NewState};
+        {'stop', #state{} = NewState} ->
+            {'stop', 'normal', NewState};
+        Return ->
+            Return
+    end;
 handle_cast({'update_server_id', ServerId}, State) ->
     {'noreply', State#state{server_id=ServerId}, 'hibernate'};
 handle_cast({'maybe_update_node', Node}, #state{node=Node}=State) ->
@@ -195,90 +214,8 @@ handle_cast({'maybe_update_node', Node}, #state{node=Node}=State) ->
 handle_cast({'maybe_update_node', Node}, #state{node=_OldNode}=State) ->
     lager:debug("updating node from ~s to ~s", [_OldNode, Node]),
     {'noreply', State#state{node=Node}, 'hibernate'};
-handle_cast({'create_uuid'}, #state{node=Node
-                                    ,originate_req=JObj
-                                    ,uuid='undefined'
-                                   }=State) ->
-    UUID = {_, Id} = create_uuid(JObj, Node),
-    wh_util:put_callid(Id),
-    lager:debug("created uuid ~p", [UUID]),
-    case wh_json:is_true(<<"Start-Control-Process">>, JObj, 'true')
-        andalso start_control_process(State#state{uuid=UUID}) of
-        'false' ->
-            gen_listener:cast(self(), {'build_originate_args'}),
-            {'noreply', State#state{uuid=UUID}, 'hibernate'};
-        {'ok', #state{control_pid=Pid}=State1} ->
-            lager:debug("started control proc ~p uuid ~p", [Pid, UUID]),
-            maybe_send_originate_uuid(UUID, Pid, State),
-            gen_listener:cast(self(), {'build_originate_args'}),
-            {'noreply', State1, 'hibernate'};
-        {'error', _E} ->
-            lager:debug("failed to start control proc for ~p: ~p", [UUID, _E]),
-            {'stop', 'normal', State}
-    end;
-handle_cast({'get_originate_action'}, #state{originate_req=JObj
-                                             ,node=Node
-                                            }=State) ->
-    gen_listener:cast(self(), {'build_originate_args'}),
-    ApplicationName = wh_json:get_value(<<"Application-Name">>, JObj),
-    Action = get_originate_action(ApplicationName, JObj),
-    UseNode = maybe_update_node(JObj, Node),
-    lager:debug("maybe updating node from ~s to ~s", [Node, UseNode]),
-    lager:debug("originate action: ~s", [Action]),
-    {'noreply', State#state{action=Action
-                            ,app=ApplicationName
-                            ,node=UseNode
-                           }
-    ,'hibernate'
-    };
-handle_cast({'build_originate_args'}, #state{uuid='undefined'}=State) ->
-    gen_listener:cast(self(), {'create_uuid'}),
-    {'noreply', State};
-
-handle_cast({'build_originate_args'}, #state{originate_req=JObj
-                                             ,action = ?ORIGINATE_PARK
-                                             ,fetch_id=FetchId
-                                             ,dialstrings='undefined'
-                                            }=State) ->
-    case wh_json:is_true(<<"Originate-Immediate">>, JObj) of
-        'true' -> gen_listener:cast(self(), {'originate_execute'});
-        'false' -> gen_listener:cast(self(), {'originate_ready'})
-    end,
-    Endpoints = [update_endpoint(Endpoint, State)
-                 || Endpoint <- wh_json:get_ne_value(<<"Endpoints">>, JObj, [])
-                ],
-    {'noreply', State#state{dialstrings=build_originate_args_from_endpoints(?ORIGINATE_PARK, Endpoints, JObj, FetchId)}};
-handle_cast({'build_originate_args'}, #state{originate_req=JObj
-                                             ,action = Action
-                                             ,app = ?ORIGINATE_EAVESDROP
-                                             ,fetch_id=FetchId
-                                             ,dialstrings='undefined'
-                                            }=State) ->
-    gen_listener:cast(self(), {'originate_ready'}),
-    {'noreply', State#state{dialstrings=build_originate_args(Action, State, JObj, FetchId)}};
-handle_cast({'build_originate_args'}, #state{originate_req=JObj
-                                             ,action=Action
-                                             ,fetch_id=FetchId
-                                             ,dialstrings='undefined'
-                                            }=State) ->
-    gen_listener:cast(self(), {'originate_execute'}),
-    {'noreply', State#state{dialstrings=build_originate_args(Action, State, JObj, FetchId)}};
-
-handle_cast({'originate_ready'}, #state{node=_Node}=State) ->
-    case start_control_process(State) of
-        {'ok', #state{control_pid=Pid
-                      ,uuid=UUID
-                      ,originate_req=JObj
-                      ,server_id=ServerId
-                      ,queue=Q
-                     }=State1} ->
-            CtrlQ = gen_listener:queue_name(Pid),
-            _ = publish_originate_ready(CtrlQ, UUID, JObj, Q, ServerId),
-            {'noreply', State1#state{tref=start_abandon_timer()}};
-        {'error', _E} ->
-            lager:debug("failed to start control process: ~p", [_E]),
-            {'stop', 'normal', State}
-    end;
+handle_cast({'originate_ready'}, State) ->
+    originate_ready(State);
 handle_cast({'originate_execute'}, #state{tref=TRef}=State) when is_reference(TRef) ->
     _ = erlang:cancel_timer(TRef),
     handle_cast({'originate_execute'}, State#state{tref='undefined'});
@@ -435,6 +372,129 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+-spec set_app(state()) -> state().
+set_app(#state{originate_req=JObj} = State) ->
+    ApplicationName = wh_json:get_value(<<"Application-Name">>, JObj),
+    State#state{app = ApplicationName}.
+
+-spec maybe_update_endpoints(state()) -> state().
+maybe_update_endpoints(#state{originate_req=JObj} = State) ->
+    case wh_json:get_value(<<"Loopback-Handler">>, JObj) of
+        <<"ecallmgr">> ->
+            lager:debug("trying to resolve loopback endpoints"),
+            update_endpoints(State);
+        _ ->
+            lager:debug("loopback endpoints will be handled by freeswitch"),
+            State
+    end.
+
+-spec update_endpoints(state()) -> state().
+update_endpoints(#state{originate_req=JObj} = State) ->
+    Endpoints = wh_json:get_value(<<"Endpoints">>, JObj, []),
+    CallId = wh_json:get_value(<<"Call-ID">>, JObj),
+    ResourceType = wh_json:get_value(<<"Resource-Type">>, JObj, <<"audio">>),
+    DialMethod = wh_json:get_value(<<"Dial-Endpoint-Method">>, JObj),
+    {LoopbackEndpoints, NormalEndpoints} = lists:splitwith(fun is_loopback/1, Endpoints),
+    {NewDialMethod, NormalizedEndpoints} = lists:foldl(normalized_endpoints_acc(CallId, ResourceType)
+                                                       ,{DialMethod, NormalEndpoints}
+                                                       ,LoopbackEndpoints
+                                                      ),
+    NewJObj = wh_json:set_values([{<<"Endpoints">>, NormalizedEndpoints}
+                                  ,{<<"Dial-Endpoint-Method">>, NewDialMethod}
+                                 ]
+                                 ,JObj),
+    State#state{originate_req = NewJObj}.
+
+-spec is_loopback(wh_json:object()) -> boolean().
+is_loopback(JObj) ->
+    wh_json:get_value(<<"Invite-Format">>, JObj) =:= <<"loopback">>.
+
+-spec normalized_endpoints_acc(api_binary(), ne_binary()) ->
+    fun((wh_json:object(), wh_json:objects()) -> wh_json:objects()).
+normalized_endpoints_acc(CallId, ResourceType) ->
+    fun (Endpoint, {DialMethod, Acc}) ->
+            LoopbackId = wh_util:rand_hex_binary(8),
+            {'ok', CtrlPid} = ecallmgr_loopback_control:start_link(CallId, ResourceType, LoopbackId, Endpoint),
+            {'ok', SuggestedDialMethod, NormalizedEndpoints} =
+                try
+                    ecallmgr_loopback_control:get_endpoints(CtrlPid)
+                catch
+                    _:_ ->
+                        {'ok', DialMethod, []}
+                end,
+            {choose_dial_method(DialMethod, SuggestedDialMethod)
+             ,Acc ++ [set_ccv(<<"Loopback-ID">>, LoopbackId, E) || E <- NormalizedEndpoints]
+            }
+    end.
+
+-spec choose_dial_method(api_binary(), api_binary()) -> api_binary().
+choose_dial_method('undefined' = _OldMethod, NewMethod) ->
+    NewMethod;
+choose_dial_method(OldMethod, _NewMethod) ->
+    OldMethod.
+
+-spec set_ccv(ne_binary(), ne_binary(), wh_json:object()) -> wh_json:object().
+set_ccv(Var, Value, Endpoint) ->
+    wh_json:set_value([<<"Custom-Channel-Vars">>, Var], Value, Endpoint).
+
+-spec get_originate_action(state()) -> state().
+get_originate_action(#state{originate_req=JObj
+                            ,node=Node
+                            ,app = ApplicationName
+                           }=State) ->
+    Action = get_originate_action(ApplicationName, JObj),
+    UseNode = maybe_update_node(JObj, Node),
+    lager:debug("maybe updating node from ~s to ~s", [Node, UseNode]),
+    lager:debug("originate action: ~s", [Action]),
+    State#state{action=Action
+                ,node=UseNode
+               }.
+
+-spec build_originate_args(state()) -> state().
+build_originate_args(#state{originate_req=JObj
+                            ,action = ?ORIGINATE_PARK
+                            ,fetch_id=FetchId
+                            ,dialstrings='undefined'
+                           }=State) ->
+    Endpoints = [update_endpoint(Endpoint, State)
+                 || Endpoint <- wh_json:get_ne_value(<<"Endpoints">>, JObj, [])
+                ],
+    NewState = State#state{dialstrings=build_originate_args_from_endpoints(Endpoints, JObj, FetchId)},
+    case wh_json:is_true(<<"Originate-Immediate">>, JObj) of
+        'true' -> NewState;
+        'false' -> originate_ready(NewState)
+    end;
+build_originate_args(#state{originate_req=JObj
+                            ,app = ?ORIGINATE_EAVESDROP
+                            ,fetch_id=FetchId
+                            ,dialstrings='undefined'
+                           }=State) ->
+    State#state{dialstrings=build_originate_args(State, JObj, FetchId)};
+build_originate_args(#state{originate_req=JObj
+                            ,fetch_id=FetchId
+                            ,dialstrings='undefined'
+                           }=State) ->
+    State#state{dialstrings=build_originate_args(State, JObj, FetchId)}.
+
+update_dialstrings(#state{dialstrings=DialString, action = Action} = State) ->
+    State#state{dialstrings = iolist_to_binary([DialString, " ", Action])}.
+
+originate_ready(#state{node = _Node} = State) ->
+    case start_control_process(State) of
+        {'ok', #state{control_pid=Pid
+                      ,uuid=UUID
+                      ,originate_req=JObj
+                      ,server_id=ServerId
+                      ,queue=Q
+                     }=State1} ->
+            CtrlQ = gen_listener:queue_name(Pid),
+            _ = publish_originate_ready(CtrlQ, UUID, JObj, Q, ServerId),
+            {'noreply', State1#state{tref=start_abandon_timer()}};
+        {'error', _E} ->
+            lager:debug("failed to start control process: ~p", [_E]),
+            {'stop', 'normal', State}
+    end.
+
 -spec get_originate_action(ne_binary(), wh_json:object()) -> ne_binary().
 get_originate_action(<<"fax">>, JObj) ->
     lager:debug("got originate with action fax"),
@@ -514,32 +574,28 @@ get_eavesdrop_action(JObj) ->
         'undefined' -> <<Group/binary, "eavesdrop:", CallId/binary, " inline">>
     end.
 
--spec build_originate_args(ne_binary(), state(), wh_json:object(), ne_binary()) -> api_binary().
-build_originate_args(Action, State, JObj, FetchId) ->
+-spec build_originate_args(state(), wh_json:object(), ne_binary()) -> api_binary().
+build_originate_args(State, JObj, FetchId) ->
     case wh_json:get_value(<<"Endpoints">>, JObj, []) of
         [] ->
             lager:warning("no endpoints defined in originate request"),
             'undefined';
         [Endpoint] ->
             lager:debug("only one endpoint, don't create per-endpoint UUIDs"),
-            build_originate_args_from_endpoints(Action, [update_endpoint(Endpoint, State)], JObj, FetchId);
+            build_originate_args_from_endpoints([update_endpoint(Endpoint, State)], JObj, FetchId);
         Endpoints ->
             lager:debug("multiple endpoints defined, assigning uuids to each"),
             UpdatedEndpoints = [update_endpoint(Endpoint, State) || Endpoint <- Endpoints],
-            build_originate_args_from_endpoints(Action, UpdatedEndpoints, JObj, FetchId)
+            build_originate_args_from_endpoints(UpdatedEndpoints, JObj, FetchId)
     end.
 
--spec build_originate_args_from_endpoints(ne_binary(), wh_json:objects(), wh_json:object(), ne_binary()) ->
-                                                 ne_binary().
-build_originate_args_from_endpoints(Action, Endpoints, JObj, FetchId) ->
+-spec build_originate_args_from_endpoints(wh_json:objects(), wh_json:object(), ne_binary()) -> ne_binary().
+build_originate_args_from_endpoints(Endpoints, JObj, FetchId) ->
     lager:debug("building originate command arguments"),
     DialSeparator = ecallmgr_util:get_dial_separator(JObj, Endpoints),
-
     DialStrings = ecallmgr_util:build_bridge_string(Endpoints, DialSeparator),
-
     ChannelVars = get_channel_vars(JObj, FetchId),
-
-    list_to_binary([ChannelVars, DialStrings, " ", Action]).
+    list_to_binary([ChannelVars, DialStrings]).
 
 -spec get_channel_vars(wh_json:object(), ne_binary()) -> iolist().
 get_channel_vars(JObj, FetchId) ->
@@ -625,8 +681,30 @@ update_uuid(OldUUID, NewUUID) ->
 -spec create_uuid(atom()) -> created_uuid().
 -spec create_uuid(wh_json:object(), atom()) -> created_uuid().
 -spec create_uuid(wh_json:object(), wh_json:object(), atom()) -> created_uuid().
+create_uuid(#state{node=Node
+                   ,originate_req=JObj
+                   ,uuid='undefined'
+                  }=State) ->
+    UUID = {_, Id} = create_uuid(JObj, Node),
+    wh_util:put_callid(Id),
+    lager:debug("created uuid ~p", [UUID]),
+    case wh_json:is_true(<<"Start-Control-Process">>, JObj, 'true')
+        andalso start_control_process(State#state{uuid=UUID}) of
+        'false' ->
+            State#state{uuid=UUID};
+        {'ok', #state{control_pid=Pid}=State1} ->
+            lager:debug("started control proc ~p uuid ~p", [Pid, UUID]),
+            maybe_send_originate_uuid(UUID, Pid, State),
+            State1;
+        {'error', _E} ->
+            lager:debug("failed to start control proc for ~p: ~p", [UUID, _E]),
+            {'stop', 'normal', State}
+    end;
 
-create_uuid(Node) ->
+create_uuid(#state{} = State) ->
+    State;
+
+create_uuid(Node) when is_atom(Node) ->
     case freeswitch:api(Node, 'create_uuid', " ") of
         {'ok', UUID} ->
             wh_util:put_callid(UUID),

--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -476,9 +476,11 @@ build_originate_args(#state{originate_req=JObj
                            }=State) ->
     State#state{dialstrings=build_originate_args(State, JObj, FetchId)}.
 
+-spec update_dialstrings(state()) -> state().
 update_dialstrings(#state{dialstrings=DialString, action = Action} = State) ->
     State#state{dialstrings = iolist_to_binary([DialString, " ", Action])}.
 
+-spec originate_ready(state()) -> {'noreply', state()} | {'stop', 'normal', state()}.
 originate_ready(#state{node = _Node} = State) ->
     case start_control_process(State) of
         {'ok', #state{control_pid=Pid

--- a/applications/ecallmgr/src/ecallmgr_sup.erl
+++ b/applications/ecallmgr/src/ecallmgr_sup.erl
@@ -20,6 +20,7 @@
                    ,?SUPER('ecallmgr_auxiliary_sup')
                    ,?SUPER('ecallmgr_call_sup')
                    ,?SUPER('ecallmgr_fs_sup')
+                   ,?CACHE(?ECALLMGR_CMDS_CACHE)
                   ]).
 
 %% ===================================================================

--- a/core/whistle/src/api/wapi_resource.erl
+++ b/core/whistle/src/api/wapi_resource.erl
@@ -82,6 +82,7 @@
                                          ,<<"Fax-Identity-Number">>
                                          ,<<"Fax-Timezone">>
                                          ,<<"Intercept-Unbridged-Only">>
+                                         ,<<"Loopback-Handler">>
                                          ,<<"Simplify-Loopback">> %% loopback_bowout flag
                                          ,<<"Loopback-Bowout">>
                                          ,<<"Start-Control-Process">>
@@ -94,6 +95,7 @@
                                ,{<<"Application-Name">>, [<<"park">>, <<"bridge">>, <<"transfer">>
                                                           ,<<"fax">>, <<"eavesdrop">>
                                                          ]}
+                               ,{<<"Loopback-Handler">>, [<<"ecallmgr">>]}
                                %% Eavesdrop
                                ,?EAVESDROP_MODE
                               ]).


### PR DESCRIPTION
This patch is to prevent loopbacks legs created by freeswitch.
Modified only clicktocall to use it.
