### PR TITLE
Apply tidier --cases --straighten to files in core dir

### DIFF
--- a/core/braintree/src/braintree_card.erl
+++ b/core/braintree/src/braintree_card.erl
@@ -84,8 +84,7 @@ find(#bt_card{token = CardId}) -> find(CardId);
 find(Token) ->
 % github.com/braintree/braintree_php/blob/master/lib/Braintree/CreditCardGateway.php#L149
     Url = url(Token, ''),
-    Xml = try braintree_request:get(Url) of
-              Ok -> Ok
+    Xml = try braintree_request:get(Url)
           catch
               'throw':{'not_found', _JObj} ->
                   #bt_card{}

--- a/core/kazoo/src/gen_listener.erl
+++ b/core/kazoo/src/gen_listener.erl
@@ -894,8 +894,7 @@ start_consumer(Q, ConsumeProps) -> amqp_util:basic_consume(Q, ConsumeProps).
 remove_binding(Binding, Props, Q) ->
     Wapi = list_to_binary([<<"kapi_">>, kz_util:to_binary(Binding)]),
     lager:debug("trying to remove bindings with ~s:unbind_q(~s, ~p)", [Wapi, Q, Props]),
-    try (kz_util:to_atom(Wapi, 'true')):unbind_q(Q, Props) of
-        Return -> Return
+    try (kz_util:to_atom(Wapi, 'true')):unbind_q(Q, Props)
     catch
         'error':'undef' ->
             erlang:error({'api_module_undefined', Wapi})
@@ -906,8 +905,7 @@ create_binding(Binding, Props, Q) when not is_binary(Binding) ->
     create_binding(kz_util:to_binary(Binding), Props, Q);
 create_binding(Binding, Props, Q) ->
     Wapi = list_to_binary([<<"kapi_">>, kz_util:to_binary(Binding)]),
-    try (kz_util:to_atom(Wapi, 'true')):bind_q(Q, Props) of
-        Return -> Return
+    try (kz_util:to_atom(Wapi, 'true')):bind_q(Q, Props)
     catch
         'error':'undef' ->
             erlang:error({'api_module_undefined', Wapi})

--- a/core/kazoo/src/kz_json.erl
+++ b/core/kazoo/src/kz_json.erl
@@ -116,8 +116,7 @@ unsafe_decode(Thing) when is_list(Thing)
     unsafe_decode(Thing, <<"application/json">>).
 
 unsafe_decode(JSON, <<"application/json">>) ->
-    try jiffy:decode(JSON) of
-        JObj -> JObj
+    try jiffy:decode(JSON)
     catch
         'throw':{'error',{_Loc, 'invalid_string'}}=Error ->
             lager:debug("invalid string(near char ~p) in input, checking for unicode", [_Loc]),
@@ -139,8 +138,7 @@ decode(Thing) when is_list(Thing)
     decode(Thing, <<"application/json">>).
 
 decode(JSON, <<"application/json">>) ->
-    try unsafe_decode(JSON) of
-        JObj -> JObj
+    try unsafe_decode(JSON)
     catch
         _:{'invalid_json', {'error', {_Loc, _Msg}}, _JSON} ->
             lager:debug("decode error ~s near char # ~b", [_Msg, _Loc]),
@@ -503,8 +501,7 @@ get_integer_value(Key, JObj, Default) ->
 
 -spec safe_cast(json_term(), json_term(), fun()) -> json_term().
 safe_cast(Value, Default, CastFun) ->
-    try CastFun(Value) of
-        Casted -> Casted
+    try CastFun(Value)
     catch
         _:_ -> Default
     end.

--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -940,8 +940,7 @@ rand_hex_binary(Size) when is_integer(Size)
 
 -spec rand_hex(pos_integer()) -> ne_binary().
 rand_hex(Size) ->
-    try crypto:strong_rand_bytes(Size) of
-        Bytes -> Bytes
+    try crypto:strong_rand_bytes(Size)
     catch
         _:'low_entropy' -> crypto:rand_bytes(Size)
     end.
@@ -1023,8 +1022,7 @@ to_integer(X, 'strict') when is_float(X) -> erlang:error('badarg');
 to_integer(X, 'notstrict') when is_float(X) -> round(X);
 to_integer(X, S) when is_binary(X) -> to_integer(binary_to_list(X), S);
 to_integer(X, S) when is_list(X) ->
-    try list_to_integer(X) of
-        I -> I
+    try list_to_integer(X)
     catch
         'error':'badarg' when S =:= 'notstrict' ->
             round(list_to_float(X))
@@ -1038,8 +1036,7 @@ to_float(X) -> to_float(X, 'notstrict').
 
 to_float(X, S) when is_binary(X) -> to_float(binary_to_list(X), S);
 to_float(X, S) when is_list(X) ->
-    try list_to_float(X) of
-        F -> F
+    try list_to_float(X)
     catch
         'error':'badarg' when S =:= 'notstrict' -> list_to_integer(X)*1.0 %% "500" -> 500.0
     end;
@@ -1051,8 +1048,7 @@ to_float(X, _) when is_float(X) -> X.
 to_number(X) when is_number(X) -> X;
 to_number(X) when is_binary(X) -> to_number(to_list(X));
 to_number(X) when is_list(X) ->
-    try list_to_integer(X) of
-        Int -> Int
+    try list_to_integer(X)
     catch
         'error':'badarg' -> list_to_float(X)
     end.
@@ -1117,8 +1113,7 @@ to_datetime(X) when is_list(X) -> to_datetime(to_integer(X)).
 error_to_binary({'error', Reason}) ->
     error_to_binary(Reason);
 error_to_binary(Reason) ->
-    try to_binary(Reason) of
-        Message -> Message
+    try to_binary(Reason)
     catch
         _:_ -> <<"Unknown Error">>
     end.
@@ -1284,8 +1279,7 @@ truncate_right_binary(Bin, _) ->
 -spec suffix_binary(binary(), binary()) -> boolean().
 suffix_binary(<<>>, _Bin) -> 'false';
 suffix_binary(<<_/binary>> = Suffix, <<_/binary>> = Bin) ->
-    try truncate_left_binary(Bin, byte_size(Suffix)) =:= Suffix of
-        Bool -> Bool
+    try truncate_left_binary(Bin, byte_size(Suffix)) =:= Suffix
     catch
         _:_ -> 'false'
     end.

--- a/core/kazoo_amqp/src/kz_amqp_channel.erl
+++ b/core/kazoo_amqp/src/kz_amqp_channel.erl
@@ -255,8 +255,7 @@ command(#kz_amqp_assignment{channel=Channel
             lager:debug("queue ~s is not bound to ~s(~s)", [QueueName, Exchange, RoutingKey])
     end;
 command(#kz_amqp_assignment{channel=Channel}=Assignment, Command) ->
-    Result = try amqp_channel:call(Channel, Command) of
-                 R -> R
+    Result = try amqp_channel:call(Channel, Command)
              catch
                  E:R ->
                      lager:debug("amqp command exception ~p : ~p", [E, R]),

--- a/core/kazoo_amqp/src/kz_amqp_worker.erl
+++ b/core/kazoo_amqp/src/kz_amqp_worker.erl
@@ -203,8 +203,6 @@ call(Req, PubFun, VFun, Timeout, Worker) when is_pid(Worker) ->
                           ,{'request', Prop, PubFun, VFun, Timeout}
                           ,fudge_timeout(Timeout)
                          )
-    of
-        Reply -> Reply
     catch
         _E:R ->
             lager:warning("request failed: ~s: ~p", [_E, R]),
@@ -274,8 +272,6 @@ call_custom(Req, PubFun, VFun, Timeout, Bind, Worker) ->
                           ,{'request', Prop, PubFun, VFun, Timeout}
                           ,fudge_timeout(Timeout)
                          )
-    of
-        Reply -> Reply
     catch
         _E:R ->
             lager:debug("request failed: ~s: ~p", [_E, R]),
@@ -377,8 +373,6 @@ call_collect(Req, PubFun, UntilFun, Timeout, Acc, Worker) ->
                           ,{'call_collect', Prop, PubFun, UntilFun, Timeout, Acc}
                           ,fudge_timeout(Timeout)
                          )
