### PR TITLE
KAZOO-4804: stepswitch resource selectors

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/resource_selector_rules.json
+++ b/applications/crossbar/priv/couchdb/schemas/resource_selector_rules.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "_id": "resource_selector_rules",
+    "default": {},
+    "description": "Schema for resource selector rules",
+    "name": "Resource Selectord Rules",
+    "required": true,
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/resource_selectors.json
+++ b/applications/crossbar/priv/couchdb/schemas/resource_selectors.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "_id": "resource_selectors",
+    "description": "Schema for resource selectors",
+    "name": "Resource Selectors",
+    "properties": {
+        "selectors_data": {
+            "description": "Data used for selectors",
+            "items": {
+                "required": false,
+                "type": "string"
+            },
+            "name": "Selectors Data",
+            "required": true,
+            "type": "array"
+        }
+    },
+    "required": true,
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/views/resource_selectors.json
+++ b/applications/crossbar/priv/couchdb/views/resource_selectors.json
@@ -1,0 +1,34 @@
+{
+    "_id": "_design/selectors",
+    "language": "javascript",
+    "views": {
+        "cid_prefix_listing": {
+            "map": "function(doc) { if (doc.pvt_type != 'resource_selector' || doc.pvt_deleted || doc.selector_type != 'cid_prefix') return; emit(doc.selector_data, doc.resource); }"
+        },
+        "crossbar_listing": {
+            "map": "function(doc) { if (doc.pvt_type != 'resource_selector' || doc.pvt_deleted) return; emit([doc.resource, doc.selector_type], doc.selector_data); }"
+        },
+        "crossbar_search": {
+            "map": "function(doc) { if (doc.pvt_type != 'resource_selector' || doc.pvt_deleted) return; emit([doc.resource, doc.selector_type, doc.selector_data]); }"
+        },
+        "flag_listing": {
+            "map": "function(doc) { if (doc.pvt_type != 'resource_selector' || doc.pvt_deleted || doc.selector_type != 'flag') return; emit(doc.selector_data, doc.resource); }"
+        },
+        "has_flag_listing": {
+            "map": "function(doc) { if (doc.pvt_type != 'resource_selector' || doc.pvt_deleted || doc.selector_type != 'flag') return; emit(doc.resource, doc.selector_data); }",
+            "reduce": "_count"
+        },
+        "prefix_listing": {
+            "map": "function(doc) { if (doc.pvt_type != 'resource_selector' || doc.pvt_deleted || doc.selector_type != 'prefix') return; emit(doc.selector_data, doc.resource); }"
+        },
+        "regex_cid_listing": {
+            "map": "function(doc) { if (doc.pvt_type != 'resource_selector' || doc.pvt_deleted || doc.selector_type != 'regex_cid') return; emit(doc.resource, doc.selector_data); }"
+        },
+        "regex_listing": {
+            "map": "function(doc) { if (doc.pvt_type != 'resource_selector' || doc.pvt_deleted || doc.selector_type != 'regex') return; emit(doc.resource, doc.selector_data); }"
+        },
+        "weight_listing": {
+            "map": "function(doc) { if (doc.pvt_type != 'resource_selector' || doc.pvt_deleted || doc.selector_type != 'weight') return; emit(doc.resource, doc.selector_data); }"
+        }
+    }
+}

--- a/applications/stepswitch/src/resource_selectors/kz_srs_filter_cid_prefix.erl
+++ b/applications/stepswitch/src/resource_selectors/kz_srs_filter_cid_prefix.erl
@@ -1,0 +1,67 @@
+%%%-------------------------------------------------------------------
+%%% @copyright
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kz_srs_filter_cid_prefix).
+
+-export([handle_req/5]).
+
+-include("stepswitch.hrl").
+
+-define(MOD_NAME, <<"filter_cid_prefix">>).
+-define(LIST_PREFIX, <<"selectors/cid_prefix_listing">>).
+
+-spec handle_req(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_josn:object()) ->
+    stepswitch_resources:resources().
+handle_req(Resources, _Number, OffnetJObj, DB, _Params) ->
+    CIDNumber = case ?RULES_HONOR_DIVERSION of
+                    'false' -> kapi_offnet_resource:outbound_caller_id_number(OffnetJObj);
+                    'true' -> stepswitch_resources:check_diversion_fields(OffnetJObj)
+                end,
+    Keys = build_keys(CIDNumber),
+    Options = [{'keys', Keys}],
+    case kz_datamgr:get_results(DB, ?LIST_PREFIX, Options) of
+        {'ok', []} ->
+            lager:info("no matching cid prefix found for: ~p in: ~s",[CIDNumber, DB]),
+            [];
+        {'ok', Rows} ->
+            DBResult = lists:foldl(fun parse_row/2, [], Rows),
+            lists:filtermap(fun(Res) ->
+                                    Id = stepswitch_resources:get_resrc_id(Res),
+                                    case proplists:is_defined(Id, DBResult) of
+                                        'true' ->
+                                            OldSelectors = stepswitch_resources:get_resrc_selectors(Res),
+                                            PrefixMatch = props:get_value(Id, DBResult),
+                                            NewSelectors = props:set_value('cid_prefix_match', PrefixMatch, OldSelectors),
+                                            {'true', stepswitch_resources:set_resrc_selectors(Res, NewSelectors)};
+                                        'false' -> 'false'
+                                    end
+                            end
+                            ,Resources
+                           );
+        {'error', E} ->
+            lager:error("failed to get cid prefixes data from ~s: ~p", [DB, E]),
+            []
+    end.
+
+build_keys(<<"+", E164/binary>>) ->
+    build_keys(E164);
+build_keys(<<D:1/binary, Rest/binary>>) ->
+    build_keys(Rest, D, [D]).
+
+build_keys(<<D:1/binary, Rest/binary>>, Prefix, Acc) ->
+    build_keys(Rest, <<Prefix/binary, D/binary>>, [<<Prefix/binary, D/binary>> | Acc]);
+build_keys(<<>>, _, Acc) -> Acc.
+
+parse_row(Row, Acc) ->
+    Prefix = kz_json:get_ne_value(<<"key">>, Row),
+    ResId = kz_json:get_ne_value(<<"value">>, Row),
+    OldPrefix = proplists:get_value(ResId, Acc, <<>>),
+    case ResId of
+        'undefined' -> Acc;
+        _ when byte_size(Prefix) =< byte_size(OldPrefix) -> Acc;
+        _ -> props:set_value(ResId, Prefix, Acc)
+    end.

--- a/applications/stepswitch/src/resource_selectors/kz_srs_filter_flags.erl
+++ b/applications/stepswitch/src/resource_selectors/kz_srs_filter_flags.erl
@@ -1,0 +1,91 @@
+%%%-------------------------------------------------------------------
+%%% @copyright
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kz_srs_filter_flags).
+
+-export([handle_req/5]).
+
+-include("stepswitch.hrl").
+
+-define(MOD_NAME, <<"filter_flags">>).
+-define(LIST_FLAGS, <<"selectors/flag_listing">>).
+-define(LIST_HAS_FLAGS, <<"selectors/has_flag_listing">>).
+-define(DEFAULT_FLAGS_SOURCE, <<"resource">>).
+
+-spec handle_req(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_json:object()) ->
+   stepswitch_resources:resources().
+handle_req(Resources, _Number, OffnetJObj, DB, Params) ->
+    FilterSource = kz_json:get_ne_binary_value(<<"source">>, Params, ?DEFAULT_FLAGS_SOURCE),
+    lager:debug("filtering resources by flags with data from ~s", [FilterSource]),
+    filter_by_flags(Resources, kapi_offnet_resource:flags(OffnetJObj, []), DB, FilterSource).
+
+-spec filter_by_flags(stepswitch_resources:resources(), ne_binaries(), ne_binary(), ne_binary()) -> stepswitch_resources:resources().
+filter_by_flags(Resources, [], DB, <<"database">>) ->
+    lager:debug("no flags provided, filtering resources that require flags"),
+    Keys = lists:map(fun stepswitch_resources:get_resrc_id/1, Resources),
+    Options = [{'keys', Keys}, group],
+    case kz_datamgr:get_results(DB, ?LIST_HAS_FLAGS, Options) of
+        {'ok', []} -> Resources;
+        {'ok', Rows} ->
+            WithFlags = kz_datamgr:get_result_keys(Rows),
+            lists:filter(fun(Res) ->
+                                 ResId = stepswitch_resources:get_resrc_id(Res),
+                                 not lists:member(ResId, WithFlags)
+                         end
+                         ,Resources
+                        );
+        {'error', E} ->
+            lager:error("failed to get flags data from ~s: ~p", [DB, E]),
+            []
+    end;
+filter_by_flags(Resources, Flags, DB, <<"database">>) ->
+    lager:debug("filtering resources without flags: ~p",[Flags]),
+    Options = [{'keys', Flags}],
+    case kz_datamgr:get_results(DB, ?LIST_FLAGS, Options) of
+        {'ok', []} -> [];
+        {'ok', Rows} ->
+            Result = parse_rows(Rows),
+            ReqSet = sets:from_list(Flags),
+            lists:filter(fun(Res) ->
+                                 ResId = stepswitch_resources:get_resrc_id(Res),
+                                 ResSet = proplists:get_value(ResId, Result, sets:new()),
+                                 sets:is_subset(ReqSet, ResSet)
+                         end
+                         ,Resources
+                        );
+        {'error', E} ->
+            lager:error("failed to get flags data from ~s: ~p", [DB, E]),
+            []
+    end;
+filter_by_flags(Resources, [], _DB, <<"resource">>) ->
+    lager:debug("no flags provided, filtering resources that require flags"),
+    lists:filter(fun(Res) ->
+                         kz_util:is_empty(stepswitch_resources:get_resrc_flags(Res))
+                 end
+                 ,Resources
+                );
+filter_by_flags(Resources, Flags, _DB, <<"resource">>) ->
+    lager:debug("filtering resources without flags: ~p",[Flags]),
+    ReqSet = sets:from_list(Flags),
+    lists:filter(fun(Res) ->
+                         ResSet = sets:from_list(stepswitch_resources:get_resrc_flags(Res)),
+                         sets:is_subset(ReqSet, ResSet)
+                 end
+                 ,Resources
+                ).
+
+-spec parse_rows(kz_json:objects()) -> kz_proplists().
+parse_rows(Rows) ->
+    lists:foldl(fun(JObj, Acc) ->
+                        Flag = kz_json:get_value(<<"key">>, JObj),
+                        ResId = kz_json:get_value(<<"value">>, JObj),
+                        FlagsSet = proplists:get_value(ResId, Acc, sets:new()),
+                        props:set_value(ResId, sets:add_element(Flag, FlagsSet), Acc)
+                end
+                ,[]
+                ,Rows
+               ).

