### PR TITLE
KAZOO-4595_master: cherry pick PR 1693 from 3.22 to master

### DIFF
--- a/applications/crossbar/src/modules/cb_callflows.erl
+++ b/applications/crossbar/src/modules/cb_callflows.erl
@@ -383,13 +383,11 @@ maybe_reconcile_numbers(Context) ->
             Set1 = sets:from_list(wh_json:get_value(<<"numbers">>, CurrentJObj, [])),
             Set2 = sets:from_list(wh_json:get_value(<<"numbers">>, cb_context:doc(Context), [])),
             NewNumbers = sets:subtract(Set2, Set1),
-
-            AssignTo = cb_context:account_id(Context),
-            AuthBy = cb_context:auth_account_id(Context),
-
-            _Numbers = [knm_number:reconcile(Number, AssignTo, AuthBy)
-                        || Number <- sets:to_list(NewNumbers)
-                       ],
+            Options = [ {'assigned_to', cb_context:account_id(Context)}
+                      , {'auth_by', cb_context:auth_account_id(Context)}
+                      , {'dry_run', not cb_context:accepting_charges(Context)}
+                      ],
+            _ = knm_numbers:reconcile(sets:to_list(NewNumbers), Options),
             Context
     end.
 

--- a/applications/crossbar/src/modules/cb_callflows.erl
+++ b/applications/crossbar/src/modules/cb_callflows.erl
@@ -383,8 +383,9 @@ maybe_reconcile_numbers(Context) ->
             Set1 = sets:from_list(wh_json:get_value(<<"numbers">>, CurrentJObj, [])),
             Set2 = sets:from_list(wh_json:get_value(<<"numbers">>, cb_context:doc(Context), [])),
             NewNumbers = sets:subtract(Set2, Set1),
+            {'ok', MasterAccountId} = whapps_util:get_master_account_id(),
             Options = [ {'assigned_to', cb_context:account_id(Context)}
-                      , {'auth_by', cb_context:auth_account_id(Context)}
+                      , {'auth_by', MasterAccountId}
                       , {'dry_run', not cb_context:accepting_charges(Context)}
                       ],
             _ = knm_numbers:reconcile(sets:to_list(NewNumbers), Options),

--- a/applications/crossbar/src/modules_v2/cb_devices_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_devices_v2.erl
@@ -38,6 +38,7 @@
 -define(CB_LIST_MAC, <<"devices/listing_by_macaddress">>).
 
 -define(KEY_MAC_ADDRESS, <<"mac_address">>).
+-define(KEY_MOBILE_MDN, [<<"mobile">>, <<"mdn">>]).
 
 %%%===================================================================
 %%% API
@@ -245,6 +246,7 @@ validate(Context, DeviceId, ?QUICKCALL_PATH_TOKEN, _ToDial) ->
 post(Context, DeviceId) ->
     _ = wh_util:spawn(fun crossbar_util:flush_registration/1, [Context]),
     case changed_mac_address(Context) of
+        'false' -> error_used_mac_address(Context);
         'true' ->
             _ = crossbar_util:maybe_refresh_fs_xml('device', Context),
             Context1 = cb_modules_util:take_sync_field(Context),
@@ -255,9 +257,7 @@ post(Context, DeviceId) ->
                           _ = provisioner_util:maybe_provision(Context2),
                           _ = provisioner_util:maybe_sync_sip_data(Context1, 'device')
                   end),
-            Context1;
-        'false' ->
-            error_used_mac_address(Context)
+            maybe_add_mobile_mdn(Context2)
     end.
 
 -spec post(cb_context:context(), path_token(), path_token()) ->
