### PR TITLE
CB-METRICS: add basic metrics per request

### DIFF
--- a/core/whistle/Makefile
+++ b/core/whistle/Makefile
@@ -17,6 +17,9 @@ all: compile
 
 include $(ROOT)/make/kz.mk
 
+proper: ERLC_OPTS += -DPROPER
+proper: compile-test test
+
 clean-generated:
 	$(if $(wildcard src/kz_mime.erl), rm src/kz_mime.erl)
 

--- a/core/whistle/include/wh_types.hrl
+++ b/core/whistle/include/wh_types.hrl
@@ -14,6 +14,11 @@
 -define(SECONDS_IN_WEEK, 604800).
 -define(SECONDS_IN_YEAR, 31540000).
 
+-define(BYTES_K, 1024).
+-define(BYTES_M, 1048576).
+-define(BYTES_G, 1073741824).
+-define(BYTES_T, 1099511627776).
+
 -define(ANY_DIGIT, [<<"1">>, <<"2">>, <<"3">>
                     ,<<"4">>, <<"5">>, <<"6">>
                     ,<<"7">>, <<"8">>, <<"9">>

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,7 +1,7 @@
 DEPS = lager eiconv gen_smtp amqp_client cowboy jesse jiffy certifi couchbeam wsock zucchini \
        erlsom erlydtl exml escalus folsom detergent erlang_localtime \
        nklib nksip gproc poolboy syslog lager_syslog eflame socketio hep ecsv reloader \
-	proper
+	proper recon
 
 dep_escalus = hex 2.6.4
 dep_exml = git https://github.com/paulgray/exml 2.2.1

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,6 +1,7 @@
 DEPS = lager eiconv gen_smtp amqp_client cowboy jesse jiffy certifi couchbeam wsock zucchini \
        erlsom erlydtl exml escalus folsom detergent erlang_localtime \
-       nklib nksip gproc poolboy syslog lager_syslog eflame socketio hep ecsv reloader
+       nklib nksip gproc poolboy syslog lager_syslog eflame socketio hep ecsv reloader \
+	proper
 
 dep_escalus = hex 2.6.4
 dep_exml = git https://github.com/paulgray/exml 2.2.1

--- a/make/kz.mk
+++ b/make/kz.mk
@@ -12,7 +12,7 @@ ERLC_OPTS += -Werror +warn_export_all +warn_unused_import +warn_unused_vars
 ELIBS = $(ERL_LIBS):$(ROOT)/deps:$(ROOT)/core
 EBINS += $(ROOT)/core/whistle/ebin \
 	     $(ROOT)/deps/lager/ebin
-TEST_EBINS += $(EBINS)
+TEST_EBINS += $(EBINS) $(ROOT)/deps/proper/ebin
 PA      = -pa ebin/ $(foreach EBIN,$(EBINS),-pa $(EBIN))
 TEST_PA = -pa ebin/ $(foreach EBIN,$(TEST_EBINS),-pa $(EBIN))
 


### PR DESCRIPTION
Tracks memory usage and binary allocations for each request, in addition to time spent.