### PR TITLE
KAZOO-4998: support offset in number search

### DIFF
--- a/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
@@ -369,49 +369,35 @@ read(Context, Number) ->
 %%--------------------------------------------------------------------
 -spec find_numbers(cb_context:context()) -> cb_context:context().
 find_numbers(Context) ->
-    JObj = get_find_numbers_req(Context),
-    OnSuccess = fun(C) ->
-                        cb_context:setters(C
-                                          ,[{fun cb_context:set_resp_data/2, get_numbers(JObj)}
-                                           ,{fun cb_context:set_resp_status/2, 'success'}
-                                           ])
-                end,
-    cb_context:validate_request_data(kz_json:decode(?FIND_NUMBER_SCHEMA)
-                                    ,cb_context:set_req_data(Context, JObj)
-                                    ,OnSuccess
-                                    ).
+    Options = get_find_numbers_req(Context),
+    Context1 = cb_context:set_req_data(Context, kz_json:from_list(Options)),
+    CountryPrefix = knm_util:prefix_for_country(knm_carriers:country(Options)),
+    Prefix = <<CountryPrefix/binary, (knm_carriers:prefix(Options))/binary>>,
+    OnSuccess =
+        fun(C) ->
+                lager:debug("carriers find: ~p", [Options]),
+                Found =
+                    [kz_json:get_value(<<"number">>, JObj)
+                     || JObj <- knm_carriers:find(Prefix, knm_carriers:quantity(Options), Options)
+                    ],
+                cb_context:setters(C
+                                  ,[{fun cb_context:set_resp_data/2, Found}
+                                   ,{fun cb_context:set_resp_status/2, 'success'}
+                                   ])
+        end,
+    Schema = kz_json:decode(?FIND_NUMBER_SCHEMA),
+    cb_context:validate_request_data(Schema, Context1, OnSuccess).
 
 -spec get_find_numbers_req(cb_context:context()) -> kz_json:object().
 get_find_numbers_req(Context) ->
-    JObj = cb_context:query_string(Context),
-    AccountId = cb_context:auth_account_id(Context),
-    Quantity = kz_json:get_integer_value(<<"quantity">>, JObj, 1),
-    kz_json:set_values([{<<"quantity">>, Quantity}
-                       ,{?KNM_ACCOUNTID_CARRIER, AccountId}
-                       ], JObj).
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%%
-%% @end
-%%--------------------------------------------------------------------
--spec get_numbers(kz_json:object()) -> ne_binaries().
-get_numbers(QueryString) ->
-    PrefixQuery = kz_json:get_ne_value(?PREFIX, QueryString),
-    Country = kz_json:get_ne_value(?COUNTRY, QueryString, ?DEFAULT_COUNTRY),
-    CountryPrefix = knm_util:prefix_for_country(Country),
-    Prefix = <<CountryPrefix/binary, PrefixQuery/binary>>,
-    Quantity = kz_json:get_ne_value(<<"quantity">>, QueryString, 1),
-    lists:reverse(
-      lists:foldl(
-        fun(JObj, Acc) ->
-                [kz_json:get_value(<<"number">>, JObj)|Acc]
-        end
-                 ,[]
-                 ,knm_carriers:find(Prefix, Quantity, kz_json:to_proplist(QueryString))
-       )
-     ).
+    QS = cb_context:query_string(Context),
+    [{'quantity', kz_json:get_ne_value(<<"quantity">>, QS, 1)}
+    ,{'prefix', kz_json:get_ne_value(?PREFIX, QS)}
+    ,{'country', kz_json:get_ne_value(?COUNTRY, QS, ?DEFAULT_COUNTRY)}
+    ,{'offset', kz_json:get_integer_value(<<"offset">>, QS, 0)}
+    ,{'account_id', cb_context:auth_account_id(Context)}
+    ,{'reseller_id', cb_context:reseller_id(Context)}
+    ].
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -58,6 +58,8 @@
 -define(DEFAULT_COUNTRY, <<"US">>).
 -define(KEY_PHONEBOOK_FREE_URL, <<"phonebook_url">>).
 -define(PREFIX, <<"prefix">>).
+-define(QUANTITY, <<"quantity">>).
+-define(OFFSET, <<"offset">>).
 -define(LOCALITY, <<"locality">>).
 -define(CHECK, <<"check">>).
 -define(COUNTRY, <<"country">>).
@@ -560,6 +562,7 @@ find_numbers(Context) ->
     Prefix = <<CountryPrefix/binary, (knm_carriers:prefix(Options))/binary>>,
     OnSuccess =
         fun(C) ->
