### PR TITLE
Apply tidier --structs to modules of the core dirs

### DIFF
--- a/core/gcm/src/gcm.erl
+++ b/core/gcm/src/gcm.erl
@@ -100,9 +100,9 @@ do_push(RegIds, Message, Key, Retry) ->
             lager:info("retry after: ~p", [RetryAfter]),
             _ = do_backoff(RetryAfter, RegIds, Message, Key, Retry),
             {error, retry};
-        {error, Reason} ->
+        {error, Reason} = Error ->
             lager:info("error pushing: ~p", [Reason]),
-            {error, Reason}
+            Error
     end.
 
 %% handle_result(GCMResult, RegIds) ->

--- a/core/gcm/src/gcm_api.erl
+++ b/core/gcm/src/gcm_api.erl
@@ -25,8 +25,8 @@ push(RegIds, Message, Key) ->
             {error, {retry, RetryTime}};
         {ok, {{_StatusLine, _, _}, _, _Body}} ->
             {error, timeout};
-        {error, Reason} ->
-            {error, Reason};
+        {error, _Reason} = Error ->
+            Error;
         _OtherError ->
             {noreply, unknown}
     catch

--- a/core/kazoo/src/kz_json.erl
+++ b/core/kazoo/src/kz_json.erl
@@ -1051,14 +1051,15 @@ flatten([_ | _] = Elems, Acc, Keys, Depth) ->
                 end,
                 Acc, Elems);
 flatten({Key, Value}, Acc, Keys, Depth) ->
+    KList = [Key | Keys],
     case length(Keys) + 2 =:=  Depth of
         'false' ->
-            flatten(Value, Acc, [Key | Keys], Depth);
+            flatten(Value, Acc, KList, Depth);
         'true' ->
-            case flatten(Value, [], [Key | Keys], Depth) of
+            case flatten(Value, [], KList, Depth) of
                 [] -> Acc;
                 Group ->
-                    Pos = lists:reverse([Key | Keys]),
+                    Pos = lists:reverse(KList),
                     [{Pos, Group} | Acc]
             end
     end;

--- a/core/kazoo/src/kz_perf_transform.erl
+++ b/core/kazoo/src/kz_perf_transform.erl
@@ -45,19 +45,15 @@ kz_trace_opt(Options, Forms) ->
 
 
 tree(N, Mod, Fun, Ari, Args) ->
+    Attr = {attr,N,[],none},
     {tree,application,
-     {attr,N,[],none},
+     Attr,
      {application,
       {tree,module_qualifier,
-       {attr,N,[],none},
+       Attr,
        {module_qualifier,{atom,N,kzs_perf},{atom,N,profile}}},
-      [{tree,tuple,
-        {attr,N,[],none},
-        [{atom,N,Mod},{atom,N,Fun},{integer,N,Ari}]},
-       {tree,list,
-        {attr,N,[],none},
-        {list, Args,
-         none}}]}}.
+      [{tree,tuple,Attr,[{atom,N,Mod},{atom,N,Fun},{integer,N,Ari}]},
+       {tree,list, Attr,{list,Args,none}}]}}.
 
 yup(Mod, Fun, Ari, Form) ->
     N = erl_syntax:get_pos(Form),

--- a/core/kazoo/src/listener_federator.erl
+++ b/core/kazoo/src/listener_federator.erl
@@ -68,10 +68,8 @@ stop(Pid) ->
 %%                     {stop, Reason}
 %% @end
 %%--------------------------------------------------------------------
