### PR TITLE
qf-views: pattern wasn't minimal enough

### DIFF
--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -234,7 +234,7 @@ maybe_adapt_multilines(JObj) ->
 %% @private
 -spec inline_js_fun(ne_binary(), ne_binaries() | kz_json:json_term(), kz_json:object()) ->
                            kz_json:object().
-inline_js_fun(Type, Code=[<<"function(",_/binary>>|_], Acc) ->
+inline_js_fun(Type, Code=[<<"function",_/binary>>|_], Acc) ->
     kz_json:set_value(Type, iolist_to_binary(Code), Acc);
 inline_js_fun(Type, Code, Acc) ->
     kz_json:set_value(Type, Code, Acc).


### PR DESCRIPTION
and that's potentially bad (couchdb adding not-flattened views to db and failing)

so now: pattern matching js code is as minimal as the one in validate-js.sh