### PR TITLE
change the variables in get_sip_request

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -194,8 +194,8 @@ get_sip_from(Props, _) ->
 -spec get_sip_request(wh_proplist()) -> ne_binary().
 get_sip_request(Props) ->
     User = props:get_first_defined([<<"Hunt-Destination-Number">>
-                                    ,<<"Caller-Destination-Number">>
-                                    ,<<"sip_to_user">>
+                                    ,<<"variable_sip_req_uri">>
+                                    ,<<"variable_sip_to_user">>
                                    ], Props, <<"nouser">>),
     Realm = props:get_first_defined([?GET_CCV(<<"Realm">>)
                                      ,<<"variable_sip_auth_realm">>


### PR DESCRIPTION
resolves : if call is put on park it keeps the park number in the final cdr

backport to 3.22