@@ -272,10 +272,10 @@ post(Context, DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
 put(Context) ->
     Callback =
         fun() ->
-            Context1 = crossbar_doc:save(Context),
-            _ = maybe_aggregate_device('undefined', Context1),
-            _ = wh_util:spawn(fun provisioner_util:maybe_provision/1, [Context1]),
-            Context1
+                Context1 = crossbar_doc:save(Context),
+                _ = maybe_aggregate_device('undefined', Context1),
+                _ = wh_util:spawn(fun provisioner_util:maybe_provision/1, [Context1]),
+                maybe_add_mobile_mdn(Context1)
         end,
     crossbar_services:maybe_dry_run(Context, Callback).
 
@@ -283,10 +283,14 @@ put(Context) ->
 delete(Context, DeviceId) ->
     _ = crossbar_util:refresh_fs_xml(Context),
     Context1 = crossbar_doc:delete(Context),
-    _ = crossbar_util:flush_registration(Context),
-    _ = wh_util:spawn(fun provisioner_util:maybe_delete_provision/1, [Context]),
-    _ = maybe_remove_aggregate(DeviceId, Context),
-    Context1.
+    case get_device_type(Context) of
+        <<"mobile">> -> remove_mobile_mdn(Context);
+        _Else ->
+            _ = crossbar_util:flush_registration(Context),
+            _ = wh_util:spawn(fun provisioner_util:maybe_delete_provision/1, [Context]),
+            _ = maybe_remove_aggregate(DeviceId, Context),
+            Context1
+    end.
 
 %%%===================================================================
 %%% Internal functions
@@ -331,9 +335,103 @@ load_users_device_summary(Context, UserId) ->
 %%--------------------------------------------------------------------
 -spec validate_request(api_binary(), cb_context:context()) -> cb_context:context().
 validate_request('undefined', Context) ->
-    check_mac_address('undefined', Context);
+    maybe_check_mdn('undefined', Context);
 validate_request(DeviceId, Context) ->
-    prepare_outbound_flags(DeviceId, Context).
+    Context1 = crossbar_doc:load(DeviceId, Context),
+    case cb_context:resp_status(Context1) of
+        'success' -> maybe_check_mdn(DeviceId, Context1);
+        _Else -> Context1
+    end.
+
+-spec maybe_check_mdn(api_binary(), cb_context:context()) -> cb_context:context().
+maybe_check_mdn(DeviceId, Context) ->
+    case get_device_type(Context) of
+        <<"mobile">> -> check_mdn_undefined(DeviceId, Context);
+        _Else when DeviceId =:= 'undefined' ->
+            check_mac_address(DeviceId, Context);
+        _Else ->
+            prepare_outbound_flags(DeviceId, Context)
+    end.
+
+-spec check_mdn_undefined(api_binary(), cb_context:context()) -> cb_context:context().
+check_mdn_undefined(DeviceId, Context) ->
+    case get_mdn(Context) =:= 'undefined' of
+        'true' -> error_mdn_undefined(Context);
+        'false' -> check_mdn_changed(DeviceId, Context)
+    end.
+
+-spec error_mdn_undefined(cb_context:context()) -> cb_context:context().
+error_mdn_undefined(Context) ->
+    cb_context:add_validation_error(
+      ?KEY_MOBILE_MDN
+      ,<<"required">>
+      ,wh_json:from_list(
+         [{<<"message">>, <<"Field is required but missing">>}]
+        )
+      ,Context
+     ).
+
+-spec check_mdn_changed(api_binary(), cb_context:context()) -> cb_context:context().
+check_mdn_changed('undefined', Context) ->
+    check_mdn_taken('undefined', Context);
+check_mdn_changed(DeviceId, Context) ->
+    IsSuperAdmin = cb_modules_util:is_superduper_admin(Context),
+    case has_mdn_changed(Context) of
+        'true' when IsSuperAdmin ->
+            Context1 = cb_context:store(Context, 'remove_mobile_mdn', 'true'),
+            check_mdn_taken(DeviceId, Context1);
+        'true' -> error_mdn_changed(Context);
+        'false' -> prepare_outbound_flags(DeviceId, Context)
+    end.
+
+-spec error_mdn_changed(cb_context:context()) -> cb_context:context().
+error_mdn_changed(Context) ->
+    _OldMDN = wh_json:get_ne_value(?KEY_MOBILE_MDN, cb_context:fetch(Context, 'db_doc')),
+    NewMDN = cb_context:req_value(Context, ?KEY_MOBILE_MDN),
+    lager:debug("mobile device number attempted to be changed from ~p to ~p"
+               ,[_OldMDN, NewMDN]),
+    cb_context:add_validation_error(
+      ?KEY_MOBILE_MDN
+      ,<<"invalid">>
+      ,wh_json:from_list(
+         [ {<<"message">>, <<"Mobile Device Number cannot be changed">>}
+         , {<<"cause">>, NewMDN}
+         ])
+      ,Context
+     ).
+
+-spec check_mdn_taken(api_binary(), cb_context:context()) -> cb_context:context().
+check_mdn_taken(DeviceId, Context) ->
+    MDN = get_mdn(Context),
+    case knm_number:get(MDN) of
+        {'ok', _Number} -> error_mdn_taken(MDN, Context);
+        _Otherwise ->
+            lager:debug("endpoint mdn ~s is not taken: ~p", [MDN, _Otherwise]),
+            check_mdn_registered(DeviceId, Context)
+    end.
+
+-spec error_mdn_taken(ne_binary(), cb_context:context()) -> cb_context:context().
+error_mdn_taken(MDN, Context) ->
+    cb_context:add_validation_error(
+      ?KEY_MOBILE_MDN
+      ,<<"unique">>
+      ,wh_json:from_list(
+         [ {<<"message">>, <<"Mobile Device Number already exists in the system">>}
+         , {<<"cause">>, MDN}
+         ])
+      ,Context
+     ).
+
+-spec check_mdn_registered(api_binary(), cb_context:context()) -> cb_context:context().
+check_mdn_registered(DeviceId, Context) ->
+    %%TODO: issue API request to TOP (if configured with URL) and validate
+    %%   that the number is present in that system, if not stop the request
+    %%   and don't set handle_modible_mdn
+    Context1 = cb_context:store(Context, 'add_mobile_mdn', 'true'),
+    case DeviceId == 'undefined' of
+        'true' -> check_mac_address(DeviceId, Context1);
+        'false' -> prepare_outbound_flags(DeviceId, Context1)
+    end.
 
 -spec changed_mac_address(cb_context:context()) -> boolean().
 changed_mac_address(Context) ->
@@ -487,15 +585,38 @@ validate_device_ip_unique(IP, DeviceId, Context) ->
 -spec check_emergency_caller_id(api_binary(), cb_context:context()) -> cb_context:context().
 check_emergency_caller_id(DeviceId, Context) ->
     Context1 = crossbar_util:format_emergency_caller_id_number(Context),
-    check_device_schema(DeviceId, Context1).
+    check_device_type_change(DeviceId, Context1).
+
+-spec check_device_type_change(api_binary(), cb_context:context()) -> cb_context:context().
+check_device_type_change('undefined', Context) ->
+    check_device_schema('undefined', Context);
+check_device_type_change(DeviceId, Context) ->
+    NewDeviceType = kz_device:device_type(cb_context:req_data(Context)),
+    IsSuperAdmin = cb_modules_util:is_superduper_admin(Context),
+    OldDeviceType = kz_device:device_type(cb_context:fetch(Context, 'db_doc')),
+    case {NewDeviceType, OldDeviceType} of
+        {Same, Same} -> check_device_schema(DeviceId, Context);
+        _Else when IsSuperAdmin -> check_device_schema(DeviceId, Context);
+        {'undefined', _} -> error_device_type_change(<<>>, Context);
+        _Else -> error_device_type_change(NewDeviceType, Context)
+    end.
+
+-spec error_device_type_change(api_binary(), cb_context:context()) -> cb_context:context().
+error_device_type_change(DeviceType, Context) ->
+    cb_context:add_validation_error(
+      <<"device_type">>
+      ,<<"invalid">>
+      ,wh_json:from_list(
+         [ {<<"message">>, <<"Not authorized to change type of device">>}
+         , {<<"cause">>, DeviceType}
+         ])
+      ,Context
+     ).
 
 -spec check_device_schema(api_binary(), cb_context:context()) -> cb_context:context().
 check_device_schema(DeviceId, Context) ->
     OnSuccess = fun(C) -> on_successful_validation(DeviceId, C) end,
-    cb_context:validate_request_data(<<"devices">>
-                                     ,Context
-                                     ,OnSuccess
-                                    ).
+    cb_context:validate_request_data(<<"devices">>, Context, OnSuccess).
 
 -spec on_successful_validation(api_binary(), cb_context:context()) -> cb_context:context().
 on_successful_validation('undefined', Context) ->
@@ -666,3 +787,133 @@ maybe_remove_aggregate(DeviceId, _Context, 'success') ->
         {'error', 'not_found'} -> 'false'
     end;
 maybe_remove_aggregate(_, _, _) -> 'false'.
+
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Looks for device_type from DB but if it is undefined there,
+%%   gets the one from request data.
+%% @end
+%%--------------------------------------------------------------------
+-spec get_device_type(cb_context:context()) -> api_binary().
+get_device_type(Context) ->
+    case kz_device:device_type(cb_context:fetch(Context, 'db_doc')) of
+        'undefined' ->
+            kz_device:device_type(cb_context:req_data(Context));
+        DeviceType -> DeviceType
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec maybe_add_mobile_mdn(cb_context:context()) -> cb_context:context().
+maybe_add_mobile_mdn(Context) ->
+    case wh_util:is_true(cb_context:fetch(Context, 'add_mobile_mdn')) of
+        'true' -> add_mobile_mdn(Context);
+        'false' -> Context
+    end.
+
+-spec add_mobile_mdn(cb_context:context()) -> cb_context:context().
+add_mobile_mdn(Context) ->
+    {'ok', MasterAccountId} = whapps_util:get_master_account_id(),
+    Normalized = knm_converters:normalize(get_mdn(Context)),
+    Options = [ {'assigned_to', cb_context:account_id(Context)}
+              , {'auth_by', MasterAccountId}
+              , {'dry_run', not cb_context:accepting_charges(Context)}
+              ],
+    case knm_number:reconcile(Normalized, Options) of
+        {'error', _R} ->
+            lager:debug("unable to add mdn ~s to database: ~p", [Normalized, _R]),
+            _ = crossbar_doc:delete(Context),
+            cb_context:add_system_error('datastore_fault', Context);
+        _Else ->
+            lager:debug("created new mdn ~s", [Normalized]),
+            set_mobile_public_fields(Normalized, Context)
+    end.
+
+-spec set_mobile_public_fields(ne_binary(), cb_context:context()) -> cb_context:context().
+set_mobile_public_fields(Normalized, Context) ->
+    AuthAccountId = cb_context:auth_account_id(Context),
+    MobileField =
+        wh_json:from_list(
+          [ {<<"provider">>, <<"tower-of-power">>}
+          , {<<"authorizing">>, wh_json:from_list(
+                                  [ {<<"account-id">>, AuthAccountId}
+                                  ])}
+          , {<<"device-id">>, wh_doc:id(cb_context:doc(Context))}
+          ]),
+    PublicFields = wh_json:from_list([{<<"mobile">>, MobileField}]),
+    Options = [ {'auth_by', AuthAccountId}
+              , {'dry_run', not cb_context:accepting_charges(Context)}
+              , {'public_fields', PublicFields}
+              ],
+    case knm_number:move(Normalized, cb_context:account_id(Context), Options) of
+        {'error', _R} ->
+            lager:debug("unable to update public fields on mdn ~s: ~p"
+                       ,[Normalized, _R]),
+            _ = crossbar_doc:delete(Context),
+            cb_context:add_system_error('datastore_fault', Context);
+        _Else ->
+            lager:debug("set public fields for new mdn ~s to ~s"
+                       ,[Normalized, wh_json:encode(PublicFields)]),
+            maybe_remove_mobile_mdn(Context)
+    end.
+
+-spec maybe_remove_mobile_mdn(cb_context:context()) -> cb_context:context().
+maybe_remove_mobile_mdn(Context) ->
+    case wh_util:is_true(cb_context:fetch(Context, 'remove_mobile_mdn')) of
+        'true' -> remove_mobile_mdn(Context);
+        'false' -> Context
+    end.
+
+-spec remove_mobile_mdn(cb_context:context()) -> cb_context:context().
+remove_mobile_mdn(Context) ->
+    case wh_json:get_ne_value(?KEY_MOBILE_MDN, cb_context:fetch(Context, 'db_doc')) of
+        'undefined' -> Context;
+        MDN -> remove_if_mobile(MDN, Context)
+    end.
+
+-spec remove_if_mobile(ne_binary(), cb_context:context()) -> cb_context:context().
+remove_if_mobile(MDN, Context) ->
+    Normalized = knm_converters:normalize(MDN),
+    Options = [ {'auth_by', <<"system">>}
+              , {'dry_run', not cb_context:accepting_charges(Context)}
+              ],
+    case knm_number:get(Normalized) of
+        {'ok', Number} ->
+            case wh_json:get_ne_value(<<"mobile">>, knm_number:to_public_json(Number)) of
+                'undefined' -> Context;
+                Mobile ->
+                    lager:debug("removing mdn ~s with mobile properties ~s"
+                               ,[Normalized, wh_json:encode(Mobile)]),
+                    _ = knm_number:delete(Normalized, Options),
+                    Context
+            end;
+        {'error', _R} ->
+            lager:debug("unable to fetch mdn ~s for removal: ~p", [Normalized, _R]),
+            Context
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec get_mdn(cb_context:context()) -> api_binary().
+get_mdn(Context) ->
+    case cb_context:req_value(Context, ?KEY_MOBILE_MDN) of
+        'undefined' ->
+            wh_json:get_ne_value(?KEY_MOBILE_MDN, cb_context:fetch(Context, 'db_doc'));
+        MDN -> MDN
+    end.
+
+-spec has_mdn_changed(cb_context:context()) -> boolean().
+has_mdn_changed(Context) ->
+    NewMDN = cb_context:req_value(Context, ?KEY_MOBILE_MDN),
+    case wh_json:get_ne_value(?KEY_MOBILE_MDN, cb_context:fetch(Context, 'db_doc')) of
+        'undefined' -> 'true';
+        OldMDN -> knm_converters:normalize(NewMDN) =/=
+                      knm_converters:normalize(OldMDN)
+    end.

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -476,6 +476,7 @@ delete(Context, ?COLLECTION) ->
     set_response({'ok', Results}, <<>>, Context);
 delete(Context, Number) ->
     Options = [{'auth_by', cb_context:auth_account_id(Context)}
+               ,{'dry_run', not cb_context:accepting_charges(Context)}
               ],
     Result = knm_number:delete(Number, Options),
     set_response(Result, Number, Context).
@@ -940,6 +941,7 @@ identify(Context, Number) ->
 -spec read(cb_context:context(), ne_binary()) -> cb_context:context().
 read(Context, Number) ->
     Options = [{'auth_by', cb_context:auth_account_id(Context)}
+               ,{'dry_run', not cb_context:accepting_charges(Context)}
               ],
     Result = case knm_number:get(Number, Options) of
                  {'ok', KNum} -> {'ok', knm_number:to_public_json(KNum)};
@@ -1162,6 +1164,7 @@ number_action(Context, Number, ?HTTP_POST) ->
     knm_number:update(Number, [{fun knm_phone_number:update_doc/2, ToMerge}], Options);
 number_action(Context, Number, ?HTTP_DELETE) ->
     Options = [{'auth_by', cb_context:auth_account_id(Context)}
+               ,{'dry_run', not cb_context:accepting_charges(Context)}
               ],
     knm_number:delete(Number, Options).
 

--- a/core/kazoo_number_manager/src/converters/knm_converter_regex.erl
+++ b/core/kazoo_number_manager/src/converters/knm_converter_regex.erl
@@ -35,19 +35,19 @@
 %%--------------------------------------------------------------------
 -spec normalize(ne_binary()) ->
                        ne_binary().
-normalize(<<_/binary>> = Num) ->
+normalize(?NE_BINARY = Num) ->
     to_e164(Num).
 
 -spec normalize(ne_binary(), api_binary()) ->
                        ne_binary().
-normalize(<<_/binary>> = Num, 'undefined') ->
+normalize(?NE_BINARY = Num, 'undefined') ->
     to_e164(Num);
-normalize(<<_/binary>> = Num, AccountId) ->
+normalize(?NE_BINARY = Num, AccountId) ->
     to_e164(Num, AccountId).
 
 -spec normalize(ne_binary(), ne_binary(), wh_json:object()) ->
                        ne_binary().
-normalize(<<_/binary>> = Num, AccountId, DialPlan) ->
+normalize(?NE_BINARY = Num, AccountId, DialPlan) ->
     to_e164_from_account_dialplan(Num, AccountId, DialPlan).
 
 %%--------------------------------------------------------------------
@@ -84,13 +84,13 @@ to_1npan(Num) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec to_e164(ne_binary()) -> ne_binary().
-to_e164(<<$+, _/binary>> = N) -> N;
+to_e164(<<"+",_/binary>> = N) -> N;
 to_e164(Number) ->
     Converters = get_e164_converters(),
     Regexes = wh_json:get_keys(Converters),
     maybe_convert_to_e164(Regexes, Converters, Number).
 
-to_e164(<<$+, _/binary>> = N, _AccountId) -> N;
+to_e164(<<"+",_/binary>> = N, _AccountId) -> N;
 to_e164(Number, Account) ->
     AccountId = wh_util:format_account_id(Account, 'raw'),
     case kz_account:fetch(AccountId) of
@@ -101,7 +101,7 @@ to_e164(Number, Account) ->
     end.
 
 -spec to_e164_from_account(ne_binary(), ne_binary()) -> ne_binary().
-to_e164_from_account(Number, <<_/binary>> = AccountId) ->
+to_e164_from_account(Number, ?NE_BINARY = AccountId) ->
     Converters = get_e164_converters(AccountId),
     Regexes = wh_json:get_keys(Converters),
     maybe_convert_to_e164(Regexes, Converters, Number).

--- a/core/kazoo_number_manager/src/converters/knm_converters.erl
+++ b/core/kazoo_number_manager/src/converters/knm_converters.erl
@@ -297,7 +297,7 @@ get_classifier_regex(JObj) ->
 %%--------------------------------------------------------------------
 -spec correct_depreciated_classifiers(wh_json:key(), wh_json:json_term(), wh_json:object()) ->
                                              wh_json:object().
-correct_depreciated_classifiers(Classifier, <<_/binary>> = Regex, JObj) ->
+correct_depreciated_classifiers(Classifier, ?NE_BINARY = Regex, JObj) ->
     J = wh_json:from_list([{<<"regex">>, Regex}
                            ,{<<"friendly_name">>, Classifier}
                           ]),

--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -411,7 +411,7 @@ save(Number) ->
 %% @public
 %% @doc
 %% Note: option 'assigned_to' needs to be non-empty
-%% Note: option 'auth_by' needs to be non-empty
+%% Note: option 'auth_by' should always be MasterAccountId
 %% @end
 %%--------------------------------------------------------------------
 -spec reconcile(ne_binary(), knm_number_options:options()) ->

--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -19,7 +19,7 @@
          ,lookup_account/1
          ,buy/2, buy/3
          ,save/1
-         ,reconcile/3
+         ,reconcile/2
          ,reserve/2
         ]).
 