--- a/applications/stepswitch/src/resource_selectors/kz_srs_filter_prefix.erl
+++ b/applications/stepswitch/src/resource_selectors/kz_srs_filter_prefix.erl
@@ -1,0 +1,63 @@
+%%%-------------------------------------------------------------------
+%%% @copyright
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kz_srs_filter_prefix).
+
+-export([handle_req/5]).
+
+-include("stepswitch.hrl").
+
+-define(MOD_NAME, <<"filter_prefix">>).
+-define(LIST_PREFIX, <<"selectors/prefix_listing">>).
+
+-spec handle_req(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_json:object()) ->
+    stepswitch_resources:resources().
+handle_req(Resources, Number, _OffnetJObj, DB, _Params) ->
+    Keys = build_keys(Number),
+    Options = [{'keys', Keys}],
+    case kz_datamgr:get_results(DB, ?LIST_PREFIX, Options) of
+        {'ok', []} ->
+            lager:info("no matching prefix found for: ~p in: ~s",[Number, DB]),
+            [];
+        {'ok', Rows} ->
+            DBResult = lists:foldl(fun parse_row/2, [], Rows),
+            lists:filtermap(fun(Res) ->
+                                    Id = stepswitch_resources:get_resrc_id(Res),
+                                    case proplists:is_defined(Id, DBResult) of
+                                        'true' ->
+                                            OldSelectors = stepswitch_resources:get_resrc_selectors(Res),
+                                            PrefixMatch = props:get_value(Id, DBResult),
+                                            NewSelectors = props:set_value('prefix_match', PrefixMatch, OldSelectors),
+                                            {'true', stepswitch_resources:set_resrc_selectors(Res, NewSelectors)};
+                                        'false' -> 'false'
+                                    end
+                            end
+                            ,Resources
+                           );
+        {'error', E} ->
+            lager:error("failed to get prefixes data from ~s: ~p", [DB, E]),
+            []
+    end.
+
+build_keys(<<"+", E164/binary>>) ->
+    build_keys(E164);
+build_keys(<<D:1/binary, Rest/binary>>) ->
+    build_keys(Rest, D, [D]).
+
+build_keys(<<D:1/binary, Rest/binary>>, Prefix, Acc) ->
+    build_keys(Rest, <<Prefix/binary, D/binary>>, [<<Prefix/binary, D/binary>> | Acc]);
+build_keys(<<>>, _, Acc) -> Acc.
+
+parse_row(Row, Acc) ->
+    Prefix = kz_json:get_ne_value(<<"key">>, Row),
+    ResId = kz_json:get_ne_value(<<"value">>, Row),
+    OldPrefix = proplists:get_value(ResId, Acc, <<>>),
+    case ResId of
+        'undefined' -> Acc;
+        _ when byte_size(Prefix) =< byte_size(OldPrefix) -> Acc;
+        _ -> props:set_value(ResId, Prefix, Acc)
+    end.

--- a/applications/stepswitch/src/resource_selectors/kz_srs_filter_regex_cid_rules.erl
+++ b/applications/stepswitch/src/resource_selectors/kz_srs_filter_regex_cid_rules.erl
@@ -1,0 +1,78 @@
+%%%-------------------------------------------------------------------
+%%% @copyright
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kz_srs_filter_regex_cid_rules).
+
+-export([handle_req/5]).
+
+-include("stepswitch.hrl").
+
+-define(MOD_NAME, <<"filter_regex_cid_rules">>).
+-define(DEFAULT_RULES_SOURCE, <<"resource">>).
+-define(DEFAULT_EMPTY_RULES_ACTION, <<"allow">>).
+
+-spec handle_req(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_json:object()) ->
+    stepswitch_resources:resources().
+handle_req(Resources, _Number, OffnetJObj, DB, Params) ->
+    CIDNumber = case ?RULES_HONOR_DIVERSION of
+                    'false' -> kapi_offnet_resource:outbound_caller_id_number(OffnetJObj);
+                    'true' -> stepswitch_resources:check_diversion_fields(OffnetJObj)
+                end,
+    FilterSource = kz_json:get_ne_binary_value(<<"source">>, Params, ?DEFAULT_RULES_SOURCE),
+    EmptyRulesAction = kz_json:get_ne_binary_value(<<"empty_rules_action">>, Params,  ?DEFAULT_EMPTY_RULES_ACTION),
+    lager:debug("filtering resources by regex cid rules with data from ~s", [FilterSource]),
+    filter_by_regex_cid_rules(Resources, CIDNumber, DB, FilterSource, EmptyRulesAction).
+
+-spec filter_by_regex_cid_rules(stepswitch_resources:resources(), ne_binary(), ne_binary(), ne_binary(), ne_binary()) ->
+    stepswitch_resources:resources().
+filter_by_regex_cid_rules(Resources, CIDNumber, _DB, <<"resource">>, EmptyRulesAction) ->
+    lists:filter(fun(R) ->
+                         Rules = stepswitch_resources:get_resrc_cid_rules(R),
+                         Id = stepswitch_resources:get_resrc_id(R),
+                         case evaluate_rules(Rules, CIDNumber) of
+                             {'error', 'empty_rules'} when EmptyRulesAction =:= <<"allow">> ->
+                                 lager:debug("resource ~s has empty rules for caller idr, allow", [Id]),
+                                 'true';
+                             {'error', 'empty_rules'} when EmptyRulesAction =:= <<"deny">> ->
+                                 lager:debug("resource ~s has empty rules for caller id, skipping", [Id]),
+                                 'false';
+                             {'ok', CIDMatch} ->
+                                 lager:debug("resource ~s matches caller id match '~s'"
+                                             ,[Id, CIDMatch]
+                                            ),
+                                 'true';
+                             {'error', 'no_match'} ->
+                                 lager:debug("resource ~s does not match caller id number '~s', skipping", [Id, CIDNumber]),
+                                 'false'
+                         end
+                 end
+                 ,Resources
+                ).
+
+-spec evaluate_rules(re:mp(), ne_binary()) ->
+                            {'ok', ne_binary()} |
+                            {'error', 'empty_rules'} |
+                            {'error', 'no_match'}.
+evaluate_rules([], _) -> {'error', 'empty_rules'};
+evaluate_rules(Rules, Number) -> do_evaluate_rules(Rules, Number).
+
+-spec do_evaluate_rules(re:mp(), ne_binary()) ->
+                            {'ok', ne_binary()} |
+                            {'error', 'no_match'}.
+do_evaluate_rules([], _) -> {'error', 'no_match'};
+do_evaluate_rules([Rule|Rules], Number) ->
+    case re:run(Number, Rule) of
+        {'match', [{Start,End}]} ->
+            {'ok', binary:part(Number, Start, End)};
+        {'match', CaptureGroups} ->
+            %% find the largest matching group if present by sorting the position of the
+            %% matching groups by list, reverse so head is largest, then take the head of the list
+            {Start, End} = hd(lists:reverse(lists:keysort(2, tl(CaptureGroups)))),
+            {'ok', binary:part(Number, Start, End)};
+        _ -> do_evaluate_rules(Rules, Number)
+    end.
+

