### PR TITLE
qf-js: add a check for JS function that caused KAZOO-5012 (#2460)

### DIFF
--- a/scripts/validate-js.sh
+++ b/scripts/validate-js.sh
@@ -32,9 +32,13 @@ def fmap(F, data):
 
 
 def couchjs((field, js)):
+    JS = ''.join(js) + '\n'
+    if 'Object.keys' in JS:
+        print field, 'contains "Object.keys" which is not available until ECMA2015'
+        exit(1)
     TMP = '_'
     with open(TMP, 'w') as wd:
-        wd.write(''.join(js) + '\n')
+        wd.write(JS)
     try:
         code = call(['couchjs', TMP])
         if code != 0:


### PR DESCRIPTION
Script exits with non-zero return code if JS code even mentions `Object.keys`