### PR TITLE
KAZOO-4118

### DIFF
--- a/core/kazoo/include/kz_types.hrl
+++ b/core/kazoo/include/kz_types.hrl
@@ -376,7 +376,7 @@
 -type kz_node() :: #kz_node{}.
 -type kz_nodes() :: [kz_node()].
 
--type task_return() :: 'ok' | ne_binary() | kz_csv:row().
+-type task_return() :: 'ok' | ne_binary() | kz_csv:row() | [kz_csv:row()].
 -type task_iterator() :: 'init' | 'stop' | {task_return(), any()}.
 
 -define(KAZOO_TYPES_INCLUDED, 'true').

--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -1702,7 +1702,7 @@ application_version(Application) ->
       Sep :: T,
       List1 :: [T],
       List2 :: [T],
-      T :: iolist().
+      T :: iodata().
 iolist_join(_, []) -> [];
 iolist_join(Sep, [H|T]) ->
     [H | iolist_join_prepend(Sep, T)].

--- a/core/kazoo_apps/src/kazoo_apps.app.src
+++ b/core/kazoo_apps/src/kazoo_apps.app.src
@@ -13,9 +13,9 @@
                   , kazoo_config
                   , kazoo_data
                   , kazoo_amqp
+                  , kazoo_tasks
                   , kazoo_services
                   , kazoo_documents
-                  , kazoo_tasks
                   , kazoo_number_manager
                   , kazoo_token_buckets
                   , kazoo_caches

--- a/core/kazoo_apps/src/kazoo_apps.app.src
+++ b/core/kazoo_apps/src/kazoo_apps.app.src
@@ -13,7 +13,6 @@
                   , kazoo_config
                   , kazoo_data
                   , kazoo_amqp
-                  , kazoo_tasks
                   , kazoo_services
                   , kazoo_documents
                   , kazoo_number_manager

--- a/core/kazoo_modb/src/kazoo_modb_maintenance.erl
+++ b/core/kazoo_modb/src/kazoo_modb_maintenance.erl
@@ -159,9 +159,7 @@ rollup_accounts() ->
 -spec rollup_account_fold(ne_binary(), {pos_integer(), pos_integer()}) ->
                                  {pos_integer(), pos_integer()}.
 rollup_account_fold(AccountDb, {Current, Total}) ->
-    io:format("rollup accounts (~p/~p) '~s'~n"
-              ,[Current, Total, AccountDb]
-             ),
+    io:format("rollup accounts (~p/~p) '~s'~n", [Current, Total, AccountDb]),
     _ = rollup_account(AccountDb),
     {Current + 1, Total}.
 
@@ -174,9 +172,7 @@ rollup_account(Account) ->
 -spec rollup_account(ne_binary(), integer()) -> 'ok'.
 rollup_account(AccountId, Balance) ->
     AccountMODb = kazoo_modb:get_modb(AccountId),
-    lager:debug("rolling up ~p credits to ~s"
-                ,[Balance, AccountMODb]
-               ),
+    lager:debug("rolling up ~p credits to ~s", [Balance, AccountMODb]),
     wht_util:rollup(AccountMODb, Balance).
 
 -spec rollup_balance(kz_json:object()) -> integer().

--- a/core/kazoo_number_manager/src/kazoo_number_manager.app.src
+++ b/core/kazoo_number_manager/src/kazoo_number_manager.app.src
@@ -14,6 +14,7 @@
                  , kazoo
                  , kazoo_services
                  , kazoo_transactions
+                 , kazoo_tasks
 
                  , lager
                  , cowlib

--- a/core/kazoo_number_manager/src/knm_tasks.erl
+++ b/core/kazoo_number_manager/src/knm_tasks.erl
@@ -69,10 +69,6 @@ output_header('list') ->
 help() ->
     [{<<"list">>
      ,kz_json:from_list([{<<"description">>, <<"List all numbers in the system">>}
-                        ,{<<"mandatory">>, [
-                                           ]}
-                        ,{<<"optional">>, [
-                                          ]}
                         ])
      }
 

--- a/core/kazoo_number_manager/src/knm_tasks.erl
+++ b/core/kazoo_number_manager/src/knm_tasks.erl
@@ -42,7 +42,7 @@
 -spec category() -> ne_binary().
 category() -> <<"number_management">>.
 
--spec module() -> module().
+-spec module() -> ne_binary().
 module() -> kz_util:to_binary(?MODULE).
 
 -spec output_header(atom()) -> kz_csv:row().

--- a/core/kazoo_services/src/kazoo_services.app.src
+++ b/core/kazoo_services/src/kazoo_services.app.src
@@ -11,6 +11,7 @@
                  , kazoo_config
                  , kazoo_modb
                  , braintree
+                 , kazoo_tasks
 
                  , lager
                  ]},

