### PR TITLE
handle undefined ItemPlans

### DIFF
--- a/core/whistle_services-1.0.0/src/wh_service_plan.erl
+++ b/core/whistle_services-1.0.0/src/wh_service_plan.erl
@@ -72,7 +72,15 @@ create_items(ServicePlan, ServiceItems, Services) ->
 
 create_items(ServicePlan, ServiceItems, Services, CategoryId, ItemId) ->
     ItemPlan = kzd_service_plan:item(ServicePlan, CategoryId, ItemId),
+    create_items(ServicePlan, ServiceItems, Services, CategoryId, ItemId, ItemPlan).
 
+create_items(ServicePlan, ServiceItems, _Services, _CategoryId, _ItemId, 'undefined') ->
+    AccountId = kzd_service_plan:account_id(ServicePlan),
+    lager:warning("unable to create service plan items (~s/~s) for account ~s", [_CategoryId, _ItemId, AccountId]),
+    lager:warning("account ~s service plan : ~p", [AccountId, ServicePlan]),
+    lager:warning("account ~s services : ~p", [AccountId, _Services]),
+    ServiceItems;
+create_items(ServicePlan, ServiceItems, Services, CategoryId, ItemId, ItemPlan) ->
     {Rate, Quantity} = get_rate_at_quantity(CategoryId, ItemId, ItemPlan, Services),
     lager:debug("for ~s/~s, found rate ~p for quantity ~p", [CategoryId, ItemId, Rate, Quantity]),
 


### PR DESCRIPTION
prevents wh_service_sync from crashing

`whistle service sync terminating: {function_clause,[{wh_json,get_json_value,[<<"flat_rates">>,undefined,{[]}],[{file,"src/wh_json.erl"},{line,309}]},{wh_service_plan,get_flat_rate,2,[{file,"src/wh_service_plan.erl"},{line,229}]},{wh_service_plan,get_rate_at_quantity,4,[{file,"src/wh_service_plan.erl"},{line,196}]},{wh_service_plan,create_items,5,[{file,"src/wh_service_plan.erl"},{line,76}]},{lists,foldl,3,[{file,"lists.erl"},{line,1197}]},{wh_service_plans,create_items,1,[{file,"src/wh_service_plans.erl"},{line,172}]},{wh_service_sync,maybe_sync_services,2,[{file,"src/wh_service_sync.erl"},{line,249}]},{wh_service_sync,handle_info,2,[{file,"src/wh_service_sync.erl"},{line,131}]}]}`