### PR TITLE
KAZOO-4916 (also with KAZOO-4201)

### DIFF
--- a/applications/blackhole/src/blackhole.hrl
+++ b/applications/blackhole/src/blackhole.hrl
@@ -28,6 +28,7 @@
                     ,metadata :: any() | '_'
                     ,destination = kz_util:node_hostname() :: ne_binary() | '_'
                     ,source :: api_binary() | '_'
+                    ,binding :: api_binary() | '_'
          }).
 
 -define(BLACKHOLE_HRL, 'true').

--- a/applications/blackhole/src/blackhole_listener.erl
+++ b/applications/blackhole/src/blackhole_listener.erl
@@ -171,9 +171,20 @@ handle_info(?HOOK_EVT(_AccountId, EventType, JObj), State) ->
 handle_info(_Info, State) ->
     {'noreply', State}.
 
+-spec get_account_id(kz_json:object()) -> ne_binary().
+get_account_id(EventJObj) ->
+    kz_json:get_first_defined([<<"Account-ID">>
+                              ,[<<"Custom-Channel-Vars">>, <<"Account-ID">>]
+                              ], EventJObj).
+
+-spec get_call_id(kz_json:object()) -> ne_binary().
+get_call_id(EventJObj) ->
+    kz_json:get_value(<<"Call-ID">>, EventJObj).
+
+%% forge internal routing_key to restrict subscirber (bh_call) to specific account
 -spec call_routing(ne_binary(), kz_json:object()) -> ne_binary().
 call_routing(EventType, JObj) ->
-    kapi_call:event_routing_key(EventType, kz_json:get_value(<<"Call-ID">>, JObj)).
+    kz_util:join_binary([<<"call">>, get_account_id(JObj), EventType, get_call_id(JObj)], <<".">>).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/blackhole/src/blackhole_socket_callback.erl
+++ b/applications/blackhole/src/blackhole_socket_callback.erl
@@ -127,7 +127,7 @@ check_binding(Context, JObj, Binding) ->
 subscribe(Context, _JObj, _Binding, 'undefined') ->
     {'ok', blackhole_util:respond_with_error(Context)};
 subscribe(Context, _JObj, Binding, Module) ->
-    try Module:subscribe(Context, Binding) of
+    try Module:subscribe(Context#bh_context{binding=Binding}, Binding) of
         {'ok', Context1} ->
             Context2 = bh_context:add_binding(Context1, Binding),
             _ = blackhole_tracking:update_socket(Context2),

--- a/applications/blackhole/src/modules/bh_call.erl
+++ b/applications/blackhole/src/modules/bh_call.erl
@@ -22,13 +22,14 @@
                    ]).
 
 -spec handle_event(bh_context:context(), kz_json:object()) -> 'ok'.
-handle_event(Context, EventJObj) ->
+handle_event(#bh_context{binding=Binding} = Context, EventJObj) ->
     kz_util:put_callid(EventJObj),
     lager:debug("handle_event fired for ~s ~s", [bh_context:account_id(Context), bh_context:websocket_session_id(Context)]),
     'true' = kapi_call:event_v(EventJObj)
         andalso is_account_event(Context, EventJObj),
     lager:debug("valid event and emitting to ~p: ~s", [bh_context:websocket_pid(Context), event_name(EventJObj)]),
-    blackhole_data_emitter:emit(bh_context:websocket_pid(Context), event_name(EventJObj), EventJObj).
+    NormJObj = kz_json:normalize_jobj(kz_json:set_value(<<"Binding">>, Binding, EventJObj)),
+    blackhole_data_emitter:emit(bh_context:websocket_pid(Context), event_name(EventJObj), NormJObj).
 
 is_account_event(Context, EventJObj) ->
     kz_json:get_first_defined([<<"Account-ID">>
@@ -44,13 +45,13 @@ event_name(JObj) ->
 -spec subscribe(bh_context:context(), ne_binary()) -> 'ok'.
 subscribe(Context, <<"call.*.*">>) ->
     AccountId = bh_context:account_id(Context),
-    add_call_binding(AccountId, ?LISTEN_TO),
+    add_call_binding(AccountId, Context, ?LISTEN_TO),
     {'ok', Context};
 subscribe(Context, <<"call.", Binding/binary>>) ->
     case binary:split(Binding, <<".">>, ['global']) of
         [Event, <<"*">>] ->
             AccountId = bh_context:account_id(Context),
-            add_call_binding(AccountId, [Event]);
+            add_call_binding(AccountId, Context, [Event]);
         _ ->
             blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding)
     end,
@@ -62,13 +63,13 @@ subscribe(Context, Binding) ->
 -spec unsubscribe(bh_context:context(), ne_binary()) -> 'ok'.
 unsubscribe(Context, <<"call.*.*">>) ->
     AccountId = bh_context:account_id(Context),
-    rm_call_binding(AccountId, ?LISTEN_TO),
+    rm_call_binding(AccountId, Context, ?LISTEN_TO),
     {'ok', Context};
 unsubscribe(Context, <<"call.", Binding/binary>>) ->
     case binary:split(Binding, <<".">>, ['global']) of
         [Event, <<"*">>] ->
             AccountId = bh_context:account_id(Context),
-            rm_call_binding(AccountId, [Event]);
+            rm_call_binding(AccountId, Context, [Event]);
         _ ->
             blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding)
     end,
@@ -77,14 +78,16 @@ unsubscribe(Context, Binding) ->
     blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding),
     {'ok', Context}.
 
