### PR TITLE
KAZOO-4736: add bulk update/delete in vmboxes crossbar module for 4.0 (#1910)

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -741,7 +741,7 @@ play_messages([H|T]=Messages, PrevMessages, Count, #mailbox{timezone=Timezone
         {'ok', 'keep'} ->
             lager:info("caller chose to save the message"),
             _ = kapps_call_command:b_prompt(<<"vm-saved">>, Call),
-            {'ok', NMessage} = kz_vm_message:set_folder(?VM_FOLDER_SAVED, H, AccountId),
+            {_, NMessage} = kz_vm_message:set_folder(?VM_FOLDER_SAVED, H, AccountId),
             play_messages(T, [NMessage|PrevMessages], Count, Box, Call);
         {'ok', 'prev'} ->
             lager:info("caller chose to listen to previous message"),

--- a/applications/crossbar/doc/ref/vmboxes.md
+++ b/applications/crossbar/doc/ref/vmboxes.md
@@ -122,6 +122,16 @@ curl -v -X GET \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages
 ```
 
+#### Change
+
+> POST /v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages
+
+```shell
+curl -v -X POST \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages
+```
+
 #### Remove
 
 > DELETE /v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages/{MSG_ID}

--- a/applications/crossbar/doc/voicemail.md
+++ b/applications/crossbar/doc/voicemail.md
@@ -105,29 +105,179 @@ curl -v http://{SERVER}:8000//v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}
 
 > DELETE /v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages
 
-```curl
-curl -v http://{SERVER}:8000//v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages
+Deleting all message is easy, just use `DELETE` method on message API endpoint to delete all account's messages.
+
+Optional payload for deleting a group of messages:
+
+* One can apply a filter to delete all messages in a particular folder(e.g. new or saved) by adding a query string `?folder=saved` to the URL or set it in the payload as `{"data": {"folder": "saved"}}`
+* Or providing an array of message ids, e.g `{"data": {"messages": [MSG_ID1, MSG_ID2, ...]}}`.
+
+**Note:** If you didn't move voicemail messages to the new format already, messages that are in old format will be moved to the new MODB format, which will cause their message id to change to the new format.
+
+```shell
+curl -v -X DELETE \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages
+```
+
+##### Response
+
+```json
+{
+    "auth_token": "{AUTH_TOKEN}",
+    "data": {
+        "suceeded": [
+            {
+                "timestamp": 63630058722,
+                "from": "1001@aeac33.sip.2600hz.com",
+                "to": "1000@aeac33.sip.2600hz.com",
+                "caller_id_number": "1001",
+                "caller_id_name": "userb userb",
+                "call_id": "79959ZDNmM2I5ZTliMzA0NzA4N2FjNjlmODA5OWVkZjUxZWU",
+                "folder": "new",
+                "length": 3140,
+                "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba"
+            }
+        ],
+        "failed": [{"201605-49be0985ea3a33046f8073083517d27b":"not_found"}]
+    },
+    "revision": "undefined",
+    "request_id": "{REQUEST_ID}",
+    "status": "success"
+}
 ```
 
 #### Fetch all messages for a voicemail box
 
 > GET /v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages
 
-```curl
-curl -v http://{SERVER}:8000//v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages
+```shell
+curl -v -X GET \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages
+```
+
+##### Response
+
+```json
+{
+    "auth_token": "{AUTH_TOKEN}",
+    "data": [
+        {
+            "timestamp": 63630058722,
+            "from": "1001@aeac33.sip.2600hz.com",
+            "to": "1000@aeac33.sip.2600hz.com",
+            "caller_id_number": "1001",
+            "caller_id_name": "userb userb",
+            "call_id": "79959ZDNmM2I5ZTliMzA0NzA4N2FjNjlmODA5OWVkZjUxZWU",
+            "folder": "new",
+            "length": 3140,
+            "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba"
+        },
+        {
+            "timestamp": 63630058413,
+            "from": "1002@aeac33.sip.2600hz.com",
+            "to": "1000@aeac33.sip.2600hz.com",
+            "caller_id_number": "1002",
+            "caller_id_name": "userd userd",
+            "call_id": "79959MmNiMmJiMTIxODhjZjk0ZDhmOGNkMjJkN2MwNGQyNWY",
+            "folder": "new",
+            "length": 5500,
+            "media_id": "201605-f0c3c16551a5ff7b5753a381892e2e01"
+        }
+    ],
+    "revision": "undefined",
+    "request_id": "{REQUEST_ID}",
+    "status": "success"
+}
+```
+
+#### Change folder of a list of messages
+
+> POST /v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages
+
+Provide an array of message ids, e.g `{"data": {"messages": ["MSG_ID1", "MSG_ID2", "MSG_ID3"]}}` and the folder that messaged should move to(e.g. new or saved) by adding a query string `?folder=saved` to the URL or set it in the payload as `{"data": {"folder": "saved"}}`. It will return two objects. The first is all the message ids that were successfully moved and the second is those that failed with the reasons.
+
+**Note:** If you didn't move voicemail messages to the new format already, messages that are in old format will be moved to the new MODB format, which will cause their message id to change to the new format.
+
+```shell
+curl -v -X POST \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -H "Content-Type: application/json"
+    -d '{"data": {"folder": "saved", "messages": ["MSG_ID1", "MSG_ID2", "MSG_ID3"]}}'
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages
+```
+
+##### Response
+
+```json
+{
+    "auth_token": "{AUTH_TOKEN}",
+    "data": {
+        "suceeded": [
+            {
+                "timestamp": 63630058722,
+                "from": "1001@aeac33.sip.2600hz.com",
+                "to": "1000@aeac33.sip.2600hz.com",
+                "caller_id_number": "1001",
+                "caller_id_name": "userb userb",
+                "call_id": "79959ZDNmM2I5ZTliMzA0NzA4N2FjNjlmODA5OWVkZjUxZWU",
+                "folder": "new",
+                "length": 3140,
+                "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba"
+            }
+        ],
+        "failed": [{"201605-49be0985ea3a33046f8073083517d27b":"not_found"}]
+    },
+    "revision": "undefined",
+    "request_id": "{REQUEST_ID}",
+    "status": "success"
+}
 ```
 
 #### Remove a message from the voicemail box
 
 > DELETE /v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages/{MSGID}
 
-```curl
-curl -v http://{SERVER}:8000//v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages/{MSGID}
+**Note:** If you didn't move voicemail messages to the new format already, messages that are in old format will be moved to the new MODB format, which will cause their message id to change to the new format.
+
+```shell
+curl -v -X DELETE \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages/201605-6aadef09f6fcf5fd8bcdfca312e923ba
+```
+
+##### Response
+
+```json
+{
+    "auth_token": "{AUTH_TOKEN}",
+    "data": {
+        "timestamp": 63630058722,
+        "from": "1001@aeac33.sip.2600hz.com",
+        "to": "1000@aeac33.sip.2600hz.com",
+        "caller_id_number": "1001",
+        "caller_id_name": "userb userb",
+        "call_id": "79959ZDNmM2I5ZTliMzA0NzA4N2FjNjlmODA5OWVkZjUxZWU",
+        "folder": "new",
+        "length": 3140,
+        "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba"
+    },
+    "revision": "undefined",
+    "request_id": "{REQUEST_ID}",
+    "status": "success"
+}
 ```
 
 #### Fetch a message from the voicemail box
 
-> GET /v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages/{MSGID}
+> GET /v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages/{MSG_ID}
+
+```shell
+curl -v -X GET \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages/201605-6aadef09f6fcf5fd8bcdfca312e923ba
+```
 
 ```curl
 curl -v http://{SERVER}:8000//v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages/{MSGID}
@@ -135,16 +285,43 @@ curl -v http://{SERVER}:8000//v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages
 
 #### Change a message from a voicemail box
 
-> POST /v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages/{MSGID}
+**Note:** If you didn't move voicemail messages to the new format already, messages that are in old format will be moved to the new MODB format, which will cause their message id to change to the new format.
 
-```curl
-curl -v http://{SERVER}:8000//v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages/{MSGID}
+```shell
+curl -v -X POST \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -d '{"data": {"folder": "saved"}}' \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages/201605-6aadef09f6fcf5fd8bcdfca312e923ba
+```
+
+##### Response
+
+```json
+{
+    "auth_token": "{AUTH_TOKEN}",
+    "data": {
+        "timestamp": 63630058722,
+        "from": "1001@aeac33.sip.2600hz.com",
+        "to": "1000@aeac33.sip.2600hz.com",
+        "caller_id_number": "1001",
+        "caller_id_name": "userb userb",
+        "call_id": "79959ZDNmM2I5ZTliMzA0NzA4N2FjNjlmODA5OWVkZjUxZWU",
+        "folder": "saved",
+        "length": 3140,
+        "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba"
+    },
+    "revision": "undefined",
+    "request_id": "{REQUEST_ID}",
+    "status": "success"
+}
 ```
 
 #### Fetch the raw audio of the message
 
 > GET /v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages/{MSGID}/raw
 
-```curl
-curl -v http://{SERVER}:8000//v2/accounts/{ACCOUNTID}/vmboxes/{VMBOXID}/messages/{MSGID}/raw
+```shell
+curl -v -X GET \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages/201605-6aadef09f6fcf5fd8bcdfca312e923ba/raw
 ```

--- a/applications/crossbar/priv/couchdb/schemas/callflows.voicemail.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.voicemail.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "_id": "callflows.language",
+    "description": "Validator for the Voicemail callflow element",
+    "properties": {
+        "action": {
+            "default": "compose",
+            "description": "Whether to check voicemail box or compose a new voicemail message",
+            "enum": [
+                "check",
+                "compose"
+            ],
+            "name": "Action",
+            "required": false,
+            "type": "string"
+        },
+        "id": {
+            "description": "The ID of the voicemail box",
+            "maxLength": 32,
+            "minLength": 32,
+            "name": "ID",
+            "required": false,
+            "type": "string"
+        },
+        "interdigit_timeout": {
+            "default": 2000,
+            "description": "The amount of time (in milliseconds) to wait for the caller to press the next digit after pressing a digit",
+            "name": "Interdigit Timeout",
+            "required": false,
+            "type": "integer"
+        },
+        "max_message_length": {
+            "default": 500,
+            "description": "Max length of the message that caller can leave in voicemail box",
+            "name": "Max Message Lenght",
+            "required": false,
+            "type": "integer"
+        }
+    },
+    "required": true,
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/swagger/swagger.json
+++ b/applications/crossbar/priv/couchdb/swagger/swagger.json
@@ -8420,18 +8420,30 @@
                         "description": "A listing of messages"
                     }
                 }
+            },
+            "post": {
+                "description": "Change the folder of a list message",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A listing of messages"
+                    }
+                }
             }
         },
         "/v2/accounts/{ACCOUNT_ID}/vmboxes/{VMBOX_ID}/messages/{MSG_ID}": {
             "delete": {},
             "get": {},
             "post": {
-                "parameters": {
-                    "in": "body",
-                    "name": "vmboxes",
-                    "required": true,
-                    "schema": {
-                        "$ref": "#/definitions/vmboxes"
+                "description": "Change the folder of a message",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A listing of messages"
                     }
                 }
             }

--- a/applications/crossbar/src/modules_v1/cb_vmboxes_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_vmboxes_v1.erl
@@ -18,7 +18,7 @@
          ,validate/1, validate/2, validate/3, validate/4, validate/5
          ,content_types_provided/5
          ,put/1
-         ,post/2, post/4
+         ,post/2, post/3, post/4
          ,patch/2
          ,delete/2, delete/3, delete/4
 
@@ -46,8 +46,7 @@ init() ->
     _ = crossbar_bindings:bind(<<"v1_resource.execute.put.vmboxes">>, ?MODULE, 'put'),
     _ = crossbar_bindings:bind(<<"v1_resource.execute.post.vmboxes">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"v1_resource.execute.patch.vmboxes">>, ?MODULE, 'patch'),
-    _ = crossbar_bindings:bind(<<"v1_resource.execute.delete.vmboxes">>, ?MODULE, 'delete'),
-    _ = crossbar_bindings:bind(crossbar_cleanup:binding_account(), 'kz_vm_message', 'cleanup_heard_voicemail').
+    _ = crossbar_bindings:bind(<<"v1_resource.execute.delete.vmboxes">>, ?MODULE, 'delete').
 
 %%--------------------------------------------------------------------
 %% @public
@@ -69,7 +68,7 @@ allowed_methods() ->
 allowed_methods(_VMBoxID) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE, ?HTTP_PATCH].
 allowed_methods(_VMBoxID, ?MESSAGES_RESOURCE) ->
-    [?HTTP_GET, ?HTTP_DELETE].
+    [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 allowed_methods(_VMBoxID, ?MESSAGES_RESOURCE, _MsgID) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 allowed_methods(_VMBoxID, ?MESSAGES_RESOURCE, _MsgID, ?BIN_DATA) ->
@@ -86,6 +85,8 @@ allowed_methods(_VMBoxID, ?MESSAGES_RESOURCE, _MsgID, ?BIN_DATA) ->
 -spec resource_exists() -> 'true'.
 -spec resource_exists(path_token()) -> 'true'.
 -spec resource_exists(path_token(), path_token()) -> 'true'.
+-spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
+-spec resource_exists(path_token(), path_token(), path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
 resource_exists(_) -> 'true'.
 resource_exists(_, ?MESSAGES_RESOURCE) -> 'true'.
@@ -157,10 +158,8 @@ validate(Context, DocId, ?MESSAGES_RESOURCE, MediaId) ->
 validate(Context, DocId, ?MESSAGES_RESOURCE, MediaId, ?BIN_DATA) ->
     case load_message_binary(DocId, MediaId, Context) of
         {'true', C1} ->
-            C2 = update_message_doc(MediaId, C1),
-            update_mwi(
-              cb_context:set_resp_data(C2, cb_context:resp_data(C1))
-             );
+            C2 = update_message_folder(DocId, MediaId, C1),
+            update_mwi(C2);
         {_, C} -> C
     end.
 
@@ -170,31 +169,29 @@ validate(Context, DocId, ?MESSAGES_RESOURCE, MediaId, ?BIN_DATA) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 -spec post(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 post(Context, DocId) ->
     AccountId = cb_context:account_id(Context),
     Doc = cb_context:doc(Context),
     DocM = kz_json:get_value(?VM_KEY_MESSAGES, Doc),
     {Diff, BoxMsg} = kz_vm_message:find_message_differences(AccountId, DocId, DocM),
-    _ = apply_messages_changes(AccountId, Diff),
+    _ = kz_vm_message:bulk_update(cb_context:account_id(Context), DocId, Diff),
 
     Props = [{?VM_KEY_MESSAGES, BoxMsg}],
     C = crossbar_doc:save(cb_context:set_doc(Context, kz_json:set_values(Props, Doc))),
     update_mwi(C).
-post(Context, _DocId, ?MESSAGES_RESOURCE, MediaId) ->
-    C = update_message_doc(MediaId, Context),
+
+post(Context, DocId, ?MESSAGES_RESOURCE) ->
+    MsgIds = cb_context:req_value(Context, ?VM_KEY_MESSAGES, []),
+    Folder = get_folder_filter(Context, ?VM_FOLDER_SAVED),
+    {'ok', Result} = kz_vm_message:update_folder(Folder, MsgIds, cb_context:account_id(Context), DocId),
+    C = cb_context:set_resp_data(Context, Result),
     update_mwi(C).
 
--spec apply_messages_changes(ne_binary(), kz_json:objects()) -> 'ok'.
-apply_messages_changes(AccountId, Msgs) when is_list(Msgs) ->
-    _ = [apply_messages_changes(AccountId, M) || M <- Msgs],
-    'ok';
-apply_messages_changes(AccountId, Msg) ->
-    Fun = [fun(JObj) ->
-               kzd_box_message:set_metadata(Msg, JObj)
-           end
-          ],
-    {'ok', _} = kz_vm_message:update_message_doc(AccountId, kzd_box_message:media_id(Msg), Fun).
+post(Context, DocId, ?MESSAGES_RESOURCE, MediaId) ->
+    C = update_message_folder(DocId, MediaId, Context),
+    update_mwi(C).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -214,20 +211,20 @@ put(Context) ->
 -spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 -spec delete(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 delete(Context, DocId) ->
-    C = crossbar_doc:delete(Context),
     AccountId = cb_context:account_id(Context),
-    Messages = kz_vm_message:messages(AccountId, DocId),
-    _ = [kz_vm_message:set_folder(?VM_FOLDER_DELETED, M, AccountId) || M <- Messages],
+    Msgs = kz_vm_message:messages(AccountId, DocId),
+    _ = kz_vm_message:update_folder(?VM_FOLDER_DELETED, Msgs, cb_context:account_id(Context), DocId),
+    C = crossbar_doc:delete(Context),
     update_mwi(C).
 
 delete(Context, DocId, ?MESSAGES_RESOURCE) ->
-    Messages = kz_json:get_ne_value(?VM_KEY_MESSAGES, cb_context:doc(Context), []),
-    _ = [kz_vm_message:set_folder(?VM_FOLDER_DELETED, M, cb_context:account_id(Context)) || M <- Messages],
-    C = load_vmbox(DocId, Context),
+    MsgIds = cb_context:resp_data(Context),
+    {'ok', Result} = kz_vm_message:update_folder(?VM_FOLDER_DELETED, MsgIds, cb_context:account_id(Context), DocId),
+    C = cb_context:set_resp_data(Context, Result),
     update_mwi(C).
 
-delete(Context, _DocId, ?MESSAGES_RESOURCE, MediaId) ->
-    C = update_message_doc(MediaId, Context),
+delete(Context, DocId, ?MESSAGES_RESOURCE, MediaId) ->
+    C = update_message_folder(DocId, MediaId, Context),
     update_mwi(C).
 
 %%--------------------------------------------------------------------
@@ -241,7 +238,7 @@ patch(Context, Id) ->
     Doc = cb_context:doc(Context),
     DocM = kz_json:get_value(?VM_KEY_MESSAGES, Doc),
     {Diff, BoxMsg} = kz_vm_message:find_message_differences(AccountId, Id, DocM),
-    _ = apply_messages_changes(AccountId, Diff),
+    {'ok', _} = kz_vm_message:bulk_update(cb_context:account_id(Context), Id, Diff),
 
     Props = [{?VM_KEY_MESSAGES, BoxMsg}],
     crossbar_doc:save(cb_context:set_doc(Context, kz_json:set_values(Props, Doc))).
@@ -256,13 +253,11 @@ patch(Context, Id) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec validate_message(cb_context:context(), path_token(), path_token(), http_method()) -> cb_context:context().
-validate_message(Context, _DocId, MediaId, ?HTTP_GET) ->
+validate_message(Context, DocId, MediaId, ?HTTP_GET) ->
     case load_message(MediaId, 'undefined', Context) of
         {'true', C1} ->
-            C2 = update_message_doc(MediaId, C1),
-            update_mwi(
-              cb_context:set_resp_data(C2, cb_context:resp_data(C1))
-             );
+            C2 = update_message_folder(DocId, MediaId, C1),
+            update_mwi(C2);
         {_, C} -> C
     end;
 validate_message(Context, _DocId, MediaId, ?HTTP_POST) ->
@@ -281,43 +276,74 @@ validate_message(Context, _DocId, MediaId, ?HTTP_DELETE) ->
 -spec validate_messages(cb_context:context(), path_token(), http_method()) -> cb_context:context().
 validate_messages(Context, DocId, ?HTTP_GET) ->
     load_message_summary(DocId, Context);
+validate_messages(Context, _DocId, ?HTTP_POST) ->
+    case cb_context:req_value(Context, ?VM_KEY_MESSAGES, []) =/= [] of
+        'false' ->
+            cb_context:add_validation_error(<<"messages">>
+                                            ,<<"required">>
+                                            ,kz_json:from_list([{<<"message">>, <<"No message ids are specified">>}])
+                                            ,Context
+                                           );
+        _ ->
+            cb_context:set_resp_status(Context, 'success')
+    end;
 validate_messages(Context, DocId, ?HTTP_DELETE) ->
-    Context1 = load_vmbox(DocId, Context),
-    case cb_context:resp_status(Context1) of
-        'success' ->
-            Messages = kz_json:get_ne_value(?VM_KEY_MESSAGES, cb_context:doc(Context1), []),
-            Filter = cb_context:req_value(Context, ?VM_KEY_FOLDER, <<"all">>),
+    Messages = kz_vm_message:messages(cb_context:account_id(Context), DocId),
 
-            Deleted = delete_messages(Messages, Filter),
+    Filter = case cb_context:req_value(Context, ?VM_KEY_MESSAGES) of
+                 L when is_list(L) -> L;
+                 _ -> get_folder_filter(Context, <<"all">>)
+             end,
 
-            cb_context:update_doc(
-                Context1
-                ,fun(Doc) -> kz_json:set_value(?VM_KEY_MESSAGES, Deleted, Doc) end
-            );
-        _Status -> Context1
+    ToDelete = filter_messages(Messages, Filter),
+
+    cb_context:set_resp_data(
+        cb_context:set_resp_status(Context, 'success')
+        ,ToDelete
+    ).
+
+-spec get_folder_filter(cb_context:context(), ne_binary()) -> ne_binary().
+get_folder_filter(Context, Default) ->
+    ReqData = cb_context:req_data(Context),
+    QS = cb_context:query_string(Context),
+    ReqJObj = cb_context:req_json(Context),
+
+    case kz_json:find(?VM_KEY_FOLDER, [ReqData, QS, ReqJObj]) of
+        ?VM_FOLDER_NEW -> ?VM_FOLDER_NEW;
+        ?VM_FOLDER_SAVED -> ?VM_FOLDER_SAVED;
+        _ -> Default
     end.
-
 
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec delete_messages(kz_json:objects(), ne_binary()) -> kz_json:objects().
--spec delete_messages(kz_json:objects(), ne_binary(), kz_json:objects()) -> kz_json:objects().
-delete_messages(Messages, Filter) ->
-    delete_messages(Messages, Filter, []).
+-spec filter_messages(kz_json:objects(), ne_binary() | ne_binaries()) -> kz_json:objects().
+-spec filter_messages(kz_json:objects(), ne_binary() | ne_binaries(), kz_json:objects()) -> kz_json:objects().
+filter_messages(Messages, Filter) ->
+    filter_messages(Messages, Filter, []).
 
-delete_messages([], _Filter, Deleted) ->
-    Deleted;
-delete_messages([Mess|Messages], <<"all">> = Filter, Deleted) ->
-    delete_messages(Messages, Filter, [Mess|Deleted]);
-delete_messages([Mess|Messages], Filter, Deleted) ->
+filter_messages([], _Filter, Selected) ->
+    Selected;
+filter_messages([Mess|Messages], <<"all">>=Filter, Selected) ->
+    Id = kzd_box_message:media_id(Mess),
+    filter_messages(Messages, Filter, [Id|Selected]);
+filter_messages([Mess|Messages], Filter, Selected) when Filter =:= ?VM_FOLDER_NEW;
+                                                        Filter =:= ?VM_FOLDER_SAVED;
+                                                        Filter =:= ?VM_FOLDER_DELETED ->
+    Id = kzd_box_message:media_id(Mess),
     case kzd_box_message:folder(Mess) of
-        Filter ->
-            delete_messages(Messages, Filter, [Mess|Deleted]);
-        _ ->
-            delete_messages(Messages, Filter, Deleted)
+        Filter -> filter_messages(Messages, Filter, [Id|Selected]);
+        _ -> filter_messages(Messages, Filter, Selected)
+    end;
+filter_messages(_, [], Selected) ->
+    Selected;
+filter_messages([Mess|Messages], Filter, Selected) ->
+    Id = kzd_box_message:media_id(Mess),
+    case lists:member(Id, Filter) of
+        'true' -> filter_messages(Messages, Filter, [Id|Selected]);
+        'false' -> filter_messages(Messages, Filter, Selected)
     end.
 
 %%--------------------------------------------------------------------
@@ -462,9 +488,9 @@ load_message_summary(DocId, Context) ->
 load_message(MediaId, 'undefined', Context) ->
     load_message(MediaId, kz_json:new(), Context);
 load_message(MediaId, UpdateJObj, Context) ->
-    case kz_vm_message:message_doc(cb_context:account_id(Context), MediaId) of
+    case kz_vm_message:message(cb_context:account_id(Context), MediaId) of
         {'ok', Message} ->
-            load_message_metadata(Message, UpdateJObj, crossbar_doc:handle_json_success(Message, Context));
+            ensure_message_in_folder(Message, UpdateJObj, crossbar_doc:handle_json_success(Message, Context));
         {'error', Error} ->
             {'false', crossbar_doc:handle_couch_mgr_errors(Error, MediaId, Context)}
     end.
@@ -475,25 +501,22 @@ load_message(MediaId, UpdateJObj, Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec load_message_metadata(kz_json:object(), kz_json:object(), cb_context:context()) ->
+-spec ensure_message_in_folder(kz_json:object(), kz_json:object(), cb_context:context()) ->
                                         {boolean(), cb_context:context()}.
-load_message_metadata(Message, UpdateJObj, Context) ->
-    CurrentMetaData = kzd_box_message:metadata(Message, kz_json:new()),
-    CurrentFolder = kzd_box_message:folder(CurrentMetaData, ?VM_FOLDER_NEW),
+ensure_message_in_folder(Message, UpdateJObj, Context) ->
+    CurrentFolder = kzd_box_message:folder(Message, ?VM_FOLDER_NEW),
 
     RequestedFolder = cb_context:req_value(Context
                                            ,?VM_KEY_FOLDER
                                            ,kzd_box_message:folder(UpdateJObj, CurrentFolder)
                                           ),
     lager:debug("ensuring message is in folder ~s", [RequestedFolder]),
-    MetaData = kz_json:merge_jobjs(kzd_box_message:set_folder(RequestedFolder, UpdateJObj)
-                                   ,CurrentMetaData
-                                  ),
+    NewMessage = kz_json:merge_jobjs(kzd_box_message:set_folder(RequestedFolder, UpdateJObj)
+                                     ,Message
+                                    ),
     {CurrentFolder =/= RequestedFolder
-     ,cb_context:set_resp_data(
-        cb_context:set_doc(Context, kzd_box_message:set_metadata(MetaData, Message))
-        ,MetaData
-       )}.
+     ,cb_context:set_resp_data(cb_context:set_doc(Context, NewMessage), NewMessage)
+    }.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -574,13 +597,16 @@ generate_media_name(CallerId, GregorianSeconds, Ext, Timezone) ->
 
 %%--------------------------------------------------------------------
 %% @private
-%% @doc update vm message doc and handle the result
+%% @doc update message folder
 %% @end
 %%--------------------------------------------------------------------
-update_message_doc(MediaId, Context) ->
-    case kz_vm_message:update_message_doc(cb_context:account_id(Context), MediaId) of
-        {'ok', JObj} ->
-            crossbar_doc:handle_json_success(JObj, Context);
+-spec update_message_folder(ne_binary(), ne_binary(), cb_context:context()) -> cb_context:context().
+update_message_folder(BoxId, MediaId, Context) ->
+    AccountId = cb_context:account_id(Context),
+    Folder = kzd_box_message:folder(cb_context:doc(Context)),
+    case kz_vm_message:update_folder(Folder, MediaId, AccountId, BoxId) of
+        {'ok', Message} ->
+            crossbar_util:response(Message, cb_context:set_resp_status(Context, 'success'));
         {'error', Error} ->
             crossbar_doc:handle_couch_mgr_errors(Error, MediaId, Context)
     end.

--- a/core/kazoo_documents/src/kzd_box_message.erl
+++ b/core/kazoo_documents/src/kzd_box_message.erl
@@ -10,7 +10,6 @@
 
 -export([new/0, new/6, build_metadata_object/6
          ,count_folder/2, normalize_count/1
-         ,filter_vmbox_messages/2
          ,type/0
          ,folder/1, folder/2, set_folder/2, set_folder_saved/1, set_folder_deleted/1, filter_folder/2
          ,media_id/1, set_media_id/2
@@ -143,7 +142,7 @@ type() -> ?PVT_TYPE.
 folder(JObj) ->
     folder(JObj, 'undefined').
 
--spec folder(doc(), Default) -> ne_binary() | Default.
+-spec folder(doc(), Default) -> kz_json:object() | Default.
 folder(JObj, Default) ->
     kz_json:get_value(?VM_KEY_FOLDER, JObj, Default).
 
@@ -227,30 +226,3 @@ count_folder(Messages, Folders) when is_list(Folders) ->
               ]);
 count_folder(Messages, Folder) ->
     count_folder(Messages, [Folder]).
-
-%%--------------------------------------------------------------------
-%% @public
-%% @doc Given the media_id of a message, filter the message out of messages in vmbox
-%% and return a tuple of deleted message and messages list
-%% @end
-%%--------------------------------------------------------------------
--type message_filter_ret() :: {kz_json:object(), kz_json:objects()} | {'error', 'not_found'}.
-
--spec filter_vmbox_messages(ne_binary(), kz_json:objects()) -> message_filter_ret().
-filter_vmbox_messages(_MediaId, []) ->
-    lager:warning("found media doc ~s but messages in vmbox is empty", [_MediaId]),
-    {'error', 'not_found'};
-filter_vmbox_messages(MediaId, [H|T]) ->
-    filter_vmbox_messages(MediaId, media_id(H), H, T, []).
-
--spec filter_vmbox_messages(ne_binary(), ne_binary(), kz_json:object(), kz_json:objects(), kz_json:objects()) ->
-                                message_filter_ret().
-filter_vmbox_messages(MediaId, MediaId, Msg, [], Acc) ->
-    {Msg, Acc};
-filter_vmbox_messages(_MediaId, _, _, [], _) ->
-    lager:warning("found media doc ~s but could not find metadata in vmbox", [_MediaId]),
-    {'error', 'not_found'};
-filter_vmbox_messages(MediaId, MediaId, Msg, Tail, Acc) ->
-    {Msg, lists:flatten([Acc | Tail])};
-filter_vmbox_messages(MediaId, _, _, [H|T], Acc) ->
-    filter_vmbox_messages(MediaId, media_id(H), H, T, [H|Acc]).


### PR DESCRIPTION
* KAZOO-4736: change folder after setting metadata in notify_and_save_meta

* KAZOO-4736: change folder correctly in cb_vmboxes

* KAZOO-4736: add callflow voicemail element schema

* KAZOO-4736: bulk update/delete on voicemail messages

* KAZOO-4736: enhancement in voicemail migration/cleanup

* KAZOO-4736: add missing specs

* KAZOO-4736: return suceeded and failed vm message ids due

to a bulk update/move ops

* KAZOO-4736: pattern match in func header and add specs

* KAZOO-4736: fix dialyzer specs/types warning

* KAZOO-4736: some fixes and cleanup

* KAZOO-4736: iterate just once to do voicemail bulk ops

* KAZOO-4736: fix specs, better naming

* KAZOO-4736: fix spec

* KAZOO-4736: fix specs, use helper modules