### PR TITLE
KAZOO-4530: sanity checks for dns and timezone

### DIFF
--- a/core/whistle_apps-1.0.0/src/whistle_apps_init.erl
+++ b/core/whistle_apps-1.0.0/src/whistle_apps_init.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2013, 2600Hz
+%%% @copyright (C) 2013-2016, 2600Hz
 %%% @doc
 %%% Init to be done
 %%% @end
@@ -9,17 +9,20 @@
 -module(whistle_apps_init).
 
 -export([start_link/0
+         ,sanity_checks/0
          ,init/0
         ]).
 
 -include("whistle_apps.hrl").
 
 start_link() ->
+    _ = sanity_checks(), %% one day make this true
     _ = wh_util:spawn(?MODULE, 'init', []),
     'ignore'.
 
 init() ->
     wh_util:put_callid(?MODULE),
+
     case wh_config:get_atom('whistle_apps', 'cookie') of
         [] ->
             lager:warning("failed to set whistle_apps cookie trying node ~s", [node()]),
@@ -45,3 +48,57 @@ set_loglevel() ->
     [Error|_] = wh_config:get_atom('log', 'error', ['error']),
     wh_util:change_error_log_level(Error),
     'ok'.
+
+-spec sanity_checks() -> boolean().
+sanity_checks() ->
+    lists:all(fun(F) -> F() end
+              ,[fun does_hostname_resolve_speedily/0
+               ,fun is_system_clock_is_utc/0
+               ]
+             ).
+
+-spec does_hostname_resolve_speedily() -> boolean().
+does_hostname_resolve_speedily() ->
+    InitTime = time_hostname_resolution(),
+    Tests = 20,
+    {Min, Max, Total} =
+        lists:foldl(fun time_hostname_resolution/2
+                   ,{InitTime, InitTime, InitTime}
+                   ,lists:seq(1, Tests)
+                   ),
+    case Max < 5000 of
+        'true' -> 'true';
+        'false' ->
+            lager:warning("hostname results (in us): ~p < ~p < ~p"
+                         ,[Min, (Total div (Tests+1)), Max]
+                         ),
+            lager:critical("hostname resolution is painfully slow!!! This will cause "),
+            'false'
+    end.
+
+-spec time_hostname_resolution(any(), {pos_integer(), pos_integer(), pos_integer()}) ->
+                                      {pos_integer(), pos_integer(), pos_integer()}.
+time_hostname_resolution(_, {Min, Max, Total}) ->
+    case time_hostname_resolution() of
+        Time when Time < Min ->
+            {Time, Max, Total+Time};
+        Time when Time > Max ->
+            {Min, Time, Total+Time};
+        Time ->
+            {Min, Max, Total+Time}
+    end.
+
+-spec time_hostname_resolution() -> pos_integer().
+time_hostname_resolution() ->
+    {Time, _} = timer:tc('wh_network_utils', 'get_hostname', []),
+    Time.
+
+-spec is_system_clock_is_utc() -> boolean().
+is_system_clock_is_utc() ->
+    case {calendar:local_time(), calendar:universal_time()} of
+        {UTC, UTC} -> 'true';
+        {_Local, _UTC} ->
+            lager:warning("local: ~p utc: ~p", [_Local, _UTC]),
+            lager:critical("system is not running in UTC and Kazoo expects it"),
+            'false'
+    end.


### PR DESCRIPTION
Was concerned the time check might be weird, but seems pretty reliable. Not sure if we want to make the dns time check configurable (5ms seemed reasonable on my box, as I was getting an occasional outlier around 3ms).

```erlang
19> lists:all(fun(_) -> whistle_apps_init:sanity_checks() end, lists:seq(1,1000)).
true
```

For now, just logs it at critical and continues on its merry way.