### PR TITLE
Crossbar: create MODB before reconciliation when add account

### DIFF
--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -1246,11 +1246,11 @@ create_new_account_db(Context) ->
             _ = crossbar_bindings:map(<<"account.created">>, C),
             lager:debug("alerted listeners of new account"),
 
-            _ = wh_services:reconcile(AccountDb),
-            lager:debug("performed initial services reconcile"),
-
             _ = create_account_mod(cb_context:account_id(C)),
             lager:debug("created this month's MODb for account"),
+
+            _ = wh_services:reconcile(AccountDb),
+            lager:debug("performed initial services reconcile"),
 
             _ = create_first_transaction(cb_context:account_id(C)),
             lager:debug("created first transaction for account"),


### PR DESCRIPTION
Call `wh_services:reconcile/1` before creating MODB lead to crash:
> |0000000000|Undefined:Undefined (<0.1771.0>) CRASH REPORT Process <0.1771.0> with 0 neighbours exited with reason: timeout in couchbeam_view_stream:do_init_stream/2 line 120

because `wh_service_ledgers` trying to get data from nonexistent MODB, but `couchbeam_view_stream:do_init_stream/2` is not handle responce with 404 code and died with `timeout` reason.