### PR TITLE
KAZOO-4575: use check_sync instead of registrar_flush when device doc…

### DIFF
--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -384,6 +384,7 @@ flush_registration(Username, <<_/binary>> = Realm) ->
                 ,{<<"Username">>, Username}
                 | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
                ],
+    whapps_util:amqp_pool_send(FlushCmd, fun wapi_switch:publish_check_sync/1),
     whapps_util:amqp_pool_send(FlushCmd, fun wapi_registration:publish_flush/1);
 flush_registration(Username, Context) ->
     Realm = wh_util:get_account_realm(cb_context:account_id(Context)),


### PR DESCRIPTION
use check_sync instead of registrar_flush when device doc is updated