### PR TITLE
Small fix to make ACDC usable on 3.22

### DIFF
--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2012-2015, 2600Hz INC
+%%% @copyright (C) 2012-2016, 2600Hz INC
 %%% @doc
 %%%
 %%% @end
@@ -7,57 +7,56 @@
 %%%   James Aimonetti
 %%%-------------------------------------------------------------------
 -module(acdc_agent_listener).
-
 -behaviour(gen_listener).
 
 %% API
 -export([start_link/2, start_link/3, start_link/5
-         ,member_connect_resp/2
-         ,member_connect_retry/2
-         ,member_connect_accepted/1, member_connect_accepted/2
-         ,agent_timeout/1
-         ,bridge_to_member/6
-         ,monitor_call/4
-         ,channel_hungup/2
-         ,rebind_events/3
-         ,unbind_from_events/2
-         ,originate_execute/2
-         ,originate_uuid/3
-         ,outbound_call/2
-         ,send_sync_req/1
-         ,send_sync_resp/3, send_sync_resp/4
-         ,config/1, refresh_config/2
-         ,send_status_resume/1
-         ,add_acdc_queue/2
-         ,rm_acdc_queue/2
-         ,call_status_req/1, call_status_req/2
-         ,stop/1
-         ,fsm_started/2
-         ,add_endpoint_bindings/3, remove_endpoint_bindings/3
-         ,outbound_call_id/2
-         ,remove_cdr_urls/2
-         ,logout_agent/1
-         ,agent_info/2
-         ,maybe_update_presence_id/2
-         ,maybe_update_presence_state/2
-         ,presence_update/2
-         ,update_agent_status/2
+        ,member_connect_resp/2
+        ,member_connect_retry/2
+        ,member_connect_accepted/1, member_connect_accepted/2
+        ,agent_timeout/1
+        ,bridge_to_member/6
+        ,monitor_call/4
+        ,channel_hungup/2
+        ,rebind_events/3
+        ,unbind_from_events/2
+        ,originate_execute/2
+        ,originate_uuid/3
+        ,outbound_call/2
+        ,send_sync_req/1
+        ,send_sync_resp/3, send_sync_resp/4
+        ,config/1, refresh_config/2
+        ,send_status_resume/1
+        ,add_acdc_queue/2
+        ,rm_acdc_queue/2
+        ,call_status_req/1, call_status_req/2
+        ,stop/1
+        ,fsm_started/2
+        ,add_endpoint_bindings/3, remove_endpoint_bindings/3
+        ,outbound_call_id/2
+        ,remove_cdr_urls/2
+        ,logout_agent/1
+        ,agent_info/2
+        ,maybe_update_presence_id/2
+        ,maybe_update_presence_state/2
+        ,presence_update/2
+        ,update_agent_status/2
         ]).
 
 %% Introspection
 -export([presence_id/1
-         ,queues/1
-         ,id/1
+        ,queues/1
+        ,id/1
         ]).
 
 %% gen_server callbacks
 -export([init/1
-         ,handle_call/3
-         ,handle_cast/2
-         ,handle_info/2
-         ,handle_event/2
-         ,terminate/2
-         ,code_change/3
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
         ]).
 
 -type config() :: {ne_binary(), ne_binary(), ne_binary()}.
@@ -65,32 +64,34 @@
 
 -include("acdc.hrl").
 
--record(state, {
-         call :: whapps_call:call()
-         ,acdc_queue_id :: ne_binary() % the ACDc Queue ID
-         ,msg_queue_id :: ne_binary() % the AMQP Queue ID of the ACDc Queue process
-         ,agent_id :: ne_binary()
-         ,acct_db :: ne_binary()
-         ,acct_id :: ne_binary()
-         ,fsm_pid :: pid()
-         ,agent_queues = [] :: ne_binaries()
-         ,last_connect :: wh_now() % last connection
-         ,last_attempt :: wh_now() % last attempt to connect
-         ,my_id :: ne_binary()
-         ,my_q :: api_binary() % AMQP queue name
-         ,timer_ref :: reference()
-         ,sync_resp :: wh_json:object() % furthest along resp
-         ,supervisor :: pid()
-         ,record_calls = 'false' :: boolean()
-         ,recording_url :: api_binary() %% where to send recordings after the call
-         ,is_thief = 'false' :: boolean()
-         ,agent :: agent()
-         ,agent_call_ids = [] :: api_binaries() | wh_proplist()
-         ,cdr_urls = dict:new() :: dict() %% {CallId, Url}
-         ,agent_presence_id :: api_binary()
-         }).
+-define(SERVER, ?MODULE).
 
--type agent() :: whapps_call:call() | wh_json:object().
+-record(state, {call :: kapps_call:call()
+               ,acdc_queue_id :: ne_binary() % the ACDc Queue ID
+               ,msg_queue_id :: ne_binary() % the AMQP Queue ID of the ACDc Queue process
+               ,agent_id :: ne_binary()
+               ,acct_db :: ne_binary()
+               ,acct_id :: ne_binary()
+               ,fsm_pid :: pid()
+               ,agent_queues = [] :: ne_binaries()
+               ,last_connect :: kz_now() % last connection
+               ,last_attempt :: kz_now() % last attempt to connect
+               ,my_id :: ne_binary()
+               ,my_q :: api_binary() % AMQP queue name
+               ,timer_ref :: reference()
+               ,sync_resp :: kz_json:object() % furthest along resp
+               ,supervisor :: pid()
+               ,record_calls = 'false' :: boolean()
+               ,recording_url :: api_binary() %% where to send recordings after the call
+               ,is_thief = 'false' :: boolean()
+               ,agent :: agent()
+               ,agent_call_ids = [] :: api_binaries() | kz_proplist()
+               ,cdr_urls = dict:new() :: dict:dict() %% {CallId, Url}
+               ,agent_presence_id :: api_binary()
+               }).
+-type state() :: #state{}.
+
+-type agent() :: kapps_call:call() | kz_json:object().
 
 %%%===================================================================
 %%% Defines for different functionality
@@ -115,47 +116,47 @@
 -define(PAUSED_TIMER_MESSAGE, 'paused_timeout').
 
 -define(BINDINGS(AcctId, AgentId), [{'self', []}
-                                    ,{'acdc_agent', [{'account_id', AcctId}
-                                                     ,{'agent_id', AgentId}
-                                                     ,{'restrict_to', ['sync', 'stats_req']}
-                                                    ]}
-                                    ,{'conf', [{'action', <<"*">>}
-                                               ,{'db', wh_util:format_account_id(AcctId, 'encoded')}
-                                               ,{'id', AgentId}
-                                               ,'federate'
-                                              ]}
+                                   ,{'acdc_agent', [{'account_id', AcctId}
+                                                   ,{'agent_id', AgentId}
+                                                   ,{'restrict_to', ['sync', 'stats_req']}
+                                                   ]}
+                                   ,{'conf', [{'action', <<"*">>}
+                                             ,{'db', kz_util:format_account_id(AcctId, 'encoded')}
+                                             ,{'id', AgentId}
+                                             ,'federate'
+                                             ]}
                                    ]).
 
 -define(RESPONDERS, [{{'acdc_agent_handler', 'handle_sync_req'}
-                      ,[{<<"agent">>, <<"sync_req">>}]
+                     ,[{<<"agent">>, <<"sync_req">>}]
                      }
-                     ,{{'acdc_agent_handler', 'handle_sync_resp'}
-                       ,[{<<"agent">>, <<"sync_resp">>}]
-                      }
-                     ,{{'acdc_agent_handler', 'handle_stats_req'}
-                       ,[{<<"agent">>, <<"stats_req">>}]
-                      }
-                     ,{{'acdc_agent_handler', 'handle_call_event'}
-                       ,[{<<"call_event">>, <<"*">>}]
-                      }
-                     ,{{'acdc_agent_handler', 'handle_originate_resp'}
-                       ,[{<<"resource">>, <<"*">>}]
-                      }
-                     ,{{'acdc_agent_handler', 'handle_call_event'}
-                       ,[{<<"error">>, <<"*">>}]
-                      }
-                     ,{{'acdc_agent_handler', 'handle_member_message'}
-                       ,[{<<"member">>, <<"*">>}]
-                      }
-                     ,{{'acdc_agent_handler', 'handle_agent_message'}
-                       ,[{<<"agent">>, <<"*">>}]
-                      }
-                     ,{{'acdc_agent_handler', 'handle_destroy'}
-                       ,[{<<"channel">>, <<"destroy">>}]
-                      }
-                     ,{{'acdc_agent_handler', 'handle_config_change'}
-                       ,[{<<"configuration">>, <<"*">>}]
-                      }
+                    ,{{'acdc_agent_handler', 'handle_sync_resp'}
+                     ,[{<<"agent">>, <<"sync_resp">>}]
+                     }
+                    ,{{'acdc_agent_handler', 'handle_stats_req'}
+                     ,[{<<"agent">>, <<"stats_req">>}]
+                     }
+                    ,{{'acdc_agent_handler', 'handle_call_event'}
+                     ,[{<<"call_event">>, <<"*">>}]
+                     }
+                    ,{{'acdc_agent_handler', 'handle_originate_resp'}
+                     ,[{<<"resource">>, <<"*">>}]
+                     }
+                    ,{{'acdc_agent_handler', 'handle_call_event'}
+                     ,[{<<"error">>, <<"*">>}]
+                     }
+                    ,{{'acdc_agent_handler', 'handle_member_message'}
+                     ,[{<<"member">>, <<"*">>}]
+                     }
+                    ,{{'acdc_agent_handler', 'handle_agent_message'}
+                     ,[{<<"agent">>, <<"*">>}]
+                     }
+                    ,{{'acdc_agent_handler', 'handle_destroy'}
+                     ,[{<<"channel">>, <<"destroy">>}]
+                     }
+                    ,{{'acdc_agent_handler', 'handle_config_change'}
+                     ,[{<<"configuration">>, <<"*">>}]
+                     }
                     ]).
 
 %%%===================================================================
