### PR TITLE
HELP-21214: set timeout based on noop id

### DIFF
--- a/core/whistle_apps-1.0.0/src/whapps_call_command.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_call_command.erl
@@ -2050,18 +2050,21 @@ b_privacy(Mode, Call) ->
 collect_digits(MaxDigits, Call) ->
     do_collect_digits(#wcc_collect_digits{max_digits=wh_util:to_integer(MaxDigits)
                                           ,call=Call
+                                          ,after_timeout=?DEFAULT_INTERDIGIT_TIMEOUT
                                          }).
 
 collect_digits(MaxDigits, Timeout, Call) ->
     do_collect_digits(#wcc_collect_digits{max_digits=wh_util:to_integer(MaxDigits)
-                                          ,timeout=wh_util:to_integer(Timeout)
-                                          ,call=Call
+                                         ,timeout=wh_util:to_integer(Timeout)
+                                         ,call=Call
+                                         ,after_timeout=wh_util:to_integer(Timeout)
                                          }).
 
 collect_digits(MaxDigits, Timeout, Interdigit, Call) ->
     do_collect_digits(#wcc_collect_digits{max_digits=wh_util:to_integer(MaxDigits)
                                           ,timeout=wh_util:to_integer(Timeout)
                                           ,interdigit=wh_util:to_integer(Interdigit)
+                                         ,after_timeout=wh_util:to_integer(Timeout)
                                           ,call=Call
                                          }).
 


### PR DESCRIPTION
If there is no NoopId, after_timeout should be set to timeout; otherwise
we will wait for one day for events that may never happen.