-init([Parent, Broker]) ->
-    lager:debug("federating listener ~p on broker ~s"
-                ,[Parent, Broker]
-               ),
+init([Parent, Broker]=L) ->
+    lager:debug("federating listener ~p on broker ~s", L),
     kz_amqp_channel:consumer_broker(Broker),
     Zone = kz_util:to_binary(kz_amqp_connections:broker_zone(Broker)),
     {'ok', #state{parent=Parent

--- a/core/kazoo_amqp/src/kz_amqp_connections.erl
+++ b/core/kazoo_amqp/src/kz_amqp_connections.erl
@@ -96,11 +96,11 @@ add(#kz_amqp_connection{broker=Broker, tags=Tags}=Connection, Zone) ->
         {'ok', Pid} ->
             gen_server:cast(?SERVER, {'new_connection', Pid, Broker, Zone, Tags}),
             Connection;
-        {'error', Reason} ->
+        {'error', Reason} = Error ->
             lager:warning("unable to start amqp connection to '~s': ~p"
                           ,[Broker, Reason]
                          ),
-            {'error', Reason}
+            Error
     end;
 add(Broker, Zone) when not is_binary(Broker) ->
     add(kz_util:to_binary(Broker), Zone);

--- a/core/kazoo_amqp/src/kz_amqp_worker.erl
+++ b/core/kazoo_amqp/src/kz_amqp_worker.erl
@@ -572,9 +572,9 @@ handle_call({'request', ReqProp, PublishFun, VFun, Timeout}
                 ,callid = CallId
                }
             };
-        {'error', Err} ->
+        {'error', Err}=Error ->
             lager:debug("failed to send request: ~p", [Err]),
-            {'reply', {'error', Err}, reset(State)}
+            {'reply', Error, reset(State)}
     end;
 handle_call({'call_collect', ReqProp, PublishFun, UntilFun, Timeout, Acc}
             ,{ClientPid, _}=From
@@ -602,9 +602,9 @@ handle_call({'call_collect', ReqProp, PublishFun, UntilFun, Timeout, Acc}
                 ,callid = CallId
                }
             };
-        {'error', Err} ->
+        {'error', Err}=Error ->
             lager:debug("failed to send request: ~p", [Err]),
-            {'reply', {'error', Err}, reset(State)}
+            {'reply', Error, reset(State)}
     end;
 handle_call({'publish', ReqProp, PublishFun}, {Pid, _}=From, #state{confirms=C}=State) ->
     _ = kz_util:put_callid(ReqProp),
@@ -665,8 +665,8 @@ handle_cast({'gen_listener', {'created_queue', Q}}, #state{defer={Call,From}}=St
         {'reply', Reply, NewState} ->
             gen_server:reply(From, Reply),
             {'noreply', NewState};
-        {'noreply', NewState} ->
-            {'noreply', NewState}
+        {'noreply', _NewState}=NoReply ->
+            NoReply
     end;
 handle_cast({'set_negative_threshold', NegThreshold}, State) ->
     lager:debug("set negative threshold to ~p", [NegThreshold]),

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -821,9 +821,9 @@ find_attachment_content_type(A) ->
     end.
 
 -spec maybe_add_extension({ne_binary(), ne_binary()}) -> {ne_binary(), ne_binary()}.
-maybe_add_extension({A, CT}) ->
+maybe_add_extension({A, CT}=T) ->
     case kz_util:is_empty(filename:extension(A)) of
-        'false' -> {A, CT};
+        'false' -> T;
         'true' -> {add_extension(A, CT), CT}
     end.
 

--- a/core/kazoo_apps/src/kapps_sms_command.erl
+++ b/core/kazoo_apps/src/kapps_sms_command.erl
@@ -315,13 +315,13 @@ wait_for_correlated_message(CallId, Event, Type, Timeout) when is_binary(CallId)
     Start = os:timestamp(),
     case kapps_call_command:receive_event(Timeout) of
         {'error', 'timeout'}=E -> E;
-        {'ok', JObj} ->
+        {'ok', JObj}=Ok ->
             case get_correlated_msg_type(JObj) of
                 {<<"error">>, _, CallId} ->
                     lager:debug("channel execution error while waiting for ~s", [CallId]),
                     {'error', JObj};
                 {Type, Event, CallId } ->
-                    {'ok', JObj};
+                    Ok;
                 {_Type, _Event, _CallId} ->
                     lager:debug("received message (~s , ~s, ~s)",[_Type, _Event, _CallId]),
                     wait_for_correlated_message(CallId, Event, Type, kz_util:decr_timeout(Timeout, Start))

--- a/core/kazoo_apps/src/kapps_util.erl
+++ b/core/kazoo_apps/src/kapps_util.erl
@@ -379,9 +379,10 @@ get_ccvs_by_ip(IP) ->
 do_get_ccvs_by_ip(IP) ->
     case kz_datamgr:get_results(?KZ_SIP_DB, ?AGG_LIST_BY_IP, [{'key', IP}]) of
         {'ok', []} ->
+	    NotF = {'error', 'not_found'},
             lager:debug("no entry in ~s for IP: ~s", [?KZ_SIP_DB, IP]),
-            kz_cache:store_local(?KAPPS_GETBY_CACHE, ?ACCT_BY_IP_CACHE(IP), {'error', 'not_found'}),
-            {'error', 'not_found'};
+            kz_cache:store_local(?KAPPS_GETBY_CACHE, ?ACCT_BY_IP_CACHE(IP), NotF),
+            NotF;
         {'ok', [Doc|_]} ->
             lager:debug("found IP ~s in db ~s (~s)", [IP, ?KZ_SIP_DB, kz_doc:id(Doc)]),
             AccountCCVs = account_ccvs_from_ip_auth(Doc),

--- a/core/kazoo_apps/src/kz_hooks_util.erl
+++ b/core/kazoo_apps/src/kz_hooks_util.erl
@@ -184,7 +184,7 @@ lookup_account_id(JObj) ->
         'undefined' ->
             Number = get_inbound_destination(JObj),
             case kz_cache:peek_local(?HOOKS_CACHE_NAME, cache_key_number(Number)) of
-                {'ok', AccountId} -> {'ok', AccountId};
+                {'ok', _AccountId}=Ok -> Ok;
                 {'error', 'not_found'} -> fetch_account_id(Number)
             end;
         Id -> {'ok', Id}

--- a/core/kazoo_attachments/src/aws/kz_aws.erl
+++ b/core/kazoo_attachments/src/aws/kz_aws.erl
@@ -48,8 +48,8 @@ aws_request_xml2(Method, Protocol, Host, Port, Path, Params, #aws_config{} = Con
     case aws_request2(Method, Protocol, Host, Port, Path, Params, Config) of
         {ok, Body} ->
             {ok, element(1, xmerl_scan:string(binary_to_list(Body)))};
-        {error, Reason} ->
-            {error, Reason}
+        {error, _Reason}=Error ->
+            Error
     end.
 
 aws_request_xml4(Method, Host, Path, Params, Service, #aws_config{} = Config) ->
@@ -58,8 +58,8 @@ aws_request_xml4(Method, Protocol, Host, Port, Path, Params, Service, #aws_confi
     case aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) of
         {ok, Body} ->
             {ok, element(1, xmerl_scan:string(binary_to_list(Body)))};
-        {error, Reason} ->
-            {error, Reason}
+        {error, _Reason}=Error ->
+            Error
     end.
 
 aws_request(Method, Host, Path, Params, #aws_config{} = Config) ->
@@ -83,8 +83,8 @@ aws_request2(Method, Protocol, Host, Port, Path, Params, Config) ->
     case update_config(Config) of
         {ok, Config1} ->
             aws_request2_no_update(Method, Protocol, Host, Port, Path, Params, Config1);
-        {error, Reason} ->
-            {error, Reason}
+        {error, _Reason}=Error ->
+            Error
     end.
 
 aws_request2_no_update(Method, Protocol, Host, Port, Path, Params,
@@ -133,8 +133,8 @@ aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) ->
     case update_config(Config) of
         {ok, Config1} ->
             aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service, Config1);
-        {error, Reason} ->
-            {error, Reason}
+        {error, _Reason}=Error ->
+            Error
     end.
 
 aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service, #aws_config{} = Config) ->
@@ -242,8 +242,8 @@ update_config(#aws_config{access_key_id = KeyId} = Config)
 update_config(#aws_config{} = Config) ->
     %% AccessKey is not set. Try to read from role metadata.
     case get_metadata_credentials(Config) of
-        {error, Reason} ->
-            {error, Reason};
+        {error, _Reason}=Error ->
+            Error;
         {ok, Credentials} ->
             {ok, Config#aws_config {
                    access_key_id = Credentials#metadata_credentials.access_key_id,
@@ -285,8 +285,8 @@ get_credentials_from_metadata(Config) ->
            kz_aws_httpc:request(
              "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
              get, [], <<>>, timeout(Config), Config)) of
-        {error, Reason} ->
-            {error, Reason};
+        {error, _Reason}=Error ->
+            Error;
         {ok, Body} ->
             %% Always use the first role
             [Role | _] = binary:split(Body, <<$\n>>),
@@ -295,8 +295,8 @@ get_credentials_from_metadata(Config) ->
                      "http://169.254.169.254/latest/meta-data/iam/security-credentials/" ++
                          binary_to_list(Role),
                      get, [], <<>>, timeout(Config), Config)) of
-                {error, Reason} ->
-                    {error, Reason};
+                {error, _Reason}=Error ->
+                    Error;
                 {ok, Json} ->
                     Creds = kz_json:decode(Json),
                     Record = #metadata_credentials
@@ -322,8 +322,8 @@ http_body(Return) ->
     case http_headers_body(Return) of
         {ok, {_, Body}} ->
             {ok, Body};
-        {error, Reason} ->
-            {error, Reason}
+        {error, _Reason}=Error ->
+            Error
     end.
 
 -type headers() :: [{string(), string()}].

--- a/core/kazoo_attachments/src/aws/kz_aws_s3.erl
+++ b/core/kazoo_attachments/src/aws/kz_aws_s3.erl
@@ -1146,8 +1146,8 @@ s3_request(Config, Method, Host, Path, Subresource, Params, POSTData, Headers) -
     case kz_aws:update_config(Config) of
         {'ok', Config1} ->
             s3_request2_no_update(Config1, Method, Host, Path, Subresource, Params, POSTData, Headers);
-        {'error', Reason} ->
-            {'error', Reason}
+        {'error', _Reason}=Error ->
+            Error
     end.
 
 s3_xml_request2(Config, Method, Host, Path, Subresource, Params, POSTData, Headers) ->
@@ -1260,8 +1260,8 @@ make_authorization(Config, Method, ContentMD5, ContentType, Date, AmzHeaders,
         [[Name, $:, Value, $\n] || {Name, Value} <- lists:sort(AmzHeaders)],
 
     SubResourcesToInclude = ["acl", "lifecycle", "location", "logging", "notification", "partNumber", "policy", "requestPayment", "torrent", "uploadId", "uploads", "versionId", "versioning", "versions", "website"],
-    FilteredParams = [{Name, Value}
-                      || {Name, Value} <- Params,
+    FilteredParams = [NV
+                      || {Name, _Value}=NV <- Params,
                          lists:member(Name, SubResourcesToInclude)
                      ],
 

--- a/core/kazoo_caches/src/kz_cache.erl
+++ b/core/kazoo_caches/src/kz_cache.erl
@@ -206,10 +206,10 @@ peek_local(Srv, K) ->
 fetch_local(Srv, K) ->
     case peek_local(Srv, K) of
         {'error', 'not_found'}=E -> E;
-        {'ok', Value} ->
+        {'ok', _Value}=Ok ->
             ets:update_element(Srv, K, {#cache_obj.timestamp, kz_util:current_tstamp()}),
 %            gen_server:cast(Srv, {'update_timestamp', K, }),
-            {'ok', Value}
+            Ok
     end.
 
 -spec erase_local(atom(), any()) -> 'ok'.

--- a/core/kazoo_config/src/kapps_config.erl
+++ b/core/kazoo_config/src/kapps_config.erl
@@ -461,10 +461,10 @@ maybe_save_category(Category, JObj, PvtFields, Looped, _) ->
     JObj1 = update_pvt_fields(Category, JObj, PvtFields),
 
     case kz_datamgr:save_doc(?KZ_CONFIG_DB, JObj1) of
-        {'ok', SavedJObj} ->
+        {'ok', SavedJObj}=Ok ->
             lager:debug("saved cat ~s to db ~s (~s)", [Category, ?KZ_CONFIG_DB, kz_doc:revision(SavedJObj)]),
             kz_datamgr:add_to_doc_cache(?KZ_CONFIG_DB, Category, SavedJObj),
-            {'ok', SavedJObj};
+            Ok;
         {'error', 'not_found'} when not Looped ->
             lager:debug("attempting to create ~s DB", [?KZ_CONFIG_DB]),
             kz_datamgr:db_create(?KZ_CONFIG_DB),

--- a/core/kazoo_config/src/kapps_config.erl
+++ b/core/kazoo_config/src/kapps_config.erl
@@ -410,12 +410,12 @@ update_category(Category, Keys, Value, Node, Options) ->
                      -> {'ok', kz_json:object()}.
 update_category(Category, Keys, Value, Node, Options, JObj) ->
     PvtFields = props:get_value('pvt_fields', Options),
-
-    case kz_json:get_value([Node | Keys], JObj) =/= 'undefined'
+    L = [Node | Keys],
+    case kz_json:get_value(L, JObj) =/= 'undefined'
         orelse props:is_true('node_specific', Options, 'false')
     of
         'true' ->
-            update_category(Category, kz_json:set_value([Node | Keys], Value, JObj), PvtFields);
+            update_category(Category, kz_json:set_value(L, Value, JObj), PvtFields);
         'false' ->
             update_category(Category, kz_json:set_value([?KEY_DEFAULT | Keys], Value, JObj), PvtFields)
     end.

--- a/core/kazoo_couch/src/kz_couch_doc.erl
+++ b/core/kazoo_couch/src/kz_couch_doc.erl
@@ -305,8 +305,8 @@ move_doc(Conn, CopySpec, Options) ->
                  ,source_doc_id = SourceDocId
                 } = CopySpec,
     case copy_doc(Conn, CopySpec, Options) of
-        {'ok', JObj} ->
+        {'ok', _JObj}=Ok ->
             _ = del_doc(Conn, SourceDbName, SourceDocId, []),
-            {'ok', JObj};
+            Ok;
         Error -> Error
      end.

--- a/core/kazoo_couch/src/kz_couch_util.erl
+++ b/core/kazoo_couch/src/kz_couch_util.erl
@@ -68,9 +68,9 @@ retry504s(Fun, Cnt) ->
             kazoo_stats:increment_counter(<<"bigcouch-other-error">>),
             lager:critical("response code ~b not expected : ~p", [_Code, _Body]),
             {'error', format_error(Response)};
-        {'error', Other} when is_binary(Other) ->
+        {'error', Other}=Error when is_binary(Other) ->
             kazoo_stats:increment_counter(<<"bigcouch-other-error">>),
-            {'error', Other};
+            Error;
         {'error', Other} ->
             kazoo_stats:increment_counter(<<"bigcouch-other-error">>),
             {'error', format_error(Other)};
@@ -119,11 +119,11 @@ filter_options(Options) ->
 convert_options(Options) ->
     [convert_option(O) || O <- Options].
 
-convert_option({K, V}) ->
+convert_option({K, V} = KV) ->
     case lists:member(K, ?ATOM_OPTIONS) of
         'true' -> {K, kz_util:to_atom(V, 'true')};
         'false' when is_map(V) -> {K, maps:to_list(V)};
-        'false' -> {K, V}
+        'false' -> KV
     end.
 
 -spec connection_parse(any(), any(), couch_connection()) -> couch_connection().

--- a/core/kazoo_data/src/kzs_perf.erl
+++ b/core/kazoo_data/src/kzs_perf.erl
@@ -22,10 +22,10 @@
 %% ====================================================================
 -export([profile/2]).
 
--spec profile({atom(), atom(), arity()}, list()) -> any().
-profile({Mod, Fun, Arity}, Args) ->
+-spec profile(mfa(), list()) -> any().
+profile({Mod, Fun, Arity}=MFA, Args) ->
     case profile_match(Mod, Fun, Arity) of
-        #{} -> do_profile({Mod, Fun, Arity}, Args, #{});
+        #{} -> do_profile(MFA, Args, #{});
         _ -> erlang:apply(Mod, Fun, Args)
     end.
 

--- a/core/kazoo_data/src/kzs_plan.erl
+++ b/core/kazoo_data/src/kzs_plan.erl
@@ -268,7 +268,8 @@ fetch_storage_dataplan({AccountId, StorageId}) ->
 
 -spec fetch_cached_dataplan(term(), fun()) -> map().
 fetch_cached_dataplan(Key, Fun) ->
-    case kz_cache:fetch_local(?KAZOO_DATA_PLAN_CACHE, {'plan', Key}) of
+    PT = {'plan', Key},
+    case kz_cache:fetch_local(?KAZOO_DATA_PLAN_CACHE, PT) of
         {'ok', Plan} -> Plan;
         {'error', 'not_found'} ->
             lager:debug("creating new dataplan ~p", [Key]),
@@ -277,7 +278,7 @@ fetch_cached_dataplan(Key, Fun) ->
             CacheProps = [{'origin', [{'db', ?KZ_DATA_DB, K } || K <- Keys]}
                           ,{'expires','infinity'}
                          ],
-            kz_cache:store_local(?KAZOO_DATA_PLAN_CACHE, {'plan', Key}, Plan, CacheProps),
+            kz_cache:store_local(?KAZOO_DATA_PLAN_CACHE, PT, Plan, CacheProps),
             Plan
     end.
 

--- a/core/kazoo_documents/src/kzd_user.erl
+++ b/core/kazoo_documents/src/kzd_user.erl
@@ -83,8 +83,9 @@ to_vcard(JObj) ->
 
 -spec vcard_escape_chars(binary()) -> binary().
 vcard_escape_chars(Val) ->
-    Val1 = re:replace(Val, "(:|;|,)", "\\\\&", ['global', {'return', 'binary'}]),
-    re:replace(Val1, "\n", "\\\\n", ['global', {'return', 'binary'}]).
+    Opts = ['global', {'return', 'binary'}],
+    Val1 = re:replace(Val, "(:|;|,)", "\\\\&", Opts),
+    re:replace(Val1, "\n", "\\\\n", Opts).
 
 -spec vcard_fields_acc(vcard_field(), [{ne_binary(), binary()}]) -> [{ne_binary(), binary()}].
 vcard_fields_acc({_, Val}, Acc)

--- a/core/kazoo_media/src/kazoo_media_maintenance.erl
+++ b/core/kazoo_media/src/kazoo_media_maintenance.erl
@@ -104,9 +104,9 @@ import_prompt(Path, Lang) ->
         {'ok', Contents} ->
             io:format("importing prompt '~s' with language '~s'~n", [Path, Lang]),
             import_prompt(Path, Lang, Contents);
-        {'error', E} ->
+        {'error', E}=Error ->
             io:format("failed to open path '~s' for importing: ~p~n", [Path, E]),
-            {'error', E}
+            Error
     end.
 
 import_prompt(Path0, Lang0, Contents) ->
@@ -154,9 +154,9 @@ import_prompt(Path0, Lang0, Contents) ->
                             ,{'rev', kz_doc:revision(MetaJObj1)}
                            ]
                          );
-        {'error', E} ->
+        {'error', E}=Error ->
             io:format("  error saving metadata: ~p~n", [E]),
-            {'error', E}
+            Error
     end.
 
 -spec upload_prompt(ne_binary(), ne_binary(), ne_binary(), kz_proplist()) ->
@@ -190,9 +190,9 @@ maybe_cleanup_metadoc(ID, E) ->
         {'ok', _} ->
             io:format("  removed metadata for ~s~n", [ID]),
             {'error', E};
-        {'error', E1} ->
+        {'error', E1}=Error ->
             io:format("  failed to remove metadata for ~s: ~p~n", [ID, E1]),
-            {'error', E1}
+            Error
     end.
 
 -spec maybe_retry_upload(ne_binary(), ne_binary(), ne_binary(), kz_proplist(), non_neg_integer()) ->
@@ -209,9 +209,9 @@ maybe_retry_upload(ID, AttachmentName, Contents, Options, Retries) ->
                 _Attachment ->
                     io:format("  attachment appears to have uploaded successfully!")
             end;
-        {'error', E} ->
+        {'error', E}=Error ->
             io:format("  failed to open the media doc again: ~p~n", [E]),
-            {'error', E}
+            Error
     end.
 
 -spec refresh() -> 'ok'.

--- a/core/kazoo_perf/src/kz_tracers.erl
+++ b/core/kazoo_perf/src/kz_tracers.erl
@@ -159,7 +159,7 @@ cache_data() ->
 wait_for_cache(Start) ->
     wait_for_cache(Start, {0, 'ok'}).
 
-wait_for_cache(Start, {N, F}=NF) ->
+wait_for_cache(Start, {N, _}=NF) ->
     case cache_data() of
         {M, G}=MG when M > N ->
             io:format("~p new max msg queue size ~p (~p)~n", [Start, M, G]),

--- a/core/kazoo_services/src/kz_service_sync.erl
+++ b/core/kazoo_services/src/kz_service_sync.erl
@@ -326,7 +326,7 @@ handle_topup_transactions(Account, JObjs, Failed) when is_list(Failed) ->
         'false' -> handle_topup_transactions(Account, JObjs, 3)
     end;
 handle_topup_transactions(_, [], _) -> 'ok';
-handle_topup_transactions(Account, [JObj|JObjs], Retry) when Retry > 0 ->
+handle_topup_transactions(Account, [JObj|JObjs]=List, Retry) when Retry > 0 ->
     case kz_json:get_integer_value(<<"pvt_code">>, JObj) of
         ?CODE_TOPUP ->
             Amount = kz_json:get_value(<<"pvt_amount">>, JObj),
@@ -340,7 +340,7 @@ handle_topup_transactions(Account, [JObj|JObjs], Retry) when Retry > 0 ->
                     lager:error("failed to write top up transaction ~p , for account ~s (amount: ~p), retrying ~p..."
                                 ,[_E, Account, Amount, Retry]
                                ),
-                    handle_topup_transactions(Account, [JObj|JObjs], Retry-1)
+                    handle_topup_transactions(Account, List, Retry-1)
             end;
         _ -> handle_topup_transactions(Account, JObjs, 3)
     end;

--- a/core/kazoo_stats/src/kazoo_stats.erl
+++ b/core/kazoo_stats/src/kazoo_stats.erl
@@ -139,9 +139,9 @@ handle_cast(_,State) ->
 %%                                   {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
-handle_info({'send_stats', SendStats},State) ->
+handle_info({'send_stats', SendStats}=Info,State) ->
     send_stats(State#state.variables, State#state.sip),
-    erlang:send_after(SendStats, self(), {'send_stats', SendStats}),
+    erlang:send_after(SendStats, self(), Info),
     {'noreply', State};
 handle_info(_Info, State) ->
     {'noreply', State}.

--- a/core/kazoo_translator/src/kzt_translator.erl
+++ b/core/kazoo_translator/src/kzt_translator.erl
@@ -37,8 +37,8 @@ exec(Call, Cmds, CT) ->
 just_the_type(ContentType) ->
     case binary:split(ContentType, <<";">>) of
         [ContentType] -> kz_util:strip_binary(ContentType);
-        [JustContentType | _Other] ->
-            lager:debug("just using content type ~s, ignoring ~p", [JustContentType, _Other]),
+        [JustContentType | _Other]=L ->
+            lager:debug("just using content type ~s, ignoring ~p", L),
             kz_util:strip_binary(JustContentType)
     end.
 

--- a/core/kazoo_web/src/kz_http.erl
+++ b/core/kazoo_web/src/kz_http.erl
@@ -209,17 +209,17 @@ execute_request(Method, Request, Opts) ->
 %% @doc Response to caller in a proper manner
 %%--------------------------------------------------------------------
 -spec handle_response(httpc_ret()) -> ret().
-handle_response({'ok', 'saved_to_file'}) ->
-    {'ok', 'saved_to_file'};
+handle_response({'ok', 'saved_to_file'}=Ok) ->
+    Ok;
 handle_response({'ok', ReqId})
   when is_reference(ReqId) ->
     {'http_req_id', ReqId};
 handle_response({'ok', {{_, StatusCode, _}, Headers, Body}})
   when is_integer(StatusCode) ->
     {'ok', StatusCode, Headers, Body};
-handle_response({'error', 'timeout'}) ->
+handle_response({'error', 'timeout'}=Err) ->
     lager:debug("connection timeout"),
-    {'error', 'timeout'};
+    Err;
 handle_response({'EXIT', {Error,_Trace}}) ->
     lager:debug("caught EXIT ~p: ~p", [Error, _Trace]),
     {'error', Error};
@@ -232,9 +232,9 @@ handle_response({'error', {'failed_connect',[{_, _Address}, {_, _, 'econnrefused
 handle_response({'error', {'malformed_url', _, Url}}) ->
     lager:debug("failed to parse URL ~p", [Url]),
     {'error', {'malformed_url', Url}};
-handle_response({'error', Error}) ->
+handle_response({'error', Error}=Err) ->
     lager:debug("request failed with ~p", [Error]),
-    {'error', Error}.
+    Err.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -284,4 +284,4 @@ ensure_string_headers(Headers) ->
 %%--------------------------------------------------------------------
 -spec get_options(list(), kz_proplist()) -> kz_proplist().
 get_options(Type, Options) ->
-    [{K, V} || {K, V} <- Options, lists:member(K, Type)].
+    [KV || KV = {K, _V} <- Options, lists:member(K, Type)].


### PR DESCRIPTION
This factors out common structure creations, which typically both
shortens the text of the source and makes the code faster by avoiding
unnecessary term creations.

DO NOT merge yet -- more to come here...