### PR TITLE
Fixed an issue with adding a customer

### DIFF
--- a/core/braintree/src/braintree_card.erl
+++ b/core/braintree/src/braintree_card.erl
@@ -176,11 +176,10 @@ expiring(Start, End) ->
 %% Accessors for field 'make_default'.
 %% @end
 %%--------------------------------------------------------------------
--spec make_default(bt_card() | 'undefined') -> api_boolean().
+-spec make_default(bt_card()) -> api_boolean().
 -spec make_default(bt_card(), boolean()) -> bt_card().
 
-make_default(#bt_card{make_default = 'true'}) -> 'true';
-make_default(_) -> 'false'.
+make_default(#bt_card{make_default = Value}) -> Value.
 
 make_default(#bt_card{}=Card, Value) ->
     Card#bt_card{make_default = Value}.
@@ -300,7 +299,6 @@ record_to_xml(#bt_card{}=Card, ToString) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec json_to_record(api_object()) -> bt_card().
-json_to_record('undefined') -> 'undefined';
 json_to_record(JObj) ->
     #bt_card{token = create_or_get_json_id(JObj)
              ,cardholder_name = kz_json:get_binary_value(<<"cardholder_name">>, JObj)

--- a/core/braintree/src/braintree_card.erl
+++ b/core/braintree/src/braintree_card.erl
@@ -176,11 +176,11 @@ expiring(Start, End) ->
 %% Accessors for field 'make_default'.
 %% @end
 %%--------------------------------------------------------------------
--spec make_default(bt_card()) -> api_boolean().
+-spec make_default(bt_card() | 'undefined') -> api_boolean().
 -spec make_default(bt_card(), boolean()) -> bt_card().
 
-make_default(#bt_card{make_default = Value}) -> Value;
-make_default('undefined') -> 'false'.
+make_default(#bt_card{make_default = 'true'}) -> 'true';
+make_default(_) -> 'false'.
 
 make_default(#bt_card{}=Card, Value) ->
     Card#bt_card{make_default = Value}.

--- a/core/braintree/src/braintree_card.erl
+++ b/core/braintree/src/braintree_card.erl
@@ -179,7 +179,8 @@ expiring(Start, End) ->
 -spec make_default(bt_card()) -> api_boolean().
 -spec make_default(bt_card(), boolean()) -> bt_card().
 
-make_default(#bt_card{make_default = Value}) -> Value.
+make_default(#bt_card{make_default = Value}) -> Value;
+make_default('undefined') -> 'false'.
 
 make_default(#bt_card{}=Card, Value) ->
     Card#bt_card{make_default = Value}.

--- a/core/braintree/src/braintree_customer.erl
+++ b/core/braintree/src/braintree_customer.erl
@@ -346,8 +346,15 @@ json_to_record(JObj) ->
                  ,phone = kz_json:get_binary_value(<<"phone">>, JObj)
                  ,fax = kz_json:get_binary_value(<<"fax">>, JObj)
                  ,website = kz_json:get_binary_value(<<"website">>, JObj)
-                 ,credit_cards = [braintree_card:json_to_record(kz_json:get_value(<<"credit_card">>, JObj))]
+                 ,credit_cards = maybe_add_credit_card(JObj)
                 }.
+
+-spec maybe_add_credit_card(api_object()) -> bt_cards().
+maybe_add_credit_card(JObj) ->
+  case kz_json:get_binary_value(<<"credit_card">>, JObj) of
+      'undefined' -> [];
+      Card -> [braintree_card:json_to_record(Card)]
+  end.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/braintree/src/braintree_customer.erl
+++ b/core/braintree/src/braintree_customer.erl
@@ -351,7 +351,7 @@ json_to_record(JObj) ->
 
 -spec maybe_add_credit_card(api_object()) -> bt_cards().
 maybe_add_credit_card(JObj) ->
-  case kz_json:get_binary_value(<<"credit_card">>, JObj) of
+  case kz_json:get_value(<<"credit_card">>, JObj) of
       'undefined' -> [];
       Card -> [braintree_card:json_to_record(Card)]
   end.


### PR DESCRIPTION
When someone needed to add a customer without having their credit card braintree send an error that make_default(undefined) clause is not defined in braintree_card.erl. now we can add a new customer in braintree by just having using his info and adding a card is not needed.