### PR TITLE
Revert "quick fix"

### DIFF
--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -491,9 +491,7 @@ set_used_by(N, UsedBy=?NE_BINARY) ->
 -spec features(knm_phone_number()) -> kz_json:object().
 features(#knm_phone_number{features=Features}) -> Features.
 
--spec set_features(knm_phone_number(), kz_json:object() | list()) -> knm_phone_number().
-set_features(N, Features) when is_list(Features) ->
-    set_features(N, kz_json:from_list(Features));
+-spec set_features(knm_phone_number(), kz_json:object()) -> knm_phone_number().
 set_features(N, Features=?JSON_WRAPPER(_)) ->
     N#knm_phone_number{features=Features}.
 


### PR DESCRIPTION
This reverts commit e0d05d87b446ec0e3e84d81b6a57003c9fe62c5c.

WNM internals have nothing to do with KNM's. What you need is a migration tool.
Please don't add clutter to a brand new project already.