### PR TITLE
add a country to search numbers parameters

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/find_numbers.json
+++ b/applications/crossbar/priv/couchdb/schemas/find_numbers.json
@@ -2,6 +2,13 @@
     "$schema": "http://json-schema.org/draft-03/schema#",
     "_id": "find_numbers",
     "properties": {
+        "country": {
+            "default": "US",
+            "maxLength": 2,
+            "minLength": 2,
+            "required": false,
+            "type": "string"
+        },
         "prefix": {
             "maxLength": 10,
             "minLength": 3,

--- a/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
@@ -50,6 +50,10 @@
 
 -define(MAX_TOKENS, kapps_config:get_integer(?PHONE_NUMBERS_CONFIG_CAT, <<"activations_per_day">>, 100)).
 
+-define(DEFAULT_COUNTRY, <<"US">>).
+-define(PREFIX, <<"prefix">>).
+-define(COUNTRY, <<"country">>).
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -412,7 +416,10 @@ get_find_numbers_req(Context) ->
 %%--------------------------------------------------------------------
 -spec get_numbers(kz_json:object()) -> ne_binaries().
 get_numbers(QueryString) ->
-    Prefix = kz_json:get_ne_value(<<"prefix">>, QueryString),
+    PrefixQuery = kz_json:get_ne_value(?PREFIX, QueryString),
+    Country = kz_json:get_ne_value(?COUNTRY, QueryString, ?DEFAULT_COUNTRY),
+    CountryPrefix = knm_util:prefix_for_country(Country),
+    Prefix = <<CountryPrefix/binary, PrefixQuery/binary>>,     
     Quantity = kz_json:get_ne_value(<<"quantity">>, QueryString, 1),
     lists:reverse(
         lists:foldl(

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -59,6 +59,7 @@
 -define(PREFIX, <<"prefix">>).
 -define(LOCALITY, <<"locality">>).
 -define(CHECK, <<"check">>).
+-define(COUNTRY, <<"country">>).
 
 -define(MAX_TOKENS, kapps_config:get_integer(?PHONE_NUMBERS_CONFIG_CAT, <<"activations_per_day">>, 100)).
 
@@ -489,7 +490,10 @@ normalize_view_results(JObj, Acc) ->
 find_numbers(Context) ->
     JObj = get_find_numbers_req(Context),
     Context1 = cb_context:set_req_data(Context, JObj),
-    Prefix = kz_json:get_ne_value(?PREFIX, JObj),
+    PrefixQuery = kz_json:get_ne_value(?PREFIX, JObj),
+    Country = kz_json:get_ne_value(?COUNTRY, JObj, ?DEFAULT_COUNTRY),
+    CountryPrefix = knm_util:prefix_for_country(Country),
+    Prefix = <<CountryPrefix/binary, PrefixQuery/binary>>, 
     Quantity = kz_json:get_value(<<"quantity">>, JObj),
     OnSuccess =
         fun(C) ->

--- a/core/kazoo_number_manager/src/knm_util.erl
+++ b/core/kazoo_number_manager/src/knm_util.erl
@@ -13,6 +13,7 @@
 
 -export([pretty_print/1, pretty_print/2
          ,fixture/1
+         ,prefix_for_country/1
         ]).
 
 -include("knm.hrl").
@@ -126,3 +127,9 @@ read_fixture({'ok', Contents}, _F) ->
     kz_util:to_list(Contents);
 read_fixture({'error', 'enoent'}, F) ->
     throw({'error', 'missing_fixture', F}).
+
+%% TODO
+%% this should be replaced with a call to elibphonenumber
+%% when/if we integrate that lib or do it ourselves
+-spec prefix_for_country(ne_binary()) -> ne_binary().
+prefix_for_country(<<"US">>) -> <<"+1">>.


### PR DESCRIPTION
adds a country to search numbers parameters so we can infer the country
prefix to pass to number search.

used knm_managed to generate +1555 numbers (Hollywood)
simple test in monster-ui 

before patch
search area code 424. it correctly returns 424 US numbers (bandwidth2)
search area code 555. no knm_managed numbers returned
search area code 155. knm_managed numbers returned

after patch
search area code 424. it correctly returns 424 US numbers (bandwidth2)
search area code 555. knm_managed numbers returned