@@ -163,56 +164,50 @@
 %%%===================================================================
 
 %%--------------------------------------------------------------------
-%% @doc
-%% Starts the server
-%%
-%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
-%% @end
+%% @doc Starts the server
 %%--------------------------------------------------------------------
+-spec start_link(pid(), kz_json:object()) -> startlink_ret().
 start_link(Supervisor, AgentJObj) ->
-    AgentId = wh_doc:id(AgentJObj),
+    AgentId = kz_doc:id(AgentJObj),
     AcctId = account_id(AgentJObj),
 
-    Queues = case wh_json:get_value(<<"queues">>, AgentJObj) of
-                 'undefined' -> [];
-                 Qs -> Qs
-             end,
+    Queues = kz_json:get_value(<<"queues">>, AgentJObj, []),
     start_link(Supervisor, AgentJObj, AcctId, AgentId, Queues).
 start_link(Supervisor, _, _AcctId, _AgentId, []) ->
     lager:debug("agent ~s has no queues, not starting", [_AgentId]),
-    _ = wh_util:spawn('acdc_agent_sup', 'stop', [Supervisor]),
+    _ = kz_util:spawn(fun acdc_agent_sup:stop/1, [Supervisor]),
     'ignore';
 start_link(Supervisor, AgentJObj, AcctId, AgentId, Queues) ->
     case acdc_agent_util:most_recent_status(AcctId, AgentId) of
         {'ok', <<"logged_out">>} ->
             lager:debug("agent ~s in ~s is logged out, not starting", [AgentId, AcctId]),
-            _ = wh_util:spawn('acdc_agent_sup', 'stop', [Supervisor]),
+            _ = kz_util:spawn(fun acdc_agent_sup:stop/1, [Supervisor]),
             'ignore';
         {'ok', _S} ->
             lager:debug("start bindings for ~s(~s) in ~s", [AcctId, AgentId, _S]),
-            gen_listener:start_link(?MODULE
-                                    ,[{'bindings', ?BINDINGS(AcctId, AgentId)}
-                                      ,{'responders', ?RESPONDERS}
-                                     ]
-                                    ,[Supervisor, AgentJObj, Queues]
+            gen_listener:start_link(?SERVER
+                                   ,[{'bindings', ?BINDINGS(AcctId, AgentId)}
+                                    ,{'responders', ?RESPONDERS}
+                                    ]
+                                   ,[Supervisor, AgentJObj, Queues]
                                    )
     end.
 
 start_link(Supervisor, ThiefCall, QueueId) ->
-    AgentId = whapps_call:owner_id(ThiefCall),
-    AcctId = whapps_call:account_id(ThiefCall),
+    AgentId = kapps_call:owner_id(ThiefCall),
+    AcctId = kapps_call:account_id(ThiefCall),
 
     lager:debug("starting thief agent ~s(~s)", [AgentId, AcctId]),
-    gen_listener:start_link(?MODULE
-                            ,[{'bindings', ?BINDINGS(AcctId, AgentId)}
-                              ,{'responders', ?RESPONDERS}
-                             ]
-                            ,[Supervisor, ThiefCall, [QueueId]]
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS(AcctId, AgentId)}
+                            ,{'responders', ?RESPONDERS}
+                            ]
+                           ,[Supervisor, ThiefCall, [QueueId]]
                            ).
 
 stop(Srv) -> gen_listener:cast(Srv, {'stop_agent', self()}).
 
--spec member_connect_resp(pid(), wh_json:object()) -> 'ok'.
+-spec member_connect_resp(pid(), kz_json:object()) -> 'ok'.
 member_connect_resp(Srv, ReqJObj) ->
     gen_listener:cast(Srv, {'member_connect_resp', ReqJObj}).
 
@@ -227,8 +222,8 @@ member_connect_accepted(Srv) ->
 member_connect_accepted(Srv, ACallId) ->
     gen_listener:cast(Srv, {'member_connect_accepted', ACallId}).
 
--spec bridge_to_member(pid(), whapps_call:call(), wh_json:object()
-                       ,wh_json:objects(), api_binary(), api_binary()
+-spec bridge_to_member(pid(), kapps_call:call(), kz_json:object()
+                      ,kz_json:objects(), api_binary(), api_binary()
                       ) -> 'ok'.
 bridge_to_member(Srv, Call, WinJObj, EPs, CDRUrl, RecordingUrl) ->
     gen_listener:cast(Srv, {'bridge_to_member', Call, WinJObj, EPs, CDRUrl, RecordingUrl}).
@@ -269,7 +264,7 @@ config(Srv) -> gen_listener:call(Srv, 'config').
 refresh_config(_, 'undefined') -> 'ok';
 refresh_config(Srv, Qs) -> gen_listener:cast(Srv, {'refresh_config', Qs}).
 
--spec agent_info(pid(), wh_json:key()) -> wh_json:json_term() | 'undefined'.
+-spec agent_info(pid(), kz_json:key()) -> kz_json:json_term() | 'undefined'.
 agent_info(Srv, Field) -> gen_listener:call(Srv, {'agent_info', Field}).
 
 send_status_resume(Srv) ->
@@ -294,12 +289,12 @@ add_endpoint_bindings(_Srv, _Realm, 'undefined') ->
 add_endpoint_bindings(Srv, Realm, User) ->
     lager:debug("adding route bindings to ~p for endpoint ~s@~s", [Srv, User, Realm]),
     gen_listener:add_binding(Srv, 'route', [{'realm', Realm}
-                                            ,{'user', User}
+                                           ,{'user', User}
                                            ]).
 remove_endpoint_bindings(Srv, Realm, User) ->
     lager:debug("removing route bindings to ~p for endpoint ~s@~s", [Srv, User, Realm]),
     gen_listener:rm_binding(Srv, 'route', [{'realm', Realm}
-                                           ,{'user', User}
+                                          ,{'user', User}
                                           ]).
 
 remove_cdr_urls(Srv, CallId) -> gen_listener:cast(Srv, {'remove_cdr_urls', CallId}).
@@ -351,19 +346,19 @@ id(Srv) ->
 %%--------------------------------------------------------------------
 init([Supervisor, Agent, Queues]) ->
     AgentId = agent_id(Agent),
-    wh_util:put_callid(AgentId),
+    kz_util:put_callid(AgentId),
     lager:debug("starting acdc agent listener"),
 
     {'ok', #state{agent_id=AgentId
-                  ,acct_id=account_id(Agent)
-                  ,acct_db=account_db(Agent)
-                  ,my_id=acdc_util:proc_id()
-                  ,supervisor=Supervisor
-                  ,record_calls=record_calls(Agent)
-                  ,is_thief=is_thief(Agent)
-                  ,agent=Agent
-                  ,agent_queues=Queues
-                  ,agent_presence_id=AgentId
+                 ,acct_id=account_id(Agent)
+                 ,acct_db=account_db(Agent)
+                 ,my_id=acdc_util:proc_id()
+                 ,supervisor=Supervisor
+                 ,record_calls=record_calls(Agent)
+                 ,is_thief=is_thief(Agent)
+                 ,agent=Agent
+                 ,agent_queues=Queues
+                 ,agent_presence_id=AgentId
                  }}.
 
 %%--------------------------------------------------------------------
