### PR TITLE
Refactoring stepswitch_resources:get_endpoints/3

### DIFF
--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -153,7 +153,7 @@ endpoints(Number, OffnetJObj) ->
 -spec maybe_get_endpoints(ne_binary(), kapi_offnet_resource:req()) -> kz_json:objects().
 maybe_get_endpoints(Number, OffnetJObj) ->
     case kapi_offnet_resource:hunt_account_id(OffnetJObj) of
-        'undefined' -> 
+        'undefined' ->
             lager:debug("attempting to find global resources"),
             get_endpoints(get(), Number, OffnetJObj);
         HuntAccount -> maybe_get_local_endpoints(HuntAccount, Number, OffnetJObj)

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -175,6 +175,7 @@ maybe_get_local_endpoints(HuntAccount, Number, OffnetJObj) ->
     end.
 
 -spec get_endpoints(resources(), ne_binary(), kapi_offnet_resource:req()) -> kz_json:objects().
+get_endpoints([], _Number, _OffnetJObj) -> [];
 get_endpoints(Resources, Number, OffnetJObj) ->
     CallerIdNumber = case ?RULES_HONOR_DIVERSION of
                          'false' -> kapi_offnet_resource:outbound_caller_id_number(OffnetJObj);


### PR DESCRIPTION
Refactoring filtering resources by flags/rules/cid in `get_endpoints/3`.

I planing continue refactoring and adding features to stepswitch. so I have some questions:

1. Since we have formatters, maybe `rules` should be only for filtering number? And all number modification do only by formatters?
2. In our setup we have to route calls to different carriers by lists of prefixes (very long lists). This lists cant be fited in regexes. For now its solved with custom patch. where stepswitch search prefixes in ets tables, but i want make it more scalable and use couchdb for this. So what i want to do:

- Create system-wide DB "offnet_prefixes" (offnet_routing? offnet_... ?) and per account DB (place this prefixes in account DB or use separate DB?)
- Fill this DB via cb_resources (JSON request or upload CSV file)
- Each document in DB contain prefix, resource id, some "prefix-resource-weight" (if we put here price for this resource, then we have LCR routing)
- In stepswitch_resources add request to filter resources which have prefix in DB
- After filtering, we order endpoint with standart resource-wheight and prefix-carrier-weight