### PR TITLE
acdc: Track multiple outbounds (fixes a number of bugs regarding multiple calls)

### DIFF
--- a/applications/acdc/src/acdc.hrl
+++ b/applications/acdc/src/acdc.hrl
@@ -28,7 +28,7 @@
 
 -define(NEW_CHANNEL_REG(AcctId, User), {'p', 'l', {'new_channel', AcctId, User}}).
 -define(NEW_CHANNEL_FROM(CallId), {'call_from', CallId}).
--define(NEW_CHANNEL_TO(CallId), {'call_to', CallId}).
+-define(NEW_CHANNEL_TO(CallId, MemberCallId), {'call_to', CallId, MemberCallId}).
 
 -type abandon_reason() :: ?ABANDON_TIMEOUT | ?ABANDON_EXIT |
                           ?ABANDON_HANGUP.

--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -1266,13 +1266,13 @@ outbound({'channel_unbridged', _}, State) ->
 outbound(?NEW_CHANNEL_TO(CallId, _), #state{outbound_call_ids=[CallId]}=State) ->
     {'next_state', 'outbound', State};
 outbound(?NEW_CHANNEL_FROM(CallId), #state{agent_listener=AgentListener
-                                           ,outbound_call_ids=OutboundCallIds
+                                          ,outbound_call_ids=OutboundCallIds
                                           }=State) ->
     lager:debug("outbound call_from outbound: ~s", [CallId]),
     acdc_util:bind_to_call_events(CallId, AgentListener),
     {'next_state', 'outbound', State#state{outbound_call_ids=[CallId | lists:delete(CallId, OutboundCallIds)]}};
 outbound(?NEW_CHANNEL_TO(CallId, 'undefined'), #state{agent_listener=AgentListener
-                                                      ,outbound_call_ids=OutboundCallIds
+                                                     ,outbound_call_ids=OutboundCallIds
                                                      }=State) ->
     lager:debug("outbound call_to outbound: ~s", [CallId]),
     acdc_util:bind_to_call_events(CallId, AgentListener),

--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -117,7 +117,6 @@
                ,queue_notifications :: api_object()
 
                ,agent_call_id :: api_binary()
-               ,ambiguous_uuids = [] :: ne_binaries()
                ,next_status :: api_binary()
                ,fsm_call_id :: api_binary() % used when no call-ids are available
                ,endpoints = [] :: kz_json:objects()

--- a/applications/acdc/src/acdc_agent_handler.erl
+++ b/applications/acdc/src/acdc_agent_handler.erl
@@ -5,6 +5,7 @@
 %%% @end
 %%% @contributors
 %%%   James Aimonetti
+%%%   Daniel Finke
 %%%-------------------------------------------------------------------
 -module(acdc_agent_handler).
 
@@ -246,17 +247,22 @@ handle_new_channel(JObj, AccountId) ->
 -spec handle_new_channel_acct(kz_json:object(), api_binary()) -> 'ok'.
 handle_new_channel_acct(_, 'undefined') -> 'ok';
 handle_new_channel_acct(JObj, AccountId) ->
-    [FromUser, _FromHost] = binary:split(kz_json:get_value(<<"From">>, JObj), <<"@">>),
-    [ToUser, _ToHost] = binary:split(kz_json:get_value(<<"To">>, JObj), <<"@">>),
-    [ReqUser, _ReqHost] = binary:split(kz_json:get_value(<<"Request">>, JObj), <<"@">>),
+    FromUser = hd(binary:split(kz_json:get_value(<<"From">>, JObj), <<"@">>)),
+    ToUser = hd(binary:split(kz_json:get_value(<<"To">>, JObj), <<"@">>)),
+    ReqUser = hd(binary:split(kz_json:get_value(<<"Request">>, JObj), <<"@">>)),
 
     CallId = kz_json:get_value(<<"Call-ID">>, JObj),
+    MemberCallId = kz_json:get_value([<<"Custom-Channel-Vars">>, <<"Member-Call-ID">>], JObj),
 
     lager:debug("new channel in acct ~s: from ~s to ~s(~s)", [AccountId, FromUser, ToUser, ReqUser]),
 
-    gproc:send(?NEW_CHANNEL_REG(AccountId, FromUser), ?NEW_CHANNEL_FROM(CallId)),
-    gproc:send(?NEW_CHANNEL_REG(AccountId, ToUser), ?NEW_CHANNEL_TO(CallId)),
-    gproc:send(?NEW_CHANNEL_REG(AccountId, ReqUser), ?NEW_CHANNEL_TO(CallId)).
+    case kz_json:get_value(<<"Call-Direction">>, JObj) of
+        <<"inbound">> -> gproc:send(?NEW_CHANNEL_REG(AccountId, FromUser), ?NEW_CHANNEL_FROM(CallId));
+        <<"outbound">> ->
+            gproc:send(?NEW_CHANNEL_REG(AccountId, ToUser), ?NEW_CHANNEL_TO(CallId, MemberCallId)),
+            gproc:send(?NEW_CHANNEL_REG(AccountId, ReqUser), ?NEW_CHANNEL_TO(CallId, MemberCallId));
+        _ -> lager:debug("invalid call direction for call ~s", [CallId])
+    end.
 
 handle_originate_resp(JObj, Props) ->
     case kz_json:get_value(<<"Event-Name">>, JObj) of


### PR DESCRIPTION
Fixes agent falling out of state when answering non-queue calls while in ringing
Allows agent to move to outbound after answered if there happens to be another line up
Pre-requisite to upcoming fixes to transfers
Resolves problems that would occur when conferencing a queue caller with another endpoint
Fixes agent getting into unexpected state if originate_uuid shows up after originate_failed and the caller has picked up the call