### PR TITLE
Sysconf should send answer when "Value" is undefined.

### DIFF
--- a/applications/sysconf/src/sysconf_get.erl
+++ b/applications/sysconf/src/sysconf_get.erl
@@ -28,22 +28,19 @@ handle_req(ApiJObj, _Props) ->
 
     lager:debug("received sysconf get for ~s:~s from ~s", [Category, Key, Node]),
 
-    case get_value(Category, Key, Default, Node) of
-        'undefined' -> 'ok';
-        Value ->
-            RespQ = kz_json:get_value(<<"Server-ID">>, ApiJObj),
+    Value = get_value(Category, Key, Default, Node),
+    RespQ = kz_json:get_value(<<"Server-ID">>, ApiJObj),
 
-            lager:debug("sending reply for ~s.~s(~s): ~p"
-                        ,[Category, Key, Node, Value]
-                       ),
-            Resp = [{<<"Category">>, Category}
-                    ,{<<"Key">>, Key}
-                    ,{<<"Value">>, Value}
-                    ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, ApiJObj)}
-                    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
-                   ],
-            kapi_sysconf:publish_get_resp(RespQ, Resp)
-    end.
+    lager:debug("sending reply for ~s.~s(~s): ~p"
+                ,[Category, Key, Node, Value]
+               ),
+    Resp = [{<<"Category">>, Category}
+            ,{<<"Key">>, Key}
+            ,{<<"Value">>, Value}
+            ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, ApiJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_sysconf:publish_get_resp(RespQ, Resp).
 
 -spec get_value(ne_binary(), ne_binary(), any(), ne_binary()) -> any().
 get_value(_, <<"acls">>, _, Node) ->

--- a/core/kazoo/src/api/kapi_sysconf.erl
+++ b/core/kazoo/src/api/kapi_sysconf.erl
@@ -51,8 +51,8 @@
 -define(SYSCONF_GET_REQ_VALUES, [{<<"Event-Name">>, <<"get_req">>} | ?SYSCONF_VALUES]).
 
 %% answer to a read request
--define(SYSCONF_GET_RESP_HEADERS, [?CAT_KEY, ?KEY_KEY, ?VALUE_KEY]).
--define(OPTIONAL_SYSCONF_GET_RESP_HEADERS, []).
+-define(SYSCONF_GET_RESP_HEADERS, [?CAT_KEY, ?KEY_KEY]).
+-define(OPTIONAL_SYSCONF_GET_RESP_HEADERS, [?VALUE_KEY]).
 -define(SYSCONF_GET_RESP_VALUES, [{<<"Event-Name">>, <<"get_resp">>} | ?SYSCONF_VALUES]).
 
 %% request a write


### PR DESCRIPTION
Sysconfig doesnt send any answer when return value will be empty, this leads to unnecessary delays in call procedding. In my situation i had 3 seconds delay on every call, because ecallmgr couldnt get value for "should_detect_inband_dtmf".
Manualy set this parameter in DB solves my problem, but does not eliminate the root of the problem.