### PR TITLE
HELP-22210: kz_cache backport to 3.22

### DIFF
--- a/core/whistle-1.0.0/Makefile
+++ b/core/whistle-1.0.0/Makefile
@@ -3,6 +3,8 @@ ROOT = ../..
 
 EBINS = $(shell find $(ROOT)/deps/lager-* -maxdepth 2 -name ebin -print) \
 	$(shell find $(ROOT)/core/whistle-* -maxdepth 2 -name ebin -print) \
+	$(shell find $(ROOT)/core/whistle_couch-* -maxdepth 2 -name ebin -print) \
+	$(shell find $(ROOT)/deps/couchbeam-* -maxdepth 2 -name ebin -print) \
 	$(shell find $(ROOT)/deps/rabbitmq_client-* -maxdepth 2 -name ebin -print)
 PA = $(foreach EBIN,$(EBINS),-pa $(EBIN))
 

--- a/core/whistle-1.0.0/src/kz_tracers.erl
+++ b/core/whistle-1.0.0/src/kz_tracers.erl
@@ -14,6 +14,7 @@ add_trace(Pid) ->
 add_trace(Pid, CollectFor) ->
     spawn(fun() ->
                   io:format("started trace for ~p in ~p~n", [Pid, self()]),
+                  dbg:stop_clear(),
                   BinFile = wh_util:to_list(<<"/home/james/eflame.trace">>),
                   eflame2:write_trace('global_calls_plus_new_procs'
                                      ,BinFile
@@ -32,7 +33,12 @@ gen_load(N) ->
     wait_for_refs(Start, {0, 'ok'}, PidRefs).
 
 wait_for_refs(Start, MaxMailbox, []) ->
-    io:format("finished test after ~pms: ~p~n", [wh_util:elapsed_ms(Start), MaxMailbox]);
+    case cache_data() of
+        [{message_queue_len, 0} | _] ->
+            io:format("finished test after ~pms: ~p~n", [wh_util:elapsed_ms(Start), MaxMailbox]);
+        _ -> timer:sleep(1000),
+             wait_for_refs(Start, MaxMailbox, [])
+    end;
 wait_for_refs(Start, {M, G}, [{Pid, Ref}|R]=PRs) ->
     receive
         {'DOWN', Ref, 'process', Pid, _Reason} ->
@@ -42,7 +48,7 @@ wait_for_refs(Start, {M, G}, [{Pid, Ref}|R]=PRs) ->
                 [{message_queue_len, N}
                  ,{current_function, F}
                 ] when N > M ->
-                    cache_status(Start),
+                    io:format("new max message queue size ~p (~p)~n", [N, F]),
                     wait_for_refs(Start, {N, F}, PRs);
                 _ ->
                     wait_for_refs(Start, {M, G}, PRs)
@@ -50,13 +56,12 @@ wait_for_refs(Start, {M, G}, [{Pid, Ref}|R]=PRs) ->
     end.
 
 do_load_gen(1) ->
-    add_trace(whereis(whistle_couch_cache)),
+    %% add_trace(whereis(whistle_couch_cache)),
     do_load_gen();
 do_load_gen(_) ->
     do_load_gen().
 
 do_load_gen() ->
-    Start = os:timestamp(),
     AccountId = wh_util:rand_hex_binary(16),
     AccountDb = wh_util:format_account_db(AccountId),
     'true' = couch_mgr:db_create(AccountDb),
@@ -64,31 +69,35 @@ do_load_gen() ->
     io:format("building ~p~n", [AccountDb]),
 
     Docs = [new_doc(AccountDb, Doc) || Doc <- lists:seq(1,1000)],
-    {'ok', Saved} = couch_mgr:save_docs(AccountDb, Docs),
-    _Result = (catch do_stuff_to_docs(Start, AccountDb, Saved)),
+
+    Start = os:timestamp(),
+
+    _Result = (catch do_stuff_to_docs(Start, AccountDb, Docs)),
     couch_mgr:db_delete(AccountDb),
     io:format("deleted ~s~nafter ~p~n", [AccountDb, _Result]).
 
 new_doc(AccountDb, Ref) ->
-    wh_doc:update_pvt_parameters(
-      wh_json:from_list([{<<"_id">>, wh_util:rand_hex_binary(16)}
-                        ,{<<"ref">>, Ref}
-                        ,{<<"pvt_type">>, <<"load_test">>}
-                         | [{wh_util:rand_hex_binary(8)
-                             ,wh_util:rand_hex_binary(8)
-                            }
-                            || _ <- lists:seq(1, 12)
-                           ]
-                        ])
-                                ,AccountDb
-     ).
+    Doc = wh_doc:update_pvt_parameters(
+            wh_json:from_list([{<<"_id">>, wh_util:rand_hex_binary(16)}
+                              ,{<<"ref">>, Ref}
+                              ,{<<"pvt_type">>, <<"load_test">>}
+                               | [{wh_util:rand_hex_binary(8)
+                                  ,wh_util:rand_hex_binary(8)
+                                  }
+                                  || _ <- lists:seq(1, 12)
+                                 ]
+                              ])
+                                      ,AccountDb
+           ),
+    {'ok', Saved} = couch_mgr:save_doc(AccountDb, Doc),
+    {'ok', _Loaded} = couch_mgr:open_cache_doc(AccountDb, wh_doc:id(Saved)),
+    Saved.
 
 do_stuff_to_docs(Start, _AccountDb, []) ->
     wait_for_cache(Start);
 do_stuff_to_docs(Start, AccountDb, Docs) ->
     cache_status(Start),
     Ops = [{op(), Doc} || Doc <- Docs],
-    io:format("doing stuff to ~p docs~n", [length(Docs)]),
     perform_ops(Start, AccountDb, Ops).
 
 perform_ops(Start, AccountDb, Ops) ->
@@ -113,23 +122,29 @@ cache_data() ->
                        ).
 
 wait_for_cache(Start) ->
+    wait_for_cache(Start, {0, 'ok'}).
+
+wait_for_cache(Start, {N, F}) ->
     case cache_data() of
+        [{message_queue_len, M}
+         ,{current_function, G}
+        ] when M > N ->
+            io:format("~p new max msg queue size ~p (~p)~n", [Start, M, G]),
+            timer:sleep(1000),
+            wait_for_cache(Start, {M, G});
         [{message_queue_len, 0}
-         ,{current_function, _F}
+        ,{current_function, _F}
         ] ->
             io:format("~pms done (in ~p)~n", [wh_util:elapsed_ms(Start), _F]);
-        [{message_queue_len, Len}
-         ,{current_function, F}
-        ] ->
-            io:format("~pms msg left ~p in ~p~n", [wh_util:elapsed_ms(Start), Len, F]),
+        _ ->
             timer:sleep(1000),
-            wait_for_cache(Start)
+            wait_for_cache(Start, {N, F})
     end.
 
 perform_op({'edit', Doc}, Acc, AccountDb) ->
     Inc = wh_json:get_integer_value(<<"inc">>, Doc, 0),
     Edited = wh_json:set_value(<<"inc">>, Inc+1, Doc),
-    {'ok', Saved} = couch_mgr:ensure_saved(AccountDb, Edited),
+    {'ok', Saved} = couch_mgr:save_doc(AccountDb, Edited),
     {'ok', _Loaded} = couch_mgr:open_cache_doc(AccountDb, wh_doc:id(Saved)),
     [Saved | Acc];
 perform_op({'delete', Doc}, Acc, AccountDb) ->

--- a/core/whistle-1.0.0/src/kz_tracers.erl
+++ b/core/whistle-1.0.0/src/kz_tracers.erl
@@ -1,0 +1,141 @@
+-module(kz_tracers).
+
+%% To generate the flame.svg:
+%% flamegraph.riak-color.pl is found in the eflame dep folder
+%% cat /path/to/eflame.trace.out | grep -v 'SLEEP' | ./flamegraph.riak-color.pl > /var/www/html/flame.svg
+
+-export([add_trace/1, add_trace/2
+         ,gen_load/1
+        ]).
+
+add_trace(Pid) ->
+    add_trace(Pid, 100*1000).
+
+add_trace(Pid, CollectFor) ->
+    spawn(fun() ->
+                  io:format("started trace for ~p in ~p~n", [Pid, self()]),
+                  BinFile = wh_util:to_list(<<"/home/james/eflame.trace">>),
+                  eflame2:write_trace('global_calls_plus_new_procs'
+                                     ,BinFile
+                                     ,Pid
+                                     ,CollectFor
+                                     ),
+                  io:format("trace for ~p done~n", [Pid]),
+                  eflame2:format_trace(BinFile, BinFile ++ ".out"),
+                  io:format("trace formatted to ~s.out~n", [BinFile])
+          end),
+    'ok'.
+
+gen_load(N) ->
+    Start = os:timestamp(),
+    PidRefs = [spawn_monitor(fun() -> do_load_gen(X) end) || X <- lists:seq(1, N)],
+    wait_for_refs(Start, PidRefs).
+
+wait_for_refs(Start, []) ->
+    io:format("finished test after ~pms", [wh_util:elapsed_ms(Start)]);
+wait_for_refs(Start, [{Pid, Ref}|R]=PRs) ->
+    receive
+        {'DOWN', Ref, 'process', Pid, _Reason} ->
+            wait_for_refs(Start, R)
+    after 1000 ->
+            cache_status(Start),
+            wait_for_refs(Start, PRs)
+    end.
+
+do_load_gen(1) ->
+    add_trace(whereis(whistle_couch_cache)),
+    do_load_gen();
+do_load_gen(_) ->
+    do_load_gen().
+
+do_load_gen() ->
+    Start = os:timestamp(),
+    AccountId = wh_util:rand_hex_binary(16),
+    AccountDb = wh_util:format_account_db(AccountId),
+    'true' = couch_mgr:db_create(AccountDb),
+
+    io:format("building ~p~n", [AccountDb]),
+
+    Docs = [new_doc(AccountDb, Doc) || Doc <- lists:seq(1,1000)],
+    {'ok', Saved} = couch_mgr:save_docs(AccountDb, Docs),
+    _Result = (catch do_stuff_to_docs(Start, AccountDb, Saved)),
+    couch_mgr:db_delete(AccountDb),
+    io:format("deleted ~s~nafter ~p~n", [AccountDb, _Result]).
+
+new_doc(AccountDb, Ref) ->
+    wh_doc:update_pvt_parameters(
+      wh_json:from_list([{<<"_id">>, wh_util:rand_hex_binary(16)}
+                        ,{<<"ref">>, Ref}
+                        ,{<<"pvt_type">>, <<"load_test">>}
+                         | [{wh_util:rand_hex_binary(8)
+                             ,wh_util:rand_hex_binary(8)
+                            }
+                            || _ <- lists:seq(1, 12)
+                           ]
+                        ])
+                                ,AccountDb
+     ).
+
+do_stuff_to_docs(Start, _AccountDb, []) ->
+    wait_for_cache(Start);
+do_stuff_to_docs(Start, AccountDb, Docs) ->
+    cache_status(Start),
+    Ops = [{op(), Doc} || Doc <- Docs],
+    io:format("doing stuff to ~p docs~n", [length(Docs)]),
+    perform_ops(Start, AccountDb, Ops).
+
+perform_ops(Start, AccountDb, Ops) ->
+    do_stuff_to_docs(Start
+                    ,AccountDb
+                    ,lists:foldl(fun(Op, Acc) -> perform_op(Op, Acc, AccountDb) end
+                                ,[]
+                                ,Ops
+                                )
+                    ).
+
+cache_status(Start) ->
+    io:format("~p proc info: ~p~n"
+             ,[wh_util:elapsed_ms(Start)
+              ,erlang:process_info(whereis(whistle_couch_cache)
+                                  ,[message_queue_len, current_function]
+                                  )
+              ]
+             ).
+
+wait_for_cache(Start) ->
+    case erlang:process_info(whereis(whistle_couch_cache)
+                            ,[message_queue_len
+                             ,current_function
+                             ]
+                            )
+    of
+        [{message_queue_len, 0}
+         ,{current_function, _F}
+        ] ->
+            io:format("~pms done (in ~p)~n", [wh_util:elapsed_ms(Start), _F]);
+        [{message_queue_len, Len}
+         ,{current_function, F}
+        ] ->
+            io:format("~pms msg left ~p in ~p~n", [wh_util:elapsed_ms(Start), Len, F]),
+            timer:sleep(1000),
+            wait_for_cache(Start)
+    end.
+
+perform_op({'edit', Doc}, Acc, AccountDb) ->
+    Inc = wh_json:get_integer_value(<<"inc">>, Doc, 0),
+    Edited = wh_json:set_value(<<"inc">>, Inc+1, Doc),
+    {'ok', Saved} = couch_mgr:ensure_saved(AccountDb, Edited),
+    {'ok', _Loaded} = couch_mgr:open_cache_doc(AccountDb, wh_doc:id(Saved)),
+    [Saved | Acc];
+perform_op({'delete', Doc}, Acc, AccountDb) ->
+    couch_mgr:del_doc(AccountDb, Doc),
+    Acc;
+perform_op({'noop', Doc}, Acc, _AccountDb) ->
+    [Doc | Acc].
+
+op() ->
+    case random:uniform(3) of
+        1 -> 'edit';
+        2 -> 'delete';
+        3 -> 'noop'
+    end.

--- a/core/whistle-1.0.0/src/kz_tracers.erl
+++ b/core/whistle-1.0.0/src/kz_tracers.erl
@@ -96,7 +96,6 @@ new_doc(AccountDb, Ref) ->
 do_stuff_to_docs(Start, _AccountDb, []) ->
     wait_for_cache(Start);
 do_stuff_to_docs(Start, AccountDb, Docs) ->
-    cache_status(Start),
     Ops = [{op(), Doc} || Doc <- Docs],
     perform_ops(Start, AccountDb, Ops).
 
@@ -108,13 +107,6 @@ perform_ops(Start, AccountDb, Ops) ->
                                 ,Ops
                                 )
                     ).
