### PR TITLE
KAZOO-4983 handle unset interaction-id due to no_route

### DIFF
--- a/applications/cdr/src/cdr_channel_destroy.erl
+++ b/applications/cdr/src/cdr_channel_destroy.erl
@@ -175,18 +175,18 @@ maybe_leak_ccv(JObj, Key, {GetFun, Default}) ->
 -spec set_interaction(api_binary(), gregorian_seconds(), kz_json:object()) ->
                              kz_json:object().
 set_interaction(_AccountId, _Timestamp, JObj) ->
-    <<Time:11/binary, "-", Key/binary>> = Interaction = kz_call_event:custom_channel_var(JObj, <<?CALL_INTERACTION_ID>>),
+    Interaction = kz_call_event:custom_channel_var(JObj, <<?CALL_INTERACTION_ID>>, ?CALL_INTERACTION_DEFAULT),
+    <<Time:11/binary, "-", Key/binary>> = Interaction,
     Timestamp = kz_util:to_integer(Time),
     CallId = kz_call_event:call_id(JObj),
     DocId = cdr_util:get_cdr_doc_id(Timestamp, CallId),
 
-    kz_json:set_values(
-      [{<<"Interaction-Time">>, Timestamp}
-      ,{<<"Interaction-Key">>, Key}
-      ,{<<"Interaction-Id">>, Interaction}
-      ]
+    kz_json:set_values([{<<"Interaction-Time">>, Timestamp}
+                       ,{<<"Interaction-Key">>, Key}
+                       ,{<<"Interaction-Id">>, Interaction}
+                       ]
                       ,kz_json:delete_key(?CCV(<<?CALL_INTERACTION_ID>>), kz_doc:set_id(JObj, DocId))
-     ).
+                      ).
 
 -spec save_cdr(api_binary(), gregorian_seconds(), kz_json:object()) -> kz_json:object().
 save_cdr(_, _, JObj) ->

--- a/applications/ecallmgr/src/ecallmgr.hrl
+++ b/applications/ecallmgr/src/ecallmgr.hrl
@@ -461,10 +461,5 @@
 
 -define(CHANNEL_VARS_EXT, "Execute-Extension-Original-").
 
--define(CALL_INTERACTION_DEFAULT
-       ,<<(kz_util:to_binary(kz_util:current_tstamp()))/binary
-          ,"-", (kz_util:rand_hex_binary(4))/binary
-        >>).
-
 -define(ECALLMGR_HRL, 'true').
 -endif.

--- a/core/kazoo/include/kz_types.hrl
+++ b/core/kazoo/include/kz_types.hrl
@@ -244,6 +244,10 @@
 
 -define(CHANNEL_LOOPBACK_HEADER_PREFIX, "Export-Loopback-").
 -define(CALL_INTERACTION_ID, "Call-Interaction-ID").
+-define(CALL_INTERACTION_DEFAULT
+       ,<<(kz_util:to_binary(kz_util:current_tstamp()))/binary
+          ,"-", (kz_util:rand_hex_binary(4))/binary
+        >>).
 
 -type xml_thing() :: xml_el() | xml_text().
 -type xml_things() :: xml_els() | xml_texts().


### PR DESCRIPTION
fixes crashing in cdr_channel_destroy
