### PR TITLE
Fix crossbar versioned endpoint token parsing

### DIFF
--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -605,8 +605,8 @@ is_cb_module(Context, Elem) ->
     try (kz_util:to_atom(<<"cb_", Elem/binary>>)):module_info('exports') of
         _ -> 'true'
     catch
-        % try module_version, regardless of whether it was the atom or the
-        % module which did not exist
+        %% try module_version, regardless of whether it was the atom or the
+        %% module which did not exist
         _E:_R -> is_cb_module_version(Context, Elem)
     end.
 

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -605,7 +605,8 @@ is_cb_module(Context, Elem) ->
     try (kz_util:to_atom(<<"cb_", Elem/binary>>)):module_info('exports') of
         _ -> 'true'
     catch
-        'error':'badarg' -> 'false'; %% atom didn't exist already
+        % try module_version, regardless of whether it was the atom or the
+        % module which did not exist
         _E:_R -> is_cb_module_version(Context, Elem)
     end.
 


### PR DESCRIPTION
In some cases a versioned crossbar endpoint (for example cb_lists_v2) will not work as the non versioned atom (in this case cb_lists) does not exist. This fixes this bug.