@@ -106,6 +106,13 @@ new() -> #knm_number{}.
 is_number(#knm_number{}) -> 'true';
 is_number(_) -> 'false'.
 
+%%--------------------------------------------------------------------
+%% @public
+%% @doc Attempts to get a number from DB.
+%% Note: Number parameter has to be normalized.
+%% Note: get/1,2 should not throw, instead returns: {ok,_} | {error,_} | ...
+%% @end
+%%--------------------------------------------------------------------
 -spec get(ne_binary()) ->
                  knm_number_return().
 -spec get(ne_binary(), knm_number_options:options()) ->
@@ -163,14 +170,14 @@ ensure_state(PhoneNumber, ExpectedState) ->
     case knm_phone_number:state(PhoneNumber) of
         ExpectedState -> 'true';
         _State ->
+            lager:debug("wrong state: expected ~s, got ~s", [ExpectedState, _State]),
             knm_errors:number_exists(
               knm_phone_number:number(PhoneNumber)
              )
     end.
 
--spec create_phone_number(knm_number()) ->
-                                 knm_number() |
-                                 dry_run_return().
+-spec create_phone_number(knm_number()) -> knm_number() |
+                                           dry_run_return().
 create_phone_number(Number) ->
     ensure_state(phone_number(Number), ?NUMBER_STATE_AVAILABLE),
     Routines = [fun knm_number_states:to_reserved/1
@@ -281,18 +288,16 @@ ensure_number_is_not_porting(Num) ->
 
 -spec create_updaters(ne_binary(), knm_number_options:options()) ->
                              knm_phone_number:set_functions().
-create_updaters(<<_/binary>> = Num, Props) when is_list(Props) ->
+create_updaters(?NE_BINARY=Num, Props) when is_list(Props) ->
     NormalizedNum = knm_converters:normalize(Num),
-    NumberDb = knm_converters:to_db(NormalizedNum),
-
     props:filter_undefined(
       [{fun knm_phone_number:set_number/2, NormalizedNum}
-       ,{fun knm_phone_number:set_number_db/2, NumberDb}
+       ,{fun knm_phone_number:set_number_db/2, knm_converters:to_db(NormalizedNum)}
        ,{fun knm_phone_number:set_state/2
          ,knm_number_options:state(Props, ?NUMBER_STATE_AVAILABLE)
         }
        ,{fun knm_phone_number:set_ported_in/2
-         ,knm_number_options:ported_in(Props, 'false')
+         ,knm_number_options:ported_in(Props)
         }
        ,{fun knm_phone_number:set_assign_to/2
          ,knm_number_options:assign_to(Props)
@@ -301,7 +306,7 @@ create_updaters(<<_/binary>> = Num, Props) when is_list(Props) ->
          ,knm_number_options:auth_by(Props)
         }
        ,{fun knm_phone_number:set_dry_run/2
-         ,knm_number_options:dry_run(Props, 'false')
+         ,knm_number_options:dry_run(Props)
         }
        ,{fun knm_phone_number:set_module_name/2
          ,knm_number_options:module_name(Props, knm_carriers:default_carrier())
@@ -335,7 +340,7 @@ move(Num, MoveTo, Options) ->
 -spec move_to(knm_number:knm_number(), ne_binary()) ->
                      knm_number_return().
 move_to(Number, MoveTo) ->
-    AccountId = wh_util:format_account_id(MoveTo, 'raw'),
+    AccountId = wh_util:format_account_id(MoveTo),
     PhoneNumber = phone_number(Number),
     MovedPhoneNumber = knm_phone_number:set_assign_to(PhoneNumber, AccountId),
     MovedNumber = set_phone_number(Number, MovedPhoneNumber),
@@ -405,31 +410,38 @@ save(Number) ->
 %%--------------------------------------------------------------------
 %% @public
 %% @doc
+%% Note: option 'assigned_to' needs to be non-empty
+%% Note: option 'auth_by' needs to be non-empty
 %% @end
 %%--------------------------------------------------------------------
--spec reconcile(ne_binary(), ne_binary(), ne_binary()) ->
+-spec reconcile(ne_binary(), knm_number_options:options()) ->
                        knm_number_return().
-reconcile(DID, AssignTo, AuthBy) ->
+reconcile(DID, Options) ->
     case ?MODULE:get(DID) of
         {'ok', Number} ->
-            reconcile_number(Number, AssignTo, AuthBy);
+            reconcile_number(Number, Options);
         {'error', 'not_found'} ->
-            create(DID, [{'assigned_to', AssignTo}
-                         ,{'auth_by', AuthBy}
-                         ,{'state', ?NUMBER_STATE_IN_SERVICE}
-                        ]);
+            AssignedTo = knm_number_options:assigned_to(Options),
+            %% Ensures state to be IN_SERVICE
+            move(DID, AssignedTo, Options);
         {'error', _}=E -> E
     end.
 
-reconcile_number(Number, AssignTo, AuthBy) ->
+-spec reconcile_number(knm_number(), knm_number_options:options()) ->
+                              knm_number_return().
+reconcile_number(Number, Options) ->
     PhoneNumber = phone_number(Number),
-    Updaters = [{AssignTo
+    Updaters = [{knm_number_options:assigned_to(Options)
                  ,knm_phone_number:assigned_to(PhoneNumber)
                  ,fun knm_phone_number:set_assigned_to/2
                 }
-                ,{AuthBy
+                ,{knm_number_options:auth_by(Options)
                   ,knm_phone_number:auth_by(PhoneNumber)
                   ,fun knm_phone_number:set_auth_by/2
+                 }
+                ,{knm_number_options:public_fields(Options)
+                  ,knm_phone_number:doc(PhoneNumber)
+                  ,fun knm_phone_number:set_doc/2
                  }
                 ,{?NUMBER_STATE_IN_SERVICE
                   ,knm_phone_number:state(PhoneNumber)
@@ -968,7 +980,7 @@ attempt(Fun, Args) ->
 -spec num_to_did(api_binary() | knm_number() | knm_phone_number:knm_phone_number()) ->
                         api_binary().
 num_to_did('undefined') -> 'undefined';
-num_to_did(<<_/binary>> = DID) -> DID;
+num_to_did(?NE_BINARY = DID) -> DID;
 num_to_did(#knm_number{}=Number) ->
     num_to_did(phone_number(Number));
 num_to_did(PhoneNumber) ->

--- a/core/kazoo_number_manager/src/knm_number_states.erl
+++ b/core/kazoo_number_manager/src/knm_number_states.erl
@@ -28,7 +28,7 @@
                       kn().
 to_state(DID, ToState) ->
     to_state(DID, ToState, knm_number_options:default()).
-to_state(<<_/binary>> = DID, ToState, Options) ->
+to_state(?NE_BINARY = DID, ToState, Options) ->
     case knm_number:get(DID, Options) of
         {'error', E} -> knm_errors:unspecified(E, DID);
         {'ok', Number} -> change_state(Number, ToState)

--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -12,6 +12,7 @@
          ,create/1
          ,move/1 ,move/2
          ,update/1 ,update/2
+         ,reconcile/2
          ,delete/1 ,delete/2
          ,change_state/1 ,change_state/2
          ,assigned_to_app/1 ,assigned_to_app/2
@@ -33,14 +34,14 @@
                  numbers_return().
 -spec get(ne_binaries(), knm_number_options:options()) ->
                  numbers_return().
--spec get(ne_binaries(), knm_number_options:options(), numbers_return()) ->
-                 numbers_return().
 get(Nums) ->
     get(Nums, knm_number_options:default()).
 
 get(Nums, Options) ->
     get(Nums, Options, []).
 
+-spec get(ne_binaries(), knm_number_options:options(), numbers_return()) ->
+                 numbers_return().
 get([], _Options, Acc) -> Acc;
 get([Num|Nums], Options, Acc) ->
     Return = knm_number:get(Num, Options),
@@ -52,10 +53,10 @@ get([Num|Nums], Options, Acc) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec create(wh_proplist()) -> numbers_return().
--spec create(wh_proplist(), numbers_return()) -> numbers_return().
 create(Props) ->
     create(Props, []).
 
+-spec create(wh_proplist(), numbers_return()) -> numbers_return().
 create([], Acc) -> Acc;
 create([{Num, Data}|Props], Acc) ->
     Return = knm_number:create(Num, Data),
@@ -70,14 +71,14 @@ create([{Num, Data}|Props], Acc) ->
                   numbers_return().
 -spec move(wh_proplist(), knm_number_options:options()) ->
                   numbers_return().
--spec move(wh_proplist(), knm_number_options:options(), numbers_return()) ->
-                  numbers_return().
 move(Props) ->
     move(Props, knm_number_options:default()).
 
 move(Props, Options) ->
     move(Props, Options, []).
 
+-spec move(wh_proplist(), knm_number_options:options(), numbers_return()) ->
+                  numbers_return().
 move([], _Options, Acc) -> Acc;
 move([{Num, MoveTo}|Props], Options, Acc) ->
     Return = knm_number:move(Num, MoveTo, Options),
@@ -92,14 +93,14 @@ move([{Num, MoveTo}|Props], Options, Acc) ->
                     numbers_return().
 -spec update(wh_proplist(), knm_number_options:options()) ->
                     numbers_return().
--spec update(wh_proplist(), knm_number_options:options(), numbers_return()) ->
-                    numbers_return().
 update(Props) ->
     update(Props, knm_number_options:default()).
 
 update(Props, Options) ->
     update(Props, Options, []).
 
+-spec update(wh_proplist(), knm_number_options:options(), numbers_return()) ->
+                    numbers_return().
 update([], _Options, Acc) -> Acc;
 update([{Num, Data}|Props], Options, Acc) ->
     Return = knm_number:update(Num, Data, Options),
@@ -110,11 +111,26 @@ update([{Num, Data}|Props], Options, Acc) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+-spec reconcile(ne_binaries(), knm_number_options:options()) ->
+                       numbers_return().
+reconcile(Numbers, Options) ->
+    reconcile(Numbers, Options, []).
+
+-spec reconcile(ne_binaries(), knm_number_options:options(), numbers_return()) ->
+                       numbers_return().
+reconcile([], _Options, Acc) -> Acc;
+reconcile([Number|Numbers], Options, Acc) ->
+    Return = knm_number:reconcile(Number, Options),
+    reconcile(Numbers, Options, [{Number, Return}|Acc]).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
 -spec delete(ne_binaries()) ->
                     numbers_return().
 -spec delete(ne_binaries(), knm_number_options:options()) ->
-                    numbers_return().
--spec delete(ne_binaries(), knm_number_options:options(), numbers_return()) ->
                     numbers_return().
 delete(Props) ->
     delete(Props, knm_number_options:default()).
@@ -122,6 +138,8 @@ delete(Props) ->
 delete(Props, Options) ->
     delete(Props, Options, []).
 
+-spec delete(ne_binaries(), knm_number_options:options(), numbers_return()) ->
+                    numbers_return().
 delete([], _Options, Acc) -> Acc;
 delete([Num|Nums], Options, Acc) ->
     Return = knm_number:delete(Num, Options),
@@ -136,14 +154,14 @@ delete([Num|Nums], Options, Acc) ->
                           numbers_return().
 -spec change_state(wh_proplist(), knm_number_options:options()) ->
                           numbers_return().
--spec change_state(wh_proplist(), knm_number_options:options(), numbers_return()) ->
-                          numbers_return().
 change_state(Props) ->
     change_state(Props, knm_number_options:default()).
 
 change_state(Props, Options) ->
     change_state(Props, Options, []).
 
+-spec change_state(wh_proplist(), knm_number_options:options(), numbers_return()) ->
+                          numbers_return().
 change_state([], _Options, Acc) -> Acc;
 change_state([{Num, State}|Props], Options, Acc) ->
     try knm_number_states:to_state(Num, State, Options) of
@@ -162,14 +180,14 @@ change_state([{Num, State}|Props], Options, Acc) ->
                              numbers_return().
 -spec assigned_to_app(wh_proplist(), knm_number_options:options()) ->
                              numbers_return().
--spec assigned_to_app(wh_proplist(), knm_number_options:options(), numbers_return()) ->
-                             numbers_return().
 assigned_to_app(Props) ->
     assigned_to_app(Props, knm_number_options:default()).
 
 assigned_to_app(Props, Options) ->
     assigned_to_app(Props, Options, []).
 
+-spec assigned_to_app(wh_proplist(), knm_number_options:options(), numbers_return()) ->
+                             numbers_return().
 assigned_to_app([], _Options, Acc) -> Acc;
 assigned_to_app([{Num, App}|Props], Options, Acc) ->
     Return = knm_number:assign_to_app(Num, App, Options),

--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -65,7 +65,7 @@
                            ,auth_by :: api_binary()
                            ,dry_run = 'false' :: boolean()
                            ,locality :: wh_json:object()
-                           ,doc :: wh_json:object()
+                           ,doc = wh_json:new() :: wh_json:object()
                           }).
 -opaque knm_phone_number() :: #knm_phone_number{}.
 
@@ -90,15 +90,15 @@ new(DID) ->
 new(DID, Options) ->
     NormalizedNum = knm_converters:normalize(DID),
     NumberDb = knm_converters:to_db(NormalizedNum),
-
-    #knm_phone_number{number=NormalizedNum
-                     ,number_db=NumberDb
-                     ,assign_to=knm_number_options:assign_to(Options)
-                     ,state=?NUMBER_STATE_DISCOVERY
-                     ,module_name=?CARRIER_OTHER
-                     ,carrier_data=wh_json:new()
-                     ,auth_by=knm_number_options:auth_by(Options)
-                     ,dry_run=knm_number_options:dry_run(Options)
+    #knm_phone_number{number = NormalizedNum
+                     ,number_db = NumberDb
+                     ,assign_to = knm_number_options:assign_to(Options)
+                     ,state = ?NUMBER_STATE_DISCOVERY
+                     ,module_name = ?CARRIER_OTHER
+                     ,carrier_data = wh_json:new()
+                     ,auth_by = knm_number_options:auth_by(Options)
+                     ,dry_run = knm_number_options:dry_run(Options)
+                     ,doc = knm_number_options:public_fields(Options)
                      }.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
"Cherry pick" of #1693 

**Potential problem**: `reconcile` will actually create/move number to set its state as IN_SERVICE instead of  using `create` with this state parameter (because that is not how `create` is able to be used as).
However, during `reconcile` there will be requests made to phonebook and I am unsure that's the intent of reconcile. Maybe @jamesaimonetti or @k-anderson can tune in?