### PR TITLE
Request envelope requires "data"

### DIFF
--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -238,7 +238,7 @@ set_request_data_in_context(Context, Req, JObj, QS) ->
     case is_valid_request_envelope(JObj) of
         'false' ->
             lager:info("failed to find 'data' in envelope, invalid request"),
-            ?MODULE:halt(Req, Context);
+            halt_on_invalid_envelope(Req, Context);
         'true' ->
             Setters = [{fun cb_context:set_req_json/2, JObj}
                       ,{fun cb_context:set_req_data/2, wh_json:get_value(<<"data">>, JObj)}
@@ -275,7 +275,7 @@ halt_on_invalid_envelope(Req, Context) ->
                                                     ,{<<"target">>, <<"data">>}
                                                     ]
                                                    )
-                                                 ,Context
+                                                 ,cb_context:set_resp_error_code(Context, 400)
                                                  )
                 ).
 
@@ -1196,7 +1196,7 @@ fix_header(H, V, _) ->
                   halt_return().
 halt(Req0, Context) ->
     StatusCode = cb_context:resp_error_code(Context),
-    lager:debug("halting execution here"),
+    lager:debug("halting execution here with ~p", [StatusCode]),
 
     {Content, Req1} = create_resp_content(Req0, Context),
     lager:debug("setting resp body: ~s", [Content]),

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -156,14 +156,7 @@ get_parsed_content_type({'ok', {Main, Sub, _Opts}, Req}) ->
 get_req_data(Context, {'undefined', Req0}, QS) ->
     lager:debug("undefined content type when getting req data, assuming application/json"),
     {JSON, Req1} = get_json_body(Req0),
-
-    Setters = [{fun cb_context:set_req_json/2, JSON}
-               ,{fun cb_context:set_req_data/2, wh_json:get_value(<<"data">>, JSON, wh_json:new())}
-               ,{fun cb_context:set_query_string/2, QS}
-              ],
-    {lists:foldl(fun({F, D}, C) -> F(C, D) end, Context, Setters)
-     ,Req1
-    };
+    set_request_data_in_context(Context, Req1, JSON, QS);
 get_req_data(Context, {<<"multipart/form-data">>, Req}, QS) ->
     lager:debug("multipart/form-data content type when getting req data"),
     maybe_extract_multipart(cb_context:set_query_string(Context, QS), Req, QS);
@@ -177,23 +170,11 @@ get_req_data(Context, {<<"application/json">>, Req1}, QS) ->
     lager:debug("application/json content type when getting req data"),
     {JSON, Req2} = get_json_body(Req1),
 
-    Setters = [{fun cb_context:set_req_json/2, JSON}
-               ,{fun cb_context:set_req_data/2, wh_json:get_value(<<"data">>, JSON, wh_json:new())}
-               ,{fun cb_context:set_query_string/2, QS}
-              ],
-    {lists:foldl(fun({F, D}, C) -> F(C, D) end, Context, Setters)
-     ,Req2
-    };
+    set_request_data_in_context(Context, Req2, JSON, QS);
 get_req_data(Context, {<<"application/x-json">>, Req1}, QS) ->
     lager:debug("application/x-json content type when getting req data"),
     {JSON, Req2} = get_json_body(Req1),
-    Setters = [{fun cb_context:set_req_json/2, JSON}
-               ,{fun cb_context:set_req_data/2, wh_json:get_value(<<"data">>, JSON, wh_json:new())}
-               ,{fun cb_context:set_query_string/2, QS}
-              ],
-    {lists:foldl(fun({F, D}, C) -> F(C, D) end, Context, Setters)
-     ,Req2
-    };
+    set_request_data_in_context(Context, Req2, JSON, QS);
 get_req_data(Context, {<<"application/base64">>, Req1}, QS) ->
     lager:debug("application/base64 content type when getting req data"),
     decode_base64(cb_context:set_query_string(Context, QS), <<"application/base64">>, Req1);
@@ -245,14 +226,25 @@ handle_url_encoded_body(Context, Req, QS, ReqBody, JObj) ->
             lager:debug("failed to parse url-encoded request body, but we'll give json a go on ~p", [_JSON]),
             try_json(ReqBody, QS, Context, Req);
         _Vs ->