+                lager:debug("carriers find: ~p", [Options]),
                 Found = knm_carriers:find(Prefix, knm_carriers:quantity(Options), Options),
                 cb_context:setters(C
                                   ,[{fun cb_context:set_resp_data/2, Found}
@@ -575,9 +578,10 @@ get_find_numbers_req(Context) ->
                     Account -> Account
                 end,
     QS = cb_context:query_string(Context),
-    [{'quantity', max(1, kz_json:get_integer_value(<<"quantity">>, QS, 1))}
+    [{'quantity', max(1, kz_json:get_integer_value(?QUANTITY, QS, 1))}
     ,{'prefix', kz_json:get_ne_value(?PREFIX, QS)}
     ,{'country', kz_json:get_ne_value(?COUNTRY, QS, ?DEFAULT_COUNTRY)}
+    ,{'offset', kz_json:get_integer_value(?OFFSET, QS, 0)}
     ,{'account_id', AccountId}
     ,{'reseller_id', cb_context:reseller_id(Context)}
     ].

--- a/core/kazoo_number_manager/include/knm_phone_number.hrl
+++ b/core/kazoo_number_manager/include/knm_phone_number.hrl
@@ -64,8 +64,5 @@
 -define(CARRIER_RESERVED, <<"knm_reserved">>).
 -define(CARRIER_RESERVED_RESELLER, <<"knm_reserved_reseller">>).
 
--define(KNM_ACCOUNTID_CARRIER, <<"account_id">>).
--define(KNM_RESELLERID_CARRIER, <<"reseller_id">>).
-
 -define(KNM_NUMBER_MANAGER_HRL, 'true').
 -endif.

--- a/core/kazoo_number_manager/include/knm_phone_number.hrl
+++ b/core/kazoo_number_manager/include/knm_phone_number.hrl
@@ -5,6 +5,8 @@
 
 -define(KNM_DEFAULT_AUTH_BY, <<"system">>).
 
+-define(KNM_DEFAULT_COUNTRY, <<"US">>).
+
 -type knm_phone_number_return() ::
         {'ok', knm_phone_number:knm_phone_number()} |
         {'error', any()}.

--- a/core/kazoo_number_manager/src/carriers/knm_bandwidth.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_bandwidth.erl
@@ -79,7 +79,7 @@ is_local() -> 'false'.
 %% in a rate center
 %% @end
 %%--------------------------------------------------------------------
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(<<"+", Rest/binary>>, Quanity, Options) ->
@@ -104,7 +104,7 @@ find_numbers(Search, Quanity, Options) ->
         {'ok', Xml} -> process_numbers_search_resp(Xml, Options)
     end.
 
--spec process_numbers_search_resp(xml_el(), kz_proplist()) ->
+-spec process_numbers_search_resp(xml_el(), knm_carriers:options()) ->
                                          {'ok', knm_number:knm_numbers()}.
 process_numbers_search_resp(Xml, Options) ->
     TelephoneNumbers = "/numberSearchResponse/telephoneNumbers/telephoneNumber",

--- a/core/kazoo_number_manager/src/carriers/knm_bandwidth.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_bandwidth.erl
@@ -108,7 +108,7 @@ find_numbers(Search, Quanity, Options) ->
                                          {'ok', knm_number:knm_numbers()}.
 process_numbers_search_resp(Xml, Options) ->
     TelephoneNumbers = "/numberSearchResponse/telephoneNumbers/telephoneNumber",
-    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
+    AccountId = knm_carriers:account_id(Options),
     {'ok', [N
             || Number <- xmerl_xpath:string(TelephoneNumbers, Xml),
                {'ok', N} <- [found_number_to_KNM(Number, AccountId)]

--- a/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
@@ -112,7 +112,7 @@ is_number_billable(_Number) -> 'true'.
 %% @end
 %%--------------------------------------------------------------------
 -type search_ret() :: {'ok', knm_number:knm_numbers()} | {'error', any()}.
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) -> search_ret().
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) -> search_ret().
 find_numbers(<<"+", Rest/binary>>, Quantity, Options) ->
     find_numbers(Rest, Quantity, Options);
 
@@ -145,7 +145,7 @@ find_numbers(Search, Quantity, Options) ->
              ],
     {'ok', process_search_response(search(Search, Params), Options)}.
 
--spec process_search_response(xml_el(), kz_proplist()) -> knm_number:knm_numbers().
+-spec process_search_response(xml_el(), knm_carriers:options()) -> knm_number:knm_numbers().
 process_search_response(Result, Options) ->
     AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
     [N

--- a/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
@@ -125,7 +125,7 @@ find_numbers(<<Prefix:3/binary, _/binary>>=Num, Quantity, Options) when ?IS_US_T
                "&enableTNDetail=true&quantity=", integer_to_list(Quantity)
              ],
     Result = search(Num, Params),
-    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
+    AccountId = knm_carriers:account_id(Options),
     {'ok', [N
             || X <- xmerl_xpath:string("TelephoneNumberList/TelephoneNumber", Result),
                {'ok', N} <- [tollfree_search_response_to_KNM(X, AccountId)]
@@ -147,7 +147,7 @@ find_numbers(Search, Quantity, Options) ->
 
 -spec process_search_response(xml_el(), knm_carriers:options()) -> knm_number:knm_numbers().
 process_search_response(Result, Options) ->
-    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
+    AccountId = knm_carriers:account_id(Options),
     [N
      || X <- xmerl_xpath:string("TelephoneNumberDetailList/TelephoneNumberDetail", Result),
         {'ok', N} <- [search_response_to_KNM(X, AccountId)]

--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -31,6 +31,10 @@
         ]).
 -endif.
 
+-type option() :: {ne_binary(), any()}.
+-type options() :: [option()].
+-export_type([option/0, options/0]).
+
 -define(DEFAULT_CARRIER_MODULE
        ,kapps_config:get_binary(?KNM_CONFIG_CAT, <<"available_module_name">>, ?CARRIER_LOCAL)).
 -define(CARRIER_MODULES
@@ -45,7 +49,7 @@
 %%--------------------------------------------------------------------
 -spec find(ne_binary()) -> kz_json:objects().
 -spec find(ne_binary(), integer()) -> kz_json:objects().
--spec find(ne_binary(), integer(), kz_proplist()) -> kz_json:objects().
+-spec find(ne_binary(), integer(), options()) -> kz_json:objects().
 
 find(Num) ->
     find(Num, 1).
@@ -79,7 +83,7 @@ find(Num, Quantity, Options) ->
                      ,left => pos_integer()
                      ,should_continue => boolean()
                      }.
--spec find_fold(atom(), ne_binary(), kz_proplist(), find_acc()) -> find_acc().
+-spec find_fold(atom(), ne_binary(), options(), find_acc()) -> find_acc().
 find_fold(_Carrier, _, _, Acc=#{should_continue := ShouldContinue
                                ,count := _Count
                                ,left := Left
@@ -211,7 +215,7 @@ activation_charge(DID, AccountId) ->
                              {'EXIT', any()}
                             }].
 -spec check(ne_binaries()) -> checked_numbers().
--spec check(ne_binaries(), kz_proplist()) -> checked_numbers().
+-spec check(ne_binaries(), options()) -> checked_numbers().
 check(Numbers) ->
     check(Numbers, []).
 
@@ -226,7 +230,7 @@ check(Numbers, Options) ->
 %% @public
 %% @doc Create a list of all available carrier modules
 %%--------------------------------------------------------------------
--spec available_carriers(kz_proplist()) -> atoms().
+-spec available_carriers(options()) -> atoms().
 -ifdef(TEST).
 available_carriers(Options) ->
     case props:get_value(<<"carriers">>, Options) of
@@ -238,7 +242,7 @@ available_carriers(Options) ->
     get_available_carriers(Options).
 -endif.
 
--spec get_available_carriers(kz_proplist()) -> atoms().
+-spec get_available_carriers(options()) -> atoms().
 get_available_carriers(Options) ->
     case props:get_value(?KNM_ACCOUNTID_CARRIER, Options) of
         'undefined' ->

--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -86,8 +86,8 @@ find(Prefix, Quantity) ->
 
 find(Prefix, Quantity, Options) ->
     NormalizedPrefix = <<(knm_util:prefix_for_country(country(Options)))/binary
-               ,(prefix(Options, Prefix))/binary
-             >>,
+                         ,(prefix(Options, Prefix))/binary
+                       >>,
     Carriers = available_carriers(Options),
     lager:debug("contacting, in order: ~p", [Carriers]),
     Acc0 = #{found => []

--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -22,6 +22,7 @@
         ,quantity/1
         ,prefix/1
         ,country/1
+        ,offset/1
         ,blocks/1
         ,account_id/1
         ,reseller_id/1
@@ -45,6 +46,7 @@
                   {'tollfree', boolean()} |
                   {'prefix', ne_binary()} |
                   {'country', knm_util:country()} |
+                  {'offset', non_neg_integer()} |
                   {'blocks', boolean()} |
                   {'account_id', ne_binary()} |
                   {'reseller_id', ne_binary()}.
@@ -52,6 +54,7 @@
 -type option() :: {'quantity', pos_integer()} |
                   {'prefix', ne_binary()} |
                   {'country', knm_util:country()} |
+                  {'offset', non_neg_integer()} |
                   {'blocks', boolean()} |
                   {'account_id', ne_binary()} |
                   {'reseller_id', ne_binary()}.
@@ -367,6 +370,9 @@ prefix(Options) -> props:get_value('prefix', Options).
 
 -spec country(options()) -> knm_util:country().
 country(Options) -> props:get_value('country', Options).
+
+-spec offset(options()) -> non_neg_integer().
+offset(Options) -> props:get_integer_value('offset', Options, 0).
 
 -spec blocks(options()) -> boolean().
 blocks(Options) -> props:get_value('blocks', Options).

--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -377,7 +377,7 @@ offset(Options) -> props:get_integer_value('offset', Options, 0).
 -spec blocks(options()) -> boolean().
 blocks(Options) -> props:get_value('blocks', Options).
 
--spec account_id(options()) -> ne_binary().
+-spec account_id(options()) -> api_ne_binary().
 account_id(Options) -> props:get_value('account_id', Options).
 
 -spec reseller_id(options()) -> ne_binary().

--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -120,8 +120,8 @@ find_fold(_Carrier, _, _, Acc=#{should_continue := ShouldContinue
   when ShouldContinue == 'false'; Left < 1 ->
     lager:debug("stopping ~s with ~p (~p) numbers found", [_Carrier, _Count, Left]),
     Acc;
-find_fold(Carrier, NormalizedNumber, Options, Acc=#{left := Quantity}) ->
-    try Carrier:find_numbers(NormalizedNumber, Quantity, Options) of
+find_fold(Carrier, Prefix, Options, Acc=#{left := Quantity}) ->
+    try Carrier:find_numbers(Prefix, Quantity, Options) of
         {'ok', []} -> Acc;
         {'ok', Numbers} -> process_carrier_results(Numbers, Acc);
         {'bulk', []} -> Acc;

--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -78,17 +78,16 @@
 -spec find(ne_binary(), integer()) -> kz_json:objects().
 -spec find(ne_binary(), integer(), options()) -> kz_json:objects().
 
-find(Num) ->
-    find(Num, 1).
+find(Prefix) ->
+    find(Prefix, 1).
 
-find(Num, Quantity) ->
-    find(Num, Quantity, []).
+find(Prefix, Quantity) ->
+    find(Prefix, Quantity, []).
 
-find(Num, Quantity, Options) ->
-    Prefix = <<(knm_util:prefix_for_country(country(Options)))/binary
-               ,(prefix(Options, Num))/binary
+find(Prefix, Quantity, Options) ->
+    NormalizedPrefix = <<(knm_util:prefix_for_country(country(Options)))/binary
+               ,(prefix(Options, Prefix))/binary
              >>,
-    NormalizedNumber = knm_converters:normalize(Prefix),
     Carriers = available_carriers(Options),
     lager:debug("contacting, in order: ~p", [Carriers]),
     Acc0 = #{found => []
@@ -100,12 +99,12 @@ find(Num, Quantity, Options) ->
      ,count := _Count
      } =
         lists:foldl(fun(Carrier, Acc) ->
-                            find_fold(Carrier, NormalizedNumber, Options, Acc)
+                            find_fold(Carrier, NormalizedPrefix, Options, Acc)
                     end
                    ,Acc0
                    ,Carriers
                    ),
-    lager:debug("found ~p/~p numbers", [_Count, Quantity]),
+    lager:debug("~s found ~p/~p numbers", [NormalizedPrefix, _Count, Quantity]),
     Found.
 
 -type find_acc() :: #{found => kz_json:objects()

--- a/core/kazoo_number_manager/src/carriers/knm_inum.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_inum.erl
@@ -43,28 +43,28 @@ is_local() -> 'true'.
 %% in a rate center
 %% @end
 %%--------------------------------------------------------------------
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
-find_numbers(<<"+", _/binary>>=Number, Quantity, Opts) ->
-    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Opts),
-    find_numbers_in_account(Number, Quantity, AccountId, Opts);
-find_numbers(Number, Quantity, Opts) ->
-    find_numbers(<<"+",Number/binary>>, Quantity, Opts).
+find_numbers(<<"+", _/binary>>=Number, Quantity, Options) ->
+    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
+    find_numbers_in_account(Number, Quantity, AccountId, Options);
+find_numbers(Number, Quantity, Options) ->
+    find_numbers(<<"+",Number/binary>>, Quantity, Options).
 
--spec find_numbers_in_account(ne_binary(), pos_integer(), api_binary(), kz_proplist()) ->
+-spec find_numbers_in_account(ne_binary(), pos_integer(), api_binary(), knm_carriers:options()) ->
                                      {'ok', knm_number:knm_numbers()} |
                                      {'error', any()}.
-find_numbers_in_account(Number, Quantity, AccountId, Opts) ->
+find_numbers_in_account(Number, Quantity, AccountId, Options) ->
     case do_find_numbers_in_account(Number, Quantity, AccountId) of
         {'error', 'not_available'}=Error ->
-            ResellerId = props:get_value(?KNM_RESELLERID_CARRIER, Opts),
+            ResellerId = props:get_value(?KNM_RESELLERID_CARRIER, Options),
             case AccountId =:= 'undefined'
                 orelse AccountId =:= ResellerId
             of
                 'true' -> Error;
                 'false' ->
-                    find_numbers_in_account(Number, Quantity, ResellerId, Opts)
+                    find_numbers_in_account(Number, Quantity, ResellerId, Options)
             end;
         Result -> Result
     end.

--- a/core/kazoo_number_manager/src/carriers/knm_inum.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_inum.erl
@@ -46,17 +46,17 @@ is_local() -> 'true'.
 -spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
-find_numbers(<<"+", _/binary>>=Number, Quantity, Options) ->
+find_numbers(<<"+", _/binary>>=Prefix, Quantity, Options) ->
     AccountId = knm_carriers:account_id(Options),
-    find_numbers_in_account(Number, Quantity, AccountId, Options);
-find_numbers(Number, Quantity, Options) ->
-    find_numbers(<<"+",Number/binary>>, Quantity, Options).
+    find_numbers_in_account(Prefix, Quantity, AccountId, Options);
+find_numbers(Prefix, Quantity, Options) ->
+    find_numbers(<<"+",Prefix/binary>>, Quantity, Options).
 
 -spec find_numbers_in_account(ne_binary(), pos_integer(), api_binary(), knm_carriers:options()) ->
                                      {'ok', knm_number:knm_numbers()} |
                                      {'error', any()}.
-find_numbers_in_account(Number, Quantity, AccountId, Options) ->
-    case do_find_numbers_in_account(Number, Quantity, AccountId) of
+find_numbers_in_account(Prefix, Quantity, AccountId, Options) ->
+    case do_find_numbers_in_account(Prefix, Quantity, AccountId) of
         {'error', 'not_available'}=Error ->
             ResellerId = knm_carriers:reseller_id(Options),
             case AccountId =:= 'undefined'
@@ -64,7 +64,7 @@ find_numbers_in_account(Number, Quantity, AccountId, Options) ->
             of
                 'true' -> Error;
                 'false' ->
-                    find_numbers_in_account(Number, Quantity, ResellerId, Options)
+                    find_numbers_in_account(Prefix, Quantity, ResellerId, Options)
             end;
         Result -> Result
     end.
@@ -72,9 +72,9 @@ find_numbers_in_account(Number, Quantity, AccountId, Options) ->
 -spec do_find_numbers_in_account(ne_binary(), pos_integer(), api_binary()) ->
                                         {'ok', knm_number:knm_numbers()} |
                                         {'error', any()}.
-do_find_numbers_in_account(Number, Quantity, AccountId) ->
-    ViewOptions = [{'startkey', [AccountId, ?NUMBER_STATE_AVAILABLE, Number]}
-                  ,{'endkey', [AccountId, ?NUMBER_STATE_AVAILABLE, <<Number/binary,"\ufff0">>]}
+do_find_numbers_in_account(Prefix, Quantity, AccountId) ->
+    ViewOptions = [{'startkey', [AccountId, ?NUMBER_STATE_AVAILABLE, Prefix]}
+                  ,{'endkey', [AccountId, ?NUMBER_STATE_AVAILABLE, <<Prefix/binary,"\ufff0">>]}
                   ,{'limit', Quantity}
                   ,'include_docs'
                   ],

--- a/core/kazoo_number_manager/src/carriers/knm_inum.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_inum.erl
@@ -56,7 +56,8 @@ find_numbers(Prefix, Quantity, Options) ->
                                      {'ok', knm_number:knm_numbers()} |
                                      {'error', any()}.
 find_numbers_in_account(Prefix, Quantity, AccountId, Options) ->
-    case do_find_numbers_in_account(Prefix, Quantity, AccountId) of
+    Offset = knm_carriers:offset(Options),
+    case do_find_numbers_in_account(Prefix, Quantity, Offset, AccountId) of
         {'error', 'not_available'}=Error ->
             ResellerId = knm_carriers:reseller_id(Options),
             case AccountId =:= 'undefined'
@@ -64,18 +65,20 @@ find_numbers_in_account(Prefix, Quantity, AccountId, Options) ->
             of
                 'true' -> Error;
                 'false' ->
-                    find_numbers_in_account(Prefix, Quantity, ResellerId, Options)
+                    NewOptions = [{offset, 0} | Options],
+                    find_numbers_in_account(Prefix, Quantity, ResellerId, NewOptions)
             end;
         Result -> Result
     end.
 
--spec do_find_numbers_in_account(ne_binary(), pos_integer(), api_binary()) ->
+-spec do_find_numbers_in_account(ne_binary(), pos_integer(), non_neg_integer(), api_binary()) ->
                                         {'ok', knm_number:knm_numbers()} |
                                         {'error', any()}.
-do_find_numbers_in_account(Prefix, Quantity, AccountId) ->
+do_find_numbers_in_account(Prefix, Quantity, Offset, AccountId) ->
     ViewOptions = [{'startkey', [AccountId, ?NUMBER_STATE_AVAILABLE, Prefix]}
                   ,{'endkey', [AccountId, ?NUMBER_STATE_AVAILABLE, <<Prefix/binary,"\ufff0">>]}
                   ,{'limit', Quantity}
+                  ,{skip, Offset}
                   ,'include_docs'
                   ],
     case kz_datamgr:get_results(?KZ_INUM, <<"numbers_inum/status">>, ViewOptions) of

--- a/core/kazoo_number_manager/src/carriers/knm_inum.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_inum.erl
@@ -47,7 +47,7 @@ is_local() -> 'true'.
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(<<"+", _/binary>>=Number, Quantity, Options) ->
-    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
+    AccountId = knm_carriers:account_id(Options),
     find_numbers_in_account(Number, Quantity, AccountId, Options);
 find_numbers(Number, Quantity, Options) ->
     find_numbers(<<"+",Number/binary>>, Quantity, Options).
@@ -58,7 +58,7 @@ find_numbers(Number, Quantity, Options) ->
 find_numbers_in_account(Number, Quantity, AccountId, Options) ->
     case do_find_numbers_in_account(Number, Quantity, AccountId) of
         {'error', 'not_available'}=Error ->
-            ResellerId = props:get_value(?KNM_RESELLERID_CARRIER, Options),
+            ResellerId = knm_carriers:reseller_id(Options),
             case AccountId =:= 'undefined'
                 orelse AccountId =:= ResellerId
             of

--- a/core/kazoo_number_manager/src/carriers/knm_local.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_local.erl
@@ -39,7 +39,7 @@ is_local() -> 'true'.
 %% in a rate center
 %% @end
 %%--------------------------------------------------------------------
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(Number, Quantity, Options) ->

--- a/core/kazoo_number_manager/src/carriers/knm_local.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_local.erl
@@ -43,7 +43,7 @@ is_local() -> 'true'.
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(Number, Quantity, Options) ->
-    case props:get_value(?KNM_ACCOUNTID_CARRIER, Options) of
+    case knm_carriers:account_id(Options) of
         'undefined' -> {'error', 'not_available'};
         AccountId -> do_find_numbers(Number, Quantity, AccountId)
     end.

--- a/core/kazoo_number_manager/src/carriers/knm_managed.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_managed.erl
@@ -46,7 +46,7 @@ is_local() -> 'true'.
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(<<"+", _/binary>>=Number, Quantity, Options) ->
-    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
+    AccountId = knm_carriers:account_id(Options),
     find_numbers_in_account(Number, Quantity, AccountId, Options);
 find_numbers(Number, Quantity, Options) ->
     find_numbers(<<"+",Number/binary>>, Quantity, Options).
@@ -57,7 +57,7 @@ find_numbers(Number, Quantity, Options) ->
 find_numbers_in_account(Number, Quantity, AccountId, Options) ->
     case do_find_numbers_in_account(Number, Quantity, AccountId) of
         {'error', 'not_available'}=Error ->
-            ResellerId = props:get_value(?KNM_RESELLERID_CARRIER, Options),
+            ResellerId = knm_carriers:reseller_id(Options),
             case AccountId =:= 'undefined'
                 orelse AccountId =:= ResellerId
             of

--- a/core/kazoo_number_manager/src/carriers/knm_managed.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_managed.erl
@@ -42,28 +42,28 @@ is_local() -> 'true'.
 %% in a rate center
 %% @end
 %%--------------------------------------------------------------------
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
-find_numbers(<<"+", _/binary>>=Number, Quantity, Opts) ->
-    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Opts),
-    find_numbers_in_account(Number, Quantity, AccountId, Opts);
-find_numbers(Number, Quantity, Opts) ->
-    find_numbers(<<"+",Number/binary>>, Quantity, Opts).
+find_numbers(<<"+", _/binary>>=Number, Quantity, Options) ->
+    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
+    find_numbers_in_account(Number, Quantity, AccountId, Options);
+find_numbers(Number, Quantity, Options) ->
+    find_numbers(<<"+",Number/binary>>, Quantity, Options).
 
--spec find_numbers_in_account(ne_binary(), pos_integer(), api_binary(), kz_proplist()) ->
+-spec find_numbers_in_account(ne_binary(), pos_integer(), api_binary(), knm_carriers:options()) ->
                                      {'ok', knm_number:knm_numbers()} |
                                      {'error', any()}.
-find_numbers_in_account(Number, Quantity, AccountId, Opts) ->
+find_numbers_in_account(Number, Quantity, AccountId, Options) ->
     case do_find_numbers_in_account(Number, Quantity, AccountId) of
         {'error', 'not_available'}=Error ->
-            ResellerId = props:get_value(?KNM_RESELLERID_CARRIER, Opts),
+            ResellerId = props:get_value(?KNM_RESELLERID_CARRIER, Options),
             case AccountId =:= 'undefined'
                 orelse AccountId =:= ResellerId
             of
                 'true' -> Error;
                 'false' ->
-                    find_numbers_in_account(Number, Quantity, ResellerId, Opts)
+                    find_numbers_in_account(Number, Quantity, ResellerId, Options)
             end;
         Result -> Result
     end.

--- a/core/kazoo_number_manager/src/carriers/knm_managed.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_managed.erl
@@ -45,17 +45,17 @@ is_local() -> 'true'.
 -spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
-find_numbers(<<"+", _/binary>>=Number, Quantity, Options) ->
+find_numbers(<<"+", _/binary>>=Prefix, Quantity, Options) ->
     AccountId = knm_carriers:account_id(Options),
-    find_numbers_in_account(Number, Quantity, AccountId, Options);
-find_numbers(Number, Quantity, Options) ->
-    find_numbers(<<"+",Number/binary>>, Quantity, Options).
+    find_numbers_in_account(Prefix, Quantity, AccountId, Options);
+find_numbers(Prefix, Quantity, Options) ->
+    find_numbers(<<"+",Prefix/binary>>, Quantity, Options).
 
 -spec find_numbers_in_account(ne_binary(), pos_integer(), api_binary(), knm_carriers:options()) ->
                                      {'ok', knm_number:knm_numbers()} |
                                      {'error', any()}.
-find_numbers_in_account(Number, Quantity, AccountId, Options) ->
-    case do_find_numbers_in_account(Number, Quantity, AccountId) of
+find_numbers_in_account(Prefix, Quantity, AccountId, Options) ->
+    case do_find_numbers_in_account(Prefix, Quantity, AccountId) of
         {'error', 'not_available'}=Error ->
             ResellerId = knm_carriers:reseller_id(Options),
             case AccountId =:= 'undefined'
@@ -63,7 +63,7 @@ find_numbers_in_account(Number, Quantity, AccountId, Options) ->
             of
                 'true' -> Error;
                 'false' ->
-                    find_numbers_in_account(Number, Quantity, ResellerId, Options)
+                    find_numbers_in_account(Prefix, Quantity, ResellerId, Options)
             end;
         Result -> Result
     end.
@@ -71,9 +71,9 @@ find_numbers_in_account(Number, Quantity, AccountId, Options) ->
 -spec do_find_numbers_in_account(ne_binary(), pos_integer(), api_binary()) ->
                                         {'ok', knm_number:knm_numbers()} |
                                         {'error', any()}.
-do_find_numbers_in_account(Number, Quantity, AccountId) ->
-    ViewOptions = [{'startkey', [AccountId, ?NUMBER_STATE_AVAILABLE, Number]}
-                  ,{'endkey', [AccountId, ?NUMBER_STATE_AVAILABLE, <<Number/binary,"\ufff0">>]}
+do_find_numbers_in_account(Prefix, Quantity, AccountId) ->
+    ViewOptions = [{'startkey', [AccountId, ?NUMBER_STATE_AVAILABLE, Prefix]}
+                  ,{'endkey', [AccountId, ?NUMBER_STATE_AVAILABLE, <<Prefix/binary,"\ufff0">>]}
                   ,{'limit', Quantity}
                   ,'include_docs'
                   ],

--- a/core/kazoo_number_manager/src/carriers/knm_mdn.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_mdn.erl
@@ -38,7 +38,7 @@ is_local() -> 'false'.
 %% in a rate center
 %% @end
 %%--------------------------------------------------------------------
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(_Number, _Quantity, _Options) ->

--- a/core/kazoo_number_manager/src/carriers/knm_mdn.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_mdn.erl
@@ -41,7 +41,7 @@ is_local() -> 'false'.
 -spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
-find_numbers(_Number, _Quantity, _Options) ->
+find_numbers(_Prefix, _Quantity, _Options) ->
     {'error', 'not_available'}.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/carriers/knm_other.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_other.erl
@@ -29,9 +29,17 @@
 -define(COUNTRY, ?DEFAULT_COUNTRY).
 -else.
 -define(COUNTRY
-       ,kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?DEFAULT_COUNTRY)
-       ).
+       ,kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?DEFAULT_COUNTRY)).
 -endif.
+
+-ifdef(TEST).
+-define(PHONEBOOK_URL(Options)
+       ,props:get_value('phonebook_url', Options)).
+-else.
+-define(PHONEBOOK_URL(_Options)
+       ,kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"phonebook_url">>)).
+-endif.
+
 
 %%--------------------------------------------------------------------
 %% @public
