### PR TITLE
Prompt flushing

### DIFF
--- a/applications/crossbar/src/crossbar.erl
+++ b/applications/crossbar/src/crossbar.erl
@@ -116,19 +116,23 @@ stop_mod(CBMod) ->
 -spec start_deps() -> 'ok'.
 start_deps() ->
     whistle_apps_deps:ensure(?MODULE), % if started by the whistle_controller, this will exist
-    _ = [wh_util:ensure_started(App) || App <- ['crypto'
-                                                ,'public_key'
-                                                ,'ssl'
-                                                ,'inets'
-                                                ,'lager'
-                                                ,'whistle_amqp'
-                                                ,'whistle_couch'
-                                                ,'kazoo_bindings'
-                                                ,'ranch'
-                                                ,'cowlib'
-                                                ,'cowboy'
-                                               ]],
-    'ok'.
+    _Started =
+        [{App, wh_util:ensure_started(App)}
+         || App <- ['crypto'
+                   ,'asn1'
+                   ,'public_key'
+                   ,'ssl'
+                   ,'inets'
+                   ,'lager'
+                   ,'whistle_amqp'
+                   ,'whistle_couch'
+                   ,'kazoo_bindings'
+                   ,'ranch'
+                   ,'cowlib'
+                   ,'cowboy'
+                   ]
+        ],
+    lager:debug("deps result: ~p", [_Started]).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -660,11 +660,7 @@ delete(Context, 'soft') ->
         {'error', _E} -> soft_delete(Context, wh_doc:revision(Doc))
     end;
 delete(Context, 'permanent') ->
-    JObj = cb_context:doc(Context),
-    Del = wh_json:from_list([{<<"_id">>, wh_doc:id(JObj)}
-                             ,{<<"_rev">>, wh_doc:revision(JObj)}
-                            ]),
-    do_delete(Context, Del, fun couch_mgr:del_doc/2).
+    do_delete(Context, cb_context:doc(Context), fun couch_mgr:del_doc/2).
 
 -spec soft_delete(cb_context:context(), api_binary()) -> cb_context:context().
 soft_delete(Context, Rev) ->

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -41,6 +41,7 @@
 -export([fix_contact/3]).
 
 -include_lib("whistle/src/api/wapi_dialplan.hrl").
+-include_lib("whistle/include/wh_databases.hrl").
 -include("ecallmgr.hrl").
 -include_lib("nksip/include/nksip.hrl").
 
@@ -1005,6 +1006,9 @@ request_media_url(MediaName, CallId, JObj, Type) ->
         {'ok', MediaResp} ->
             MediaUrl = wh_json:find(<<"Stream-URL">>, MediaResp, <<>>),
             CacheProps = media_url_cache_props(MediaName),
+
+            lager:debug("cache props for ~s: ~p", [MediaName, CacheProps]),
+
             _ = wh_cache:store_local(?ECALLMGR_UTIL_CACHE
                                      ,?ECALLMGR_PLAYBACK_MEDIA_KEY(MediaName)
                                      ,MediaUrl
@@ -1030,6 +1034,15 @@ media_url_cache_props(<<"/", _/binary>> = MediaName) ->
             AccountDb = wh_util:format_account_id(AccountId, 'encoded'),
             [{'origin', {'db', AccountDb, MediaId}}];
         _Parts -> []
+    end;
+media_url_cache_props(<<"prompt://", Prompt/binary>>) ->
+    case binary:split(Prompt, <<"/">>) of
+        [?WH_MEDIA_DB, _MediaId] ->
+            [{'origin', {'db', ?WH_MEDIA_DB, <<"media">>}}];
+        [AccountId, _MediaId] ->
+            AccountDb = wh_util:format_account_id(AccountId, 'encoded'),
+            [{'origin', {'db', AccountDb, <<"media">>}}];
+        _ -> []
     end;
 media_url_cache_props(<<"tts://", Text/binary>>) ->
     Id = wh_util:binary_md5(Text),

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -1007,8 +1007,6 @@ request_media_url(MediaName, CallId, JObj, Type) ->
             MediaUrl = wh_json:find(<<"Stream-URL">>, MediaResp, <<>>),
             CacheProps = media_url_cache_props(MediaName),
 
-            lager:debug("cache props for ~s: ~p", [MediaName, CacheProps]),
-
             _ = wh_cache:store_local(?ECALLMGR_UTIL_CACHE
                                      ,?ECALLMGR_PLAYBACK_MEDIA_KEY(MediaName)
                                      ,MediaUrl

--- a/core/whistle_couch-1.0.0/src/couch_util.erl
+++ b/core/whistle_couch-1.0.0/src/couch_util.erl
@@ -86,6 +86,8 @@
                          ,<<"pvt_account_id">>
                          ,<<"pvt_created">>
                          ,<<"pvt_modified">>
+                         ,<<"_deleted">>
+                         ,<<"pvt_deleted">>
                         ]).
 
 -type db_create_options() :: [{'q',integer()} | {'n',integer()}].