-            lager:debug("was able to parse request body as url-encoded: ~p", [JObj]),
+            lager:debug("was able to parse request body as url-encoded to json: ~p", [JObj]),
+
+            set_request_data_in_context(Context, Req, JObj, QS)
+    end.
+
+-spec set_request_data_in_context(cb_context:context(), cowboy_req:req(), wh_json:object(), wh_json:object()) ->
+                                         {cb_context:context(), cowboy_req:req()} |
+                                         halt_return().
+set_request_data_in_context(Context, Req, JObj, QS) ->
+    case is_valid_request_envelope(JObj) of
+        'undefined' ->
+            lager:info("failed to find 'data' in envelope, invalid request"),
+            halt(Req, Context);
+        Data ->
             Setters = [{fun cb_context:set_req_json/2, JObj}
-                       ,{fun cb_context:set_req_data/2, wh_json:get_value(<<"data">>, JObj, wh_json:new())}
-                       ,{fun cb_context:set_query_string/2, QS}
+                      ,{fun cb_context:set_req_data/2, Data}
+                      ,{fun cb_context:set_query_string/2, QS}
                       ],
-            {lists:foldl(fun({F, D}, C) -> F(C, D) end, Context, Setters)
-             ,Req
-            }
+            {cb_context:setters(Context, Setters), Req}
     end.
 
 -spec try_json(ne_binary(), wh_json:object(), cb_context:context(), cowboy_req:req()) ->
@@ -262,14 +254,7 @@ try_json(ReqBody, QS, Context, Req) ->
     try get_json_body(ReqBody, Req) of
         {JObj, Req1} ->
             lager:debug("was able to parse as JSON"),
-
-            Setters = [{fun cb_context:set_req_json/2, JObj}
-                       ,{fun cb_context:set_req_data/2, wh_json:get_value(<<"data">>, JObj, wh_json:new())}
-                       ,{fun cb_context:set_query_string/2, QS}
-                      ],
-            {lists:foldl(fun({F, D}, C) -> F(C, D) end, Context, Setters)
-             ,Req1
-            }
+            set_request_data_in_context(Context, Req1, JObj, QS)
     catch
         'throw':_R ->
             lager:debug("failed to get JSON too: ~p", [_R]),

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -238,7 +238,7 @@ set_request_data_in_context(Context, Req, JObj, QS) ->
     case is_valid_request_envelope(JObj) of
         'undefined' ->
             lager:info("failed to find 'data' in envelope, invalid request"),