--- a/applications/stepswitch/src/resource_selectors/kz_srs_filter_regex_rules.erl
+++ b/applications/stepswitch/src/resource_selectors/kz_srs_filter_regex_rules.erl
@@ -13,32 +13,37 @@
 
 -define(MOD_NAME, <<"filter_regex_rules">>).
 -define(DEFAULT_RULES_SOURCE, <<"resource">>).
--define(DEFAULT_EMPTY_RULES_ACTION, <<"deny">>).
+-define(DEFAULT_DENY_ON_EMPTY_RULES, 'true').
+-define(DEFAULT_UPDATE_NUMBER, 'true').
 
 -spec handle_req(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_json:object()) ->
     stepswitch_resources:resources().
 handle_req(Resources, Number, _OffnetJObj, DB, Params) ->
     FilterSource = kz_json:get_ne_binary_value(<<"source">>, Params, ?DEFAULT_RULES_SOURCE),
-    EmptyRulesAction = kz_json:get_ne_binary_value(<<"empty_rules_action">>, Params,  ?DEFAULT_EMPTY_RULES_ACTION),
     lager:debug("filtering resources by regex rules with data from ~s", [FilterSource]),
-    filter_by_regex_rules(Resources, Number, DB, FilterSource, EmptyRulesAction).
+    filter_by_regex_rules(Resources, Number, DB, FilterSource, Params).
 
 -spec filter_by_regex_rules(stepswitch_resources:resources(), ne_binary(), ne_binary(), ne_binary(), ne_binary()) ->
     stepswitch_resources:resources().
-filter_by_regex_rules(Resources, Number, _DB, <<"resource">>, EmptyRulesAction) ->
-    lists:filter(fun(R) ->
+filter_by_regex_rules(Resources, Number, _DB, <<"resource">>, Params) ->
+    IsDenyOnEmptyRules = kz_json:is_true(<<"deny_on_empty_rules">>, Params,  ?DEFAULT_DENY_ON_EMPTY_RULES),
+    IsUpdateNumber = kz_json:is_true(<<"update_number">>, Params,  ?DEFAULT_UPDATE_NUMBER),
+    lists:filtermap(fun(R) ->
                          Rules = stepswitch_resources:get_resrc_rules(R),
                          Id = stepswitch_resources:get_resrc_id(R),
                          case evaluate_rules(Rules, Number) of
-                             {'error', 'empty_rules'} when EmptyRulesAction =:= <<"allow">> ->
-                                 lager:debug("resource ~s has empty rules, allow", [Id]),
-                                 'true';
-                             {'error', 'empty_rules'} when EmptyRulesAction =:= <<"deny">> ->
+                             {'error', 'empty_rules'} when IsDenyOnEmptyRules ->
                                  lager:debug("resource ~s has empty rules, skipping", [Id]),
                                  'false';
+                             {'error', 'empty_rules'} ->
+                                 lager:debug("resource ~s has empty rules, allow", [Id]),
+                                 'true';
                              {'error', 'no_match'} ->
                                  lager:debug("resource ~s does not match request, skipping", [Id]),
                                  'false';
+                             {'ok', Match} when IsUpdateNumber ->
+                                 lager:debug("resource ~s does match request, match result: ~p", [Id, Match]),
+                                 {'true', save_matched_number(R, Match)};
                              {'ok', Match} ->
                                  lager:debug("resource ~s does match request, match result: ~p", [Id, Match]),
                                  'true'
@@ -70,3 +75,9 @@ do_evaluate_rules([Rule|Rules], Number) ->
         _ -> do_evaluate_rules(Rules, Number)
     end.
 
+-spec save_matched_number(stepswitch_resources:resource(), binary()) ->
+    stepswitch_resources:resource().
+save_matched_number(Resource, Number) ->
+    OldSelectors = stepswitch_resources:get_resrc_selectors(Resource),
+    NewSelectors = props:set_value('regex_number_match', Number, OldSelectors),
+    stepswitch_resources:set_resrc_selectors(Resource, NewSelectors).

--- a/applications/stepswitch/src/resource_selectors/kz_srs_filter_regex_rules.erl
+++ b/applications/stepswitch/src/resource_selectors/kz_srs_filter_regex_rules.erl
@@ -1,0 +1,72 @@
+%%%-------------------------------------------------------------------
+%%% @copyright
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kz_srs_filter_regex_rules).
+
+-export([handle_req/5]).
+
+-include("stepswitch.hrl").
+
+-define(MOD_NAME, <<"filter_regex_rules">>).
+-define(DEFAULT_RULES_SOURCE, <<"resource">>).
+-define(DEFAULT_EMPTY_RULES_ACTION, <<"deny">>).
+
+-spec handle_req(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_json:object()) ->
+    stepswitch_resources:resources().
+handle_req(Resources, Number, _OffnetJObj, DB, Params) ->
+    FilterSource = kz_json:get_ne_binary_value(<<"source">>, Params, ?DEFAULT_RULES_SOURCE),
+    EmptyRulesAction = kz_json:get_ne_binary_value(<<"empty_rules_action">>, Params,  ?DEFAULT_EMPTY_RULES_ACTION),
+    lager:debug("filtering resources by regex rules with data from ~s", [FilterSource]),
+    filter_by_regex_rules(Resources, Number, DB, FilterSource, EmptyRulesAction).
+
+-spec filter_by_regex_rules(stepswitch_resources:resources(), ne_binary(), ne_binary(), ne_binary(), ne_binary()) ->
+    stepswitch_resources:resources().
+filter_by_regex_rules(Resources, Number, _DB, <<"resource">>, EmptyRulesAction) ->
+    lists:filter(fun(R) ->
+                         Rules = stepswitch_resources:get_resrc_rules(R),
+                         Id = stepswitch_resources:get_resrc_id(R),
+                         case evaluate_rules(Rules, Number) of
+                             {'error', 'empty_rules'} when EmptyRulesAction =:= <<"allow">> ->
+                                 lager:debug("resource ~s has empty rules, allow", [Id]),
+                                 'true';
+                             {'error', 'empty_rules'} when EmptyRulesAction =:= <<"deny">> ->
+                                 lager:debug("resource ~s has empty rules, skipping", [Id]),
+                                 'false';
+                             {'error', 'no_match'} ->
+                                 lager:debug("resource ~s does not match request, skipping", [Id]),
+                                 'false';
+                             {'ok', Match} ->
+                                 lager:debug("resource ~s does match request, match result: ~p", [Id, Match]),
+                                 'true'
+                         end
+                 end
+                 ,Resources
+                ).
+
+-spec evaluate_rules(re:mp(), ne_binary()) ->
+                            {'ok', ne_binary()} |
+                            {'error', 'empty_rules'} |
+                            {'error', 'no_match'}.
+evaluate_rules([], _) -> {'error', 'empty_rules'};
+evaluate_rules(Rules, Number) -> do_evaluate_rules(Rules, Number).
+
+-spec do_evaluate_rules(re:mp(), ne_binary()) ->
+                            {'ok', ne_binary()} |
+                            {'error', 'no_match'}.
+do_evaluate_rules([], _) -> {'error', 'no_match'};
+do_evaluate_rules([Rule|Rules], Number) ->
+    case re:run(Number, Rule) of
+        {'match', [{Start,End}]} ->
+            {'ok', binary:part(Number, Start, End)};
+        {'match', CaptureGroups} ->
+            %% find the largest matching group if present by sorting the position of the
+            %% matching groups by list, reverse so head is largest, then take the head of the list
+            {Start, End} = hd(lists:reverse(lists:keysort(2, tl(CaptureGroups)))),
+            {'ok', binary:part(Number, Start, End)};
+        _ -> do_evaluate_rules(Rules, Number)
+    end.
+

--- a/applications/stepswitch/src/resource_selectors/kz_srs_get_resources.erl
+++ b/applications/stepswitch/src/resource_selectors/kz_srs_get_resources.erl
@@ -1,0 +1,48 @@
+%%%-------------------------------------------------------------------
+%%% @copyright
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kz_srs_get_resources).
+
+-export([handle_req/5]).
+
+-include("stepswitch.hrl").
+
+-spec handle_req(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_proplist()) ->
+    stepswitch_resources:resources().
+handle_req(Resources, _Number, OffnetJObj, _DB, _Params) ->
+    NewResources = case kapi_offnet_resource:hunt_account_id(OffnetJObj) of
+                       'undefined' -> get_resources('undefined');
+                       HuntAccount ->
+                           AccountId = kapi_offnet_resource:account_id(OffnetJObj),
+                           maybe_get_local_resources(HuntAccount, AccountId)
+                   end,
+    lists:append(Resources, NewResources).
+
+-spec maybe_get_local_resources(ne_binary(), ne_binary()) -> kz_json:objects().
+maybe_get_local_resources(HuntAccount, AccountId) ->
+    case kz_util:is_in_account_hierarchy(HuntAccount, AccountId, 'true') of
+        'false' ->
+            lager:info("account ~s attempted to use local resources of ~s, but it is not allowed"
+                       ,[AccountId, HuntAccount]
+                      ),
+            [];
+        'true' ->
+            lager:info("account ~s is using the local resources of ~s", [AccountId, HuntAccount]),
+            get_resources(HuntAccount)
+    end.
+
+-spec get_resources(api_binary()) -> stepswitch_resources:resources().
+get_resources('undefined') ->
+    case kz_cache:fetch_local(?CACHE_NAME, 'global_resources') of
+        {'ok', Resources} -> Resources;
+        {'error', 'not_found'} -> stepswitch_resources:fetch_global_resources()
+    end;
+get_resources(AccountId) ->
+    case kz_cache:fetch_local(?CACHE_NAME, {'local_resources', AccountId}) of
+        {'ok', Resources} -> Resources;
+        {'error', 'not_found'} -> stepswitch_resources:fetch_local_resources(AccountId)
+    end.

