### PR TITLE
qf-acccra: reinstate cycle_delay_time in account_crawler

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -9116,11 +9116,6 @@
         "system_config.number_manager": {
             "description": "Schema for number_manager system_config",
             "properties": {
-                "aging_expiry_d": {
-                    "default": 90,
-                    "description": "number_manager aging expiry in days",
-                    "type": "integer"
-                },
                 "allowed_features": {
                     "default": [
                         "cnam",
@@ -9191,25 +9186,10 @@
                     "description": "number_manager converters",
                     "type": "array"
                 },
-                "crawler_timer_ms": {
-                    "default": 86400000,
-                    "description": "number_manager crawler timer in milliseconds",
-                    "type": "integer"
-                },
                 "default_force_outbound": {
                     "default": false,
                     "description": "number_manager default force outbound",
                     "type": "boolean"
-                },
-                "deleted_expiry_d": {
-                    "default": 90,
-                    "description": "number_manager deleted expiry in days",
-                    "type": "integer"
-                },
-                "discovery_expiry_d": {
-                    "default": 90,
-                    "description": "number_manager discovery expiry in days",
-                    "type": "integer"
                 },
                 "e164_converters": {
                     "description": "number_manager e164 converters"
@@ -10022,10 +10002,60 @@
         "system_config.tasks": {
             "description": "Schema for tasks system_config",
             "properties": {
+                "aging_expiry_d": {
+                    "default": 90,
+                    "description": "tasks aging expiry in days",
+                    "type": "integer"
+                },
+                "crawler_delay_time_ms": {
+                    "default": 60000,
+                    "description": "tasks crawler delay time in milliseconds",
+                    "type": "integer"
+                },
+                "crawler_timer_ms": {
+                    "default": 86400000,
+                    "description": "tasks crawler timer in milliseconds",
+                    "type": "integer"
+                },
+                "cycle_delay_time_ms": {
+                    "default": 300000,
+                    "description": "tasks cycle delay time in milliseconds",
+                    "type": "integer"
+                },
+                "deleted_expiry_d": {
+                    "default": 90,
+                    "description": "tasks deleted expiry in days",
+                    "type": "integer"
+                },
+                "discovery_expiry_d": {
+                    "default": 90,
+                    "description": "tasks discovery expiry in days",
+                    "type": "integer"
+                },
+                "interaccount_delay_ms": {
+                    "default": 10000,
+                    "description": "tasks interaccount delay in milliseconds",
+                    "type": "integer"
+                },
+                "low_balance_repeat_s": {
+                    "default": 86400,
+                    "description": "tasks low balance repeat in seconds",
+                    "type": "integer"
+                },
                 "send_progress_after_processed": {
                     "default": 1000,
                     "description": "tasks send progress after processed",
                     "type": "integer"
+                },
+                "should_crawl_for_first_occurrence": {
+                    "default": true,
+                    "description": "tasks should crawl for first occurrence",
+                    "type": "boolean"
+                },
+                "should_crawl_for_low_balance": {
+                    "default": true,
+                    "description": "tasks should crawl for low balance",
+                    "type": "boolean"
                 },
                 "wait_after_row_ms": {
                     "default": 500,

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.json
@@ -3,11 +3,6 @@
     "_id": "system_config.number_manager",
     "description": "Schema for number_manager system_config",
     "properties": {
-        "aging_expiry_d": {
-            "default": 90,
-            "description": "number_manager aging expiry in days",
-            "type": "integer"
-        },
         "allowed_features": {
             "default": [
                 "cnam",
@@ -78,25 +73,10 @@
             "description": "number_manager converters",
             "type": "array"
         },
-        "crawler_timer_ms": {
-            "default": 86400000,
-            "description": "number_manager crawler timer in milliseconds",
-            "type": "integer"
-        },
         "default_force_outbound": {
             "default": false,
             "description": "number_manager default force outbound",
             "type": "boolean"
-        },
-        "deleted_expiry_d": {
-            "default": 90,
-            "description": "number_manager deleted expiry in days",
-            "type": "integer"
-        },
-        "discovery_expiry_d": {
-            "default": 90,
-            "description": "number_manager discovery expiry in days",
-            "type": "integer"
         },
         "e164_converters": {
             "description": "number_manager e164 converters"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.tasks.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.tasks.json
@@ -3,10 +3,60 @@
     "_id": "system_config.tasks",
     "description": "Schema for tasks system_config",
     "properties": {
+        "aging_expiry_d": {
+            "default": 90,
+            "description": "tasks aging expiry in days",
+            "type": "integer"
+        },
+        "crawler_delay_time_ms": {
+            "default": 60000,
+            "description": "tasks crawler delay time in milliseconds",
+            "type": "integer"
+        },
+        "crawler_timer_ms": {
+            "default": 86400000,
+            "description": "tasks crawler timer in milliseconds",
+            "type": "integer"
+        },
+        "cycle_delay_time_ms": {
+            "default": 300000,
+            "description": "tasks cycle delay time in milliseconds",
+            "type": "integer"
+        },
+        "deleted_expiry_d": {
+            "default": 90,
+            "description": "tasks deleted expiry in days",
+            "type": "integer"
+        },
+        "discovery_expiry_d": {
+            "default": 90,
+            "description": "tasks discovery expiry in days",
+            "type": "integer"
+        },
+        "interaccount_delay_ms": {
+            "default": 10000,
+            "description": "tasks interaccount delay in milliseconds",
+            "type": "integer"
+        },
+        "low_balance_repeat_s": {
+            "default": 86400,
+            "description": "tasks low balance repeat in seconds",
+            "type": "integer"
+        },
         "send_progress_after_processed": {
             "default": 1000,
             "description": "tasks send progress after processed",
             "type": "integer"
+        },
+        "should_crawl_for_first_occurrence": {
+            "default": true,
+            "description": "tasks should crawl for first occurrence",
+            "type": "boolean"
+        },
+        "should_crawl_for_low_balance": {
+            "default": true,
+            "description": "tasks should crawl for low balance",
+            "type": "boolean"
         },
         "wait_after_row_ms": {
             "default": 500,

--- a/applications/tasks/src/knm_number_crawler.erl
+++ b/applications/tasks/src/knm_number_crawler.erl
@@ -22,27 +22,25 @@
         ,code_change/3
         ]).
 
--include_lib("kazoo/include/kz_databases.hrl").
+-include("tasks.hrl").
 -include_lib("kazoo_number_manager/include/knm_phone_number.hrl").
 
 -define(SERVER, ?MODULE).
 
--define(KNM_CONFIG_CAT, <<"number_manager">>).
-
--define(DELETED_EXPIRY,
-        kapps_config:get_integer(?KNM_CONFIG_CAT, <<"deleted_expiry_d">>, 90)).
-
--define(DISCOVERY_EXPIRY,
-        kapps_config:get_integer(?KNM_CONFIG_CAT, <<"discovery_expiry_d">>, 90)).
-
--define(AGING_EXPIRY,
-        kapps_config:get_integer(?KNM_CONFIG_CAT, <<"aging_expiry_d">>, 90)).
-
 -define(NUMBERS_TO_CRAWL,
         kapps_config:get_integer(?SYSCONFIG_COUCH, <<"default_chunk_size">>, 1000)).
 
+-define(DELETED_EXPIRY,
+        kapps_config:get_integer(?CONFIG_CAT, <<"deleted_expiry_d">>, 90)).
+
+-define(DISCOVERY_EXPIRY,
+        kapps_config:get_integer(?CONFIG_CAT, <<"discovery_expiry_d">>, 90)).
+
+-define(AGING_EXPIRY,
+        kapps_config:get_integer(?CONFIG_CAT, <<"aging_expiry_d">>, 90)).
+
 -define(TIME_BETWEEN_CRAWLS,
-        kapps_config:get_integer(?KNM_CONFIG_CAT, <<"crawler_timer_ms">>, ?MILLISECONDS_IN_DAY)).
+        kapps_config:get_integer(?CONFIG_CAT, <<"crawler_timer_ms">>, ?MILLISECONDS_IN_DAY)).
 
 -record(state, {cleanup_ref :: reference()
                }).

--- a/applications/tasks/src/knm_port_request_crawler.erl
+++ b/applications/tasks/src/knm_port_request_crawler.erl
@@ -23,13 +23,11 @@
         ,code_change/3
         ]).
 
--include_lib("kazoo/include/kz_databases.hrl").
+-include("tasks.hrl").
 -include_lib("kazoo_number_manager/include/knm_phone_number.hrl").
--define(KNM_CONFIG_CAT, <<"number_manager">>).
 
--define(MOD_CONFIG_CAT, <<(?KNM_CONFIG_CAT)/binary, ".port_request">>).
 -define(CLEANUP_ROUNDTRIP_TIME,
-        kapps_config:get_integer(?MOD_CONFIG_CAT, <<"crawler_delay_time_ms">>, ?MILLISECONDS_IN_MINUTE)).
+        kapps_config:get_integer(?CONFIG_CAT, <<"crawler_delay_time_ms">>, ?MILLISECONDS_IN_MINUTE)).
 
 -record(state, {cleanup_ref :: reference()
                }).

--- a/core/kazoo_config/src/kapps_config.erl
+++ b/core/kazoo_config/src/kapps_config.erl
@@ -666,9 +666,6 @@ get_category(Category, 'false') ->
         ,{{<<"callflow">>, <<"ensure_valid_emergency_number">>}
          ,{<<"stepswitch">>, <<"ensure_valid_emergency_cid">>}
          }
-        ,{{<<"trunkstore">>, <<"ensure_valid_emergency_number">>}
-         ,{<<"stepswitch">>, <<"ensure_valid_emergency_cid">>}
-         }
         ,{{<<"callflow">>, <<"default_caller_id_number">>}
          ,{<<"kazoo_endpoint">>, <<"default_caller_id_number">>}
          }
@@ -726,6 +723,46 @@ get_category(Category, 'false') ->
         ,{{<<"callflow">>, <<"recorder_module">>}
          ,{<<"kazoo_endpoint">>, <<"recorder_module">>}
          }
+
+        ,{{<<"trunkstore">>, <<"ensure_valid_emergency_number">>}
+         ,{<<"stepswitch">>, <<"ensure_valid_emergency_cid">>}
+         }
+
+        ,{{<<"number_manager">>, <<"aging_expiry_d">>}
+         ,{<<"tasks">>, <<"aging_expiry_d">>}
+         }
+        ,{{<<"number_manager">>, <<"deleted_expiry_d">>}
+         ,{<<"tasks">>, <<"deleted_expiry_d">>}
+         }
+        ,{{<<"number_manager">>, <<"discovery_expiry_d">>}
+         ,{<<"tasks">>, <<"discovery_expiry_d">>}
+         }
+        ,{{<<"number_manager">>, <<"aging_expiry_d">>}
+         ,{<<"tasks">>, <<"aging_expiry_d">>}
+         }
+        ,{{<<"number_manager">>, <<"crawler_timer_ms">>}
+         ,{<<"tasks">>, <<"crawler_timer_ms">>}
+         }
+        ,{{<<"number_manager.port_request">>, <<"crawler_delay_time_ms">>}
+         ,{<<"tasks">>, <<"crawler_delay_time_ms">>}
+         }
+
+        ,{{<<"notify.account_crawler">>, <<"interaccount_delay">>}
+         ,{<<"tasks">>, <<"interaccount_delay_ms">>}
+         }
+        ,{{<<"notify.account_crawler">>, <<"cycle_delay_time">>}
+         ,{<<"tasks">>, <<"cycle_delay_time_ms">>}
+         }
+        ,{{<<"notify.account_crawler">>, <<"crawl_for_first_occurrence">>}
+         ,{<<"tasks">>, <<"should_crawl_for_first_occurrence">>}
+         }
+        ,{{<<"notify.account_crawler">>, <<"crawl_for_low_balance">>}
+         ,{<<"tasks">>, <<"should_crawl_for_low_balance">>}
+         }
+        ,{{<<"notify.account_crawler">>, <<"low_balance_repeat_s">>}
+         ,{<<"tasks">>, <<"low_balance_repeat_s">>}
+         }
+
         ]).
 
 -spec migrate() -> 'ok'.


### PR DESCRIPTION
Should I [move kapps_config categories](https://github.com/2600hz/kazoo/blob/master/core/kazoo_config/src/kapps_config.erl#L662)?

These files in `applications/tasks/src` are concerned:

* knm_number_crawler.erl
* knm_port_request_crawler.erl
* kz_account_crawler.erl
