### PR TITLE
KAZOO-4659: allow set empty used_by if UI unassign a number from a callflow

### DIFF
--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -486,8 +486,8 @@ set_prev_assigned_to(N, PrevAssignedTo=?MATCH_ACCOUNT_RAW(_)) ->
 -spec used_by(knm_phone_number()) -> api_binary().
 used_by(#knm_phone_number{used_by=UsedBy}) -> UsedBy.
 
--spec set_used_by(knm_phone_number(), ne_binary()) -> knm_phone_number().
-set_used_by(N, UsedBy=?NE_BINARY) ->
+-spec set_used_by(knm_phone_number(), api_binary()) -> knm_phone_number().
+set_used_by(N, UsedBy) ->
     N#knm_phone_number{used_by=UsedBy}.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
If cb_callflows wants to remove a number from a callflow it sets `used_by` to an empty binary, which cause `set_used_by` to crash although we already saved the callflow and removed number from it, so number is not get release from that app and there is no way to see it in spare numbers in UI.