### PR TITLE
added alternate way to add credit cards

### DIFF
--- a/core/braintree/include/braintree.hrl
+++ b/core/braintree/include/braintree.hrl
@@ -111,6 +111,7 @@
                   ,update_existing = 'false' :: boolean() | ne_binary()
                   ,billing_address_id :: api_binary()
                   ,billing_address :: bt_address() | 'undefined'
+                  ,payment_method_nonce :: api_binary()
                  }).
 -type bt_card() :: #bt_card{}.
 -type bt_cards() :: [bt_card()].
@@ -189,6 +190,7 @@
                       ,credit_cards = [] :: bt_cards()
                       ,addresses = [] :: bt_addresses()
                       ,subscriptions = [] :: bt_subscriptions()
+                      ,payment_method_nonce :: api_binary()
                      }).
 -type bt_customer() :: #bt_customer{}.
 -type bt_customers() :: [bt_customer()].

--- a/core/braintree/src/braintree_card.erl
+++ b/core/braintree/src/braintree_card.erl
@@ -12,6 +12,7 @@
 -export([default_payment_token/1]).
 -export([default_payment_card/1]).
 -export([payment_token/1]).
+-export([payment_tokens/1]).
 -export([find/1]).
 -export([create/1, create/2]).
 -export([update/1]).
@@ -72,6 +73,16 @@ default_payment_card(Cards) ->
 
 -spec payment_token(bt_card()) -> api_binary().
 payment_token(#bt_card{token = Value}) -> Value.
+
+-spec payment_tokens(bt_cards()) -> api_binaries().
+payment_tokens(Cards) ->
+    payment_tokens(Cards, []).
+
+-spec payment_tokens(bt_cards(), api_binaries()) -> api_binaries().
+payment_tokens([], Acc) ->
+    Acc;
+payment_tokens([Card | Cards], Acc) ->
+    payment_tokens(Cards, [payment_token(Card)|Acc]).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -236,6 +247,7 @@ record_to_xml(#bt_card{}=Card, ToString) ->
              ,{'customer-id', Card#bt_card.customer_id}
              ,{'number', Card#bt_card.number}
              ,{'cvv', Card#bt_card.cvv}
+             ,{'payment-method-nonce', Card#bt_card.payment_method_nonce}
             ],
     Conditionals =
         [fun(#bt_card{billing_address=BA, billing_address_id=BAID}, P) ->
@@ -314,6 +326,7 @@ json_to_record(JObj) ->
              ,update_existing = kz_json:get_binary_value(<<"update_existing">>, JObj)
              ,verify = kz_json:is_true(<<"verify">>, JObj, 'true')
              ,make_default = kz_json:is_true(<<"make_default">>, JObj, 'true')
+             ,payment_method_nonce = kz_json:get_binary_value(<<"payment_method_nonce">>, JObj)
             }.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
with this update user can add, payment_method_nonce to their json requests without needing to enter credit card info, The payment_method_nonce is provided by the Braintree JS library which validates the credit card info and return the nonce token which can than be sent to the braintree servers and that will add the credit card to the braintree vault. This will help with the compliance issue as the credit card information will no longer be exposed to the kazoo servers.

The user now can be added without any credit card,
{"data":{
        "first_name": "John",
        "last_name": "Doe",
        "company": "ACME CORP",
        "phone": "6000000000",
}}
Without any credit card and contains payment method nonce in their json request
{"data":{
        "first_name": "John",
        "last_name": "Doe",
        "company": "ACME CORP",
        "phone": "6000000000",
        "payment_method_nonce":"valid-nonce"
}}
Payment method nonce is added to the credit card section
{"data":{
        "first_name": "John",
        "last_name": "Doe",
        "company": "ACME CORP",
        "phone": "6000000000",
        "credit_card":{ 
                              "payment_method_nonce":"valid-nonce"
                              }      
}}

Credit cards can now be added with just payment method nonce
{"data":{
             "payment_method_nonce":"valid-nonce" 
}}


Things working: 
User can add a his info
User can add credit card with his info
User can add credit card
User can create transactions

Whats not ready yet:
Client token generation so that the js client knows for which customer we are trying to send request

Please let me know what are your thoughts on this :) i will update the pr when the client token generation is compelete