### PR TITLE
Qf tasks

### DIFF
--- a/applications/crossbar/doc/phone_numbers.md
+++ b/applications/crossbar/doc/phone_numbers.md
@@ -352,6 +352,26 @@ curl -v -X PUT \
 }
 ```
 
+####### Number does not conform to E.164 format
+
+A non-conforming `{PHONENUMBER}`: `"+141510010+15"`.
+
+```json
+{
+    "auth_token": "{AUTH_TOKEN}",
+    "data": {
+        "cause": "{PHONENUMBER}",
+        "code": 404,
+        "error": "not_reconcilable",
+        "message": "number {PHONENUMBER} is not reconcilable"
+    },
+    "error": "404",
+    "message": "not_reconcilable",
+    "request_id": "fe5547b999afe27a85a92d97f786ffa4",
+    "status": "error"
+}
+```
+
 ####### Account unauthorized
 
 ```json

--- a/core/kazoo_number_manager/src/knm_errors.erl
+++ b/core/kazoo_number_manager/src/knm_errors.erl
@@ -153,7 +153,7 @@ to_json('not_found', Num=?NE_BINARY, _) ->
     build_error(404, 'not_found', Message, Num);
 to_json('not_reconcilable', Num=?NE_BINARY, _) ->
     Message = <<"number ", Num/binary, " is not reconcilable">>,
-    build_error(404, 'not_found', Message, Num);
+    build_error(404, 'not_reconcilable', Message, Num);
 to_json('unauthorized', _, Cause) ->
     Message = <<"requestor is unauthorized to perform operation">>,
     build_error(403, 'forbidden', Message, Cause);
@@ -182,15 +182,14 @@ to_json(Reason, _, Cause) ->
                          error().
 build_error(Code, Error, Message, Cause) ->
     kz_json:from_list(
-      [{?CODE, kz_util:to_integer(Code)}
-       | [{K, kz_util:to_binary(V)}
+      [{?CODE, Code}]
+      ++ [{K, kz_util:to_binary(V)}
           || {K, V} <- [{?ERROR, Error}
                        ,{?CAUSE, Cause}
                        ,{?MESSAGE, Message}
                        ],
              V =/= 'undefined'
          ]
-      ]
      ).
 
 -spec code(error()) -> api_integer().

--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -117,7 +117,11 @@ get_number(Num, Options) ->
 -spec create(ne_binary(), knm_number_options:options()) ->
                     knm_number_return().
 create(Num, Options) ->
-    attempt(fun create_or_load/2, [Num, Options]).
+    case knm_converters:is_reconcilable(Num) of
+        'false' -> {'error', knm_errors:to_json('not_reconcilable', Num)};
+        'true' ->
+            attempt(fun create_or_load/2, [Num, Options])
+    end.
 
 -spec create_or_load(ne_binary(), knm_number_options:options()) -> knm_number() |
                                                                    dry_run_return().

--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -233,6 +233,9 @@ ensure_account_can_create(Options) ->
        ).
 -endif.
 
+ensure_account_is_allowed_to_create(_, ?KNM_DEFAULT_AUTH_BY) ->
+    lager:info("bypassing auth"),
+    'true';
 ensure_account_is_allowed_to_create(_Options, _AccountId) ->
     {'ok', JObj} = ?LOAD_ACCOUNT(_Options, _AccountId),
     kz_account:allow_number_additions(JObj) orelse knm_errors:unauthorized().

--- a/core/kazoo_number_manager/src/knm_tasks.erl
+++ b/core/kazoo_number_manager/src/knm_tasks.erl
@@ -272,25 +272,31 @@ list(Props, [{E164,JObj} | Rest]) ->
 list_number_row(AuthBy, E164, JObj) ->
     Options = [{'auth_by', AuthBy}
               ],
-    {'ok', KNMNumber} = knm_number:get(E164, Options),
-    PhoneNumber = knm_number:phone_number(KNMNumber),
-    [E164
-    ,knm_phone_number:assigned_to(PhoneNumber)
-    ,knm_phone_number:prev_assigned_to(PhoneNumber)
-    ,knm_phone_number:state(PhoneNumber)
-    ,integer_to_binary(kz_json:get_value(<<"created">>, JObj))
-    ,integer_to_binary(kz_json:get_value(<<"updated">>, JObj))
-    ,knm_phone_number:used_by(PhoneNumber)
-    ,kz_util:to_binary(knm_phone_number:ported_in(PhoneNumber))
-    ,knm_phone_number:module_name(PhoneNumber)
-    ,'undefined'%%TODO
-    ,'undefined'%%TODO
-    ,'undefined'%%TODO
-    ,'undefined'%%TODO
-    ,'undefined'%%TODO
-    ,'undefined'%%TODO
-    ,'undefined'%%TODO
-    ].
+    case knm_number:get(E164, Options) of
+        {'ok', KNMNumber} ->
+            PhoneNumber = knm_number:phone_number(KNMNumber),
+            [E164
+            ,knm_phone_number:assigned_to(PhoneNumber)
+            ,knm_phone_number:prev_assigned_to(PhoneNumber)
+            ,knm_phone_number:state(PhoneNumber)
+            ,integer_to_binary(kz_json:get_value(<<"created">>, JObj))
+            ,integer_to_binary(kz_json:get_value(<<"updated">>, JObj))
+            ,knm_phone_number:used_by(PhoneNumber)
+            ,kz_util:to_binary(knm_phone_number:ported_in(PhoneNumber))
+            ,knm_phone_number:module_name(PhoneNumber)
+            ,'undefined'%%TODO
+            ,'undefined'%%TODO
+            ,'undefined'%%TODO
+            ,'undefined'%%TODO
+            ,'undefined'%%TODO
+            ,'undefined'%%TODO
+            ,'undefined'%%TODO
+            ];
+        {'error', 'not_reconcilable'} ->
+            %% Numbers that shouldn't be in the system (e.g. '+141510010+14')
+            %% Their fields are not queriable but we return the id to show it exists.
+            [E164 | lists:duplicate(length(list_output_header()) - 1, 'undefined')]
+    end.
 
 -spec list_all(kz_proplist(), task_iterator()) -> task_iterator().
 list_all(_, 'init') ->

--- a/core/kazoo_tasks/src/kz_task_noinput_worker.erl
+++ b/core/kazoo_tasks/src/kz_task_noinput_worker.erl
@@ -87,6 +87,14 @@ loop(IterValue, State=#state{task_id = TaskId
         'stop' ->
             _ = kz_tasks:worker_finished(TaskId, TotalSucceeded, TotalFailed, ?OUT(TaskId)),
             'stop';
+        {IsSuccessful, Written, 'stop'} ->
+            NewState = state_after_writing(IsSuccessful, Written, State),
+            _ = kz_tasks:worker_finished(TaskId
+                                        ,NewState#state.total_succeeded
+                                        ,NewState#state.total_failed
+                                        ,?OUT(TaskId)
+                                        ),
+            'stop';
         {IsSuccessful, Written, {_PrevRow, NewIterValue}} ->
             NewState = state_after_writing(IsSuccessful, Written, State),
             loop(NewIterValue, NewState)


### PR DESCRIPTION
* Handle an issue for noinput worker stopping with a failure (would otherwise crash thus preventing output.csv to ever be uploaded)
* Do not call kz_util:to_integer/1 on integers
* `list_all` failed on not_reconciliable numbers, handle that specifically (all but 1 fields are empty)
* **Forbid users from creating/adding numbers that are not E.164 compliant.**
