### PR TITLE
KAZOO-4569: set PAs to …/test instead of …/ebin when running test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,6 @@ after_success:
   - make build-plt
   - ./scripts/check-dialyzer.escript .kazoo.plt $files
   - make build-release
+  - make compile-test
   - ERL_LIBS="$HOME/proper" make eunit
   - ./scripts/check-whitespace.sh core/ applications/

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,16 @@ clean: $(MAKEDIRS)
 clean-test: ACTION = clean-test
 clean-test: $(KAZOODIRS)
 
-eunit: ACTION = test
+clean-kazoo: ACTION = clean
+clean-kazoo: $(KAZOODIRS)
+
+compile-test: ACTION = compile-test
+compile-test: $(KAZOODIRS)
+
+eunit: ACTION = eunit
 eunit: $(KAZOODIRS)
 
-proper: ACTION = test
+proper: ACTION = eunit
 proper: ERLC_OPTS += -DPROPER
 proper: $(KAZOODIRS)
 

--- a/README.md
+++ b/README.md
@@ -159,12 +159,18 @@ If you have a non-US deployment, please consider sharing your system configurati
 
 ## How to Build
 
-* Once the dependencies are all here, after a fresh `git clone` just `make`.
-* When developing, one can `cd` into any app directory and run:
+* Once the dependencies are all here, after a fresh `git clone https://github.com/2600hz/kazoo.git` just `make`.
+* When developing, one can `cd` into any app directory (within `applications/` or `core/`) and run:
     * `make` (`make all` or `make clean`)
     * `make xref` to look for calls to undefined functions (uses [Xref](http://www.erlang.org/doc/apps/tools/xref_chapter.html))
     * `make dialyze` to statically type-check the app (uses [Dialyzer](http://www.erlang.org/doc/man/dialyzer.html))
     * `make test` runs the app / sub-apps test suite, if any.
+        * **Note:** make sure to `make clean all` after running your tests, as test BEAMs are generated in `ebin/`!
+* To run the full test suite it is advised to
+    1. `cd` into the root of the project
+    1. `make compile-test` to compile every app with the `TEST` macro defined
+    1. `make eunit` (instead of `make test`) to run the test suite without recompiling each app
+    * *This way apps can call code from other apps that was compiled with the `TEST` macro defined*
 * `make build-release` will generate a [deployable release](http://learnyousomeerlang.com/release-is-the-word)
     * [More on using releases with Kazoo](https://github.com/2600hz/kazoo/blob/master/doc/engineering/releases.md)
 * `make sup_completion` creates `sup.bash`: a Bash completion file for the SUP command

--- a/applications/Makefile
+++ b/applications/Makefile
@@ -2,18 +2,24 @@ ROOT = ..
 
 MAKEDIRS = */Makefile
 
-.PHONY: all compile clean $(MAKEDIRS)
+.PHONY: all compile compile-test clean clean-test eunit test $(MAKEDIRS)
 
 all: compile
 
 compile: ACTION = all
 compile: $(MAKEDIRS)
 
+compile-test: ACTION = compile-test
+compile-test: $(MAKEDIRS)
+
 clean: ACTION = clean
 clean: $(MAKEDIRS)
 
 clean-test: ACTION = clean-test
 clean-test: $(MAKEDIRS)
+
+eunit: ACTION = eunit
+eunit: $(MAKEDIRS)
 
 test: ACTION = test
 test: $(MAKEDIRS)

--- a/core/Makefile
+++ b/core/Makefile
@@ -2,12 +2,15 @@ ROOT = ..
 
 MAKEDIRS = */Makefile
 
-.PHONY: all compile clean test $(MAKEDIRS)
+.PHONY: all compile compile-test clean clean-test eunit test first $(MAKEDIRS)
 
 all: compile
 
 compile: ACTION = all
-compile: kazoo $(MAKEDIRS)
+compile: $(MAKEDIRS)
+
+compile-test: ACTION = compile-test
+compile-test: $(MAKEDIRS)
 
 clean: ACTION = clean
 clean: $(MAKEDIRS)
@@ -15,11 +18,14 @@ clean: $(MAKEDIRS)
 clean-test: ACTION = clean-test
 clean-test: $(MAKEDIRS)
 
+eunit: ACTION = eunit
+eunit: $(MAKEDIRS)
+
 test: ACTION = test
 test: $(MAKEDIRS)
 
-kazoo:
-	$(MAKE) -C whistle/ compile
+first:
+	$(MAKE) -C whistle/ $(ACTION)
 
-$(MAKEDIRS):
-	$(MAKE) -C $(@D) $(ACTION)
+$(MAKEDIRS): first
+	$(MAKE) -C $(@D)    $(ACTION)


### PR DESCRIPTION
Ticket explains a bit what this does.

Tests rely on other apps' code off course, and we've always been running the test suite app by app.

BUT I'm stuck in KNM as stepswitch relies on KNM code, and KNM's calls to whapps_config are replaced at test-time. Thus stepswitch doesn't know about them and directly calls whapps_config…

Now, maybe whapps_config should provide mock functions for when we're running the test suite,
but that would be unreliable until now:

This patch compiles all the code in "test mode" (setting `-DTEST`) before running apps tests app-by-app.

(Providing mock functions and testing against them is probably terrible BTW).


BUT since it's easier for development to not pollute ebin/ we're generating these BEAMs to test/ then `-pa`ing apps with `-pa my/app/test` (instead of `-pa my/app/ebin`).

So, either
* we stay inside `test/` and we write our own `lib_dir/1` JUST to please the tests suite
* we pollute `ebin/` with test modules & normal modules *that were recompiled in test mode* (ie: a module can have changed completely)
    * but that's not too bad: one just needs to run `make clean` before anything else

so here I'm stuck