@@ -50,27 +58,17 @@ is_local() -> 'false'.
 %% in a rate center
 %% @end
 %%--------------------------------------------------------------------
--ifdef(TEST).
--define(PHONEBOOK_URL(Options)
-       ,props:get_value(<<"phonebook_url">>, Options)
-       ).
--else.
--define(PHONEBOOK_URL(_Options)
-       ,kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"phonebook_url">>)
-       ).
--endif.
-
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
-                          {'error', any()} |
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
+                          {'ok', knm_number:knm_numbers()} |
                           {'bulk', knm_number:knm_numbers()} |
-                          {'ok', knm_number:knm_numbers()}.
+                          {'error', any()}.
 find_numbers(Number, Quantity, Options) ->
     case ?PHONEBOOK_URL(Options) of
         'undefined' -> {'error', 'not_available'};
         Url ->
-            case props:is_defined(<<"blocks">>, Options) of
+            case props:is_defined('blocks', Options) of
                 'false' -> get_numbers(Url, Number, Quantity, Options);
-                'true' ->  get_blocks(Url, Number, Quantity, Options)
+                'true' -> get_blocks(Url, Number, Quantity, Options)
             end
     end.
 
@@ -81,14 +79,13 @@ find_numbers(Number, Quantity, Options) ->
 %% in a rate center
 %% @end
 %%--------------------------------------------------------------------