@@ -380,6 +375,7 @@ init([Supervisor, Agent, Queues]) ->
 %%                                   {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
 handle_call('presence_id', _, #state{agent_presence_id=PresenceId}=State) ->
     {'reply', PresenceId, State, 'hibernate'};
 handle_call('queues', _, #state{agent_queues=Queues}=State) ->
@@ -387,10 +383,10 @@ handle_call('queues', _, #state{agent_queues=Queues}=State) ->
 handle_call('my_id', _, #state{agent_id=AgentId}=State) ->
     {'reply', AgentId, State, 'hibernate'};
 handle_call({'agent_info', Field}, _, #state{agent=Agent}=State) ->
-    {'reply', wh_json:get_value(Field, Agent), State};
+    {'reply', kz_json:get_value(Field, Agent), State};
 handle_call('config', _From, #state{acct_id=AcctId
-                                    ,agent_id=AgentId
-                                    ,my_q=Q
+                                   ,agent_id=AgentId
+                                   ,my_q=Q
                                    }=State) ->
     {'reply', {AcctId, AgentId, Q}, State};
 handle_call(_Request, _From, #state{}=State) ->
@@ -407,6 +403,7 @@ handle_call(_Request, _From, #state{}=State) ->
 %%                                  {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
 handle_cast({'refresh_config', Qs}, #state{agent_queues=Queues}=State) ->
     {Add, Rm} = acdc_agent_util:changed(Queues, Qs),
 
@@ -416,22 +413,22 @@ handle_cast({'refresh_config', Qs}, #state{agent_queues=Queues}=State) ->
     {'noreply', State};
 handle_cast({'stop_agent', Req}, #state{supervisor=Supervisor}=State) ->
     lager:debug("stop agent requested by ~p", [Req]),
-    _ = wh_util:spawn('acdc_agent_sup', 'stop', [Supervisor]),
+    _ = kz_util:spawn(fun acdc_agent_sup:stop/1, [Supervisor]),
     {'noreply', State};
 
 handle_cast({'fsm_started', FSMPid}, State) ->
     lager:debug("fsm started: ~p", [FSMPid]),
     handle_fsm_started(FSMPid),
     {'noreply', State#state{fsm_pid=FSMPid
-                            ,my_id=acdc_util:proc_id(FSMPid)
+                           ,my_id=acdc_util:proc_id(FSMPid)
                            }};
 
 handle_cast({'gen_listener', {'created_queue', Q}}, State) ->
     {'noreply', State#state{my_q=Q}, 'hibernate'};
 
 handle_cast({'queue_login', Q}, #state{agent_queues=Qs
-                                       ,acct_id=AcctId
-                                       ,agent_id=AgentId
+                                      ,acct_id=AcctId
+                                      ,agent_id=AgentId
                                       }=State) when is_binary(Q) ->
     case lists:member(Q, Qs) of
         'true' ->
@@ -444,19 +441,19 @@ handle_cast({'queue_login', Q}, #state{agent_queues=Qs
     end;
 handle_cast({'queue_login', QJObj}, State) ->
     lager:debug("queue jobj: ~p", [QJObj]),
-    handle_cast({'queue_login', wh_doc:id(QJObj)}, State);
+    handle_cast({'queue_login', kz_doc:id(QJObj)}, State);
 
 handle_cast({'queue_logout', Q}, #state{agent_queues=[Q]
-                                        ,acct_id=AcctId
-                                        ,agent_id=AgentId
+                                       ,acct_id=AcctId
+                                       ,agent_id=AgentId
                                        }=State) ->
     lager:debug("agent logged out of last known queue ~s, logging out", [Q]),
     logout_from_queue(AcctId, AgentId, Q),
-    ?MODULE:logout_agent(self()),
+    logout_agent(self()),
     {'noreply', State#state{agent_queues=[]}};
 handle_cast({'queue_logout', Q}, #state{agent_queues=Qs
-                                        ,acct_id=AcctId
-                                        ,agent_id=AgentId
+                                       ,acct_id=AcctId
+                                       ,agent_id=AgentId
                                        }=State) ->
     case lists:member(Q, Qs) of
         'true' ->
@@ -469,8 +466,8 @@ handle_cast({'queue_logout', Q}, #state{agent_queues=Qs
     end;
 
 handle_cast('bind_to_member_reqs', #state{agent_queues=Qs
-                                          ,acct_id=AcctId
-                                          ,agent_id=AgentId
+                                         ,acct_id=AcctId
+                                         ,agent_id=AgentId
                                          }=State) ->
     lager:debug("binding to queues: ~p", [Qs]),
     _ = [login_to_queue(AcctId, AgentId, Q) || Q <- Qs],
@@ -486,9 +483,9 @@ handle_cast({'unbind_from_events', CallId}, State) ->
     {'noreply', State};
 
 handle_cast({'channel_hungup', CallId}, #state{call=Call
-                                               ,is_thief=IsThief
-                                               ,agent_call_ids=ACallIds
-                                               ,agent_id=AgentId
+                                              ,is_thief=IsThief
+                                              ,agent_call_ids=ACallIds
+                                              ,agent_id=AgentId
                                               }=State) ->
     CCallId = call_id(Call),
     case CallId of
@@ -498,19 +495,19 @@ handle_cast({'channel_hungup', CallId}, #state{call=Call
 
             _ = filter_agent_calls(ACallIds, CallId),
 
-            wh_util:put_callid(AgentId),
+            kz_util:put_callid(AgentId),
             case IsThief of
                 'false' ->
                     {'noreply', State#state{call='undefined'
-                                            ,msg_queue_id='undefined'
-                                            ,acdc_queue_id='undefined'
-                                            ,agent_call_ids=[]
-                                            ,recording_url='undefined'
+                                           ,msg_queue_id='undefined'
+                                           ,acdc_queue_id='undefined'
+                                           ,agent_call_ids=[]
+                                           ,recording_url='undefined'
                                            }
-                     ,'hibernate'};
+                    ,'hibernate'};
                 'true' ->
                     lager:debug("thief is done, going down"),
-                    ?MODULE:stop(self()),
+                    stop(self()),
                     {'noreply', State}
             end;
         _ ->
@@ -527,31 +524,34 @@ handle_cast({'channel_hungup', CallId}, #state{call=Call
                 'undefined' ->
                     lager:debug("unknown call id ~s for channel_hungup, ignoring", [CallId]),
                     lager:debug("listening for call id(~s) and agents (~p)", [CCallId, ACallIds]),
+                    {'noreply', State};
+                _ ->
+                    lager:debug("listening for call id(~s) and agents (~p)", [CallId, ACallIds]),
                     {'noreply', State}
             end
     end;
 
 handle_cast('agent_timeout', #state{agent_call_ids=ACallIds
-                                    ,agent_id=AgentId
+                                   ,agent_id=AgentId
                                    }=State) ->
     lager:debug("agent timeout recv, stopping agent call"),
 
     _ = filter_agent_calls(ACallIds, AgentId),
 
-    wh_util:put_callid(AgentId),
+    kz_util:put_callid(AgentId),
     {'noreply', State#state{msg_queue_id='undefined'
-                            ,acdc_queue_id='undefined'
-                            ,agent_call_ids=[]
-                            ,call='undefined'
+                           ,acdc_queue_id='undefined'
+                           ,agent_call_ids=[]
+                           ,call='undefined'
                            }
-     ,'hibernate'};
+    ,'hibernate'};
 handle_cast({'member_connect_retry', CallId}, #state{my_id=MyId
-                                                     ,msg_queue_id=Server
-                                                     ,agent_call_ids=ACallIds
-                                                     ,call=Call
-                                                     ,agent_id=AgentId
+                                                    ,msg_queue_id=Server
+                                                    ,agent_call_ids=ACallIds
+                                                    ,call=Call
+                                                    ,agent_id=AgentId
                                                     }=State) when is_binary(CallId) ->
-    case catch whapps_call:call_id(Call) of
+    case catch kapps_call:call_id(Call) of
         CallId ->
             lager:debug("need to retry member connect, agent isn't able to take it"),
             send_member_connect_retry(Server, CallId, MyId, AgentId),
@@ -559,42 +559,42 @@ handle_cast({'member_connect_retry', CallId}, #state{my_id=MyId
             _ = [acdc_util:unbind_from_call_events(ACallId) || ACallId <- ACallIds],
             acdc_util:unbind_from_call_events(CallId),
 
-            wh_util:put_callid(AgentId),
+            kz_util:put_callid(AgentId),
 
             {'noreply', State#state{msg_queue_id='undefined'
-                                    ,acdc_queue_id='undefined'
-                                    ,agent_call_ids=[]
-                                    ,call='undefined'
+                                   ,acdc_queue_id='undefined'
+                                   ,agent_call_ids=[]
+                                   ,call='undefined'
                                    }
-             ,'hibernate'
+            ,'hibernate'
             };
         _MCallId ->
             lager:debug("retry call id(~s) is not our member call id ~p, ignoring", [CallId, _MCallId]),
             {'noreply', State}
     end;
 handle_cast({'member_connect_retry', WinJObj}, #state{my_id=MyId
-                                                      ,agent_id=AgentId
+                                                     ,agent_id=AgentId
                                                      }=State) ->
     lager:debug("cannot process this win, sending a retry: ~s", [call_id(WinJObj)]),
     send_member_connect_retry(WinJObj, MyId, AgentId),
     {'noreply', State};
 
 handle_cast({'bridge_to_member', Call, WinJObj, EPs, CDRUrl, RecordingUrl}, #state{is_thief='false'
-                                                                                   ,agent_queues=Qs
-                                                                                   ,acct_id=AcctId
-                                                                                   ,agent_id=AgentId
-                                                                                   ,my_q=MyQ
-                                                                                   ,cdr_urls=Urls
-                                                                                   ,agent=Agent
+                                                                                  ,agent_queues=Qs
+                                                                                  ,acct_id=AcctId
+                                                                                  ,agent_id=AgentId
+                                                                                  ,my_q=MyQ
+                                                                                  ,cdr_urls=Urls
+                                                                                  ,agent=Agent
                                                                                   }=State) ->
-    _ = whapps_call:put_callid(Call),
+    _ = kapps_call:put_callid(Call),
     lager:debug("bridging to agent endpoints"),
 
-    RingTimeout = wh_json:get_value(<<"Ring-Timeout">>, WinJObj),
+    RingTimeout = kz_json:get_value(<<"Ring-Timeout">>, WinJObj),
     lager:debug("ring agent for ~ps", [RingTimeout]),
 
     ShouldRecord = should_record_endpoints(EPs, record_calls(Agent)
-                                           ,wh_json:is_true(<<"Record-Caller">>, WinJObj, 'false')
+                                          ,kz_json:is_true(<<"Record-Caller">>, WinJObj, 'false')
                                           ),
 
     acdc_util:bind_to_call_events(Call),
@@ -604,50 +604,51 @@ handle_cast({'bridge_to_member', Call, WinJObj, EPs, CDRUrl, RecordingUrl}, #sta
     lager:debug("originate sent, waiting on successful bridge now"),
     update_my_queues_of_change(AcctId, AgentId, Qs),
     {'noreply', State#state{call=Call
-                            ,record_calls=ShouldRecord
-                            ,msg_queue_id=wh_json:get_value(<<"Server-ID">>, WinJObj)
-                            ,agent_call_ids=AgentCallIds
-                            ,cdr_urls=dict:store(whapps_call:call_id(Call), CDRUrl,
-                                                 dict:store(AgentCallIds, CDRUrl, Urls)
-                                                )
-                            ,recording_url=RecordingUrl
+                           ,record_calls=ShouldRecord
+                           ,msg_queue_id=kz_json:get_value(<<"Server-ID">>, WinJObj)
+                           ,agent_call_ids=AgentCallIds
+                           ,cdr_urls=dict:store(kapps_call:call_id(Call), CDRUrl,
+                                                dict:store(AgentCallIds, CDRUrl, Urls)
+                                               )
+                           ,recording_url=RecordingUrl
                            }
-     ,'hibernate'};
+    ,'hibernate'};
 
 handle_cast({'bridge_to_member', Call, WinJObj, _, CDRUrl, RecordingUrl}, #state{is_thief='true'
-                                                                                 ,agent=Agent
-                                                                                 ,agent_id=AgentId
-                                                                                 ,cdr_urls=Urls
+                                                                                ,agent=Agent
+                                                                                ,agent_id=AgentId
+                                                                                ,cdr_urls=Urls
                                                                                 }=State) ->
-    _ = whapps_call:put_callid(Call),
-    lager:debug("connecting to thief at ~s", [whapps_call:call_id(Agent)]),
+    _ = kapps_call:put_callid(Call),
+    lager:debug("connecting to thief at ~s", [kapps_call:call_id(Agent)]),
     acdc_util:bind_to_call_events(Call),
 
     AgentCallId = outbound_call_id(Call, AgentId),
     acdc_util:bind_to_call_events(AgentCallId),
 
-    ShouldRecord = record_calls(Agent) orelse wh_json:is_true(<<"Record-Caller">>, WinJObj, 'false'),
+    ShouldRecord = record_calls(Agent)
+        orelse kz_json:is_true(<<"Record-Caller">>, WinJObj, 'false'),
 
-    whapps_call_command:pickup(whapps_call:call_id(Agent), <<"now">>, Call),
+    kapps_call_command:pickup(kapps_call:call_id(Agent), <<"now">>, Call),
 
     {'noreply', State#state{call=Call
-                            ,msg_queue_id=wh_json:get_value(<<"Server-ID">>, WinJObj)
-                            ,agent_call_ids=[AgentCallId]
-                            ,cdr_urls=dict:store(whapps_call:call_id(Call), CDRUrl,
-                                                 dict:store(AgentCallId, CDRUrl, Urls)
-                                                )
-                            ,record_calls=ShouldRecord
-                            ,recording_url=RecordingUrl
+                           ,msg_queue_id=kz_json:get_value(<<"Server-ID">>, WinJObj)
+                           ,agent_call_ids=[AgentCallId]
+                           ,cdr_urls=dict:store(kapps_call:call_id(Call), CDRUrl,
+                                                dict:store(AgentCallId, CDRUrl, Urls)
+                                               )
+                           ,record_calls=ShouldRecord
+                           ,recording_url=RecordingUrl
                            }
-     ,'hibernate'};
+    ,'hibernate'};
 
 handle_cast({'member_connect_accepted'}, #state{msg_queue_id=AmqpQueue
-                                                ,call=Call
-                                                ,acct_id=AcctId
-                                                ,agent_id=AgentId
-                                                ,my_id=MyId
-                                                ,record_calls=ShouldRecord
-                                                ,recording_url=RecordingUrl
+                                               ,call=Call
+                                               ,acct_id=AcctId
+                                               ,agent_id=AgentId
+                                               ,my_id=MyId
+                                               ,record_calls=ShouldRecord
+                                               ,recording_url=RecordingUrl
                                                }=State) ->
     lager:debug("member bridged to agent! waiting on agent call id though"),
     maybe_start_recording(Call, ShouldRecord, RecordingUrl),