--- a/applications/stepswitch/src/resource_selectors/kz_srs_null.erl
+++ b/applications/stepswitch/src/resource_selectors/kz_srs_null.erl
@@ -1,0 +1,17 @@
+%%%-------------------------------------------------------------------
+%%% @copyright
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kz_srs_null).
+
+-export([handle_req/5]).
+
+-include("stepswitch.hrl").
+
+-spec handle_req(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_json:object()) ->
+    stepswitch_resources:resources().
+handle_req(_Resources, _Number, _OffnetJObj, _Db, _Params) ->
+    [].

--- a/applications/stepswitch/src/resource_selectors/kz_srs_order_weight.erl
+++ b/applications/stepswitch/src/resource_selectors/kz_srs_order_weight.erl
@@ -1,0 +1,81 @@
+
+%%%-------------------------------------------------------------------
+%%% @copyright
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kz_srs_order_weight).
+
+-export([handle_req/5]).
+
+-include("stepswitch.hrl").
+
+-define(MOD_NAME, <<"order_weight">>).
+-define(LIST_WEIGHT, <<"selectors/weight_listing">>).
+-define(DEFAULT_WEIGHT_SOURCE, <<"resource">>).
+-define(DEFAULT_SORT_ORDER, <<"ascend">>).
+-define(DEFAULT_DESC_WEIGHT, 0).
+-define(DEFAULT_ASC_WEIGHT, 9999).
+
+-spec handle_req(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_json:object()) ->
+    stepswitch_resources:resources().
+handle_req([Resource], _Number, _OffnetJObj, _DB, _Params) ->
+    Id = stepswitch_resources:get_resrc_id(Resource),
+    lager:debug("resources list contains ony one resource (~p), skip sorting", [Id]),
+    [Resource];
+handle_req(Resources, _Number, _OffnetJObj, DB, Rules) ->
+    WeightSource = kz_json:get_ne_binary_value(<<"source">>, Rules, ?DEFAULT_WEIGHT_SOURCE),
+    SortOrder = kz_json:get_ne_binary_value(<<"sort_order">>, Rules, ?DEFAULT_SORT_ORDER),
+    lager:debug("ordering (~s) resources by weight with data from ~s", [SortOrder, WeightSource]),
+    order_by_weight(Resources, SortOrder, WeightSource, DB).
+
+-spec order_by_weight(stepswitch_resources:resources(), ne_binary(), ne_binary(), ne_binary()) -> stepswitch_resources:resources().
+order_by_weight(Resources, SortOrder, <<"resource">>, _DB) ->
+    lists:sort(fun(R1, R2) ->
+                       Weight1 = kz_util:to_integer(stepswitch_resources:get_resrc_weight(R1)),
+                       Weight2 = kz_util:to_integer(stepswitch_resources:get_resrc_weight(R2)),
+                       case SortOrder of
+                           <<"ascend">> -> Weight1 =< Weight2;
+                           <<"descend">> -> Weight2 =< Weight1
+                       end
+               end
+               ,Resources
+              );
+order_by_weight(Resources, SortOrder, <<"database">>, DB) ->
+    ResIDs = [ stepswitch_resources:get_resrc_id(R) || R <- Resources ],
+    Options = [{'keys', ResIDs}],
+    case kz_datamgr:get_results(DB, ?LIST_WEIGHT, Options) of
+        {'ok', []} -> Resources;
+        {'ok', Result} ->
+            Parsed = lists:foldl(fun parse_db_result/2, [], Result),
+            lists:sort(fun(R1, R2) ->
+                               ID1 = stepswitch_resources:get_resrc_id(R1),
+                               ID2 = stepswitch_resources:get_resrc_id(R2),
+                               case SortOrder of
+                                   <<"ascend">> ->
+                                       Weight1 = props:get_value(ID1, Parsed, ?DEFAULT_ASC_WEIGHT),
+                                       Weight2 = props:get_value(ID2, Parsed, ?DEFAULT_ASC_WEIGHT),
+                                       Weight1 =< Weight2;
+                                   <<"descend">> ->
+                                       Weight1 = props:get_value(ID1, Parsed, ?DEFAULT_DESC_WEIGHT),
+                                       Weight2 = props:get_value(ID2, Parsed, ?DEFAULT_DESC_WEIGHT),
+                                       Weight2 =< Weight1
+                               end
+                       end
+                       ,Resources
+                      );
+        {'error', E} ->
+            lager:error("failed to find weight data in ~s: ~p", [DB, E]),
+            Resources
+    end.
+
+parse_db_result(Row, Acc) ->
+    ID = kz_json:get_ne_value(<<"key">>, Row),
+    case {kz_json:get_integer_value(<<"value">>, Row), props:get_value(ID, Acc)} of
+        {'undefined', _} -> Acc;
+        {Value, 'undefined'} -> props:set_value(ID, Value, Acc);
+        {Value, OldValue} when Value > OldValue -> props:set_value(ID, Value, Acc);
+        {_, _} -> Acc
+    end.

--- a/applications/stepswitch/src/stepswitch.hrl
+++ b/applications/stepswitch/src/stepswitch.hrl
@@ -21,6 +21,8 @@
 -define(CACHE_NAME, 'stepswitch_cache').
 -define(STEPSWITCH_CNAM_POOL, 'stepswitch_cnam_pool').
 
+-define(DEFAULT_ROUTE_BY, <<"stepswitch_resources">>).
+
 -define(CCV(Key), [<<"Custom-Channel-Vars">>, Key]).
 
 -type direction() :: 'inbound' | 'outbound' | 'both'.

--- a/applications/stepswitch/src/stepswitch_maintenance.erl
+++ b/applications/stepswitch/src/stepswitch_maintenance.erl
@@ -131,10 +131,16 @@ cnam_flush() ->
 refresh() ->
     lager:debug("ensuring database ~s exists", [?RESOURCES_DB]),
     kz_datamgr:db_create(?RESOURCES_DB), % RESOURCES_DB = KZ_OFFNET_DB
+    lager:debug("ensuring database ~s exists", [?KZ_RESOURCE_SELECTORS_DB]),
+    kz_datamgr:db_create(?KZ_RESOURCE_SELECTORS_DB),
     Views = [kapps_util:get_view_json('crossbar', <<"views/resources.json">>)
              | kapps_util:get_views_json('stepswitch', "views")
             ],
     kapps_util:update_views(?RESOURCES_DB, Views, 'true'),
+    kapps_util:update_views(?KZ_RESOURCE_SELECTORS_DB
+                            ,[kapps_util:get_view_json('crossbar', <<"views/resource_selectors.json">>)]
+                            ,'true'
+                           ),
     case catch kz_datamgr:all_docs(?RESOURCES_DB, ['include_docs']) of
         {'error', _} -> 'ok';
         {'EXIT', _E} ->

--- a/applications/stepswitch/src/stepswitch_outbound.erl
+++ b/applications/stepswitch/src/stepswitch_outbound.erl
@@ -144,7 +144,8 @@ maybe_force_outbound_sms(Props, OffnetReq) ->
 %%--------------------------------------------------------------------
 -spec maybe_bridge(ne_binary(), kapi_offnet_resource:req()) -> any().
 maybe_bridge(Number, OffnetReq) ->
-    case stepswitch_resources:endpoints(Number, OffnetReq) of
+    RouteBy = stepswitch_util:route_by(),
+    case RouteBy:endpoints(Number, OffnetReq) of
         [] -> maybe_correct_shortdial(Number, OffnetReq);
         Endpoints -> stepswitch_request_sup:bridge(Endpoints, OffnetReq)
     end.
@@ -171,7 +172,8 @@ maybe_correct_shortdial(Number, OffnetReq) ->
 %%--------------------------------------------------------------------
 -spec maybe_sms(ne_binary(), kapi_offnet_resource:req()) -> any().
 maybe_sms(Number, OffnetReq) ->
-    case stepswitch_resources:endpoints(Number, OffnetReq) of
+    RouteBy = stepswitch_util:route_by(),
+    case RouteBy:endpoints(Number, OffnetReq) of
         [] -> publish_no_resources(OffnetReq);
         Endpoints -> stepswitch_request_sup:sms(Endpoints, OffnetReq)
     end.
@@ -205,7 +207,8 @@ local_sms(Props, OffnetReq) ->
 %%--------------------------------------------------------------------
 -spec maybe_originate(ne_binary(), kapi_offnet_resource:req()) -> any().
 maybe_originate(Number, OffnetReq) ->