--- a/core/kazoo_services/src/kazoo_services.hrl
+++ b/core/kazoo_services/src/kazoo_services.hrl
@@ -18,5 +18,8 @@
 -define(SUPPORT_BILLING_ID, 'true').
 -endif.
 
+-define(SERVICES_BOM, <<"services_bom">>).
+-define(SERVICES_EOM, <<"services_eom">>).
+
 -define(KAZOO_SERVICES_HRL, 'true').
 -endif.

--- a/core/kazoo_services/src/kazoo_services_sup.erl
+++ b/core/kazoo_services/src/kazoo_services_sup.erl
@@ -24,8 +24,9 @@
 
 %% Helper macro for declaring children of supervisor
 -define(CHILDREN, [?CACHE_ARGS(?CACHE_NAME, ?CACHE_PROPS)
-                   ,?WORKER('kz_services_modb')
-                   ,?WORKER('kz_service_sync')
+                  ,?WORKER('kz_services_modb')
+                  ,?WORKER('kz_service_sync')
+                  ,?WORKER('kz_services_tasks_listener')
                   ]).
 
 %% ===================================================================

--- a/core/kazoo_services/src/kz_services_modb.erl
+++ b/core/kazoo_services/src/kz_services_modb.erl
@@ -24,7 +24,7 @@ modb(?MATCH_MODB_SUFFIX_ENCODED(_AccountId, _Year, _Month) = AccountMODb) ->
     modb(kz_util:format_account_modb(AccountMODb, 'raw'));
 modb(?MATCH_MODB_SUFFIX_RAW(AccountId, _Year, _Month) = AccountMODb) ->
     ServicesJObj = kz_services:to_json(kz_services:fetch(AccountId)),
-    save_services_to_modb(AccountMODb, ServicesJObj, <<"services_bom">>),
+    save_services_to_modb(AccountMODb, ServicesJObj, ?SERVICES_BOM),
     maybe_save_to_previous_modb(AccountMODb, ServicesJObj).
 
 -spec save_services_to_modb(ne_binary(), kz_json:object(), ne_binary()) -> 'ok'.
@@ -38,7 +38,7 @@ maybe_save_to_previous_modb(NewMODb, ServicesJObj) ->
     PrevMODb = kazoo_modb_util:prev_year_month_mod(NewMODb),
     AccountDb = kz_util:format_account_modb(PrevMODb, 'encoded'),
     case kz_datamgr:db_exists(AccountDb) of
-        'true' -> save_services_to_modb(PrevMODb, ServicesJObj, <<"services_eom">>);
+        'true' -> save_services_to_modb(PrevMODb, ServicesJObj, ?SERVICES_EOM);
         'false' -> 'ok'
     end.
 

--- a/core/kazoo_services/src/kz_services_modb.erl
+++ b/core/kazoo_services/src/kz_services_modb.erl
@@ -45,8 +45,8 @@ maybe_save_to_previous_modb(NewMODb, ServicesJObj) ->
 -spec update_pvts(ne_binary(), kz_json:object(), ne_binary()) -> kz_json:object().
 update_pvts(?MATCH_MODB_SUFFIX_RAW(AccountId, _Year, _Month) = AccountMODb, ServicesJObj, Id) ->
     kz_doc:update_pvt_parameters(kz_json:delete_key(<<"_rev">>, kz_doc:set_id(ServicesJObj, Id))
-                                 ,AccountMODb
-                                 ,[{'account_db', AccountMODb}
-                                   ,{'account_id', AccountId}
-                                  ]
+                                ,AccountMODb
+                                ,[{'account_db', AccountMODb}
+                                 ,{'account_id', AccountId}
+                                 ]
                                 ).

--- a/core/kazoo_services/src/kz_services_tasks.erl
+++ b/core/kazoo_services/src/kz_services_tasks.erl
@@ -86,11 +86,6 @@ descendant_quantities(_, [SubAccountMoDB | DescendantsMoDBs]) ->
            ,Category
            ,Item
            ,integer_to_binary(kz_json:get_integer_value(Item, BoMItem, 0))
-           ]
-          ,[AccountId
-           ,YYYYMM
-           ,Category
-           ,Item
            ,integer_to_binary(kz_json:get_integer_value(Item, EoMItem, 0))
            ]
           ]

