### PR TITLE
use-funs: use wh_util:identity/1

### DIFF
--- a/applications/crossbar/src/modules/cb_simple_authz.erl
+++ b/applications/crossbar/src/modules/cb_simple_authz.erl
@@ -159,6 +159,6 @@ allowed_if_sys_admin_mod(IsSysAdmin, Context) ->
 -spec is_sys_admin_mod(cb_context:context()) -> boolean().
 is_sys_admin_mod(Context) ->
     Nouns = cb_context:req_nouns(Context),
-    lists:any(fun(E) -> E end
+    lists:any(fun wh_util:identity/1
               ,[props:get_value(Mod, Nouns) =/= 'undefined' || Mod <- ?SYS_ADMIN_MODS]
              ).

--- a/core/kazoo_bindings/test/kazoo_bindings_test.erl
+++ b/core/kazoo_bindings/test/kazoo_bindings_test.erl
@@ -90,7 +90,7 @@ prop_expands() ->
     ?FORALL(Paths
             ,expanded_paths(),
             ?WHENFAIL(io:format("Failed on ~p~n", [Paths])
-                      ,lists:all(fun(X) -> X end, %% checks if all true
+                      ,lists:all(fun wh_util:identity/1,
                                  [binding_matches(Pattern, Expanded) =:= Expected
                                   || {Pattern, Expanded, Expected} <- Paths
                                  ])


### PR DESCRIPTION
Found with `git grep -InE 'fun\s*\(([^,]+)\)\s*\->\s*\1\s*end'`

Thinking about adding such a command as a CI check.. Or an elvis rule, if elvis' datastructure wasn't that much of a pain