--spec check_numbers(ne_binaries(), kz_proplist()) ->
-                           {'error', any()} |
-                           {'ok', kz_json:object()}.
-check_numbers(Numbers, _Props) ->
+-spec check_numbers(ne_binaries(), knm_carriers:options()) ->
+                           {'ok', kz_json:object()} |
+                           {'error', any()}.
+check_numbers(Numbers, _Options) ->
     FormatedNumbers = [knm_converters:to_npan(Number) || Number <- Numbers],
     case kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"phonebook_url">>) of
-        'undefined' ->
-            {'error', 'not_available'};
+        'undefined' -> {'error', 'not_available'};
         Url ->
             DefaultCountry = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?DEFAULT_COUNTRY),
             ReqBody = kz_json:set_value(<<"data">>, FormatedNumbers, kz_json:new()),
@@ -185,8 +182,8 @@ should_lookup_cnam() -> 'true'.
 %% @end
 %%--------------------------------------------------------------------
 -spec format_check_numbers(kz_json:object()) ->
-                                  {'error', 'resp_error'} |
-                                  {'ok', kz_json:object()}.
+                                  {'ok', kz_json:object()} |
+                                  {'error', 'resp_error'}.
 format_check_numbers(Body) ->
     case kz_json:get_value(<<"status">>, Body) of
         <<"success">> ->
@@ -199,15 +196,15 @@ format_check_numbers(Body) ->
 -spec format_check_numbers_success(kz_json:object()) ->
                                           {'ok', kz_json:object()}.
 format_check_numbers_success(Body) ->
-    JObj = lists:foldl(
-             fun(NumberJObj, Acc) ->
-                     Number = kz_json:get_value(<<"number">>, NumberJObj),
-                     Status = kz_json:get_value(<<"status">>, NumberJObj),
-                     kz_json:set_value(Number, Status, Acc)
-             end
+    F = fun(NumberJObj, Acc) ->
+                Number = kz_json:get_value(<<"number">>, NumberJObj),
+                Status = kz_json:get_value(<<"status">>, NumberJObj),
+                kz_json:set_value(Number, Status, Acc)
+        end,
+    JObj = lists:foldl(F
                       ,kz_json:new()
                       ,kz_json:get_value(<<"data">>, Body, [])
-            ),
+                      ),
     {'ok', JObj}.
 
 %%--------------------------------------------------------------------
