### PR TITLE
KAZOO-4481: move formatting to bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ notifications:
 otp_release:
   - 18.1
   - 17.5
-  - R15B03
 
 addons:
   apt:

--- a/applications/stepswitch/src/stepswitch_formatters.erl
+++ b/applications/stepswitch/src/stepswitch_formatters.erl
@@ -158,7 +158,7 @@ maybe_replace(JObj, Key, _Value, Formatter) ->
         Replace -> wh_json:set_value(Key, Replace, JObj)
     end.
 
--spec maybe_match_invite_format(wh_json:object(), ne_binary(), wh_json:json_term(), wh_json:objects()) ->
+-spec maybe_match_invite_format(wh_json:object(), ne_binary(), wh_json:json_term(), wh_json:object()) ->
                                        ffun_return().
 maybe_match_invite_format(JObj, Key, Value, Formatter) ->
     case maybe_match_invite_format(JObj, Formatter) of

--- a/applications/stepswitch/src/stepswitch_originate.erl
+++ b/applications/stepswitch/src/stepswitch_originate.erl
@@ -24,7 +24,7 @@
 
 -record(state, {msg_id=wh_util:rand_hex_binary(12)
                 ,endpoints = [] :: wh_json:objects()
-                ,resource_req :: wh_json:object()
+                ,resource_req :: wapi_offnet_resource:req()
                 ,request_handler :: pid()
                 ,response_queue :: api_binary()
                 ,queue :: api_binary()
@@ -50,14 +50,14 @@
 %% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
 %% @end
 %%--------------------------------------------------------------------
--spec start_link(wh_json:objects(), wh_json:object()) -> startlink_ret().
-start_link(Endpoints, JObj) ->
+-spec start_link(wh_json:objects(), wapi_offnet_resource:req()) -> startlink_ret().
+start_link(Endpoints, OffnetReq) ->
     gen_listener:start_link(?MODULE, [{'bindings', ?BINDINGS}
                                       ,{'responders', ?RESPONDERS}
                                       ,{'queue_name', ?QUEUE_NAME}
                                       ,{'queue_options', ?QUEUE_OPTIONS}
                                       ,{'consume_options', ?CONSUME_OPTIONS}
-                                     ], [Endpoints, JObj]).
+                                     ], [Endpoints, OffnetReq]).
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -74,12 +74,12 @@ start_link(Endpoints, JObj) ->
 %%                     {stop, Reason}
 %% @end
 %%--------------------------------------------------------------------
-init([Endpoints, JObj]) ->
-    wh_util:put_callid(JObj),
+init([Endpoints, OffnetReq]) ->
+    wh_util:put_callid(OffnetReq),
     {'ok', #state{endpoints=Endpoints
-                  ,resource_req=JObj
+                  ,resource_req=OffnetReq
                   ,request_handler=self()
-                  ,response_queue=wh_json:get_ne_value(<<"Server-ID">>, JObj)
+                  ,response_queue=wh_api:server_id(OffnetReq)
                   ,timeout=erlang:send_after(120000, self(), 'originate_timeout')
                  }}.
 
