### PR TITLE
Use correct macros for kz_device:sip_invite_format and kz_device:set_sip_invite_format

### DIFF
--- a/core/kazoo_documents/src/kz_device.erl
+++ b/core/kazoo_documents/src/kz_device.erl
@@ -50,6 +50,7 @@
 -define(REALM, [?SIP, <<"realm">>]).
 -define(IP, [?SIP, <<"ip">>]).
 -define(INVITE_FORMAT, [?SIP, <<"invite_format">>]).
+-define(ROUTE, [?SIP, <<"route">>]).
 -define(CUSTOM_SIP_HEADERS, <<"custom_sip_headers">>).
 -define(CUSTOM_SIP_HEADERS_KV_ONLY, [?SIP, ?CUSTOM_SIP_HEADERS]).
 -define(CUSTOM_SIP_HEADERS_IN, [?SIP, ?CUSTOM_SIP_HEADERS, <<"in">>]).
@@ -128,7 +129,7 @@ sip_route(DeviceJObj) ->
     sip_route(DeviceJObj, 'undefined').
 
 sip_route(DeviceJObj, Default) ->
-    kz_json:get_value(?IP, DeviceJObj, Default).
+    kz_json:get_value(?ROUTE, DeviceJObj, Default).
 
 -spec custom_sip_headers_inbound(doc()) -> api_object().
 -spec custom_sip_headers_inbound(doc(), Default) -> kz_json:object() | Default.
@@ -191,8 +192,8 @@ set_sip_invite_format(DeviceJObj, InviteFormat) ->
     kz_json:set_value(?INVITE_FORMAT, InviteFormat, DeviceJObj).
 
 -spec set_sip_route(doc(), ne_binary()) -> doc().
-set_sip_route(DeviceJObj, Ip) ->
-    kz_json:set_value(?IP, Ip, DeviceJObj).
+set_sip_route(DeviceJObj, Route) ->
+    kz_json:set_value(?ROUTE, Route, DeviceJObj).
 
 -spec set_custom_sip_headers_inbound(doc(), kz_json:object()) -> doc().
 set_custom_sip_headers_inbound(Device, Headers) ->

--- a/core/kazoo_documents/src/kz_device.erl
+++ b/core/kazoo_documents/src/kz_device.erl
@@ -120,7 +120,7 @@ sip_invite_format(DeviceJObj) ->
     sip_invite_format(DeviceJObj, 'undefined').
 
 sip_invite_format(DeviceJObj, Default) ->
-    kz_json:get_value(?IP, DeviceJObj, Default).
+    kz_json:get_value(?INVITE_FORMAT, DeviceJObj, Default).
 
 -spec sip_route(doc()) -> api_binary().
 -spec sip_route(doc(), Default) -> ne_binary() | Default.
@@ -187,8 +187,8 @@ set_sip_ip(DeviceJObj, Ip) ->
     kz_json:set_value(?IP, Ip, DeviceJObj).
 
 -spec set_sip_invite_format(doc(), ne_binary()) -> doc().
-set_sip_invite_format(DeviceJObj, Ip) ->
-    kz_json:set_value(?IP, Ip, DeviceJObj).
+set_sip_invite_format(DeviceJObj, InviteFormat) ->
+    kz_json:set_value(?INVITE_FORMAT, InviteFormat, DeviceJObj).
 
 -spec set_sip_route(doc(), ne_binary()) -> doc().
 set_sip_route(DeviceJObj, Ip) ->

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1327,7 +1327,11 @@ maybe_add_alert_info(JObj, Endpoint, _Inception) ->
 maybe_add_aor(JObj, Endpoint, Call) ->
     Realm = kz_device:sip_realm(Endpoint, kapps_call:account_realm(Call)),
     Username = kz_device:sip_username(Endpoint),
-    maybe_add_aor(JObj, Endpoint, Username, Realm).
+    case kz_device:sip_invite_format(Endpoint) of
+        <<"username">> -> maybe_add_aor(JObj, Endpoint, Username, Realm);
+        'undefined' -> maybe_add_aor(JObj, Endpoint, Username, Realm);
+        _ -> JObj
+    end.
 
 maybe_add_aor(JObj, _, 'undefined', _Realm) -> JObj;
 maybe_add_aor(JObj, _, Username, Realm) ->

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1327,11 +1327,7 @@ maybe_add_alert_info(JObj, Endpoint, _Inception) ->
 maybe_add_aor(JObj, Endpoint, Call) ->
     Realm = kz_device:sip_realm(Endpoint, kapps_call:account_realm(Call)),
     Username = kz_device:sip_username(Endpoint),
-    case kz_device:sip_invite_format(Endpoint) of
-        <<"username">> -> maybe_add_aor(JObj, Endpoint, Username, Realm);
-        'undefined' -> maybe_add_aor(JObj, Endpoint, Username, Realm);
-        _ -> JObj
-    end.
+    maybe_add_aor(JObj, Endpoint, Username, Realm).
 
 maybe_add_aor(JObj, _, 'undefined', _Realm) -> JObj;
 maybe_add_aor(JObj, _, Username, Realm) ->


### PR DESCRIPTION
If device configured with `invite_format = e164` (or any other not `username`) we shouldn't add X-KAZOO-AOR header.
If X-KAZOO-AOR header exist, kamailio replace INVITE RURI with stored Contact (from REGISTRATION request).
BTW: kz_device:sip_route/2 and kz_device:set_sip_route/2 must be fixed? Is macro `?IP` should be replaced to something other?