### PR TITLE
KAZOO-4364: honor private flag per account

### DIFF
--- a/applications/callflow/src/cf_attributes.erl
+++ b/applications/callflow/src/cf_attributes.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2011-2014, 2600Hz INC
+%%% @copyright (C) 2011-2016, 2600Hz INC
 %%% @doc
 %%% @end
 %%% @contributors
@@ -25,8 +25,9 @@
 -include("callflow.hrl").
 
 -define(CALLER_PRIVACY(CCVs)
-        ,(wh_json:is_true(<<"Caller-Privacy-Number">>, CCVs, 'false')
-        orelse wh_json:is_true(<<"Caller-Privacy-Name">>, CCVs, 'false'))
+       ,(wh_json:is_true(<<"Caller-Privacy-Number">>, CCVs, 'false')
+         orelse wh_json:is_true(<<"Caller-Privacy-Name">>, CCVs, 'false')
+        )
        ).
 
 %%-----------------------------------------------------------------------------
@@ -204,20 +205,18 @@ maybe_ensure_cid_valid(Number, Name, _, Attribute, Call) ->
                                {api_binary(), api_binary()}.
 maybe_cid_privacy(Number, Name, Call) ->
     case wh_util:is_true(whapps_call:kvs_fetch('cf_privacy', Call))
-            orelse ?CALLER_PRIVACY(whapps_call:custom_channel_vars(Call))
+        orelse ?CALLER_PRIVACY(whapps_call:custom_channel_vars(Call))
     of
         'true' ->
             lager:info("overriding caller id to maintain privacy"),
