### PR TITLE
sync support (online re-compile)

### DIFF
--- a/core/kazoo/src/kz_rel.erl
+++ b/core/kazoo/src/kz_rel.erl
@@ -1,0 +1,6 @@
+-module(kz_rel).
+-export([start/0]).
+
+start() ->
+	{ok, Cwd} = file:get_cwd(),
+	code:add_path(Cwd).

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,7 +1,7 @@
 DEPS = lager eiconv gen_smtp amqp_client cowboy jesse jiffy certifi couchbeam wsock zucchini \
        erlsom erlydtl exml escalus folsom detergent erlang_localtime \
        nklib gproc poolboy syslog lager_syslog eflame hep ecsv reloader \
-       proper recon getopt
+       proper recon getopt sync eunit
 
 BUILD_DEPS = parse_trans
 

--- a/rel/args
+++ b/rel/args
@@ -30,3 +30,4 @@
 
 -s lager
 -s kazoo_apps_app
+-s kz_rel

--- a/rel/sys.config
+++ b/rel/sys.config
@@ -1,4 +1,10 @@
 [
+ {sync, [
+        {src_dirs, {replace, [
+				{"../../applications", []},
+				{"../../core", []}
+			]}}
+ ]},
  {lager, [
           {handlers, [
                       {lager_console_backend, info}


### PR DESCRIPTION
Allow to dynamically recompile Erlang source code.

Usage:
#!/bin/sh
export KAZOO_CONFIG=$HOME/kazoo/config.ini
make build-dev-release
RELX_REPLACE_OS_VARS=true KZname='-name kazoo@localhost' _rel/kazoo/bin/kazoo console

(kazoo@localhost)1> sync:go().
