### PR TITLE
KAZOO-4220: set custom-sip-headers on outbound legs

### DIFF
--- a/applications/callflow/src/cf_endpoint.erl
+++ b/applications/callflow/src/cf_endpoint.erl
@@ -1226,8 +1226,7 @@ generate_sip_headers(Endpoint, Acc, Call) ->
 maybe_add_sip_headers(JObj, Endpoint, Call) ->
     case ?MODULE:get(Call) of
         {'ok', AuthorizingEndpoint} ->
-            MergeFuns = [fun() -> kz_device:custom_sip_headers(Endpoint) end
-                         ,fun() -> kz_device:custom_sip_headers_inbound(Endpoint) end
+            MergeFuns = [fun() -> kz_device:custom_sip_headers_inbound(Endpoint) end
                          ,fun() -> kz_device:custom_sip_headers_outbound(AuthorizingEndpoint) end
                         ],
             Fun = fun(Routine, Acc) ->

--- a/applications/callflow/src/cf_endpoint.erl
+++ b/applications/callflow/src/cf_endpoint.erl
@@ -1216,18 +1216,32 @@ generate_sip_headers(Endpoint, Call) ->
 generate_sip_headers(Endpoint, Acc, Call) ->
     Inception = whapps_call:inception(Call),
 
-    HeaderFuns = [fun maybe_add_sip_headers/1
+    HeaderFuns = [fun(J) -> maybe_add_sip_headers(J, Endpoint, Call) end
                   ,fun(J) -> maybe_add_alert_info(J, Endpoint, Inception) end
                   ,fun(J) -> maybe_add_aor(J, Endpoint, Call) end
                  ],
     lists:foldr(fun(F, JObj) -> F(JObj) end, Acc, HeaderFuns).
 
--spec maybe_add_sip_headers(wh_json:object()) -> wh_json:object().
-maybe_add_sip_headers(JObj) ->
-    case kz_device:custom_sip_headers(JObj) of
-        'undefined' -> JObj;
-        CustomHeaders -> wh_json:merge_jobjs(CustomHeaders, JObj)
+-spec maybe_add_sip_headers(wh_json:object(), wh_json:object(), whapps_call:call()) -> wh_json:object().
+maybe_add_sip_headers(JObj, Endpoint, Call) ->
+    case ?MODULE:get(Call) of
+        {'ok', AuthorizingEndpoint} ->
+            MergeFuns = [fun() -> kz_device:custom_sip_headers(Endpoint) end
+                         ,fun() -> kz_device:custom_sip_headers_inbound(Endpoint) end
+                         ,fun() -> kz_device:custom_sip_headers_outbound(AuthorizingEndpoint) end
+                        ],
+            Fun = fun(Routine, Acc) ->
+                      merge_custom_sip_headers(Routine(), Acc)
+                  end,
+            lists:foldl(Fun, JObj, MergeFuns);
+        {'error', _} -> JObj
     end.
+
+-spec merge_custom_sip_headers(wh_json:object(), wh_json:object()) -> wh_json:object().
+merge_custom_sip_headers('undefined', JObj) ->
+    JObj;
+merge_custom_sip_headers(CustomHeaders, JObj) ->
+    wh_json:merge_jobjs(CustomHeaders, JObj).
 
 -spec maybe_add_alert_info(wh_json:object(), wh_json:object(), api_binary()) -> wh_json:object().
 maybe_add_alert_info(JObj, Endpoint, 'undefined') ->

--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -215,7 +215,14 @@ get_sip_headers(Data, Call) ->
                         end
                 end
                ],
-    CustomHeaders = wh_json:get_value(<<"custom_sip_headers">>, Data, wh_json:new()),
+    AuthEndCSH = case cf_endpoint:get(Call) of
+                     {'ok', AuthorizingEndpoint} ->
+                         kz_device:custom_sip_headers_outbound(AuthorizingEndpoint);
+                     _ -> wh_json:new()
+                 end,
+    CSH = wh_json:get_value(<<"custom_sip_headers">>, Data, wh_json:new()),
+    CustomHeaders = wh_json:merge_jobjs(AuthEndCSH, CSH),
+
 
     Diversions = whapps_call:custom_sip_header(<<"Diversions">>, Call),
 

--- a/core/kazoo_documents-1.0.0/src/kz_device.erl
+++ b/core/kazoo_documents-1.0.0/src/kz_device.erl
@@ -16,6 +16,8 @@
          ,sip_invite_format/1, sip_invite_format/2, set_sip_invite_format/2
          ,sip_route/1, sip_route/2, set_sip_route/2
          ,custom_sip_headers/1, custom_sip_headers/2, set_custom_sip_headers/2
+         ,custom_sip_headers_inbound/1, custom_sip_headers_inbound/2, set_custom_sip_headers_inbound/2
+         ,custom_sip_headers_outbound/1, custom_sip_headers_outbound/2, set_custom_sip_headers_outbound/2
 
          ,sip_settings/1, sip_settings/2, set_sip_settings/2
 
@@ -45,7 +47,10 @@
 -define(REALM, [?SIP, <<"realm">>]).
 -define(IP, [?SIP, <<"ip">>]).
 -define(INVITE_FORMAT, [?SIP, <<"invite_format">>]).
--define(CUSTOM_SIP_HEADERS, [?SIP, <<"custom_sip_headers">>]).
+-define(CUSTOM_SIP_HEADERS, <<"custom_sip_headers">>).
+-define(CUSTOM_SIP_HEADERS_KV_ONLY, [?SIP, ?CUSTOM_SIP_HEADERS]).
+-define(CUSTOM_SIP_HEADERS_IN, [?SIP, ?CUSTOM_SIP_HEADERS, <<"in">>]).
+-define(CUSTOM_SIP_HEADERS_OUT, [?SIP, ?CUSTOM_SIP_HEADERS, <<"out">>]).
 
 -define(PRESENCE_ID, <<"presence_id">>).
 -define(NAME, <<"name">>).
@@ -121,7 +126,32 @@ custom_sip_headers(DeviceJObj) ->
     custom_sip_headers(DeviceJObj, 'undefined').
 
 custom_sip_headers(DeviceJObj, Default) ->
-    wh_json:get_value(?CUSTOM_SIP_HEADERS, DeviceJObj, Default).
+    case wh_json:get_value(?CUSTOM_SIP_HEADERS_KV_ONLY, DeviceJObj) of
+        'undefined' -> Default;
+        CustomHeaders ->
+            wh_json:filter(fun filter_custom_sip_headers/1, CustomHeaders)
+    end.
+
+-spec filter_custom_sip_headers({ne_binary(), any()}) -> boolean().
+filter_custom_sip_headers({<<"in">>, _}) -> 'false';
+filter_custom_sip_headers({<<"out">>, _}) -> 'false';
+filter_custom_sip_headers(_) -> 'true'.
+
+-spec custom_sip_headers_inbound(doc()) -> api_object().
+-spec custom_sip_headers_inbound(doc(), Default) -> wh_json:object() | Default.
+custom_sip_headers_inbound(DeviceJObj) ->
+    custom_sip_headers_inbound(DeviceJObj, 'undefined').
+
+custom_sip_headers_inbound(DeviceJObj, Default) ->
+    wh_json:get_value(?CUSTOM_SIP_HEADERS_IN, DeviceJObj, Default).
+
+-spec custom_sip_headers_outbound(doc()) -> api_object().
+-spec custom_sip_headers_outbound(doc(), Default) -> wh_json:object() | Default.
+custom_sip_headers_outbound(DeviceJObj) ->
+    custom_sip_headers_outbound(DeviceJObj, 'undefined').
+
+custom_sip_headers_outbound(DeviceJObj, Default) ->
+    wh_json:get_value(?CUSTOM_SIP_HEADERS_OUT, DeviceJObj, Default).
 
 -spec sip_settings(doc()) -> api_object().
 -spec sip_settings(doc(), Default) -> wh_json:object() | Default.
@@ -162,6 +192,14 @@ set_sip_route(DeviceJObj, Ip) ->
 -spec set_custom_sip_headers(doc(), wh_json:object()) -> doc().
 set_custom_sip_headers(Device, Headers) ->
     wh_json:set_value(?CUSTOM_SIP_HEADERS, Headers, Device).
+
+-spec set_custom_sip_headers_inbound(doc(), wh_json:object()) -> doc().
+set_custom_sip_headers_inbound(Device, Headers) ->
+    wh_json:set_value(?CUSTOM_SIP_HEADERS_IN, Headers, Device).
+
+-spec set_custom_sip_headers_outbound(doc(), wh_json:object()) -> doc().
+set_custom_sip_headers_outbound(Device, Headers) ->
+    wh_json:set_value(?CUSTOM_SIP_HEADERS_OUT, Headers, Device).
 
 -spec set_sip_settings(doc(), wh_json:object()) -> doc().
 set_sip_settings(DeviceJObj, SipJObj) ->


### PR DESCRIPTION
Set custom-sip-headers on outbound legs for calls from the device.
It reads CSH from the old key-value format and then merge it with
the new format which is a nest of two objects, e.g.:

custom_sip_headers: {x-device-header: value}
custom_sip_headers: {out:{x-outbound-header: value},in:{x-device-header: value}}