--spec add_call_binding(ne_binary(), [ne_binary()]) -> ok.
-add_call_binding(_AccountId, []) -> ok;
-add_call_binding(AccountId, [Event | Events]) ->
+-spec add_call_binding(ne_binary(), bh_context:context(), [ne_binary()]) -> ok.
+add_call_binding(_AccountId, _Context, []) -> ok;
+add_call_binding(AccountId, Context, [Event | Events]) ->
+    blackhole_bindings:bind(<<"call.", Event/binary, ".*">>, ?MODULE, 'handle_event', Context),
     blackhole_listener:add_call_binding(AccountId, Event),
-    add_call_binding(AccountId, Events).
+    add_call_binding(AccountId, Context, Events).
 
--spec rm_call_binding(ne_binary(), [ne_binary()]) -> ok.
-rm_call_binding(_AccountId, []) -> ok;
-rm_call_binding(AccountId, [Event | Events]) ->
+-spec rm_call_binding(ne_binary(), bh_context:context(), [ne_binary()]) -> ok.
+rm_call_binding(_AccountId, _Context, []) -> ok;
+rm_call_binding(AccountId, Context, [Event | Events]) ->
+    blackhole_bindings:unbind(<<"call.", Event/binary, ".*">>, ?MODULE, 'handle_event', Context),
     blackhole_listener:remove_call_binding(AccountId, Event),
-    rm_call_binding(AccountId, Events).
+    rm_call_binding(AccountId, Context, Events).

--- a/applications/blackhole/src/modules/bh_call.erl
+++ b/applications/blackhole/src/modules/bh_call.erl
@@ -44,7 +44,8 @@ event_name(JObj) ->
 -spec subscribe(bh_context:context(), ne_binary()) -> 'ok'.
 subscribe(Context, <<"call.*.*">>) ->
     AccountId = bh_context:account_id(Context),
-    add_call_binding(AccountId, ?LISTEN_TO);
+    add_call_binding(AccountId, ?LISTEN_TO),
+    {'ok', Context};
 subscribe(Context, <<"call.", Binding/binary>>) ->
     case binary:split(Binding, <<".">>, ['global']) of
         [Event, <<"*">>] ->
@@ -52,14 +53,17 @@ subscribe(Context, <<"call.", Binding/binary>>) ->
             add_call_binding(AccountId, [Event]);
         _ ->
             blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding)
-    end;
+    end,
+    {'ok', Context};
 subscribe(Context, Binding) ->
-    blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding).
+    blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding),
+    {'ok', Context}.
 
 -spec unsubscribe(bh_context:context(), ne_binary()) -> 'ok'.
 unsubscribe(Context, <<"call.*.*">>) ->
     AccountId = bh_context:account_id(Context),
-    rm_call_binding(AccountId, ?LISTEN_TO);
+    rm_call_binding(AccountId, ?LISTEN_TO),
+    {'ok', Context};
 unsubscribe(Context, <<"call.", Binding/binary>>) ->
     case binary:split(Binding, <<".">>, ['global']) of
         [Event, <<"*">>] ->
