### PR TITLE
KAZOO-4904 fax notifications

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -9898,6 +9898,13 @@
                 },
                 "default_to": {
                     "description": "notify.fax_inbound_error_to_email default to"
+                },
+                "filter_error_codes": {
+                    "default": [
+                        "49"
+                    ],
+                    "description": "notify.fax_inbound_error_to_email filter error codes",
+                    "type": "array"
                 }
             },
             "required": [

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -9901,7 +9901,7 @@
                 },
                 "filter_error_codes": {
                     "default": [
-                        "49"
+                        "0", "49"
                     ],
                     "description": "notify.fax_inbound_error_to_email filter error codes",
                     "type": "array"

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -9901,7 +9901,8 @@
                 },
                 "filter_error_codes": {
                     "default": [
-                        "0", "49"
+                        "0",
+                        "49"
                     ],
                     "description": "notify.fax_inbound_error_to_email filter error codes",
                     "type": "array"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.fax_inbound_error_to_email.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.fax_inbound_error_to_email.json
@@ -13,7 +13,8 @@
         },
         "filter_error_codes": {
             "default": [
-                "0", "49"
+                "0",
+                "49"
             ],
             "description": "notify.fax_inbound_error_to_email filter error codes",
             "type": "array"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.fax_inbound_error_to_email.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.fax_inbound_error_to_email.json
@@ -10,6 +10,13 @@
         },
         "default_to": {
             "description": "notify.fax_inbound_error_to_email default to"
+        },
+        "filter_error_codes": {
+            "default": [
+                "49"
+            ],
+            "description": "notify.fax_inbound_error_to_email filter error codes",
+            "type": "array"
         }
     },
     "required": [

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.fax_inbound_error_to_email.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.fax_inbound_error_to_email.json
@@ -13,7 +13,7 @@
         },
         "filter_error_codes": {
             "default": [
-                "49"
+                "0", "49"
             ],
             "description": "notify.fax_inbound_error_to_email filter error codes",
             "type": "array"

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -883,6 +883,7 @@ fax_specific(Props) ->
       ,{<<"Fax-ECM-Used">>, get_fax_ecm_used(Props)}
       ,{<<"Fax-T38-Used">>, get_fax_t38_used(Props)}
       ,{<<"Fax-Result-Text">>, props:get_value(<<"variable_fax_result_text">>, Props)}
+      ,{<<"Fax-Result-Code">>, props:get_value(<<"variable_fax_result_code">>, Props)}
       ,{<<"Fax-Transferred-Pages">>, props:get_value(<<"variable_fax_document_transferred_pages">>, Props)}
       ,{<<"Fax-Total-Pages">>, props:get_value(<<"variable_fax_document_total_pages">>, Props)}
       ,{<<"Fax-Bad-Rows">>, props:get_value(<<"variable_fax_bad_rows">>, Props)}

--- a/applications/ecallmgr/src/fs_event_filters.hrl
+++ b/applications/ecallmgr/src/fs_event_filters.hrl
@@ -135,6 +135,7 @@
         ,<<"variable_fax_remote_station_id">>
         ,<<"variable_fax_remote_vendor">>
         ,<<"variable_fax_result_text">>
+        ,<<"variable_fax_result_code">>
         ,<<"variable_fax_success">>
         ,<<"variable_fax_timezone">>
         ,<<"variable_fax_transfer_rate">>

--- a/applications/ecallmgr/src/fs_event_filters.hrl
+++ b/applications/ecallmgr/src/fs_event_filters.hrl
@@ -185,7 +185,7 @@
         ,<<"variable_transfer_to">>
         ,<<"variable_user_name">>
         ,<<"variable_uuid">>
-        | ?FS_MANUAL_HEADERS
+             | ?FS_MANUAL_HEADERS
         ]).
 -define(FS_EVENT_FILTERS_HRL, 'true').
 -endif.

--- a/applications/ecallmgr/src/fs_event_filters.hrl
+++ b/applications/ecallmgr/src/fs_event_filters.hrl
@@ -185,7 +185,7 @@
         ,<<"variable_transfer_to">>
         ,<<"variable_user_name">>
         ,<<"variable_uuid">>
-             | ?FS_MANUAL_HEADERS
+        | ?FS_MANUAL_HEADERS
         ]).
 -define(FS_EVENT_FILTERS_HRL, 'true').
 -endif.

--- a/applications/ecallmgr/src/fs_event_filters.hrl
+++ b/applications/ecallmgr/src/fs_event_filters.hrl
@@ -136,7 +136,6 @@
         ,<<"variable_fax_remote_vendor">>
         ,<<"variable_fax_result_code">>
         ,<<"variable_fax_result_text">>
-        ,<<"variable_fax_result_code">>
         ,<<"variable_fax_success">>
         ,<<"variable_fax_timezone">>
         ,<<"variable_fax_transfer_rate">>