@@ -138,8 +138,8 @@ handle_cast('answered', #state{timeout=TimerRef}=State) ->
     lager:debug("channel answered, canceling timeout"),
     _ = erlang:cancel_timer(TimerRef),
     {'noreply', State#state{timeout='undefined'}};
-handle_cast({'bind_to_call', 'undefined'}, #state{resource_req=Request}=State) ->
-    gen_listener:cast(self(), {'originate_result', originate_failure(wh_json:new(), Request)}),
+handle_cast({'bind_to_call', 'undefined'}, #state{resource_req=OffnetReq}=State) ->
+    gen_listener:cast(self(), {'originate_result', originate_failure(wh_json:new(), OffnetReq)}),
     {'stop', 'normal', State};
 handle_cast({'bind_to_call', CallId}, State) ->
     wh_util:put_callid(CallId),
@@ -169,9 +169,9 @@ handle_cast(_Msg, State) ->
 handle_info('originate_timeout', #state{timeout='undefined'}=State) ->
     {'noreply', State};
 handle_info('originate_timeout', #state{response_queue=ResponseQ
-                                        ,resource_req=JObj
+                                        ,resource_req=OffnetReq
                                        }=State) ->
-    wapi_offnet_resource:publish_resp(ResponseQ, originate_timeout(JObj)),
+    wapi_offnet_resource:publish_resp(ResponseQ, originate_timeout(OffnetReq)),
     {'stop', 'normal', State#state{timeout='undefined'}};
 handle_info(_Info, State) ->
     lager:debug("unhandled info: ~p", [_Info]),
@@ -186,36 +186,37 @@ handle_info(_Info, State) ->
 %% @end
 %%--------------------------------------------------------------------
 handle_event(JObj, #state{request_handler=RequestHandler
-                          ,resource_req=Request
+                          ,resource_req=OffnetReq
                           ,msg_id=MsgId
                          }) ->
     case whapps_util:get_event_type(JObj) of
         {<<"call_event">>, <<"CHANNEL_DESTROY">>} ->
             lager:debug("channel was destroy while waiting for execute extension", []),
-            gen_listener:cast(RequestHandler, {'originate_result', originate_success(JObj, Request)});
+            gen_listener:cast(RequestHandler, {'originate_result', originate_success(JObj, OffnetReq)});
         {<<"call_event">>, <<"CHANNEL_BRIDGE">>} ->
-            CallId = wh_json:get_value(<<"Other-Leg-Call-ID">>, JObj),
+            CallId = kz_call_event:other_leg_call_id(JObj),
             gen_listener:cast(RequestHandler, {'bridged', CallId});
         {<<"call_event">>, <<"CHANNEL_ANSWER">>} ->
             gen_listener:cast(RequestHandler, 'answered');
         {<<"resource">>, <<"originate_resp">>} ->
-            MsgId = wh_json:get_value(<<"Msg-ID">>, JObj),
-            case wh_json:get_value(<<"Application-Response">>, JObj) =:= <<"SUCCESS">> of
+            MsgId = wh_api:msg_id(JObj),
+            case kz_call_event:application_response(JObj) =:= <<"SUCCESS">> of
                 'true' ->
-                    gen_listener:cast(RequestHandler, {'originate_result', originate_success(JObj, Request)});
+                    gen_listener:cast(RequestHandler, {'originate_result', originate_success(JObj, OffnetReq)});
                 'false' ->
-                    gen_listener:cast(RequestHandler, {'originate_result', originate_failure(JObj, Request)})
+                    gen_listener:cast(RequestHandler, {'originate_result', originate_failure(JObj, OffnetReq)})
             end;
         {<<"error">>, <<"originate_resp">>} ->
-            MsgId = wh_json:get_value(<<"Msg-ID">>, JObj),
+            MsgId = wh_api:msg_id(JObj),
             lager:debug("channel execution error while waiting for originate: ~s"
-                        ,[wh_util:to_binary(wh_json:encode(JObj))]),
-            gen_listener:cast(RequestHandler, {'originate_result', originate_error(JObj, Request)});
+                        ,[wh_json:encode(JObj)]
+                       ),
+            gen_listener:cast(RequestHandler, {'originate_result', originate_error(JObj, OffnetReq)});
         {<<"dialplan">>, <<"originate_ready">>} ->
-            gen_listener:cast(RequestHandler, {'originate_result', originate_ready(JObj, Request)});
+            gen_listener:cast(RequestHandler, {'originate_result', originate_ready(JObj, OffnetReq)});
         _ -> 'ok'
     end,
-    {'reply', []}.
+    'ignore'.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -246,59 +247,62 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 build_originate(#state{endpoints=Endpoints
-                       ,resource_req=JObj
+                       ,resource_req=OffnetReq
                        ,queue=Q
                        ,msg_id=MsgId
                       }) ->
-    {CIDNum, CIDName} = originate_caller_id(JObj),
+    {CIDNum, CIDName} = originate_caller_id(OffnetReq),
     lager:debug("set outbound caller id to ~s '~s'", [CIDNum, CIDName]),
-    AccountId = wh_json:get_value(<<"Account-ID">>, JObj),
-    CCVs = wh_json:get_value(<<"Custom-Channel-Vars">>, JObj, wh_json:new()),
+    AccountId = wh_json:get_value(<<"Account-ID">>, OffnetReq),
+    CCVs = wh_json:get_value(<<"Custom-Channel-Vars">>, OffnetReq, wh_json:new()),
     CCVUpdates = props:filter_undefined(
                    [{<<"Global-Resource">>, <<"true">>}
                     ,{<<"Account-ID">>, AccountId}
-                    ,{<<"From-URI">>, originate_from_uri(CIDNum, JObj)}
+                    ,{<<"From-URI">>, originate_from_uri(CIDNum, OffnetReq)}
                     ,{<<"Reseller-ID">>, wh_services:find_reseller_id(AccountId)}
                    ]),
-    Application = wh_json:get_value(<<"Application-Name">>, JObj, <<"park">>),
+    Application = wh_json:get_value(<<"Application-Name">>, OffnetReq, <<"park">>),
+
+    FmtEndpoints = stepswitch_util:format_endpoints(Endpoints, CIDName, CIDNum, OffnetReq),
+
     props:filter_undefined(
       [{<<"Dial-Endpoint-Method">>, <<"single">>}
        ,{<<"Application-Name">>, Application}
        ,{<<"Msg-ID">>, MsgId}
-       ,{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, JObj)}
-       ,{<<"Outbound-Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, JObj)}
-       ,{<<"Existing-Call-ID">>, wh_json:get_value(<<"Existing-Call-ID">>, JObj)}
-       ,{<<"Originate-Immediate">>, wh_json:get_value(<<"Originate-Immediate">>, JObj)}
-       ,{<<"Simplify-Loopback">>, wh_json:get_value(<<"Simplify-Loopback">>, JObj)}
-       ,{<<"Endpoints">>, Endpoints}
+       ,{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, OffnetReq)}
+       ,{<<"Outbound-Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, OffnetReq)}
+       ,{<<"Existing-Call-ID">>, wh_json:get_value(<<"Existing-Call-ID">>, OffnetReq)}
+       ,{<<"Originate-Immediate">>, wh_json:get_value(<<"Originate-Immediate">>, OffnetReq)}
+       ,{<<"Simplify-Loopback">>, wh_json:get_value(<<"Simplify-Loopback">>, OffnetReq)}
+       ,{<<"Endpoints">>, FmtEndpoints}
        ,{<<"Outbound-Caller-ID-Number">>, CIDNum}
        ,{<<"Outbound-Caller-ID-Name">>, CIDName}
        ,{<<"Caller-ID-Number">>, CIDNum}
        ,{<<"Caller-ID-Name">>, CIDName}
-       ,{<<"Application-Data">>, wh_json:get_value(<<"Application-Data">>, JObj)}
-       ,{<<"Timeout">>, wh_json:get_value(<<"Timeout">>, JObj)}
-       ,{<<"Ignore-Early-Media">>, wh_json:get_value(<<"Ignore-Early-Media">>, JObj)}
-       ,{<<"Media">>, wh_json:get_value(<<"Media">>, JObj)}
-       ,{<<"Hold-Media">>, wh_json:get_value(<<"Hold-Media">>, JObj)}
-       ,{<<"Presence-ID">>, wh_json:get_value(<<"Presence-ID">>, JObj)}
-       ,{<<"Outbound-Callee-ID-Number">>, wh_json:get_value(<<"Outbound-Callee-ID-Number">>, JObj)}
-       ,{<<"Outbound-Callee-ID-Name">>, wh_json:get_value(<<"Outbound-Callee-ID-Name">>, JObj)}
-       ,{<<"Fax-Identity-Number">>, wh_json:get_value(<<"Fax-Identity-Number">>, JObj, CIDNum)}
-       ,{<<"Fax-Identity-Name">>, wh_json:get_value(<<"Fax-Identity-Name">>, JObj, CIDName)}
-       ,{<<"Fax-Timezone">>, wh_json:get_value(<<"Fax-Timezone">>, JObj)}
-       ,{<<"Ringback">>, wh_json:get_value(<<"Ringback">>, JObj)}
-       ,{<<"Custom-SIP-Headers">>, wh_json:get_value(<<"Custom-SIP-Headers">>, JObj)}
+       ,{<<"Application-Data">>, wh_json:get_value(<<"Application-Data">>, OffnetReq)}
+       ,{<<"Timeout">>, wh_json:get_value(<<"Timeout">>, OffnetReq)}
+       ,{<<"Ignore-Early-Media">>, wh_json:get_value(<<"Ignore-Early-Media">>, OffnetReq)}
+       ,{<<"Media">>, wh_json:get_value(<<"Media">>, OffnetReq)}
+       ,{<<"Hold-Media">>, wh_json:get_value(<<"Hold-Media">>, OffnetReq)}
+       ,{<<"Presence-ID">>, wh_json:get_value(<<"Presence-ID">>, OffnetReq)}
+       ,{<<"Outbound-Callee-ID-Number">>, wh_json:get_value(<<"Outbound-Callee-ID-Number">>, OffnetReq)}
+       ,{<<"Outbound-Callee-ID-Name">>, wh_json:get_value(<<"Outbound-Callee-ID-Name">>, OffnetReq)}
+       ,{<<"Fax-Identity-Number">>, wh_json:get_value(<<"Fax-Identity-Number">>, OffnetReq, CIDNum)}
+       ,{<<"Fax-Identity-Name">>, wh_json:get_value(<<"Fax-Identity-Name">>, OffnetReq, CIDName)}
+       ,{<<"Fax-Timezone">>, wh_json:get_value(<<"Fax-Timezone">>, OffnetReq)}
+       ,{<<"Ringback">>, wh_json:get_value(<<"Ringback">>, OffnetReq)}
+       ,{<<"Custom-SIP-Headers">>, wh_json:get_value(<<"Custom-SIP-Headers">>, OffnetReq)}
        ,{<<"Custom-Channel-Vars">>, wh_json:set_values(CCVUpdates, CCVs)}
        | wh_api:default_headers(Q, <<"resource">>, <<"originate_req">>, ?APP_NAME, ?APP_VERSION)
       ]).
 
 -spec originate_from_uri(ne_binary(), wh_json:object()) -> api_binary().
-originate_from_uri(CIDNum, JObj) ->
+originate_from_uri(CIDNum, OffnetReq) ->
     Realm = wh_json:get_first_defined([<<"From-URI-Realm">>
                                        ,<<"Account-Realm">>
-                                      ], JObj),
+                                      ], OffnetReq),
     case (whapps_config:get_is_true(?SS_CONFIG_CAT, <<"format_from_uri">>, 'false')
-          orelse wh_json:is_true(<<"Format-From-URI">>, JObj))
+          orelse wh_json:is_true(<<"Format-From-URI">>, OffnetReq))
         andalso (is_binary(CIDNum) andalso is_binary(Realm))
     of
         'false' -> 'undefined';