@@ -782,7 +784,14 @@ maybe_tombstone(JObj) ->
     maybe_tombstone(JObj, wh_json:is_true(<<"_deleted">>, JObj, 'false')).
 
 maybe_tombstone(JObj, 'true') ->
-    wh_json:delete_keys(?PUBLISH_FIELDS, JObj);
+    wh_json:from_list(
+      props:filter_undefined(
+        [{<<"_id">>, wh_doc:id(JObj)}
+         ,{<<"_rev">>, wh_doc:revision(JObj)}
+         ,{<<"_deleted">>, 'true'}
+        ]
+       )
+     );
 maybe_tombstone(JObj, 'false') -> JObj.
 
 -spec maybe_set_docid(wh_json:object()) -> wh_json:object().
@@ -1075,7 +1084,10 @@ publish(Action, Db, Doc) ->
     Id = wh_doc:id(Doc),
 
     IsSoftDeleted = wh_doc:is_soft_deleted(Doc),
-    EventName = doc_change_event_name(Action, IsSoftDeleted),
+    IsHardDeleted = wh_doc:is_deleted(Doc),
+
+    EventName = doc_change_event_name(Action, IsSoftDeleted orelse IsHardDeleted),
+    lager:debug("media event name ~s (~p/~p): ~p", [EventName, IsSoftDeleted, IsHardDeleted, Doc]),
 
     Props =
         [{<<"ID">>, Id}

--- a/core/whistle_couch-1.0.0/src/couch_util.erl
+++ b/core/whistle_couch-1.0.0/src/couch_util.erl
@@ -1087,7 +1087,6 @@ publish(Action, Db, Doc) ->
     IsHardDeleted = wh_doc:is_deleted(Doc),
 
     EventName = doc_change_event_name(Action, IsSoftDeleted orelse IsHardDeleted),
-    lager:debug("media event name ~s (~p/~p): ~p", [EventName, IsSoftDeleted, IsHardDeleted, Doc]),
 
     Props =
         [{<<"ID">>, Id}

--- a/core/whistle_couch-1.0.0/src/wh_doc.erl
+++ b/core/whistle_couch-1.0.0/src/wh_doc.erl
@@ -32,6 +32,7 @@
          ,modified/1, modified/2, set_modified/2
          ,vsn/1, vsn/2, set_vsn/2
          ,set_soft_deleted/2, is_soft_deleted/1
+         ,set_deleted/1, set_deleted/2, is_deleted/1
 
          ,account_id/1, account_id/2, set_account_id/2
          ,account_db/1, account_db/2, set_account_db/2
@@ -49,9 +50,13 @@
                    ,fun add_id/3
                   ]).
 
+%% CouchDB keys
 -define(KEY_ID, <<"_id">>).
 -define(KEY_REV, <<"_rev">>).
+-define(KEY_DELETED, <<"_deleted">>).
 -define(KEY_ATTACHMENTS, <<"_attachments">>).
