### PR TITLE
HELP-21582 use System-Log-ID instead of Call-ID

### DIFF
--- a/core/whistle-1.0.0/include/wh_api.hrl
+++ b/core/whistle-1.0.0/include/wh_api.hrl
@@ -48,6 +48,7 @@
 -define(KEY_MSG_REPLY_ID, <<"Msg-Reply-ID">>).
 -define(KEY_NODE, <<"Node">>).
 -define(KEY_SERVER_ID, <<"Server-ID">>).
+-define(KEY_LOG_ID, <<"System-Log-ID">>).
 
 %% Default Headers
 %% All messages MUST include the DEFAULT_HEADERS list.
@@ -60,7 +61,7 @@
 -define(OPTIONAL_DEFAULT_HEADERS, [<<"Raw-Headers">>, <<"Destination-Server">>
                                    ,<<"Geo-Location">>, <<"Access-Group">>
                                    ,?KEY_NODE, ?KEY_SERVER_ID
-                                   ,<<"Defer-Response">>
+                                   ,<<"Defer-Response">>, ?KEY_LOG_ID
                                   ]).
 -define(DEFAULT_VALUES, [{?KEY_NODE, wh_util:to_binary(node())}
                          ,{?KEY_MSG_ID, wh_util:rand_hex_binary(16)}

--- a/core/whistle-1.0.0/src/wh_util.erl
+++ b/core/whistle-1.0.0/src/wh_util.erl
@@ -130,6 +130,7 @@
 -include_lib("whistle/include/wh_types.hrl").
 -include_lib("whistle/include/wh_log.hrl").
 -include_lib("whistle/include/wh_databases.hrl").
+-include_lib("whistle/include/wh_api.hrl").
 
 -define(WHISTLE_VERSION_CACHE_KEY, {?MODULE, 'whistle_version'}).
 
@@ -612,9 +613,9 @@ put_callid(JObj) -> erlang:put('callid', callid(JObj)).
 get_callid() -> erlang:get('callid').
 
 callid(Prop) when is_list(Prop) ->
-    props:get_first_defined([<<"Call-ID">>, <<"Msg-ID">>], Prop, ?LOG_SYSTEM_ID);
+    props:get_first_defined([?KEY_LOG_ID, <<"Call-ID">>, ?KEY_MSG_ID], Prop, ?LOG_SYSTEM_ID);
 callid(JObj) ->
-    wh_json:get_first_defined([<<"Call-ID">>, <<"Msg-ID">>], JObj, ?LOG_SYSTEM_ID).
+    wh_json:get_first_defined([?KEY_LOG_ID, <<"Call-ID">>, ?KEY_MSG_ID], JObj, ?LOG_SYSTEM_ID).
 
 %% @public
 -spec spawn(fun(() -> any())) -> pid().

--- a/core/whistle_amqp-1.0.0/src/amqp_util.hrl
+++ b/core/whistle_amqp-1.0.0/src/amqp_util.hrl
@@ -3,6 +3,7 @@
 -include_lib("whistle/include/wh_amqp.hrl").
 -include_lib("whistle/include/wh_types.hrl").
 -include_lib("whistle/include/wh_log.hrl").
+-include_lib("whistle/include/wh_api.hrl").
 
 -define(AMQP_UTIL_HRL, 'true').
 -endif.

--- a/core/whistle_amqp-1.0.0/src/wh_amqp_worker.erl
+++ b/core/whistle_amqp-1.0.0/src/wh_amqp_worker.erl
@@ -458,8 +458,8 @@ send_request(CallId, Self, PublishFun, ReqProps)
   when is_function(PublishFun, 1) ->
     wh_util:put_callid(CallId),
     Props = props:insert_values(
-              [{<<"Server-ID">>, Self}
-               | maybe_send_call_id(CallId)
+              [{?KEY_SERVER_ID, Self}
+               ,{?KEY_LOG_ID, CallId}
               ]
               ,props:filter(fun request_proplist_filter/1, ReqProps)
              ),
@@ -468,12 +468,6 @@ send_request(CallId, Self, PublishFun, ReqProps)
     catch
         _:E -> {'error', E}
     end.
-
--spec maybe_send_call_id(api_binary()) -> wh_proplist().
-maybe_send_call_id('undefined') -> [];
-maybe_send_call_id(?LOG_SYSTEM_ID) -> [];
-maybe_send_call_id(CallId) ->
-    [{<<"Call-ID">>, CallId}].
 
 -spec request_proplist_filter({wh_proplist_key(), wh_proplist_value()}) -> boolean().
 request_proplist_filter({<<"Server-ID">>, Value}) ->


### PR DESCRIPTION
api calls that have Call-ID as optional header will still get the Call-ID.
this fixes it by using System-Log-ID instead