@@ -215,15 +212,14 @@ format_check_numbers_success(Body) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec get_numbers(ne_binary(), ne_binary(), ne_binary(), kz_proplist()) ->
-                         {'error', 'not_available'} |
-                         {'ok', knm_number:knm_numbers()}.
+-spec get_numbers(ne_binary(), ne_binary(), ne_binary(), knm_carriers:options()) ->
+                         {'ok', knm_number:knm_numbers()} |
+                         {'error', 'not_available'}.
 get_numbers(Url, Number, Quantity, Options) ->
     Offset = props:get_binary_value(<<"offset">>, Options, <<"0">>),
     Country = ?COUNTRY,
     ReqBody = <<"?prefix=", Number/binary, "&limit=", (kz_util:to_binary(Quantity))/binary, "&offset=", Offset/binary>>,
     Uri = <<Url/binary, "/numbers/", Country/binary, "/search", ReqBody/binary>>,
-
     Results = query_for_numbers(Uri),
     handle_number_query_results(Results, Options).
 
@@ -237,9 +233,9 @@ query_for_numbers(Uri) ->
     kz_http:get(binary:bin_to_list(Uri)).
 -endif.
 
--spec handle_number_query_results(kz_http:http_ret(), kz_proplist()) ->
-                                         {'error', 'not_available'} |
-                                         {'ok', knm_number:knm_numbers()}.
+-spec handle_number_query_results(kz_http:http_ret(), knm_carriers:options()) ->
+                                         {'ok', knm_number:knm_numbers()} |
+                                         {'error', 'not_available'}.
 handle_number_query_results({'error', _Reason}, _Options) ->
     lager:error("number query failed: ~p", [_Reason]),
     {'error', 'not_available'};
@@ -249,36 +245,23 @@ handle_number_query_results({'ok', _Status, _Headers, _Body}, _Options) ->
     lager:error("number query failed with ~p: ~s", [_Status, _Body]),
     {'error', 'not_available'}.
 
--spec format_numbers_resp(kz_json:object(), kz_proplist()) ->
-                                 {'error', 'not_available'} |
-                                 {'ok', knm_number:knm_numbers()}.
+-spec format_numbers_resp(kz_json:object(), knm_carriers:options()) ->
+                                 {'ok', knm_number:knm_numbers()} |
+                                 {'error', 'not_available'}.
 format_numbers_resp(JObj, Options) ->
     case kz_json:get_value(<<"status">>, JObj) of
         <<"success">> ->
             DataJObj = kz_json:get_value(<<"data">>, JObj),
-            AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
-
+            AccountId = knm_carriers:account_id(Options),
             {'ok'
-            ,lists:reverse(
-               kz_json:foldl(fun(K, V, Acc) ->
-                                     format_number_resp(K, V, AccountId, Acc)
-                             end
-                            ,[]
-                            ,DataJObj
-                            )
-              )
+            ,[N
+              || {DID, CarrierData} <- kz_json:to_proplist(DataJObj),
+                 {'ok', N} <- [knm_carriers:create_found(DID, ?MODULE, AccountId, CarrierData)]
+             ]
             };
         _Error ->
             lager:error("block lookup resp error: ~p", [_Error]),
             {'error', 'not_available'}
-    end.
-
--spec format_number_resp(ne_binary(), kz_json:object(), ne_binary(), knm_number:knm_numbers()) ->
-                                knm_number:knm_number_return().
-format_number_resp(DID, CarrierData, AccountId, Acc) ->
-    case knm_carriers:create_found(DID, ?MODULE, AccountId, CarrierData) of
-        {'ok', N} -> [N | Acc];
-        _ -> Acc
     end.
 
 %%--------------------------------------------------------------------
@@ -286,16 +269,16 @@ format_number_resp(DID, CarrierData, AccountId, Acc) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec get_blocks(ne_binary(), ne_binary(), ne_binary(), kz_proplist()) ->
-                        {'error', 'not_available'} |
-                        {'ok', knm_number:knm_numbers()}.
+-spec get_blocks(ne_binary(), ne_binary(), ne_binary(), knm_carriers:options()) ->
+                        {'ok', knm_number:knm_numbers()} |
+                        {'error', 'not_available'}.
 -ifdef(TEST).
-get_blocks(?BLOCK_PHONEBOOK_URL, _Number, _Quantity, Props) ->
-    format_blocks_resp(?BLOCKS_RESP, Props).
+get_blocks(?BLOCK_PHONEBOOK_URL, _Number, _Quantity, Options) ->
+    format_blocks_resp(?BLOCKS_RESP, Options).
 -else.
-get_blocks(Url, Number, Quantity, Props) ->
-    Offset = props:get_binary_value(<<"offset">>, Props, <<"0">>),
-    Limit = props:get_binary_value(<<"blocks">>, Props, <<"0">>),
+get_blocks(Url, Number, Quantity, Options) ->
+    Offset = props:get_binary_value(<<"offset">>, Options, <<"0">>),
+    Limit = props:get_binary_value('blocks', Options, <<"0">>),
     Country = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?DEFAULT_COUNTRY),
     ReqBody = <<"?prefix=", (kz_util:uri_encode(Number))/binary
                 ,"&size=", (kz_util:to_binary(Quantity))/binary
@@ -309,7 +292,7 @@ get_blocks(Url, Number, Quantity, Props) ->
     lager:debug("making request to ~s", [Uri]),
     case kz_http:get(binary:bin_to_list(Uri)) of
         {'ok', 200, _Headers, Body} ->
-            format_blocks_resp(kz_json:decode(Body), Props);
+            format_blocks_resp(kz_json:decode(Body), Options);
         {'ok', _Status, _Headers, Body} ->
             lager:error("block lookup failed: ~p ~p", [_Status, Body]),
             {'error', 'not_available'};
@@ -324,18 +307,17 @@ get_blocks(Url, Number, Quantity, Props) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec format_blocks_resp(kz_json:object(), kz_proplist()) ->
-                                {'error', 'not_available'} |
-                                {'bulk', knm_number:knm_numbers()}.
+-spec format_blocks_resp(kz_json:object(), knm_carriers:options()) ->
+                                {'bulk', knm_number:knm_numbers()} |
+                                {'error', 'not_available'}.
 format_blocks_resp(JObj, Options) ->
     case kz_json:get_value(<<"status">>, JObj) of
         <<"success">> ->
-            AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
+            AccountId = knm_carriers:account_id(Options),
             Numbers =
-                lists:flatmap(
-                  fun(I) -> format_block_resp_fold(I, AccountId) end
+                lists:flatmap(fun(I) -> format_block_resp_fold(I, AccountId) end
                              ,kz_json:get_value(<<"data">>, JObj, [])
-                 ),
+                             ),
             {'bulk', Numbers};
         _Error ->
             lager:error("block lookup resp error: ~p", [JObj]),

--- a/core/kazoo_number_manager/src/carriers/knm_other.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_other.erl
@@ -216,7 +216,7 @@ format_check_numbers_success(Body) ->
                          {'ok', knm_number:knm_numbers()} |
                          {'error', 'not_available'}.
 get_numbers(Url, Number, Quantity, Options) ->
-    Offset = props:get_binary_value(<<"offset">>, Options, <<"0">>),
+    Offset = props:get_binary_value('offset', Options, <<"0">>),
     Country = ?COUNTRY,
     ReqBody = <<"?prefix=", Number/binary, "&limit=", (kz_util:to_binary(Quantity))/binary, "&offset=", Offset/binary>>,
     Uri = <<Url/binary, "/numbers/", Country/binary, "/search", ReqBody/binary>>,
@@ -277,7 +277,7 @@ get_blocks(?BLOCK_PHONEBOOK_URL, _Number, _Quantity, Options) ->
     format_blocks_resp(?BLOCKS_RESP, Options).
 -else.
 get_blocks(Url, Number, Quantity, Options) ->
-    Offset = props:get_binary_value(<<"offset">>, Options, <<"0">>),
+    Offset = props:get_binary_value('offset', Options, <<"0">>),
     Limit = props:get_binary_value('blocks', Options, <<"0">>),
     Country = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?DEFAULT_COUNTRY),
     ReqBody = <<"?prefix=", (kz_util:uri_encode(Number))/binary

--- a/core/kazoo_number_manager/src/carriers/knm_other.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_other.erl
@@ -22,14 +22,13 @@
 
 -include("knm.hrl").
 
--define(DEFAULT_COUNTRY, <<"US">>).
 -define(KNM_OTHER_CONFIG_CAT, <<?KNM_CONFIG_CAT/binary, ".other">>).
 
 -ifdef(TEST).
