### PR TITLE
KAZOO-5063 ensure to-did not being empty

### DIFF
--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -47,6 +47,7 @@
         ]).
 -export([to_boolean/1, is_boolean/1
         ,is_true/1, is_false/1
+        ,is_ne_binary/1
         ,is_empty/1, is_not_empty/1
         ,is_proplist/1
         ,identity/1
@@ -1140,6 +1141,11 @@ is_false(_) -> 'false'.
 
 -spec always_false(any()) -> 'false'.
 always_false(_) -> 'false'.
+
+-spec is_ne_binary(binary()) -> boolean().
+is_ne_binary(V) ->
+    is_binary(V)
+        andalso is_not_empty(V).
 
 -spec is_boolean(binary() | string() | atom()) -> boolean().
 is_boolean(<<"true">>) -> 'true';

--- a/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
+++ b/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
@@ -155,7 +155,7 @@
         ,{?KEY_FLAGS, fun is_list/1}
         ,{?KEY_FORCE_FAX, fun kz_util:is_boolean/1}
         ,{?KEY_FORCE_OUTBOUND, fun kz_util:is_boolean/1}
-        ,{?KEY_TO_DID, fun is_ne_binary/1}
+        ,{?KEY_TO_DID, fun kz_util:is_ne_binary/1}
         ,{?KEY_BYPASS_E164, fun kz_util:is_boolean/1}
         ]).
 
@@ -170,10 +170,6 @@
                                      ]).
 -define(OFFNET_RESOURCE_RESP_TYPES, []).
 
--spec is_ne_binary(binary()) -> boolean().
-is_ne_binary(V) ->
-    is_binary(V)
-        andalso kz_util:is_not_empty(V).
 
 %%--------------------------------------------------------------------
 %% @doc Offnet resource request - see wiki

--- a/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
+++ b/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
@@ -187,7 +187,8 @@ req(JObj) -> req(kz_json:to_proplist(JObj)).
 
 -spec req_v(api_terms()) -> boolean().
 req_v(Prop) when is_list(Prop) ->
-    kz_api:validate(Prop, ?OFFNET_RESOURCE_REQ_HEADERS, ?OFFNET_RESOURCE_REQ_VALUES, ?OFFNET_RESOURCE_REQ_TYPES);
+    kz_api:validate(Prop, ?OFFNET_RESOURCE_REQ_HEADERS, ?OFFNET_RESOURCE_REQ_VALUES, ?OFFNET_RESOURCE_REQ_TYPES)
+        andalso not kz_util:is_empty(props:get_value(?KEY_TO_DID, Prop));
 req_v(JObj) -> req_v(kz_json:to_proplist(JObj)).
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
+++ b/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
@@ -155,7 +155,7 @@
         ,{?KEY_FLAGS, fun is_list/1}
         ,{?KEY_FORCE_FAX, fun kz_util:is_boolean/1}
         ,{?KEY_FORCE_OUTBOUND, fun kz_util:is_boolean/1}
-        ,{?KEY_TO_DID, fun is_binary/1}
+        ,{?KEY_TO_DID, fun is_ne_binary/1}
         ,{?KEY_BYPASS_E164, fun kz_util:is_boolean/1}
         ]).
 
@@ -169,6 +169,9 @@
                                      ,{<<"Event-Name">>, <<"offnet_resp">>}
                                      ]).
 -define(OFFNET_RESOURCE_RESP_TYPES, []).
+
+-spec is_ne_binary(binary()) -> boolean().
+is_ne_binary(V) -> is_binary(V) andalso kz_util:is_not_empty(V).
 
 %%--------------------------------------------------------------------
 %% @doc Offnet resource request - see wiki
@@ -187,8 +190,7 @@ req(JObj) -> req(kz_json:to_proplist(JObj)).
 
 -spec req_v(api_terms()) -> boolean().
 req_v(Prop) when is_list(Prop) ->
-    kz_api:validate(Prop, ?OFFNET_RESOURCE_REQ_HEADERS, ?OFFNET_RESOURCE_REQ_VALUES, ?OFFNET_RESOURCE_REQ_TYPES)
-        andalso not kz_util:is_empty(props:get_value(?KEY_TO_DID, Prop));
+    kz_api:validate(Prop, ?OFFNET_RESOURCE_REQ_HEADERS, ?OFFNET_RESOURCE_REQ_VALUES, ?OFFNET_RESOURCE_REQ_TYPES);
 req_v(JObj) -> req_v(kz_json:to_proplist(JObj)).
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
+++ b/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
@@ -171,7 +171,9 @@
 -define(OFFNET_RESOURCE_RESP_TYPES, []).
 
 -spec is_ne_binary(binary()) -> boolean().
-is_ne_binary(V) -> is_binary(V) andalso kz_util:is_not_empty(V).
+is_ne_binary(V) ->
+    is_binary(V)
+        andalso kz_util:is_not_empty(V).
 
 %%--------------------------------------------------------------------
 %% @doc Offnet resource request - see wiki


### PR DESCRIPTION
Messages with is_empty To-DID field (<<"0">> as example) should not pass validation.