### PR TITLE
Bug fixed

### DIFF
--- a/applications/jonny5/src/j5_limits.erl
+++ b/applications/jonny5/src/j5_limits.erl
@@ -269,7 +269,7 @@ get_limit(Key, JObj, Default) ->
 get_public_limit(Key, JObj, Default) ->
     case kz_json:get_integer_value(Key, JObj) of
         'undefined' -> get_default_limit(Key, Default);
-        Value when Value < 0 -> 0;
+        Value when Value < -1 -> 0;
         Value -> Value
     end.
 


### PR DESCRIPTION
If value of limit is setted to -1 (no limits), the app will read 0. (-1 when -1 < 0 => true, so return 0)
Changing this condition, will fix this bug.