### PR TITLE
Fix _design/numbers

### DIFF
--- a/core/kazoo_number_manager/priv/couchdb/views/managed.json
+++ b/core/kazoo_number_manager/priv/couchdb/views/managed.json
@@ -3,7 +3,7 @@
     "language": "javascript",
     "views": {
         "status": {
-            "map": "function(doc) { emit([doc.pvt_account_id,doc.pvt_number_state, doc._id], null); }"
+            "map": "function(doc) { emit([doc.pvt_account_id,doc.pvt_state, doc._id], null); }"
         }
     }
 }

--- a/core/kazoo_number_manager/priv/couchdb/views/numbers.json
+++ b/core/kazoo_number_manager/priv/couchdb/views/numbers.json
@@ -3,7 +3,7 @@
     "language": "javascript",
     "views": {
         "status": {
-            "map": "function(doc) { emit([doc.pvt_number_state, doc._id], null); }"
+            "map": "function(doc) { emit([doc.pvt_state, doc._id], null); }"
         }
     }
 }


### PR DESCRIPTION
In knm_number_manager property "pvt_number_state" renamed to "pvt_state".
PS: maybe [core/whistle_apps/priv/couchdb/views/inum.json](https://github.com/2600hz/kazoo/blob/master/core/whistle_apps/priv/couchdb/views/inum.json) need change too?