### PR TITLE
get-mods: filter after formatting

### DIFF
--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -151,6 +151,8 @@
 
 -define(KAZOO_VERSION_CACHE_KEY, {?MODULE, 'kazoo_version'}).
 
+-export_type([account_format/0]).
+
 %%--------------------------------------------------------------------
 %% @public
 %% @doc


### PR DESCRIPTION
So that, for an existing `AccountId`:

```erlang
kapps_util:get_account_mods(<<"009afc511c97b2ae693c6cc4920988e8">>, raw) =/= [].
kapps_util:get_account_mods(<<"009afc511c97b2ae693c6cc4920988e8">>, encoded) =/= [].
kapps_util:get_account_mods(<<"009afc511c97b2ae693c6cc4920988e8">>, unencoded) =/= [].
```

Possible issue: code that relied on this function returning `[]` (due to wrong encoding) is broken by this change.