--define(COUNTRY, ?DEFAULT_COUNTRY).
+-define(COUNTRY, ?KNM_DEFAULT_COUNTRY).
 -else.
 -define(COUNTRY
-       ,kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?DEFAULT_COUNTRY)).
+       ,kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?KNM_DEFAULT_COUNTRY)).
 -endif.
 
 -ifdef(TEST).
@@ -87,7 +86,7 @@ check_numbers(Numbers, _Options) ->
     case kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"phonebook_url">>) of
         'undefined' -> {'error', 'not_available'};
         Url ->
-            DefaultCountry = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?DEFAULT_COUNTRY),
+            DefaultCountry = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?KNM_DEFAULT_COUNTRY),
             ReqBody = kz_json:set_value(<<"data">>, FormatedNumbers, kz_json:new()),
             Uri = <<Url/binary,  "/numbers/", DefaultCountry/binary, "/status">>,
             lager:debug("making request to ~s with body ~p", [Uri, ReqBody]),
@@ -123,7 +122,7 @@ is_number_billable(_Number) -> 'true'.
                             knm_number:knm_number().
 acquire_number(Number) ->
     Num = knm_phone_number:number(knm_number:phone_number(Number)),
-    DefaultCountry = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?DEFAULT_COUNTRY),
+    DefaultCountry = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?KNM_DEFAULT_COUNTRY),
     case kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"phonebook_url">>) of
         'undefined' ->
             knm_errors:unspecified('missing_provider_url', Num);
@@ -279,7 +278,7 @@ get_blocks(?BLOCK_PHONEBOOK_URL, _Number, _Quantity, Options) ->
 get_blocks(Url, Number, Quantity, Options) ->
     Offset = props:get_binary_value('offset', Options, <<"0">>),
     Limit = props:get_binary_value('blocks', Options, <<"0">>),
-    Country = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?DEFAULT_COUNTRY),
+    Country = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?KNM_DEFAULT_COUNTRY),
     ReqBody = <<"?prefix=", (kz_util:uri_encode(Number))/binary
                 ,"&size=", (kz_util:to_binary(Quantity))/binary
                 ,"&offset=", Offset/binary

--- a/core/kazoo_number_manager/src/carriers/knm_reserved.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_reserved.erl
@@ -41,7 +41,7 @@ is_local() -> 'true'.
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(Number, Quantity, Options) ->
-    case props:get_value(?KNM_ACCOUNTID_CARRIER, Options) of
+    case knm_carriers:account_id(Options) of
         'undefined' -> {'error', 'not_available'};
         AccountId ->
             do_find_numbers(Number, Quantity, AccountId)

--- a/core/kazoo_number_manager/src/carriers/knm_reserved.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_reserved.erl
@@ -37,7 +37,7 @@ is_local() -> 'true'.
 %% assigned to an account's reseller account.
 %% @end
 %%--------------------------------------------------------------------
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(Number, Quantity, Options) ->

--- a/core/kazoo_number_manager/src/carriers/knm_reserved.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_reserved.erl
@@ -40,22 +40,24 @@ is_local() -> 'true'.
 -spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
-find_numbers(Number, Quantity, Options) ->
+find_numbers(Prefix, Quantity, Options) ->
     case knm_carriers:account_id(Options) of
         'undefined' -> {'error', 'not_available'};
         AccountId ->
-            do_find_numbers(Number, Quantity, AccountId)
+            Offset = knm_carriers:offset(Options),
+            do_find_numbers(Prefix, Quantity, Offset, AccountId)
     end.
 
--spec do_find_numbers(ne_binary(), pos_integer(), ne_binary()) ->
+-spec do_find_numbers(ne_binary(), pos_integer(), non_neg_integer(), ne_binary()) ->
                              {'ok', knm_number:knm_numbers()} |
                              {'error', any()}.
-do_find_numbers(<<"+",_/binary>>=Number, Quantity, AccountId)
+do_find_numbers(<<"+",_/binary>>=Prefix, Quantity, Offset, AccountId)
   when is_integer(Quantity), Quantity > 0 ->
     AccountDb = kz_util:format_account_db(AccountId),
-    ViewOptions = [{'startkey', Number}
-                  ,{'endkey', <<Number/binary, "\ufff0">>}
+    ViewOptions = [{'startkey', Prefix}
+                  ,{'endkey', <<Prefix/binary, "\ufff0">>}
                   ,{'limit', Quantity}
+                  ,{skip, Offset}
                   ],
     case kz_datamgr:get_results(AccountDb, <<"numbers/list_reserved">>, ViewOptions) of
         {'ok', []} ->
@@ -64,24 +66,23 @@ do_find_numbers(<<"+",_/binary>>=Number, Quantity, AccountId)
         {'ok', JObjs} ->
             lager:debug("found reserved numbers in ~s", [AccountDb]),
             Numbers = format_numbers(AccountId, JObjs),
-            find_more(Quantity, AccountId, length(Numbers), Numbers);
+            find_more(Prefix, Quantity, Offset, AccountId, length(Numbers), Numbers);
         {'error', _R}=E ->
             lager:debug("failed to lookup reserved numbers in ~s: ~p", [AccountDb, _R]),
             E
     end;
-do_find_numbers(_, _, _) ->
+do_find_numbers(_, _, _, _) ->
     {'error', 'not_available'}.
 
--spec find_more(pos_integer(), ne_binary(), pos_integer(), knm_number:knm_numbers()) ->
+-spec find_more(ne_binary(), pos_integer(), non_neg_integer(), ne_binary(), pos_integer(), knm_number:knm_numbers()) ->
                        knm_number:knm_numbers().
-find_more(Quantity, AccountId, NotEnough, Numbers)
+find_more(Prefix, Quantity, Offset, AccountId, NotEnough, Numbers)
   when NotEnough < Quantity ->
-    NewStart = bump(knm_phone_number:number(knm_number:phone_number(lists:last(Numbers)))),
-    case do_find_numbers(NewStart, Quantity - NotEnough, AccountId) of
+    case do_find_numbers(Prefix, Quantity - NotEnough, Offset + NotEnough, AccountId) of
         {'ok', MoreNumbers} -> {'ok', Numbers ++ MoreNumbers};
         _Error -> {'ok', Numbers}
     end;
-find_more(_, _, _Enough, Numbers) ->
+find_more(_, _, _, _, _Enough, Numbers) ->
     {'ok', Numbers}.
 
 -spec format_numbers(ne_binary(), kz_json:objects()) -> knm_number:knm_numbers().
@@ -90,11 +91,6 @@ format_numbers(AuthBy, JObjs) ->
     Options = [{'auth_by', AuthBy}
               ],
     [Number || {_Num,{'ok',Number}} <- knm_numbers:get(Nums, Options)].
-
--spec bump(ne_binary()) -> ne_binary().
-bump(<<"+", Num/binary>>) ->
-    Bumped = erlang:integer_to_binary(1 + erlang:binary_to_integer(Num)),
-    <<"+", Bumped/binary>>.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_number_manager/src/carriers/knm_reserved_reseller.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_reserved_reseller.erl
@@ -40,22 +40,24 @@ is_local() -> 'true'.
 -spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
-find_numbers(Number, Quantity, Options) ->
+find_numbers(Prefix, Quantity, Options) ->
     case knm_carriers:account_id(Options) of
         'undefined' -> {'error', 'not_available'};
         _AccountId ->
-            do_find_numbers(Number, Quantity, knm_carriers:reseller_id(Options))
+            Offset = knm_carriers:offset(Options),
+            do_find_numbers(Prefix, Quantity, Offset, knm_carriers:reseller_id(Options))
     end.
 
--spec do_find_numbers(ne_binary(), pos_integer(), ne_binary()) ->
+-spec do_find_numbers(ne_binary(), pos_integer(), non_neg_integer(), ne_binary()) ->
                              {'ok', knm_number:knm_numbers()} |
                              {'error', any()}.
-do_find_numbers(<<"+",_/binary>>=Number, Quantity, AccountId)
+do_find_numbers(<<"+",_/binary>>=Prefix, Quantity, Offset, AccountId)
   when is_integer(Quantity), Quantity > 0 ->
     AccountDb = kz_util:format_account_db(AccountId),
-    ViewOptions = [{'startkey', Number}
-                  ,{'endkey', <<Number/binary, "\ufff0">>}
+    ViewOptions = [{'startkey', Prefix}
+                  ,{'endkey', <<Prefix/binary, "\ufff0">>}
                   ,{'limit', Quantity}
+                  ,{skip, Offset}
                   ],
     case kz_datamgr:get_results(AccountDb, <<"numbers/list_reserved">>, ViewOptions) of
         {'ok', []} ->
@@ -64,24 +66,23 @@ do_find_numbers(<<"+",_/binary>>=Number, Quantity, AccountId)
         {'ok', JObjs} ->
             lager:debug("found reserved numbers in ~s", [AccountDb]),
             Numbers = format_numbers(AccountId, JObjs),
-            find_more(Quantity, AccountId, length(Numbers), Numbers);
+            find_more(Prefix, Quantity, Offset, AccountId, length(Numbers), Numbers);
         {'error', _R}=E ->
             lager:debug("failed to lookup reserved numbers in ~s: ~p", [AccountDb, _R]),
             E
     end;
-do_find_numbers(_, _, _) ->
+do_find_numbers(_, _, _, _) ->
     {'error', 'not_available'}.
 
--spec find_more(pos_integer(), ne_binary(), pos_integer(), knm_number:knm_numbers()) ->
+-spec find_more(ne_binary(), pos_integer(), non_neg_integer(), ne_binary(), pos_integer(), knm_number:knm_numbers()) ->
                        knm_number:knm_numbers().
-find_more(Quantity, AccountId, NotEnough, Numbers)
+find_more(Prefix, Quantity, Offset, AccountId, NotEnough, Numbers)
   when NotEnough < Quantity ->
-    NewStart = bump(knm_phone_number:number(knm_number:phone_number(lists:last(Numbers)))),
-    case do_find_numbers(NewStart, Quantity - NotEnough, AccountId) of
+    case do_find_numbers(Prefix, Quantity - NotEnough, Offset + NotEnough, AccountId) of
         {'ok', MoreNumbers} -> {'ok', Numbers ++ MoreNumbers};
         _Error -> {'ok', Numbers}
     end;
-find_more(_, _, _Enough, Numbers) ->
+find_more(_, _, _, _, _Enough, Numbers) ->
     {'ok', Numbers}.
 
 -spec format_numbers(ne_binary(), kz_json:objects()) -> knm_number:knm_numbers().
@@ -90,11 +91,6 @@ format_numbers(AuthBy, JObjs) ->
     Options = [{'auth_by', AuthBy}
               ],
     [Number || {_Num,{'ok',Number}} <- knm_numbers:get(Nums, Options)].
-
--spec bump(ne_binary()) -> ne_binary().
-bump(<<"+", Num/binary>>) ->
-    Bumped = erlang:integer_to_binary(1 + erlang:binary_to_integer(Num)),
-    <<"+", Bumped/binary>>.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_number_manager/src/carriers/knm_reserved_reseller.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_reserved_reseller.erl
@@ -37,7 +37,7 @@ is_local() -> 'true'.
 %% assigned to an account's reseller account.
 %% @end
 %%--------------------------------------------------------------------
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(Number, Quantity, Options) ->

--- a/core/kazoo_number_manager/src/carriers/knm_reserved_reseller.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_reserved_reseller.erl
@@ -41,11 +41,10 @@ is_local() -> 'true'.
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(Number, Quantity, Options) ->
-    case props:get_value(?KNM_ACCOUNTID_CARRIER, Options) of
+    case knm_carriers:account_id(Options) of
         'undefined' -> {'error', 'not_available'};
         _AccountId ->
-            ResellerId = props:get_value(?KNM_RESELLERID_CARRIER, Options),
-            do_find_numbers(Number, Quantity, ResellerId)
+            do_find_numbers(Number, Quantity, knm_carriers:reseller_id(Options))
     end.
 
 -spec do_find_numbers(ne_binary(), pos_integer(), ne_binary()) ->

--- a/core/kazoo_number_manager/src/carriers/knm_simwood.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_simwood.erl
@@ -52,7 +52,7 @@ is_local() -> 'false'.
 %% Query Simwood.com for available numbers
 %% @end
 %%--------------------------------------------------------------------
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()}.
 find_numbers(Prefix, Quantity, Options) ->
     URL = list_to_binary([?SW_NUMBER_URL, "/", ?SW_ACCOUNT_ID, <<"/available/standard/">>, sw_quantity(Quantity), "?pattern=", Prefix, "*"]),
@@ -157,7 +157,7 @@ query_simwood(URL, Verb) ->
 %%--------------------------------------------------------------------
 -spec sw_quantity(pos_integer()) -> ne_binary().
 sw_quantity(Quantity) when Quantity == 1 -> <<"1">>;
-sw_quantity(Quantity) when Quantity > 1, Quantity =< 10  -> <<"10">>;
+sw_quantity(Quantity) when Quantity > 1, Quantity =< 10 -> <<"10">>;
 sw_quantity(_Quantity) -> <<"100">>.
 
 %%--------------------------------------------------------------------
@@ -165,7 +165,7 @@ sw_quantity(_Quantity) -> <<"100">>.
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec process_response(kz_json:objects(), kz_proplist()) ->
+-spec process_response(kz_json:objects(), knm_carriers:options()) ->
                               {'ok', knm_number:knm_numbers()}.
 process_response(JObjs, Options) ->
     AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),