--- a/core/kazoo_services/src/kz_services_tasks.erl
+++ b/core/kazoo_services/src/kz_services_tasks.erl
@@ -73,8 +73,8 @@ descendant_quantities(_, [SubAccountMoDB | DescendantsMoDBs]) ->
     ?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, Year, Month) = SubAccountMoDB,
     AccountId = ?MATCH_ACCOUNT_RAW(A, B, Rest),
     YYYYMM = <<Year/binary, Month/binary>>,
-    BoM = modb_service_quantities(SubAccountMoDB, 'true'),
-    EoM = modb_service_quantities(SubAccountMoDB, 'false'),
+    BoM = modb_service_quantities(SubAccountMoDB, ?SERVICES_BOM),
+    EoM = modb_service_quantities(SubAccountMoDB, ?SERVICES_EOM),
     Data =
         [
          [
@@ -120,12 +120,8 @@ get_descendants(AccountId) ->
             []
     end.
 
--spec modb_service_quantities(ne_binary(), boolean()) -> kz_json:object().
-modb_service_quantities(MoDB, IsBoM) ->
-    Id = case IsBoM of
-             'true' -> <<"services_bom">>;
-             'false' -> <<"services_eom">>
-         end,
+-spec modb_service_quantities(ne_binary(), ne_binary()) -> kz_json:object().
+modb_service_quantities(MoDB, Id) ->
     case kz_datamgr:open_doc(MoDB, Id) of
         {'ok', JObj} -> kz_json:get_value(<<"quantities">>, JObj);
         {'error', _R} ->

--- a/core/kazoo_services/src/kz_services_tasks.erl
+++ b/core/kazoo_services/src/kz_services_tasks.erl
@@ -1,0 +1,144 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2016, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%   Pierre Fenoll
+%%%-------------------------------------------------------------------
+-module(kz_services_tasks).
+%% behaviour: tasks_provider
+
+-export([help/0
+        ,category/0
+        ,module/0
+        ,output_header/1
+        ]).
+
+%% Verifiers
+-export([
+        ]).
+
+%% Appliers
+-export([descendant_quantities/2
+        ]).
+
+-include("kazoo_services.hrl").
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec category() -> ne_binary().
+category() -> <<"services">>.
+
+-spec module() -> module().
+module() -> kz_util:to_binary(?MODULE).
+
+-spec output_header(atom()) -> kz_csv:row().
+output_header('descendant_quantities') ->
+    [<<"account_id">>
+    ,<<"month">>
+    ,<<"category">>
+    ,<<"item">>
+    ,<<"quantity_bom">>
+    ,<<"quantity_eom">>
+    ].
+
+-spec help() -> kz_proplist().
+help() ->
+    [{<<"descendant_quantities">>
+     ,kz_json:from_list([{<<"description">>, <<"List per-month descendant accounts quantities">>}
+                        ,{<<"mandatory">>, [
+                                           ]}
+                        ,{<<"optional">>, [
+                                          ]}
+                        ])
+     }
+    ].
+
+%%% Verifiers
+
+
+%%% Appliers
+
+-spec descendant_quantities(kz_proplist(), task_iterator()) -> task_iterator().
+descendant_quantities(Props, 'init') ->
+    Descendants = get_descendants(props:get_value('auth_account_id', Props)),
+    DescendantsMoDBs = lists:flatmap(fun kapps_util:get_account_mods/1, Descendants),
+    {'ok', DescendantsMoDBs};
+
+descendant_quantities(_, []) ->
+    'stop';
+
+descendant_quantities(_, [SubAccountMoDB | DescendantsMoDBs]) ->
+    ?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, Year, Month) = SubAccountMoDB,
+    AccountId = ?MATCH_ACCOUNT_RAW(A, B, Rest),
+    YYYYMM = <<Year/binary, Month/binary>>,
+    BoM = modb_service_quantities(SubAccountMoDB, 'true'),
+    EoM = modb_service_quantities(SubAccountMoDB, 'false'),
+    Data =
+        [
+         [
+          [
+           [AccountId
+           ,YYYYMM
+           ,Category
+           ,Item
+           ,integer_to_binary(kz_json:get_integer_value(Item, BoMItem, 0))
+           ]
+          ,[AccountId
+           ,YYYYMM
+           ,Category
+           ,Item
+           ,integer_to_binary(kz_json:get_integer_value(Item, EoMItem, 0))
+           ]
+          ]
+          || Item <- fields(BoMItem, EoMItem)
+         ]
+         || Category <- fields(BoM, EoM),
+            BoMItem <- [kz_json:get_value(Category, BoM)],
+            EoMItem <- [kz_json:get_value(Category, EoM)],
+            BoMItem =/= 'undefined' andalso EoMItem =/= 'undefined'
+        ],
+    Rows = lists:append(lists:append(Data)),
+    {Rows, DescendantsMoDBs}.
+
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+-spec get_descendants(ne_binary()) -> ne_binaries().
+get_descendants(AccountId) ->
+    ViewOptions = [{'startkey', [AccountId]}
+                  ,{'endkey', [AccountId, kz_json:new()]}
+                  ],
+    case kz_datamgr:get_results(?KZ_ACCOUNTS_DB, <<"accounts/listing_by_descendants">>, ViewOptions) of
+        {'ok', JObjs} ->
+            [Id || JObj <- JObjs,
+                   (Id = kz_doc:id(JObj)) =/= AccountId
+            ];
+        {'error', _R} ->
+            lager:debug("unable to get descendants of ~s: ~p", [AccountId, _R]),
+            []
+    end.
+
+-spec modb_service_quantities(ne_binary(), boolean()) -> kz_json:object().
+modb_service_quantities(MoDB, IsBoM) ->
+    Id = case IsBoM of
+             'true' -> <<"services_bom">>;
+             'false' -> <<"services_eom">>
+         end,
+    case kz_datamgr:open_doc(MoDB, Id) of
+        {'ok', JObj} -> kz_json:get_value(<<"quantities">>, JObj);
+        {'error', _R} ->
+            lager:debug("could not fetch ~s in modb ~s: ~p", [Id, MoDB, _R]),
+            kz_json:new()
+    end.
+
+-spec fields(kz_json:object(), kz_json:object()) -> ne_binaries().
+fields(JObjA, JObjB) ->
+    lists:usort(kz_json:get_keys(JObjA) ++ kz_json:get_keys(JObjB)).
+
+%%% End of Module.

--- a/core/kazoo_services/src/kz_services_tasks.erl
+++ b/core/kazoo_services/src/kz_services_tasks.erl
@@ -91,8 +91,7 @@ descendant_quantities(_, [SubAccountMoDB | DescendantsMoDBs]) ->
          ]
          || Category <- fields(BoM, EoM),
             BoMItem <- [kz_json:get_value(Category, BoM)],