@@ -656,13 +657,13 @@ handle_cast({'member_connect_accepted'}, #state{msg_queue_id=AmqpQueue
     {'noreply', State};
 
 handle_cast({'member_connect_accepted', ACallId}, #state{msg_queue_id=AmqpQueue
-                                                         ,call=Call
-                                                         ,acct_id=AcctId
-                                                         ,agent_id=AgentId
-                                                         ,my_id=MyId
-                                                         ,record_calls=ShouldRecord
-                                                         ,recording_url=RecordingUrl
-                                                         ,agent_call_ids=ACallIds
+                                                        ,call=Call
+                                                        ,acct_id=AcctId
+                                                        ,agent_id=AgentId
+                                                        ,my_id=MyId
+                                                        ,record_calls=ShouldRecord
+                                                        ,recording_url=RecordingUrl
+                                                        ,agent_call_ids=ACallIds
                                                         }=State) ->
     lager:debug("member bridged to agent!"),
     maybe_start_recording(Call, ShouldRecord, RecordingUrl),
@@ -675,12 +676,12 @@ handle_cast({'member_connect_accepted', ACallId}, #state{msg_queue_id=AmqpQueue
     {'noreply', State#state{agent_call_ids=ACallIds1}, 'hibernate'};
 
 handle_cast({'member_connect_resp', ReqJObj}, #state{agent_id=AgentId
-                                                     ,last_connect=LastConn
-                                                     ,agent_queues=Qs
-                                                     ,my_id=MyId
-                                                     ,my_q=MyQ
+                                                    ,last_connect=LastConn
+                                                    ,agent_queues=Qs
+                                                    ,my_id=MyId
+                                                    ,my_q=MyQ
                                                     }=State) ->
-    ACDcQueue = wh_json:get_value(<<"Queue-ID">>, ReqJObj),
+    ACDcQueue = kz_json:get_value(<<"Queue-ID">>, ReqJObj),
     case is_valid_queue(ACDcQueue, Qs) of
         'false' ->
             lager:debug("queue ~s isn't one of ours", [ACDcQueue]),
@@ -690,23 +691,23 @@ handle_cast({'member_connect_resp', ReqJObj}, #state{agent_id=AgentId
 
             send_member_connect_resp(ReqJObj, MyQ, AgentId, MyId, LastConn),
             {'noreply', State#state{acdc_queue_id = ACDcQueue
-                                    ,msg_queue_id = wh_json:get_value(<<"Server-ID">>, ReqJObj)
+                                   ,msg_queue_id = kz_json:get_value(<<"Server-ID">>, ReqJObj)
                                    }
-             ,'hibernate'}
+            ,'hibernate'}
     end;
 
 handle_cast({'monitor_call', Call, _CDRUrl, RecordingUrl}, State) ->