--- a/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
@@ -47,14 +47,14 @@
 init() ->
     kz_util:put_callid(?MODULE),
     Fields = [{'macros', ?TEMPLATE_MACROS}
-                                          ,{'subject', ?TEMPLATE_SUBJECT}
-                                          ,{'category', ?TEMPLATE_CATEGORY}
-                                          ,{'friendly_name', ?TEMPLATE_NAME}
-                                          ,{'to', ?TEMPLATE_TO}
-                                          ,{'from', ?TEMPLATE_FROM}
-                                          ,{'cc', ?TEMPLATE_CC}
-                                          ,{'bcc', ?TEMPLATE_BCC}
-                                          ,{'reply_to', ?TEMPLATE_REPLY_TO}],
+             ,{'subject', ?TEMPLATE_SUBJECT}
+             ,{'category', ?TEMPLATE_CATEGORY}
+             ,{'friendly_name', ?TEMPLATE_NAME}
+             ,{'to', ?TEMPLATE_TO}
+             ,{'from', ?TEMPLATE_FROM}
+             ,{'cc', ?TEMPLATE_CC}
+             ,{'bcc', ?TEMPLATE_BCC}
+             ,{'reply_to', ?TEMPLATE_REPLY_TO}],
     teletype_templates:init(?TEMPLATE_ID_FILTERED, Fields),
     teletype_templates:init(?TEMPLATE_ID, Fields).
 

--- a/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
@@ -81,8 +81,8 @@ handle_fax_inbound_error(JObj, _Props) ->
 is_true_fax_error(JObj) ->
     Code = kz_json:get_value(<<"Fax-Result-Code">>, JObj),
     %% see: https://wiki.freeswitch.org/wiki/Variable_fax_result_code
-    Codes = kapps_config:get(?MOD_CONFIG_CAT, <<"filter_error_codes">>, [<<"49">>]),
-    lists:member(Code, Codes).
+    Codes = kapps_config:get(?MOD_CONFIG_CAT, <<"filter_error_codes">>, [<<"0">>, <<"49">>]),
+    not lists:member(Code, Codes).
 
 -spec handle_fax_inbound(kz_json:object(), ne_binary()) -> 'ok'.
 handle_fax_inbound(DataJObj, TemplateId) ->

--- a/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
@@ -27,6 +27,7 @@
           ,?MACRO_VALUE(<<"fax.success">>, <<"fax_success">>, <<"Fax Success">>, <<"Was the fax successful">>)
           ,?MACRO_VALUE(<<"fax.ecm_used">>, <<"fax_ecm_used">>, <<"ECM Used">>, <<"Was ECM used">>)
           ,?MACRO_VALUE(<<"fax.result_text">>, <<"fax_result_text">>, <<"Fax Result Text">>, <<"Result text from transmission">>)
+          ,?MACRO_VALUE(<<"fax.result_code">>, <<"fax_result_code">>, <<"Fax Result Code">>, <<"Result code from transmission">>)
           ,?MACRO_VALUE(<<"fax.transferred_pages">>, <<"fax_transferred_pages">>, <<"Transferred Pages">>, <<"How many pages were transferred">>)
           ,?MACRO_VALUE(<<"fax.bad_rows">>, <<"fax_bad_rows">>, <<"Bad Rows">>, <<"How many bad rows">>)
           ,?MACRO_VALUE(<<"fax.transfer_rate">>, <<"fax_transfer_rate">>, <<"Transfer Rate">>, <<"Transfer Rate">>)

--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -75,27 +75,21 @@ handle_new_voicemail(JObj, _Props) ->
     {'ok', UserJObj} = get_owner(VMBox, DataJObj),
 
     BoxEmails = kzd_voicemail_box:notification_emails(VMBox),
-    Emails = maybe_add_user_email(BoxEmails, kzd_user:email(UserJObj)),
+    Emails = maybe_add_user_email(BoxEmails, kzd_user:email(UserJObj), kzd_user:voicemail_notification_enabled(UserJObj)),
 
     %% If the box has emails, continue processing
-    %% or If the voicemail notification is enabled on the user, continue processing
     %% otherwise stop processing
-    (Emails =/= []
-     andalso (kzd_user:voicemail_notification_enabled(UserJObj)
-              orelse kz_json:is_empty(UserJObj)
-             )
-    )
+    Emails =/= []
         orelse teletype_util:stop_processing("box ~s has no emails or owner doesn't want emails", [VMBoxId]),
 
     ReqData =
-        kz_json:set_values(
-          [{<<"voicemail">>, VMBox}
-          ,{<<"owner">>, UserJObj}
-          ,{<<"account">>, AccountJObj}
-          ,{<<"to">>, Emails}
-          ]
+        kz_json:set_values([{<<"voicemail">>, VMBox}
+                           ,{<<"owner">>, UserJObj}
+                           ,{<<"account">>, AccountJObj}
+                           ,{<<"to">>, Emails}
+                           ]
                           ,DataJObj
-         ),
+                          ),
 
     case teletype_util:is_preview(DataJObj) of
         'false' -> process_req(ReqData);
@@ -103,9 +97,10 @@ handle_new_voicemail(JObj, _Props) ->
             process_req(kz_json:merge_jobjs(DataJObj, ReqData))
     end.
 
--spec maybe_add_user_email(ne_binaries(), api_binary()) -> ne_binaries().
-maybe_add_user_email(BoxEmails, 'undefined') -> BoxEmails;
-maybe_add_user_email(BoxEmails, UserEmail) -> [UserEmail | BoxEmails].
+-spec maybe_add_user_email(ne_binaries(), api_binary(), boolean()) -> ne_binaries().
+maybe_add_user_email(BoxEmails, 'undefined', _) -> BoxEmails;
+maybe_add_user_email(BoxEmails, _UserEmail, 'false') -> BoxEmails;
+maybe_add_user_email(BoxEmails, UserEmail, 'true') -> [UserEmail | BoxEmails].
 
 -spec get_owner(kzd_voicemail_box:doc(), kz_json:object()) ->
                        {'ok', kz_json:object()}.


### PR DESCRIPTION
- distinguish fax errors by fax error code
- allow system administrator to specify error codes to ignore (e.g. fax wasn't negotiated because of premature call end)