### PR TITLE
Fix: kazoo_couch doesn't have del_docs/3 or del_doc/3

### DIFF
--- a/core/kazoo_data/src/kzs_doc.erl
+++ b/core/kazoo_data/src/kzs_doc.erl
@@ -90,14 +90,14 @@ ensure_saved(#{server := {App, Conn}}, DbName, Doc, Options) ->
                      data_error().
 del_doc(#{server := {App, Conn}}, DbName, Doc) ->
     kzs_cache:flush_cache_doc(DbName, Doc),
-    App:del_doc(Conn, DbName, Doc).
+    App:del_doc(Conn, DbName, Doc, []).
 
 -spec del_docs(map(), ne_binary(), wh_json:objects()) ->
                       {'ok', wh_json:objects()} |
                       data_error().
 del_docs(#{server := {App, Conn}}, DbName, Docs) ->
     kzs_cache:flush_cache_docs(DbName, Docs),
-    App:del_docs(Conn, DbName, Docs).
+    App:del_docs(Conn, DbName, Docs, []).
 
 
 -spec copy_doc(map(), copy_doc(), wh_proplist()) ->


### PR DESCRIPTION
Starting KAZOO-4 on empty DB lead to error:

> refreshing database (9/18) 'offnet'
11:46:02.761 [error] Error in process <0.374.0> on node 'whistle_apps@t13-dev.dinkor.net' with exit value: {undef,[{kazoo_couch,del_docs,[{server,<<"http://127.0.0.1:5984">>,[{pool_size,100},{max_sessions,512},{max_pipeline_size,10},{connect_timeout,500},{connect_options,[{keepalive,true}]}]},<<"offnet">>,[]],[]},{stepswitch_maintenance,refresh,0,[{file,"src/stepswitch_maintenance.erl"},{line,143}]},{whapps_maintenance,refresh,3,[{file,"src/whapps_maintenance.erl"},{line,165}]},{whapps_controller,initialize_whapps,0,[{file,"src/whapps_controller.erl"},{line,138}]}]}