@@ -309,20 +313,20 @@ originate_from_uri(CIDNum, JObj) ->
     end.
 
 -spec originate_caller_id(wh_json:object()) -> {api_binary(), api_binary()}.
-originate_caller_id(JObj) ->
+originate_caller_id(OffnetReq) ->
     {wh_json:get_first_defined([<<"Outbound-Caller-ID-Number">>
                                 ,<<"Emergency-Caller-ID-Number">>
-                               ], JObj)
+                               ], OffnetReq)
      ,wh_json:get_first_defined([<<"Outbound-Caller-ID-Name">>
                                  ,<<"Emergency-Caller-ID-Name">>
-                                ], JObj)
+                                ], OffnetReq)
     }.
 
 -spec originate_timeout(wh_json:object()) -> wh_proplist().
 originate_timeout(Request) ->
     lager:debug("attempt to connect to resources timed out"),
     [{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, Request)}
-     ,{<<"Msg-ID">>, wh_json:get_value(<<"Msg-ID">>, Request, <<>>)}
+     ,{<<"Msg-ID">>, wh_api:msg_id(Request)}
      ,{<<"Response-Message">>, <<"NORMAL_TEMPORARY_FAILURE">>}
      ,{<<"Response-Code">>, <<"sip:500">>}
      ,{<<"Error-Message">>, <<"originate request timed out">>}