-
-cache_status(Start) ->
-    io:format("~p proc info: ~p~n"
-             ,[wh_util:elapsed_ms(Start)
-              ,cache_data()
-              ]
-             ).
 
 cache_data() ->
     erlang:process_info(whereis(whistle_couch_cache)

--- a/deps/eflame/.gitignore
+++ b/deps/eflame/.gitignore
@@ -1,0 +1,5 @@
+*~
+ebin/*
+*.svg
+*.out
+erl_crash.dump

--- a/deps/eflame/LICENSE
+++ b/deps/eflame/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2014 Vladimir Kirillov <proger@hackndev.com>
+Copyright (c) 2014 Scott Lystig Fritchie <slfritchie@snookles.com>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/deps/eflame/Makefile
+++ b/deps/eflame/Makefile
@@ -1,0 +1,42 @@
+PROJECT = eflame
+ROOT = ../..
+
+ERLC_OPTS = +debug_info
+
+DIRS =  .
+
+.PHONY: all compile clean
+
+all: compile
+
+MODULES = $(shell ls src/*.erl | sed 's/src\///;s/\.erl/,/' | sed '$$s/.$$//')
+
+compile: ebin/$(PROJECT).app
+	@cat src/$(PROJECT).app.src \
+		| sed 's/{modules, \[\]}/{modules, \[$(MODULES)\]}/' \
+		> ebin/$(PROJECT).app
+	-@$(MAKE) ebin/$(PROJECT).app
+
+ebin/$(PROJECT).app: src/*.erl
+	@mkdir -p ebin/
+	erlc -v $(ERLC_OPTS) -o ebin/ -pa ebin/ $?
+
+compile-test: test/$(PROJECT).app
+	@cat src/$(PROJECT).app.src \
+		| sed 's/{modules, \[\]}/{modules, \[$(MODULES)\]}/' \
+		> test/$(PROJECT).app
+	-@$(MAKE) test/$(PROJECT).app
+
+test/$(PROJECT).app: src/*.erl
+	@mkdir -p test/
+	erlc -v $(ERLC_OPTS)  -o test/ -pa test/  $?
+
+clean:
+	rm -f ebin/*
+	rm -f test/*.beam test/$(PROJECT).app
+	rm -f erl_crash.dump
+
+test: clean compile-test eunit
+
+eunit: compile-test
+	erl -noshell -pa test -eval "eunit:test([$(MODULES)], [verbose])" -s init stop

--- a/deps/eflame/README-Riak-Example.md
+++ b/deps/eflame/README-Riak-Example.md
@@ -1,0 +1,202 @@
+
+# A detailed example of investigations using flame graphs and Riak
+
+In our very first example, as described in
+[README.md](README.md), we generated a flame graph for all Riak
+processes that were executing during:
+
+* A time window of 10 seconds
+* We ran 25 Riak `get` requests while inside the measurement time window
+
+... and we got something that looks like this:
+
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.0.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.0.png"></a>
+
+Wow, that's impossible to read without zooming in via the SVG version
+of the image.  (Remember that the SVG versions of flame graphs are
+"zoomable".  Click on the PNG image of any flame graph in this
+document to fetch the SVG version of that image.)
+
+## Strip out Erlang process sleeping/descheduled time
+
+However, we know that the flame graphs are colored with "SLEEP" time
+as a purple bar at the top of the stack.  We can use this command to
+strip out all Erlang process sleep time and create a new graph:
+
+    cat /tmp/ef.test.0.out | grep -v 'SLEEP ' | \
+        ./flamegraph.riak-color.pl > /tmp/output.0.nosleep.svg
+
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.1.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.1.png"></a>
+
+Now we can see a few PIDs near the bottom: `0.1333.0` and `0.28843.0`
+and so on.  But this is still too cluttered: there are over 150 Erlang
+processes in this graph, with stacks for each process presented
+**separately**.
+
+## Collapse stacks for different processes
+
+What happens if we both:
+
+* ignore sleep time, and
+* collapse same stacks in different processes?
+
+Let's try it.
+
+    cat /tmp/ef.test.0.out | grep -v 'SLEEP ' | sed 's/^[^;]*;//' | \
+        ./flamegraph.riak-color.pl > /tmp/output.0.nosleep-nopid.svg
+
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.2.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.2.png"></a>
+
+Now we can see several sets of related activities!  Going from left to
+right:
+
+1. (All in orange) Miscellaneous OTP processes
+2. (With green, on top of `gen_fsm:handle_msg/7`) Riak KV get FSM
+   process activity intermixed with Riak Core vnode activity.
+   The Riak vnode also uses the `gen_fsm` behavior, so the stacks for
+   these very dissimilar-acting processes are collapsed to the same
+   base of `gen_fsm:handle_msg/7` near the bottom of their call stacks.
+3. (With green, on top of `gen_server:handle_msg/5`) Riak Core and KV
+   vnode process activity.
+4. (On top of `riak_core_stat_cache:'-do_get_stats/2-fun-0-'/4`) Riak
+   Core and KV statistics processing (both for the get FSM activity and
+   also for OS stats monitoring).
+5. (On top of `shell:eval_loop/3`) Activity related to the Riak
+   console and the Erlang REPL shell.
+
+## Look at a single process
+
+Let's look at a single process.  We are interested in Riak KV vnode
+processes that are executing Bitcask code.  So, if we use
+`grep bitcask /tmp/ef.test.0.out`, we see that PID `0.450.0` has a lot
+of activity.  Let's see what that PID alone is doing.
+
+    cat /tmp/ef.test.0.out | egrep '0\.450\.0' | \
+        ./flamegraph.riak-color.pl > /tmp/output.0.only-450.svg
+
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.3.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.3.png"></a>
+
+Oops, that process is sleeping, mostly.  Let's ignore the sleep time
+also.
+
+    cat /tmp/ef.test.0.out | egrep '0\.450\.0' | grep -v 'SLEEP ' | \
+        ./flamegraph.riak-color.pl > /tmp/output.0.only-450-nosleep.svg
+
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.4.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.4.png"></a>
+
+Now we have a nice breakdown for what a Riak KV vnode process is doing
+while under our workload.  Our workload only performs get operations,
+so it should be no surprise that we do not see any put or delete
+activity.
+
+Also, during the 10 seconds that we were profiling, this process was
+asked to check its backend status.  Since this Riak cluster is using
+Bitcask, we see the Bitcask-related activity for handling the status
+request(s).
+
+## Let's make a code change and see how the graphs change.
+
+Let's assume that we've done some work, altering the behavior of the
+Riak system's get operation.  We have altered both the client side
+(i.e., the get FSM process) and also the server side (the vnode
+process).  Performance of the new code is terrible.  Why?
+
+Let's try to find out.  We cut-and-paste this single blob into the
+Riak console shell:
+
+   spawn(fun() ->
+       io:format("Tracing started...\n"),
+       eflame2:write_trace(like_fprof, "/tmp/ef.test.1", all, timer, sleep, [10*1000]),
+       io:format("Tracing finished!\n")
+    end).
+    
+    timer:sleep(1000).
+    f(C).
+    {ok, C} = riak:local_client().
+    [C:get(<<"test bucket">>, <<Key:32>>) || Key <- lists:seq(1, 25)].
+
+Then process the trace:
+
+    eflame2:format_trace("/tmp/ef.test.1", "/tmp/ef.test.1.out").
+    %% ... wait for the trace to finish generating the text output ...
+
+Then we create the SVGs by using a couple of extra flags for the Perl
+script: `--hash` and `--seed`.  This forces the color choices to be
+the same for functions with exactly the same name ... the sameness
+makes it easier to see differences in two graphs.
+
+    cat /tmp/ef.test.0.out | egrep '0\.450\.0' | grep -v 'SLEEP ' | \
+        ./flamegraph.riak-color.pl --seed 42 --hash > /tmp/output.0.only-450-nosleep.svg
+    cat /tmp/ef.test.1.out | egrep '0\.450\.0' | grep -v 'SLEEP ' | \
+        ./flamegraph.riak-color.pl --seed 42 --hash > /tmp/output.1.only-450-nosleep.svg
+
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.10.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.10.png"></a>
+<br>
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.11.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.11.png"></a>
+
+Oops, our profiling the first time (in the `/tmp/ef.test.0.out` file)
+caught some `riak_kv_vnode:handle_command/3` activity that the second
+version does not.  Let's remove those call stack entries and compare
+again.
+
+    cat /tmp/ef.test.0.out | egrep '0\.450\.0' | grep -v riak_kv_vnode:handle_command/3 | grep -v 'SLEEP ' | \
+        ./flamegraph.riak-color.pl --seed 42 --hash > /tmp/output.0.only-450-nosleep.svg
+
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.12.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.12.png"></a>
+<br>
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.11.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.11.png"></a>
+
+Hrrrmmmm, those graphs are pretty similar.  Very similar.  Perhaps
+within the normal & typical range of individual runs.  We could try to
+continue by:
+
+1. Performing 10 or more runs of each type, before & after our patch.
+   Then see how much variation there is in each graph.
+2. Look at other parts of the system that also changed with our patch.
+   Perhaps the real problem is not in the vnode code at all!
+3. Let's try one more quick experiment: try looking at the flame
+   graphs, before & after the patch, but **include** the sleep time.
+
+The commands to generate the SVGs:
+
+    cat /tmp/ef.test.0.out | egrep '0\.450\.0' | grep -v riak_kv_vnode:handle_command/3 | \
+        ./flamegraph.riak-color.pl --seed 42 --hash > /tmp/output.0.only-450.svg
+    cat /tmp/ef.test.1.out | egrep '0\.450\.0' | \
+        ./flamegraph.riak-color.pl --seed 42 --hash > /tmp/output.1.only-450.svg
+
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.13.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.13.png"></a>
+<br>
+<a href="http://www.snookles.com/scotttmp/eflame2/riak.14.svg"><img src="http://www.snookles.com/scotttmp/eflame2/riak.14.png"></a>
+
+**YES!** There's a big difference now.  After our patch, the bottom
+half clearly shows that there's an extra function that is forcing the
+vnode to go to sleep during `riak_core_vnode:vnode_command/3` work!
+
+What is that change that we made?  This is an artificial example, but
+here's the main reason for the difference: a call to a new function,
+`riak_kv_vnode:do_alternate_processing/1`, included a 'receive' clause
+that waits for some optional data.
+
+    diff --git a/src/riak_kv_vnode.erl b/src/riak_kv_vnode.erl
+    index 80e2a50..6d7b287 100644
+    --- a/src/riak_kv_vnode.erl
+    +++ b/src/riak_kv_vnode.erl
+    @@ -1913,6 +1914,14 @@ uses_r_object(Mod, ModState, Bucket) ->
+         {ok, Capabilities} = Mod:capabilities(Bucket, ModState),
+         lists:member(uses_r_object, Capabilities).
+     
+    +do_alternate_processing(S) ->
+    +    receive
+    +        {extra_mod_state, Stuff} ->
+    +            S#state{modstate=Stuff}
+    +    after 20 ->
+    +        S
+    +    end.
+    +
+     -ifdef(TEST).
+     
+     %% Check assigning a vnodeid twice in the same second
+
+The `after 20` clause is the reason why the process is put to sleep by
+the VM's scheduler.  And the flame graph makes this extra sleep very
+obvious to the programmer's eye.

--- a/deps/eflame/README.md
+++ b/deps/eflame/README.md
@@ -1,0 +1,236 @@
+## eflame
+
+[Flame Graphs](http://dtrace.org/blogs/brendan/2011/12/16/flame-graphs/) for Erlang.  Uses `erlang:trace/3` API.
+
+![screenshot](http://i.imgur.com/XIDAcd3.png)
+
+
+
+## eflame2: Experimental variations of Vlad Ki's original eflame
+
+[Vlad Ki](https://github.com/proger/) wrote (and is still maintaining)
+the original
+[eflame](https://github.com/proger/eflame) source.  Its API focuses on
+ease-of-use for profiling a single function call in a single process.
+
+[Scott Lystig Fritchie](https://github.com/slfritchie/ uses Vlad's
+work as a base for several experiments.
+
+1. Generate flame graph data for multi-process systems, e.g.
+the [Riak](https://github.com/basho/riak database.  Such flame graphs
+can give analysis on a process-by-process basis.
+
+2. Generate flame graph data based on experimental Erlang VM (virtual
+machine) tracing changes.  When using a custom-patched Erlang VM, each
+function trace event requires much less CPU to generate stack trace
+information.
+
+3. Generate flame graph data based on an experimental Erlang VM change
+to support time-sampling, e.g. stack traces that are generated every
+100 milliseconds.  Time sampling, which is the base technique for
+tools such as
+(gprof)[http://en.wikipedia.org/wiki/Gprof] and by
+(DTrace stack() and ustack())[http://en.wikipedia.org/wiki/DTrace],
+have very low overhead when compared to the Erlang VM's function call
+tracing.  (This method also requires a custom-patched Erlang VM.)
+
+## Example usage
+
+Let's assume that we wish to trace all processes (including all
+processes that may be `spawn()`ed in the future inside of Riak for 10
+seconds.  The Riak server is under only a moderate workload, but this
+method can easily create 1 GByte or more of trace data, beware!
+
+### Step 0: Compile eflame and copy BEAM files to the target system.
+
+Compile the source with:
+
+    erlc -o ebin src/*erl
+
+Next, copy `eflame.beam` and `eflame2.beam` to someplace accessible
+on the target Riak machine, such as `/tmp`.  Then run this command (and
+all of the following commands in this example) on the Riak console:
+
+   code:add_pathz("/tmp").
+
+### Step 0: Whenever you need a quick reference guide
+
+Run the function `eflame2:help()` for a quick reference guide,
+whenever you need it.
+
+### Step 1: Start a workload, then start eflame2 tracing.
+
+Get your workload running.  In this example, we're using Riak.  The
+workload could be a
+[basho_bench](https://github.com/basho/basho_bench) test or
+something much simpler.  Riak has got a large amount of background
+activity, so we want to make it pretty obvious that some work is being
+performed.
+
+Whatever the workload is that you wish to profile, start it.  Then,
+while the load is still running, use this command to capture 10
+seconds of activity by all processes:
+
+   spawn(fun() ->
+       io:format("Tracing started...\n"),
+       eflame2:write_trace(global_calls_plus_new_procs, "/tmp/ef.test.0", all, 10*1000),
+       io:format("Tracing finished!\n")
+    end).
+
+For this example, we're going to do something very simple for our workload.
+
+    {ok, C} = riak:local_client().
+    [C:get(<<"test bucket">>, <<Key:32>>) || Key <- lists:seq(1, 25)].
+
+We recommend that you choose a different output file for each test
+run; the 2nd argument names the output file.
+
+The 3rd argument specifies which Erlang processes to trace.  Valid
+`PidSpec` types for this argument are:
+
+    'all' | 'existing' | 'new' | pid() | [pid()]
+
+### Step 2: Format the binary trace data into text call stack output.
+
+Run this:
+
+   eflame2:format_trace("/tmp/ef.test.0", "/tmp/ef.test.0.out").
+
+This function can take several seconds to finish processing a 30 MByte
+input file, so please be patient.  The output will look something like
+the following -- please wait until you see the "finished" message!
+
+    Hello, world, I'm <0.1771.0> and I'm running....
+    <0.1333.0> <0.180.0> <0.181.0> <0.182.0> <0.183.0> <0.184.0> <0.185.0> <0.186.0> <0.187.0> <0.188.0> <0.189.0> <0.190.0> <0.191.0> <0.192.0> <0.193.0> <0.194.0> <0.195.0> <0.177.0> <0.1509.0> <0.1510.0> <0.178.0> <0.373.0> <0.1511.0> <0.375.0> <0.1512.0> <0.377.0> <0.1513.0> <0.1514.0> <0.380.0> <0.1515.0> <0.382.0> <0.1516.0> <0.225.0> <0.243.0> <0.259.0> <0.254.0> <0.247.0> <0.242.0> <0.258.0> <0.246.0> <0.245.0> <0.244.0> <0.256.0> <0.257.0> <0.270.0> <0.265.0> <0.269.0> <0.271.0> <0.253.0> <0.240.0> <0.241.0> <0.263.0> <0.268.0> <0.264.0> <0.251.0> <0.266.0> <0.252.0> <0.239.0> <0.255.0> <0.267.0> <0.92.0> <0.91.0> <0.1517.0> <0.352.0> <0.351.0> <0.145.0> <0.1518.0> <0.1520.0> <0.1519.0> <0.385.0> <0.103.0> <0.104.0> <0.1521.0> <0.102.0>
+    
+    Writing to /tmp/ef.test.0.out for 76 processes... finished           
+
+The output file, the 2nd argument, will look something like this:
+
+    (0.1515.0);riak_core_stat_calc_proc:'-do_calc_stat/1-fun-0-'/2;folsom_metrics:ge
+    t_metric_value/1 28
+    (0.1515.0);riak_core_stat_q:calc_stat/1 36
+    (0.1515.0);riak_core_stat_calc_proc:'-do_calc_stat/1-fun-0-'/2 20
+    (0.1515.0);erlang:apply/2 16
+    (0.251.0);proc_lib:init_p_do_apply/3;gen_server:loop/6;gen_server:loop/6;gen_server:loop/6;SLEEP 0
+    (0.251.0);proc_lib:init_p_do_apply/3;gen_server:loop/6;gen_server:loop/6 48
+    (0.251.0);proc_lib:init_p_do_apply/3;gen_server:loop/6;gen_server:loop/6;SLEEP 1201677
+    (0.251.0);proc_lib:init_p_do_apply/3;gen_server:handle_common_reply/6 35
+    (0.251.0);proc_lib:init_p_do_apply/3;gen_server:handle_msg/5 38
+
+Each trace sample is a single text line.  Each line is a collection of
+items separated by a semicolon: the first item is the Erlang PID that
+generated the trace event, and all other items are the Erlang function
+names on the call stack at that time.
+
+Step 3 (optional): Massage the call stack output into something more convenient
+
+Perhaps you are only interested in a single process's activity.  If
+that's true, then don't use the `all` PidSpec in step #1: specify the
+single pid directly in the call to `eflame2:write_trace()`.
+
+However, if you don't know exactly what process that you're interested
+in, the `all` PidSpec can be very useful.  The `all` PidSpec can
+generate a huge amount of data and create a very cluttered flame
+graph.
+
+The SVG output is "click and zoom'able" when viewed inside of a Web
+browser such as Firefox or Safari.  When you click on any flame graph
+box (which represents an Erlang process or an Erlang function inside
+of a call stack), all other call stacks will be excluded.  Use the
+"Reset Zoom" button in the upper left corner to reset the zoome state.
+
+Once you've identified a specific PID to examine more closely, you can
+use a command like this to filter out all other PIDs:
+
+    egrep ".0\.251\.0.;" /tmp/ef.test.0.out > /tmp/ef.test.0.out.only-0.329.0
+
+... and then use the filtered file in step #4 below.  The result will be
+
+Step 4: Convert text call stack output to SVG.
+
+   cat /tmp/ef.test.0.out | ./flamegraph.riak-color.pl > output.svg
+
+Then open the `output.svg` file using an SVG-aware application, e.g.
+Firefox.
+
+**NOTE**: The output of `eflame2` **does not require** processing by
+the `stack_to_flame.sh` script.
+
+Step 5: Variations of step #4
+
+Only pids <0.1102.0> and <0.1104.0> ... note that the "<>" characters
+in the PID do *not* appear in the output:
+
+   egrep '0\.1102\.0|0\.1104\.0' /tmp/ef.test.0.out | \
+       ./flamegraph.riak-color.pl > output.svg
+
+Only pids <0.1102.0> and <0.1104.0> and also removing sleep time:
+
+   egrep '0\.1102\.0|0\.1104\.0' /tmp/ef.test.0.out | \
+       grep -v 'SLEEP ' | \
+       ./flamegraph.riak-color.pl > output.svg
+
+Other examples are available in the 'More Examples' section below.
+
+Step 6: Follow the tutorial in [README-Riak-Example.md](README-Riak-Example.md).
+
+----------------
+----------------
+----------------
+
+## Vlad's original README text (from here to end of file)
+
+Usage example: https://github.com/proger/active/commit/81e7e40c9dc5a4666742636ea4c5dfafc41508a5
+
+```erlang
+> eflame:apply(normal_with_children, "stacks.out", my_module, awesome_calculation, []).
+> eflame:apply(my_module, awesome_calculation, []). % same as above
+> eflame:apply(normal, "stacks.out", my_module, awesome_calculation, []). % won't trace children
+```
+
+```sh
+$ stack_to_flame.sh < stacks.out > flame.svg
+$ open flame.svg
+```
+
+### Notes
+
+* as stacks are collected through tracing, blocking calls are noticed and are drawn in blue
+
+* unlike the reference implementation, `flamegraph.pl` does not sort the input to preserve the order of calls
+  (since this is possible due to current method of collecting stacks)
+
+```sh
+$ grep 0.90.0 stacks.out | deps/eflame/flamegraph.pl > flame.svg
+
+# this invocation draws a separate flame graph for each traced process
+$ for pid in $(cat stacks.out | awk -F';' '{print $1}' | uniq | tr -d '<>'); do
+    grep $pid stacks.out | deps/eflame/flamegraph.pl --title="$pid" > flame_$pid.svg;
+done
+
+# you may also use stacks_to_flames.sh (uses zsh)
+$ deps/eflame/stacks_to_flames.sh stacks.out
+```
+
+### More examples
+
+Of course you can also apply a bazillion of transformations to get a more understandable stack, for example:
+
+```sh
+$ grep 0.90.0 stacks.out | sort | uniq -c | sort -n -k1 | sort -k2 | awk '{print $2, "", $1}' > stacks.90
+$ perl -pi -e 's#eflame:apply/5;rebar_core:process_commands/2;##' stacks.90
+$ perl -pi -e 's#rebar_core:execute/.;##g' stacks.90
+$ perl -pi -e 's#rebar_core:process_dir.?/.;##g' stacks.90
+$ perl -pi -e 's#rebar_core:process_each/.;##g' stacks.90
+$ perl -pi -e 's#rebar_core:run_modules\w*/.;##g' stacks.90
+$ perl -pi -e 's#lists:\w+/.;##g' stacks.90
+$ perl -pi -e 's#/\d+;#;#g' stacks.90
+$ perl -pi -e 's#io_lib_pretty:[^;]+;##g' stacks.90
+$ cat stacks.90 | sort -k1 | deps/eflame/flamegraph.pl --width=1430 > flame.svg
+```
+
+The following picture is a cleaned flame graph for a run of `rebar compile` (using [active](https://github.com/proger/active))
+on a project with 15 dependencies where all files are already compiled:
+
+![rebar compile cleaned flame graph](http://i.imgur.com/hLXx7LO.png)

--- a/deps/eflame/eflame.d
+++ b/deps/eflame/eflame.d
@@ -1,0 +1,2 @@
+
+COMPILE_FIRST +=

--- a/deps/eflame/flamegraph.pl
+++ b/deps/eflame/flamegraph.pl
@@ -1,0 +1,846 @@
+#!/usr/bin/perl -w
+#
+# flamegraph.pl		flame stack grapher.
+#
+# This takes stack samples and renders a call graph, allowing hot functions
+# and codepaths to be quickly identified.  Stack samples can be generated using
+# tools such as DTrace, perf, SystemTap, and Instruments.
+#
+# USAGE: ./flamegraph.pl [options] input.txt > graph.svg
+#
+#        grep funcA input.txt | ./flamegraph.pl [options] > graph.svg
+#
+# Options are listed in the usage message (--help).
+#
+# The input is stack frames and sample counts formatted as single lines.  Each
+# frame in the stack is semicolon separated, with a space and count at the end
+# of the line.  These can be generated using DTrace with stackcollapse.pl,
+# and other tools using the stackcollapse variants.
+#
+# An optional extra column of counts can be provided to generate a differential
+# flame graph of the counts, colored red for more, and blue for less.  This
+# can be useful when using flame graphs for non-regression testing.
+# See the header comment in the difffolded.pl program for instructions.
+#
+# The output graph shows relative presence of functions in stack samples.  The
+# ordering on the x-axis has no meaning; since the data is samples, time order
+# of events is not known.  The order used sorts function names alphabetically.
+#
+# While intended to process stack samples, this can also process stack traces.
+# For example, tracing stacks for memory allocation, or resource usage.  You
+# can use --title to set the title to reflect the content, and --countname
+# to change "samples" to "bytes" etc.
+#
+# There are a few different palettes, selectable using --color.  By default,
+# the colors are selected at random (except for differentials).  Functions
+# called "-" will be printed gray, which can be used for stack separators (eg,
+# between user and kernel stacks).
+#
+# HISTORY
+#
+# This was inspired by Neelakanth Nadgir's excellent function_call_graph.rb
+# program, which visualized function entry and return trace events.  As Neel
+# wrote: "The output displayed is inspired by Roch's CallStackAnalyzer which
+# was in turn inspired by the work on vftrace by Jan Boerhout".  See:
+# https://blogs.oracle.com/realneel/entry/visualizing_callstacks_via_dtrace_and
+#
+# Copyright 2011 Joyent, Inc.  All rights reserved.
+# Copyright 2011 Brendan Gregg.  All rights reserved.
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at docs/cddl1.txt or
+# http://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at docs/cddl1.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# 21-Nov-2013   Shawn Sterling  Added consistent palette file option
+# 17-Mar-2013   Tim Bunce       Added options and more tunables.
+# 15-Dec-2011	Dave Pacheco	Support for frames with whitespace.
+# 10-Sep-2011	Brendan Gregg	Created this.
+
+use strict;
+
+use Getopt::Long;
+
+# tunables
+my $encoding;
+my $fonttype = "Verdana";
+my $imagewidth = 1200;          # max width, pixels
+my $frameheight = 16;           # max height is dynamic
+my $fontsize = 12;              # base text size
+my $fontwidth = 0.59;           # avg width relative to fontsize
+my $minwidth = 0.1;             # min function width, pixels
+my $nametype = "Function:";     # what are the names in the data?
+my $countname = "samples";      # what are the counts in the data?
+my $colors = "hot";             # color theme
+my $bgcolor1 = "#eeeeee";       # background color gradient start
+my $bgcolor2 = "#eeeeb0";       # background color gradient stop
+my $nameattrfile;               # file holding function attributes
+my $timemax;                    # (override the) sum of the counts
+my $factor = 1;                 # factor to scale counts by
+my $hash = 0;                   # color by function name
+my $palette = 0;                # if we use consistent palettes (default off)
+my %palette_map;                # palette map hash
+my $pal_file = "palette.map";   # palette map file name
+my $stackreverse = 0;           # reverse stack order, switching merge end
+my $inverted = 0;               # icicle graph
+my $negate = 0;                 # switch differential hues
+my $titletext = "";             # centered heading
+my $titledefault = "Flame Graph";	# overwritten by --title
+my $titleinverted = "Icicle Graph";	#   "    "
+
+GetOptions(
+	'fonttype=s'  => \$fonttype,
+	'width=i'     => \$imagewidth,
+	'height=i'    => \$frameheight,
+	'encoding=s'  => \$encoding,
+	'fontsize=f'  => \$fontsize,
+	'fontwidth=f' => \$fontwidth,
+	'minwidth=f'  => \$minwidth,
+	'title=s'     => \$titletext,
+	'nametype=s'  => \$nametype,
+	'countname=s' => \$countname,
+	'nameattr=s'  => \$nameattrfile,
+	'total=s'     => \$timemax,
+	'factor=f'    => \$factor,
+	'colors=s'    => \$colors,
+	'hash'        => \$hash,
+	'cp'          => \$palette,
+	'reverse'     => \$stackreverse,
+	'inverted'    => \$inverted,
+	'negate'      => \$negate,
+) or die <<USAGE_END;
+USAGE: $0 [options] infile > outfile.svg\n
+	--title       # change title text
+	--width       # width of image (default 1200)
+	--height      # height of each frame (default 16)
+	--minwidth    # omit smaller functions (default 0.1 pixels)
+	--fonttype    # font type (default "Verdana")
+	--fontsize    # font size (default 12)
+	--countname   # count type label (default "samples")
+	--nametype    # name type label (default "Function:")
+	--colors      # set color palette. choices are: hot (default), mem, io,
+	              # java, js, red, green, blue, yellow, purple, orange
+	--hash        # colors are keyed by function name hash
+	--cp          # use consistent palette (palette.map)
+	--reverse     # generate stack-reversed flame graph
+	--inverted    # icicle graph
+	--negate      # switch differential hues (blue<->red)
+
+	eg,
+	$0 --title="Flame Graph: malloc()" trace.txt > graph.svg
+USAGE_END
+
+# internals
+my $ypad1 = $fontsize * 4;      # pad top, include title
+my $ypad2 = $fontsize * 2 + 10; # pad bottom, include labels
+my $xpad = 10;                  # pad lefm and right
+my $framepad = 1;		# vertical padding for frames
+my $depthmax = 0;
+my %Events;
+my %nameattr;
+
+if ($titletext eq "") {
+	unless ($inverted) {
+		$titletext = $titledefault;
+	} else {
+		$titletext = $titleinverted;
+	}
+}
+
+if ($nameattrfile) {
+	# The name-attribute file format is a function name followed by a tab then
+	# a sequence of tab separated name=value pairs.
+	open my $attrfh, $nameattrfile or die "Can't read $nameattrfile: $!\n";
+	while (<$attrfh>) {
+		chomp;
+		my ($funcname, $attrstr) = split /\t/, $_, 2;
+		die "Invalid format in $nameattrfile" unless defined $attrstr;
+		$nameattr{$funcname} = { map { split /=/, $_, 2 } split /\t/, $attrstr };
+	}
+}
+
+if ($colors eq "mem") { $bgcolor1 = "#eeeeee"; $bgcolor2 = "#e0e0ff"; }
+if ($colors eq "io")  { $bgcolor1 = "#f8f8f8"; $bgcolor2 = "#e8e8e8"; }
+
+# SVG functions
+{ package SVG;
+	sub new {
+		my $class = shift;
+		my $self = {};
+		bless ($self, $class);
+		return $self;
+	}
+
+	sub header {
+		my ($self, $w, $h) = @_;
+		my $enc_attr = '';
+		if (defined $encoding) {
+			$enc_attr = qq{ encoding="$encoding"};
+		}
+		$self->{svg} .= <<SVG;
+<?xml version="1.0"$enc_attr standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="$w" height="$h" onload="init(evt)" viewBox="0 0 $w $h" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+SVG
+	}
+
+	sub include {
+		my ($self, $content) = @_;
+		$self->{svg} .= $content;
+	}
+
+	sub colorAllocate {
+		my ($self, $r, $g, $b) = @_;
+		return "rgb($r,$g,$b)";
+	}
+
+	sub group_start {
+		my ($self, $attr) = @_;
+
+		my @g_attr = map {
+			exists $attr->{$_} ? sprintf(qq/$_="%s"/, $attr->{$_}) : ()
+		} qw(class style onmouseover onmouseout onclick);
+		push @g_attr, $attr->{g_extra} if $attr->{g_extra};
+		$self->{svg} .= sprintf qq/<g %s>\n/, join(' ', @g_attr);
+
+		$self->{svg} .= sprintf qq/<title>%s<\/title>/, $attr->{title}
+			if $attr->{title}; # should be first element within g container
+
+		if ($attr->{href}) {
+			my @a_attr;
+			push @a_attr, sprintf qq/xlink:href="%s"/, $attr->{href} if $attr->{href};
+			# default target=_top else links will open within SVG <object>
+			push @a_attr, sprintf qq/target="%s"/, $attr->{target} || "_top";
+			push @a_attr, $attr->{a_extra}                           if $attr->{a_extra};
+			$self->{svg} .= sprintf qq/<a %s>/, join(' ', @a_attr);
+		}
+	}
+
+	sub group_end {
+		my ($self, $attr) = @_;
+		$self->{svg} .= qq/<\/a>\n/ if $attr->{href};
+		$self->{svg} .= qq/<\/g>\n/;
+	}
+
+	sub filledRectangle {
+		my ($self, $x1, $y1, $x2, $y2, $fill, $extra) = @_;
+		$x1 = sprintf "%0.1f", $x1;
+		$x2 = sprintf "%0.1f", $x2;
+		my $w = sprintf "%0.1f", $x2 - $x1;
+		my $h = sprintf "%0.1f", $y2 - $y1;
+		$extra = defined $extra ? $extra : "";
+		$self->{svg} .= qq/<rect x="$x1" y="$y1" width="$w" height="$h" fill="$fill" $extra \/>\n/;
+	}
+
+	sub stringTTF {
+		my ($self, $color, $font, $size, $angle, $x, $y, $str, $loc, $extra) = @_;
+		$x = sprintf "%0.2f", $x;
+		$loc = defined $loc ? $loc : "left";
+		$extra = defined $extra ? $extra : "";
+		$self->{svg} .= qq/<text text-anchor="$loc" x="$x" y="$y" font-size="$size" font-family="$font" fill="$color" $extra >$str<\/text>\n/;
+	}
+
+	sub svg {
+		my $self = shift;
+		return "$self->{svg}</svg>\n";
+	}
+	1;
+}
+
+sub namehash {
+	# Generate a vector hash for the name string, weighting early over
+	# later characters. We want to pick the same colors for function
+	# names across different flame graphs.
+	my $name = shift;
+	my $vector = 0;
+	my $weight = 1;
+	my $max = 1;
+	my $mod = 10;
+	# if module name present, trunc to 1st char
+	$name =~ s/.(.*?)`//;
+	foreach my $c (split //, $name) {
+		my $i = (ord $c) % $mod;
+		$vector += ($i / ($mod++ - 1)) * $weight;
+		$max += 1 * $weight;
+		$weight *= 0.70;
+		last if $mod > 12;
+	}
+	return (1 - $vector / $max)
+}
+
+sub color {
+	my ($type, $hash, $name) = @_;
+	my ($v1, $v2, $v3);
+
+	if ($hash) {
+		$v1 = namehash($name);
+		$v2 = $v3 = namehash(scalar reverse $name);
+	} else {
+		$v1 = rand(1);
+		$v2 = rand(1);
+		$v3 = rand(1);
+	}
+
+	# theme palettes
+	if (defined $type and $type eq "hot") {
+		my $r = 205 + int(50 * $v3);
+		my $g = 0 + int(230 * $v1);
+		my $b = 0 + int(55 * $v2);
+		return "rgb($r,$g,$b)";
+	}
+	if (defined $type and $type eq "mem") {
+		my $r = 0;
+		my $g = 190 + int(50 * $v2);
+		my $b = 0 + int(210 * $v1);
+		return "rgb($r,$g,$b)";
+	}
+	if (defined $type and $type eq "io") {
+		my $r = 80 + int(60 * $v1);
+		my $g = $r;
+		my $b = 190 + int(55 * $v2);
+		return "rgb($r,$g,$b)";
+	}
+
+	# multi palettes
+	if (defined $type and $type eq "java") {
+		if ($name =~ /::/) {		# C++
+			$type = "yellow";
+		} elsif ($name =~ m:/:) {	# Java (match "/" in path)
+			$type = "green"
+		} else {			# system
+			$type = "red";
+		}
+		# fall-through to color palettes
+	}
+	if (defined $type and $type eq "js") {
+		if ($name =~ /::/) {		# C++
+			$type = "yellow";
+		} elsif ($name =~ m:/:) {	# JavaScript (match "/" in path)
+			$type = "green"
+		} elsif ($name =~ m/:/) {	# JavaScript (match ":" in builtin)
+			$type = "aqua"
+		} elsif ($name =~ m/^ $/) {	# Missing symbol
+			$type = "green"
+		} else {			# system
+			$type = "red";
+		}
+		# fall-through to color palettes
+	}
+
+	# color palettes
+	if (defined $type and $type eq "red") {
+		my $r = 200 + int(55 * $v1);
+		my $x = 50 + int(80 * $v1);
+		return "rgb($r,$x,$x)";
+	}
+	if (defined $type and $type eq "green") {
+		my $g = 200 + int(55 * $v1);
+		my $x = 50 + int(60 * $v1);
+		return "rgb($x,$g,$x)";
+	}
+	if (defined $type and $type eq "blue") {
+		my $b = 205 + int(50 * $v1);
+		my $x = 80 + int(60 * $v1);
+		return "rgb($x,$x,$b)";
+	}
+	if (defined $type and $type eq "yellow") {
+		my $x = 175 + int(55 * $v1);
+		my $b = 50 + int(20 * $v1);
+		return "rgb($x,$x,$b)";
+	}
+	if (defined $type and $type eq "purple") {
+		my $x = 190 + int(65 * $v1);
+		my $g = 80 + int(60 * $v1);
+		return "rgb($x,$g,$x)";
+	}
+	if (defined $type and $type eq "aqua") {
+		my $r = 50 + int(60 * $v1);
+		my $g = 165 + int(55 * $v1);
+		my $b = 165 + int(55 * $v1);
+		return "rgb($r,$g,$b)";
+	}
+	if (defined $type and $type eq "orange") {
+		my $r = 190 + int(65 * $v1);
+		my $g = 90 + int(65 * $v1);
+		return "rgb($r,$g,0)";
+	}
+
+	return "rgb(0,0,0)";
+}
+
+sub color_scale {
+	my ($value, $max) = @_;
+	my ($r, $g, $b) = (255, 255, 255);
+	$value = -$value if $negate;
+	if ($value > 0) {
+		$g = $b = int(210 * ($max - $value) / $max);
+	} elsif ($value < 0) {
+		$r = $g = int(210 * ($max + $value) / $max);
+	}
+	return "rgb($r,$g,$b)";
+}
+
+sub color_map {
+	my ($colors, $func) = @_;
+	if (exists $palette_map{$func}) {
+		return $palette_map{$func};
+	} else {
+		$palette_map{$func} = color($colors);
+		return $palette_map{$func};
+	}
+}
+
+sub write_palette {
+	open(FILE, ">$pal_file");
+	foreach my $key (sort keys %palette_map) {
+		print FILE $key."->".$palette_map{$key}."\n";
+	}
+	close(FILE);
+}
+
+sub read_palette {
+	if (-e $pal_file) {
+	open(FILE, $pal_file) or die "can't open file $pal_file: $!";
+	while ( my $line = <FILE>) {
+		chomp($line);
+		(my $key, my $value) = split("->",$line);
+		$palette_map{$key}=$value;
+	}
+	close(FILE)
+	}
+}
+
+my %Node;	# Hash of merged frame data
+my %Tmp;
+
+# flow() merges two stacks, storing the merged frames and value data in %Node.
+sub flow {
+	my ($last, $this, $v, $d) = @_;
+
+	my $len_a = @$last - 1;
+	my $len_b = @$this - 1;
+
+	my $i = 0;
+	my $len_same;
+	for (; $i <= $len_a; $i++) {
+		last if $i > $len_b;
+		last if $last->[$i] ne $this->[$i];
+	}
+	$len_same = $i;
+
+	for ($i = $len_a; $i >= $len_same; $i--) {
+		my $k = "$last->[$i];$i";
+		# a unique ID is constructed from "func;depth;etime";
+		# func-depth isn't unique, it may be repeated later.
+		$Node{"$k;$v"}->{stime} = delete $Tmp{$k}->{stime};
+		if (defined $Tmp{$k}->{delta}) {
+			$Node{"$k;$v"}->{delta} = delete $Tmp{$k}->{delta};
+		}
+		delete $Tmp{$k};
+	}
+
+	for ($i = $len_same; $i <= $len_b; $i++) {
+		my $k = "$this->[$i];$i";
+		$Tmp{$k}->{stime} = $v;
+		if (defined $d) {
+			$Tmp{$k}->{delta} += $i == $len_b ? $d : 0;
+		}
+	}
+
+        return $this;
+}
+
+# parse input
+my @Data;
+my $last = [];
+my $time = 0;
+my $delta = undef;
+my $ignored = 0;
+my $line;
+my $maxdelta = 1;
+
+# reverse if needed
+foreach (<>) {
+	chomp;
+	$line = $_;
+	if ($stackreverse) {
+		# there may be an extra samples column for differentials
+		# XXX todo: redo these REs as one. It's repeated below.
+		my ($stack, $samples) = (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+		my $samples2 = undef;
+		if ($stack =~ /^(.*)\s+?(\d+(?:\.\d*)?)$/) {
+			$samples2 = $samples;
+			($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+			unshift @Data, join(";", reverse split(";", $stack)) . " $samples $samples2";
+		} else {
+			unshift @Data, join(";", reverse split(";", $stack)) . " $samples";
+		}
+	} else {
+		unshift @Data, $line;
+	}
+}
+
+# process and merge frames
+foreach (sort @Data) {
+	chomp;
+	# process: folded_stack count
+	# eg: func_a;func_b;func_c 31
+	my ($stack, $samples) = (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+	unless (defined $samples and defined $stack) {
+		++$ignored;
+		next;
+	}
+
+	# there may be an extra samples column for differentials:
+	my $samples2 = undef;
+	if ($stack =~ /^(.*)\s+?(\d+(?:\.\d*)?)$/) {
+		$samples2 = $samples;
+		($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+	}
+	$delta = undef;
+	if (defined $samples2) {
+		$delta = $samples2 - $samples;
+		$maxdelta = abs($delta) if abs($delta) > $maxdelta;
+	}
+
+	$stack =~ tr/<>/()/;
+
+	# merge frames and populate %Node:
+	$last = flow($last, [ '', split ";", $stack ], $time, $delta);
+
+	if (defined $samples2) {
+		$time += $samples2;
+	} else {
+		$time += $samples;
+	}
+}
+flow($last, [], $time, $delta);
+
+warn "Ignored $ignored lines with invalid format\n" if $ignored;
+unless ($time) {
+	warn "ERROR: No stack counts found\n";
+	my $im = SVG->new();
+	# emit an error message SVG, for tools automating flamegraph use
+	my $imageheight = $fontsize * 5;
+	$im->header($imagewidth, $imageheight);
+	$im->stringTTF($im->colorAllocate(0, 0, 0), $fonttype, $fontsize + 2,
+	    0.0, int($imagewidth / 2), $fontsize * 2,
+	    "ERROR: No valid input provided to flamegraph.pl.", "middle");
+	print $im->svg;
+	exit 2;
+}
+if ($timemax and $timemax < $time) {
+	warn "Specified --total $timemax is less than actual total $time, so ignored\n"
+	if $timemax/$time > 0.02; # only warn is significant (e.g., not rounding etc)
+	undef $timemax;
+}
+$timemax ||= $time;
+
+my $widthpertime = ($imagewidth - 2 * $xpad) / $timemax;
+my $minwidth_time = $minwidth / $widthpertime;
+
+# prune blocks that are too narrow and determine max depth
+while (my ($id, $node) = each %Node) {
+	my ($func, $depth, $etime) = split ";", $id;
+	my $stime = $node->{stime};
+	die "missing start for $id" if not defined $stime;
+
+	if (($etime-$stime) < $minwidth_time) {
+		delete $Node{$id};
+		next;
+	}
+	$depthmax = $depth if $depth > $depthmax;
+}
+
+# draw canvas, and embed interactive JavaScript program
+my $imageheight = ($depthmax * $frameheight) + $ypad1 + $ypad2;
+my $im = SVG->new();
+$im->header($imagewidth, $imageheight);
+my $inc = <<INC;
+<defs >
+	<linearGradient id="background" y1="0" y2="1" x1="0" x2="0" >
+		<stop stop-color="$bgcolor1" offset="5%" />
+		<stop stop-color="$bgcolor2" offset="95%" />
+	</linearGradient>
+</defs>
+<style type="text/css">
+	.func_g:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+</style>
+<script type="text/ecmascript">
+<![CDATA[
+	var details, svg;
+	function init(evt) { 
+		details = document.getElementById("details").firstChild; 
+		svg = document.getElementsByTagName("svg")[0];
+	}
+	function s(info) { details.nodeValue = "$nametype " + info; }
+	function c() { details.nodeValue = ' '; }
+	function find_child(parent, name, attr) {
+		var children = parent.childNodes;
+		for (var i=0; i<children.length;i++) {
+			if (children[i].tagName == name)
+				return (attr != undefined) ? children[i].attributes[attr].value : children[i];
+		}
+		return;
+	}
+	function orig_save(e, attr, val) {
+		if (e.attributes["_orig_"+attr] != undefined) return;
+		if (e.attributes[attr] == undefined) return;
+		if (val == undefined) val = e.attributes[attr].value;
+		e.setAttribute("_orig_"+attr, val);
+	}
+	function orig_load(e, attr) {
+		if (e.attributes["_orig_"+attr] == undefined) return;
+		e.attributes[attr].value = e.attributes["_orig_"+attr].value;
+		e.removeAttribute("_orig_"+attr);
+	}
+	function update_text(e) {
+		var r = find_child(e, "rect");
+		var t = find_child(e, "text");
+		var w = parseFloat(r.attributes["width"].value) -3;
+		var txt = find_child(e, "title").textContent.replace(/\\([^(]*\\)/,"");
+		t.attributes["x"].value = parseFloat(r.attributes["x"].value) +3;
+		
+		// Smaller than this size won't fit anything
+		if (w < 2*$fontsize*$fontwidth) {
+			t.textContent = "";
+			return;
+		}
+		
+		t.textContent = txt;
+		// Fit in full text width
+		if (/^ *\$/.test(txt) || t.getSubStringLength(0, txt.length) < w)
+			return;
+		
+		for (var x=txt.length-2; x>0; x--) {
+			if (t.getSubStringLength(0, x+2) <= w) { 
+				t.textContent = txt.substring(0,x) + "..";
+				return;
+			}
+		}
+		t.textContent = "";
+	}
+	function zoom_reset(e) {
+		if (e.attributes != undefined) {
+			orig_load(e, "x");
+			orig_load(e, "width");
+		}
+		if (e.childNodes == undefined) return;
+		for(var i=0, c=e.childNodes; i<c.length; i++) {
+			zoom_reset(c[i]);
+		}
+	}
+	function zoom_child(e, x, ratio) {
+		if (e.attributes != undefined) {
+			if (e.attributes["x"] != undefined) {
+				orig_save(e, "x");
+				e.attributes["x"].value = (parseFloat(e.attributes["x"].value) - x - $xpad) * ratio + $xpad;
+				if(e.tagName == "text") e.attributes["x"].value = find_child(e.parentNode, "rect", "x") + 3;
+			}
+			if (e.attributes["width"] != undefined) {
+				orig_save(e, "width");
+				e.attributes["width"].value = parseFloat(e.attributes["width"].value) * ratio;
+			}
+		}
+		
+		if (e.childNodes == undefined) return;
+		for(var i=0, c=e.childNodes; i<c.length; i++) {
+			zoom_child(c[i], x-$xpad, ratio);
+		}
+	}
+	function zoom_parent(e) {
+		if (e.attributes) {
+			if (e.attributes["x"] != undefined) {
+				orig_save(e, "x");
+				e.attributes["x"].value = $xpad;
+			}
+			if (e.attributes["width"] != undefined) {
+				orig_save(e, "width");
+				e.attributes["width"].value = parseInt(svg.width.baseVal.value) - ($xpad*2);
+			}
+		}
+		if (e.childNodes == undefined) return;
+		for(var i=0, c=e.childNodes; i<c.length; i++) {
+			zoom_parent(c[i]);
+		}
+	}
+	function zoom(node) { 
+		var attr = find_child(node, "rect").attributes;
+		var width = parseFloat(attr["width"].value);
+		var xmin = parseFloat(attr["x"].value);
+		var xmax = parseFloat(xmin + width);
+		var ymin = parseFloat(attr["y"].value);
+		var ratio = (svg.width.baseVal.value - 2*$xpad) / width;
+		
+		// XXX: Workaround for JavaScript float issues (fix me)
+		var fudge = 0.0001;
+		
+		var unzoombtn = document.getElementById("unzoom");
+		unzoombtn.style["opacity"] = "1.0";
+		
+		var el = document.getElementsByTagName("g");
+		for(var i=0;i<el.length;i++){
+			var e = el[i];
+			var a = find_child(e, "rect").attributes;
+			var ex = parseFloat(a["x"].value);
+			var ew = parseFloat(a["width"].value);
+			// Is it an ancestor
+			if ($inverted == 0) {
+				var upstack = parseFloat(a["y"].value) > ymin;
+			} else {
+				var upstack = parseFloat(a["y"].value) < ymin;
+			}
+			if (upstack) {
+				// Direct ancestor
+				if (ex <= xmin && (ex+ew+fudge) >= xmax) {
+					e.style["opacity"] = "0.5";
+					zoom_parent(e);
+					e.onclick = function(e){unzoom(); zoom(this);};
+					update_text(e);
+				}
+				// not in current path
+				else
+					e.style["display"] = "none";
+			}
+			// Children maybe
+			else {
+				// no common path
+				if (ex < xmin || ex + fudge >= xmax) {
+					e.style["display"] = "none";
+				}
+				else {
+					zoom_child(e, xmin, ratio);
+					e.onclick = function(e){zoom(this);};
+					update_text(e);
+				}
+			}
+		}
+	}
+	function unzoom() {
+		var unzoombtn = document.getElementById("unzoom");
+		unzoombtn.style["opacity"] = "0.0";
+		
+		var el = document.getElementsByTagName("g");
+		for(i=0;i<el.length;i++) {
+			el[i].style["display"] = "block";
+			el[i].style["opacity"] = "1";
+			zoom_reset(el[i]);
+			update_text(el[i]);
+		}
+	}	
+]]>
+</script>
+INC
+$im->include($inc);
+$im->filledRectangle(0, 0, $imagewidth, $imageheight, 'url(#background)');
+my ($white, $black, $vvdgrey, $vdgrey) = (
+	$im->colorAllocate(255, 255, 255),
+	$im->colorAllocate(0, 0, 0),
+	$im->colorAllocate(40, 40, 40),
+	$im->colorAllocate(160, 160, 160),
+    );
+$im->stringTTF($black, $fonttype, $fontsize + 5, 0.0, int($imagewidth / 2), $fontsize * 2, $titletext, "middle");
+$im->stringTTF($black, $fonttype, $fontsize, 0.0, $xpad, $imageheight - ($ypad2 / 2), " ", "", 'id="details"');
+$im->stringTTF($black, $fonttype, $fontsize, 0.0, $xpad, $fontsize * 2,
+    "Reset Zoom", "", 'id="unzoom" onclick="unzoom()" style="opacity:0.0;cursor:pointer"');
+
+if ($palette) {
+	read_palette();
+}
+
+# draw frames
+while (my ($id, $node) = each %Node) {
+	my ($func, $depth, $etime) = split ";", $id;
+	my $stime = $node->{stime};
+	my $delta = $node->{delta};
+
+	$etime = $timemax if $func eq "" and $depth == 0;
+
+	my $x1 = $xpad + $stime * $widthpertime;
+	my $x2 = $xpad + $etime * $widthpertime;
+	my ($y1, $y2);
+	unless ($inverted) {
+		$y1 = $imageheight - $ypad2 - ($depth + 1) * $frameheight + $framepad;
+		$y2 = $imageheight - $ypad2 - $depth * $frameheight;
+	} else {
+		$y1 = $ypad1 + $depth * $frameheight;
+		$y2 = $ypad1 + ($depth + 1) * $frameheight - $framepad;
+	}
+
+	my $samples = sprintf "%.0f", ($etime - $stime) * $factor;
+	(my $samples_txt = $samples) # add commas per perlfaq5
+		=~ s/(^[-+]?\d+?(?=(?>(?:\d{3})+)(?!\d))|\G\d{3}(?=\d))/$1,/g;
+
+	my $info;
+	if ($func eq "" and $depth == 0) {
+		$info = "all ($samples_txt $countname, 100%)";
+	} else {
+		my $pct = sprintf "%.2f", ((100 * $samples) / ($timemax * $factor));
+		my $escaped_func = $func;
+		$escaped_func =~ s/&/&amp;/g;
+		$escaped_func =~ s/</&lt;/g;
+		$escaped_func =~ s/>/&gt;/g;
+		unless (defined $delta) {
+			$info = "$escaped_func ($samples_txt $countname, $pct%)";
+		} else {
+			my $deltapct = sprintf "%.2f", ((100 * $delta) / ($timemax * $factor));
+			$deltapct = $delta > 0 ? "+$deltapct" : $deltapct;
+			$info = "$escaped_func ($samples_txt $countname, $pct%; $deltapct%)";
+		}
+	}
+
+	my $nameattr = { %{ $nameattr{$func}||{} } }; # shallow clone
+	$nameattr->{class}       ||= "func_g";
+	$nameattr->{onmouseover} ||= "s('".$info."')";
+	$nameattr->{onmouseout}  ||= "c()";
+	$nameattr->{onclick}     ||= "zoom(this)";
+	$nameattr->{title}       ||= $info;
+	$im->group_start($nameattr);
+
+	my $color;
+	if ($func eq "-") {
+		$color = $vdgrey;
+	} elsif (defined $delta) {
+		$color = color_scale($delta, $maxdelta);
+	} elsif ($palette) {
+		$color = color_map($colors, $func);
+	} else {
+		$color = color($colors, $hash, $func);
+	}
+	$im->filledRectangle($x1, $y1, $x2, $y2, $color, 'rx="2" ry="2"');
+
+	my $chars = int( ($x2 - $x1) / ($fontsize * $fontwidth));
+	my $text = "";
+	if ($chars >= 3) { # room for one char plus two dots
+		$text = substr $func, 0, $chars;
+		substr($text, -2, 2) = ".." if $chars < length $func;
+		$text =~ s/&/&amp;/g;
+		$text =~ s/</&lt;/g;
+		$text =~ s/>/&gt;/g;
+	}
+	$im->stringTTF($black, $fonttype, $fontsize, 0.0, $x1 + 3, 3 + ($y1 + $y2) / 2, $text, "");
+
+	$im->group_end($nameattr);
+}
+
+print $im->svg;
+
+if ($palette) {
+	write_palette();
+}
+
+# vim: ts=8 sts=8 sw=8 noexpandtab

--- a/deps/eflame/flamegraph.riak-color.pl
+++ b/deps/eflame/flamegraph.riak-color.pl
@@ -1,0 +1,863 @@
+#!/usr/bin/perl -w
+#
+# flamegraph.pl		flame stack grapher.
+#
+# This takes stack samples and renders a call graph, allowing hot functions
+# and codepaths to be quickly identified.  Stack samples can be generated using
+# tools such as DTrace, perf, SystemTap, and Instruments.
+#
+# USAGE: ./flamegraph.pl [options] input.txt > graph.svg
+#
+#        grep funcA input.txt | ./flamegraph.pl [options] > graph.svg
+#
+# Options are listed in the usage message (--help).
+#
+# The input is stack frames and sample counts formatted as single lines.  Each
+# frame in the stack is semicolon separated, with a space and count at the end
+# of the line.  These can be generated using DTrace with stackcollapse.pl,
+# and other tools using the stackcollapse variants.
+#
+# An optional extra column of counts can be provided to generate a differential
+# flame graph of the counts, colored red for more, and blue for less.  This
+# can be useful when using flame graphs for non-regression testing.
+# See the header comment in the difffolded.pl program for instructions.
+#
+# The output graph shows relative presence of functions in stack samples.  The
+# ordering on the x-axis has no meaning; since the data is samples, time order
+# of events is not known.  The order used sorts function names alphabetically.
+#
+# While intended to process stack samples, this can also process stack traces.
+# For example, tracing stacks for memory allocation, or resource usage.  You
+# can use --title to set the title to reflect the content, and --countname
+# to change "samples" to "bytes" etc.
+#
+# There are a few different palettes, selectable using --color.  By default,
+# the colors are selected at random (except for differentials).  Functions
+# called "-" will be printed gray, which can be used for stack separators (eg,
+# between user and kernel stacks).
+#
+# HISTORY
+#
+# This was inspired by Neelakanth Nadgir's excellent function_call_graph.rb
+# program, which visualized function entry and return trace events.  As Neel
+# wrote: "The output displayed is inspired by Roch's CallStackAnalyzer which
+# was in turn inspired by the work on vftrace by Jan Boerhout".  See:
+# https://blogs.oracle.com/realneel/entry/visualizing_callstacks_via_dtrace_and
+#
+# Copyright 2011 Joyent, Inc.  All rights reserved.
+# Copyright 2011 Brendan Gregg.  All rights reserved.
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at docs/cddl1.txt or
+# http://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at docs/cddl1.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# 21-Nov-2013   Shawn Sterling  Added consistent palette file option
+# 17-Mar-2013   Tim Bunce       Added options and more tunables.
+# 15-Dec-2011	Dave Pacheco	Support for frames with whitespace.
+# 10-Sep-2011	Brendan Gregg	Created this.
+
+use strict;
+
+use Getopt::Long;
+
+# tunables
+my $encoding;
+my $fonttype = "Verdana";
+my $imagewidth = 1200;          # max width, pixels
+my $frameheight = 16;           # max height is dynamic
+my $fontsize = 12;              # base text size
+my $fontwidth = 0.59;           # avg width relative to fontsize
+my $minwidth = 0.1;             # min function width, pixels
+my $nametype = "Function:";     # what are the names in the data?
+my $countname = "samples";      # what are the counts in the data?
+my $colors = "hot";             # color theme
+my $bgcolor1 = "#eeeeee";       # background color gradient start
+my $bgcolor2 = "#eeeeb0";       # background color gradient stop
+my $nameattrfile;               # file holding function attributes
+my $timemax;                    # (override the) sum of the counts
+my $factor = 1;                 # factor to scale counts by
+my $hash = 0;                   # color by function name
+my $palette = 0;                # if we use consistent palettes (default off)
+my %palette_map;                # palette map hash
+my $pal_file = "palette.map";   # palette map file name
+my $stackreverse = 0;           # reverse stack order, switching merge end
+my $inverted = 0;               # icicle graph
+my $negate = 0;                 # switch differential hues
+my $seed = time;                # random seed is a bit random
+my $titletext = "";             # centered heading
+my $titledefault = "Flame Graph";	# overwritten by --title
+my $titleinverted = "Icicle Graph";	#   "    "
+
+GetOptions(
+	'fonttype=s'  => \$fonttype,
+	'width=i'     => \$imagewidth,
+	'height=i'    => \$frameheight,
+	'encoding=s'  => \$encoding,
+	'fontsize=f'  => \$fontsize,
+	'fontwidth=f' => \$fontwidth,
+	'minwidth=f'  => \$minwidth,
+	'title=s'     => \$titletext,
+	'nametype=s'  => \$nametype,
+	'countname=s' => \$countname,
+	'nameattr=s'  => \$nameattrfile,
+	'total=s'     => \$timemax,
+	'factor=f'    => \$factor,
+	'colors=s'    => \$colors,
+	'hash'        => \$hash,
+	'cp'          => \$palette,
+	'reverse'     => \$stackreverse,
+	'inverted'    => \$inverted,
+	'negate'      => \$negate,
+        'seed=i'      => \$seed,
+) or die <<USAGE_END;
+USAGE: $0 [options] infile > outfile.svg\n
+	--title       # change title text
+	--width       # width of image (default 1200)
+	--height      # height of each frame (default 16)
+	--minwidth    # omit smaller functions (default 0.1 pixels)
+	--fonttype    # font type (default "Verdana")
+	--fontsize    # font size (default 12)
+	--countname   # count type label (default "samples")
+	--nametype    # name type label (default "Function:")
+	--colors      # set color palette. choices are: hot (default), mem, io,
+	              # java, js, red, green, blue, yellow, purple, orange
+	--hash        # colors are keyed by function name hash
+	--cp          # use consistent palette (palette.map)
+	--reverse     # generate stack-reversed flame graph
+	--inverted    # icicle graph
+	--negate      # switch differential hues (blue<->red)
+        --seed        # srand() seed integer
+
+	eg,
+	$0 --title="Flame Graph: malloc()" trace.txt > graph.svg
+USAGE_END
+
+# internals
+my $ypad1 = $fontsize * 4;      # pad top, include title
+my $ypad2 = $fontsize * 2 + 10; # pad bottom, include labels
+my $xpad = 10;                  # pad lefm and right
+my $framepad = 1;		# vertical padding for frames
+my $depthmax = 0;
+my %Events;
+my %nameattr;
+
+srand($seed);
+
+if ($titletext eq "") {
+	unless ($inverted) {
+		$titletext = $titledefault;
+	} else {
+		$titletext = $titleinverted;
+	}
+}
+
+if ($nameattrfile) {
+	# The name-attribute file format is a function name followed by a tab then
+	# a sequence of tab separated name=value pairs.
+	open my $attrfh, $nameattrfile or die "Can't read $nameattrfile: $!\n";
+	while (<$attrfh>) {
+		chomp;
+		my ($funcname, $attrstr) = split /\t/, $_, 2;
+		die "Invalid format in $nameattrfile" unless defined $attrstr;
+		$nameattr{$funcname} = { map { split /=/, $_, 2 } split /\t/, $attrstr };
+	}
+}
+
+if ($colors eq "mem") { $bgcolor1 = "#eeeeee"; $bgcolor2 = "#e0e0ff"; }
+if ($colors eq "io")  { $bgcolor1 = "#f8f8f8"; $bgcolor2 = "#e8e8e8"; }
+
+# SVG functions
+{ package SVG;
+	sub new {
+		my $class = shift;
+		my $self = {};
+		bless ($self, $class);
+		return $self;
+	}
+
+	sub header {
+		my ($self, $w, $h) = @_;
+		my $enc_attr = '';
+		if (defined $encoding) {
+			$enc_attr = qq{ encoding="$encoding"};
+		}
+		$self->{svg} .= <<SVG;
+<?xml version="1.0"$enc_attr standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="$w" height="$h" onload="init(evt)" viewBox="0 0 $w $h" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+SVG
+	}
+
+	sub include {
+		my ($self, $content) = @_;
+		$self->{svg} .= $content;
+	}
+
+	sub colorAllocate {
+		my ($self, $r, $g, $b) = @_;
+		return "rgb($r,$g,$b)";
+	}
+
+	sub group_start {
+		my ($self, $attr) = @_;
+
+		my @g_attr = map {
+			exists $attr->{$_} ? sprintf(qq/$_="%s"/, $attr->{$_}) : ()
+		} qw(class style onmouseover onmouseout onclick);
+		push @g_attr, $attr->{g_extra} if $attr->{g_extra};
+		$self->{svg} .= sprintf qq/<g %s>\n/, join(' ', @g_attr);
+
+		$self->{svg} .= sprintf qq/<title>%s<\/title>/, $attr->{title}
+			if $attr->{title}; # should be first element within g container
+
+		if ($attr->{href}) {
+			my @a_attr;
+			push @a_attr, sprintf qq/xlink:href="%s"/, $attr->{href} if $attr->{href};
+			# default target=_top else links will open within SVG <object>
+			push @a_attr, sprintf qq/target="%s"/, $attr->{target} || "_top";
+			push @a_attr, $attr->{a_extra}                           if $attr->{a_extra};
+			$self->{svg} .= sprintf qq/<a %s>/, join(' ', @a_attr);
+		}
+	}
+
+	sub group_end {
+		my ($self, $attr) = @_;
+		$self->{svg} .= qq/<\/a>\n/ if $attr->{href};
+		$self->{svg} .= qq/<\/g>\n/;
+	}
+
+	sub filledRectangle {
+		my ($self, $x1, $y1, $x2, $y2, $fill, $extra) = @_;
+		$x1 = sprintf "%0.1f", $x1;
+		$x2 = sprintf "%0.1f", $x2;
+		my $w = sprintf "%0.1f", $x2 - $x1;
+		my $h = sprintf "%0.1f", $y2 - $y1;
+		$extra = defined $extra ? $extra : "";
+		$self->{svg} .= qq/<rect x="$x1" y="$y1" width="$w" height="$h" fill="$fill" $extra \/>\n/;
+	}
+
+	sub stringTTF {
+		my ($self, $color, $font, $size, $angle, $x, $y, $str, $loc, $extra) = @_;
+		$x = sprintf "%0.2f", $x;
+		$loc = defined $loc ? $loc : "left";
+		$extra = defined $extra ? $extra : "";
+		$self->{svg} .= qq/<text text-anchor="$loc" x="$x" y="$y" font-size="$size" font-family="$font" fill="$color" $extra >$str<\/text>\n/;
+	}
+
+	sub svg {
+		my $self = shift;
+		return "$self->{svg}</svg>\n";
+	}
+	1;
+}
+
+sub namehash {
+	# Generate a vector hash for the name string, weighting early over
+	# later characters. We want to pick the same colors for function
+	# names across different flame graphs.
+	my $name = shift;
+	my $vector = 0;
+	my $weight = 1;
+	my $max = 1;
+	my $mod = 10;
+	# if module name present, trunc to 1st char
+	$name =~ s/.(.*?)`//;
+	foreach my $c (split //, $name) {
+		my $i = (ord $c) % $mod;
+		$vector += ($i / ($mod++ - 1)) * $weight;
+		$max += 1 * $weight;
+		$weight *= 0.70;
+		last if $mod > 12;
+	}
+	return (1 - $vector / $max)
+}
+
+sub color {
+	my ($type, $hash, $name) = @_;
+	my ($v1, $v2, $v3);
+
+	if ($hash) {
+		$v1 = namehash($name);
+		$v2 = $v3 = namehash(scalar reverse $name);
+	} else {
+		$v1 = rand(1);
+		$v2 = rand(1);
+		$v3 = rand(1);
+	}
+
+	# theme palettes
+	if (defined $type and $type eq "hot") {
+		my $r = 205 + int(50 * $v3);
+		my $g = 0 + int(230 * $v1);
+		my $b = 0 + int(55 * $v2);
+		return "rgb($r,$g,$b)";
+	}
+	if (defined $type and $type eq "mem") {
+		my $r = 0;
+		my $g = 190 + int(50 * $v2);
+		my $b = 0 + int(210 * $v1);
+		return "rgb($r,$g,$b)";
+	}
+	if (defined $type and $type eq "io") {
+		my $r = 80 + int(60 * $v1);
+		my $g = $r;
+		my $b = 190 + int(55 * $v2);
+		return "rgb($r,$g,$b)";
+	}
+
+	# multi palettes
+	if (defined $type and $type eq "java") {
+		if ($name =~ /::/) {		# C++
+			$type = "yellow";
+		} elsif ($name =~ m:/:) {	# Java (match "/" in path)
+			$type = "green"
+		} else {			# system
+			$type = "red";
+		}
+		# fall-through to color palettes
+	}
+	if (defined $type and $type eq "js") {
+		if ($name =~ /::/) {		# C++
+			$type = "yellow";
+		} elsif ($name =~ m:/:) {	# JavaScript (match "/" in path)
+			$type = "green"
+		} elsif ($name =~ m/:/) {	# JavaScript (match ":" in builtin)
+			$type = "aqua"
+		} elsif ($name =~ m/^ $/) {	# Missing symbol
+			$type = "green"
+		} else {			# system
+			$type = "red";
+		}
+		# fall-through to color palettes
+	}
+
+	# color palettes
+	if (defined $type and $type eq "red") {
+		my $r = 200 + int(55 * $v1);
+		my $x = 50 + int(80 * $v1);
+		return "rgb($r,$x,$x)";
+	}
+	if (defined $type and $type eq "green") {
+		my $g = 200 + int(55 * $v1);
+		my $x = 50 + int(60 * $v1);
+		return "rgb($x,$g,$x)";
+	}
+	if (defined $type and $type eq "blue") {
+		my $b = 205 + int(50 * $v1);
+		my $x = 80 + int(60 * $v1);
+		return "rgb($x,$x,$b)";
+	}
+	if (defined $type and $type eq "yellow") {
+		my $x = 175 + int(55 * $v1);
+		my $b = 50 + int(20 * $v1);
+		return "rgb($x,$x,$b)";
+	}
+	if (defined $type and $type eq "purple") {
+		my $x = 190 + int(65 * $v1);
+		my $g = 80 + int(60 * $v1);
+		return "rgb($x,$g,$x)";
+	}
+	if (defined $type and $type eq "aqua") {
+		my $r = 50 + int(60 * $v1);
+		my $g = 165 + int(55 * $v1);
+		my $b = 165 + int(55 * $v1);
+		return "rgb($r,$g,$b)";
+	}
+	if (defined $type and $type eq "orange") {
+		my $r = 190 + int(65 * $v1);
+		my $g = 90 + int(65 * $v1);
+		return "rgb($r,$g,0)";
+	}
+
+	return "rgb(0,0,0)";
+}
+
+sub color_scale {
+	my ($value, $max) = @_;
+	my ($r, $g, $b) = (255, 255, 255);
+	$value = -$value if $negate;
+	if ($value > 0) {
+		$g = $b = int(210 * ($max - $value) / $max);
+	} elsif ($value < 0) {
+		$r = $g = int(210 * ($max + $value) / $max);
+	}
+	return "rgb($r,$g,$b)";
+}
+
+sub color_map {
+	my ($colors, $func) = @_;
+	if (exists $palette_map{$func}) {
+		return $palette_map{$func};
+	} else {
+		$palette_map{$func} = color($colors);
+		return $palette_map{$func};
+	}
+}
+
+sub write_palette {
+	open(FILE, ">$pal_file");
+	foreach my $key (sort keys %palette_map) {
+		print FILE $key."->".$palette_map{$key}."\n";
+	}
+	close(FILE);
+}
+
+sub read_palette {
+	if (-e $pal_file) {
+	open(FILE, $pal_file) or die "can't open file $pal_file: $!";
+	while ( my $line = <FILE>) {
+		chomp($line);
+		(my $key, my $value) = split("->",$line);
+		$palette_map{$key}=$value;
+	}
+	close(FILE)
+	}
+}
+
+my %Node;	# Hash of merged frame data
+my %Tmp;
+
+# flow() merges two stacks, storing the merged frames and value data in %Node.
+sub flow {
+	my ($last, $this, $v, $d) = @_;
+
+	my $len_a = @$last - 1;
+	my $len_b = @$this - 1;
+
+	my $i = 0;
+	my $len_same;
+	for (; $i <= $len_a; $i++) {
+		last if $i > $len_b;
+		last if $last->[$i] ne $this->[$i];
+	}
+	$len_same = $i;
+
+	for ($i = $len_a; $i >= $len_same; $i--) {
+		my $k = "$last->[$i];$i";
+		# a unique ID is constructed from "func;depth;etime";
+		# func-depth isn't unique, it may be repeated later.
+		$Node{"$k;$v"}->{stime} = delete $Tmp{$k}->{stime};
+		if (defined $Tmp{$k}->{delta}) {
+			$Node{"$k;$v"}->{delta} = delete $Tmp{$k}->{delta};
+		}
+		delete $Tmp{$k};
+	}
+
+	for ($i = $len_same; $i <= $len_b; $i++) {
+		my $k = "$this->[$i];$i";
+		$Tmp{$k}->{stime} = $v;
+		if (defined $d) {
+			$Tmp{$k}->{delta} += $i == $len_b ? $d : 0;
+		}
+	}
+
+        return $this;
+}
+
+# parse input
+my @Data;
+my $last = [];
+my $time = 0;
+my $delta = undef;
+my $ignored = 0;
+my $line;
+my $maxdelta = 1;
+
+# reverse if needed
+foreach (<>) {
+	chomp;
+	$line = $_;
+	if ($stackreverse) {
+		# there may be an extra samples column for differentials
+		# XXX todo: redo these REs as one. It's repeated below.
+		my ($stack, $samples) = (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+		my $samples2 = undef;
+		if ($stack =~ /^(.*)\s+?(\d+(?:\.\d*)?)$/) {
+			$samples2 = $samples;
+			($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+			unshift @Data, join(";", reverse split(";", $stack)) . " $samples $samples2";
+		} else {
+			unshift @Data, join(";", reverse split(";", $stack)) . " $samples";
+		}
+	} else {
+		unshift @Data, $line;
+	}
+}
+
+# process and merge frames
+foreach (sort @Data) {
+	chomp;
+	# process: folded_stack count
+	# eg: func_a;func_b;func_c 31
+	my ($stack, $samples) = (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+	unless (defined $samples and defined $stack) {
+		++$ignored;
+		next;
+	}
+
+	# there may be an extra samples column for differentials:
+	my $samples2 = undef;
+	if ($stack =~ /^(.*)\s+?(\d+(?:\.\d*)?)$/) {
+		$samples2 = $samples;
+		($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+	}
+	$delta = undef;
+	if (defined $samples2) {
+		$delta = $samples2 - $samples;
+		$maxdelta = abs($delta) if abs($delta) > $maxdelta;
+	}
+
+	$stack =~ tr/<>/()/;
+
+	# merge frames and populate %Node:
+	$last = flow($last, [ '', split ";", $stack ], $time, $delta);
+
+	if (defined $samples2) {
+		$time += $samples2;
+	} else {
+		$time += $samples;
+	}
+}
+flow($last, [], $time, $delta);
+
+warn "Ignored $ignored lines with invalid format\n" if $ignored;
+unless ($time) {
+	warn "ERROR: No stack counts found\n";
+	my $im = SVG->new();
+	# emit an error message SVG, for tools automating flamegraph use
+	my $imageheight = $fontsize * 5;
+	$im->header($imagewidth, $imageheight);
+	$im->stringTTF($im->colorAllocate(0, 0, 0), $fonttype, $fontsize + 2,
+	    0.0, int($imagewidth / 2), $fontsize * 2,
+	    "ERROR: No valid input provided to flamegraph.pl.", "middle");
+	print $im->svg;
+	exit 2;
+}
+if ($timemax and $timemax < $time) {
+	warn "Specified --total $timemax is less than actual total $time, so ignored\n"
+	if $timemax/$time > 0.02; # only warn is significant (e.g., not rounding etc)
+	undef $timemax;
+}
+$timemax ||= $time;
+
+my $widthpertime = ($imagewidth - 2 * $xpad) / $timemax;
+my $minwidth_time = $minwidth / $widthpertime;
+
+# prune blocks that are too narrow and determine max depth
+while (my ($id, $node) = each %Node) {
+	my ($func, $depth, $etime) = split ";", $id;
+	my $stime = $node->{stime};
+	die "missing start for $id" if not defined $stime;
+
+	if (($etime-$stime) < $minwidth_time) {
+		delete $Node{$id};
+		next;
+	}
+	$depthmax = $depth if $depth > $depthmax;
+}
+
+# draw canvas, and embed interactive JavaScript program
+my $imageheight = ($depthmax * $frameheight) + $ypad1 + $ypad2;
+my $im = SVG->new();
+$im->header($imagewidth, $imageheight);
+my $inc = <<INC;
+<defs >
+	<linearGradient id="background" y1="0" y2="1" x1="0" x2="0" >
+		<stop stop-color="$bgcolor1" offset="5%" />
+		<stop stop-color="$bgcolor2" offset="95%" />
+	</linearGradient>
+</defs>
+<style type="text/css">
+	.func_g:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+</style>
+<script type="text/ecmascript">
+<![CDATA[
+	var details, svg;
+	function init(evt) { 
+		details = document.getElementById("details").firstChild; 
+		svg = document.getElementsByTagName("svg")[0];
+	}
+	function s(info) { details.nodeValue = "$nametype " + info; }
+	function c() { details.nodeValue = ' '; }
+	function find_child(parent, name, attr) {
+		var children = parent.childNodes;
+		for (var i=0; i<children.length;i++) {
+			if (children[i].tagName == name)
+				return (attr != undefined) ? children[i].attributes[attr].value : children[i];
+		}
+		return;
+	}
+	function orig_save(e, attr, val) {
+		if (e.attributes["_orig_"+attr] != undefined) return;
+		if (e.attributes[attr] == undefined) return;
+		if (val == undefined) val = e.attributes[attr].value;
+		e.setAttribute("_orig_"+attr, val);
+	}
+	function orig_load(e, attr) {
+		if (e.attributes["_orig_"+attr] == undefined) return;
+		e.attributes[attr].value = e.attributes["_orig_"+attr].value;
+		e.removeAttribute("_orig_"+attr);
+	}
+	function update_text(e) {
+		var r = find_child(e, "rect");
+		var t = find_child(e, "text");
+		var w = parseFloat(r.attributes["width"].value) -3;
+		var txt = find_child(e, "title").textContent.replace(/\\([^(]*\\)/,"");
+		t.attributes["x"].value = parseFloat(r.attributes["x"].value) +3;
+		
+		// Smaller than this size won't fit anything
+		if (w < 2*$fontsize*$fontwidth) {
+			t.textContent = "";
+			return;
+		}
+		
+		t.textContent = txt;
+		// Fit in full text width
+		if (/^ *\$/.test(txt) || t.getSubStringLength(0, txt.length) < w)
+			return;
+		
+		for (var x=txt.length-2; x>0; x--) {
+			if (t.getSubStringLength(0, x+2) <= w) { 
+				t.textContent = txt.substring(0,x) + "..";
+				return;
+			}
+		}
+		t.textContent = "";
+	}
+	function zoom_reset(e) {
+		if (e.attributes != undefined) {
+			orig_load(e, "x");
+			orig_load(e, "width");
+		}
+		if (e.childNodes == undefined) return;
+		for(var i=0, c=e.childNodes; i<c.length; i++) {
+			zoom_reset(c[i]);
+		}
+	}
+	function zoom_child(e, x, ratio) {
+		if (e.attributes != undefined) {
+			if (e.attributes["x"] != undefined) {
+				orig_save(e, "x");
+				e.attributes["x"].value = (parseFloat(e.attributes["x"].value) - x - $xpad) * ratio + $xpad;
+				if(e.tagName == "text") e.attributes["x"].value = find_child(e.parentNode, "rect", "x") + 3;
+			}
+			if (e.attributes["width"] != undefined) {
+				orig_save(e, "width");
+				e.attributes["width"].value = parseFloat(e.attributes["width"].value) * ratio;
+			}
+		}
+		
+		if (e.childNodes == undefined) return;
+		for(var i=0, c=e.childNodes; i<c.length; i++) {
+			zoom_child(c[i], x-$xpad, ratio);
+		}
+	}
+	function zoom_parent(e) {
+		if (e.attributes) {
+			if (e.attributes["x"] != undefined) {
+				orig_save(e, "x");
+				e.attributes["x"].value = $xpad;
+			}
+			if (e.attributes["width"] != undefined) {
+				orig_save(e, "width");
+				e.attributes["width"].value = parseInt(svg.width.baseVal.value) - ($xpad*2);
+			}
+		}
+		if (e.childNodes == undefined) return;
+		for(var i=0, c=e.childNodes; i<c.length; i++) {
+			zoom_parent(c[i]);
+		}
+	}
+	function zoom(node) { 
+		var attr = find_child(node, "rect").attributes;
+		var width = parseFloat(attr["width"].value);
+		var xmin = parseFloat(attr["x"].value);
+		var xmax = parseFloat(xmin + width);
+		var ymin = parseFloat(attr["y"].value);
+		var ratio = (svg.width.baseVal.value - 2*$xpad) / width;
+		
+		// XXX: Workaround for JavaScript float issues (fix me)
+		var fudge = 0.0001;
+		
+		var unzoombtn = document.getElementById("unzoom");
+		unzoombtn.style["opacity"] = "1.0";
+		
+		var el = document.getElementsByTagName("g");
+		for(var i=0;i<el.length;i++){
+			var e = el[i];
+			var a = find_child(e, "rect").attributes;
+			var ex = parseFloat(a["x"].value);
+			var ew = parseFloat(a["width"].value);
+			// Is it an ancestor
+			if ($inverted == 0) {
+				var upstack = parseFloat(a["y"].value) > ymin;
+			} else {
+				var upstack = parseFloat(a["y"].value) < ymin;
+			}
+			if (upstack) {
+				// Direct ancestor
+				if (ex <= xmin && (ex+ew+fudge) >= xmax) {
+					e.style["opacity"] = "0.5";
+					zoom_parent(e);
+					e.onclick = function(e){unzoom(); zoom(this);};
+					update_text(e);
+				}
+				// not in current path
+				else
+					e.style["display"] = "none";
+			}
+			// Children maybe
+			else {
+				// no common path
+				if (ex < xmin || ex + fudge >= xmax) {
+					e.style["display"] = "none";
+				}
+				else {
+					zoom_child(e, xmin, ratio);
+					e.onclick = function(e){zoom(this);};
+					update_text(e);
+				}
+			}
+		}
+	}
+	function unzoom() {
+		var unzoombtn = document.getElementById("unzoom");
+		unzoombtn.style["opacity"] = "0.0";
+		
+		var el = document.getElementsByTagName("g");
+		for(i=0;i<el.length;i++) {
+			el[i].style["display"] = "block";
+			el[i].style["opacity"] = "1";
+			zoom_reset(el[i]);
+			update_text(el[i]);
+		}
+	}	
+]]>
+</script>
+INC
+$im->include($inc);
+$im->filledRectangle(0, 0, $imagewidth, $imageheight, 'url(#background)');
+my ($white, $black, $vvdgrey, $vdgrey) = (
+	$im->colorAllocate(255, 255, 255),
+	$im->colorAllocate(0, 0, 0),
+	$im->colorAllocate(40, 40, 40),
+	$im->colorAllocate(160, 160, 160),
+    );
+$im->stringTTF($black, $fonttype, $fontsize + 5, 0.0, int($imagewidth / 2), $fontsize * 2, $titletext, "middle");
+$im->stringTTF($black, $fonttype, $fontsize, 0.0, $xpad, $imageheight - ($ypad2 / 2), " ", "", 'id="details"');
+$im->stringTTF($black, $fonttype, $fontsize, 0.0, $xpad, $fontsize * 2,
+    "Reset Zoom", "", 'id="unzoom" onclick="unzoom()" style="opacity:0.0;cursor:pointer"');
+
+if ($palette) {
+	read_palette();
+}
+
+# draw frames
+while (my ($id, $node) = each %Node) {
+	my ($func, $depth, $etime) = split ";", $id;
+	my $stime = $node->{stime};
+	my $delta = $node->{delta};
+
+	$etime = $timemax if $func eq "" and $depth == 0;
+
+	my $x1 = $xpad + $stime * $widthpertime;
+	my $x2 = $xpad + $etime * $widthpertime;
+	my ($y1, $y2);
+	unless ($inverted) {
+		$y1 = $imageheight - $ypad2 - ($depth + 1) * $frameheight + $framepad;
+		$y2 = $imageheight - $ypad2 - $depth * $frameheight;
+	} else {
+		$y1 = $ypad1 + $depth * $frameheight;
+		$y2 = $ypad1 + ($depth + 1) * $frameheight - $framepad;
+	}
+
+	my $samples = sprintf "%.0f", ($etime - $stime) * $factor;
+	(my $samples_txt = $samples) # add commas per perlfaq5
+		=~ s/(^[-+]?\d+?(?=(?>(?:\d{3})+)(?!\d))|\G\d{3}(?=\d))/$1,/g;
+
+	my $info;
+	if ($func eq "" and $depth == 0) {
+		$info = "all ($samples_txt $countname, 100%)";
+	} else {
+		my $pct = sprintf "%.2f", ((100 * $samples) / ($timemax * $factor));
+		my $escaped_func = $func;
+		$escaped_func =~ s/&/&amp;/g;
+		$escaped_func =~ s/</&lt;/g;
+		$escaped_func =~ s/>/&gt;/g;
+		unless (defined $delta) {
+			$info = "$escaped_func ($samples_txt $countname, $pct%)";
+		} else {
+			my $deltapct = sprintf "%.2f", ((100 * $delta) / ($timemax * $factor));
+			$deltapct = $delta > 0 ? "+$deltapct" : $deltapct;
+			$info = "$escaped_func ($samples_txt $countname, $pct%; $deltapct%)";
+		}
+	}
+
+	my $nameattr = { %{ $nameattr{$func}||{} } }; # shallow clone
+	$nameattr->{class}       ||= "func_g";
+	$nameattr->{onmouseover} ||= "s('".$info."')";
+	$nameattr->{onmouseout}  ||= "c()";
+	$nameattr->{onclick}     ||= "zoom(this)";
+	$nameattr->{title}       ||= $info;
+	$im->group_start($nameattr);
+
+	my $color;
+	if ($func eq "-") {
+		$color = $vdgrey;
+        } elsif ($func eq "sleep" || $func eq "SLEEP") {
+		$color = color("blue", $hash, $func);
+        } elsif ($func =~ /riak_cs/) {
+		$color = color("aqua", $hash, $func);
+        } elsif ($func =~ /riak/) {
+		$color = color("green", $hash, $func);
+        } elsif ($func =~ /snappy/i) {
+		$color = color("aqua", $hash, $func);
+        } elsif ($func =~ /leveldb/i) {
+		$color = color("aqua", $hash, $func);
+        } elsif ($func =~ /bitcask/i) {
+		$color = color("yellow", $hash, $func);
+	} elsif (defined $delta) {
+		$color = color_scale($delta, $maxdelta);
+	} elsif ($palette) {
+		$color = color_map($colors, $func);
+	} else {
+		$color = color($colors, $hash, $func);
+	}
+	$im->filledRectangle($x1, $y1, $x2, $y2, $color, 'rx="2" ry="2"');
+
+	my $chars = int( ($x2 - $x1) / ($fontsize * $fontwidth));
+	my $text = "";
+	if ($chars >= 3) { # room for one char plus two dots
+		$text = substr $func, 0, $chars;
+		substr($text, -2, 2) = ".." if $chars < length $func;
+		$text =~ s/&/&amp;/g;
+		$text =~ s/</&lt;/g;
+		$text =~ s/>/&gt;/g;
+	}
+	$im->stringTTF($black, $fonttype, $fontsize, 0.0, $x1 + 3, 3 + ($y1 + $y2) / 2, $text, "");
+
+	$im->group_end($nameattr);
+}
+
+print $im->svg;
+
+if ($palette) {
+	write_palette();
+}
+
+# vim: ts=8 sts=8 sw=8 noexpandtab

--- a/deps/eflame/src/eflame.app.src
+++ b/deps/eflame/src/eflame.app.src
@@ -1,0 +1,8 @@
+{application,eflame,
+             [{description,[]},
+              {vsn,"git"},
+              {registered,[]},
+              {applications,[kernel,stdlib]},
+              {mod,{eflame_app,[]}},
+              {env,[]},
+              {modules,[]}]}.

--- a/deps/eflame/src/eflame.erl
+++ b/deps/eflame/src/eflame.erl
@@ -1,0 +1,146 @@
+-module(eflame).
+-export([apply/3, apply/5]).
+
+-define(RESOLUTION, 1000). %% us
+-record(dump, {stack=[], us=0, acc=[]}). % per-process state
+
+apply(M, F, A) ->
+    ?MODULE:apply(normal_with_children, "stacks.out", M, F, A).
+
+apply(Mode, OutputFile, M, F, A) ->
+    Tracer = spawn_tracer(),
+
+    start_trace(Tracer, self(), Mode),
+    Return = (catch erlang:apply(M, F, A)),
+    {ok, Bytes} = stop_trace(Tracer, self()),
+
+    ok = file:write_file(OutputFile, Bytes),
+    Return.
+
+start_trace(Tracer, Target, Mode) ->
+    MatchSpec = [{'_', [], [{message, {{cp, {caller}}}}]}],
+    erlang:trace_pattern(on_load, MatchSpec, [local]),
+    erlang:trace_pattern({'_', '_', '_'}, MatchSpec, [local]),
+    erlang:trace(Target, true, [{tracer, Tracer} | trace_flags(Mode)]),
+    ok.
+
+stop_trace(Tracer, Target) ->
+    erlang:trace(Target, false, [all]),
+    Tracer ! {dump_bytes, self()},
+
+    Ret = receive {bytes, B} -> {ok, B}
+    after 5000 -> {error, timeout}
+    end,
+
+    exit(Tracer, normal),
+    Ret.
+
+spawn_tracer() -> spawn(fun() -> trace_listener(dict:new()) end).
+
+trace_flags(normal) ->
+    [call, arity, return_to, timestamp, running];
+trace_flags(normal_with_children) ->
+    [call, arity, return_to, timestamp, running, set_on_spawn];
+trace_flags(like_fprof) -> % fprof does this as 'normal', will not work!
+    [call, return_to, running, procs, garbage_collection, arity, timestamp, set_on_spawn].
+
+trace_listener(State) ->
+    receive
+        {dump, Pid} ->
+            Pid ! {stacks, dict:to_list(State)};
+        {dump_bytes, Pid} ->
+            Bytes = iolist_to_binary([dump_to_iolist(TPid, Dump) || {TPid, [Dump]} <- dict:to_list(State)]),
+            Pid ! {bytes, Bytes};
+        Term ->
+            trace_ts = element(1, Term),
+            PidS = element(2, Term),
+
+            PidState = case dict:find(PidS, State) of
+                {ok, [Ps]} -> Ps;
+                error -> #dump{}
+            end,
+
+            NewPidState = trace_proc_stream(Term, PidState),
+
+            D1 = dict:erase(PidS, State),
+            D2 = dict:append(PidS, NewPidState, D1),
+            trace_listener(D2)
+    end.
+
+us({Mega, Secs, Micro}) ->
+    Mega*1000*1000*1000*1000 + Secs*1000*1000 + Micro.
+
+new_state(#dump{us=Us, acc=Acc} = State, Stack, Ts) ->
+    %io:format("new state: ~p ~p ~p~n", [Us, length(Stack), Ts]),
+    UsTs = us(Ts),
+    case Us of
+        0 -> State#dump{us=UsTs, stack=Stack};
+        _ when Us > 0 ->
+            Diff = us(Ts) - Us,
+            NOverlaps = Diff div ?RESOLUTION,
+            Overlapped = NOverlaps * ?RESOLUTION,
+            %Rem = Diff - Overlapped,
+            case NOverlaps of
+                X when X >= 1 ->
+                    StackRev = lists:reverse(Stack),
+                    Stacks = [StackRev || _ <- lists:seq(1, NOverlaps)],
+                    State#dump{us=Us+Overlapped, acc=lists:append(Stacks, Acc), stack=Stack};
+                _ ->
+                    State#dump{stack=Stack}
+            end
+    end.
+
+trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, {_,_,_} = CallerMFA}, Ts}, #dump{stack=[]} = State) ->
+    new_state(State, [MFA, CallerMFA], Ts);
+
+trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}, #dump{stack=[]} = State) ->
+    new_state(State, [MFA], Ts);
+
+trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, MFA}, Ts}, #dump{stack=[MFA|Stack]} = State) ->
+    new_state(State, [MFA|Stack], Ts); % collapse tail recursion
+
+trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, CpMFA}, Ts}, #dump{stack=[CpMFA|Stack]} = State) ->
+    new_state(State, [MFA, CpMFA|Stack], Ts);
+
+trace_proc_stream({trace_ts, _Ps, call, _MFA, {cp, _}, _Ts} = TraceTs, #dump{stack=[_|StackRest]} = State) ->
+    trace_proc_stream(TraceTs, State#dump{stack=StackRest});
+
+trace_proc_stream({trace_ts, _Ps, return_to, MFA, Ts}, #dump{stack=[_Current, MFA|Stack]} = State) ->
+    new_state(State, [MFA|Stack], Ts); % do not try to traverse stack down because we've already collapsed it
+
+trace_proc_stream({trace_ts, _Ps, return_to, undefined, _Ts}, State) ->
+    State;
+
+trace_proc_stream({trace_ts, _Ps, return_to, _, _Ts}, State) ->
+    State;
+
+trace_proc_stream({trace_ts, _Ps, in, _MFA, Ts}, #dump{stack=[sleep|Stack]} = State) ->
+    new_state(new_state(State, [sleep|Stack], Ts), Stack, Ts);
+
+trace_proc_stream({trace_ts, _Ps, in, _MFA, Ts}, #dump{stack=Stack} = State) ->
+    new_state(State, Stack, Ts);
+
+trace_proc_stream({trace_ts, _Ps, out, _MFA, Ts}, #dump{stack=Stack} = State) ->
+    new_state(State, [sleep|Stack], Ts);
+
+trace_proc_stream(TraceTs, State) ->
+    io:format("trace_proc_stream: unknown trace: ~p~n", [TraceTs]),
+    State.
+
+stack_collapse(Stack) ->
+    intercalate(";", [entry_to_iolist(S) || S <- Stack]).
+
+entry_to_iolist({M, F, A}) ->
+    [atom_to_binary(M, utf8), <<":">>, atom_to_binary(F, utf8), <<"/">>, integer_to_list(A)];
+entry_to_iolist(A) when is_atom(A) ->
+    [atom_to_binary(A, utf8)].
+
+dump_to_iolist(Pid, #dump{acc=Acc}) ->
+    [[pid_to_list(Pid), <<";">>, stack_collapse(S), <<"\n">>] || S <- lists:reverse(Acc)].
+
+intercalate(Sep, Xs) -> lists:concat(intersperse(Sep, Xs)).
+
+intersperse(_, []) -> [];
+intersperse(_, [X]) -> [X];
+intersperse(Sep, [X | Xs]) -> [X, Sep | intersperse(Sep, Xs)].
+

--- a/deps/eflame/src/eflame2.erl
+++ b/deps/eflame/src/eflame2.erl
@@ -1,0 +1,403 @@
+-module(eflame2).
+
+%% Public API
+-export([%% 1st phase: generate a binary trace
+         write_trace/4, write_trace/6,
+         %% The following forms used with experimental VM only!
+         write_trace_exp/4, write_trace_exp/6,
+
+         %% 2nd phase: convert binary trace to an ASCII trace
+         format_trace/1, format_trace/2]).
+-export([help/0, custom_trace_flags/0]).
+-compile(export_all). %% SLF debugging
+
+-record(state, {
+          output_path="",
+          pid,
+          last_ts,
+          count=0,
+          acc=[]}). % per-process state
+
+%% For help & use recommendations, run help().
+
+write_trace(Mode, BinaryFile, PidSpec, SleepMSecs) when is_number(SleepMSecs) ->
+    write_trace(Mode, BinaryFile, PidSpec, timer, sleep, [SleepMSecs]).
+
+write_trace(Mode, BinaryFile, PidSpec, M, F, A) ->
+    write_trace2(normal, Mode, BinaryFile, PidSpec, M, F, A).
+
+write_trace_exp(Mode, BinaryFile, PidSpec, SleepMSecs) when is_number(SleepMSecs) ->
+    write_trace_exp(Mode, BinaryFile, PidSpec, timer, sleep, [SleepMSecs]).
+
+write_trace_exp(Mode, BinaryFile, PidSpec, M, F, A) ->
+    write_trace2(backtrace, Mode, BinaryFile, PidSpec, M, F, A).
+
+write_trace2(Style, Mode, BinaryFile, PidSpec, M, F, A) ->
+    {ok, Tracer} = start_tracer(BinaryFile),
+    io:format(user, "Tracer ~p\n", [Tracer]),
+    io:format(user, "self() ~p\n", [self()]),
+
+    start_trace(Style, Tracer, PidSpec, Mode),
+    Return = (catch erlang:apply(M, F, A)),
+    stop_trace(Tracer, PidSpec),
+
+    %% ok = file:write_file(OutputFile, Bytes),
+    Return.
+
+start_trace(normal, _Tracer, PidSpec, Mode) ->
+    MatchSpec = [{'_',[],[{message,{process_dump}}]}],
+    start_trace2(_Tracer, PidSpec, Mode, MatchSpec);
+start_trace(backtrace, _Tracer, PidSpec, Mode) ->
+    io:format("\n\nYEAH, using the new hackery!\n\n"),
+    MatchSpec = [{'_',[],[{message,{process_backtrace}}]}],
+    start_trace2(_Tracer, PidSpec, Mode, MatchSpec).
+
+start_trace2(_Tracer, PidSpec, Mode, MatchSpec) ->
+    Verb = case is_list(Mode) andalso lists:member(global_and_local_calls, Mode) of
+               true ->
+                   {v_global_and_local_calls, dbg:tpl('_', '_', MatchSpec)};
+               false ->
+                   if Mode == 'global_and_local_calls' orelse
+                      Mode == 'global_and_local_calls_plus_new_procs'  ->
+                           {v_global_and_local_calls, dbg:tpl('_', '_', MatchSpec)};
+                      true ->
+                           {v_global_calls_only, dbg:tp('_', '_', MatchSpec)}
+                   end
+           end,
+    io:format("Starting tracer results: ~p\n", [Verb]),
+    if is_list(PidSpec) ->
+            [dbg:p(PS, trace_flags(Mode)) || PS <- PidSpec];
+       true ->
+            dbg:p(PidSpec, trace_flags(Mode))
+    end,
+    ok.
+
+stop_trace(Tracer, _PidSpec) ->
+    _X00 = dbg:flush_trace_port(),
+    (catch dbg:ctp()),
+    (catch dbg:stop()),
+    (catch dbg:stop_clear()),
+    (exit(Tracer, normal)),
+    ok.
+
+format_trace(BinaryFile) ->
+    format_trace(BinaryFile, BinaryFile ++ ".out").
+
+format_trace(BinaryFile, OutFile) ->
+    Acc = exp1_init(OutFile),
+    dbg:trace_client(file, BinaryFile, {fun exp1/2, Acc}).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+exp0({trace_ts, Pid, call, {M,F,A}, BIN, _TS}, _Acc) ->
+    Stak = lists:filter(fun("unknown function") -> false;
+                           (_)                  -> true
+                        end, stak(BIN)), % Thank you, Mats!
+    MFA_str = lists:flatten(io_lib:format("~w:~w/~w", [M, F, A])),
+    Total0 = Stak ++ [MFA_str],
+    Total = stak_trim(Total0),
+    io:format("~w;~s\n", [Pid, intercalate(";", Total)]);
+exp0(end_of_trace, _Acc) ->
+    io:format("End of trace found, hooray!\n");
+exp0(Else, _Acc) ->
+    io:format("?? ~P\n", [Else, 10]).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+exp1_init(OutputPath) ->
+    #state{output_path=OutputPath}.
+
+exp1(end_of_trace = _Else, #state{output_path=OutputPath} = OuterS) ->
+    (catch erlang:delete(hello_world)),
+    PidStates = get(),
+    {ok, FH} = file:open(OutputPath, [write, raw, binary, delayed_write]),
+    io:format("\n\nWriting to ~s for ~w processes... ", [OutputPath, length(PidStates)]),
+    [
+        [begin
+             Pid_str0 = lists:flatten(io_lib:format("~w", [Pid])),
+             Size = length(Pid_str0),
+             Pid_str = [$(, lists:sublist(Pid_str0, 2, Size-2), $)],
+             Time_str = integer_to_list(Time),
+             file:write(FH, [Pid_str, $;, intersperse($;, lists:reverse(Stack)), 32, Time_str, 10])
+         end || {Stack, Time} <- Acc]
+     || {Pid, #state{acc=Acc} = _S} <- PidStates],
+    file:close(FH),
+    io:format("finished!\n"),
+    OuterS;
+exp1(T, #state{output_path=OutputPath} = S) ->
+    trace_ts = element(1, T),
+    Pid = element(2, T),
+    PidState = case erlang:get(Pid) of
+                   undefined ->
+                       io:format("~p ", [Pid]),
+                       #state{output_path=OutputPath};
+                   SomeState ->
+                       SomeState
+               end,
+    NewPidState = exp1_inner(T, PidState),
+    erlang:put(Pid, NewPidState),
+    S.
+
+exp1_inner({trace_ts, _Pid, InOut, _MFA, _TS}, #state{last_ts=undefined} = S)
+  when InOut == in; InOut == out ->
+    exp1_hello_world(),
+    %% in & out, without call context, don't help us
+    S;
+exp1_inner({trace_ts, _Pid, Return, _MFA, _TS}, #state{last_ts=undefined} = S)
+  when Return == return_from; Return == return_to ->
+    exp1_hello_world(),
+    %% return_from and return_to, without call context, don't help us
+    S;
+exp1_inner({trace_ts, Pid, call, MFA, BIN, TS},
+     #state{last_ts=LastTS, acc=Acc, count=Count} = S) ->
+  try
+    exp1_hello_world(),
+    %% Calculate time elapsed, TS-LastTs.
+    %% 0. If Acc is empty, then skip step #1.
+    %% 1. Credit elapsed time to the stack on the top of Acc.
+    %% 2. Push a 0 usec item with this stack onto Acc.
+    Stak = lists:filter(fun(<<"unknown function">>) -> false;
+                           (_)                      -> true
+                        end, stak_binify(BIN)),
+    Stack0 = stak_trim(Stak),
+    MFA_bin = mfa_binify(MFA),
+    Stack1 = [MFA_bin|lists:reverse(Stack0)],
+    Acc2 = case Acc of
+               [] ->
+                   [{Stack1, 0}];
+               [{LastStack, LastTime}|Tail] ->
+                   USec = timer:now_diff(TS, LastTS),
+%                   io:format("Stack1: ~p ~p\n", [Stack1, USec]),
+                   [{Stack1, 0},
+                    {LastStack, LastTime + USec}|Tail]
+           end,
+    %% TODO: more state tracking here.
+    S#state{pid=Pid, last_ts=TS, count=Count+1, acc=Acc2}
+  catch XX:YY ->
+            io:format(user, "~p: ~p:~p @ ~p\n", [?LINE, XX, YY, erlang:get_stacktrace()]),
+            S
+  end;
+exp1_inner({trace_ts, _Pid, return_to, MFA, TS}, #state{last_ts=LastTS, acc=Acc} = S) ->
+  try
+    %% Calculate time elapsed, TS-LastTs.
+    %% 1. Credit elapsed time to the stack on the top of Acc.
+    %% 2. Push a 0 usec item with the "best" stack onto Acc.
+    %%    "best" = MFA exists in the middle of the stack onto Acc,
+    %%    or else MFA exists at the top of a stack elsewhere in Acc.
+    [{LastStack, LastTime}|Tail] = Acc,
+    MFA_bin = mfa_binify(MFA),
+    BestStack = lists:dropwhile(fun(SomeMFA) when SomeMFA /= MFA_bin -> true;
+                                   (_)                               -> false
+                                end, find_matching_stack(MFA_bin, Acc)),
+    USec = timer:now_diff(TS, LastTS),
+    Acc2 = [{BestStack, 0},
+            {LastStack, LastTime + USec}|Tail],
+%    io:format(user, "return-to: ~p\n", [lists:sublist(Acc2, 4)]),
+    S#state{last_ts=TS, acc=Acc2}
+  catch XX:YY ->
+            io:format(user, "~p: ~p:~p @ ~p\n", [?LINE, XX, YY, erlang:get_stacktrace()]),
+            S
+  end;
+    
+exp1_inner({trace_ts, _Pid, gc_start, _Info, TS}, #state{last_ts=LastTS, acc=Acc} = S) ->
+  try
+    %% Push a 0 usec item onto Acc.
+    [{LastStack, LastTime}|Tail] = Acc,
+    NewStack = [<<"GARBAGE-COLLECTION">>|LastStack],
+    USec = timer:now_diff(TS, LastTS),
+    Acc2 = [{NewStack, 0},
+            {LastStack, LastTime + USec}|Tail],
+%    io:format(user, "GC 1: ~p\n", [lists:sublist(Acc2, 4)]),
+    S#state{last_ts=TS, acc=Acc2}
+  catch _XX:_YY ->
+            %% io:format(user, "~p: ~p:~p @ ~p\n", [?LINE, _XX, _YY, erlang:get_stacktrace()]),
+            S
+  end;
+exp1_inner({trace_ts, _Pid, gc_end, _Info, TS}, #state{last_ts=LastTS, acc=Acc} = S) ->
+  try
+    %% Push the GC time onto Acc, then push 0 usec item from last exec
+    %% stack onto Acc.
+    [{GCStack, GCTime},{LastExecStack,_}|Tail] = Acc,
+    USec = timer:now_diff(TS, LastTS),
+    Acc2 = [{LastExecStack, 0}, {GCStack, GCTime + USec}|Tail],
+%    io:format(user, "GC 2: ~p\n", [lists:sublist(Acc2, 4)]),
+    S#state{last_ts=TS, acc=Acc2}
+  catch _XX:_YY ->
+            %% io:format(user, "~p: ~p:~p @ ~p\n", [?LINE, _XX, _YY, erlang:get_stacktrace()]),
+            S
+  end;
+
+exp1_inner({trace_ts, _Pid, out, MFA, TS}, #state{last_ts=LastTS, acc=Acc} = S) ->
+  try
+    %% Push a 0 usec item onto Acc.
+    %% The MFA reported here probably doesn't appear in the stacktrace
+    %% given to us by the last 'call', so add it here.
+    [{LastStack, LastTime}|Tail] = Acc,
+    MFA_bin = mfa_binify(MFA),
+    NewStack = [<<"SLEEP">>,MFA_bin|LastStack],
+    USec = timer:now_diff(TS, LastTS),
+    Acc2 = [{NewStack, 0},
+            {LastStack, LastTime + USec}|Tail],
+    S#state{last_ts=TS, acc=Acc2}
+  catch XX:YY ->
+            io:format(user, "~p: ~p:~p @ ~p\n", [?LINE, XX, YY, erlang:get_stacktrace()]),
+            S
+  end;
+exp1_inner({trace_ts, _Pid, in, MFA, TS}, #state{last_ts=LastTS, acc=Acc} = S) ->
+  try
+    %% Push the Sleep time onto Acc, then push 0 usec item from last
+    %% exec stack onto Acc.
+    %% The MFA reported here probably doesn't appear in the stacktrace
+    %% given to us by the last 'call', so add it here.
+    MFA_bin = mfa_binify(MFA),
+    [{SleepStack, SleepTime},{LastExecStack,_}|Tail] = Acc,
+    USec = timer:now_diff(TS, LastTS),
+    Acc2 = [{[MFA_bin|LastExecStack], 0}, {SleepStack, SleepTime + USec}|Tail],
+    S#state{last_ts=TS, acc=Acc2}
+  catch XX:YY ->
+            io:format(user, "~p: ~p:~p @ ~p\n", [?LINE, XX, YY, erlang:get_stacktrace()]),
+            S
+  end;
+
+exp1_inner(end_of_trace = _Else, #state{pid=Pid, output_path=OutputPath, acc=Acc} = S) ->
+    {ok, FH} = file:open(OutputPath, [write, raw, binary, delayed_write]),
+    io:format("Writing to ~s ... ", [OutputPath]),
+    [begin
+         Pid_str = io_lib:format("~w", [Pid]),
+         Time_str = integer_to_list(Time),
+         file:write(FH, [Pid_str, $;, intersperse($;, lists:reverse(Stack)), 32, Time_str, 10])
+     end || {Stack, Time} <- Acc],
+    file:close(FH),
+    io:format("finished\n"),
+    S;
+exp1_inner(_Else, S) ->
+    io:format("?? ~P\n", [_Else, 10]),
+    S.
+
+exp1_hello_world() ->
+    case erlang:get(hello_world) of
+        undefined ->
+            io:format("Hello, world, I'm ~p and I'm running....\n", [self()]),
+            erlang:put(hello_world, true);
+        _ ->
+            ok
+    end.
+
+find_matching_stack(MFA_bin, [{H,_Time}|_] = Acc) ->
+    case lists:member(MFA_bin, H) of
+        true ->
+            H;
+        false ->
+            find_matching_stack2(MFA_bin, Acc)
+    end.
+
+find_matching_stack2(MFA_bin, [{[MFA_bin|_StackTail]=Stack,_Time}|_]) ->
+    Stack;
+find_matching_stack2(MFA_bin, [_H|T]) ->
+    find_matching_stack2(MFA_bin, T);
+find_matching_stack2(_MFA_bin, []) ->
+    [<<"FIND-MATCHING-FAILED">>].    
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+start_tracer(BinaryFile) ->
+    dbg:tracer(port, dbg:trace_port(file, BinaryFile)).
+
+help() ->
+    io:format("
+    Usage: 1st phase: Generate a binary trace
+
+        ~s:write_trace(Mode, BinaryFile, PidSpec, SleepMSecs)
+        ~s:write_trace(Mode, BinaryFile, PidSpec, M, F, A)
+        %% The following forms used with experimental VM only!
+        ~s:write_trace_exp(Mode, BinaryFile, PidSpec, SleepMSecs)
+        ~s:write_trace_exp(Mode, BinaryFile, PidSpec, M, F, A)
+
+    Mode = 'global_calls' | 'global_calls_plus_new_procs' |
+           'global_and_local_calls' | 'global_and_local_calls_plus_new_procs' |
+           erlang_trace_flags()
+    erlang_trace_flags() = See OTP docs for erlang:trace() BIF
+
+    PidSpec = 'all' | 'existing' | 'new' | pid() | [pid()]
+
+    To trace current pid and execution of {M,F,A} only, we suggest:
+        ~s:write_trace(Mode, BinaryFile, self(), M, F, A)
+
+    To trace all pids and gather traces on all pids for some time, we suggest:
+        ~s:write_trace(Mode, BinaryFile, PidSpec, SleepMSecs)
+
+    Usage: 2nd phase: Convert a binary trace to an ASCII trace
+
+        ~s:format_trace(BinaryFile).  % output = input ++ \".out\"
+      or else
+        ~s:format_trace(BinaryFile, OutputFile).
+
+        Remember to wait for 'finished!' message!
+", [?MODULE || _ <- lists:seq(1, 8)]).
+
+trace_flags(Mode) when Mode == global_calls; Mode == global_and_local_calls ->
+    [call, arity, return_to, timestamp, running];
+trace_flags(Mode) when Mode == global_calls_plus_new_procs; Mode == global_and_local_calls_plus_new_procs ->
+    [call, arity, return_to, timestamp, running, set_on_spawn];
+trace_flags(Mode) when is_list(Mode) ->
+    io:format(user, "\nWARNING: we assume that you know what you're doing "
+              "when\nspecifying trace_flags(Mode=~w)\n", [Mode]),
+    Mode -- custom_trace_flags().
+
+custom_trace_flags() ->
+    [global_and_local_calls, global_calls_only].
+
+entry_to_iolist({M, F, A}) ->
+    [atom_to_binary(M, utf8), <<":">>, atom_to_binary(F, utf8), <<"/">>, integer_to_list(A)];
+entry_to_iolist(A) when is_atom(A) ->
+    [atom_to_binary(A, utf8)].
+
+intercalate(Sep, Xs) -> lists:concat(intersperse(Sep, Xs)).
+
+intersperse(_, []) -> [];
+intersperse(_, [X]) -> [X];
+intersperse(Sep, [X | Xs]) -> [X, Sep | intersperse(Sep, Xs)].
+
+stak_trim([<<"proc_lib:init_p_do_apply/3">>,<<"gen_fsm:decode_msg/9">>,<<"gen_fsm:handle_msg/7">>,<<"gen_fsm:loop/7">>|T]) ->
+    stak_trim([<<"GEN-FSM">>|T]);
+stak_trim([<<"GEN-FSM">>,<<"gen_fsm:decode_msg/9">>,<<"gen_fsm:handle_msg/7">>,<<"gen_fsm:loop/7">>|T]) ->
+    stak_trim([<<"GEN-FSM">>|T]);
+stak_trim(Else) ->
+    Else.
+
+stak_binify(Bin) when is_binary(Bin) ->
+    [list_to_binary(X) || X <- stak(Bin)];
+stak_binify(X) ->
+    list_to_binary(io_lib:format("~w", [X])).
+
+mfa_binify({M,F,A}) ->
+    list_to_binary(io_lib:format("~w:~w/~w", [M, F, A]));
+mfa_binify(X) ->
+    list_to_binary(io_lib:format("~w", [X])).
+
+%% Borrowed from redbug.erl
+
+stak(Bin) ->
+  lists:foldl(fun munge/2,[],string:tokens(binary_to_list(Bin),"\n")).
+
+munge(I,Out) ->
+  case I of %% lists:reverse(I) of
+    "..."++_ -> ["truncated!!!"|Out];
+    _ ->
+      case string:str(I, "Return addr") of
+        0 ->
+          case string:str(I, "cp = ") of
+            0 -> Out;
+            _ -> [mfaf(I)|Out]
+          end;
+        _ ->
+          case string:str(I, "erminate process normal") of
+            0 -> [mfaf(I)|Out];
+            _ -> Out
+          end
+      end
+  end.
+
+mfaf(I) ->
+  [_, C|_] = string:tokens(I,"()+"),
+  string:strip(C).

--- a/deps/eflame/src/eflame_app.erl
+++ b/deps/eflame/src/eflame_app.erl
@@ -1,0 +1,16 @@
+-module(eflame_app).
+
+-behaviour(application).
+
+%% Application callbacks
+-export([start/2, stop/1]).
+
+%% ===================================================================
+%% Application callbacks
+%% ===================================================================
+
+start(_StartType, _StartArgs) ->
+    eflame_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/deps/eflame/src/eflame_sup.erl
+++ b/deps/eflame/src/eflame_sup.erl
@@ -1,0 +1,27 @@
+-module(eflame_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% Helper macro for declaring children of supervisor
+-define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% ===================================================================
+%% Supervisor callbacks
+%% ===================================================================
+
+init([]) ->
+    {ok, { {one_for_one, 5, 10}, []} }.
+

--- a/deps/eflame/stack_to_flame.sh
+++ b/deps/eflame/stack_to_flame.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+me="$(dirname $0)"
+
+uniq -c | awk '{print $2, " ", $1}' | $me/flamegraph.pl

--- a/deps/eflame/stacks_to_flames.sh
+++ b/deps/eflame/stacks_to_flames.sh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+
+# This scripts renders separate flame graphs for each process in the file at the first argument
+# Canvas sizes are tuned relatively to the longest running process (max is $maxwidth)
+
+# usage:
+# deps/eflame/stacks_to_flames.sh stacks.out
+
+me="$(dirname $0)"
+f=${1:-stacks.out}
+maxwidth=${maxwidth:-1430}
+
+for width pid in $(awk -F';' '{print $1}' $f | uniq -c | tr -d '<>' | sort -rn -k1); do
+	max=${max:-$width.0}
+	echo -n "pid: $pid\tsamples: $width\t"
+	grep $pid $f | $me/flamegraph.pl --title="$title ($pid)" --width=$(($maxwidth / $max * $width)) > flame_$pid.svg
+	echo flame_$pid.svg
+done


### PR DESCRIPTION
Tested thusly:

`kz_tracers:gen_load(N).` will spawn N workers who will create a new database and 1000 documents inside that database, and will perform edit/delete operations against those documents until all are deleted, at which point the database is deleted.

The parent process will track the `whistle_couch_cache` process' largest `message_queue_len` and `current_function`, and will output those values (along with runtime):

```
kz_tracers:gen_load(5).
...processing...
finished test after 531140ms: {23, {lager_format, build2, 3}}
```

In this case, the largest mailbox length found was 23 messages and the whistle_couch_cache process was in `lager_format:build2/3` when that was read.

For perspective, the previous `wh_cache` topped out around 23K messages in the queue, so this PR marks a significant improvement.