### PR TITLE
Correct content length for crossbar CSV response

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -738,7 +738,7 @@ to_csv(Req, Context) ->
         _ ->
             RespBody = maybe_flatten_jobj(Context1),
             RespHeaders1 = [{<<"Content-Type">>, <<"application/octet-stream">>}
-                            ,{<<"Content-Length">>, iolist_size(RespBody)}
+                            ,{<<"Content-Length">>, size(wh_util:to_binary(RespBody))/8}
                             ,{<<"Content-Disposition">>, <<"attachment; filename=\"data.csv\"">>}
                             | cb_context:resp_headers(Context1)
                            ],

--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -738,7 +738,6 @@ to_csv(Req, Context) ->
         _ ->
             RespBody = maybe_flatten_jobj(Context1),
             RespHeaders1 = [{<<"Content-Type">>, <<"application/octet-stream">>}
-                            ,{<<"Content-Length">>, iolist_size(RespBody)}
                             ,{<<"Content-Disposition">>, <<"attachment; filename=\"data.csv\"">>}
                             | cb_context:resp_headers(Context1)
                            ],

--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -738,7 +738,7 @@ to_csv(Req, Context) ->
         _ ->
             RespBody = maybe_flatten_jobj(Context1),
             RespHeaders1 = [{<<"Content-Type">>, <<"application/octet-stream">>}
-                            ,{<<"Content-Length">>, size(wh_util:to_binary(RespBody))/8}
+                            ,{<<"Content-Length">>, iolist_size(RespBody)}
                             ,{<<"Content-Disposition">>, <<"attachment; filename=\"data.csv\"">>}
                             | cb_context:resp_headers(Context1)
                            ],


### PR DESCRIPTION
The Content-Length header was incorrect before - though I'm not sure why. This works as intended.
I know this is potentially inefficient, but if the CSV response is expected to be large then it will probably be chunked anyway.