@@ -331,22 +335,22 @@ originate_timeout(Request) ->
     ].
 
 -spec originate_error(wh_json:object(), wh_json:object()) -> wh_proplist().
-originate_error(JObj, Request) ->
+originate_error(JObj, OffnetReq) ->
     lager:debug("error during originate request: ~s", [wh_util:to_binary(wh_json:encode(JObj))]),
-    [{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, Request)}
-     ,{<<"Msg-ID">>, wh_json:get_value(<<"Msg-ID">>, Request, <<>>)}
+    [{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, OffnetReq)}
+     ,{<<"Msg-ID">>, wh_api:msg_id(OffnetReq)}
      ,{<<"Response-Message">>, <<"NORMAL_TEMPORARY_FAILURE">>}
      ,{<<"Response-Code">>, <<"sip:500">>}
      ,{<<"Error-Message">>, wh_json:get_value(<<"Error-Message">>, JObj, <<"failed to process request">>)}
-     ,{<<"To-DID">>, wh_json:get_value(<<"To-DID">>, Request)}
+     ,{<<"To-DID">>, wh_json:get_value(<<"To-DID">>, OffnetReq)}
      | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 
 -spec originate_success(wh_json:object(), wh_json:object()) -> wh_proplist().
-originate_success(JObj, Request) ->
+originate_success(JObj, OffnetReq) ->
     lager:debug("originate request successfully completed"),
-    [{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, Request)}
-     ,{<<"Msg-ID">>, wh_json:get_value(<<"Msg-ID">>, Request, <<>>)}
+    [{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, OffnetReq)}
+     ,{<<"Msg-ID">>, wh_api:msg_id(OffnetReq)}
      ,{<<"Response-Message">>, <<"SUCCESS">>}
      ,{<<"Response-Code">>, <<"sip:200">>}
      ,{<<"Resource-Response">>, JObj}
