### PR TITLE
sync support (online re-compile)

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,7 +1,7 @@
 DEPS = lager eiconv gen_smtp amqp_client cowboy jesse jiffy certifi couchbeam wsock zucchini \
        erlsom erlydtl exml escalus folsom detergent erlang_localtime \
        nklib gproc poolboy syslog lager_syslog eflame hep ecsv reloader \
-       proper recon getopt
+       proper recon getopt sync eunit
 
 BUILD_DEPS = parse_trans
 

--- a/rel/sys.config
+++ b/rel/sys.config
@@ -1,4 +1,10 @@
 [
+ {sync, [
+        {src_dirs, {replace, [
+				{"../../applications", []},
+				{"../../core", []}
+			]}}
+ ]},
  {lager, [
           {handlers, [
                       {lager_console_backend, info}

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# this script should be run from kazoo repository clone root
+
+if [ "$KAZOO_CONFIG" = "" ]
+then
+	export KAZOO_CONFIG=$PWD/config.ini
+fi
+
+if [ "$KAZOO_NODE" = "" ]
+then
+	KAZOO_NODE=kazoo@localhost
+fi
+
+CMD=$1
+if [ "$CMD" = "" ]
+then
+	CMD=console
+fi
+
+# some modules get compiled to this path by sync
+export ERL_LIBS=_rel/kazoo
+
+make build-dev-release
+
+RELX_REPLACE_OS_VARS=true KZname="-name $KAZOO_NODE" _rel/kazoo/bin/kazoo $CMD


### PR DESCRIPTION
To recompile project's *.erl files (and then reload *.beam) automatically on changes.
Release must be built with symlinks (make build-dev-release).

In erlang shell:
> lager:set_loglevel(lager_console_backend, info).
> sync:go().

Then edit and save a file (actually just save will do):
> 18:26:38.254 [info] ../../core/kazoo_apps/src/kz_nodes.erl:0: Recompiled.