### PR TITLE
HELP-24133: seperate the page and default profiles 

### DIFF
--- a/applications/conference/src/conf_config_req.erl
+++ b/applications/conference/src/conf_config_req.erl
@@ -62,7 +62,7 @@ default_profile() ->
 page_profile() ->
     kapps_config:get(?CONFIG_CAT
                     ,[<<"profiles">>, ?PAGE_PROFILE_NAME]
-                    ,wh_json:from_list(?PAGE_PROFILE_CONFIG)
+                    ,kz_json:from_list(?PAGE_PROFILE_CONFIG)
                     ).
 
 -spec profiles(ne_binary(), kz_json:object()) -> kz_json:object().

--- a/applications/conference/src/conf_config_req.erl
+++ b/applications/conference/src/conf_config_req.erl
@@ -20,6 +20,8 @@ handle_req(JObj, _Options) ->
 -spec fetch_config(kz_json:object(), ne_binary()) -> 'ok'.
 fetch_config(JObj, ?DEFAULT_PROFILE_NAME = ConfigName) ->
     fetch_config(JObj, ConfigName, default_profile());
+fetch_config(JObj, ?PAGE_PROFILE_NAME = ConfigName) ->
+    fetch_config(JObj, ConfigName, page_profile());
 fetch_config(JObj, ConfigName) ->
     Config = kapps_config:get(?CONFIG_CAT, [<<"profiles">>, ConfigName]),
     fetch_config(JObj, ConfigName, Config).
@@ -56,6 +58,13 @@ default_profile() ->
                     ,kz_json:from_list(?DEFAULT_PROFILE_CONFIG)
                     ).
 
+-spec page_profile() -> wh_json:object().
+page_profile() ->
+    whapps_config:get(?CONFIG_CAT
+                      ,[<<"profiles">>, ?PAGE_PROFILE_NAME]
+                      ,wh_json:from_list(?PAGE_PROFILE_CONFIG)
+                     ).
+
 -spec profiles(ne_binary(), kz_json:object()) -> kz_json:object().
 profiles(ConfigName, Profile) ->
     NewContent = add_conference_params(ConfigName, Profile),
@@ -85,7 +94,8 @@ max_members_sound(Conference) ->
     end.
 
 -spec get_conference(ne_binary()) -> kapps_conference:conference().
