### PR TITLE
fix warning of unhandled account ID

### DIFF
--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -1094,8 +1094,8 @@ change_notice() ->
 %% @private
 %% @doc
 %% NOTE: the attempt to correct the dbname is not very erlang like, but
-%%  when since there are more places that expect an error and do not
-%%  handle a crash appropriately/gracefully this is a quick solution....
+%%  since there are more places that expect an error and do not
+%%  handle a crash appropriately/gracefully this is a quick solution...
 %% @end
 %%--------------------------------------------------------------------
 -spec maybe_convert_dbname(text()) ->

--- a/core/kazoo_data/src/kzs_publish.erl
+++ b/core/kazoo_data/src/kzs_publish.erl
@@ -149,7 +149,6 @@ doc_change_event_name(Action, 'false') ->
 
 -spec doc_acct_id(ne_binary(), kz_json:object()) -> ne_binary().
 doc_acct_id(Db, Doc) ->
-    Classification = kzs_util:db_classification(Db),
     case kz_doc:account_id(Doc) of
         'undefined' -> maybe_account_id_from_db(kzs_util:db_classification(Db), Db);
         AccountId -> AccountId

--- a/core/kazoo_data/src/kzs_publish.erl
+++ b/core/kazoo_data/src/kzs_publish.erl
@@ -150,6 +150,6 @@ doc_change_event_name(Action, 'false') ->
 -spec doc_acct_id(ne_binary(), kz_json:object()) -> ne_binary().
 doc_acct_id(Db, Doc) ->
     case kz_doc:account_id(Doc) of
-        'undefined' -> kz_util:format_account_id(Db, 'raw');
+        'undefined' -> kz_util:format_account_id(Db);
         AccountId -> AccountId
     end.

--- a/core/kazoo_data/src/kzs_publish.erl
+++ b/core/kazoo_data/src/kzs_publish.erl
@@ -122,22 +122,22 @@ publish(Action, Db, Doc) ->
 
     EventName = doc_change_event_name(Action, IsSoftDeleted orelse IsHardDeleted),
 
-    Props =
-        [{<<"ID">>, Id}
-        ,{<<"Origin-Cache">>, ?CACHE_NAME}
-        ,{<<"Type">>, Type}
-        ,{<<"Database">>, Db}
-        ,{<<"Rev">>, kz_doc:revision(Doc)}
-        ,{<<"Account-ID">>, doc_acct_id(Db, Doc)}
-        ,{<<"Date-Modified">>, kz_doc:created(Doc)}
-        ,{<<"Date-Created">>, kz_doc:modified(Doc)}
-        ,{<<"Is-Soft-Deleted">>, IsSoftDeleted}
-         | kz_api:default_headers(<<"configuration">>
-                                 ,EventName
-                                 ,?APP_NAME
-                                 ,?APP_VERSION
-                                 )
-        ],
+    Props = props:filter_undefined(
+              [{<<"ID">>, Id}
+               ,{<<"Origin-Cache">>, ?CACHE_NAME}
+               ,{<<"Type">>, Type}
+               ,{<<"Database">>, Db}
+               ,{<<"Rev">>, kz_doc:revision(Doc)}
+               ,{<<"Account-ID">>, doc_acct_id(Db, Doc)}
+               ,{<<"Date-Modified">>, kz_doc:created(Doc)}
+               ,{<<"Date-Created">>, kz_doc:modified(Doc)}
+               ,{<<"Is-Soft-Deleted">>, IsSoftDeleted}
+                   | kz_api:default_headers(<<"configuration">>
+                                            ,EventName
+                                            ,?APP_NAME
+                                            ,?APP_VERSION
+                                           )
+              ]),
     Fun = fun(P) -> kapi_conf:publish_doc_update(Action, Db, Type, Id, P) end,
     kz_amqp_worker:cast(Props, Fun).
 
@@ -149,7 +149,16 @@ doc_change_event_name(Action, 'false') ->
 
 -spec doc_acct_id(ne_binary(), kz_json:object()) -> ne_binary().
 doc_acct_id(Db, Doc) ->
+    Classification = kzs_util:db_classification(Db),
     case kz_doc:account_id(Doc) of
-        'undefined' -> kz_util:format_account_id(Db);
+        'undefined' -> maybe_account_id_from_db(kzs_util:db_classification(Db), Db);
         AccountId -> AccountId
     end.
+
+-spec maybe_account_id_from_db(atom(), ne_binary()) -> api_binary().
+maybe_account_id_from_db('account', Db) ->
+    kz_util:format_account_id(Db);
+maybe_account_id_from_db('modb', Db) ->
+    kz_util:format_account_id(Db);
+maybe_account_id_from_db(_, _) ->
+    'undefined'.

--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -738,9 +738,7 @@ save_to_number_db(PhoneNumber) ->
             kz_datamgr:revise_views_from_folder(NumberDb, kz_util:to_atom(?APP_NAME)),
             save_to_number_db(PhoneNumber);
         {'error', E} ->
-            lager:error("failed to save ~s in ~s: ~p"
-                        ,[number(PhoneNumber), NumberDb, E]
-                       ),
+            lager:error("failed to save ~s in ~s: ~p", [number(PhoneNumber), NumberDb, E]),
             knm_errors:database_error(E, PhoneNumber)
     end.
 -endif.


### PR DESCRIPTION
@lazedo I get a warning every time a number db is created because revise_views tries to convert NumberDb to an account ID (format_account_id fails & returns NumberDb).

Should revise_views really take an account ID? What do you think should be done here?