### PR TITLE
Kazoo 4575: Assigning user to unassigned device, initially de-registeres device

### DIFF
--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -384,7 +384,7 @@ flush_registration(Username, <<_/binary>> = Realm) ->
                 ,{<<"Username">>, Username}
                 | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
                ],
-    whapps_util:amqp_pool_send(FlushCmd, fun wapi_registration:publish_flush/1);
+    whapps_util:amqp_pool_send(FlushCmd, fun wapi_switch:publish_flush/1);
 flush_registration(Username, Context) ->
     Realm = wh_util:get_account_realm(cb_context:account_id(Context)),
     flush_registration(Username, Realm).

--- a/applications/ecallmgr/src/ecallmgr_fs_notify.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_notify.erl
@@ -124,7 +124,9 @@ check_sync(Username, Realm) ->
             case ensure_contact_user(Contact, Username, Realm) of
                 'undefined' ->
                     lager:error("invalid contact : ~p : ~p", [Contact, Registration]);
-                Valid -> send_check_sync(Node, Username, Realm, Valid)
+                Valid ->
+                    ecallmgr_registrar:flush(Realm, Username),
+                    send_check_sync(Node, Username, Realm, Valid)
             end
     end.
 


### PR DESCRIPTION
use check_sync instead of registrar_flush when device's configuration is updated