### PR TITLE
KAZOO-4657: braintree_request/kz_http binary to string vars change

### DIFF
--- a/core/braintree/src/braintree_request.erl
+++ b/core/braintree/src/braintree_request.erl
@@ -17,10 +17,10 @@
 
 -type http_verb() :: 'put' | 'post' | 'get' | 'delete'.
 
--define(BT_DEFAULT_ENVIRONMENT, whapps_config:get_string(<<"braintree">>, <<"default_environment">>, <<>>)).
--define(BT_DEFAULT_MERCHANT_ID, whapps_config:get_string(<<"braintree">>, <<"default_merchant_id">>, <<>>)).
--define(BT_DEFAULT_PUBLIC_KEY, whapps_config:get_string(<<"braintree">>, <<"default_public_key">>, <<>>)).
--define(BT_DEFAULT_PRIVATE_KEY, whapps_config:get_string(<<"braintree">>, <<"default_private_key">>, <<>>)).
+-define(BT_DEFAULT_ENVIRONMENT, whapps_config:get_string(<<"braintree">>, <<"default_environment">>, [])).
+-define(BT_DEFAULT_MERCHANT_ID, whapps_config:get_string(<<"braintree">>, <<"default_merchant_id">>, [])).
+-define(BT_DEFAULT_PUBLIC_KEY, whapps_config:get_binary(<<"braintree">>, <<"default_public_key">>, <<>>)).
+-define(BT_DEFAULT_PRIVATE_KEY, whapps_config:get_binary(<<"braintree">>, <<"default_private_key">>, <<>>)).
 
 %%--------------------------------------------------------------------
 %% @public


### PR DESCRIPTION
Attempt #2

http:maybe_basic_auth/2 still waits for binaries: 

AuthString = "Basic " ++ base64:encode_to_string(<<Username/binary, ":", Password/binary>>), 