@@ -67,9 +71,11 @@ unsubscribe(Context, <<"call.", Binding/binary>>) ->
             rm_call_binding(AccountId, [Event]);
         _ ->
             blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding)
-    end;
+    end,
+    {'ok', Context};
 unsubscribe(Context, Binding) ->
-    blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding).
+    blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding),
+    {'ok', Context}.
 
 -spec add_call_binding(ne_binary(), [ne_binary()]) -> ok.
 add_call_binding(_AccountId, []) -> ok;

--- a/applications/blackhole/src/modules/bh_call.erl
+++ b/applications/blackhole/src/modules/bh_call.erl
@@ -42,7 +42,7 @@ is_account_event(Context, EventJObj) ->
 event_name(JObj) ->
     kz_json:get_value(<<"Event-Name">>, JObj).
 
--spec subscribe(bh_context:context(), ne_binary()) -> 'ok'.
+-spec subscribe(bh_context:context(), ne_binary()) -> {'ok', bh_context:context()}.
 subscribe(Context, <<"call.*.*">>) ->
     AccountId = bh_context:account_id(Context),
     add_call_binding(AccountId, Context, ?LISTEN_TO),
@@ -60,7 +60,7 @@ subscribe(Context, Binding) ->
     blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding),
     {'ok', Context}.
 
--spec unsubscribe(bh_context:context(), ne_binary()) -> 'ok'.
+-spec unsubscribe(bh_context:context(), ne_binary()) -> {'ok', bh_context:context()}.
 unsubscribe(Context, <<"call.*.*">>) ->
     AccountId = bh_context:account_id(Context),
     rm_call_binding(AccountId, Context, ?LISTEN_TO),

--- a/applications/blackhole/src/modules/bh_conference.erl
+++ b/applications/blackhole/src/modules/bh_conference.erl
@@ -7,6 +7,7 @@
 %%%   James Aimonetti
 %%%   Peter Defebvre
 %%%   Ben Wann
+%%%   Roman Galeev
 %%%-------------------------------------------------------------------
 -module(bh_conference).
 

--- a/applications/blackhole/src/modules/bh_conference.erl
+++ b/applications/blackhole/src/modules/bh_conference.erl
@@ -43,9 +43,8 @@ subscribe(Context, <<"conference.event.*.", _CallId/binary>> = Binding) ->
 subscribe(Context, <<"conference.event.", Args/binary>> = Binding) ->
     case binary:split(Args, <<".">>, ['global']) of
         [ConfId, CallId] ->
-            BindKey = kz_util:join_binary([<<"conference.event">>, ConfId, CallId], <<".">>),
             blackhole_listener:add_binding('conference', event_binding_options(ConfId, CallId)),
-            blackhole_bindings:bind(BindKey, ?MODULE, 'handle_event', Context);
+            blackhole_bindings:bind(Binding, ?MODULE, 'handle_event', Context);
         _Else ->
             blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding)
     end,
@@ -58,10 +57,9 @@ subscribe(Binding, Context) ->
 unsubscribe(Context, <<"conference.command.*">> = Binding) ->
     blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding),
     {'ok', Context};
-unsubscribe(<<"conference.command.", ConfId/binary>>, Context) ->
-    BindKey = <<"conference.command.", ConfId/binary>>,
+unsubscribe(Context, <<"conference.command.", ConfId/binary>> = Binding) ->
     blackhole_listener:remove_binding('conference', command_binding_options(ConfId)),
-    blackhole_bindings:unbind(BindKey, ?MODULE, 'handle_event', Context),
+    blackhole_bindings:unbind(Binding, ?MODULE, 'handle_event', Context),
     {'ok', Context};
 unsubscribe(Context, <<"conference.event.*.*">> = Binding) ->
     blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding),
@@ -69,17 +67,16 @@ unsubscribe(Context, <<"conference.event.*.*">> = Binding) ->
 unsubscribe(Context, <<"conference.event.*.", _CallId/binary>> = Binding) ->
     blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding),
     {'ok', Context};
-unsubscribe(<<"conference.event.", Binding/binary>>, Context) ->
+unsubscribe(Context, <<"conference.event.", Binding/binary>> = Binding) ->
     case binary:split(Binding, <<".">>, ['global']) of
         [ConfId, CallId] ->