@@ -354,10 +358,10 @@ originate_success(JObj, Request) ->
     ].
 
 -spec originate_failure(wh_json:object(), wh_json:object()) -> wh_proplist().
-originate_failure(JObj, Request) ->
+originate_failure(JObj, OffnetReq) ->
     lager:debug("originate request failed: ~s", [wh_json:get_value(<<"Application-Response">>, JObj)]),
-    [{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, Request)}
-     ,{<<"Msg-ID">>, wh_json:get_value(<<"Msg-ID">>, Request, <<>>)}
+    [{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, OffnetReq)}
+     ,{<<"Msg-ID">>, wh_api:msg_id(OffnetReq)}
      ,{<<"Response-Message">>, wh_json:get_first_defined([<<"Application-Response">>
                                                           ,<<"Hangup-Cause">>
                                                          ], JObj)}
@@ -367,10 +371,10 @@ originate_failure(JObj, Request) ->
     ].
 
 -spec originate_ready(wh_json:object(), wh_json:object()) -> wh_proplist().
-originate_ready(JObj, Request) ->
+originate_ready(JObj, OffnetReq) ->
     lager:debug("originate is ready to execute"),
     [{<<"Call-ID">>, wh_json:get_value(<<"Outbound-Call-ID">>, JObj)}
-     ,{<<"Msg-ID">>, wh_json:get_value(<<"Msg-ID">>, Request)}
+     ,{<<"Msg-ID">>, wh_api:msg_id(OffnetReq)}
      ,{<<"Control-Queue">>, wh_json:get_value(<<"Control-Queue">>, JObj)}
      ,{<<"Response-Message">>, <<"READY">>}
      ,{<<"Resource-Response">>, JObj}

--- a/applications/stepswitch/src/stepswitch_outbound.erl
+++ b/applications/stepswitch/src/stepswitch_outbound.erl
@@ -114,7 +114,7 @@ handle_sms_req(OffnetReq) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec maybe_force_outbound(wh_proplist(), wapi_offnet_resource:req()) -> any().
+-spec maybe_force_outbound(number_properties(), wapi_offnet_resource:req()) -> any().
 maybe_force_outbound(Props, OffnetReq) ->
     case wh_number_properties:should_force_outbound(Props)
         orelse wapi_offnet_resource:force_outbound(OffnetReq, 'false')
@@ -131,7 +131,7 @@ maybe_force_outbound(Props, OffnetReq) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec maybe_force_outbound_sms(wh_proplist(), wapi_offnet_resource:req()) -> any().
+-spec maybe_force_outbound_sms(number_properties(), wapi_offnet_resource:req()) -> any().
 maybe_force_outbound_sms(Props, OffnetReq) ->
     case props:get_is_true('force_outbound', Props)
         orelse wapi_offnet_resource:force_outbound(OffnetReq, 'false')
@@ -188,7 +188,7 @@ maybe_sms(Number, OffnetReq) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec local_extension(wh_proplist(), wapi_offnet_resource:req()) -> any().
+-spec local_extension(number_properties(), wapi_offnet_resource:req()) -> any().
 local_extension(Props, OffnetReq) -> stepswitch_request_sup:local_extension(Props, OffnetReq).
 
 %%--------------------------------------------------------------------
@@ -197,7 +197,7 @@ local_extension(Props, OffnetReq) -> stepswitch_request_sup:local_extension(Prop
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec local_sms(wh_proplist(), wapi_offnet_resource:req()) -> 'ok'.
+-spec local_sms(number_properties(), wapi_offnet_resource:req()) -> 'ok'.
 local_sms(Props, OffnetReq) -> stepswitch_local_sms:local_message_handling(Props, OffnetReq).
 
 %%--------------------------------------------------------------------

--- a/applications/stepswitch/src/stepswitch_request_sup.erl
+++ b/applications/stepswitch/src/stepswitch_request_sup.erl
@@ -56,7 +56,7 @@ bridge(Endpoints, OffnetReq) ->
                                                   )
                           ).
 
--spec local_extension(wh_proplist(), wapi_offnet_resource:req()) -> sup_startchild_ret().
+-spec local_extension(number_properties(), wapi_offnet_resource:req()) -> sup_startchild_ret().
 local_extension(Props, OffnetReq) ->
     supervisor:start_child(?MODULE
                            ,?WORKER_NAME_ARGS_TYPE(child_name(OffnetReq)

--- a/applications/stepswitch/src/stepswitch_sms.erl
+++ b/applications/stepswitch/src/stepswitch_sms.erl
@@ -31,7 +31,7 @@
                 ,response_queue :: api_binary()
                 ,queue :: api_binary()
                 ,message = [] :: wh_proplist()
-                ,messages = queue:new() :: queue()
+                ,messages = queue:new() :: queue:queue()
                }).
 -type state() :: #state{}.
 
