### PR TITLE
Adding kvs cf_capture_group to call when we hunt for branch in cf_menu.

### DIFF
--- a/applications/callflow/src/module/cf_menu.erl
+++ b/applications/callflow/src/module/cf_menu.erl
@@ -249,7 +249,11 @@ hunt_for_callflow(Digits, Menu, Call) ->
             lager:info("callflow hunt succeeded, branching"),
             _ = kapps_call_command:flush_dtmf(Call),
             _ = play_transferring_prompt(Menu, Call),
-            cf_exe:branch(kz_json:get_value(<<"flow">>, Flow, kz_json:new()), Call),
+            Props = [{'cf_capture_group', kz_json:get_ne_value(<<"capture_group">>, Flow)}
+                    ,{'cf_capture_groups', kz_json:get_value(<<"capture_groups">>, Flow, kz_json:new())}
+                    ],
+            UpdatedCall = kapps_call:kvs_store_proplist(Props, Call),
+            cf_exe:branch(kz_json:get_value(<<"flow">>, Flow, kz_json:new()), UpdatedCall),
             'true';
         _ ->
             lager:info("callflow hunt failed"),

--- a/applications/callflow/src/module/cf_menu.erl
+++ b/applications/callflow/src/module/cf_menu.erl
@@ -253,6 +253,7 @@ hunt_for_callflow(Digits, Menu, Call) ->
                     ,{'cf_capture_groups', kz_json:get_value(<<"capture_groups">>, Flow, kz_json:new())}
                     ],
             UpdatedCall = kapps_call:kvs_store_proplist(Props, Call),
+            cf_exe:set_call(UpdatedCall),
             cf_exe:branch(kz_json:get_value(<<"flow">>, Flow, kz_json:new()), UpdatedCall),
             'true';
         _ ->


### PR DESCRIPTION
The idea here is if the menu has to hunt for a callflow that we then set the cf_capture_group on the call so that the flow we are branching to has access to the captured group(s)

Discussion here. https://groups.google.com/forum/#!topic/2600hz-dev/O1CfULJyqgs

keys should be accesiable with these calls. 

``` erlang
kapps_call:kvs_fetch('cf_capture_group', Call)
kapps_call:kvs_fetch('cf_capture_groups', Call)
```
