### PR TITLE
Modernize calls to random-generating functions

### DIFF
--- a/applications/acdc/src/acdc_init.erl
+++ b/applications/acdc/src/acdc_init.erl
@@ -117,7 +117,7 @@ init_agents(AccountId, {'error', _E}) ->
 init_agents(AccountId, {'ok', As}) ->
     [acdc_agents_sup:new(AccountId, kz_doc:id(A)) || A <- As].
 
-wait_a_bit() -> timer:sleep(1000 + random:uniform(500)).
+wait_a_bit() -> timer:sleep(1000 + rand:uniform(500)).
 
 try_queues_again(AccountId) ->
     try_again(AccountId, <<"queues/crossbar_listing">>, fun init_queues/2).

--- a/applications/callflow/src/callflow_maintenance.erl
+++ b/applications/callflow/src/callflow_maintenance.erl
@@ -212,7 +212,7 @@ do_menu_migration(Menu, Db) ->
         {'ok', Bin} ->
             Name = <<(kz_json:get_value(<<"name">>, Doc, <<>>))/binary, " menu greeting">>,
             MediaId = create_media_doc(Name, <<"menu">>, MenuId, Db),
-            AName = <<(kz_util:to_hex_binary(crypto:rand_bytes(16)))/binary, ".mp3">>,
+            AName = <<(kz_util:to_hex_binary(crypto:strong_rand_bytes(16)))/binary, ".mp3">>,
             {'ok', _} = kz_datamgr:put_attachment(Db, MediaId, AName, Bin),
             'ok' = update_doc([<<"media">>, <<"greeting">>], MediaId, MenuId, Db),
             'ok' = update_doc([<<"pvt_vsn">>], <<"2">>, MenuId, Db),

--- a/applications/callflow/src/module/cf_menu.erl
+++ b/applications/callflow/src/module/cf_menu.erl
@@ -410,7 +410,7 @@ maybe_delete_attachments(AccountDb, _MediaId, JObj) ->
 %%--------------------------------------------------------------------
 -spec tmp_file() -> ne_binary().
 tmp_file() ->
-    <<(kz_util:to_hex_binary(crypto:rand_bytes(16)))/binary, ".mp3">>.
+    <<(kz_util:to_hex_binary(crypto:strong_rand_bytes(16)))/binary, ".mp3">>.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/callflow/src/module/cf_ring_group.erl
+++ b/applications/callflow/src/module/cf_ring_group.erl
@@ -272,7 +272,7 @@ create_group_member(Key, Endpoint, GroupWeight, Member) ->
 
 -spec weighted_random_sort(kz_proplist()) -> kz_json:objects().
 weighted_random_sort(Endpoints) ->
-    _ = random:seed(os:timestamp()),
+    _ = rand:seed(exsplus),
     WeightSortedEndpoints = lists:sort(Endpoints),
     weighted_random_sort(WeightSortedEndpoints, []).
 
@@ -304,7 +304,7 @@ weighted_random_get_element(List, Pivot) ->
 
 -spec random_integer(integer()) -> integer().
 random_integer(I) ->
-    random:uniform(I).
+    rand:uniform(I).
 
 -spec repeats(kz_json:object()) -> pos_integer().
 repeats(Data) ->

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -1734,7 +1734,7 @@ update_doc(Key, Value, Id, Call) ->
 -spec tmp_file() -> ne_binary().
 tmp_file() ->
     Ext = ?DEFAULT_VM_EXTENSION,
-    <<(kz_util:to_hex_binary(crypto:rand_bytes(16)))/binary, ".", Ext/binary>>.
+    <<(kz_util:to_hex_binary(crypto:strong_rand_bytes(16)))/binary, ".", Ext/binary>>.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/cdr/src/cdr_v3_migrate_lib.erl
+++ b/applications/cdr/src/cdr_v3_migrate_lib.erl
@@ -122,7 +122,7 @@ get_account_by_realm(AccountRealm) ->
 -spec generate_test_account_cdrs(ne_binary(), kz_json:object(), kz_date(), pos_integer()) -> 'ok'.
 generate_test_account_cdrs(_, _, _, 0) -> 'ok';
 generate_test_account_cdrs(AccountDb, CdrJObjFixture, Date, NumCdrs) ->
