### PR TITLE
KAZOO-4657

### DIFF
--- a/core/kazoo_web/src/kz_http.erl
+++ b/core/kazoo_web/src/kz_http.erl
@@ -245,7 +245,7 @@ maybe_basic_auth(Headers, Options) ->
     case props:get_value('basic_auth', Options) of
         'undefined' -> {Headers, Options};
         {Username, Password} ->
-            AuthString = "Basic " ++ base64:encode_to_string(<<Username/binary, ":", Password/binary>>),
+            AuthString = "Basic " ++ base64:encode_to_string(<<(wh_util:to_binary(Username))/binary, ":", (wh_util:to_binary(Password))/binary>>),
             BasicAuth = {"Authorization", AuthString},
             {[BasicAuth|Headers], props:delete('basic_auth', Options)}
     end.


### PR DESCRIPTION
braintree_request uses get_string: 
-define(BT_DEFAULT_PUBLIC_KEY, whapps_config:get_string(<<"braintree">>, <<"default_public_key">>, <<>>)) 

But kz_http:maybe_basic_auth/2 waits for binaries: base64:encode_to_string(< < Username/binary, ":", Password/binary > >)

We possibly can just concatenate strings: base64:encode_to_string(Username ++ ":" ++ Password), but who knows whether somewhere binaries still used..