+
+%% Private Kazoo keys
 -define(KEY_PVT_TYPE, <<"pvt_type">>).
 -define(KEY_ACCOUNT_ID, <<"pvt_account_id">>).
 -define(KEY_ACCOUNT_DB, <<"pvt_account_db">>).
@@ -310,6 +315,17 @@ set_soft_deleted(JObj, IsSoftDeleted) ->
 -spec is_soft_deleted(wh_json:object()) -> boolean().
 is_soft_deleted(JObj) ->
     wh_json:is_true(?KEY_SOFT_DELETED, JObj).
+
+-spec set_deleted(wh_json:object()) -> wh_json:object().
+-spec set_deleted(wh_json:object(), boolean()) -> wh_json:object().
+set_deleted(JObj) ->
+    set_deleted(JObj, 'true').
+set_deleted(JObj, Bool) when is_boolean(Bool) ->
+    wh_json:set_value(?KEY_DELETED, Bool, JObj).
+
+-spec is_deleted(wh_json:object()) -> boolean().
+is_deleted(JObj) ->
+    wh_json:is_true(?KEY_DELETED, JObj, 'false').
 
 -spec created(wh_json:object()) -> api_integer().
 -spec created(wh_json:object(), Default) -> integer() | Default.

--- a/core/whistle_media-1.0.0/src/wh_media_map.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_map.erl
@@ -357,6 +357,8 @@ maybe_add_prompt(AccountId, JObj, PromptId) ->
 
     insert_map(UpdatedMap).
 
+-spec insert_map(media_map()) -> 'ok' | 'true'.
+-spec insert_map(media_map(), pid()) -> 'ok' | 'true'.
 insert_map(Map) ->
     insert_map(Map, whereis(?MODULE)).
 insert_map(Map, Srv) when Srv =:= self() ->
@@ -400,6 +402,8 @@ init_account_map(AccountId, PromptId) ->
                                     },
     new_map(AccountMap).
 
+-spec new_map(media_map()) -> 'true'.
+-spec new_map(media_map(), pid()) -> 'true'.
 new_map(Map) ->
     new_map(Map, whereis(?MODULE)).
 

--- a/core/whistle_media-1.0.0/src/wh_media_map.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_map.erl
@@ -306,6 +306,7 @@ init_map(Db, View, _StartKey, Limit, SendFun, ViewResults) ->
     end.
 
 -spec add_mapping(ne_binary(), fun(), wh_json:objects()) -> 'ok'.
+-spec add_mapping(ne_binary(), fun(), wh_json:objects(), pid()) -> 'ok'.
 add_mapping(Db, SendFun, JObjs) ->
     add_mapping(Db, SendFun, JObjs, whereis(?MODULE)).
 

--- a/core/whistle_media-1.0.0/src/wh_media_util.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_util.erl
@@ -205,10 +205,12 @@ media_path(Path, Call) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec prompt_path(ne_binary()) -> ne_binary().
--spec prompt_path(ne_binary(), ne_binary()) -> ne_binary().
+-spec prompt_path(api_binary(), ne_binary()) -> ne_binary().
 prompt_path(PromptId) ->
     prompt_path(?WH_MEDIA_DB, PromptId).
 
+prompt_path('undefined', PromptId) ->
+    prompt_path(?WH_MEDIA_DB, PromptId);
 prompt_path(Db, <<"/system_media/", PromptId/binary>>) ->
     prompt_path(Db, PromptId);
 prompt_path(Db, PromptId) ->


### PR DESCRIPTION
We accomplish several improvements here:

1. Tombstoning of documents is handled in `couch_util`, so we remove the code in `crossbar_doc` as we lost valuable information for the publishing of the doc change AMQP payload.
2. `ecallmgr_util` was failing to set prompt-specific cache bindings to process the doc changes for media. Currently, we remove all account-specific media on changes, as we can't easily reconstruct the prompt name that would be in the doc change routing key.
3. Checks have been added to either directly execute ETS operations or call into the `wh_media_map` process to do the ETS work. This alleviates some deadlock conditions found.
4. Check for undefined when building the prompt path and use `system_media`