### PR TITLE
Qf tasks

### DIFF
--- a/core/kazoo_number_manager/src/knm_tasks.erl
+++ b/core/kazoo_number_manager/src/knm_tasks.erl
@@ -30,7 +30,6 @@
         ,delete/3
         ,reserve/4
         ,add/5
-                                                %,update_features/5
         ]).
 
 -include("knm.hrl").
@@ -139,19 +138,6 @@ help() ->
                                           ]}
                         ])
      }
-
-     %% ,{<<"update_features">>
-     %%  ,kz_json:from_list([{<<"description">>, <<"Bulk-update features of numbers">>}
-     %%                     ,{<<"expected_content">>, <<"text/csv">>}
-     %%                     ,{<<"mandatory">>, [<<"number">>
-     %%                                        ]}
-     %%                     ,{<<"optional">>, [<<"cnam.inbound">>
-     %%                                       ,<<"cnam.outbound">>
-     %%                                       ,<<"e911.street_address">>
-     %%                                            %%TODO: exhaustive list
-     %%                                       ]}
-     %%                     ])
-     %%  }
     ].
 
 %%% Verifiers
@@ -277,9 +263,6 @@ add(Props, Number, AccountId, AuthBy, ModuleName0) ->
               ,{'module_name', ModuleName0}
               ],
     handle_result(knm_number:create(Number, Options)).
-
-%% -spec update_features(kz_proplist(), ne_binary(), api_binary(), ...) -> any().
-%% update_features(Props, Number, CNAMInbound0, ...) ->
 
 
 %%%===================================================================


### PR DESCRIPTION
Still race issues!

Anyone can enlighten me on how to avoid db conflicts when saving attachments & non-attachments??
These are always the source of kazoo_tasks db conflicts.

So on the server node I may be saving new doc fields occasionally.
But when the task ends it both tries to
* update some of these doc fields
* and add an output.csv attachment.

How can I explicitly say to couch to merge these changes in case of conflicts?
Like, "oh you are putting an attachment & saving some json fields? Nice, here, merge this attachment stuff on its own & these other fields with the other data" Boom.

@k-anderson 