-            EoMItem <- [kz_json:get_value(Category, EoM)],
-            BoMItem =/= 'undefined' andalso EoMItem =/= 'undefined'
+            EoMItem <- [kz_json:get_value(Category, EoM)]
         ],
     case lists:append(lists:append(Data)) of
         [] ->
@@ -134,11 +133,16 @@ modb_service_quantities(MoDB, IsBoM) ->
             kz_json:new()
     end.
 
--spec fields(kz_json:object(), kz_json:object()) -> ne_binaries().
+-spec fields(api_object(), api_object()) -> ne_binaries().
+fields('undefined', JObjB) ->
+    fields(kz_json:new(), JObjB);
+fields(JObjA, 'undefined') ->
+    fields(JObjA, kz_json:new());
 fields(JObjA, JObjB) ->
     lists:usort(kz_json:get_keys(JObjA) ++ kz_json:get_keys(JObjB)).
 
--spec maybe_integer_to_binary(ne_binary(), kz_json:object()) -> api_non_neg_integer().
+-spec maybe_integer_to_binary(ne_binary(), api_object()) -> api_non_neg_integer().
+maybe_integer_to_binary(_, 'undefined') -> 'undefined';
 maybe_integer_to_binary(Item, JObj) ->
     case kz_json:get_integer_value(Item, JObj) of
         'undefined' -> 'undefined';

--- a/core/kazoo_services/src/kz_services_tasks.erl
+++ b/core/kazoo_services/src/kz_services_tasks.erl
@@ -32,7 +32,7 @@
 -spec category() -> ne_binary().
 category() -> <<"services">>.
 
--spec module() -> module().
+-spec module() -> ne_binary().
 module() -> kz_util:to_binary(?MODULE).
 
 -spec output_header(atom()) -> kz_csv:row().

