### PR TITLE
trunkstore_honor_diversion by ensure valid cid

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -10485,6 +10485,11 @@
                     "description": "trunkstore ensure valid caller id",
                     "type": "boolean"
                 },
+                "honor_diversions_by_cid_validation": {
+                    "default": false,
+                    "description": "trunkstore honor diversions by cid validation",
+                    "type": "boolean"
+                },
                 "ring_ready_offnet": {
                     "default": true,
                     "description": "trunkstore ring ready offnet",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.trunkstore.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.trunkstore.json
@@ -18,6 +18,11 @@
             "description": "trunkstore ensure valid caller id",
             "type": "boolean"
         },
+        "honor_diversions_by_cid_validation": {
+            "default": false,
+            "description": "trunkstore honor diversions by cid validation",
+            "type": "boolean"
+        },
         "ring_ready_offnet": {
             "default": true,
             "description": "trunkstore ring ready offnet",


### PR DESCRIPTION
At the moment, if connected over trunkstore PBX adds diversion field, it is ignored on valid caller ID check. Looks like diversions header also even absent in offnet resource request. Would like to give a try to address this. 