### PR TITLE
Trunkstore REFER support

### DIFF
--- a/applications/trunkstore/src/ts_from_offnet.erl
+++ b/applications/trunkstore/src/ts_from_offnet.erl
@@ -21,15 +21,19 @@ init(Parent, RouteReqJObj) ->
     proc_lib:init_ack(Parent, {'ok', self()}),
     start_amqp(ts_callflow:init(RouteReqJObj, ['undefined', <<"resource">>])).
 
+-spec start_amqp(ts_callflow:state() |
+                 {'error', 'not_ts_account'}
+                ) -> 'ok'.
 start_amqp({'error', 'not_ts_account'}) -> 'ok';
 start_amqp(State) ->
     endpoint_data(ts_callflow:start_amqp(State)).
 
+-spec endpoint_data(ts_callflow:state()) -> 'ok'.
 endpoint_data(State) ->
     JObj = ts_callflow:get_request_data(State),
     try get_endpoint_data(JObj) of
-        {'endpoint', EP} ->
-            proceed_with_endpoint(State, EP, JObj)
+        {'endpoint', Endpoint} ->
+            proceed_with_endpoint(State, Endpoint, JObj)
     catch
         'throw':'no_did_found' ->
             lager:info("call was not for a trunkstore number");
@@ -37,27 +41,29 @@ endpoint_data(State) ->
             lager:info("thrown exception caught, not continuing: ~p", [_E])
     end.
 
-proceed_with_endpoint(State, EP, JObj) ->
+-spec proceed_with_endpoint(ts_callflow:state(), wh_json:object(), wh_json:object()) -> 'ok'.
+proceed_with_endpoint(State, Endpoint, JObj) ->
     CallID = ts_callflow:get_aleg_id(State),
     Q = ts_callflow:get_my_queue(State),
-    'true' = wapi_dialplan:bridge_endpoint_v(EP),
+    'true' = wapi_dialplan:bridge_endpoint_v(Endpoint),
+
     MediaHandling = case wh_json:get_value([<<"Custom-Channel-Vars">>, <<"Offnet-Loopback-Number">>], JObj) of
                         'undefined' ->
