### PR TITLE
Revert "fix is_matched_account_mod"

### DIFF
--- a/core/kazoo_apps/src/kapps_util.erl
+++ b/core/kazoo_apps/src/kapps_util.erl
@@ -331,22 +331,6 @@ is_matched_account_mod(?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, _, _)  %% DbActId
                        ,?MATCH_ACCOUNT_ENCODED(A, B, Rest)  %% SearchId
                       ) ->
     'true';
-is_matched_account_mod(?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, _, _)  %% DbActId
-                       ,?MATCH_ACCOUNT_UNENCODED(A, B, Rest)  %% SearchId
-                      ) ->
-    'true';
-is_matched_account_mod(?MATCH_MODB_SUFFIX_UNENCODED(A, B, Rest, _, _)  %% DbActId
-                       ,?MATCH_ACCOUNT_ENCODED(A, B, Rest)  %% SearchId
-                      ) ->
-    'true';
-is_matched_account_mod(?MATCH_MODB_SUFFIX_UNENCODED(A, B, Rest, _, _)  %% DbActId
-                       ,?MATCH_ACCOUNT_RAW(A, B, Rest)  %% SearchId
-                      ) ->
-    'true';
-is_matched_account_mod(?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, _, _)  %% DbActId
-                       ,?MATCH_ACCOUNT_RAW(A, B, Rest)  %% SearchId
-                      ) ->
-    'true';
 is_matched_account_mod(_, _) ->
     'false'.
 


### PR DESCRIPTION
Reverts 2600hz/kazoo#2176

kapps_util:get_account_mods(AccountId / AccountDb) only gives back [AccountDb * X] for me
where X = number of modbs for said account

