### PR TITLE
Fixed some ACDC Bugs which were making it unusable

### DIFF
--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -1172,8 +1172,7 @@ handle_event({'agent_logout'} = Event, StateName, #state{agent_state_updates = Q
 handle_event({'resume'}, 'ready', State) ->
     {'next_state', 'ready', State};
 handle_event({'resume'}, 'paused', State) ->
-    {Next, SwitchTo, State1} = apply_state_updates(handle_resume(State)),
-    {Next, SwitchTo, State1};
+    apply_state_updates(handle_resume(State));
 handle_event({'resume'} = Event, StateName, #state{agent_state_updates = Queue} = State) ->
     NewQueue = [Event | Queue],
     {'next_state', StateName, State#state{agent_state_updates = NewQueue}};

--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -1172,8 +1172,8 @@ handle_event({'agent_logout'} = Event, StateName, #state{agent_state_updates = Q
 handle_event({'resume'}, 'ready', State) ->
     {'next_state', 'ready', State};
 handle_event({'resume'}, 'paused', State) ->
-    ReadyState = handle_resume(State),
-    {'next_state', 'ready', apply_state_updates(ReadyState)};
+    {Next, SwitchTo, State1} = apply_state_updates(handle_resume(State)),
+    {Next, SwitchTo, State1};
 handle_event({'resume'} = Event, StateName, #state{agent_state_updates = Queue} = State) ->
     NewQueue = [Event | Queue],
     {'next_state', StateName, State#state{agent_state_updates = NewQueue}};

--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -491,9 +491,9 @@ sync({'sync_resp', JObj}, #state{sync_ref=Ref
             _ = erlang:cancel_timer(Ref),
             acdc_agent_stats:agent_ready(AccountId, AgentId),
             acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_GREEN),
-            {Next, SwitchTo, State} =
+            {Next, SwitchTo, State1} =
                 apply_state_updates(State#state{sync_ref='undefined'}),
-            {Next, SwitchTo, State, 'hibernate'};
+            {Next, SwitchTo, State1, 'hibernate'};
         {'EXIT', _} ->
             lager:debug("other agent sent unusable state, ignoring"),
             {'next_state', 'sync', State};
@@ -1515,8 +1515,8 @@ outbound_hungup(#state{agent_listener=AgentListener
                     lager:debug("wrapup left: ~p pause left: ~p", [_W, _P]),
                     acdc_agent_stats:agent_ready(AccountId, AgentId),
                     acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_GREEN),
-                    {Next, SwitchTo, State} = apply_state_updates(clear_call(State, 'ready')),
-                    {Next, SwitchTo, State, 'hibernate'}
+                    {Next, SwitchTo, State1} = apply_state_updates(clear_call(State, 'ready')),
+                    {Next, SwitchTo, State1, 'hibernate'}
             end
     end.
 

--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -728,8 +728,7 @@ handle_cast({'send_sync_req'}, #state{my_id=MyId
     case MyQ of
         'undefined' ->
             lager:debug("queue not ready yet, waiting for sync request"),
-            timer:sleep(100),
-            gen_listener:cast(self(), {'send_sync_req'});
+            timer:apply_after(100 , gen_listener, cast, [self(), {'send_sync_req'}]);
          _ ->
             lager:debug("queue retrieved: ~p , sending sync request", [MyQ]),
             send_sync_request(AcctId, AgentId, MyId, MyQ)

--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -725,8 +725,15 @@ handle_cast({'send_sync_req'}, #state{my_id=MyId
                                       ,acct_id=AcctId
                                       ,agent_id=AgentId
                                      }=State) ->
-    lager:debug("sending sync request"),
-    send_sync_request(AcctId, AgentId, MyId, MyQ),
+    case MyQ of
+        'undefined' ->
+            lager:debug("queue not ready yet, waiting for sync request"),
+            timer:sleep(100),
+            gen_listener:cast(self(), {'send_sync_req'});
+         _ ->
+            lager:debug("queue retrieved: ~p , sending sync request", [MyQ]), 
+            send_sync_request(AcctId, AgentId, MyId, MyQ)
+    end,
     {'noreply', State};
 
 handle_cast({'send_sync_resp', Status, ReqJObj, Options}, #state{my_id=MyId

--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -731,7 +731,7 @@ handle_cast({'send_sync_req'}, #state{my_id=MyId
             timer:sleep(100),
             gen_listener:cast(self(), {'send_sync_req'});
          _ ->
-            lager:debug("queue retrieved: ~p , sending sync request", [MyQ]), 
+            lager:debug("queue retrieved: ~p , sending sync request", [MyQ]),
             send_sync_request(AcctId, AgentId, MyId, MyQ)
     end,
     {'noreply', State};
@@ -739,8 +739,9 @@ handle_cast({'send_sync_req'}, #state{my_id=MyId
 handle_cast({'send_sync_resp', Status, ReqJObj, Options}, #state{my_id=MyId
                                                                  ,acct_id=AcctId
                                                                  ,agent_id=AgentId
+                                                                 ,my_q=MyQ
                                                                 }=State) ->
-    send_sync_response(ReqJObj, AcctId, AgentId, MyId, Status, Options),
+    send_sync_response(ReqJObj, AcctId, AgentId, MyId, MyQ, Status, Options),
     {'noreply', State};
 
 handle_cast({'send_status_update', Status}, #state{acct_id=AcctId
@@ -960,13 +961,13 @@ send_sync_request(AcctId, AgentId, MyId, MyQ) ->
            ],
     wapi_acdc_agent:publish_sync_req(Prop).
 
-send_sync_response(ReqJObj, AcctId, AgentId, MyId, Status, Options) ->
+send_sync_response(ReqJObj, AcctId, AgentId, MyId, MyQ, Status, Options) ->
     Prop = [{<<"Account-ID">>, AcctId}
             ,{<<"Agent-ID">>, AgentId}
             ,{<<"Process-ID">>, MyId}
             ,{<<"Status">>, wh_util:to_binary(Status)}
             ,{<<"Msg-ID">>, wh_json:get_value(<<"Msg-ID">>, ReqJObj)}
-            | Options ++ wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+            | Options ++ wh_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
            ],
     Q = wh_json:get_value(<<"Server-ID">>, ReqJObj),
     lager:debug("sending sync resp to ~s", [Q]),


### PR DESCRIPTION
acdc_agent_fsm.erl
AMQP Queue was not getting created on time …

bug fix for ACDC Queue, Queue was not getting created on time causing to send undefined queue name (Server-ID), making the response never reach the publishing Agent

acdc_agent_listener.erl
Insted of assigning the value was being compared …

The Value of state was not being initalised and sent but was being compared making the agent crash and giving out: no match of right hand value