### PR TITLE
KAZOO-4591: set custom tags read from endpoint doc to ccvs

### DIFF
--- a/applications/callflow/src/cf_endpoint.erl
+++ b/applications/callflow/src/cf_endpoint.erl
@@ -1307,6 +1307,7 @@ generate_ccvs(Endpoint, Call, CallFwd) ->
                ,fun set_sip_invite_domain/1
                ,fun maybe_set_call_waiting/1
                ,fun maybe_auto_answer/1
+               ,fun maybe_set_custom_tags/1
               ],
     Acc0 = {Endpoint, Call, CallFwd, wh_json:new()},
     {_Endpoint, _Call, _CallFwd, JObj} = lists:foldr(fun(F, Acc) -> F(Acc) end, Acc0, CCVFuns),
@@ -1435,6 +1436,14 @@ maybe_set_call_waiting({Endpoint, Call, CallFwd, JObj}) ->
                   'false' -> wh_json:set_value(<<"Call-Waiting-Disabled">>, 'true', JObj)
               end,
     {Endpoint, Call, CallFwd, NewJobj}.
+
+-spec maybe_set_custom_tags(ccv_acc()) -> ccv_acc().
+maybe_set_custom_tags({Endpoint, Call, CallFwd, JObj}) ->
+    {Endpoint, Call, CallFwd
+     ,wh_json:merge_recursive(
+        wh_json:get_json_value(<<"custom_tags">>, Endpoint, wh_json:new())
+        ,JObj)
+    }.
 
 -spec get_invite_format(wh_json:object()) -> ne_binary().
 get_invite_format(SIPJObj) ->

--- a/applications/registrar/src/reg_authn_req.erl
+++ b/applications/registrar/src/reg_authn_req.erl
@@ -105,7 +105,8 @@ create_ccvs(#auth_user{doc=JObj}=AuthUser) ->
              ,{<<"Register-Overwrite-Notify">>, AuthUser#auth_user.register_overwrite_notify}
              ,{<<"Pusher-Application">>, wh_json:get_value([<<"push">>, <<"Token-App">>], JObj)}
              | (create_specific_ccvs(AuthUser, AuthUser#auth_user.method)
-                 ++ generate_security_ccvs(AuthUser))
+                 ++ generate_security_ccvs(AuthUser)
+                 ++ add_custom_tags(JObj))
             ],
     wh_json:from_list(props:filter_undefined(Props)).
 
@@ -572,3 +573,9 @@ maybe_enforce_security({#auth_user{doc=JObj}=User, Acc}) ->
 -spec maybe_set_encryption_flags({auth_user(), wh_proplist()}) -> {auth_user(), wh_proplist()}.
 maybe_set_encryption_flags({#auth_user{doc=JObj}=User, Acc}) ->
     {User, encryption_method_map(Acc, JObj)}.
+
+-spec add_custom_tags(wh_json:object()) -> wh_proplist().
+add_custom_tags(JObj) ->
+    wh_json:to_proplist(
+      wh_json:get_json_value(<<"custom_tags">>, JObj, wh_json:new())
+     ).


### PR DESCRIPTION
This PR enable reading custom tags from device documents and set them to CCVS, so that whenever you make or receive a phone call from this device, channel events generated by Kazoo will carry those tags (and can also be found in CDR and Webhooks events).

The custom tags looks like this in couchdb:
"custom_tags" : {
    "k1" : "v1",
    "k2" : "v2"
}