### PR TITLE
KAZOO-4771 Added transcription data to build_voicemail_data()

### DIFF
--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -284,6 +284,7 @@ build_voicemail_data(DataJObj) ->
     props:filter_undefined(
       [{<<"box">>, wh_json:get_value(<<"voicemail_box">>, DataJObj)}
        ,{<<"name">>, wh_json:get_value(<<"voicemail_name">>, DataJObj)}
+       ,{<<"transcription">>, wh_json:get_value([<<"voicemail_transcription">>, <<"text">>], DataJObj)}
        ,{<<"length">>, pretty_print_length(DataJObj)}
       ]).
 


### PR DESCRIPTION
- voicemail.transcription macro should now work
  in the teletype voicemail to email template