--- a/core/kazoo_number_manager/src/carriers/knm_simwood.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_simwood.erl
@@ -168,7 +168,7 @@ sw_quantity(_Quantity) -> <<"100">>.
 -spec process_response(kz_json:objects(), knm_carriers:options()) ->
                               {'ok', knm_number:knm_numbers()}.
 process_response(JObjs, Options) ->
-    AccountId = props:get_value(?KNM_ACCOUNTID_CARRIER, Options),
+    AccountId = knm_carriers:account_id(Options),
     {'ok', [N || JObj <- JObjs,
                  {'ok', N} <- [response_jobj_to_number(JObj, AccountId)]
            ]}.

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -44,7 +44,7 @@ is_local() -> 'false'.
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(Prefix, Quantity, Options) ->
-    case props:is_true(<<"tollfree">>, Options, 'false') of
+    case props:is_true(tollfree, Options, 'false') of
         'false' -> classify_and_find(Prefix, Quantity, Options);
         'true' ->
             TFOpts = tollfree_options(Quantity, Options),

--- a/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
@@ -84,7 +84,7 @@ is_number_billable(_Number) -> 'true'.
 %% Query the system for a quantity of available numbers in a rate center
 %% @end
 %%--------------------------------------------------------------------
--spec find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
+-spec find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
                           {'ok', knm_number:knm_numbers()} |
                           {'error', any()}.
 find_numbers(<<"+", Rest/binary>>, Quantity, Options) ->

--- a/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
@@ -94,11 +94,11 @@ find_numbers(<<"1", Rest/binary>>, Quantity, Options) ->
 find_numbers(<<NPA:3/binary>>, Quantity, Options) ->
     Resp = soap("getDIDs", [{"npa", NPA}]),
     MaybeJson = to_json('find_numbers', Quantity, Resp),
-    to_numbers(MaybeJson, props:get_value(?KNM_ACCOUNTID_CARRIER, Options));
+    to_numbers(MaybeJson, knm_carriers:account_id(Options));
 find_numbers(<<NXX:6/binary,_/binary>>, Quantity, Options) ->
     Resp = soap("getDIDs", [{"nxx", NXX}]),
     MaybeJson = to_json('find_numbers', Quantity, Resp),
-    to_numbers(MaybeJson, props:get_value(?KNM_ACCOUNTID_CARRIER, Options)).
+    to_numbers(MaybeJson, knm_carriers:account_id(Options)).
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_number_manager/src/knm_gen_carrier.erl
+++ b/core/kazoo_number_manager/src/knm_gen_carrier.erl
@@ -13,10 +13,10 @@
 
 -include("knm.hrl").
 
--callback find_numbers(ne_binary(), pos_integer(), kz_proplist()) ->
-    {'error', any()} |
+-callback find_numbers(ne_binary(), pos_integer(), knm_carriers:options()) ->
+    {'ok', knm_number:knm_numbers()} |
     {'bulk', knm_number:knm_numbers()} |
-    {'ok', knm_number:knm_numbers()}.
+    {'error', any()}.
 
 -callback acquire_number(knm_number:knm_number()) ->
     knm_number:knm_number().

--- a/core/kazoo_number_manager/src/knm_util.erl
+++ b/core/kazoo_number_manager/src/knm_util.erl
@@ -18,6 +18,10 @@
 
 -include("knm.hrl").
 
