### PR TITLE
Small fix to make ACDC usable on 3.22

### DIFF
--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -527,7 +527,10 @@ handle_cast({'channel_hungup', CallId}, #state{call=Call
                 'undefined' ->
                     lager:debug("unknown call id ~s for channel_hungup, ignoring", [CallId]),
                     lager:debug("listening for call id(~s) and agents (~p)", [CCallId, ACallIds]),
-                    {'noreply', State}
+                    {'noreply', State};
+		_ ->
+		    lager:debug("listening for call id(~s) and agents (~p)", [CallId, ACallIds]),
+		    {'noreply', State}
             end
     end;
 


### PR DESCRIPTION
This is probably not the most sophisticated solution, but hey it's acdc ;).
In 3.22 the agent listener crashes when an agent has multiple devices or is is hotdesking. This results in the call bouncing back into the queue and ghost calling or channel hijack when another agent answers.

I did a quick fix to just ignore the hangup just as when it is undefined. Again, not the best coding but probably acceptable for a component that is being discontinued but still in use in some places.