### PR TITLE
for-debian: add `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ test: ACTION = test
 test: ERLC_OPTS += -DPROPER
 test: $(KAZOODIRS)
 
+check: ERLC_OPTS += -DPROPER
+check: compile-test eunit clean-kazoo kazoo
+
 clean-deps:
 	$(if $(wildcard deps/), $(MAKE) -C deps/ clean)
 	$(if $(wildcard deps/), rm -r deps/)


### PR DESCRIPTION
Note: the `clean-kazoo kazoo` part can be removed iff the deb has already been built: `compile-test` recompiles kazoo with test flags on, meaning you get a whole different kazoo!