--- a/core/kazoo_services/src/kz_services_tasks_listener.erl
+++ b/core/kazoo_services/src/kz_services_tasks_listener.erl
@@ -1,0 +1,174 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2016, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%   Pierre Fenoll
+%%%-------------------------------------------------------------------
+-module(kz_services_tasks_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0]).
+
+-export([help/2]).
+
+-export([init/1
+         ,handle_call/3
+         ,handle_cast/2
+         ,handle_info/2
+         ,handle_event/2
+         ,terminate/2
+         ,code_change/3
+        ]).
+
+-include("kazoo_services.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+
+-define(BINDINGS, [{'tasks', [{'restrict_to', ['help']}
+                             ]
+                   }
+                  ]).
+-define(RESPONDERS, [{{?MODULE, 'help'}, [{<<"tasks">>, <<"help_req">>}]}
+                    ]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ]
+                           ,[]
+                           ).
+
+%%--------------------------------------------------------------------
+%% @doc Declare jobs available
+%%--------------------------------------------------------------------
+-spec help(kz_json:object(), kz_proplist()) -> 'ok'.
+help(JObj, _Props) ->
+    'true' = kapi_tasks:help_req_v(JObj),
+    RespJObj =
+        kz_json:from_list([{<<"Tasks">>, kz_json:from_list(kz_services_tasks:help())}
+                          ,{<<"Tasks-Category">>, kz_services_tasks:category()}
+                          ,{<<"Tasks-Module">>, kz_services_tasks:module()}
+                          ,{<<"Msg-ID">>, kz_api:msg_id(JObj)}
+                           | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                          ]),
+    kapi_tasks:publish_help_resp(kz_api:server_id(JObj), RespJObj).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%%
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%% @end
+%%--------------------------------------------------------------------
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%%
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%%
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_cast({'gen_listener', {'created_queue', _QueueName}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Allows listener to pass options to handlers
+%%
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%% @end
+%%--------------------------------------------------------------------
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% End of Module.

--- a/core/kazoo_tasks/src/kz_task_noinput_worker.erl
+++ b/core/kazoo_tasks/src/kz_task_noinput_worker.erl
@@ -111,8 +111,8 @@ is_task_successful(TaskId, Module, Function, ExtraArgs, IterValue) ->
         {'ok', _Data}=NewIterValue ->
             %% For initialisation steps. Skeeps writing a CSV output row.
             {'true', NewIterValue};
-        {[_|_]=NewRow, _Data}=NewIterValue ->
-            store_return(TaskId, NewRow),
+        {[_|_]=NewRowOrRows, _Data}=NewIterValue ->
+            store_return(TaskId, NewRowOrRows),
             {'true', NewIterValue};
         {?NE_BINARY=NewRow, _Data}=NewIterValue ->
             store_return(TaskId, NewRow),
@@ -129,6 +129,8 @@ is_task_successful(TaskId, Module, Function, ExtraArgs, IterValue) ->
 
 %% @private
 -spec store_return(kz_tasks:task_id(), task_return()) -> 'ok'.
+store_return(TaskId, Rows=[_List|_]) when is_list(_List) ->
+    lists:foreach(fun (Row) -> store_return(TaskId, Row) end, Rows);
 store_return(TaskId, Reason) ->
     Data = [reason(Reason), $\n],
     kz_util:write_file(?OUT(TaskId), Data, ['append']).

--- a/core/kazoo_tasks/src/kz_task_noinput_worker.erl
+++ b/core/kazoo_tasks/src/kz_task_noinput_worker.erl
@@ -56,8 +56,8 @@ start(TaskId, Module, Function, ExtraArgs, OrderedFields) ->
                                                                                   {'error', any()}.
 init(TaskId, Module, Function, ExtraArgs, _) ->
     case
-        kz_util:try_load_module(Module) =:= Module andalso
-        write_output_csv_header(TaskId, Module, Function)
+        kz_util:try_load_module(Module) =:= Module
+        andalso write_output_csv_header(TaskId, Module, Function)
     of
         'false' ->
             lager:error("failed loading module '~p' for task ~s", [Module, TaskId]),

--- a/core/kazoo_tasks/src/kz_task_noinput_worker.erl
+++ b/core/kazoo_tasks/src/kz_task_noinput_worker.erl
@@ -88,52 +88,64 @@ loop(IterValue, State=#state{task_id = TaskId
             TaskRev = upload_output(TaskId),
             _ = kz_tasks:worker_finished(TaskId, TaskRev, TotalSucceeded, TotalFailed),
             'stop';
-        {'false', {_PrevRow, NewIterValue}} ->
-            NewState = State#state{total_failed = TotalFailed + 1
-                                  },
-            _ = kz_tasks:worker_maybe_send_update(TaskId, TotalSucceeded, TotalFailed+1),
-            _ = kz_tasks:worker_pause(),
-            loop(NewIterValue, NewState);
-        {'true', {_PrevRow, NewIterValue}} ->
-            NewState = State#state{total_succeeded = TotalSucceeded + 1
-                                  },
-            _ = kz_tasks:worker_maybe_send_update(TaskId, TotalSucceeded+1, TotalFailed),
-            _ = kz_tasks:worker_pause(),
+        {IsSuccessful, Written, {_PrevRow, NewIterValue}} ->
+            NewState = state_after_writing(IsSuccessful, Written, State),
             loop(NewIterValue, NewState)
     end.
 
 %% @private
+-spec state_after_writing(boolean(), non_neg_integer(), state()) -> state().
+state_after_writing('true', Written, State) ->
+    new_state_after_writing(Written, 0, State);
+state_after_writing('false', Written, State) ->
+    new_state_after_writing(0, Written, State).
+
+%% @private
+-spec new_state_after_writing(non_neg_integer(), non_neg_integer(), state()) -> state().
+new_state_after_writing(WrittenSucceeded, WrittenFailed, State) ->
+    NewTotalSucceeded = WrittenSucceeded + State#state.total_succeeded,
+    NewTotalFailed = WrittenFailed + State#state.total_failed,
+    S = State#state{total_succeeded = NewTotalSucceeded
+                   ,total_failed = NewTotalFailed
+                   },
+    _ = kz_tasks:worker_maybe_send_update(State#state.task_id, NewTotalSucceeded, NewTotalFailed),
+    _ = kz_tasks:worker_pause(),
+    S.
+
+%% @private
 -spec is_task_successful(kz_tasks:task_id(), module(), atom(), list(), task_iterator()) ->
-                                {boolean(), task_iterator()} | 'stop'.
+                                {boolean(), non_neg_integer(), task_iterator()} |
+                                'stop'.
 is_task_successful(TaskId, Module, Function, ExtraArgs, IterValue) ->
     try Module:Function(ExtraArgs, IterValue) of
         'stop' -> 'stop';
         {'ok', _Data}=NewIterValue ->
             %% For initialisation steps. Skeeps writing a CSV output row.
-            {'true', NewIterValue};
+            {'true', 0, NewIterValue};
         {[_|_]=NewRowOrRows, _Data}=NewIterValue ->
-            store_return(TaskId, NewRowOrRows),
-            {'true', NewIterValue};
+            Written = store_return(TaskId, NewRowOrRows),
+            {'true', Written, NewIterValue};
         {?NE_BINARY=NewRow, _Data}=NewIterValue ->
-            store_return(TaskId, NewRow),
-            {'true', NewIterValue};
+            Written = store_return(TaskId, NewRow),
+            {'true', Written, NewIterValue};
         {Error, _Data}=NewIterValue ->
-            store_return(TaskId, Error),
-            {'false', NewIterValue}
+            Written = store_return(TaskId, Error),
+            {'false', Written, NewIterValue}
     catch
         _E:_R ->
             kz_util:log_stacktrace(),
-            store_return(TaskId, ?WORKER_TASK_FAILED),
-            {'false', 'stop'}
+            Written = store_return(TaskId, ?WORKER_TASK_FAILED),
+            {'false', Written, 'stop'}
     end.
 
 %% @private
--spec store_return(kz_tasks:task_id(), task_return()) -> 'ok'.
+-spec store_return(kz_tasks:task_id(), task_return()) -> pos_integer().
 store_return(TaskId, Rows=[_List|_]) when is_list(_List) ->
-    lists:foreach(fun (Row) -> store_return(TaskId, Row) end, Rows);
+    lists:sum([store_return(TaskId, Row) || Row <- Rows]);
 store_return(TaskId, Reason) ->
     Data = [reason(Reason), $\n],
-    kz_util:write_file(?OUT(TaskId), Data, ['append']).
+    _ = kz_util:write_file(?OUT(TaskId), Data, ['append']),
+    1.
 
 %% @private
 -spec reason(task_return()) -> iodata().


### PR DESCRIPTION
Notes:

when either BoM or EoM is not present (but the other is) it will put the value that exists and an empty value:

```
a4349ir30r934ir0349sub_account_idwew2323,201606,number_services,local,,130
```
(note the 2 following commas `,,`).

However, if both documents are not present, no row is generated for this month.


Waiting on https://github.com/2600hz/kazoo/pull/2183 to fix CI issues.

