### PR TITLE
Kz nodes deps

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_app.erl
+++ b/applications/ecallmgr/src/ecallmgr_app.erl
@@ -27,7 +27,7 @@ start(_StartType, _StartArgs) ->
     _ = node_bindings(),
     ecallmgr_sup:start_link().
 
--spec request(list()) -> list().
+-spec request(kz_nodes:request_acc()) -> kz_nodes:request_acc().
 request(Acc) ->
     Servers = [{kz_util:to_binary(Server)
                ,kz_json:set_values([{<<"Startup">>, Started}

--- a/applications/ecallmgr/src/ecallmgr_app.erl
+++ b/applications/ecallmgr/src/ecallmgr_app.erl
@@ -11,7 +11,9 @@
 
 -include_lib("kazoo/include/kz_types.hrl").
 
--export([start/2]).
+-export([start/2
+        ,request/1
+        ]).
 -export([stop/1]).
 
 
@@ -22,14 +24,31 @@
 -spec start(application:start_type(), any()) -> startapp_ret().
 start(_StartType, _StartArgs) ->
     _ = declare_exchanges(),
+    _ = node_bindings(),
     ecallmgr_sup:start_link().
+
+-spec request(list()) -> list().
+request(Acc) ->
+    Servers = [{kz_util:to_binary(Server)
+               ,kz_json:set_values([{<<"Startup">>, Started}
+                                   ,{<<"Interface">>, kz_json:from_list(ecallmgr_fs_node:interface(Server))}
+                                   ]
+                                  ,kz_json:new()
+                                  )
+               }
+               || {Server, Started} <- ecallmgr_fs_nodes:connected('true')
+              ],
+    [{'media_servers', Servers}
+    ,{'channels', ecallmgr_fs_channels:count()}
+    ,{'registrations', ecallmgr_registrar:count()}
+     | Acc
+    ].
 
 %% @public
 %% @doc Implement the application stop behaviour
 -spec stop(any()) -> any().
 stop(_State) ->
     'ok'.
-
 
 -spec declare_exchanges() -> 'ok'.
 declare_exchanges() ->
@@ -48,3 +67,8 @@ declare_exchanges() ->
     _ = kapi_sms:declare_exchanges(),
     _ = kapi_presence:declare_exchanges(),
     kapi_self:declare_exchanges().
+
+-spec node_bindings() -> 'ok'.
+node_bindings() ->
+    _ = kz_nodes_bindings:bind('ecallmgr', 'ecallmgr_app'),
+    'ok'.

--- a/applications/ecallmgr/src/ecallmgr_app.erl
+++ b/applications/ecallmgr/src/ecallmgr_app.erl
@@ -70,5 +70,5 @@ declare_exchanges() ->
 
 -spec node_bindings() -> 'ok'.
 node_bindings() ->
-    _ = kz_nodes_bindings:bind('ecallmgr', 'ecallmgr_app'),
+    _ = kz_nodes_bindings:bind('ecallmgr', ?MODULE),
     'ok'.

--- a/core/kazoo_amqp/src/api/kapi_media.erl
+++ b/core/kazoo_amqp/src/api/kapi_media.erl
@@ -33,7 +33,7 @@
                                     ]).
 -define(MEDIA_REQ_VALUES, [{<<"Event-Category">>, <<"media">>}
                           ,{<<"Event-Name">>, <<"media_req">>}
-                          ,{<<"Stream-Type">>, [<<"new">>, <<"extant">>, 'new', 'extant']}
+                          ,{<<"Stream-Type">>, [<<"new">>, <<"extant">>]}
                           ,{<<"Voice">>, [<<"male">>, <<"female">>]}
                           ,{<<"Format">>, [<<"mp3">>, <<"wav">>]}
                           ,{<<"Protocol">>, [<<"http">>, <<"https">>, <<"shout">>, <<"vlc">>]}
@@ -67,7 +67,7 @@
 %% Takes proplist, creates JSON string or error
 %% @end
 %%--------------------------------------------------------------------
--spec req(kz_json:object() | kz_proplist()) ->
+-spec req(api_terms()) ->
                  {'ok', iolist()} |
                  {'error', string()}.
 req(Prop) when is_list(Prop) ->
@@ -77,7 +77,7 @@ req(Prop) when is_list(Prop) ->
     end;
 req(JObj) -> req(kz_json:to_proplist(JObj)).
 
--spec req_v(kz_json:object() | kz_proplist()) -> boolean().
+-spec req_v(api_terms()) -> boolean().
 req_v(Prop) when is_list(Prop) ->
     kz_api:validate(Prop, ?MEDIA_REQ_HEADERS, ?MEDIA_REQ_VALUES, ?MEDIA_REQ_TYPES);
 req_v(JObj) -> req_v(kz_json:to_proplist(JObj)).

--- a/core/kazoo_apps/src/kapps_controller.erl
+++ b/core/kazoo_apps/src/kapps_controller.erl
@@ -41,7 +41,9 @@ start_default_apps() ->
 -spec start_app(atom() | nonempty_string() | ne_binary()) -> 'ok' | {'error', any()}.
 start_app(App) when is_atom(App) ->
     case application:ensure_all_started(App) of
-        {'ok', _}=OK -> OK;
+        {'ok', _}=OK ->
+            kz_nodes_bindings:bind(App),
+            OK;
         {'error', _E}=E ->
             lager:error("~s could not start: ~p", [App, _E]),
             E
@@ -52,7 +54,9 @@ start_app(App) ->
 -spec stop_app(atom() | nonempty_string() | ne_binary()) -> 'ok' | {'error', any()}.
 stop_app(App) when is_atom(App) ->
     case application:stop(App) of
-        'ok' -> lager:info("stopped kazoo application ~s", [App]);
+        'ok' ->
+            kz_nodes_bindings:bind(App),
+            lager:info("stopped kazoo application ~s", [App]);
         {'error', {'not_started', App}} ->
             lager:error("~s is not currently running", [App]);
         {'error', _E}=Err ->

--- a/core/kazoo_apps/src/kapps_controller.erl
+++ b/core/kazoo_apps/src/kapps_controller.erl
@@ -195,5 +195,7 @@ list_apps() ->
 
 -spec is_kapp(atom()) -> boolean().
 is_kapp(App) ->
-    {ok, Deps} = application:get_key(App, applications),
-    lists:member(?APP, Deps).
+    case application:get_key(App, 'applications') of
+        {'ok', Deps} -> lists:member(?APP, Deps);
+        'undefined' -> 'false'
+    end.

--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -478,9 +478,7 @@ handle_info({'heartbeat', Ref}, #state{heartbeat_ref=Ref
             kz_amqp_worker:cast(advertise_payload(Node), fun kapi_nodes:publish_advertise/1)
     catch
         _E:_N ->
-            ST = erlang:get_stacktrace(),
-            lager:error("error creating node ~p : ~p", [_E, _N]),
-            [lager:error("~p", [S]) || S <- ST]
+            lager:error("error creating node ~p : ~p", [_E, _N])
     end,
     _ = erlang:send_after(Heartbeat, self(), {'heartbeat', Reference}),
     {'noreply', State#state{heartbeat_ref=Reference}};

--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -38,6 +38,16 @@
         ,code_change/3
         ]).
 
+
+-type request_info() :: {'app', atom()} |
+                        {'media_servers', [{ne_binary(), kz_json:object()}]} |
+                        {'channels', non_neg_integer()} |
+                        {'registrations', non_neg_integer()} |
+                        {'info', whapp_info()}.
+-type request_acc() :: [request_info()].
+
+-export_type([request_acc/0]).
+
 -include_lib("kazoo/include/kz_types.hrl").
 -include_lib("kazoo/include/kz_log.hrl").
 
@@ -573,13 +583,6 @@ normalize_amqp_uri(URI) ->
 -spec add_kapps_data(kz_node()) -> kz_node().
 add_kapps_data(Node) ->
     lists:foldl(fun kapp_data/2, Node, kapps_controller:list_apps()).
-
--type request_info() :: {'app', atom()} |
-                        {'media_servers', [{ne_binary(), kz_json:object()}]} |
-                        {'channels', non_neg_integer()} |
-                        {'registrations', non_neg_integer()} |
-                        {'info', whapp_info()}.
--type request_acc() :: [request_info()].
 
 -spec request(request_acc()) -> request_acc().
 request(Acc) ->

--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -467,9 +467,11 @@ handle_info('expire_nodes', #state{tab=Tab}=State) ->
     _ = kz_util:spawn(fun notify_expire/2, [Nodes, State]),
     _ = erlang:send_after(?EXPIRE_PERIOD, self(), 'expire_nodes'),
     {'noreply', State};
-handle_info({'heartbeat', Ref}, #state{heartbeat_ref=Ref
-                                      ,tab=Tab
-                                      }=State) ->
+handle_info({'heartbeat', Ref}
+           ,#state{heartbeat_ref=Ref
+                  ,tab=Tab
+                  }=State
+           ) ->
     Heartbeat = ?HEARTBEAT,
     Reference = erlang:make_ref(),
     try create_node(Heartbeat, State) of
@@ -482,9 +484,11 @@ handle_info({'heartbeat', Ref}, #state{heartbeat_ref=Ref
     end,
     _ = erlang:send_after(Heartbeat, self(), {'heartbeat', Reference}),
     {'noreply', State#state{heartbeat_ref=Reference}};
-handle_info({'DOWN', Ref, 'process', Pid, _}, #state{notify_new=NewSet
-                                                    ,notify_expire=ExpireSet
-                                                    }=State) ->
+handle_info({'DOWN', Ref, 'process', Pid, _}
+           ,#state{notify_new=NewSet
+                  ,notify_expire=ExpireSet
+                  }=State
+           ) ->
     erlang:demonitor(Ref, ['flush']),
     {'noreply', State#state{notify_new=sets:del_element(Pid, NewSet)
                            ,notify_expire=sets:del_element(Pid, ExpireSet)

--- a/core/kazoo_globals/src/kz_nodes_bindings.erl
+++ b/core/kazoo_globals/src/kz_nodes_bindings.erl
@@ -1,0 +1,6 @@
+-module(kz_nodes_bindings).
+
+-export([]).
+
+-include_lib("kazoo/include/kz_types.hrl").
+-include_lib("kazoo/include/kz_log.hrl").

--- a/core/kazoo_globals/src/kz_nodes_bindings.erl
+++ b/core/kazoo_globals/src/kz_nodes_bindings.erl
@@ -1,6 +1,66 @@
 -module(kz_nodes_bindings).
 
--export([]).
+-export([bind/1, bind/2, bind/3
+        ,unbind/1, unbind/2, unbind/3
+        ,request/1
+        ]).
 
 -include_lib("kazoo/include/kz_types.hrl").
 -include_lib("kazoo/include/kz_log.hrl").
+
+-define(DEFAULT_MODULE, 'kz_nodes').
+-define(DEFAULT_FUNCTION, 'request').
+-define(CALLBACK_ARITY, 1).
+
+-type bind_result() :: kazoo_bindings:bind_result().
+
+-spec bind(atom()) -> bind_result().
+-spec bind(atom(), atom()) -> bind_result().
+-spec bind(atom(), atom(), atom()) -> bind_result().
+bind(App) ->
+    bind(App, App).
+
+bind(App, Module) ->
+    bind(App, Module, ?DEFAULT_FUNCTION).
+
+bind(App, Module, Function)
+  when is_atom(App)
+       andalso is_atom(Module)
+       andalso is_atom(Function)
+       ->
+    Binding = routing_key(App),
+    case erlang:function_exported(Module, Function, ?CALLBACK_ARITY) of
+        'true' ->
+            kazoo_bindings:bind(Binding, Module, Function);
+        'false' ->
+            kazoo_bindings:bind(Binding, ?DEFAULT_MODULE, ?DEFAULT_FUNCTION)
+    end.
+
+-spec unbind(atom()) -> kazoo_bindings:unbind_result().
+-spec unbind(atom(), atom()) -> kazoo_bindings:unbind_result().
+-spec unbind(atom(), atom(), atom()) -> kazoo_bindings:unbind_result().
+unbind(App) ->
+    unbind(App, App).
+
+unbind(App, Module) ->
+    unbind(App, Module, ?DEFAULT_FUNCTION).
+
+unbind(App, Module, Function)
+  when is_atom(App)
+       andalso is_atom(Module)
+       andalso is_atom(Function)
+       ->
+    Binding = routing_key(App),
+    case erlang:function_exported(Module, Function, ?CALLBACK_ARITY) of
+        'true' ->
+            kazoo_bindings:unbind(Binding, Module, Function);
+        'false' ->
+            kazoo_bindings:unbind(Binding, ?DEFAULT_MODULE, ?DEFAULT_FUNCTION)
+    end.
+
+routing_key(App) ->
+    <<"kz_nodes.request.", (kz_util:to_binary(App))/binary>>.
+
+request(App) when is_atom(App) ->
+    Routing = routing_key(App),
+    kazoo_bindings:fold(Routing, [[{'app', App}]]).


### PR DESCRIPTION
kz_nodes had direct calls to ecallmgr functions. I've moved things around to use kazoo_bindings to retrieve those values. This also paves the way for apps to have custom handlers for providing their own data (this is not explicitly enabled in the PR but the flexibility of kazoo_bindings should allow for expansion).

This is part of the apps_of_app effort to streamline inter-app dependencies.