### PR TITLE
Create 'metaflow' exchange on start 'callflow' or 'konami' apps

### DIFF
--- a/applications/callflow/src/callflow_app.erl
+++ b/applications/callflow/src/callflow_app.erl
@@ -50,4 +50,5 @@ declare_exchanges() ->
     _ = kapi_pivot:declare_exchanges(), %% TODO: decouple
     _ = kapi_route:declare_exchanges(),
     _ = kapi_presence:declare_exchanges(),
+    _ = kapi_metaflow:declare_exchanges(),
     kapi_self:declare_exchanges().

--- a/applications/konami/src/konami_app.erl
+++ b/applications/konami/src/konami_app.erl
@@ -33,4 +33,5 @@ stop(_State) ->
 
 -spec declare_exchanges() -> 'ok'.
 declare_exchanges() ->
+    _ = kapi_metaflow:declare_exchanges(),
     kapi_self:declare_exchanges().


### PR DESCRIPTION
Without 'metaflow' exhange konami log error:
` |kz_amqp_assignments|kz_amqp_assignments:751 (<0.124.0>) floating channel <0.20552.0> on amqp://kazoo:xxx@1.2.3.4:5672 went down while still assigned to
 consumer <0.22408.0>: {shutdown,{server_initiated_close,404,<<"NOT_FOUND - no exchange 'metaflow' in vhost '/'">>}}
`