@@ -386,7 +386,7 @@ build_sms_base({CIDNum, CIDName}, OffnetReq, Q) ->
 maybe_endpoints_format_from([], _ , _) -> [];
 maybe_endpoints_format_from(Endpoints, 'undefined', _) -> Endpoints;
 maybe_endpoints_format_from(Endpoints, CIDNum, OffnetReq) ->
-    DefaultRealm = stepswitch_bridge:default_realm(OffnetReq),
+    DefaultRealm = stepswitch_util:default_realm(OffnetReq),
     [maybe_endpoint_format_from(Endpoint, CIDNum, DefaultRealm)
      || Endpoint <- Endpoints
     ].
@@ -465,7 +465,7 @@ bridge_caller_id(OffnetReq) ->
 -spec bridge_from_uri(api_binary(), wapi_offnet_resource:req()) ->
                              api_binary().
 bridge_from_uri(CIDNum, OffnetReq) ->
-    Realm = stepswitch_bridge:default_realm(OffnetReq),
+    Realm = stepswitch_util:default_realm(OffnetReq),
     case (whapps_config:get_is_true(?APP_NAME, <<"format_from_uri">>, 'false')
           orelse wapi_offnet_resource:format_from_uri(OffnetReq)
          )

--- a/applications/stepswitch/src/stepswitch_util.erl
+++ b/applications/stepswitch/src/stepswitch_util.erl
@@ -12,8 +12,12 @@
 -export([lookup_number/1]).
 -export([correct_shortdial/2]).
 -export([get_sip_headers/1]).
+-export([format_endpoints/4]).
+-export([default_realm/1]).
 
 -include("stepswitch.hrl").
+-include_lib("whistle/src/wh_json.hrl").
+-include_lib("whistle/include/wapi_offnet_resource.hrl").
 
 %%--------------------------------------------------------------------
 %% @public
@@ -194,3 +198,132 @@ find_diversion_count(Diversions) ->
                 )
                || Diversion <- Diversions
               ]).