-get_conference(?DEFAULT_PROFILE_NAME) -> kapps_conference:new();
+get_conference(?DEFAULT_PROFILE_NAME) -> whapps_conference:new();
+get_conference(?PAGE_PROFILE_NAME) -> whapps_conference:new();
 get_conference(ConferenceID) ->
     Participants =
         [Pid ||
@@ -102,8 +112,6 @@ get_conference(ConferenceID) ->
 
 -spec caller_controls(ne_binary()) -> api_object().
 -spec caller_controls(ne_binary(), api_object()) -> api_object().
-caller_controls(?DEFAULT_PROFILE_NAME = ConfigName) ->
-    caller_controls(ConfigName, ?CALLER_CONTROLS(ConfigName, ?DEFAULT_CALLER_CONTROLS_CONFIG));
 caller_controls(ConfigName) ->
     caller_controls(ConfigName, ?CALLER_CONTROLS(ConfigName)).
 
@@ -115,6 +123,8 @@ caller_controls(ConfigName, Controls) ->
 -spec advertise(ne_binary(), api_object()) -> api_object().
 advertise(?DEFAULT_PROFILE_NAME = ConfigName) ->
     advertise(ConfigName, ?ADVERTISE(ConfigName, ?DEFAULT_ADVERTISE_CONFIG));
+advertise(?PAGE_PROFILE_NAME = ConfigName) ->
+    advertise(ConfigName, ?ADVERTISE(ConfigName, ?PAGE_ADVERTISE_CONFIG));
 advertise(ConfigName) ->
     advertise(ConfigName, ?ADVERTISE(ConfigName)).
 
@@ -125,6 +135,8 @@ advertise(ConfigName, Advertise) -> kz_json:from_list([{ConfigName, Advertise}])
 -spec chat_permissions(ne_binary(), api_object()) -> api_object().
 chat_permissions(?DEFAULT_PROFILE_NAME = ConfigName) ->
     chat_permissions(ConfigName, ?CHAT_PERMISSIONS(ConfigName, ?DEFAULT_CHAT_CONFIG));
+chat_permissions(?PAGE_PROFILE_NAME= ConfigName) ->
+    chat_permissions(ConfigName, ?CHAT_PERMISSIONS(ConfigName, ?PAGE_CHAT_CONFIG));
 chat_permissions(ConfigName) ->
     chat_permissions(ConfigName, ?CHAT_PERMISSIONS(ConfigName)).
 

--- a/applications/conference/src/conf_config_req.erl
+++ b/applications/conference/src/conf_config_req.erl
@@ -60,10 +60,10 @@ default_profile() ->
 
 -spec page_profile() -> wh_json:object().
 page_profile() ->
-    whapps_config:get(?CONFIG_CAT
-                      ,[<<"profiles">>, ?PAGE_PROFILE_NAME]
-                      ,wh_json:from_list(?PAGE_PROFILE_CONFIG)
-                     ).
+    kapps_config:get(?CONFIG_CAT
+                    ,[<<"profiles">>, ?PAGE_PROFILE_NAME]
+                    ,wh_json:from_list(?PAGE_PROFILE_CONFIG)
+                    ).
 
 -spec profiles(ne_binary(), kz_json:object()) -> kz_json:object().
 profiles(ConfigName, Profile) ->
@@ -94,8 +94,8 @@ max_members_sound(Conference) ->
     end.
 
 -spec get_conference(ne_binary()) -> kapps_conference:conference().
-get_conference(?DEFAULT_PROFILE_NAME) -> whapps_conference:new();
-get_conference(?PAGE_PROFILE_NAME) -> whapps_conference:new();
+get_conference(?DEFAULT_PROFILE_NAME) -> kapps_conference:new();
+get_conference(?PAGE_PROFILE_NAME) -> kapps_conference:new();
 get_conference(ConferenceID) ->
     Participants =
         [Pid ||

--- a/applications/conference/src/conference.hrl
+++ b/applications/conference/src/conference.hrl
@@ -10,6 +10,7 @@
 -define(CONFIG_CAT, <<"conferences">>).
 
 -define(DEFAULT_PROFILE_NAME, <<"default">>).
+-define(PAGE_PROFILE_NAME, <<"page">>).
 
 -define(DEFAULT_ENTRY_TONE, <<"tone_stream://v=-7;>=2;+=.1;%(300,0,523,659);v=-7;>=3;+=.1;%(800,0,659,783)">>).
 -define(ENTRY_TONE, kapps_config:get(?CONFIG_CAT, <<"entry_tone">>, ?DEFAULT_ENTRY_TONE)).
@@ -29,23 +30,30 @@
                                 ,{<<"enter-sound">>, ?ENTRY_TONE}
                                 ]).
 
--define(CALLER_CONTROLS(ConfigName, Default)
-       ,kapps_config:get(?CONFIG_CAT, [<<"caller-controls">>, ConfigName], [])
-       ).
--define(CALLER_CONTROLS(ConfigName), ?CALLER_CONTROLS(ConfigName, 'undefined')).
+-define(PAGE_PROFILE_CONFIG, [{<<"rate">>, 8000}
+                              ,{<<"caller-controls">>, <<"default">>}
+                              ,{<<"interval">>, 20}
+                              ,{<<"energy-level">>, 20}
+                              ,{<<"comfort-noise">>, 1000}
+                              ,{<<"moh-sound">>, <<"">>}
+                              ,{<<"enter-sound">>, <<"">>}
+                             ]).
 
+-define(CALLER_CONTROLS(ConfigName), kapps_config:get(?CONFIG_CAT, [<<"caller-controls">>, ConfigName])).
+
+-define(DEFAULT_ADVERTISE_CONFIG, 'undefined').
+-define(PAGE_ADVERTISE_CONFIG, 'undefined').
 -define(ADVERTISE(ConfigName, Default)
        ,kapps_config:get(?CONFIG_CAT, [<<"advertise">>, ConfigName], Default)
        ).
 -define(ADVERTISE(ConfigName), ?ADVERTISE(ConfigName, 'undefined')).
 