-            halt(Req, Context);
+            ?MODULE:halt(Req, Context);
         Data ->
             Setters = [{fun cb_context:set_req_json/2, JObj}
                       ,{fun cb_context:set_req_data/2, Data}

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -1144,7 +1144,6 @@ add_validation_error(Property, Code, Message, Context) ->
     lager:warning("UNKNOWN ERROR CODE: ~p", [Code]),
     add_depreciated_validation_error(Property, Code, Message, Context).
 
-
 add_depreciated_validation_error(<<"account">>, <<"expired">>, Message, Context) ->
     add_depreciated_validation_error(<<"account">>, <<"expired">>, Message, Context, 423, <<"locked">>);
 add_depreciated_validation_error(<<"account">>, <<"disabled">>, Message, Context) ->

--- a/applications/crossbar/src/crossbar_types.hrl
+++ b/applications/crossbar/src/crossbar_types.hrl
@@ -11,7 +11,9 @@
 -type path_token() :: ne_binary().
 -type path_tokens() :: [path_token()].
 
--type resp_data() :: wh_json:object() | wh_json:objects() | api_binary() | wh_json:json_term() | ne_binaries().
+-type resp_data() :: wh_json:object() | wh_json:objects() |
+                     wh_json:json_term() | wh_json:json_proplist() |
+                     api_binary() | ne_binaries().
 
  %% {file_name, {"contents":<<bin>>, "headers":{"content-type":"", "content-length":1}}}
 -type req_file() :: {ne_binary(), wh_json:object()}.

--- a/applications/crossbar/src/modules/cb_local_provisioner_templates.erl
+++ b/applications/crossbar/src/modules/cb_local_provisioner_templates.erl
@@ -267,7 +267,7 @@ load_template_image(DocId, Context) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec upload_template_image(cb_context:context()) -> cb_context:context().
--spec upload_template_image(cb_context:context(), cb_context:req_files()) -> cb_context:context().
+-spec upload_template_image(cb_context:context(), req_files()) -> cb_context:context().
 upload_template_image(Context) ->
     upload_template_image(Context, cb_context:req_files(Context)).
 upload_template_image(Context, []) ->
@@ -282,14 +282,11 @@ upload_template_image(Context, []) ->
 upload_template_image(Context, [{_, _}]) ->
     crossbar_util:response(wh_json:new(), Context);
 upload_template_image(Context, [_|_]) ->
-   cb_context:add_validation_error(
-        <<"file">>
-        ,<<"maxItems">>
-        ,wh_json:from_list([
-            {<<"message">>, <<"Please provide a single image file">>}
-         ])
-        ,Context
-    ).
+   cb_context:add_validation_error(<<"file">>
+                                  ,<<"maxItems">>
+                                  ,wh_json:from_list([{<<"message">>, <<"Please provide a single image file">>}])
+                                  ,Context
+                                  ).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/modules/cb_signup.erl
+++ b/applications/crossbar/src/modules/cb_signup.erl
@@ -146,7 +146,7 @@ validate(Context, ActivationKey) ->
     end.
 
 -spec authorize(cb_context:context()) -> 'true'.
--spec authorize_nouns(cb_context:req_nouns()) -> 'true'.
+-spec authorize_nouns(req_nouns()) -> 'true'.
 authorize(Context) ->
     authorize_nouns(cb_context:req_nouns(Context)).
 
@@ -154,7 +154,7 @@ authorize_nouns([{<<"signup">>,[]}]) -> 'true';
 authorize_nouns([{<<"signup">>,[_]}]) -> 'true'.
 
 -spec authenticate(cb_context:context()) -> 'true'.
--spec authenticate_nouns(cb_context:req_nouns()) -> 'true'.
+-spec authenticate_nouns(req_nouns()) -> 'true'.
 authenticate(Context) ->
     authenticate_nouns(cb_context:req_nouns(Context)).
 

--- a/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
@@ -455,8 +455,9 @@ validate_delete(Context) ->
 %%--------------------------------------------------------------------
 -spec set_response({'ok', wh_json:object()} |
                    knm_number_return() |
-                   {binary(), binary()}, binary()
-                   ,cb_context:context()) ->
+                   {binary(), binary()}
+                  ,binary()
+                  ,cb_context:context()) ->
                           cb_context:context().
 set_response({'ok', {'ok', Doc}}, _, Context) ->
     crossbar_util:response(Doc, Context);
@@ -489,9 +490,9 @@ collection_process(Context, ?ACTIVATE) ->
     Numbers = wh_json:get_value(<<"numbers">>, cb_context:req_data(Context), []),
     collection_process(Context, Numbers, ?ACTIVATE);
 collection_process(Context, Numbers) ->
-    Temp = wh_json:set_values([{<<"success">>, wh_json:new()}
-                               ,{<<"error">>, wh_json:new()}
-                              ], wh_json:new()),
+    Temp = wh_json:from_list([{<<"success">>, wh_json:new()}
+                             ,{<<"error">>, wh_json:new()}
+                             ]),
     lists:foldl(
       fun(Number, Acc) ->
               case collection_action(Context, cb_context:req_verb(Context), Number) of
@@ -503,16 +504,15 @@ collection_process(Context, Numbers) ->
                       wh_json:set_value([<<"error">>, Number], JObj, Acc)
               end
       end
-      ,Temp
-      ,Numbers
+               ,Temp
+               ,Numbers
      ).
 
 collection_process(Context, Numbers, Action) ->
-    Base = wh_json:set_values([{<<"success">>, wh_json:new()}
-                               ,{<<"error">>, wh_json:new()}
-                              ]
-                             ,wh_json:new()
-                             ),
+    Base = wh_json:from_list([{<<"success">>, wh_json:new()}
+                             ,{<<"error">>, wh_json:new()}
+                             ]
+                            ),
     lists:foldl(
       fun(Number, Acc) ->
               case collection_action(Context, cb_context:req_verb(Context), Number, Action) of

--- a/core/kazoo_documents/src/kz_device.erl
+++ b/core/kazoo_documents/src/kz_device.erl
@@ -307,7 +307,6 @@ timezone(Box, Default) ->
 owner_timezone(Box, Default) ->
     case owner(Box) of
         'undefined'   -> account_timezone(Box, Default);
-        <<"inherit">> -> account_timezone(Box, Default);  %% UI-1808
         OwnerJObj -> owner_timezone(Box, Default, OwnerJObj)
     end.
 
@@ -322,7 +321,7 @@ owner(Box) ->
 owner(Box, OwnerId) ->
     case kz_datamgr:open_cache_doc(wh_doc:account_db(Box)
                                   ,OwnerId
-                                 )
+                                  )
     of
         {'ok', OwnerJObj} -> OwnerJObj;
         {'error', 'not_found'} -> 'undefined'