+
+format_endpoints(Endpoints, Name, Number, OffnetReq) ->
+    EndpointFilter = build_filter_fun(Name, Number),
+    format_endpoints(Endpoints, Name, Number, OffnetReq, EndpointFilter).
+
+-type filter_fun() :: fun(({ne_binary(), ne_binary()}) -> boolean()).
+-spec build_filter_fun(ne_binary(), ne_binary()) -> filter_fun().
+build_filter_fun(Name, Number) ->
+    fun({?KEY_OUTBOUND_CALLER_ID_NUMBER, N}) when N =:= Number -> 'false';
+       ({?KEY_OUTBOUND_CALLER_ID_NAME, N}) when N =:= Name -> 'false';
+       (_Else) -> 'true'
+    end.
+
+-spec format_endpoints(wh_json:objects(), api_binary(), api_binary(), wapi_offnet_resource:req(), filter_fun()) ->
+                              wh_json:objects().
+format_endpoints(Endpoints, Name, Number, OffnetReq, FilterFun) ->
+    DefaultRealm = default_realm(OffnetReq),
+    SIPHeaders = stepswitch_util:get_sip_headers(OffnetReq),
+    AccountId = wapi_offnet_resource:account_id(OffnetReq),
+
+    [format_endpoint(set_endpoint_caller_id(Endpoint, Name, Number)
+                     ,Number, FilterFun, DefaultRealm, SIPHeaders, AccountId
+                    )
+     || Endpoint <- Endpoints
+    ].
+
+-spec default_realm(wapi_offnet_resource:req()) -> api_binary().
+default_realm(OffnetReq) ->
+    case wapi_offnet_resource:from_uri_realm(OffnetReq) of
+        'undefined' -> wapi_offnet_resource:account_realm(OffnetReq);
+        Realm -> Realm
+    end.
+
+-spec set_endpoint_caller_id(wh_json:object(), api_binary(), api_binary()) -> wh_json:object().
+set_endpoint_caller_id(Endpoint, Name, Number) ->
+    wh_json:set_values(props:filter_undefined(
+                         [{?KEY_OUTBOUND_CALLER_ID_NUMBER, Number}
+                          ,{?KEY_OUTBOUND_CALLER_ID_NAME, Name}
+                         ]
+                        )
+                       ,Endpoint
+                      ).
+
+-spec format_endpoint(wh_json:object(), api_binary(), filter_fun(), api_binary(), wh_json:object(), ne_binary()) ->
+                             wh_json:object().
+format_endpoint(Endpoint, Number, FilterFun, DefaultRealm, SIPHeaders, AccountId) ->
+    FormattedEndpoint = apply_formatters(Endpoint, SIPHeaders, AccountId),
+    FilteredEndpoint = wh_json:filter(FilterFun, FormattedEndpoint),
+    maybe_endpoint_format_from(FilteredEndpoint, Number, DefaultRealm).
+
+-spec apply_formatters(wh_json:object(), wh_json:object(), ne_binary()) -> wh_json:object().
+apply_formatters(Endpoint, SIPHeaders, AccountId) ->
+    stepswitch_formatters:apply(maybe_add_sip_headers(Endpoint, SIPHeaders)
+                                ,props:get_value(<<"Formatters">>
+                                                 ,endpoint_props(Endpoint, AccountId)
+                                                 ,wh_json:new()
+                                                )
+                                ,'outbound'
+                               ).
+
+-spec endpoint_props(wh_json:object(), api_binary()) -> wh_proplist().
+endpoint_props(Endpoint, AccountId) ->
+    ResourceId = wh_json:get_value(?CCV(<<"Resource-ID">>), Endpoint),
+    case wh_json:is_true(?CCV(<<"Global-Resource">>), Endpoint) of
+        'true' ->
+            empty_list_on_undefined(stepswitch_resources:get_props(ResourceId));
+        'false' ->
+            empty_list_on_undefined(stepswitch_resources:get_props(ResourceId, AccountId))
+    end.
+
+-spec empty_list_on_undefined(wh_proplist() | 'undefined') -> wh_proplist().
+empty_list_on_undefined('undefined') -> [];
+empty_list_on_undefined(L) -> L.
+
+-spec maybe_add_sip_headers(wh_json:object(), wh_json:object()) -> wh_json:object().
+maybe_add_sip_headers(Endpoint, SIPHeaders) ->
+    LocalSIPHeaders = wh_json:get_value(<<"Custom-SIP-Headers">>, Endpoint, wh_json:new()),
+
+    case wh_json:merge_jobjs(SIPHeaders, LocalSIPHeaders) of
+        ?EMPTY_JSON_OBJECT -> Endpoint;
+        MergedHeaders -> wh_json:set_value(<<"Custom-SIP-Headers">>, MergedHeaders, Endpoint)
+    end.
+
+-spec maybe_endpoint_format_from(wh_json:object(), ne_binary(), api_binary()) ->
+                                        wh_json:object().
+maybe_endpoint_format_from(Endpoint, Number, DefaultRealm) ->
+    CCVs = wh_json:get_value(<<"Custom-Channel-Vars">>, Endpoint, wh_json:new()),
+    case wh_json:is_true(<<"Format-From-URI">>, CCVs) of
+        'true' -> endpoint_format_from(Endpoint, Number, DefaultRealm, CCVs);
+        'false' ->
+            wh_json:set_value(<<"Custom-Channel-Vars">>
+                              ,wh_json:delete_keys([<<"Format-From-URI">>
+                                                    ,<<"From-URI-Realm">>
+                                                   ]
+                                                   ,CCVs
+                                                  )
+                              ,Endpoint
+                             )
+    end.
+
+-spec endpoint_format_from(wh_json:object(), ne_binary(), api_binary(), wh_json:object()) ->
+                                  wh_json:object().
+endpoint_format_from(Endpoint, Number, DefaultRealm, CCVs) ->
+    case wh_json:get_value(<<"From-URI-Realm">>, CCVs, DefaultRealm) of
+        <<_/binary>> = Realm ->
+            FromURI = <<"sip:", Number/binary, "@", Realm/binary>>,
+            lager:debug("setting resource ~s from-uri to ~s"
+                        ,[wh_json:get_value(<<"Resource-ID">>, CCVs)
+                          ,FromURI
+                         ]),
+            UpdatedCCVs = wh_json:set_value(<<"From-URI">>, FromURI, CCVs),
+            wh_json:set_value(<<"Custom-Channel-Vars">>
+                              ,wh_json:delete_keys([<<"Format-From-URI">>
+                                                    ,<<"From-URI-Realm">>
+                                                   ]
+                                                   ,UpdatedCCVs
+                                                  )
+                              ,Endpoint
+                             );
+        _ ->
+            wh_json:set_value(<<"Custom-Channel-Vars">>
+                              ,wh_json:delete_keys([<<"Format-From-URI">>
+                                                    ,<<"From-URI-Realm">>
+                                                   ]
+                                                   ,CCVs
+                                                  )
+                              ,Endpoint
+                             )
+    end.

