### PR TITLE
KAZOO-4831 3.22 continue processing dialplans

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -785,7 +785,13 @@ maybe_apply_dialplan([Regex|Regexs], DialPlan, Number) ->
             Root = lists:last(Captures),
             Prefix = wh_json:get_binary_value([Regex, <<"prefix">>], DialPlan, <<>>),
             Suffix = wh_json:get_binary_value([Regex, <<"suffix">>], DialPlan, <<>>),
-            <<Prefix/binary, Root/binary, Suffix/binary>>
+            N = <<Prefix/binary, Root/binary, Suffix/binary>>,
+            case wh_json:get_value([Regex, <<"dialplan">>], DialPlan) of
+                'undefined' -> maybe_apply_dialplan(Regexs, DialPlan, N);
+                InnerPlan -> InnerRegexs = wh_json:get_keys(InnerPlan),
+                             N1 = maybe_apply_dialplan(InnerRegexs, InnerPlan, N),
+                             maybe_apply_dialplan(Regexs, DialPlan, N1)
+            end
     end.
 
 -spec load_system_dialplans(ne_binaries()) -> wh_json:object().


### PR DESCRIPTION
also adds support for inner dialplan

```
  "^\\d{7}$": {
       "name": "PT-LX",
       "description": "Portugal Lisboa",
       "prefix": "21",
       "dialplan": {
           "^\\d{9}$": {
               "name": "PT",
               "description": "Portugal",
               "prefix": "+351"
           }
       }
   }
```