### PR TITLE
Knm tasks

### DIFF
--- a/applications/crossbar/src/modules/cb_tasks.erl
+++ b/applications/crossbar/src/modules/cb_tasks.erl
@@ -279,10 +279,9 @@ put(Context) ->
             crossbar_util:response_bad_identifier(Category, Context);
         {'error', 'unknown_action'} ->
             crossbar_util:response_bad_identifier(Action, Context);
-        {'error', Reason} ->
-            lager:debug("new ~s task ~s cannot be created: ~s"
-                       ,[Category, Action, kz_json:encode(Reason)]),
-            cb_context:add_validation_error(<<"attachment">>, <<"type">>, Reason, Context)
+        {'error', _R} ->
+            lager:debug("new ~s task ~s cannot be created: ~s", [Category, Action, kz_json:encode(_R)]),
+            cb_context:add_system_error('parse_error', Context)
     end.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/knm_tasks.erl
+++ b/core/kazoo_number_manager/src/knm_tasks.erl
@@ -222,11 +222,12 @@ module_name(Thing) -> carrier_module(Thing).
 -spec carrier_module(ne_binary()) -> boolean().
 carrier_module(<<"knm_bandwidth2">>) -> 'true';
 carrier_module(<<"knm_bandwidth">>) -> 'true';
-carrier_module(<<"knm_carriers">>) -> 'true';
 carrier_module(<<"knm_inum">>) -> 'true';
 carrier_module(<<"knm_local">>) -> 'true';
 carrier_module(<<"knm_managed">>) -> 'true';
 carrier_module(<<"knm_other">>) -> 'true';
+carrier_module(<<"knm_reserved">>) -> 'true';
+carrier_module(<<"knm_reserved_reseller">>) -> 'true';
 carrier_module(<<"knm_simwood">>) -> 'true';
 carrier_module(<<"knm_vitelity">>) -> 'true';
 carrier_module(<<"knm_voip_innovations">>) -> 'true';

--- a/core/kazoo_number_manager/src/knm_tasks.erl
+++ b/core/kazoo_number_manager/src/knm_tasks.erl
@@ -106,8 +106,8 @@ help() ->
      }
 
     ,{<<"import">>
-     ,kz_json:from_list([{<<"description">>, <<"Bulk-import numbers">>}
-                        ,{<<"doc">>, <<"Creates numbers using superadmin privileges.\n"
+     ,kz_json:from_list([{<<"description">>, <<"Bulk-import numbers using superadmin privileges">>}
+                        ,{<<"doc">>, <<"Creates numbers from fields similar to list tasks.\n"
                                        "Note: number must be E164-formatted.\n"
                                        "Note: number must not be in the system already.\n"
                                        "If `account_id` is empty, number state will be 'available'.\n"

--- a/core/kazoo_number_manager/src/knm_tasks.erl
+++ b/core/kazoo_number_manager/src/knm_tasks.erl
@@ -227,6 +227,7 @@ carrier_module(<<"knm_reserved_reseller">>) -> 'true';
 carrier_module(<<"knm_simwood">>) -> 'true';
 carrier_module(<<"knm_vitelity">>) -> 'true';
 carrier_module(<<"knm_voip_innovations">>) -> 'true';
+carrier_module('undefined') -> 'true';
 carrier_module(_) -> 'false'.
 
 

--- a/core/kazoo_number_manager/src/knm_tasks.erl
+++ b/core/kazoo_number_manager/src/knm_tasks.erl
@@ -19,7 +19,7 @@
 -export([e164/1
         ,account_id/1
         ,auth_by/1
-        ,module_name/1, carrier_module/1
+        ,carrier_module/1
         ]).
 
 %% Appliers
@@ -214,10 +214,6 @@ account_id(_) -> 'false'.
 auth_by('undefined') -> 'true';
 auth_by(?MATCH_ACCOUNT_RAW(_)) -> 'true';
 auth_by(_) -> 'false'.
-
--spec module_name(api_binary()) -> boolean().
-module_name('undefined') -> 'true';
-module_name(Thing) -> carrier_module(Thing).
 
 -spec carrier_module(ne_binary()) -> boolean().
 carrier_module(<<"knm_bandwidth2">>) -> 'true';

--- a/core/kazoo_tasks/src/kz_task_worker.erl
+++ b/core/kazoo_tasks/src/kz_task_worker.erl
@@ -91,12 +91,16 @@ init(TaskId, Module, Function, ExtraArgs, OrderedFields) ->
 -spec build_verifier(module()) -> kz_csv:verifier().
 build_verifier(Module) ->
     fun (Field, Value) ->
-            case Module:Field(Value) of
+            try Module:Field(Value) of
                 'true' -> 'true';
                 'false' ->
                     lager:error("'~s' failed to validate with ~s:~s/1"
                                ,[Value, Module, Field]),
                     'false'
+            catch
+                _:'undef' ->
+                    %% If a verifier does not exist then it always passes
+                    'true'
             end
     end.
 
@@ -154,7 +158,9 @@ is_task_successful(TaskId, Module, Function, ExtraArgs, FAssoc, RawRow) ->
             'false'
     catch
         _:_R ->
+            ST = erlang:get_stacktrace(),
             lager:error("verifier crashed: ~p", [_R]),
+            kz_util:log_stacktrace(ST),
             store_return(TaskId, RawRow, ?WORKER_TASK_MAYBE_OK),
             'false'
     end.


### PR DESCRIPTION
only have import (remove add) and the only required column would be e164.  If the account id was not present then it would add it as available, with an account id on the row it adds it as in_service.  If no carrier_module is provided then you could set it to knm_local.