-    case stepswitch_resources:endpoints(Number, OffnetReq) of
+    RouteBy = stepswitch_util:route_by(),
+    case RouteBy:endpoints(Number, OffnetReq) of
         [] -> publish_no_resources(OffnetReq);
         Endpoints -> stepswitch_request_sup:originate(Endpoints, OffnetReq)
     end.

--- a/applications/stepswitch/src/stepswitch_resource_selectors.erl
+++ b/applications/stepswitch/src/stepswitch_resource_selectors.erl
@@ -1,0 +1,115 @@
+%%%-------------------------------------------------------------------
+%%% @copyright
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(stepswitch_resource_selectors).
+
+-export([endpoints/2]).
+
+-include("stepswitch.hrl").
+
+-define(MOD_NAME, <<"resource_selectors">>).
+-define(SRS_CONFIG_CAT, <<?SS_CONFIG_CAT/binary, ".", ?MOD_NAME/binary>>).
+-define(MOD_PREFIX, "kz_srs_").
+-define(DEFAULT_SRS_RULES, [{[{<<"get_resources">>
+                               ,{[{<<"source">>,<<"database">>}]}}
+                             ]}
+                            ,{[{<<"filter_flags">>
+                                ,{[{<<"source">>,<<"resource">>}]}}
+                              ]}
+                            ,{[{<<"filter_regex_rules">>
+                                ,{[{<<"source">>,<<"resource">>}
+                                   ,{<<"empty_rules_action">>,<<"deny">>}
+                                  ]}
+                               }]}
+                            ,{[{<<"filter_regex_cid_rules">>
+                                ,{[{<<"source">>,<<"resource">>}
+                                   ,{<<"empty_rules_action">>,<<"allow">>}
+                                  ]}
+                               }]}
+                            ,{[{<<"order_weight">>
+                                ,{[{<<"source">>,<<"resource">>}
+                                   ,{<<"sort_order">>,<<"ascend">>}
+                                  ]}
+                               }]}
+                           ]
+       ).
+
+
+-spec endpoints(ne_binary(), kapi_offnet_resource:req()) -> kz_json:objects().
+endpoints(Number, OffnetJObj) ->
+    HuntAccountId  = get_hunt_account(OffnetJObj),
+    SelectorsDb = get_selectors_db(HuntAccountId),
+    case get_selector_rules(HuntAccountId) of
+        {'ok', SelectorRules} ->
+            Resources = foldl_modules(Number, OffnetJObj, SelectorsDb, SelectorRules),
+            stepswitch_util:resources_to_endpoints(Resources, Number, OffnetJObj);
+        {'error', _E} -> []
+    end.
+
+-spec foldl_modules(ne_binary(), kapi_offnet_resource:req(), ne_binary(), kz_json:objects()) -> stepswitch_resources:resources().
+foldl_modules(Number, OffnetJObj, SelectorsDb, SelectorRules) ->
+    lists:foldl(fun(JObj, Resources) ->
+                        [Module|_] = kz_json:get_keys(JObj),
+                        ModuleName = real_module_name(Module),
+                        ModuleParams = kz_json:get_value(Module, JObj),
+                        try Res = ModuleName:handle_req(Resources
+                                                        ,Number
+                                                        ,OffnetJObj
+                                                        ,SelectorsDb
+                                                        ,ModuleParams
+                                                       ),
+                            lager:info("module ~p return resources: ~p"
+                                       ,[Module, [ stepswitch_resources:get_resrc_id(R) ||
+                                                   R <- Res ]
+                                        ]),
+                            Res
+                        catch
+                            E:R ->
+                                ST = erlang:get_stacktrace(),
+                                lager:error("failed to run module: ~p, ~p:~p",[Module, E, R]),
+                                kz_util:log_stacktrace(ST),
+                                Resources
+                        end
+                end
+                ,[]
+                ,SelectorRules
+               ).
+
+-spec get_hunt_account(kapi_offnet_resource:req()) -> api_binary().
+get_hunt_account(OffnetJObj) ->
+    HuntAccountId = kapi_offnet_resource:hunt_account_id(OffnetJObj),
+    AccountId = kapi_offnet_resource:account_id(OffnetJObj),
+    case kz_util:is_not_empty(HuntAccountId)
+         andalso kz_util:is_in_account_hierarchy(HuntAccountId, AccountId, 'true')
+    of
+        'true' -> HuntAccountId;
+        'false' -> 'undefined'
+    end.
+
+-spec get_selectors_db(api_binary()) -> ne_binary().
+get_selectors_db('undefined') -> ?KZ_RESOURCE_SELECTORS_DB;
+get_selectors_db(HuntAccountId) -> kz_util:format_resource_selectors_db(HuntAccountId).
+
+-spec get_selector_rules(api_binary()) -> {'ok', kz_json:object()} | {'error', any()}.
+get_selector_rules('undefined') ->
+    Rules = kapps_config:get(?SRS_CONFIG_CAT, <<"rules">>, ?DEFAULT_SRS_RULES),
+    {'ok', Rules};
+get_selector_rules(HuntAccountId) ->
+    Db = kz_util:format_account_db(HuntAccountId),
+    case kz_datamgr:open_doc(Db, ?MOD_NAME) of
+        {'ok', Doc} -> {'ok', Doc};
+        {'error', 'not_found'} ->
+            %% TODO: save default rules to AccoutnDB
+            {'ok', ?DEFAULT_SRS_RULES};
+        {'error', E} ->
+            lager:error("failed to get resource selector rules from ~s: ~p", [Db, E]),
+            {'error', E}
+    end.
+
+-spec real_module_name(binary()) -> atom().
+real_module_name(Module) when is_binary(Module) ->
+    kz_util:to_atom(<<?MOD_PREFIX, Module/binary>>, 'true').

