### PR TITLE
correct attachment content_type type

### DIFF
--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -827,7 +827,7 @@ update_template(Context, Id, FileJObj) ->
     Contents = wh_json:get_value(<<"contents">>, FileJObj),
     CT = wh_json:get_value([<<"headers">>, <<"content_type">>], FileJObj),
     lager:debug("file content type for ~s: ~s", [Id, CT]),
-    Opts = [{'content_type', CT}],
+    Opts = [{'content_type', wh_util:to_list(CT)}],
 
     AttachmentName = attachment_name_by_content_type(CT),
 


### PR DESCRIPTION
Attachment couldn't be retrieved because of wrong content_type:
"content_type": "<<\"text/html\">>" instead of "content_type": "text/html"

