### PR TITLE
KAZOO-4543: System dialplan. Multiple dialplans per each regexp.

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -804,12 +804,20 @@ load_system_dialplans(Names) ->
 -spec fold_system_dialplans(ne_binaries()) ->
                                    fun(({ne_binary(), wh_json:object()}, wh_json:object()) -> wh_json:object()).
 fold_system_dialplans(Names) ->
-    fun({Key, Val}, Acc) ->
-            Name = wh_util:to_lower_binary(wh_json:get_value(<<"name">>, Val)),
-            case lists:member(Name, Names) of
-                'true' -> wh_json:set_value(Key, Val, Acc);
-                'false' -> Acc
-            end
+    fun({Key, Val}, Acc) when is_list(Val) ->
+        lists:foldl(fun(ValElem, A) -> may_be_dialplan_suits({Key, ValElem}, A, Names) end, Acc, Val);
+       ({Key, Val}, Acc) ->
+        may_be_dialplan_suits({Key, Val}, Acc, Names)
+    end.
+
+-spec may_be_dialplan_suits({ne_binary(), wh_json:object()|wh_json:objects()}
+                            ,wh_json:object(), ne_binaries()
+                           ) -> wh_json:object().
+may_be_dialplan_suits({Key, Val}, Acc, Names) ->
+    Name = wh_util:to_lower_binary(wh_json:get_value(<<"name">>, Val)),
+    case lists:member(Name, Names) of
+        'true' -> wh_json:set_value(Key, Val, Acc);
+        'false' -> Acc
     end.
 
 -spec encryption_method_map(api_object(), api_binaries() | wh_json:object()) -> api_object().

--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -810,9 +810,7 @@ fold_system_dialplans(Names) ->
         may_be_dialplan_suits({Key, Val}, Acc, Names)
     end.
 
--spec may_be_dialplan_suits({ne_binary(), wh_json:object()|wh_json:objects()}
-                            ,wh_json:object(), ne_binaries()
-                           ) -> wh_json:object().
+-spec may_be_dialplan_suits({ne_binary(), wh_json:object()} ,wh_json:object(), ne_binaries()) -> wh_json:object().
 may_be_dialplan_suits({Key, Val}, Acc, Names) ->
     Name = wh_util:to_lower_binary(wh_json:get_value(<<"name">>, Val)),
     case lists:member(Name, Names) of

--- a/applications/crossbar/doc/internationalization/numbers.md
+++ b/applications/crossbar/doc/internationalization/numbers.md
@@ -187,7 +187,7 @@ It is possible to add dial plans to system config. Account/user/device `dial_pla
 
 #### Adding system `dialplan` example
 
-Create dialplans doc in case it is still absent in system_congig db:
+Create dialplans doc in case it is still absent in system_config db:
 ````
 curl -X PUT -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs -d '{"data":{"id":"dialplans"}}'
 ````

--- a/applications/crossbar/doc/internationalization/numbers.md
+++ b/applications/crossbar/doc/internationalization/numbers.md
@@ -187,17 +187,17 @@ It is possible to add dial plans to system config. Account/user/device `dial_pla
 
 #### Adding system `dialplan` example
 
-If dialplans doc absent, create it:
+Create dialplans doc in case it is still absent in system_congig db:
 ````
 curl -X PUT -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs -d '{"data":{"id":"dialplans"}}'
 ````
 Then create your dialplan:
 ````
-    curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs/dialplans -d '{"data":{"^(2\\d{6})$":{"prefix":"+7383","name":"Novosibirsk"}}}'
+curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs/dialplans -d '{"data":{"^(2\\d{6})$":{"prefix":"+7383","name":"Novosibirsk"}}}'
 ````
-Or:
+or dialplans:
 ````
-    curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs/dialplans -d '{"data":{"^(\\d{7})$":[{"prefix":"+7495","name":"Moscow"},{"prefix":"+7812","name":"Saint Petersburg"}]}}'
+curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs/dialplans -d '{"data":{"^(\\d{7})$":[{"prefix":"+7495","name":"Moscow"},{"prefix":"+7812","name":"Saint Petersburg"}]}}'
 ````
 
 #### Using system `dialplan` example

--- a/applications/crossbar/doc/internationalization/numbers.md
+++ b/applications/crossbar/doc/internationalization/numbers.md
@@ -187,7 +187,18 @@ It is possible to add dial plans to system config. Account/user/device `dial_pla
 
 #### Adding system `dialplan` example
 
-    curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs/dialplans -d '{"data":{"^(2\\d{6}$":{"prefix":"+7383","name":"Novosibirsk"}}}'
+If dialplans doc absent, create it:
+````
+curl -X PUT -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs -d '{"data":{"id":"dialplans"}}'
+````
+Then create your dialplan:
+````
+    curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs/dialplans -d '{"data":{"^(2\\d{6})$":{"prefix":"+7383","name":"Novosibirsk"}}}'
+````
+Or:
+````
+    curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: {AUTH_TOKEN}" http://server.com:8000/v2/system_configs/dialplans -d '{"data":{"^(\\d{7})$":[{"prefix":"+7495","name":"Moscow"},{"prefix":"+7812","name":"Saint Petersburg"}]}}'
+````
 
 #### Using system `dialplan` example
 


### PR DESCRIPTION
As stated in internationalization/numbers.md system dialplan looks like this: 

'{"data":{"^(2\\d{6}$":{"prefix":"+7383","name":"Novosibirsk"}}}' 

This obliges each dialplan to have unique regexp/key which is wrong, 
because different dialplans could have same dial patterns. 

So, it is good to make cf_util to be able to also parse multiple dialplans for each key: 

'{"data":{"^(\\d{7})$":[{"prefix":"+7495","name":"Moscow"},{"prefix":"+7812","name":"Saint Petersburg"}]}}' 