--- a/applications/stepswitch/src/stepswitch_resource_selectors.erl
+++ b/applications/stepswitch/src/stepswitch_resource_selectors.erl
@@ -15,19 +15,22 @@
 -define(SRS_CONFIG_CAT, <<?SS_CONFIG_CAT/binary, ".", ?MOD_NAME/binary>>).
 -define(MOD_PREFIX, "kz_srs_").
 -define(DEFAULT_SRS_RULES, [{[{<<"get_resources">>
-                               ,{[{<<"source">>,<<"database">>}]}}
+                               ,{[]}}
+                               %,{[{<<"source">>,<<"database">>}]}}
                              ]}
                             ,{[{<<"filter_flags">>
                                 ,{[{<<"source">>,<<"resource">>}]}}
                               ]}
                             ,{[{<<"filter_regex_rules">>
                                 ,{[{<<"source">>,<<"resource">>}
-                                   ,{<<"empty_rules_action">>,<<"deny">>}
+                                   ,{<<"deny_on_empty_rules">>,'true'}
+                                   ,{<<"update_number">>,'true'}
                                   ]}
                                }]}
                             ,{[{<<"filter_regex_cid_rules">>
                                 ,{[{<<"source">>,<<"resource">>}
-                                   ,{<<"empty_rules_action">>,<<"allow">>}
+                                   ,{<<"deny_on_empty_rules">>,'false'}
+                                   ,{<<"update_cid_number">>,'false'}
                                   ]}
                                }]}
                             ,{[{<<"order_weight">>

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -14,6 +14,59 @@
 -export([fetch_global_resources/0
          ,fetch_local_resources/1
         ]).
+-export([maybe_add_proxies/3]).
+-export([gateways_to_endpoints/4]).
+-export([check_diversion_fields/1]).
+
+-export([get_resrc_id/1
+         ,get_resrc_rev/1
+         ,get_resrc_name/1
+         ,get_resrc_weight/1
+         ,get_resrc_grace_period/1
+         ,get_resrc_flags/1
+         ,get_resrc_rules/1
+         ,get_resrc_raw_rules/1
+         ,get_resrc_cid_rules/1
+         ,get_resrc_cid_raw_rules/1
+         ,get_resrc_gateways/1
+         ,get_resrc_is_emergency/1
+         ,get_resrc_require_flags/1
+         ,get_resrc_global/1
+         ,get_resrc_format_from_uri/1
+         ,get_resrc_from_uri_realm/1
+         ,get_resrc_from_account_realm/1
+         ,get_resrc_fax_option/1
+         ,get_resrc_codecs/1
+         ,get_resrc_bypass_media/1
+         ,get_resrc_formatters/1
+         ,get_resrc_proxies/1
+         ,get_resrc_selectors/1
+        ]).
+
+-export([set_resrc_id/2
+         ,set_resrc_rev/2
+         ,set_resrc_name/2
+         ,set_resrc_weight/2
+         ,set_resrc_grace_period/2
+         ,set_resrc_flags/2
+         ,set_resrc_rules/2
+         ,set_resrc_raw_rules/2
+         ,set_resrc_cid_rules/2
+         ,set_resrc_cid_raw_rules/2
+         ,set_resrc_gateways/2
+         ,set_resrc_is_emergency/2
+         ,set_resrc_require_flags/2
+         ,set_resrc_global/2
+         ,set_resrc_format_from_uri/2
+         ,set_resrc_from_uri_realm/2
+         ,set_resrc_from_account_realm/2
+         ,set_resrc_fax_option/2
+         ,set_resrc_codecs/2
+         ,set_resrc_bypass_media/2
+         ,set_resrc_formatters/2
+         ,set_resrc_proxies/2
+         ,set_resrc_selectors/2
+        ]).
 
 -include("stepswitch.hrl").
 
@@ -76,6 +129,7 @@
            ,bypass_media = 'false' :: boolean()
            ,formatters :: api_objects()
            ,proxies = [] :: kz_proplist()
+           ,selectors = [] :: kz_proplist()
          }).
 
 -type resource() :: #resrc{}.
@@ -83,6 +137,12 @@
 
 -type gateway() :: #gateway{}.
 -type gateways() :: [#gateway{}].
+
+-export_type([resource/0
+              ,resources/0
+              ,gateway/0
+              ,gateways/0
+             ]).
 
 -compile({'no_auto_import', [get/0, get/1]}).
 
@@ -1053,3 +1113,99 @@ gateway_dialstring(#gateway{route='undefined'
 gateway_dialstring(#gateway{route=Route}, _) ->
     lager:debug("using pre-configured gateway route ~s", [Route]),
     Route.
+
+-spec get_resrc_id(resource()) -> api_binary().
+-spec get_resrc_rev(resource()) -> api_binary().
+-spec get_resrc_name(resource()) -> api_binary().
+-spec get_resrc_weight(resource()) -> non_neg_integer().
+-spec get_resrc_grace_period(resource()) -> non_neg_integer().
+-spec get_resrc_flags(resource()) -> list().
+-spec get_resrc_rules(resource()) -> list().
+-spec get_resrc_raw_rules(resource()) -> list().
+-spec get_resrc_cid_rules(resource()) -> list().
+-spec get_resrc_cid_raw_rules(resource()) -> list().
+-spec get_resrc_gateways(resource()) -> list().
+-spec get_resrc_is_emergency(resource()) -> boolean().
+-spec get_resrc_require_flags(resource()) -> boolean().
+-spec get_resrc_global(resource()) -> boolean().
+-spec get_resrc_format_from_uri(resource()) -> boolean().
+-spec get_resrc_from_uri_realm(resource()) -> api_binary().
+-spec get_resrc_from_account_realm(resource()) -> boolean().
+-spec get_resrc_fax_option(resource()) -> ne_binary() | boolean().
+-spec get_resrc_codecs(resource()) -> ne_binaries().
+-spec get_resrc_bypass_media(resource()) -> boolean().
+-spec get_resrc_formatters(resource()) -> api_objects().
+-spec get_resrc_proxies(resource()) -> kz_proplist().
+-spec get_resrc_selectors(resource()) -> kz_proplist().
+
+get_resrc_id(#resrc{id=Id}) -> Id.
+get_resrc_rev(#resrc{rev=Rev}) -> Rev.
+get_resrc_name(#resrc{name=Name}) -> Name.
+get_resrc_weight(#resrc{weight=Weight}) -> Weight.
+get_resrc_grace_period(#resrc{grace_period=GracePeriod}) -> GracePeriod.
+get_resrc_flags(#resrc{flags=Flags}) -> Flags.
+get_resrc_rules(#resrc{rules=Rules}) -> Rules.
+get_resrc_raw_rules(#resrc{raw_rules=RawRules}) -> RawRules.
+get_resrc_cid_rules(#resrc{cid_rules=CIDRules}) -> CIDRules.
+get_resrc_cid_raw_rules(#resrc{cid_raw_rules=CIDRawRules}) -> CIDRawRules.
+get_resrc_gateways(#resrc{gateways=Gateways}) -> Gateways.
+get_resrc_is_emergency(#resrc{is_emergency=IsEmergency}) -> IsEmergency.
+get_resrc_require_flags(#resrc{require_flags=RequireFlags}) -> RequireFlags.
+get_resrc_global(#resrc{global=Global}) -> Global.
+get_resrc_format_from_uri(#resrc{format_from_uri=FormatFromUri}) -> FormatFromUri.
+get_resrc_from_uri_realm(#resrc{from_uri_realm=FromUriRealm}) -> FromUriRealm.
+get_resrc_from_account_realm(#resrc{from_account_realm=FromAccountRealm}) -> FromAccountRealm.
+get_resrc_fax_option(#resrc{fax_option=FaxOption}) -> FaxOption.
+get_resrc_codecs(#resrc{codecs=Codecs}) -> Codecs.
+get_resrc_bypass_media(#resrc{bypass_media=BypassMedia}) -> BypassMedia.
+get_resrc_formatters(#resrc{formatters=Formatters}) -> Formatters.
+get_resrc_proxies(#resrc{proxies=Proxies}) -> Proxies.
+get_resrc_selectors(#resrc{selectors=Selectors}) -> Selectors.
+
+-spec set_resrc_id(resource(), api_binary()) -> resource().
+-spec set_resrc_rev(resource(), api_binary()) -> resource().
+-spec set_resrc_name(resource(), api_binary()) -> resource().
+-spec set_resrc_weight(resource(), non_neg_integer()) -> resource().
+-spec set_resrc_grace_period(resource(), non_neg_integer()) -> resource().
+-spec set_resrc_flags(resource(), list()) -> resource().
+-spec set_resrc_rules(resource(), list()) -> resource().
+-spec set_resrc_raw_rules(resource(), list()) -> resource().
+-spec set_resrc_cid_rules(resource(), list()) -> resource().
+-spec set_resrc_cid_raw_rules(resource(), list()) -> resource().
+-spec set_resrc_gateways(resource(), list()) -> resource().
+-spec set_resrc_is_emergency(resource(), boolean()) -> resource().
+-spec set_resrc_require_flags(resource(), boolean()) -> resource().
+-spec set_resrc_global(resource(), boolean()) -> resource().
+-spec set_resrc_format_from_uri(resource(), boolean()) -> resource().
+-spec set_resrc_from_uri_realm(resource(), api_binary()) -> resource().
+-spec set_resrc_from_account_realm(resource(), boolean()) -> resource().
+-spec set_resrc_fax_option(resource(), ne_binary() | boolean()) -> resource().
+-spec set_resrc_codecs(resource(), ne_binaries()) -> resource().
+-spec set_resrc_bypass_media(resource(), boolean()) -> resource().
+-spec set_resrc_formatters(resource(), api_objects()) -> resource().
+-spec set_resrc_proxies(resource(), kz_proplist()) -> resource().
+-spec set_resrc_selectors(resource(), kz_proplist()) -> resource().
+
+set_resrc_id(Resource, Id) -> Resource#resrc{id=Id}.
+set_resrc_rev(Resource, Rev) -> Resource#resrc{rev=Rev}.
+set_resrc_name(Resource, Name) -> Resource#resrc{name=Name}.
+set_resrc_weight(Resource, Weight) -> Resource#resrc{weight=Weight}.
+set_resrc_grace_period(Resource, GracePeriod) -> Resource#resrc{grace_period=GracePeriod}.
+set_resrc_flags(Resource, Flags) -> Resource#resrc{flags=Flags}.
+set_resrc_rules(Resource, Rules) -> Resource#resrc{rules=Rules}.
+set_resrc_raw_rules(Resource, RawRules) -> Resource#resrc{raw_rules=RawRules}.
+set_resrc_cid_rules(Resource, CIDRules) -> Resource#resrc{cid_rules=CIDRules}.
+set_resrc_cid_raw_rules(Resource, CIDRawRules) -> Resource#resrc{cid_raw_rules=CIDRawRules}.
+set_resrc_gateways(Resource, Gateways) -> Resource#resrc{gateways=Gateways}.
+set_resrc_is_emergency(Resource, IsEmergency) -> Resource#resrc{is_emergency=IsEmergency}.
+set_resrc_require_flags(Resource, RequireFlags) -> Resource#resrc{require_flags=RequireFlags}.
+set_resrc_global(Resource, Global) -> Resource#resrc{global=Global}.
+set_resrc_format_from_uri(Resource, FormatFromUri) -> Resource#resrc{format_from_uri=FormatFromUri}.
+set_resrc_from_uri_realm(Resource, FromUriRealm) -> Resource#resrc{from_uri_realm=FromUriRealm}.
+set_resrc_from_account_realm(Resource, FromAccountRealm) -> Resource#resrc{from_account_realm=FromAccountRealm}.
+set_resrc_fax_option(Resource, FaxOption) -> Resource#resrc{fax_option=FaxOption}.
+set_resrc_codecs(Resource, Codecs) -> Resource#resrc{codecs=Codecs}.
+set_resrc_bypass_media(Resource, BypassMedia) -> Resource#resrc{bypass_media=BypassMedia}.
+set_resrc_formatters(Resource, Formatters) -> Resource#resrc{formatters=Formatters}.
+set_resrc_proxies(Resource, Proxies) -> Resource#resrc{proxies=Proxies}.
+set_resrc_selectors(Resource, Selectors) -> Resource#resrc{selectors=Selectors}.

--- a/applications/stepswitch/src/stepswitch_util.erl
+++ b/applications/stepswitch/src/stepswitch_util.erl
@@ -376,7 +376,7 @@ maybe_resource_to_endpoints(Resource
     Global = stepswitch_resources:get_resrc_global(Resource),
     Weight = stepswitch_resources:get_resrc_weight(Resource),
     Proxies = stepswitch_resources:get_resrc_proxies(Resource),
-    %% TODO: update CID Number from regex_cid_rules result 
+    %% TODO: update CID Number from regex_cid_rules result
     DestinationNumber = maybe_update_number(Resource, Number),
     lager:debug("building resource ~s endpoints", [Id]),
     CCVUpdates = [{<<"Global-Resource">>, kz_util:to_binary(Global)}

--- a/applications/stepswitch/src/stepswitch_util.erl
+++ b/applications/stepswitch/src/stepswitch_util.erl
@@ -14,6 +14,8 @@
 -export([get_sip_headers/1]).
 -export([format_endpoints/4]).
 -export([default_realm/1]).
+-export([route_by/0]).
+-export([resources_to_endpoints/3]).
 
 -include("stepswitch.hrl").
 -include_lib("kazoo/src/kz_json.hrl").
@@ -339,3 +341,57 @@ get_endpoint_format_from(OffnetReq, CCVs) ->
         'true' -> DefaultRealm;
         'false' -> kz_json:get_value(<<"From-URI-Realm">>, CCVs, DefaultRealm)
     end.
+
+-spec route_by() -> atom().
+route_by() ->
+        RouteBy = kapps_config:get_ne_binary(?SS_CONFIG_CAT, <<"route_by">>, ?DEFAULT_ROUTE_BY),
+        case kz_util:try_load_module(RouteBy) of
+            'false' -> kz_util:to_atom(?DEFAULT_ROUTE_BY);
+            Module -> Module
+        end.
+
+-spec resources_to_endpoints(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req()) ->
+                                    kz_json:objects().
+-spec resources_to_endpoints(stepswitch_resources:resources(), ne_binary(), kapi_offnet_resource:req(), kz_json:objects()) ->
+                                    kz_json:objects().
+resources_to_endpoints(Resources, Number, OffnetJObj) ->
+    resources_to_endpoints(Resources, Number, OffnetJObj, []).
+
+resources_to_endpoints([], _Number, _OffnetJObj, Endpoints) ->
+    lists:reverse(Endpoints);
+resources_to_endpoints([Resource|Resources], Number, OffnetJObj, Endpoints) ->
+    MoreEndpoints = maybe_resource_to_endpoints(Resource, Number, OffnetJObj, Endpoints),
+    resources_to_endpoints(Resources, Number, OffnetJObj, MoreEndpoints).
+
+-spec maybe_resource_to_endpoints(stepswitch_resources:resource(), ne_binary(), kapi_offnet_resource:req(), kz_json:objects()) ->
+                                         kz_json:objects().
+maybe_resource_to_endpoints(Resource
+                            ,Number
+                            ,OffnetJObj
+                            ,Endpoints
+                           ) ->
+    Id = stepswitch_resources:get_resrc_id(Resource),
+    Name = stepswitch_resources:get_resrc_name(Resource),
+    Gateways = stepswitch_resources:get_resrc_gateways(Resource),
+    Global = stepswitch_resources:get_resrc_global(Resource),
+    Weight = stepswitch_resources:get_resrc_weight(Resource),
+    Proxies = stepswitch_resources:get_resrc_proxies(Resource),
+    lager:debug("building resource ~s endpoints", [Id]),
+    CCVUpdates = [{<<"Global-Resource">>, kz_util:to_binary(Global)}
+                  ,{<<"Resource-ID">>, Id}
+                  ,{<<"E164-Destination">>, Number}
+                  ,{<<"Original-Number">>, kapi_offnet_resource:to_did(OffnetJObj)}
+                 ],
+    Updates = [{<<"Name">>, Name}
+               ,{<<"Weight">>, Weight}
+              ],
+    EndpointList = [kz_json:set_values(Updates ,update_ccvs(Endpoint, CCVUpdates))
+                    || Endpoint <- stepswitch_resources:gateways_to_endpoints(Number, Gateways, OffnetJObj, [])
+                   ],
+    stepswitch_resources:maybe_add_proxies(EndpointList, Proxies, Endpoints).
+
+-spec update_ccvs(kz_json:object(), kz_proplist()) -> kz_json:object().
+update_ccvs(Endpoint, Updates) ->
+    CCVs = kz_json:get_value(<<"Custom-Channel-Vars">>, Endpoint, kz_json:new()),
+    kz_json:set_value(<<"Custom-Channel-Vars">>, kz_json:set_values(Updates, CCVs), Endpoint).
+

--- a/core/kazoo/include/kapi_conf.hrl
+++ b/core/kazoo/include/kapi_conf.hrl
@@ -4,6 +4,7 @@
 -define(DOC_CREATED, <<"doc_created">>).
 -define(DOC_DELETED, <<"doc_deleted">>).
 
+-define(DB_EDITED, <<"db_edited">>).
 -define(DB_CREATED, <<"db_created">>).
 -define(DB_DELETED, <<"db_deleted">>).
 

--- a/core/kazoo/include/kz_databases.hrl
+++ b/core/kazoo/include/kz_databases.hrl
@@ -13,6 +13,7 @@
 -define(KZ_OFFNET_DB, <<"offnet">>).
 -define(KZ_DEDICATED_IP_DB, <<"dedicated_ips">>).
 -define(KZ_ANONYMOUS_CDR_DB, <<"anonymous_cdrs">>).
+-define(KZ_RESOURCE_SELECTORS_DB, <<"resource_selectors">>).
 
 -define(KZ_TOKEN_DB, <<"token_auth">>).
 
@@ -48,6 +49,7 @@
                         ,?KZ_TOKEN_DB
                         ,?KZ_ALERTS_DB
                         ,?KZ_DATA_DB
+                        ,?KZ_RESOURCE_SELECTORS_DB
                        ]).
 
 -define(KZ_DATABASES_HRL, 'true').

--- a/core/kazoo/include/kz_types.hrl
+++ b/core/kazoo/include/kz_types.hrl
@@ -313,6 +313,40 @@
         <<(Year):4/binary, (Month):1/binary, "-", (Account)/binary>>  %% FIXME: add missing size
        ).
 
+-define(MATCH_RESOURCE_SELECTORS_RAW(Account),
+        <<(Account):32/binary, "-selectors">>
+       ).
+-define(MATCH_RESOURCE_SELECTORS_UNENCODED(Account),
+        <<"account/", (Account):34/binary, "-selectors">>
+       ).
+-define(MATCH_RESOURCE_SELECTORS_ENCODED(Account),
+        <<"account%2F", (Account):38/binary, "-selectors">>
+       ).
+-define(MATCH_RESOURCE_SELECTORS_encoded(Account),
+        <<"account%2f", (Account):38/binary, "-selectors">>
+       ).
+
+-define(MATCH_RESOURCE_SELECTORS_RAW(A, B, Rest),
+        <<(A):2/binary, (B):2/binary, (Rest):28/binary
+          ,"-selectors"
+        >>
+       ).
+-define(MATCH_RESOURCE_SELECTORS_UNENCODED(A, B, Rest),
+        <<"account/", (A):2/binary, "/", (B):2/binary, "/", (Rest):28/binary
+          ,"-selectors"
+        >>
+       ).
+-define(MATCH_RESOURCE_SELECTORS_ENCODED(A, B, Rest),
+        <<"account%2F", (A):2/binary, "%2F", (B):2/binary, "%2F", (Rest):28/binary
+          ,"-selectors"
+        >>
+       ).
+-define(MATCH_RESOURCE_SELECTORS_encoded(A, B, Rest),
+        <<"account%2f", (A):2/binary, "%2f", (B):2/binary, "%2f", (Rest):28/binary
+          ,"-selectors"
+        >>
+       ).
+
 %% KZ_NODES types
 -record(whapp_info, {startup :: gregorian_seconds()}).
 

--- a/core/kazoo/src/api/kapi_conf.erl
+++ b/core/kazoo/src/api/kapi_conf.erl
@@ -48,6 +48,7 @@
                                  ,{<<"Event-Name">>, [?DOC_EDITED
                                                       ,?DOC_CREATED
                                                       ,?DOC_DELETED
+                                                      ,?DB_EDITED
                                                       ,?DB_CREATED
                                                       ,?DB_DELETED
                                                      ]}

--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -14,6 +14,8 @@
          ,format_account_mod_id/1, format_account_mod_id/2, format_account_mod_id/3
          ,format_account_db/1
          ,format_account_modb/1, format_account_modb/2
+         ,format_resource_selectors_id/1, format_resource_selectors_id/2
+         ,format_resource_selectors_db/1
          ,normalize_account_name/1
          ,account_update/1, account_update/2
         ]).
@@ -290,6 +292,66 @@ raw_account_modb(?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, Year, Month)) ->
     ?MATCH_MODB_SUFFIX_RAW(A, B, Rest, Year, Month);
 raw_account_modb(?MATCH_MODB_SUFFIX_UNENCODED(A, B, Rest, Year, Month)) ->
     ?MATCH_MODB_SUFFIX_RAW(A, B, Rest, Year, Month).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Given a representation of an account resource_selectors return it in a 'encoded',
+%% unencoded or 'raw' format.
+%% @end
+%%--------------------------------------------------------------------
+-spec format_resource_selectors_id(api_binary()) -> api_binary().
+-spec format_resource_selectors_id(api_binary(), account_format()) -> api_binary();
+                       (api_binary(), gregorian_seconds()) -> api_binary(). %% MODb!
+
+format_resource_selectors_id(Account) ->
+    format_resource_selectors_id(Account, 'raw').
+
+format_resource_selectors_id('undefined', _Encoding) -> 'undefined';
+
+format_resource_selectors_id(?MATCH_RESOURCE_SELECTORS_RAW(_)=AccountId, 'raw') ->
+    AccountId;
+format_resource_selectors_id(?MATCH_RESOURCE_SELECTORS_ENCODED(_)=AccountDb, 'encoded') ->
+    AccountDb;
+format_resource_selectors_id(?MATCH_RESOURCE_SELECTORS_UNENCODED(_)=AccountDbUn, 'unencoded') ->
+    AccountDbUn;
+
+format_resource_selectors_id(AccountId, 'raw') ->
+    raw_resource_selectors_id(AccountId);
+format_resource_selectors_id(AccountId, 'unencoded') ->
+    ?MATCH_RESOURCE_SELECTORS_RAW(A,B,Rest) = raw_resource_selectors_id(AccountId),
+    to_binary(["account/", A, "/", B, "/", Rest]);
+format_resource_selectors_id(AccountId, 'encoded') ->
+    ?MATCH_RESOURCE_SELECTORS_RAW(A,B,Rest) = raw_resource_selectors_id(AccountId),
+    to_binary(["account%2F", A, "%2F", B, "%2F", Rest]).
+
+%% @private
+%% Returns account_id() | any()
+%% Passes input along if not account_id() | account_db() | account_db_unencoded().
+-spec raw_resource_selectors_id(ne_binary()) -> ne_binary().
+raw_resource_selectors_id(?MATCH_RESOURCE_SELECTORS_RAW(AccountId)) ->
+    AccountId;
+raw_resource_selectors_id(?MATCH_RESOURCE_SELECTORS_UNENCODED(A, B, Rest)) ->
+    ?MATCH_RESOURCE_SELECTORS_RAW(A, B, Rest);
+raw_resource_selectors_id(?MATCH_RESOURCE_SELECTORS_ENCODED(A, B, Rest)) ->
+    ?MATCH_RESOURCE_SELECTORS_RAW(A, B, Rest);
+raw_resource_selectors_id(Other) ->
+    case lists:member(Other, ?KZ_SYSTEM_DBS) of
+        'true' -> Other;
+        'false' ->
+            lager:warning("raw account resource_selectors id doesn't process '~p'", [Other]),
+            Other
+    end.
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Given a representation of an account resource_selectors return it in a 'encoded',
+%% @end
+%%--------------------------------------------------------------------
+-spec format_resource_selectors_db(api_binary()) -> api_binary().
+format_resource_selectors_db(AccountId) ->
+    format_resource_selectors_id(AccountId, 'encoded').
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_data/src/kzs_util.erl
+++ b/core/kazoo_data/src/kzs_util.erl
@@ -46,6 +46,10 @@ db_classification(?MATCH_MODB_SUFFIX_RAW(_Account,_Year,_Month)) -> 'modb';%   r
 db_classification(?MATCH_ACCOUNT_UNENCODED(_AccountId)) -> 'account';
 db_classification(?MATCH_ACCOUNT_encoded(_AccountId)) -> 'account';
 db_classification(?MATCH_ACCOUNT_ENCODED(_AccountId)) -> 'account';
+db_classification(?MATCH_RESOURCE_SELECTORS_UNENCODED(_AccountId)) -> 'account';
+db_classification(?MATCH_RESOURCE_SELECTORS_encoded(_AccountId)) -> 'account';
+db_classification(?MATCH_RESOURCE_SELECTORS_ENCODED(_AccountId)) -> 'account';
+db_classification(?MATCH_RESOURCE_SELECTORS_RAW(_AccountId)) -> 'account';
 db_classification(?KZ_RATES_DB) -> 'system';
 db_classification(?KZ_OFFNET_DB) -> 'system';
 db_classification(?KZ_ANONYMOUS_CDR_DB) -> 'system';
@@ -55,6 +59,7 @@ db_classification(?KZ_MEDIA_DB) -> 'system';
 db_classification(?KZ_SCHEMA_DB) -> 'system';
 db_classification(?KZ_OAUTH_DB) -> 'system';
 db_classification(?KZ_DATA_DB) -> 'system';
+db_classification(?KZ_RESOURCE_SELECTORS_DB) -> 'system';
 db_classification(_Database) ->
     lager:debug("unknown type for database ~s", [_Database]),
     'undefined'.


### PR DESCRIPTION
Stepswitch Resource Selectors(SRS) is new "routing engine" for stepswitch.
Enable it with command:
`sup kapps_config set stepswitch route_by stepswitch_resource_selectors` (or `kapps_config:set(<<"stepswitch">>, <<"route_by">>, <<"stepswitch_resource_selectors">>).` in erlang console).
Documentation will be added soon.
SRS is modular, each module can add, filter or order (sort) resources.
List of called modules and their behaviour controled with `rules` from system_config/stepswitch.resource_selectors document (or from `resource_selectors` in AccountDB).
Default rules:
``` JSON
"rules": [
           {
               "get_resources": {
               }
           },
           {
               "filter_flags": {
                   "source": "resource"
               }
           },
           {
               "filter_regex_rules": {
                   "source": "resource",
                   "deny_on_empty_rules": true,
                   "update_number": true
               }
           },
           {
               "filter_regex_cid_rules": {
                   "source": "resource",
                   "deny_on_empty_rules": false,
                   "update_cid_number": false
               }
           },
           {
               "order_weight": {
                   "source": "resource",
                   "sort_order": "ascend"
               }
           }
       ]
```
Default rules replicate old stepswitch_resources behaviour, load resources from DB, filter by flags, filter with regex rules in resource docment and order by `weight`.
Existing modules:
kz_srs_filter_cid_prefix.erl
kz_srs_filter_flags.erl
kz_srs_filter_prefix.erl
kz_srs_filter_regex_cid_rules.erl
kz_srs_filter_regex_rules.erl
kz_srs_get_resources.erl
kz_srs_null.erl
kz_srs_order_weight.erl

Modules kz_srs_filter_prefix.erl and kz_srs_filter_cid_prefix.erl get list of prefixes from DB (`resource_selectors` or `{{ACCOUNT_ID}}_selectors`) which match number (or Caller-ID number) and return list of resources.
kz_srs_null.erl - testing module< which retrun empty list.

"Slectors" updates via cb_resources module (WIP).
URL: `/resources/{{RESOURCE_ID}}/selectors/{{SELECTOR_TYPE}}` (or /accounts/{{ACCOUNT_ID}}/esources/{{RESOURCE_ID}}/selectors/{{SELECTOR_TYPE}}`

{{SELECTOR_TYPE}} - can be `prefix`, `cid_prefix`, `flag`, `weight`, `regex`, `regex_cid`.

Examples:
Adding list of prefxies to reource `RES-1`
PUT `http://api.example.com:8000/resources/RES-1/selectors/prefix`
Request body:
```JSON
{
  "data": {
    "selectors_data": [
      "74951000001",
      "74951000002",
      "74951000003",
      "74951000004",
      "74951000005",
      "74951000006",
      "74951000007",
      "74951000008",
      "749512",
      "749",
      "74956"
      "74951000008",
      "74951000009",
      "749560262",
      "749560263"
    ]
  }
}
```

Add prefixes to resource `RES-1` from CSV file
POST `http://api.example.com:8000/resources/RES-1/selectors/prefix`
Content-Type: text/csv
Request body - CSV file (one prefix per line).

Remove some prefixes from resource `RES-1`
DELETE `http://api.example.com:8000/resources/RES-1/selectors/prefix`
Request body:
```JSON
{
  "data": {
    "selectors_data": [
      "74951000001",
      "74951000002",
      "74951000003",
      "74951000004"
    ]
  }
}
```

Remove all prefixes from resource `RES-1`
DELETE `http://api.example.com:8000/resources/RES-1/selectors/prefix`
Request body:
```JSON
{
  "data": {
    "selectors_data": [
      "_all"
    ]
  }
}
```

PS: there is a lo work to do. For now just test "default" stepswitch behaviour.