+-type country() :: <<_:(8*2)>>.
+-export_type([country/0]).
+
+
 -spec get_all_number_dbs() -> ne_binaries().
 get_all_number_dbs() ->
     ViewOptions = [{'startkey', <<?KNM_DB_PREFIX>>}

--- a/core/kazoo_number_manager/src/knm_util.erl
+++ b/core/kazoo_number_manager/src/knm_util.erl
@@ -18,8 +18,8 @@
 
 -include("knm.hrl").
 
--type country() :: <<_:(8*2)>>.
--export_type([country/0]).
+-type country_iso3166a2() :: <<_:(8*2)>>.
+-export_type([country_iso3166a2/0]).
 
 
 -spec get_all_number_dbs() -> ne_binaries().
@@ -135,6 +135,6 @@ read_fixture({'error', 'enoent'}, F) ->
 %% TODO
 %% This should be replaced with a call to elibphonenumber
 %% when/if we integrate that lib or do it ourselves
--spec prefix_for_country(ne_binary()) -> ne_binary().
+-spec prefix_for_country(country_iso3166a2()) -> ne_binary().
 prefix_for_country(Country) ->
     knm_iso3166a2_itu:to_itu(kz_util:to_upper_binary(Country)).

--- a/core/kazoo_number_manager/src/knm_vitelity_util.erl
+++ b/core/kazoo_number_manager/src/knm_vitelity_util.erl
@@ -52,11 +52,10 @@ add_options_fold({K, V}, Options) ->
 get_query_value(Key, Options) ->
     props:get_value(Key, Options).
 -else.
--spec get_query_value(atom() | ne_binary(), query_options()) -> term().
+-spec get_query_value(ne_binary(), knm_carriers:options()) -> any().
 get_query_value(Key, Options) ->
     case props:get_value(Key, Options) of
-        'undefined' ->
-            kapps_config:get(?KNM_VITELITY_CONFIG_CAT, Key);
+        'undefined' -> kapps_config:get(?KNM_VITELITY_CONFIG_CAT, Key);
         Value -> Value
     end.
 -endif.

--- a/core/kazoo_number_manager/test/knm_bandwidth2_test.erl
+++ b/core/kazoo_number_manager/test/knm_bandwidth2_test.erl
@@ -11,8 +11,8 @@
 -include("knm.hrl").
 
 api_test_() ->
-    Options = [{?KNM_ACCOUNTID_CARRIER, ?RESELLER_ACCOUNT_ID}
-              ,{<<"carriers">>, [<<"knm_bandwidth2">>]}
+    Options = [{'account_id', ?RESELLER_ACCOUNT_ID}
+              ,{'carriers', [<<"knm_bandwidth2">>]}
               ],
     [find_numbers(Options)
     ,find_tollfree_numbers(Options)

--- a/core/kazoo_number_manager/test/knm_bandwidth_find_test.erl
+++ b/core/kazoo_number_manager/test/knm_bandwidth_find_test.erl
@@ -16,8 +16,8 @@ find_test_() ->
     ].
 
 npan_tests() ->
-    Options = [{?KNM_ACCOUNTID_CARRIER, ?RESELLER_ACCOUNT_ID}
-              ,{<<"carriers">>, [<<"knm_bandwidth">>]}
+    Options = [{'account_id', ?RESELLER_ACCOUNT_ID}
+              ,{'carriers', [<<"knm_bandwidth">>]}
               ],
     Limit = 1,
     Results = knm_carriers:find(<<"+14158867900">>, Limit, Options),
@@ -28,8 +28,8 @@ npan_tests() ->
     ].
 
 area_code_tests() ->
-    Options = [{?KNM_ACCOUNTID_CARRIER, ?RESELLER_ACCOUNT_ID}
-              ,{<<"carriers">>, [<<"knm_bandwidth">>]}
+    Options = [{'account_id', ?RESELLER_ACCOUNT_ID}
+              ,{'carriers', [<<"knm_bandwidth">>]}
               ],
     Limit = 15,
     Results = knm_carriers:find(<<"412">>, Limit, Options),

--- a/core/kazoo_number_manager/test/knm_carriers_find_test.erl
+++ b/core/kazoo_number_manager/test/knm_carriers_find_test.erl
@@ -28,7 +28,7 @@ find_other_test_() ->
     ].
 
 find_no_phonebook() ->
-    Options = [{<<"carriers">>, [?CARRIER_OTHER]}],
+    Options = [{'carriers', [?CARRIER_OTHER]}],
 
     [{"Verify no phonebook url yields no results"
      ,?_assertEqual([], knm_carriers:find(<<"415">>, 1, Options))
@@ -36,10 +36,10 @@ find_no_phonebook() ->
     ].
 
 find_blocks() ->
-    Options = [{<<"phonebook_url">>, ?BLOCK_PHONEBOOK_URL}
-              ,{<<"blocks">>, 'true'}
-              ,{?KNM_ACCOUNTID_CARRIER, ?RESELLER_ACCOUNT_ID}
-              ,{<<"carriers">>, [?CARRIER_OTHER]}
+    Options = [{'phonebook_url', ?BLOCK_PHONEBOOK_URL}
+              ,{'blocks', 'true'}
+              ,{'account_id', ?RESELLER_ACCOUNT_ID}
+              ,{'carriers', [?CARRIER_OTHER]}
               ],
     Limit = 10,
 
@@ -89,9 +89,9 @@ verify_block(PhoneNumber, JObj, DID, Activation) ->
     ].
 
 find_numbers() ->
-    Options = [{<<"phonebook_url">>, ?NUMBER_PHONEBOOK_URL}
-              ,{?KNM_ACCOUNTID_CARRIER, ?MASTER_ACCOUNT_ID}
-              ,{<<"carriers">>, [?CARRIER_OTHER]}
+    Options = [{'phonebook_url', ?NUMBER_PHONEBOOK_URL}
+              ,{'account_id', ?MASTER_ACCOUNT_ID}
+              ,{'carriers', [?CARRIER_OTHER]}
               ],
     Limit = 10,
     Results = knm_carriers:find(<<"415">>, Limit, Options),

--- a/core/kazoo_number_manager/test/knm_vitelity_find_test.erl
+++ b/core/kazoo_number_manager/test/knm_vitelity_find_test.erl
@@ -21,8 +21,9 @@ tollfree_tests() ->
               ,{'carriers', [<<"knm_vitelity">>]}
               ],
     Limit = 1,
-    [Result] = knm_carriers:find(?TEST_CREATE_TOLL, Limit, Options),
-    [Result] = knm_carriers:find(?TEST_CREATE_TOLL, Limit, [{'tollfree', 'true'} | Options]),
+    <<"+1", Num/binary>> = ?TEST_CREATE_TOLL,
+    [Result] = knm_carriers:find(Num, Limit, Options),
+    [Result] = knm_carriers:find(Num, Limit, [{'tollfree', 'true'} | Options]),
 
     [{"Verify found number"
      ,?_assertEqual(?TEST_CREATE_TOLL, kz_json:get_value(<<"number">>, Result))
@@ -37,7 +38,7 @@ local_number_tests() ->
               ,{'carriers', [<<"knm_vitelity">>]}
               ],
     Limit = 1,
-    Results = knm_carriers:find(<<"+19875559876">>, Limit, Options),
+    Results = knm_carriers:find(<<"9875559876">>, Limit, Options),
 
     [{"Verify local number search result size"
      ,?_assertEqual(Limit, length(Results))

--- a/core/kazoo_number_manager/test/knm_vitelity_find_test.erl
+++ b/core/kazoo_number_manager/test/knm_vitelity_find_test.erl
@@ -17,12 +17,12 @@ find_test_() ->
     ].
 
 tollfree_tests() ->
-    Options = [{?KNM_ACCOUNTID_CARRIER, ?RESELLER_ACCOUNT_ID}
-              ,{<<"carriers">>, [<<"knm_vitelity">>]}
+    Options = [{'account_id', ?RESELLER_ACCOUNT_ID}
+              ,{'carriers', [<<"knm_vitelity">>]}
               ],
     Limit = 1,
     [Result] = knm_carriers:find(?TEST_CREATE_TOLL, Limit, Options),
-    [Result] = knm_carriers:find(?TEST_CREATE_TOLL, Limit, [{<<"tollfree">>, 'true'} | Options]),
+    [Result] = knm_carriers:find(?TEST_CREATE_TOLL, Limit, [{'tollfree', 'true'} | Options]),
 
     [{"Verify found number"
      ,?_assertEqual(?TEST_CREATE_TOLL, kz_json:get_value(<<"number">>, Result))
@@ -33,8 +33,8 @@ tollfree_tests() ->
     ].
 
 local_number_tests() ->
-    Options = [{?KNM_ACCOUNTID_CARRIER, ?RESELLER_ACCOUNT_ID}
-              ,{<<"carriers">>, [<<"knm_vitelity">>]}
+    Options = [{'account_id', ?RESELLER_ACCOUNT_ID}
+              ,{'carriers', [<<"knm_vitelity">>]}
               ],
     Limit = 1,
     Results = knm_carriers:find(<<"+19875559876">>, Limit, Options),
@@ -45,8 +45,8 @@ local_number_tests() ->
     ].
 
 local_prefix_tests() ->
-    Options = [{?KNM_ACCOUNTID_CARRIER, ?RESELLER_ACCOUNT_ID}
-              ,{<<"carriers">>, [<<"knm_vitelity">>]}
+    Options = [{'account_id', ?RESELLER_ACCOUNT_ID}
+              ,{'carriers', [<<"knm_vitelity">>]}
               ],
     Limit = 2,
     Results = knm_carriers:find(<<"987">>, Limit, Options),

--- a/core/kazoo_number_manager/test/knm_voip_innovations_test.erl
+++ b/core/kazoo_number_manager/test/knm_voip_innovations_test.erl
@@ -11,8 +11,8 @@
 -include("knm.hrl").
 
 api_test_() ->
-    Options = [{?KNM_ACCOUNTID_CARRIER, ?RESELLER_ACCOUNT_ID}
-              ,{<<"carriers">>, [<<"knm_voip_innovations">>]}
+    Options = [{'account_id', ?RESELLER_ACCOUNT_ID}
+              ,{'carriers', [<<"knm_voip_innovations">>]}
               ],
     [find_numbers(Options)
     ,acquire_number()


### PR DESCRIPTION
Note: for inum & managed offset is only partially supported.
I would argue to split them in inum & inum_reseller and managed & managed_reseller in order to properly handle offset.