-                            case wh_util:is_false(wh_json:get_value(<<"Bypass-Media">>, EP)) of
+                            case wh_util:is_false(wh_json:get_value(<<"Bypass-Media">>, Endpoint)) of
                                 'true' -> <<"process">>; %% bypass media is false, process media
                                 'false' -> <<"bypass">>
                             end;
                         _ -> <<"process">>
                     end,
     Command = [{<<"Application-Name">>, <<"bridge">>}
-               ,{<<"Endpoints">>, [EP]}
+               ,{<<"Endpoints">>, [Endpoint]}
                ,{<<"Media">>, MediaHandling}
                ,{<<"Dial-Endpoint-Method">>, <<"single">>}
                ,{<<"Call-ID">>, CallID}
                | wh_api:default_headers(Q, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
               ],
-    State1 = ts_callflow:set_failover(State, wh_json:get_value(<<"Failover">>, EP, wh_json:new())),
-    State2 = ts_callflow:set_endpoint_data(State1, EP),
+    State1 = ts_callflow:set_failover(State, wh_json:get_value(<<"Failover">>, Endpoint, wh_json:new())),
+    State2 = ts_callflow:set_endpoint_data(State1, Endpoint),
     send_park(State2, Command).
 
 send_park(State, Command) ->
@@ -138,27 +144,30 @@ try_failover_e164(State, ToDID) ->
     OriginalCIdNumber = wh_json:get_value(<<"Caller-ID-Number">>, RouteReq),
     OriginalCIdName = wh_json:get_value(<<"Caller-ID-Name">>, RouteReq),
     CallID = ts_callflow:get_aleg_id(State),
-    AcctID = ts_callflow:get_account_id(State),
-    EP = ts_callflow:get_endpoint_data(State),
+    AccountId = ts_callflow:get_account_id(State),
+
+    Endpoint = ts_callflow:get_endpoint_data(State),
+
     CtlQ = ts_callflow:get_control_queue(State),
     Q = ts_callflow:get_my_queue(State),
     CCVs = ts_callflow:get_custom_channel_vars(State),
+
     Req = [{<<"Call-ID">>, CallID}
            ,{<<"Resource-Type">>, <<"audio">>}
            ,{<<"To-DID">>, ToDID}
-           ,{<<"Account-ID">>, AcctID}
+           ,{<<"Account-ID">>, AccountId}
            ,{<<"Control-Queue">>, CtlQ}
            ,{<<"Application-Name">>, <<"bridge">>}
-           ,{<<"Flags">>, wh_json:get_value(<<"flags">>, EP)}
-           ,{<<"Timeout">>, wh_json:get_value(<<"timeout">>, EP)}
-           ,{<<"Ignore-Early-Media">>, wh_json:get_value(<<"ignore_early_media">>, EP)}
-           ,{<<"Outbound-Caller-ID-Name">>, wh_json:get_value(<<"Outbound-Caller-ID-Name">>, EP, OriginalCIdName)}
-           ,{<<"Outbound-Caller-ID-Number">>, wh_json:get_value(<<"Outbound-Caller-ID-Number">>, EP, OriginalCIdNumber)}
-           ,{<<"Ringback">>, wh_json:get_value(<<"ringback">>, EP)}
-           ,{<<"Hunt-Account-ID">>, wh_json:get_value(<<"Hunt-Account-ID">>, EP)}
+           ,{<<"Flags">>, wh_json:get_value(<<"flags">>, Endpoint)}
+           ,{<<"Timeout">>, wh_json:get_value(<<"timeout">>, Endpoint)}
+           ,{<<"Ignore-Early-Media">>, wh_json:get_value(<<"ignore_early_media">>, Endpoint)}
+           ,{<<"Outbound-Caller-ID-Name">>, wh_json:get_value(<<"Outbound-Caller-ID-Name">>, Endpoint, OriginalCIdName)}
+           ,{<<"Outbound-Caller-ID-Number">>, wh_json:get_value(<<"Outbound-Caller-ID-Number">>, Endpoint, OriginalCIdNumber)}
+           ,{<<"Ringback">>, wh_json:get_value(<<"ringback">>, Endpoint)}
+           ,{<<"Hunt-Account-ID">>, wh_json:get_value(<<"Hunt-Account-ID">>, Endpoint)}
            ,{<<"Custom-SIP-Headers">>, ts_callflow:get_custom_sip_headers(State)}
            ,{<<"Inception">>,  wh_json:get_value(<<"Inception">>, CCVs)}
-           ,{<<"Custom-Channel-Vars">>, wh_json:from_list([{<<"Account-ID">>, AcctID}])}
+           ,{<<"Custom-Channel-Vars">>, wh_json:from_list([{<<"Account-ID">>, AccountId}])}
            | wh_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
           ],
     lager:info("sending offnet request for DID ~s", [ToDID]),
@@ -170,7 +179,6 @@ try_failover_e164(State, ToDID) ->
 %%--------------------------------------------------------------------
 -spec get_endpoint_data(wh_json:object()) -> {'endpoint', wh_json:object()}.
 get_endpoint_data(JObj) ->
-    %% wh_timer:tick("inbound_route/1"),
     {ToUser, _} = whapps_util:get_destination(JObj, ?APP_NAME, <<"inbound_user_field">>),
     ToDID = wnm_util:to_e164(ToUser),
     {'ok', AcctId, NumberProps} = wh_number_manager:lookup_account_by_number(ToDID),
@@ -186,6 +194,7 @@ get_endpoint_data(JObj) ->
 
     AuthUser = props:get_value(<<"To-User">>, RoutingData),
     AuthRealm = props:get_value(<<"To-Realm">>, RoutingData),
+    AuthzId = props:get_value(<<"Authorizing-ID">>, RoutingData),
     InFormat = props:get_value(<<"Invite-Format">>, RoutingData, <<"username">>),
     Invite = ts_util:invite_format(wh_util:to_lower_binary(InFormat), ToDID) ++ RoutingData,
     {'endpoint', wh_json:from_list(
@@ -193,6 +202,8 @@ get_endpoint_data(JObj) ->
                                                                    ,{<<"Auth-Realm">>, AuthRealm}
                                                                    ,{<<"Direction">>, <<"inbound">>}
                                                                    ,{<<"Account-ID">>, AcctId}
+                                                                   ,{<<"Authorizing-ID">>, AuthzId}
+                                                                   ,{<<"Authorizing-Type">>, <<"sys_info">>}
                                                                   ])
                     }
                     | Invite
