### PR TITLE
sync: proper config

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -17,6 +17,7 @@ dep_jesse = git https://github.com/for-GET/jesse 9e7830001deb78b57ce2ae15049afb7
 dep_nklib = git https://github.com/NetComposer/nklib
 dep_couchbeam = git https://github.com/benoitc/couchbeam 1.3.0
 dep_lager = git https://github.com/basho/lager 3.2.0
+dep_sync = git https://github.com/jamhed/sync
 
 ### PR opened upstream ###
 dep_erlang_localtime = git https://github.com/lazedo/erlang_localtime 0bb26016380cd7df5d30aa0ef284ae252b5bae31

--- a/rel/sys.config
+++ b/rel/sys.config
@@ -1,10 +1,5 @@
 [
- {sync, [
-        {src_dirs, {replace, [
-				{"../../applications", []},
-				{"../../core", []}
-			]}}
- ]},
+ {sync, [{exclude_masks, ["/deps/", "/_rel/"]}]},
  {lager, [
           {handlers, [
                       {lager_console_backend, info}


### PR DESCRIPTION
Specifying src_dir is wrong and works differently (it scans the specified folder for source files, and tries to compile them to specified folder [file:get_cwd() if not specified]. But we need to limit it scope to applications/core modules without altering the destination path. This requires changes to sync, and here they are. 