### PR TITLE
Proposal to make webseq status configurable

### DIFF
--- a/applications/konami/src/konami.hrl
+++ b/applications/konami/src/konami.hrl
@@ -12,5 +12,7 @@
         ,{'event', CallId, EventName, Event}
        ).
 
+-define(WSD_ENABLED, kapps_config:get_is_true(?APP_NAME, <<"webseq_enabled">>, 'false')).
+	   
 -define(KONAMI_HRL, 'true').
 -endif.

--- a/applications/konami/src/konami.hrl
+++ b/applications/konami/src/konami.hrl
@@ -12,7 +12,7 @@
         ,{'event', CallId, EventName, Event}
        ).
 
--define(WSD_ENABLED, kapps_config:get_is_true(?APP_NAME, <<"webseq_enabled">>, 'false')).
+-define(WSD_ENABLED, kapps_config:get_is_true(?CONFIG_CAT, <<"webseq_enabled">>, 'false')).
 	   
 -define(KONAMI_HRL, 'true').
 -endif.

--- a/applications/konami/src/konami_code_fsm.erl
+++ b/applications/konami/src/konami_code_fsm.erl
@@ -56,7 +56,7 @@
                }).
 -type state() :: #state{}.
 
--define(WSD_ENABLED, whapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'true')).
+-define(WSD_ENABLED, whapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'false')).
 
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', get('callid')}).
 

--- a/applications/konami/src/konami_code_fsm.erl
+++ b/applications/konami/src/konami_code_fsm.erl
@@ -56,7 +56,7 @@
                }).
 -type state() :: #state{}.
 
--define(WSD_ENABLED, kapps_config:get_is_true(?APP_NAME, <<"webseq_enabled">>, 'true')).
+-define(WSD_ENABLED, kapps_config:get_is_true(?APP_NAME, <<"webseq_enabled">>, 'false')).
 
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', get('callid')}).
 

--- a/applications/konami/src/konami_code_fsm.erl
+++ b/applications/konami/src/konami_code_fsm.erl
@@ -56,7 +56,7 @@
                }).
 -type state() :: #state{}.
 
--define(WSD_ENABLED, 'false').
+-define(WSD_ENABLED, whapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'true')).
 
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', get('callid')}).
 

--- a/applications/konami/src/konami_code_fsm.erl
+++ b/applications/konami/src/konami_code_fsm.erl
@@ -56,7 +56,7 @@
                }).
 -type state() :: #state{}.
 
--define(WSD_ENABLED, whapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'false')).
+-define(WSD_ENABLED, kapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'false')).
 
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', get('callid')}).
 

--- a/applications/konami/src/konami_code_fsm.erl
+++ b/applications/konami/src/konami_code_fsm.erl
@@ -56,7 +56,7 @@
                }).
 -type state() :: #state{}.
 
--define(WSD_ENABLED, kapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'false')).
+-define(WSD_ENABLED, kapps_config:get_is_true(?APP_NAME, <<"webseq_enabled">>, 'true')).
 
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', get('callid')}).
 

--- a/applications/konami/src/konami_code_fsm.erl
+++ b/applications/konami/src/konami_code_fsm.erl
@@ -56,8 +56,6 @@
                }).
 -type state() :: #state{}.
 
--define(WSD_ENABLED, kapps_config:get_is_true(?APP_NAME, <<"webseq_enabled">>, 'false')).
-
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', get('callid')}).
 
 -define(WSD_EVT(Fr, T, E), ?WSD_ENABLED andalso webseq:evt(?WSD_ID, Fr, T, <<(kz_util:to_binary(?LINE))/binary, "-", E/binary>>)).

--- a/applications/konami/src/module/konami_transfer.erl
+++ b/applications/konami/src/module/konami_transfer.erl
@@ -38,7 +38,7 @@
 
 -include("konami.hrl").
 
--define(WSD_ENABLED, whapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'true')).
+-define(WSD_ENABLED, kapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'true')).
 
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', <<(get('callid'))/binary, "_transfer">>}).
 

--- a/applications/konami/src/module/konami_transfer.erl
+++ b/applications/konami/src/module/konami_transfer.erl
@@ -38,8 +38,6 @@
 
 -include("konami.hrl").
 
--define(WSD_ENABLED, kapps_config:get_is_true(?APP_NAME, <<"webseq_enabled">>, 'true')).
-
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', <<(get('callid'))/binary, "_transfer">>}).
 
 -define(WSD_EVT(Fr, T, E), ?WSD_ENABLED andalso webseq:evt(?WSD_ID, Fr, T, <<(kz_util:to_binary(?LINE))/binary, "-", E/binary>>)).

--- a/applications/konami/src/module/konami_transfer.erl
+++ b/applications/konami/src/module/konami_transfer.erl
@@ -38,7 +38,7 @@
 
 -include("konami.hrl").
 
--define(WSD_ENABLED, 'true').
+-define(WSD_ENABLED, whapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'true')).
 
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', <<(get('callid'))/binary, "_transfer">>}).
 

--- a/applications/konami/src/module/konami_transfer.erl
+++ b/applications/konami/src/module/konami_transfer.erl
@@ -38,7 +38,7 @@
 
 -include("konami.hrl").
 
--define(WSD_ENABLED, kapps_config:get_integer(?APP_NAME, <<"webseq_enabled">>, 'true')).
+-define(WSD_ENABLED, kapps_config:get_is_true(?APP_NAME, <<"webseq_enabled">>, 'true')).
 
 -define(WSD_ID, ?WSD_ENABLED andalso {'file', <<(get('callid'))/binary, "_transfer">>}).
 


### PR DESCRIPTION
Proposal to load webseq status load from a configurable place as keeping it on everytime crashes konami. i am looking into why there is a crash on some particular call transfers