### PR TITLE
Bump couchbeam from 1.3.0 to 1.3.1

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -15,7 +15,7 @@ dep_detergent = git https://github.com/pap/detergent e86dfeded3e4f9f3f9278c6a1ae
 dep_jiffy = hex 0.14.7
 dep_jesse = git https://github.com/for-GET/jesse 9e7830001deb78b57ce2ae15049afb7fecb8d386
 dep_nklib = git https://github.com/NetComposer/nklib
-dep_couchbeam = git https://github.com/benoitc/couchbeam 1.3.0
+dep_couchbeam = git https://github.com/benoitc/couchbeam 1.3.1
 dep_lager = git https://github.com/basho/lager 3.2.1
 dep_sync = git https://github.com/jamhed/sync
 


### PR DESCRIPTION
* more return codes support
* compiles on 19.0