--- a/applications/stepswitch/src/stepswitch_util.erl
+++ b/applications/stepswitch/src/stepswitch_util.erl
@@ -233,13 +233,13 @@ default_realm(OffnetReq) ->
 
 -spec set_endpoint_caller_id(wh_json:object(), api_binary(), api_binary()) -> wh_json:object().
 set_endpoint_caller_id(Endpoint, Name, Number) ->
-    wh_json:set_values(props:filter_undefined(
-                         [{?KEY_OUTBOUND_CALLER_ID_NUMBER, Number}
-                          ,{?KEY_OUTBOUND_CALLER_ID_NAME, Name}
-                         ]
-                        )
-                       ,Endpoint
-                      ).
+    wh_json:insert_values(props:filter_undefined(
+                            [{?KEY_OUTBOUND_CALLER_ID_NUMBER, Number}
+                            ,{?KEY_OUTBOUND_CALLER_ID_NAME, Name}
+                            ]
+                           )
+                          ,Endpoint
+                         ).
 
 -spec format_endpoint(wh_json:object(), api_binary(), filter_fun(), api_binary(), wh_json:object(), ne_binary()) ->
                              wh_json:object().

--- a/core/whistle-1.0.0/src/wh_json.erl
+++ b/core/whistle-1.0.0/src/wh_json.erl
@@ -52,7 +52,7 @@
          ,get_private_keys/1
         ]).
 -export([set_value/3, set_values/2
-         ,insert_value/3
+         ,insert_value/3, insert_values/2
          ,new/0
         ]).
 -export([delete_key/2, delete_key/3, delete_keys/2]).
@@ -661,6 +661,17 @@ insert_value(Key, Value, JObj) ->
         'undefined' -> set_value(Key, Value, JObj);
         _V -> JObj
     end.
+
+-spec insert_values(json_proplist(), object()) -> object().
+insert_values(KVs, JObj) ->
+    lists:foldl(fun insert_value_fold/2
+                ,JObj
+                ,KVs
+               ).
+
+-spec insert_value_fold({key(), json_term()}, object()) -> object().
+insert_value_fold({Key, Value}, JObj) ->
+    insert_value(Key, Value, JObj).
 
 -spec set_value(key(), json_term(), object() | objects()) -> object() | objects().
 set_value(Keys, Value, JObj) when is_list(Keys) -> set_value1(Keys, Value, JObj);

--- a/core/whistle-1.0.0/test/wh_json_test.erl
+++ b/core/whistle-1.0.0/test/wh_json_test.erl
@@ -415,6 +415,13 @@ insert_value_test() ->
     ?assertEqual(<<"v1">>, wh_json:get_value(<<"k1">>, NonInsert)),
     ?assertEqual(<<"v3">>, wh_json:get_value(<<"k3">>, Insert)).
 
+insert_values_test() ->
+    JObj = wh_json:decode(<<"{\"k1\":\"v1\",\"k2\":\"v2\"}">>),
+    NonInsert = wh_json:insert_values([{<<"k1">>, <<"v3">>}], JObj),
+    Insert = wh_json:insert_values([{<<"k3">>, <<"v3">>}], JObj),
+    ?assertEqual(<<"v1">>, wh_json:get_value(<<"k1">>, NonInsert)),
+    ?assertEqual(<<"v3">>, wh_json:get_value(<<"k3">>, Insert)).
+
 get_ne_json_object_test() ->
     JObj = wh_json:decode(<<"{\"k1\":\"v1\",\"k2\":\"v2\",\"o1\":{\"k3\":\"v3\"},\"o2\":{}}">>),
     ?assertEqual('undefined'


### PR DESCRIPTION
caller id settings should be applied to the endpoints once calculated,
formatters given a chance to format the caller id, and endpoint-specific
caller id stripped if it doesn't differ from the root bridge's caller id.

KAZOO-4481: fix spec

KAZOO-4481: set caller id per endpoint

KAZOO-4481: add spec and use macros for keys

KAZOO-4481: cleanup usage of offnet req

KAZOO-4481: move formatting to util for reuse

KAZOO-4481: repoint call for default_realm/1

KAZOO-4481: update specs with more descriptive type

use wapi_offnet_resource accessors too

KAZOO-4481: format endpoints when originating

KAZOO-4481: update specs with descriptive types

KAZOO-4481: update spec

KAZOO-4481: typo ;)

Conflicts:
	applications/stepswitch/src/stepswitch_resources.erl