+-define(DEFAULT_CHAT_CONFIG, 'undefined').
+-define(PAGE_CHAT_CONFIG, 'undefined').
 -define(CHAT_PERMISSIONS(ConfigName, Default)
        ,kapps_config:get(?CONFIG_CAT, [<<"chat-permissions">>, ConfigName], Default)
        ).
 -define(CHAT_PERMISSIONS(ConfigName), ?CHAT_PERMISSIONS(ConfigName, 'undefined')).
-
--define(DEFAULT_ADVERTISE_CONFIG, 'undefined').
--define(DEFAULT_CHAT_CONFIG, 'undefined').
 
 -define(DEFAULT_MAX_MEMBERS_MEDIA, <<"conf-max_participants">>).
 

--- a/applications/conference/src/conference.hrl
+++ b/applications/conference/src/conference.hrl
@@ -31,12 +31,12 @@
                                 ]).
 
 -define(PAGE_PROFILE_CONFIG, [{<<"rate">>, 8000}
-                              ,{<<"caller-controls">>, <<"default">>}
-                              ,{<<"interval">>, 20}
-                              ,{<<"energy-level">>, 20}
-                              ,{<<"comfort-noise">>, 1000}
-                              ,{<<"moh-sound">>, <<"">>}
-                              ,{<<"enter-sound">>, <<"">>}
+                             ,{<<"caller-controls">>, <<"default">>}
+                             ,{<<"interval">>, 20}
+                             ,{<<"energy-level">>, 20}
+                             ,{<<"comfort-noise">>, 1000}
+                             ,{<<"moh-sound">>, <<"">>}
+                             ,{<<"enter-sound">>, <<"">>}
                              ]).
 
 -define(CALLER_CONTROLS(ConfigName), kapps_config:get(?CONFIG_CAT, [<<"caller-controls">>, ConfigName])).

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -7450,7 +7450,6 @@
                     "properties": {
                         "{ConfigName}": {
                             "properties": {
-                                "default": [],
                                 "description": "conferences {ConfigName}",
                                 "name": "{ConfigName}",
                                 "type": "array"
@@ -7501,6 +7500,22 @@
                                 },
                                 "description": "conferences default",
                                 "name": "default",
+                                "type": "object"
+                            }
+                        },
+                        "page": {
+                            "properties": {
+                                "default": {
+                                    "caller-controls": "default",
+                                    "comfort-noise": 1000,
+                                    "energy-level": 20,
+                                    "enter-sound": "",
+                                    "interval": 20,
+                                    "moh-sound": "",
+                                    "rate": 8000
+                                },
+                                "description": "conferences page",
+                                "name": "page",
                                 "type": "object"
                             }
                         },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.conferences.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.conferences.json
@@ -17,7 +17,6 @@
             "properties": {
                 "{ConfigName}": {
                     "properties": {
-                        "default": [],
                         "description": "conferences {ConfigName}",
                         "name": "{ConfigName}",
                         "type": "array"
@@ -68,6 +67,22 @@
                         },
                         "description": "conferences default",
                         "name": "default",
+                        "type": "object"
+                    }
+                },
+                "page": {
+                    "properties": {
+                        "default": {
+                            "caller-controls": "default",
+                            "comfort-noise": 1000,
+                            "energy-level": 20,
+                            "enter-sound": "",
+                            "interval": 20,
+                            "moh-sound": "",
+                            "rate": 8000
+                        },
+                        "description": "conferences page",
+                        "name": "page",
                         "type": "object"
                     }
                 },

--- a/applications/ecallmgr/src/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_command.erl
@@ -354,7 +354,7 @@ get_fs_app(_Node, _UUID, JObj, <<"page">>) ->
                                             end, DP, ecallmgr_util:build_simple_channels(Endpoints))
                         end
                        ,fun(DP) ->
-                                [{"application", <<"conference ", PageId/binary, "@default">>}
+                                [{"application", <<"conference ", PageId/binary, "@page">>}
                                 ,{"application", <<"park">>}
                                  |DP
                                 ]


### PR DESCRIPTION
This allows the entry-tones to be removed from page group profile.