@@ -347,4 +346,3 @@ unsolicitated_mwi_updates(DeviceJObj) ->
 -spec set_unsolicitated_mwi_updates(doc(), boolean()) -> doc().
 set_unsolicitated_mwi_updates(DeviceJObj, Enabled) ->
     wh_json:set_value(?KEY_UNSOLICITATED_MWI_UPDATES, Enabled, DeviceJObj).
-

--- a/core/kazoo_documents/src/kzd_apps_store.erl
+++ b/core/kazoo_documents/src/kzd_apps_store.erl
@@ -87,13 +87,13 @@ set_apps(JObj, Data) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec blacklist(wh_json:object()) -> ne_binaries().
--spec blacklist(wh_json:object(), any()) -> ne_binaries().
+-spec blacklist(wh_json:object(), Default) -> ne_binaries() | Default.
 blacklist(JObj) ->
     wh_json:get_value(?BLACKLIST, JObj, []).
 
 blacklist(JObj, Default) ->
     wh_json:get_value(?BLACKLIST, JObj, Default).
 
--spec set_blacklist(wh_json:object(), any()) -> ne_binaries().
+-spec set_blacklist(wh_json:object(), wh_json:json_term()) -> wh_json:object().
 set_blacklist(JObj, Data) ->
     wh_json:set_value(?BLACKLIST, Data, JObj).

--- a/core/kazoo_documents/src/kzd_schema.erl
+++ b/core/kazoo_documents/src/kzd_schema.erl
@@ -8,13 +8,14 @@
 %%%-------------------------------------------------------------------
 -module(kzd_schema).
 
--export([find_schema/1,
-		 properties/2,
-		 max_length/2]).
+-export([find_schema/1
+         ,properties/2
+         ,max_length/2
+        ]).
 
 -include("kz_documents.hrl").
 
--define(SCHEMA_KEYWORDS_MAXLENGTH,            <<"maxLength">>).
+-define(SCHEMA_KEYWORDS_MAXLENGTH, <<"maxLength">>).
 
 %%% Load schema
 -spec find_schema(ne_binary()) -> api_object().
@@ -28,19 +29,19 @@ find_schema(<<_/binary>> = Schema) ->
 
 %%% Meta keywords
 %%% ===================
--spec properties(wh_json:key(), api_object()) -> wh_json:object().
+-spec properties(wh_json:key(), ne_binary()) -> wh_json:object().
 properties(Key, Schema) ->
-	case find_schema(Schema) of
-		'undefined' ->
-			wh_json:new();
-		SchemaJObj ->
-			wh_json:get_value(Key, SchemaJObj, wh_json:new())
-	end.
+    case find_schema(Schema) of
+        'undefined' ->
+            wh_json:new();
+        SchemaJObj ->
+            wh_json:get_value(Key, SchemaJObj, wh_json:new())
+    end.
 
 %%% Keywords
 %%% ==================================
 %% String
--spec max_length(wh_json:key(), api_object()) -> api_object().
+-spec max_length(wh_json:key(), ne_binary()) -> api_object().
 max_length(Key, Schema) ->
-	Properties = properties(Key, Schema),
-	wh_json:get_value(?SCHEMA_KEYWORDS_MAXLENGTH, Properties).
+    Properties = properties(Key, Schema),
+    wh_json:get_value(?SCHEMA_KEYWORDS_MAXLENGTH, Properties).


### PR DESCRIPTION
Had an issue in training where user sent POST -d '{"real":"stuff"}' and was getting schema validation errors saying "real" is required. That is a confusing because the real error is that the user didn't create the request envelope properly. This PR checks that and returns a more appropriate error payload.