@@ -201,23 +212,23 @@ get_endpoint_data(JObj) ->
 
 -spec routing_data(ne_binary(), ne_binary()) -> [{<<_:48,_:_*8>>, any()}].
 -spec routing_data(ne_binary(), ne_binary(), wh_json:object()) -> [{<<_:48,_:_*8>>, any()}].
-routing_data(ToDID, AcctID) ->
-    case ts_util:lookup_did(ToDID, AcctID) of
+routing_data(ToDID, AccountId) ->
+    case ts_util:lookup_did(ToDID, AccountId) of
         {'ok', Settings} ->
             lager:info("got settings for DID ~s", [ToDID]),
-            routing_data(ToDID, AcctID, Settings);
+            routing_data(ToDID, AccountId, Settings);
         {'error', 'no_did_found'} ->
-            lager:info("DID ~s not found in ~s", [ToDID, AcctID]),
+            lager:info("DID ~s not found in ~s", [ToDID, AccountId]),
             throw('no_did_found')
     end.
 
-routing_data(ToDID, AcctID, Settings) ->
+routing_data(ToDID, AccountId, Settings) ->
     AuthOpts = wh_json:get_value(<<"auth">>, Settings, wh_json:new()),
     Acct = wh_json:get_value(<<"account">>, Settings, wh_json:new()),
     DIDOptions = wh_json:get_value(<<"DID_Opts">>, Settings, wh_json:new()),
     HuntAccountId = wh_json:get_value([<<"server">>, <<"hunt_account_id">>], Settings),
     RouteOpts = wh_json:get_value(<<"options">>, DIDOptions, []),
-    NumConfig = case wh_number_manager:get_public_fields(ToDID, AcctID) of
+    NumConfig = case wh_number_manager:get_public_fields(ToDID, AccountId) of
                     {'ok', Fields} -> Fields;
                     {'error', _} -> wh_json:new()
                 end,
@@ -225,7 +236,7 @@ routing_data(ToDID, AcctID, Settings) ->
     AuthR = wh_json:find(<<"auth_realm">>, [AuthOpts, Acct]),
 
     {Srv, AcctStuff} =
-        try ts_util:lookup_user_flags(AuthU, AuthR, AcctID, ToDID) of
+        try ts_util:lookup_user_flags(AuthU, AuthR, AccountId, ToDID) of
             {'ok', AccountSettings} ->
                 lager:info("got account settings"),
                 {wh_json:get_value(<<"server">>, AccountSettings, wh_json:new())
@@ -306,6 +317,7 @@ routing_data(ToDID, AcctID, Settings) ->
                          ,{<<"To-IP">>, build_ip(ToIP, ToPort)}
                          ,{<<"Route-Options">>, RouteOpts}
                          ,{<<"Hunt-Account-ID">>, HuntAccountId}
+                         ,{<<"Authorizing-ID">>, wh_doc:id(Settings)} % connectivity doc id
                        ],
            V =/= 'undefined',
            V =/= <<>>

--- a/deps/syslog-1.0.3/Makefile
+++ b/deps/syslog-1.0.3/Makefile
@@ -27,11 +27,12 @@ ifeq ($(USR_INCLUDE),)
 	USR_INCLUDE = /usr/lib/erlang/usr/include
 endif
 
-ERL_INTERFACE := $(find $USR_INCLUDE/../../ -type d -name "erl_interface-*" -print)
+ERL_INTERFACE := $(shell find ${USR_INCLUDE}/../../ -type d -name "erl_interface-*" -print)
 ifeq ($(ERL_INTERFACE),)
 # 3.7.9 is R15B03-1
 # Change to 3.7.20 for 17.5
-	ERL_INTERFACE := $(USR_INCLUDE)/../../lib/erl_interface-3.7.9
+# Change to 3.8.1 for 18.2
+	ERL_INTERFACE := $(USR_INCLUDE)/../../lib/erl_interface-3.8.1
 endif
 
 priv/syslog_drv.so: c_src/syslog_drv.c


### PR DESCRIPTION
Set authz info on endpoint's CCVs so REFERs come in as authz'd and trunkstore processes the request.