### PR TITLE
add unbinding/deregistering to kazoo_hooks and blackhole

### DIFF
--- a/applications/blackhole/src/blackhole_listener.erl
+++ b/applications/blackhole/src/blackhole_listener.erl
@@ -140,6 +140,12 @@ handle_cast({'add_call_binding', AccountId}, State) ->
 handle_cast({'add_call_binding', AccountId, EventName}, State) ->
     kz_hooks:register(AccountId, EventName),
     {'noreply', State};
+handle_cast({'remove_call_binding', AccountId}, State) ->
+    kz_hooks:deregister(AccountId),
+    {'noreply', State};
+handle_cast({'remove_call_binding', AccountId, EventName}, State) ->
+    kz_hooks:deregister(AccountId, EventName),
+    {'noreply', State};
 handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
     {'noreply', State};
 handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->

--- a/core/kazoo_apps/src/kz_hooks.erl
+++ b/core/kazoo_apps/src/kz_hooks.erl
@@ -8,7 +8,9 @@
 -module(kz_hooks).
 
 -export([register/0, register/1, register/2
+        ,deregister/0, deregister/1, deregister/2
         ,register_rr/0, register_rr/1, register_rr/2
+        ,deregister_rr/0, deregister_rr/1, deregister_rr/2
         ]).
 
 -include_lib("kazoo/include/kz_types.hrl").
@@ -20,9 +22,23 @@ register() -> kz_hooks_util:register().
 register(AccountId) -> kz_hooks_util:register(AccountId).
 register(AccountId, EventName) -> kz_hooks_util:register(AccountId, EventName).
 
+-spec deregister() -> 'true'.
+-spec deregister(ne_binary()) -> 'true'.
+-spec deregister(ne_binary(), ne_binary()) -> 'true'.
+deregister() -> kz_hooks_util:deregister().
+deregister(AccountId) -> kz_hooks_util:deregister(AccountId).
+deregister(AccountId, EventName) -> kz_hooks_util:deregister(AccountId, EventName).
+
 -spec register_rr() -> 'true'.
 -spec register_rr(ne_binary()) -> 'true'.
 -spec register_rr(ne_binary(), ne_binary()) -> 'true'.
 register_rr() -> kz_hooks_util:register_rr().
 register_rr(AccountId) -> kz_hooks_util:register_rr(AccountId).
 register_rr(AccountId, EventName) -> kz_hooks_util:register_rr(AccountId, EventName).
+
+-spec deregister_rr() -> 'true'.
+-spec deregister_rr(ne_binary()) -> 'true'.
+-spec deregister_rr(ne_binary(), ne_binary()) -> 'true'.
+deregister_rr() -> kz_hooks_util:deregister_rr().
+deregister_rr(AccountId) -> kz_hooks_util:deregister_rr(AccountId).
+deregister_rr(AccountId, EventName) -> kz_hooks_util:deregister_rr(AccountId, EventName).

--- a/core/kazoo_apps/src/kz_hooks_shared_listener.erl
+++ b/core/kazoo_apps/src/kz_hooks_shared_listener.erl
@@ -133,6 +133,22 @@ handle_cast({'maybe_add_binding', Event}, #state{call_events=Events}=State) ->
             gen_listener:add_binding(self(), ?CALL_BINDING([Event])),
             {'noreply', State#state{call_events=[Event | Events]}}
     end;
+handle_cast({'maybe_remove_binding', 'all'}, #state{call_events=Events}=State) ->
+    case [E || E <- ?ALL_EVENTS, lists:member(E, Events)] of
+        [] -> {'noreply', State};
+        Es ->
+            lager:debug("removing bindings for ~p", [Es]),
+            gen_listener:rm_binding(self(), ?CALL_BINDING(Es)),
+            {'noreply', State#state{call_events=[]}}
+    end;
+handle_cast({'maybe_remove_binding', Event}, #state{call_events=Events}=State) ->
+    case lists:member(Event, Events) of
+        'true' -> {'noreply', State};
+        'false' ->
+            lager:debug("removing bindings for ~s", [Event]),
+            gen_listener:rm_binding(self(), ?CALL_BINDING([Event])),
+            {'noreply', State#state{call_events=lists:delete(Event, Events)}}
+    end;
 handle_cast({'gen_listener', {'created_queue', _Q}}, State) ->
     {'noreply', State};
 handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->


### PR DESCRIPTION
add missing the `remove_call_binding` to blackhole and kazoo_hooks.