### PR TITLE
KAZOO-5029 conference pins and numbers

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -2639,6 +2639,7 @@
                     "default": [],
                     "description": "Defines conference numbers that can be used by members or moderators",
                     "items": {
+                        "regex": "^\\d+$",
                         "required": false,
                         "type": "string"
                     },
@@ -2676,6 +2677,7 @@
                             "default": [],
                             "description": "Defines the conference number(s) for members",
                             "items": {
+                                "regex": "^\\d+$",
                                 "required": false,
                                 "type": "string"
                             },
@@ -2689,6 +2691,7 @@
                             "default": [],
                             "description": "Defines the pin number(s) for members",
                             "items": {
+                                "regex": "^\\d+$",
                                 "required": false,
                                 "type": "string"
                             },
@@ -2723,6 +2726,7 @@
                             "default": [],
                             "description": "Defines the conference number(s) for moderators",
                             "items": {
+                                "regex": "^\\d+$",
                                 "required": false,
                                 "type": "string"
                             },
@@ -2735,6 +2739,7 @@
                             "default": [],
                             "description": "Defines the pin number(s) for moderators",
                             "items": {
+                                "regex": "^\\d+$",
                                 "required": false,
                                 "type": "string"
                             },

--- a/applications/crossbar/priv/couchdb/schemas/conferences.json
+++ b/applications/crossbar/priv/couchdb/schemas/conferences.json
@@ -9,6 +9,7 @@
             "description": "Defines conference numbers that can be used by members or moderators",
             "items": {
                 "required": false,
+                "regex": "^\\d+$",
                 "type": "string"
             },
             "name": "General Call In Numbers",
@@ -46,6 +47,7 @@
                     "description": "Defines the conference number(s) for members",
                     "items": {
                         "required": false,
+                        "regex": "^\\d+$",
                         "type": "string"
                     },
                     "minItems": 0,
@@ -59,6 +61,7 @@
                     "description": "Defines the pin number(s) for members",
                     "items": {
                         "required": false,
+                        "regex": "^\\d+$",
                         "type": "string"
                     },
                     "name": "Pin Numbers",
@@ -93,6 +96,7 @@
                     "description": "Defines the conference number(s) for moderators",
                     "items": {
                         "required": false,
+                        "regex": "^\\d+$",
                         "type": "string"
                     },
                     "name": "Call In Numbers",
@@ -105,6 +109,7 @@
                     "description": "Defines the pin number(s) for moderators",
                     "items": {
                         "required": false,
+                        "regex": "^\\d+$",
                         "type": "string"
                     },
                     "name": "Pin Numbers",

--- a/applications/crossbar/priv/couchdb/schemas/conferences.json
+++ b/applications/crossbar/priv/couchdb/schemas/conferences.json
@@ -8,8 +8,8 @@
             "default": [],
             "description": "Defines conference numbers that can be used by members or moderators",
             "items": {
-                "required": false,
                 "regex": "^\\d+$",
+                "required": false,
                 "type": "string"
             },
             "name": "General Call In Numbers",
@@ -46,8 +46,8 @@
                     "default": [],
                     "description": "Defines the conference number(s) for members",
                     "items": {
-                        "required": false,
                         "regex": "^\\d+$",
+                        "required": false,
                         "type": "string"
                     },
                     "minItems": 0,
@@ -60,8 +60,8 @@
                     "default": [],
                     "description": "Defines the pin number(s) for members",
                     "items": {
-                        "required": false,
                         "regex": "^\\d+$",
+                        "required": false,
                         "type": "string"
                     },
                     "name": "Pin Numbers",
@@ -95,8 +95,8 @@
                     "default": [],
                     "description": "Defines the conference number(s) for moderators",
                     "items": {
-                        "required": false,
                         "regex": "^\\d+$",
+                        "required": false,
                         "type": "string"
                     },
                     "name": "Call In Numbers",
@@ -108,8 +108,8 @@
                     "default": [],
                     "description": "Defines the pin number(s) for moderators",
                     "items": {
-                        "required": false,
                         "regex": "^\\d+$",
+                        "required": false,
                         "type": "string"
                     },
                     "name": "Pin Numbers",


### PR DESCRIPTION
- enforce in schema conference pin and numbers to be non-empty digit string