-            BindKey = kz_util:join_binary([<<"conference.event">>, ConfId, CallId], <<".">>),
             blackhole_listener:remove_binding('conference', event_binding_options(ConfId, CallId)),
-            blackhole_bindings:unbind(BindKey, ?MODULE, 'handle_event', Context);
+            blackhole_bindings:unbind(Binding, ?MODULE, 'handle_event', Context);
         _Else ->
             blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding)
     end,
     {'ok', Context};
-unsubscribe(Binding, Context) ->
+unsubscribe(Context, Binding) ->
     blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding),
     {'ok', Context}.
 

--- a/applications/blackhole/src/modules/bh_conference.erl
+++ b/applications/blackhole/src/modules/bh_conference.erl
@@ -17,11 +17,11 @@
 -include("blackhole.hrl").
 
 -spec handle_event(bh_context:context(), kz_json:object()) -> 'ok'.
-handle_event(Context, EventJObj) ->
+handle_event(#bh_context{binding=Binding}=Context, EventJObj) ->
     lager:debug("handling conference event ~s", [get_response_key(EventJObj)]),
     blackhole_data_emitter:emit(bh_context:websocket_pid(Context)
                                ,get_response_key(EventJObj)
-                               ,kz_json:normalize_jobj(EventJObj)
+                               ,kz_json:normalize_jobj(kz_json:set_value(<<"Binding">>, Binding, EventJObj))
                                ).
 
 -spec subscribe(ne_binary(), bh_context:context()) -> {'ok', bh_context:context()}.
@@ -39,8 +39,8 @@ subscribe(Context, <<"conference.event.*.*">> = Binding) ->
 subscribe(Context, <<"conference.event.*.", _CallId/binary>> = Binding) ->
     blackhole_util:send_error_message(Context, <<"unmatched binding">>, Binding),
     {'ok', Context};
-subscribe(Context, <<"conference.event.", Binding/binary>>) ->
-    case binary:split(Binding, <<".">>, ['global']) of
+subscribe(Context, <<"conference.event.", Args/binary>> = Binding) ->
+    case binary:split(Args, <<".">>, ['global']) of
         [ConfId, CallId] ->
             BindKey = kz_util:join_binary([<<"conference.event">>, ConfId, CallId], <<".">>),
             blackhole_listener:add_binding('conference', event_binding_options(ConfId, CallId)),

--- a/applications/ecallmgr/src/ecallmgr_fs_conference.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_conference.erl
@@ -794,6 +794,7 @@ relay_event(UUID, Node, Props) ->
     gproc:send({'p', 'l', ?FS_EVENT_REG_MSG(Node, EventName)}, Payload),
     gproc:send({'p', 'l', ?FS_CALL_EVENT_REG_MSG(Node, UUID)}, Payload).
 
+-spec maybe_get_ccv(ne_binary()) -> kz_json:object().
 maybe_get_ccv(CallId) ->
     case ecallmgr_fs_conferences:participant_get(CallId) of
         #participant{call_info=CCV} -> CCV;

--- a/applications/ecallmgr/src/ecallmgr_fs_conference.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_conference.erl
@@ -278,11 +278,9 @@ process_participant_event(<<"deaf-member">>, _, _, CallId) ->
 process_participant_event(<<"undeaf-member">>, _, _, CallId) ->
     _ = ecallmgr_fs_conferences:participant_update(CallId, [{#participant.hear, 'true'}]),
     'continue';
-process_participant_event(<<"hup-member">>, _, _, CallId) ->
-    _ = ecallmgr_fs_conferences:participant_destroy(CallId),
+process_participant_event(<<"hup-member">>, _, _, _CallId) ->
     'continue';
-process_participant_event(<<"kick-member">>, _, _, CallId) ->
-    _ = ecallmgr_fs_conferences:participant_destroy(CallId),
+process_participant_event(<<"kick-member">>, _, _, _CallId) ->
     'continue';
 process_participant_event(<<"mute-detect">>, _, _, _) -> 'stop';
 process_participant_event(<<"dtmf">>, Props, _, _) ->


### PR DESCRIPTION
- keep binding in ws context and insert it into every handled message
- adapt bh_call to ws protocol changes: low-case keys, subscribe/unsubscribe, binding field