-    of
-        Reply -> Reply
     catch
         _E:R ->
             lager:debug("request failed: ~s: ~p", [_E, R]),
@@ -406,8 +400,7 @@ cast(Req, PubFun, Pool) when is_atom(Pool) ->
     end;
 cast(Req, PubFun, Worker) when is_pid(Worker) ->
     Prop = maybe_convert_to_proplist(Req),
-    try gen_listener:call(Worker, {'publish', Prop, PubFun}) of
-        Reply -> Reply
+    try gen_listener:call(Worker, {'publish', Prop, PubFun})
     catch
         _E:R ->
             lager:debug("request failed: ~s: ~p", [_E, R]),

--- a/core/kazoo_apps/src/kapps_call.erl
+++ b/core/kazoo_apps/src/kapps_call.erl
@@ -1035,8 +1035,7 @@ kvs_flush(#kapps_call{}=Call) -> Call#kapps_call{kvs=orddict:new()}.
 -spec kvs_fetch(kz_json:key(), Default, call()) -> any() | Default.
 kvs_fetch(Key, Call) -> kvs_fetch(Key, 'undefined', Call).
 kvs_fetch(Key, Default, #kapps_call{kvs=Dict}) ->
-    try orddict:fetch(kz_util:to_binary(Key), Dict) of
-        Ok -> Ok
+    try orddict:fetch(kz_util:to_binary(Key), Dict)
     catch
         'error':'function_clause' -> Default
     end.

--- a/core/kazoo_apps/src/kapps_conference.erl
+++ b/core/kazoo_apps/src/kapps_conference.erl
@@ -453,8 +453,7 @@ kvs_erase(Key, #kapps_conference{kvs=Dict}=Conference) ->
 
 -spec kvs_fetch(any(), kapps_conference:conference()) -> any().
 kvs_fetch(Key, #kapps_conference{kvs=Dict}) ->
-    try orddict:fetch(kz_util:to_binary(Key), Dict) of
-        Ok -> Ok
+    try orddict:fetch(kz_util:to_binary(Key), Dict)
     catch
         'error':'function_clause' -> 'undefined'
     end.

--- a/core/kazoo_apps/src/kapps_speech.erl
+++ b/core/kazoo_apps/src/kapps_speech.erl
@@ -390,14 +390,11 @@ voicefabric_get_media_rate(Headers1) ->
     Headers = [{kz_util:to_lower_binary(X), kz_util:to_binary(Y)}
                || {X, Y} <- Headers1
               ],
-    case props:get_value(<<"content-type">>, Headers) of
-        <<"audio/raw; ", Params/binary>> ->
-            [<<"rate=", Rate/binary>>] =
-                lists:filter(fun voicefabric_filter_rate/1
-                             ,re:split(Params, "; ")
-                            ),
-            {'ok', Rate}
-    end.
+    <<"audio/raw; ", Params/binary>> =
+	props:get_value(<<"content-type">>, Headers),
+    [<<"rate=", Rate/binary>>] =
+	lists:filter(fun voicefabric_filter_rate/1, re:split(Params, "; ")),
+    {'ok', Rate}.
 
 -spec voicefabric_filter_rate(ne_binary()) -> boolean().
 voicefabric_filter_rate(<<"rate=", _/binary>>) -> 'true';

--- a/core/kazoo_documents/src/kzd_callflow.erl
+++ b/core/kazoo_documents/src/kzd_callflow.erl
@@ -49,8 +49,5 @@ type() -> ?PVT_TYPE.
 %%--------------------------------------------------------------------
 -spec is_feature_code(kz_json:object()) -> boolean().
 is_feature_code(JObj) ->
-    case kz_json:get_value(?FEATURE_CODE, JObj, 'false') of
-        'false' -> 'false';
-        _ -> 'true'
-    end.
+    kz_json:get_value(?FEATURE_CODE, JObj, 'false') =/= 'false'.
 

--- a/core/kazoo_services/src/kazoo_services_maintenance.erl
+++ b/core/kazoo_services/src/kazoo_services_maintenance.erl
@@ -120,8 +120,7 @@ reconcile('all') ->
 reconcile(Account) when not is_binary(Account) ->
     reconcile(kz_util:to_binary(Account));
 reconcile(Account) ->
-    try kz_services:reconcile(Account) of
-        Any -> Any
+    try kz_services:reconcile(Account)
     catch
         _E:_R ->
             io:format("failed to reconcile account ~s(~p):~n  ~p~n", [Account, _E, _R])


### PR DESCRIPTION
I was asked to whether it's possible to run tidier on kazoo's code base.
This is the result of applying two of the most basic tidier transformations on the `core` dir of `kazoo`.
The transformations are basic code simplifications and they are non-controversial.

PS. If you like them, there will be more...