### PR TITLE
Add random suffix to key in #data_connection{}

### DIFF
--- a/core/kazoo_data/src/kz_data.hrl
+++ b/core/kazoo_data/src/kz_data.hrl
@@ -11,7 +11,7 @@
 -define(APP_NAME, <<"datamgr">>).
 -define(APP_VERSION, <<"4.0.0">>).
 
--record(data_connection, {id = kz_util:current_tstamp()
+-record(data_connection, {id = {kz_util:current_tstamp(), kz_util:rand_hex_binary(4)}
                           ,app :: atom() | '$1'
                           ,props = #{} :: #{} | '_'
                           ,server :: any() | '$2'


### PR DESCRIPTION
This PR mostly for pointing to problem, not to fix.

Playing with "system_data" on test server i randomly got error (~50%) on start:
> May  5 07:57:38 dev 2600hz[5385]: |0000000000|Undefined:Undefined (emulator) Error in process <0.3263.0> on node 'kazoo_apps@dev' with exit value:#012{function_clause,[{kzs_doc,open_doc,[#{server => undefined,tag => local},<<"system_config">>,<<"kapps_controller">>,[]],[{file,"src/kzs_doc.erl"},{line,37}]},{timer,tc,1,[{file,"timer.erl"},{line,166}]},{kzs_perf,do_profile,3,[{file,"src/kzs_perf.erl"},{line,81}]},{kzs_cache,open_cache_doc,3,[{file,"src/kzs_cache.erl"},{line,54}]},{kapps_config,get,4,[{file,"src/kapps_config.erl"},{line,239}]},{kapps_controller,initialize_kapps,0,[{file,"src/kapps_controller.erl"},{line,145}]}]}

My `systemd_data/system` document:
```JSON
{
   "_id": "system",
   "_rev": "68-55ec4b43a96efc800a52a2b63aa6e92c",
   "attachments": {
   },
   "connections": {
       "local": {
           "ip": "10.0.0.254",
           "port": 5984
       },
       "accounts-db": {
           "ip": "10.0.0.253",
           "port": 5984
       },
       "modb-db": {
           "ip": "10.0.0.252",
           "port": 5984,
           "username": "kazoo",
           "password": "secret"
       },
       "system-db": {
           "ip": "10.0.0.254",
           "port": 5984
       }
   },
   "plan": {
       "account": {
           "attachments": {
           },
           "connection": "accounts-db",
           "types": {
           }
       },
       "modb": {
           "attachments": {
           },
           "connection": "modb-db",
           "types": {
           }
       },
       "system": {
           "attachments": {
           },
           "connection": "system-db",
           "types": {
           }
       }
   },
   "pvt_type": "storage"
}
```

After littlle investigation I found that `#data_connection{}` used current timestamp as key for ets:table. And this led to situation when 'system-db' connection overwrite 'local' connection in `kz_dataconnections` table (if connections start in the same second, both connections got same ID).
And this situation happens only with `-mode embedded` (make release), in `interractive` mode connections hardly ever starts in same time.

So "quick fix" is adding random suffix to ID.
Maybe better use `tag` as key? Or just random UUID?