-            {whapps_config:get_non_empty(
-               <<"callflow">>
-               ,<<"privacy_number">>
-               ,wh_util:anonymous_caller_id_number()
-              )
-             ,whapps_config:get_non_empty(
-                <<"callflow">>
-                ,<<"privacy_name">>
-                ,wh_util:anonymous_caller_id_name()
-               )
+            {whapps_config:get_non_empty(<<"callflow">>
+                                        ,<<"privacy_number">>
+                                        ,wh_util:anonymous_caller_id_number()
+                                        )
+            ,whapps_config:get_non_empty(<<"callflow">>
+                                        ,<<"privacy_name">>
+                                        ,wh_util:anonymous_caller_id_name()
+                                        )
             };
         'false' -> {Number, Name}
     end.

--- a/applications/callflow/src/cf_attributes.erl
+++ b/applications/callflow/src/cf_attributes.erl
@@ -24,6 +24,11 @@
 
 -include("callflow.hrl").
 
+-define(CALLER_PRIVACY(CCVs)
+        ,(wh_json:get_value(<<"Caller-Privacy-Number">>, CCVs, 'false')
+        orelse wh_json:get_value(<<"Caller-Privacy-Name">>, CCVs, 'false'))
+       ).
+
 %%-----------------------------------------------------------------------------
 %% @public
 %% @doc
@@ -198,7 +203,9 @@ maybe_ensure_cid_valid(Number, Name, _, Attribute, Call) ->
 -spec maybe_cid_privacy(api_binary(), api_binary(), whapps_call:call()) ->
                                {api_binary(), api_binary()}.
 maybe_cid_privacy(Number, Name, Call) ->
-    case wh_util:is_true(whapps_call:kvs_fetch('cf_privacy', Call)) of
+    case wh_util:is_true(whapps_call:kvs_fetch('cf_privacy', Call))
+            orelse ?CALLER_PRIVACY(whapps_call:custom_channel_vars(Call))
+    of
         'true' ->
             lager:info("overriding caller id to maintain privacy"),
             {whapps_config:get_non_empty(

--- a/applications/callflow/src/cf_attributes.erl
+++ b/applications/callflow/src/cf_attributes.erl
@@ -25,8 +25,8 @@
 -include("callflow.hrl").
 
 -define(CALLER_PRIVACY(CCVs)
-        ,(wh_json:get_value(<<"Caller-Privacy-Number">>, CCVs, 'false')
-        orelse wh_json:get_value(<<"Caller-Privacy-Name">>, CCVs, 'false'))
+        ,(wh_json:is_true(<<"Caller-Privacy-Number">>, CCVs, 'false')
+        orelse wh_json:is_true(<<"Caller-Privacy-Name">>, CCVs, 'false'))
        ).
 
 %%-----------------------------------------------------------------------------

--- a/applications/trunkstore/src/ts_from_offnet.erl
+++ b/applications/trunkstore/src/ts_from_offnet.erl
@@ -17,8 +17,8 @@
 -define(SERVER, ?MODULE).
 
 -define(CALLER_PRIVACY(CCVs)
-        ,(wh_json:get_value(<<"Caller-Privacy-Number">>, CCVs, 'false')
-        orelse wh_json:get_value(<<"Caller-Privacy-Name">>, CCVs, 'false'))
+        ,(wh_json:is_true(<<"Caller-Privacy-Number">>, CCVs, 'false')
+        orelse wh_json:is_true(<<"Caller-Privacy-Name">>, CCVs, 'false'))
        ).
 
 -define(ANONYMIZER_OPTIONS, [<<"caller_id_options">>, <<"anonymizer">>]).

--- a/applications/trunkstore/src/ts_from_offnet.erl
+++ b/applications/trunkstore/src/ts_from_offnet.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2011-2015, 2600Hz INC
+%%% @copyright (C) 2011-2016, 2600Hz INC
 %%% @doc
 %%% Calls coming from offnet (in this case, likely stepswitch) potentially
 %%% destined for a trunkstore client, or, if the account exists and
@@ -17,8 +17,9 @@
 -define(SERVER, ?MODULE).
 
 -define(CALLER_PRIVACY(CCVs)
-        ,(wh_json:is_true(<<"Caller-Privacy-Number">>, CCVs, 'false')
-        orelse wh_json:is_true(<<"Caller-Privacy-Name">>, CCVs, 'false'))
+       ,(wh_json:is_true(<<"Caller-Privacy-Number">>, CCVs, 'false')
+         orelse wh_json:is_true(<<"Caller-Privacy-Name">>, CCVs, 'false')
+        )
        ).
 
 -define(ANONYMIZER_OPTIONS, [<<"caller_id_options">>, <<"anonymizer">>]).
@@ -104,10 +105,10 @@ maybe_send_privacy(State) ->
             CtlQ = ts_callflow:get_control_queue(State),
             CallID = ts_callflow:get_aleg_id(State),
             Command = [{<<"Application-Name">>, <<"privacy">>}
-                        ,{<<"Privacy-Mode">>, <<"full">>}
-                        ,{<<"Call-ID">>, CallID}
-                        | wh_api:default_headers(Q, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
-                       ],
+                      ,{<<"Privacy-Mode">>, <<"full">>}
+                      ,{<<"Call-ID">>, CallID}
+                       | wh_api:default_headers(Q, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
+                      ],
             _ = wapi_dialplan:publish_command(CtlQ, Command);
         'false' -> 'ok'
     end.
@@ -375,7 +376,8 @@ callee_id([JObj | T]) ->
         'false' -> callee_id(T);
         'true' ->
             case {wh_json:get_value(<<"cid_name">>, JObj)
-                  ,wh_json:get_value(<<"cid_number">>, JObj)}
+                 ,wh_json:get_value(<<"cid_number">>, JObj)
+                 }
             of
                 {'undefined', 'undefined'} -> callee_id(T);
                 CalleeID -> CalleeID
@@ -388,10 +390,13 @@ maybe_anonymize_caller_id(State, OldCallerId, CidFormat) ->
     case should_anonymize_caller_id(State, ?CALLER_PRIVACY(CCVs)) of
         'true' ->
             [{<<"Outbound-Caller-ID-Name">>, wh_util:anonymous_caller_id_name()}
-             ,{<<"Outbound-Caller-ID-Number">>, wh_util:anonymous_caller_id_number()}];
+            ,{<<"Outbound-Caller-ID-Number">>, wh_util:anonymous_caller_id_number()}
+            ];
         'false' ->
             [{<<"Outbound-Caller-ID-Name">>
-              ,whapps_call:maybe_format_caller_id_str(OldCallerId, CidFormat)}]
+             ,whapps_call:maybe_format_caller_id_str(OldCallerId, CidFormat)
+             }
+            ]
     end.
 
 -spec should_anonymize_caller_id(any(), boolean()) -> boolean().


### PR DESCRIPTION
Introduce a new `anonymizer` field in the `caller_id_options` in the `AccountDB`. 
When a call routed through `trunkstore` if the privacy flags is on and the `anonymizer` option is set to `kazoo` then it make caller id  anonymized. Otherwise if `anonymizer` is set to `sip` privacy flag is forwarded without anonymizing caller id.