### PR TITLE
Fix crossbar v2 notify_port_request

### DIFF
--- a/applications/notify/src/notify_port_request.erl
+++ b/applications/notify/src/notify_port_request.erl
@@ -94,7 +94,7 @@ create_template_props(<<"v2">>, NotifyJObj, AccountJObj) ->
     PortData = notify_util:json_to_template_props(wh_doc:public_fields(PortDoc)),
     [Number|_]=Numbers = find_numbers(PortData, NotifyJObj),
 
-    NumberString = wh_util:join_binary(Numbers, <<" ">>),
+    NumberString = wh_util:join_binary([Num || {Num, _} <- Numbers], <<" ">>),
 
     Request = [{<<"port">>
                 ,[{<<"service_provider">>, wh_json:get_value(<<"carrier">>, PortDoc)}
@@ -159,14 +159,14 @@ get_default_from() ->
     DefaultFrom = wh_util:to_binary(node()),
     whapps_config:get_binary(?MOD_CONFIG_CAT, <<"default_from">>, DefaultFrom).
 
--spec find_numbers(wh_proplist(), wh_json:object()) -> ne_binaries().
+-spec find_numbers(wh_proplist(), wh_json:object()) -> ne_binaries() | wh_proplists().
 find_numbers(PortData, NotifyJObj) ->
     case props:get_value(<<"numbers">>, PortData) of
         'undefined' -> find_numbers(NotifyJObj);
         Ns -> Ns
     end.
 
--spec find_numbers(wh_json:object()) -> ne_binaries().
+-spec find_numbers(wh_json:object()) -> ne_binaries() | wh_proplists().
 find_numbers(NotifyJObj) ->
     [wh_json:get_value(<<"Number">>, NotifyJObj)].
 


### PR DESCRIPTION
Stopped notify_port_request from crashing when trying to join tuples.
I would have preferred to change find_numbers to only return binaries, but this broke template rendering.