### PR TITLE
qf-dupes-headers: add only LC headers to ensure no dupes

### DIFF
--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -1188,7 +1188,7 @@ set_resp_headers(Req0, Context) ->
 fix_header(<<"Location">> = H, Path, Req) ->
     {H, crossbar_util:get_path(Req, Path)};
 fix_header(H, V, _) ->
-    {wh_util:to_binary(H), wh_util:to_binary(V)}.
+    {wh_util:to_lower_binary(H), wh_util:to_binary(V)}.
 
 -spec halt(cowboy_req:req(), cb_context:context()) ->
                   halt_return().


### PR DESCRIPTION
Cherry pick of https://github.com/2600hz/kazoo/pull/2402
Was supposedly fixed by https://2600hz.atlassian.net/browse/KAZOO-3426