-    DateTime = {Date, {random:uniform(23), random:uniform(59), random:uniform(59)}},
+    DateTime = {Date, {rand:uniform(23), rand:uniform(59), rand:uniform(59)}},
     CreatedAt = calendar:datetime_to_gregorian_seconds(DateTime),
     Props = [{<<"call_id">>, <<(kz_datamgr:get_uuid())/binary>>}
             ,{<<"timestamp">>, CreatedAt}

--- a/applications/crossbar/src/cb_test.erl
+++ b/applications/crossbar/src/cb_test.erl
@@ -28,7 +28,7 @@ start(N, X, CDRTot, ECDRTot, Raw) ->
 
 start_key() ->
     %% 365 days * secs/day + start seconds - start somewhere within the year
-    (random:uniform(365) * 86400) + 63477725277.
+    (rand:uniform(365) * 86400) + 63477725277.
 
 end_key(Start) ->
-    Start + (random:uniform(30) * 86400). % up to 30 days in the future
+    Start + (rand:uniform(30) * 86400). % up to 30 days in the future

--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -1147,7 +1147,7 @@ maybe_add_pvt_api_key(Context) ->
     JObj = cb_context:doc(Context),
     case kz_account:api_key(JObj) of
         'undefined' ->
-            APIKey = kz_util:to_hex_binary(crypto:rand_bytes(32)),
+            APIKey = kz_util:to_hex_binary(crypto:strong_rand_bytes(32)),
             cb_context:set_doc(Context, kz_account:set_api_key(JObj, APIKey));
         _Else -> Context
     end.

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -464,7 +464,7 @@ is_superduper_admin(Context) ->
 attachment_name(Filename, CT) ->
     Generators = [fun(A) ->
                           case kz_util:is_empty(A) of
-                              'true' -> kz_util:to_hex_binary(crypto:rand_bytes(16));
+                              'true' -> kz_util:to_hex_binary(crypto:strong_rand_bytes(16));
                               'false' -> A
                           end
                   end

--- a/applications/crossbar/src/modules/cb_signup.erl
+++ b/applications/crossbar/src/modules/cb_signup.erl
@@ -270,8 +270,7 @@ validate_user(User, Context) ->
 %%--------------------------------------------------------------------
 -spec create_activation_key() -> ne_binary().
 create_activation_key() ->
-    ActivationKey =
-        kz_util:to_hex_binary(crypto:rand_bytes(32)),
+    ActivationKey = kz_util:to_hex_binary(crypto:strong_rand_bytes(32)),
     lager:debug("created new activation key ~s", [ActivationKey]),
     ActivationKey.
 

--- a/applications/crossbar/src/modules/cb_whitelabel.erl
+++ b/applications/crossbar/src/modules/cb_whitelabel.erl
@@ -843,7 +843,7 @@ update_whitelabel_binary(AttachType, WhitelabelId, Context) ->
 attachment_name(Filename, CT) ->
     Generators = [fun(A) ->
                           case kz_util:is_empty(A) of
-                              'true' -> kz_util:to_hex_binary(crypto:rand_bytes(16));
+                              'true' -> kz_util:to_hex_binary(crypto:strong_rand_bytes(16));
                               'false' -> A
                           end
                   end

--- a/applications/fax/src/fax_util.erl
+++ b/applications/fax/src/fax_util.erl
@@ -66,7 +66,7 @@ attachment_name(Filename, CT) ->
 -spec maybe_generate_random_filename(binary()) -> ne_binary().
 maybe_generate_random_filename(A) ->
     case kz_util:is_empty(A) of
-        'true' -> kz_util:to_hex_binary(crypto:rand_bytes(16));
+        'true' -> kz_util:to_hex_binary(crypto:strong_rand_bytes(16));
         'false' -> A
     end.
 

--- a/applications/teletype/src/teletype_renderer.erl
+++ b/applications/teletype/src/teletype_renderer.erl
@@ -98,7 +98,7 @@ next_backoff(BackoffMs) ->
 -spec backoff_fudge() -> pos_integer().
 backoff_fudge() ->
     Fudge = kapps_config:get_integer(?NOTIFY_CONFIG_CAT, <<"backoff_fudge_ms">>, 5000),
-    random:uniform(Fudge).
+    rand:uniform(Fudge).
 
 -spec init(list()) -> {'ok', atom()}.
 init(_) ->

--- a/applications/teletype/src/teletype_renderer.erl
+++ b/applications/teletype/src/teletype_renderer.erl
@@ -218,8 +218,7 @@ log_warnings(Ws, Template) ->
 -spec log_infos(string(), string(), [info()], binary()) -> 'ok'.
 log_infos(Type, Module, Errors, Template) ->
     lager:info("~s in module ~s", [Type, Module]),
-    _ = [catch log_info(Error, Template) || Error <- Errors],
-    'ok'.
+    lists:foreach(fun (Error) -> catch log_info(Error, Template) end, Errors).
 
 -spec log_info(info(), binary()) -> 'ok'.
 log_info({{Row, Column}, _ErlydtlModule, Msg}, Template) ->

--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -745,7 +745,7 @@ shuffle_list(List) when is_list(List) ->
 -spec randomize_list(pos_integer(), list()) -> list().
 
 randomize_list(List) ->
-    D = lists:keysort(1, [{random:uniform(), A} || A <- List]),
+    D = lists:keysort(1, [{rand:uniform(), A} || A <- List]),
     {_, D1} = lists:unzip(D),
     D1.
 
@@ -943,10 +943,7 @@ rand_hex_binary(Size) when is_integer(Size)
 
 -spec rand_hex(pos_integer()) -> ne_binary().
 rand_hex(Size) ->
-    try crypto:strong_rand_bytes(Size)
-    catch
-        _:'low_entropy' -> crypto:rand_bytes(Size)
-    end.
+    crypto:strong_rand_bytes(Size).
 
 -spec binary_to_hex_char(pos_integer()) -> pos_integer().
 binary_to_hex_char(N) when N < 10 -> $0 + N;

--- a/core/kazoo/src/perf.erl
+++ b/core/kazoo/src/perf.erl
@@ -34,7 +34,7 @@ get_vals(L) ->
 get_vals([], Acc) ->
     Acc;
 get_vals([H|T], Acc) ->
-    case random:uniform(20) of
+    case rand:uniform(20) of
         X when X < 5 -> get_vals(T, [{H, undefined}|Acc]);
-        _ -> get_vals(T, [{H,crypto:rand_bytes(16)}|Acc])
+        _ -> get_vals(T, [{H,crypto:strong_rand_bytes(16)}|Acc])
     end.

--- a/core/kazoo_attachments/src/aws/kz_aws_retry.erl
+++ b/core/kazoo_attachments/src/aws/kz_aws_retry.erl
@@ -29,7 +29,7 @@ no_retry(Request) ->
 -spec backoff(pos_integer()) -> ok.
 backoff(1) -> ok;
 backoff(Attempt) ->
-    timer:sleep(random:uniform((1 bsl (Attempt - 1)) * 100)).
+    timer:sleep(rand:uniform((1 bsl (Attempt - 1)) * 100)).
 
 %% Currently matches DynamoDB retry
 %% It's likely this is too many retries for other services

--- a/core/kazoo_data/src/kz_dataconnections.erl
+++ b/core/kazoo_data/src/kz_dataconnections.erl
@@ -69,12 +69,12 @@ wait_for_connection(Tag, Timeout) ->
     Start = os:timestamp(),
     try test_conn(Tag) of
         {'error', _E} ->
-            timer:sleep(random:uniform(?MILLISECONDS_IN_SECOND) + 100),
+            timer:sleep(rand:uniform(?MILLISECONDS_IN_SECOND) + 100),
             wait_for_connection(Tag, kz_util:decr_timeout(Timeout, Start));
         {'ok', Info} -> lager:info("connected to ~s : ~p", [Tag, Info])
     catch
         'error':{'badmatch','$end_of_table'} ->
-            timer:sleep(random:uniform(?MILLISECONDS_IN_SECOND) + 100),
+            timer:sleep(rand:uniform(?MILLISECONDS_IN_SECOND) + 100),
             wait_for_connection(Tag, kz_util:decr_timeout(Timeout, Start))
     end.
 

--- a/core/kazoo_media/src/kz_media_recording.erl
+++ b/core/kazoo_media/src/kz_media_recording.erl
@@ -312,7 +312,7 @@ handle_cast('store_failed', #state{retries=0}=State) ->
 handle_cast('store_failed', #state{retries=Retries
                                   ,should_store=Store
                                   }=State) ->
-    Sleep = ?MILLISECONDS_IN_SECOND * random:uniform(10),
+    Sleep = ?MILLISECONDS_IN_SECOND * rand:uniform(10),
     lager:debug("store failed, retrying ~p more times, next in ~p seconds", [Retries, Sleep]),
     timer:sleep(Sleep),
     save_recording(State, Store),

--- a/core/kazoo_perf/src/kz_tracers.erl
+++ b/core/kazoo_perf/src/kz_tracers.erl
@@ -32,8 +32,8 @@ add_trace(Pid, CollectFor) ->
 gen_load(N) ->
     gen_load(N, 1000).
 gen_load(N, D) ->
-    {A1, A2, A3} = Start = os:timestamp(),
-    _ = random:seed(A1, A2, A3),
+    Start = os:timestamp(),
+    _ = rand:seed(exsplus, Start),
 
     {PointerTab, MonitorTab} = gen_listener:call(?CACHE_NAME, {'tables'}),
     Tables = [?CACHE_NAME, PointerTab, MonitorTab],
@@ -81,10 +81,10 @@ do_load_gen(Ds) ->
 
     Docs = [new_doc(AccountDb, Doc) || Doc <- lists:seq(1,Ds)],
 
-    {A1, A2, A3} = Start = os:timestamp(),
-    _ = random:seed(A1, A2, A3),
+    Start = os:timestamp(),
+    _ = rand:seed(exsplus, Start),
 
-    case random:uniform(100) of
+    case rand:uniform(100) of
         42 ->
             io:format("unlucky account ~s getting deleted early: ", [AccountDb]);
         _N ->
@@ -185,7 +185,7 @@ perform_op({'noop', Doc}, Acc, _AccountDb) ->
     [Doc | Acc].
 
 op() ->
-    case random:uniform(3) of
+    case rand:uniform(3) of
         1 -> 'edit';
         2 -> 'delete';
         3 -> 'noop'

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -329,7 +329,7 @@ save_conflicting_as_dirty(#kz_services{account_id=AccountId}, BackOff) ->
             NewServices;
         'false' ->
             lager:debug("new services doc for ~s not dirty, marking it as so", [AccountId]),
-            timer:sleep(BackOff + random:uniform(?BASE_BACKOFF)),
+            timer:sleep(BackOff + rand:uniform(?BASE_BACKOFF)),
             save_as_dirty(NewServices, BackOff*2)
     end.
 
@@ -387,7 +387,7 @@ save(#kz_services{jobj = JObj
             save(Services, BackOff);
         {'error', 'conflict'} ->
             lager:debug("services for ~s conflicted, merging changes and retrying", [AccountId]),
-            timer:sleep(BackOff + random:uniform(?BASE_BACKOFF)),
+            timer:sleep(BackOff + rand:uniform(?BASE_BACKOFF)),
             {'ok', Existing} = kz_datamgr:open_doc(?KZ_SERVICES_DB, AccountId),
             save(Services#kz_services{jobj=Existing}, BackOff*2)
     end.


### PR DESCRIPTION
In Erlang/OTP 19 the 'random' module is marked deprecated and the 'rand'
module is expected to be used instead.  This module also exists in 18.x.

Also, the compiler issues warnings for crypto:rand_bytes/1 and prompts for
the use of crypto:strong_rand_bytes/1 instead.

This set of changes allows the kazoo code base to be compiled without errors
in 19.0 (because the current compiler options consider warnings as errors)
but most likely disables support for 17.x (because the 'rand' module is not
present there).

It should be merged to 'master' *only* if support for 17.x is not desirable.
However, if support for 17.x is still needed, the code should take out the
compiler option that turns warnings into errors, so that the code can also be
compiled in 19.0.