### PR TITLE
Fix konami_code_fsm startup after #2375

### DIFF
--- a/applications/konami/src/konami_code_fsm.erl
+++ b/applications/konami/src/konami_code_fsm.erl
@@ -83,7 +83,7 @@
 %%% API
 %%%===================================================================
 
--spec start_fsm(apps_call:call(), kz_json:object()) -> any().
+-spec start_fsm(kapps_call:call(), kz_json:object()) -> any().
 start_fsm(Call, JObj) ->
     gen_fsm:start_link(?MODULE, {Call, JObj}, []).
 

--- a/applications/konami/src/konami_code_fsm.erl
+++ b/applications/konami/src/konami_code_fsm.erl
@@ -124,19 +124,19 @@ init({Call, JObj}) ->
     ?WSD_TITLE(["FSM: ", kapps_call:call_id(Call), " listen on: ", kz_util:to_list(ListenOn)]),
 
     {'ok', 'unarmed', #state{numbers=numbers(Call, JObj)
-                             ,patterns=patterns(Call, JObj)
-                             ,binding_digit=binding_digit(Call, JObj)
-                             ,digit_timeout=digit_timeout(Call, JObj)
+                            ,patterns=patterns(Call, JObj)
+                            ,binding_digit=binding_digit(Call, JObj)
+                            ,digit_timeout=digit_timeout(Call, JObj)
 
-                             ,listen_on=ListenOn
+                            ,listen_on=ListenOn
 
-                             ,call=kapps_call:clear_helpers(
-                                     kapps_call:kvs_store(?MODULE, self(), Call)
-                                    )
-                             ,call_id=kapps_call:call_id_direct(Call)
+                            ,call=kapps_call:clear_helpers(
+                                    kapps_call:kvs_store(?MODULE, self(), Call)
+                                   )
+                            ,call_id=kapps_call:call_id_direct(Call)
 
-                             ,b_endpoint_id=BEndpointId
-                             }}.
+                            ,b_endpoint_id=BEndpointId
+                            }}.
 
 unarmed({'dtmf', CallId, BindingDigit}, #state{call_id=CallId
                                               ,listen_on='a'

--- a/applications/konami/src/konami_listener.erl
+++ b/applications/konami/src/konami_listener.erl
@@ -70,19 +70,11 @@ handle_metaflow(JObj, Props) ->
     Call = kapps_call:from_json(kz_json:get_value(<<"Call">>, JObj)),
     kapps_call:put_callid(Call),
 
-    try konami_code_fsm:start_fsm(
+    _ = konami_code_fsm:start_fsm(
           kapps_call:kvs_store('consumer_pid', props:get_value('server', Props), Call)
                                  ,JObj
-         )
-    of
-        _ -> 'ok'
-    catch
-        'exit':'normal' -> 'ok';
-        _E:_R ->
-            ST = erlang:get_stacktrace(),
-            lager:debug("failed to run FSM: ~s: ~p", [_E, _R]),
-            kz_util:log_stacktrace(ST)
-    end.
+         ),
+    'ok'.
 
 handle_route_req(JObj, _Props) ->
     'true' = kapi_route:req_v(JObj),


### PR DESCRIPTION
Konami throw error on starup of `konami_code_fsm`
> Aug  5 04:24:54 t13-devapps 2600hz[16323]: |YTEyNzkxNTE5MzViZjE1MzZiYzkxMTExOWVmYzEwYzg.|konami_code_fsm:308 (<0.14502.0>) using custom binding digit '*'
Aug  5 04:24:54 t13-devapps 2600hz[16323]: |YTEyNzkxNTE5MzViZjE1MzZiYzkxMTExOWVmYzEwYzg.|konami_listener:83 (<0.14502.0>) failed to run FSM: exit: process_was_not_started_by_proc_lib
Aug  5 04:24:54 t13-devapps 2600hz[16323]: |YTEyNzkxNTE5MzViZjE1MzZiYzkxMTExOWVmYzEwYzg.|kz_util:169 (<0.14502.0>) stacktrace:
Aug  5 04:24:54 t13-devapps 2600hz[16323]: |YTEyNzkxNTE5MzViZjE1MzZiYzkxMTExOWVmYzEwYzg.|kz_util:176 (<0.14502.0>) st: gen_fsm:get_parent/0 at (350)
Aug  5 04:24:54 t13-devapps 2600hz[16323]: |YTEyNzkxNTE5MzViZjE1MzZiYzkxMTExOWVmYzEwYzg.|kz_util:176 (<0.14502.0>) st: gen_fsm:enter_loop/6 at (309)
Aug  5 04:24:54 t13-devapps 2600hz[16323]: |YTEyNzkxNTE5MzViZjE1MzZiYzkxMTExOWVmYzEwYzg.|kz_util:176 (<0.14502.0>) st: konami_listener:handle_metaflow/2 at (73)

This hapens after 66924e3687394f42be0459f2a4a2cc0b15505fc9 (#2375) where `gen_listener` start using `kz_util:spawn/2` instead of `proc_lib:spawn/3` for `gen_listener:distribute_event/4`