### PR TITLE
revert excluding sup from release

### DIFF
--- a/rel/relx.config.src
+++ b/rel/relx.config.src
@@ -9,7 +9,6 @@ Filter = ['rabbitmq_codegen'
           ,'.settings'
           ,'skel'
           ,'parse_trans'
-          ,'sup'
          ],
 Base = lists:filter(fun(A) -> not lists:member(A, Filter) end, Apps ++ Core ++ Deps),
 Based = [{A, 'load'} || A <- lists:sort(Base) ],


### PR DESCRIPTION
Was excluded as part of https://github.com/2600hz/kazoo/pull/2267#discussion_r71717060

However mentioned error cannot be reproduced nor locally nor by CI.