-    _ = whapps_call:put_callid(Call),
+    _ = kapps_call:put_callid(Call),
 
     acdc_util:bind_to_call_events(Call),
 
-    lager:debug("monitoring member call ~s", [whapps_call:call_id(Call)]),
+    lager:debug("monitoring member call ~s", [kapps_call:call_id(Call)]),
 
     {'noreply', State#state{call=Call
-                            ,agent_call_ids=[]
-                            ,recording_url=RecordingUrl
+                           ,agent_call_ids=[]
+                           ,recording_url=RecordingUrl
                            }
-     ,'hibernate'};
+    ,'hibernate'};
 
 handle_cast({'originate_execute', JObj}, #state{my_q=Q}=State) ->
     lager:debug("execute the originate for agent: ~p", [JObj]),
@@ -718,75 +719,75 @@ handle_cast({'originate_uuid', UUID, CtlQ}, #state{agent_call_ids=ACallIds}=Stat
     {'noreply', State#state{agent_call_ids=[{UUID, CtlQ} | props:delete(UUID, ACallIds)]}};
 
 handle_cast({'outbound_call', CallId}, State) ->
-    _ = wh_util:put_callid(CallId),
+    _ = kz_util:put_callid(CallId),
     acdc_util:bind_to_call_events(CallId),
 
     lager:debug("bound to agent's outbound call ~s", [CallId]),
-    {'noreply', State#state{call=whapps_call:set_call_id(CallId, whapps_call:new())}, 'hibernate'};
+    {'noreply', State#state{call=kapps_call:set_call_id(CallId, kapps_call:new())}, 'hibernate'};
 
 handle_cast({'send_sync_req'}, #state{my_id=MyId
-                                      ,my_q=MyQ
-                                      ,acct_id=AcctId
-                                      ,agent_id=AgentId
+                                     ,my_q=MyQ
+                                     ,acct_id=AcctId
+                                     ,agent_id=AgentId
                                      }=State) ->
-    case MyQ of
-         'undefined' ->
-             lager:debug("queue not ready yet, waiting for sync request"),
-             timer:apply_after(100 , gen_listener, cast, [self(), {'send_sync_req'}]);
-          _ ->
-             lager:debug("queue retrieved: ~p , sending sync request", [MyQ]),
-             send_sync_request(AcctId, AgentId, MyId, MyQ)
-     end,
+    _ = case MyQ of
+            'undefined' ->
+                lager:debug("queue not ready yet, waiting for sync request"),
+                timer:apply_after(100 , 'gen_listener', 'cast', [self(), {'send_sync_req'}]);
+            _ ->
+                lager:debug("queue retrieved: ~p , sending sync request", [MyQ]),
+                send_sync_request(AcctId, AgentId, MyId, MyQ)
+        end,
     {'noreply', State};
 
 handle_cast({'send_sync_resp', Status, ReqJObj, Options}, #state{my_id=MyId
-                                                                 ,acct_id=AcctId
-                                                                 ,agent_id=AgentId
-                                                                 ,my_q=MyQ
+                                                                ,acct_id=AcctId
+                                                                ,agent_id=AgentId
+                                                                ,my_q=MyQ
                                                                 }=State) ->
     send_sync_response(ReqJObj, AcctId, AgentId, MyId, MyQ, Status, Options),
     {'noreply', State};
 
 handle_cast({'send_status_update', Status}, #state{acct_id=AcctId
-                                                   ,agent_id=AgentId
+                                                  ,agent_id=AgentId
                                                   }=State) ->
     send_status_update(AcctId, AgentId, Status),
     {'noreply', State};
 
 handle_cast('call_status_req', #state{call=Call, my_q=Q}=State) ->
-    CallId = whapps_call:call_id(Call),
+    CallId = kapps_call:call_id(Call),
 
     Command = [{<<"Call-ID">>, CallId}
-               ,{<<"Server-ID">>, Q}
-               | wh_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
+              ,{<<"Server-ID">>, Q}
+               | kz_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
               ],
 
-    wapi_call:publish_channel_status_req(CallId, Command),
+    kapi_call:publish_channel_status_req(CallId, Command),
     {'noreply', State};
 
 handle_cast({'call_status_req', CallId}, #state{my_q=Q}=State) when is_binary(CallId) ->
     Command = [{<<"Call-ID">>, CallId}
-               ,{<<"Server-ID">>, Q}
-               | wh_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
+              ,{<<"Server-ID">>, Q}
+               | kz_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
               ],
-    wapi_call:publish_channel_status_req(CallId, Command),
+    kapi_call:publish_channel_status_req(CallId, Command),
     {'noreply', State};
 handle_cast({'call_status_req', Call}, State) ->
-    handle_cast({'call_status_req', whapps_call:call_id(Call)}, State);
+    handle_cast({'call_status_req', kapps_call:call_id(Call)}, State);
 
 handle_cast({'remove_cdr_urls', CallId}, #state{cdr_urls=Urls}=State) ->
     {'noreply', State#state{cdr_urls=dict:erase(CallId, Urls)}, 'hibernate'};
 
 handle_cast('logout_agent', #state{acct_id=AcctId
-                                   ,agent_id=AgentId
+                                  ,agent_id=AgentId
                                   }=State) ->
     Update = props:filter_undefined(
                [{<<"Account-ID">>, AcctId}
-                ,{<<"Agent-ID">>, AgentId}
-                | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+               ,{<<"Agent-ID">>, AgentId}
+                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                ]),
 
-    wapi_acdc_agent:publish_logout(Update),
+    kapi_acdc_agent:publish_logout(Update),
     lager:debug("published agent logout message"),
     {'noreply', State};
 
@@ -797,25 +798,25 @@ handle_cast({'presence_id', PresenceId}, #state{agent_presence_id=_Id}=State) ->
     {'noreply', State#state{agent_presence_id=PresenceId}};
 
 handle_cast({'presence_update', PresenceState}, #state{acct_id=AcctId
-                                                       ,agent_presence_id='undefined'
-                                                       ,agent_id=AgentId
+                                                      ,agent_presence_id='undefined'
+                                                      ,agent_id=AgentId
                                                       }=State) ->
     lager:debug("no custom presence id, using ~s for ~s", [AgentId, PresenceState]),
     acdc_util:presence_update(AcctId, AgentId, PresenceState
-                              ,wh_util:to_hex_binary(crypto:hash(md5, AgentId))
+                             ,kz_util:to_hex_binary(crypto:hash(md5, AgentId))
                              ),
     {'noreply', State};
 handle_cast({'presence_update', PresenceState}, #state{acct_id=AcctId
-                                                       ,agent_presence_id=PresenceId
+                                                      ,agent_presence_id=PresenceId
                                                       }=State) ->
     lager:debug("custom presence id, using ~s for ~s", [PresenceId, PresenceState]),
     acdc_util:presence_update(AcctId, PresenceId, PresenceState
-                              ,wh_util:to_hex_binary(crypto:hash(md5, PresenceId))
+                             ,kz_util:to_hex_binary(crypto:hash(md5, PresenceId))
                              ),
     {'noreply', State};
 
 handle_cast({'update_status', Status}, #state{agent_id=AgentId
-                                              ,acct_id=AcctId
+                                             ,acct_id=AcctId
                                              }=State) ->
     catch acdc_agent_util:update_status(AcctId, AgentId, Status),
     {'noreply', State};
@@ -837,6 +838,7 @@ handle_cast(_Msg, State) ->
 %%                                   {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
 handle_info(_Info, State) ->
     lager:debug("unhandled message: ~p", [_Info]),
     {'noreply', State}.
@@ -850,16 +852,17 @@ handle_info(_Info, State) ->
 %%                                   ignore
 %% @end
 %%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), state()) -> handle_event_ret().
 handle_event(_JObj, #state{fsm_pid='undefined'}) -> 'ignore';
 handle_event(_JObj, #state{fsm_pid=FSM
-                           ,agent_id=AgentId
-                           ,acct_id=AcctId
-                           ,cdr_urls=Urls
+                          ,agent_id=AgentId
+                          ,acct_id=AcctId
+                          ,cdr_urls=Urls
                           }) ->
     {'reply', [{'fsm_pid', FSM}
-               ,{'agent_id', AgentId}
-               ,{'acct_id', AcctId}
-               ,{'cdr_urls', Urls}
+              ,{'agent_id', AgentId}
+              ,{'acct_id', AcctId}
+              ,{'cdr_urls', Urls}
               ]}.
 
 %%--------------------------------------------------------------------
@@ -873,9 +876,10 @@ handle_event(_JObj, #state{fsm_pid=FSM
 %% @spec terminate(Reason, State) -> void()
 %% @end
 %%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
 terminate(Reason, #state{agent_queues=Queues
-                         ,acct_id=AcctId
-                         ,agent_id=AgentId
+                        ,acct_id=AcctId
+                        ,agent_id=AgentId
                         }
          ) when Reason == 'normal'; Reason == 'shutdown' ->
     _ = [logout_from_queue(AcctId, AgentId, QueueId) || QueueId <- Queues],
@@ -891,6 +895,7 @@ terminate(_Reason, _State) ->
 %% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
 %% @end
 %%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
 code_change(_OldVsn, State, _Extra) ->
     {'ok', State}.
 
@@ -900,30 +905,30 @@ code_change(_OldVsn, State, _Extra) ->
 -spec is_valid_queue(ne_binary(), ne_binaries()) -> boolean().
 is_valid_queue(Q, Qs) -> lists:member(Q, Qs).
 
--spec send_member_connect_resp(wh_json:object(), ne_binary()
-                               ,ne_binary(), ne_binary()
-                               , wh_now() | 'undefined'
+-spec send_member_connect_resp(kz_json:object(), ne_binary()
+                              ,ne_binary(), ne_binary()
+                              , kz_now() | 'undefined'
                               ) -> 'ok'.
 send_member_connect_resp(JObj, MyQ, AgentId, MyId, LastConn) ->
-    Queue = wh_json:get_value(<<"Server-ID">>, JObj),
+    Queue = kz_json:get_value(<<"Server-ID">>, JObj),
     IdleTime = idle_time(LastConn),
     Resp = props:filter_undefined(
              [{<<"Agent-ID">>, AgentId}
-              ,{<<"Idle-Time">>, IdleTime}
-              ,{<<"Process-ID">>, MyId}
-              ,{<<"Server-ID">>, MyQ}
-              | wh_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
+             ,{<<"Idle-Time">>, IdleTime}
+             ,{<<"Process-ID">>, MyId}
+             ,{<<"Server-ID">>, MyQ}
+              | kz_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
              ]),
     lager:debug("sending connect_resp to ~s for ~s: ~s", [Queue, call_id(JObj), MyId]),
-    wapi_acdc_queue:publish_member_connect_resp(Queue, Resp).
+    kapi_acdc_queue:publish_member_connect_resp(Queue, Resp).
 
--spec send_member_connect_retry(wh_json:object(), ne_binary(), ne_binary()) -> 'ok'.
+-spec send_member_connect_retry(kz_json:object(), ne_binary(), ne_binary()) -> 'ok'.
 -spec send_member_connect_retry(ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 send_member_connect_retry(JObj, MyId, AgentId) ->
-    send_member_connect_retry(wh_json:get_value(<<"Server-ID">>, JObj)
-                              ,call_id(JObj)
-                              ,MyId
-                              ,AgentId
+    send_member_connect_retry(kz_json:get_value(<<"Server-ID">>, JObj)
+                             ,call_id(JObj)
+                             ,MyId
+                             ,AgentId
                              ).
 
 send_member_connect_retry('undefined', _, _, _) ->
@@ -931,94 +936,94 @@ send_member_connect_retry('undefined', _, _, _) ->
 send_member_connect_retry(Queue, CallId, MyId, AgentId) ->
     Resp = props:filter_undefined(
              [{<<"Process-ID">>, MyId}
-              ,{<<"Call-ID">>, CallId}
-              ,{<<"Agent-ID">>, AgentId}
-              | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+             ,{<<"Call-ID">>, CallId}
+             ,{<<"Agent-ID">>, AgentId}
+              | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    wapi_acdc_queue:publish_member_connect_retry(Queue, Resp).
+    kapi_acdc_queue:publish_member_connect_retry(Queue, Resp).
 
 -spec send_member_connect_accepted(ne_binary(), ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 send_member_connect_accepted(Queue, CallId, AcctId, AgentId, MyId) ->
     Resp = props:filter_undefined([{<<"Call-ID">>, CallId}
-                                   ,{<<"Account-ID">>, AcctId}
-                                   ,{<<"Agent-ID">>, AgentId}
-                                   ,{<<"Process-ID">>, MyId}
-                                   | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+                                  ,{<<"Account-ID">>, AcctId}
+                                  ,{<<"Agent-ID">>, AgentId}
+                                  ,{<<"Process-ID">>, MyId}
+                                   | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                                   ]),
-    wapi_acdc_queue:publish_member_connect_accepted(Queue, Resp).
+    kapi_acdc_queue:publish_member_connect_accepted(Queue, Resp).
 
--spec send_originate_execute(wh_json:object(), ne_binary()) -> 'ok'.
+-spec send_originate_execute(kz_json:object(), ne_binary()) -> 'ok'.
 send_originate_execute(JObj, Q) ->
-    Prop = [{<<"Call-ID">>, wh_json:get_value(<<"Call-ID">>, JObj)}
-            ,{<<"Msg-ID">>, wh_json:get_value(<<"Msg-ID">>, JObj)}
-            | wh_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
+    Prop = [{<<"Call-ID">>, kz_json:get_value(<<"Call-ID">>, JObj)}
+           ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
+            | kz_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
            ],
-    wapi_dialplan:publish_originate_execute(wh_json:get_value(<<"Server-ID">>, JObj), Prop).
+    kapi_dialplan:publish_originate_execute(kz_json:get_value(<<"Server-ID">>, JObj), Prop).
 
 -spec send_sync_request(ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 send_sync_request(AcctId, AgentId, MyId, MyQ) ->
     Prop = [{<<"Account-ID">>, AcctId}
-            ,{<<"Agent-ID">>, AgentId}
-            ,{<<"Process-ID">>, MyId}
-            | wh_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
+           ,{<<"Agent-ID">>, AgentId}
+           ,{<<"Process-ID">>, MyId}
+            | kz_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
            ],
-    wapi_acdc_agent:publish_sync_req(Prop).
+    kapi_acdc_agent:publish_sync_req(Prop).
 
 send_sync_response(ReqJObj, AcctId, AgentId, MyId, MyQ, Status, Options) ->
     Prop = [{<<"Account-ID">>, AcctId}
-            ,{<<"Agent-ID">>, AgentId}
-            ,{<<"Process-ID">>, MyId}
-            ,{<<"Status">>, wh_util:to_binary(Status)}
-            ,{<<"Msg-ID">>, wh_json:get_value(<<"Msg-ID">>, ReqJObj)}
-            | Options ++ wh_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
+           ,{<<"Agent-ID">>, AgentId}
+           ,{<<"Process-ID">>, MyId}
+           ,{<<"Status">>, kz_util:to_binary(Status)}
+           ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, ReqJObj)}
+            | Options ++ kz_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
            ],
-    Q = wh_json:get_value(<<"Server-ID">>, ReqJObj),
+    Q = kz_json:get_value(<<"Server-ID">>, ReqJObj),
     lager:debug("sending sync resp to ~s", [Q]),
-    wapi_acdc_agent:publish_sync_resp(Q, Prop).
+    kapi_acdc_agent:publish_sync_resp(Q, Prop).
 
 send_status_update(AcctId, AgentId, 'resume') ->
     Update = props:filter_undefined(
                [{<<"Account-ID">>, AcctId}
-                ,{<<"Agent-ID">>, AgentId}
-                | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+               ,{<<"Agent-ID">>, AgentId}
+                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                ]),
-    wapi_acdc_agent:publish_resume(Update).
+    kapi_acdc_agent:publish_resume(Update).
 
 
--spec idle_time('undefined' | wh_now()) -> api_integer().
+-spec idle_time('undefined' | kz_now()) -> api_integer().
 idle_time('undefined') -> 'undefined';
-idle_time(T) -> wh_util:elapsed_s(T).
+idle_time(T) -> kz_util:elapsed_s(T).
 
--spec call_id(whapps_call:call() | api_object()) ->
+-spec call_id(kapps_call:call() | api_object()) ->
                      api_binary().
 call_id('undefined') -> 'undefined';
 call_id(Call) ->
-    case whapps_call:is_call(Call) of
-        'true' -> whapps_call:call_id(Call);
+    case kapps_call:is_call(Call) of
+        'true' -> kapps_call:call_id(Call);
         'false' ->
             Keys = [[<<"Call">>, <<"Call-ID">>]
-                    ,[<<"Call">>, <<"call_id">>]
-                    ,<<"Call-ID">>
+                   ,[<<"Call">>, <<"call_id">>]
+                   ,<<"Call-ID">>
                    ],
-            lists:foldl(fun(K, 'undefined') -> wh_json:get_value(K, Call);
+            lists:foldl(fun(K, 'undefined') -> kz_json:get_value(K, Call);
                            (_, CallId) -> CallId
                         end, 'undefined', Keys)
     end.
 
--spec maybe_connect_to_agent(ne_binary(), wh_json:objects(), whapps_call:call(), api_integer(), ne_binary(), api_binary()) ->
+-spec maybe_connect_to_agent(ne_binary(), kz_json:objects(), kapps_call:call(), api_integer(), ne_binary(), api_binary()) ->
                                     ne_binaries().
 maybe_connect_to_agent(MyQ, EPs, Call, Timeout, AgentId, _CdrUrl) ->
-    MCallId = whapps_call:call_id(Call),
-    wh_util:put_callid(MCallId),
+    MCallId = kapps_call:call_id(Call),
+    kz_util:put_callid(MCallId),
 
-    ReqId = wh_util:rand_hex_binary(6),
-    AcctId = whapps_call:account_id(Call),
+    ReqId = kz_util:rand_hex_binary(6),
+    AcctId = kapps_call:account_id(Call),
 
     CCVs = props:filter_undefined([{<<"Account-ID">>, AcctId}
-                                   ,{<<"Authorizing-ID">>, whapps_call:authorizing_id(Call)}
-                                   ,{<<"Request-ID">>, ReqId}
-                                   ,{<<"Retain-CID">>, <<"true">>}
-                                   ,{<<"Agent-ID">>, AgentId}
+                                  ,{<<"Authorizing-ID">>, kapps_call:authorizing_id(Call)}
+                                  ,{<<"Request-ID">>, ReqId}
+                                  ,{<<"Retain-CID">>, <<"true">>}
+                                  ,{<<"Agent-ID">>, AgentId}
                                   ]),
 
     {ACallIds, Endpoints} = lists:foldl(fun(EP, {Cs, Es}) ->
@@ -1026,105 +1031,105 @@ maybe_connect_to_agent(MyQ, EPs, Call, Timeout, AgentId, _CdrUrl) ->
                                                 acdc_util:bind_to_call_events(ACallId),
 
                                                 {[ACallId | Cs]
-                                                 ,[wh_json:set_values([{<<"Endpoint-Timeout">>, Timeout}
-                                                                       ,{<<"Outbound-Call-ID">>, ACallId}
-                                                                       ,{<<"Existing-Call-ID">>, whapps_call:call_id(Call)}
-                                                                      ], EP)
-                                                   | Es
-                                                  ]}
+                                                ,[kz_json:set_values([{<<"Endpoint-Timeout">>, Timeout}
+                                                                     ,{<<"Outbound-Call-ID">>, ACallId}
+                                                                     ,{<<"Existing-Call-ID">>, kapps_call:call_id(Call)}
+                                                                     ], EP)
+                                                  | Es
+                                                 ]}
                                         end, {[], []}, EPs),
 
     Prop = props:filter_undefined(
-             [{<<"Msg-ID">>, wh_util:rand_hex_binary(6)}
-              ,{<<"Custom-Channel-Vars">>, wh_json:from_list(CCVs)}
-              ,{<<"Timeout">>, Timeout}
-              ,{<<"Endpoints">>, Endpoints}
-              ,{<<"Export-Custom-Channel-Vars">>, [<<"Account-ID">>
-                                                   ,<<"Retain-CID">>
-                                                   ,<<"Authorizing-ID">>
-                                                   ,<<"Authorizing-Type">>
-                                                  ]}
-              ,{<<"Account-ID">>, AcctId}
-              ,{<<"Resource-Type">>, <<"originate">>}
-              ,{<<"Application-Name">>, <<"bridge">>}
-              ,{<<"Caller-ID-Name">>, whapps_call:caller_id_name(Call)}
-              ,{<<"Caller-ID-Number">>, whapps_call:caller_id_number(Call)}
-              ,{<<"Outbound-Caller-ID-Name">>, whapps_call:caller_id_name(Call)}
-              ,{<<"Outbound-Caller-ID-Number">>, whapps_call:caller_id_number(Call)}
-              ,{<<"Existing-Call-ID">>, whapps_call:call_id(Call)}
-              ,{<<"Dial-Endpoint-Method">>, <<"simultaneous">>}
-              | wh_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
+             [{<<"Msg-ID">>, kz_util:rand_hex_binary(6)}
+             ,{<<"Custom-Channel-Vars">>, kz_json:from_list(CCVs)}
+             ,{<<"Timeout">>, Timeout}
+             ,{<<"Endpoints">>, Endpoints}
+             ,{<<"Export-Custom-Channel-Vars">>, [<<"Account-ID">>
+                                                 ,<<"Retain-CID">>
+                                                 ,<<"Authorizing-ID">>
+                                                 ,<<"Authorizing-Type">>
+                                                 ]}
+             ,{<<"Account-ID">>, AcctId}
+             ,{<<"Resource-Type">>, <<"originate">>}
+             ,{<<"Application-Name">>, <<"bridge">>}
+             ,{<<"Caller-ID-Name">>, kapps_call:caller_id_name(Call)}
+             ,{<<"Caller-ID-Number">>, kapps_call:caller_id_number(Call)}
+             ,{<<"Outbound-Caller-ID-Name">>, kapps_call:caller_id_name(Call)}
+             ,{<<"Outbound-Caller-ID-Number">>, kapps_call:caller_id_number(Call)}
+             ,{<<"Existing-Call-ID">>, kapps_call:call_id(Call)}
+             ,{<<"Dial-Endpoint-Method">>, <<"simultaneous">>}
+              | kz_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
              ]),
 
     lager:debug("sending originate request with agent call-ids ~p", [ACallIds]),
 
-    wapi_resource:publish_originate_req(Prop),
+    kapi_resource:publish_originate_req(Prop),
     ACallIds.
 
 outbound_call_id(CallId, AgentId) when is_binary(CallId) ->
-    Rnd = wh_util:rand_hex_binary(4),
-    <<(wh_util:to_hex_binary(erlang:md5(CallId)))/binary, "-", AgentId/binary, "-", Rnd/binary>>;
-outbound_call_id(Call, AgentId) -> outbound_call_id(whapps_call:call_id(Call), AgentId).
+    Rnd = kz_util:rand_hex_binary(4),
+    <<(kz_util:to_hex_binary(erlang:md5(CallId)))/binary, "-", AgentId/binary, "-", Rnd/binary>>;
+outbound_call_id(Call, AgentId) -> outbound_call_id(kapps_call:call_id(Call), AgentId).
 
 -spec login_to_queue(ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 login_to_queue(AcctId, AgentId, QueueId) ->
     gen_listener:add_binding(self()
-                             ,'acdc_queue'
-                             ,[{'restrict_to', ['member_connect_req']}
-                               ,{'queue_id', QueueId}
-                               ,{'account_id', AcctId}
-                              ]),
+                            ,'acdc_queue'
+                            ,[{'restrict_to', ['member_connect_req']}
+                             ,{'queue_id', QueueId}
+                             ,{'account_id', AcctId}
+                             ]),
     Prop = [{<<"Account-ID">>, AcctId}
-            ,{<<"Agent-ID">>, AgentId}
-            ,{<<"Queue-ID">>, QueueId}
-            ,{<<"Change">>, <<"available">>}
-            | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ,{<<"Agent-ID">>, AgentId}
+           ,{<<"Queue-ID">>, QueueId}
+           ,{<<"Change">>, <<"available">>}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
-    wapi_acdc_queue:publish_agent_change(Prop).
+    kapi_acdc_queue:publish_agent_change(Prop).
 
 -spec logout_from_queue(ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 logout_from_queue(AcctId, AgentId, QueueId) ->
     gen_listener:rm_binding(self()
-                            ,'acdc_queue'
-                            ,[{'restrict_to', ['member_connect_req']}
-                              ,{'queue_id', QueueId}
-                              ,{'account_id', AcctId}
-                             ]),
+                           ,'acdc_queue'
+                           ,[{'restrict_to', ['member_connect_req']}
+                            ,{'queue_id', QueueId}
+                            ,{'account_id', AcctId}
+                            ]),
     Prop = [{<<"Account-ID">>, AcctId}
-            ,{<<"Agent-ID">>, AgentId}
-            ,{<<"Queue-ID">>, QueueId}
-            ,{<<"Change">>, <<"unavailable">>}
-            | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ,{<<"Agent-ID">>, AgentId}
+           ,{<<"Queue-ID">>, QueueId}
+           ,{<<"Change">>, <<"unavailable">>}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
-    wapi_acdc_queue:publish_agent_change(Prop).
+    kapi_acdc_queue:publish_agent_change(Prop).
 
 update_my_queues_of_change(AcctId, AgentId, Qs) ->
     Props = [{<<"Account-ID">>, AcctId}
-             ,{<<"Agent-ID">>, AgentId}
-             ,{<<"Change">>, <<"ringing">>}
-             | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+            ,{<<"Agent-ID">>, AgentId}
+            ,{<<"Change">>, <<"ringing">>}
+             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
             ],
-    _ = [wapi_acdc_queue:publish_agent_change([{<<"Queue-ID">>, QueueId} | Props])
+    _ = [kapi_acdc_queue:publish_agent_change([{<<"Queue-ID">>, QueueId} | Props])
          || QueueId <- Qs
         ],
     'ok'.
 
--spec should_record_endpoints(wh_json:objects(), boolean(), api_boolean()) -> boolean().
+-spec should_record_endpoints(kz_json:objects(), boolean(), api_boolean()) -> boolean().
 should_record_endpoints(_EPs, 'true', _) -> 'true';
 should_record_endpoints(_EPs, 'false', 'true') -> 'true';
 should_record_endpoints(EPs, _, _) ->
     lists:any(fun(EP) ->
-                      wh_json:is_true(<<"record_calls">>, EP, 'false')
+                      kz_json:is_true(<<"record_calls">>, EP, 'false')
               end, EPs).
 
--spec maybe_start_recording(whapps_call:call(), boolean(), ne_binary()) -> 'ok'.
+-spec maybe_start_recording(kapps_call:call(), boolean(), ne_binary()) -> 'ok'.
 maybe_start_recording(_Call, 'false', _) ->
     lager:debug("not recording this call");
 maybe_start_recording(Call, 'true', Url) ->
     RecordingJObj =
-        wh_json:from_list(
+        kz_json:from_list(
           [{<<"format">>, recording_format()}
-           ,{<<"url">>, Url}
+          ,{<<"url">>, Url}
           ]),
     lager:debug("starting recording listener for ~s", [Url]),
     case acdc_recordings_sup:new(Call, RecordingJObj) of
@@ -1134,38 +1139,36 @@ maybe_start_recording(Call, 'true', Url) ->
     end.
 
 recording_format() ->
-    whapps_config:get(<<"callflow">>, [<<"call_recording">>, <<"extension">>], <<"mp3">>).
+    kapps_config:get(<<"callflow">>, [<<"call_recording">>, <<"extension">>], <<"mp3">>).
 
 -spec agent_id(agent()) -> api_binary().
 agent_id(Agent) ->
-    case wh_json:is_json_object(Agent) of
-        'true' -> wh_doc:id(Agent);
-        'false' -> whapps_call:owner_id(Agent)
+    case kz_json:is_json_object(Agent) of
+        'true' -> kz_doc:id(Agent);
+        'false' -> kapps_call:owner_id(Agent)
     end.
 
 -spec account_id(agent()) -> api_binary().
 account_id(Agent) ->
-    case wh_json:is_json_object(Agent) of
+    case kz_json:is_json_object(Agent) of
         'true' -> find_account_id(Agent);
-        'false' -> whapps_call:account_id(Agent)
+        'false' -> kapps_call:account_id(Agent)
     end.
 
 -spec account_db(agent()) -> api_binary().
 account_db(Agent) ->
-    case wh_json:is_json_object(Agent) of
-        'true' -> wh_doc:account_db(Agent);
-        'false' -> whapps_call:account_db(Agent)
+    case kz_json:is_json_object(Agent) of
+        'true' -> kz_doc:account_db(Agent);
+        'false' -> kapps_call:account_db(Agent)
     end.
 
 -spec record_calls(agent()) -> boolean().
 record_calls(Agent) ->
-    case wh_json:is_json_object(Agent) of
-        'true' -> wh_json:is_true(<<"record_calls">>, Agent, 'false');
-        'false' -> 'false'
-    end.
+    kz_json:is_json_object(Agent)
+        andalso kz_json:is_true(<<"record_calls">>, Agent, 'false').
 
 -spec is_thief(agent()) -> boolean().
-is_thief(Agent) -> not wh_json:is_json_object(Agent).
+is_thief(Agent) -> not kz_json:is_json_object(Agent).
 
 handle_fsm_started(_FSMPid) -> gen_listener:cast(self(), 'bind_to_member_reqs').
 
@@ -1173,20 +1176,20 @@ stop_agent_leg('undefined', _) -> lager:debug("agent call id not defined");
 stop_agent_leg(_, 'undefined') -> lager:debug("agent ctrl queue not defined");
 stop_agent_leg(ACallId, ACtrlQ) ->
     Command = [{<<"Application-Name">>, <<"hangup">>}
-               ,{<<"Insert-At">>, <<"now">>}
-               ,{<<"Call-ID">>, ACallId}
-               | wh_api:default_headers(<<>>, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
+              ,{<<"Insert-At">>, <<"now">>}
+              ,{<<"Call-ID">>, ACallId}
+               | kz_api:default_headers(<<>>, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
               ],
     lager:debug("sending hangup to ~s: ~s", [ACallId, ACtrlQ]),
-    wapi_dialplan:publish_command(ACtrlQ, Command).
+    kapi_dialplan:publish_command(ACtrlQ, Command).
 
 find_account_id(JObj) ->
-    case wh_doc:account_id(JObj) of
-        'undefined' -> wh_util:format_account_id(wh_doc:account_db(JObj), 'raw');
+    case kz_doc:account_id(JObj) of
+        'undefined' -> kz_util:format_account_id(kz_doc:account_db(JObj), 'raw');
         AcctId -> AcctId
     end.
 
--spec filter_agent_calls(wh_proplist(), ne_binary()) -> wh_proplist().
+-spec filter_agent_calls(kz_proplist(), ne_binary()) -> kz_proplist().
 filter_agent_calls(ACallIds, ACallId) ->
     lists:filter(fun({ACancelId, ACtrlQ}) when ACancelId =/= ACallId ->
                          lager:debug("cancelling and stopping leg ~s", [ACancelId]),


### PR DESCRIPTION
This is probably not the most sophisticated solution, but hey it's acdc ;).
In 3.22 the agent listener crashes when an agent has multiple devices or is is hotdesking. This results in the call bouncing back into the queue and ghost calling or channel hijack when another agent answers.

I did a quick fix to just ignore the hangup just as when it is undefined. Again, not the best coding but probably acceptable for a component that is being discontinued but still in use in some places.