### PR TITLE
Added support to callflow modules and pivot to utilize custom KVs

### DIFF
--- a/applications/callflow/src/cf_exe.erl
+++ b/applications/callflow/src/cf_exe.erl
@@ -650,7 +650,9 @@ launch_cf_module(#state{call=Call
                        ,cf_module_pid=OldPidRef
                        }=State) ->
     Module = <<"cf_", (kz_json:get_value(<<"module">>, Flow))/binary>>,
-    Data = kz_json:get_value(<<"data">>, Flow, kz_json:new()),
+    Data = apply_dynamic_values(kz_json:get_value(<<"variables">>, Flow, kz_json:new())
+                               ,kz_json:get_value(<<"data">>, Flow, kz_json:new())
+                               ,kapps_call:custom_kvs(Call)),
     {PidRef, Action} = maybe_start_cf_module(Module, Data, Call),
     link(get_pid(PidRef)),
     OldAction = kapps_call:kvs_fetch('cf_last_action', Call),
@@ -661,6 +663,42 @@ launch_cf_module(#state{call=Call
                ,cf_module_old_pid=OldPidRef
                ,call=kapps_call:exec(Routines, Call)
                }.
+
+-spec apply_dynamic_values(kz_json:object(), kz_json:object(), kz_json:object()) ->
+                                  kz_json:object().
+-spec apply_dynamic_values(kz_json:keys(), kz_json:object(), kz_json:object(), kz_json:object()) ->
+                                  kz_json:object().
+apply_dynamic_values(Variables, Data, KVs) ->
+    apply_dynamic_values(kz_json:get_keys(Variables), Variables, Data, KVs).
+
+apply_dynamic_values([], _, Data, _) -> Data;
+apply_dynamic_values([DataKey|Keys], Variables, Data, KVs) ->
+    case dynamic_value_variable_reference(DataKey, Data) of
+        'false' ->
+            lager:debug("dynamic value key '~s' not present in cf data, ignored", [DataKey]),
+            apply_dynamic_values(Keys, Variables, Data, KVs);
+        'true' ->
+            %% The KV that should replace the DataKey value in Data
+            VariableReference = kz_json:get_value(DataKey, Variables),
+            apply_dynamic_values(Keys
+                                ,Variables
+                                ,apply_dynamic_value(VariableReference, DataKey, Data, KVs)
+                                ,KVs)
+    end.
+
+-spec dynamic_value_variable_reference(kz_json:key(), kz_json:object()) -> boolean().
+dynamic_value_variable_reference(Key, Data) ->
+    kz_json:get_value(Key, Data) =/= 'undefined'.
+
+-spec apply_dynamic_value(kz_json:key(), kz_json:key(), kz_json:object(), kz_json:object()) ->
+                                 kz_json:object().
+apply_dynamic_value(VariableReference, DataKey, Data, KVs) ->
+    case kz_json:get_value(VariableReference, KVs) of
+        'undefined' ->
+            lager:debug("KV lookup key '~s' not set in KVs", [VariableReference]),
+            Data;
+        Value -> kz_json:set_value(DataKey, Value, Data)
+    end.
 
 -spec maybe_start_cf_module(ne_binary(), kz_proplist(), kapps_call:call()) ->
                                    {{pid(), reference()} | 'undefined', atom()}.

--- a/applications/callflow/src/module/cf_kvs_set.erl
+++ b/applications/callflow/src/module/cf_kvs_set.erl
@@ -1,0 +1,20 @@
+%%%-------------------------------------------------------------------
+
+%%%-------------------------------------------------------------------
+-module(cf_kvs_set).
+
+-export([handle/2]).
+
+-include("../callflow.hrl").
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
+handle(Data, Call) ->
+    Call1 = kapps_call:set_custom_kvs(Data, Call),
+    cf_exe:set_call(Call1),
+    cf_exe:continue(Call1).
+

--- a/applications/crossbar/doc/ref/callflows.md
+++ b/applications/crossbar/doc/ref/callflows.md
@@ -13,6 +13,7 @@ Key | Description | Type | Default | Required
 `flow.children` | Children callflows | `object` | `{}` | `false`
 `flow.data` | The data/arguments of the callflow module | `object` | `{}` | `true`
 `flow.module` | The name of the callflow module to excute at this node | `string(1..64)` |   | `true`
+`flow.variables` | A map of data object keys to custom KV keys whose values should replace the values in the data object | `object` |   | `false`
 `metaflow` | Actions applied to a call outside of the normal callflow, initiated by the caller(s) | `#/definitions/metaflows` |   | `false`
 `numbers` | A list of static numbers that the callflow should execute for | `array(string(1..36))` | `[]` | `false`
 `numbers.[]` |   | `string` |   | `false`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1307,6 +1307,12 @@
             "required": true,
             "type": "object"
         },
+        "callflows.kvs_set": {
+            "description": "Validator for the kvs_set callflow's data object",
+            "properties": {},
+            "required": true,
+            "type": "object"
+        },
         "callflows.language": {
             "description": "Validator for the Language callflow element",
             "properties": {

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -660,6 +660,11 @@
                             "minLength": 1,
                             "required": true,
                             "type": "string"
+                        },
+                        "variables": {
+                            "description": "A map of data object keys to custom KV keys whose values should replace the values in the data object",
+                            "required": false,
+                            "type": "object"
                         }
                     },
                     "required": true,

--- a/applications/crossbar/priv/couchdb/schemas/callflows.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.json
@@ -43,6 +43,11 @@
                     "minLength": 1,
                     "required": true,
                     "type": "string"
+                },
+                "variables": {
+                    "description": "A map of data object keys to custom KV keys whose values should replace the values in the data object",
+                    "required": false,
+                    "type": "object"
                 }
             },
             "required": true,

--- a/applications/crossbar/priv/couchdb/schemas/callflows.kvs_set.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.kvs_set.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "_id": "callflows.kvs_set",
+    "description": "Validator for the kvs_set callflow's data object",
+    "properties": {},
+    "required": true,
+    "type": "object"
+}

--- a/applications/pivot/src/pivot_call.erl
+++ b/applications/pivot/src/pivot_call.erl
@@ -141,7 +141,7 @@ init([Call, JObj]) ->
     VoiceUri = kz_json:get_value(<<"Voice-URI">>, JObj),
 
     ReqFormat = kz_json:get_value(<<"Request-Format">>, JObj, <<"twiml">>),
-    BaseParams = kz_json:from_list(req_params(ReqFormat, Call)),
+    BaseParams = kz_json:recursive_from_list(req_params(ReqFormat, Call)),
 
     lager:debug("starting pivot req to ~s to ~s", [Method, VoiceUri]),
 

--- a/core/kazoo_call/src/kapps_call.erl
+++ b/core/kazoo_call/src/kapps_call.erl
@@ -113,6 +113,10 @@
         ,kvs_update_counter/3
         ]).
 
+-export([custom_kv/2, custom_kvs/1
+        ,set_custom_kvs/2
+        ]).
+
 -export([flush/0
         ,cache/1, cache/2, cache/3
         ,retrieve/1, retrieve/2
@@ -1112,6 +1116,100 @@ kvs_update(Key, Fun, Initial, #kapps_call{kvs=Dict}=Call) ->
 -spec kvs_update_counter(any(), number(), call()) -> call().
 kvs_update_counter(Key, Number, #kapps_call{kvs=Dict}=Call) ->
     Call#kapps_call{kvs=orddict:update_counter(kz_util:to_binary(Key), Number, Dict)}.
+
+-define(CUSTOM_KVS_COLLECTION, <<"Custom-KVs">>).
+
+-spec custom_kv(kz_json:key(), call()) -> kz_json:json_term() | 'undefined'.
+custom_kv(Key, Call) ->
+    Collection = custom_kvs(Call),
+    kz_json:get_value(Key, Collection, Call).
+
+-spec custom_kvs(call()) -> kz_json:object().
+custom_kvs(Call) ->
+    kvs_fetch(?CUSTOM_KVS_COLLECTION, kz_json:new(), Call).
+
+-spec set_custom_kvs(kz_json:object(), call()) -> call().
+set_custom_kvs(JObj, Call) ->
+    set_custom_kvs_fold(kz_json:get_keys(JObj), JObj, Call).
+
+-spec set_custom_kvs_fold(kz_json:keys(), kz_json:object(), call()) -> call().
+set_custom_kvs_fold([], _JObj, Call) -> Call;
+set_custom_kvs_fold([Key|Keys], JObj, Call) ->
+    case custom_kv_evaluate(kz_json:get_value(Key, JObj), Call) of
+        {'error', {EKey, EMsg}} ->
+            lager:error("custom kv evaluate error in key '~s': ~s", [EKey, EMsg]),
+            set_custom_kvs_fold(Keys, JObj, Call);
+        Value ->
+            Call1 = set_custom_kvs_collection(Key, Value, Call),
+            set_custom_kvs_fold(Keys, JObj, Call1)
+    end.
+
+-spec set_custom_kvs_collection(kz_json:key(), kz_json:json_term(), call()) ->
+                                       call().
+set_custom_kvs_collection(Key, Value, Call) ->
+    OldCollection = kvs_fetch(?CUSTOM_KVS_COLLECTION, kz_json:new(), Call),
+    NewCollection = kz_json:set_value(Key, Value, OldCollection),
+    kvs_store(?CUSTOM_KVS_COLLECTION, NewCollection, Call).
+
+-spec custom_kv_evaluate(kz_json:json_term(), call()) ->
+                                kz_json:json_term() |
+                                {'error', {ne_binary(), ne_binary()}}.
+custom_kv_evaluate(MaybeKey, Call) ->
+    case is_custom_kv_digits_key(MaybeKey) of
+        {'error', _}=E -> E;
+        'false' -> custom_kv_evaluate2(MaybeKey, Call);
+        CollectionName ->
+            case get_dtmf_collection(CollectionName, Call) of
+                'undefined' -> <<>>;
+                DTMF -> DTMF
+            end
+    end.
+
+%% Allow a variable to be assigned the current value of another variable
+-spec custom_kv_evaluate2(kz_json:json_term(), call()) -> kz_json:json_term().
+custom_kv_evaluate2(<<"$", Key/binary>>, Call) ->
+    custom_kv(Key, Call);
+custom_kv_evaluate2(Value, Call) ->
+    custom_kv_evaluate_ui(Value, Call).
+
+-spec custom_kv_evaluate_ui(kz_json:json_term(), call()) ->
+                                   kz_json:json_term().
+-spec custom_kv_evaluate_ui(kz_json:keys(), kz_json:object(), call()) ->
+                                   kz_json:json_term().
+custom_kv_evaluate_ui(Value, Call) ->
+    case kz_json:is_json_object(Value) of
+        'true' -> custom_kv_evaluate_ui(kz_json:get_keys(Value), Value, Call);
+        'false' -> Value
+    end.
+
+%% When assigning a custom KV in Kazoo-UI, a type field is used to create a
+%% dropdown. In this case, use the value field
+custom_kv_evaluate_ui([<<"type">>, <<"value">>], Value, Call) ->
+    KeyToCheck = kz_json:get_value(<<"value">>, Value),
+    kz_json:set_value(<<"value">>, custom_kv_evaluate(KeyToCheck, Call), Value);
+custom_kv_evaluate_ui(_, Value, _) ->
+    Value.
+
+%% Allow a variable to be assigned the value of a DTMF collection
+-spec is_custom_kv_digits_key(kz_json:json_term()) ->
+                                     ne_binary() | 'false' |
+                                     {'error', {ne_binary(), ne_binary()}}.
+is_custom_kv_digits_key(<<"$_digits">>) ->
+    <<"default">>;
+is_custom_kv_digits_key(<<"$_digits[", CollectionName/binary>> = Key)
+                               when byte_size(CollectionName) > 0 ->
+    case binary:part(CollectionName, byte_size(CollectionName), -1) of
+        <<"]">> -> binary:part(CollectionName, 0, byte_size(CollectionName) - 1);
+        _ -> custom_kv_digits_key_eval_error(Key)
+    end;
+is_custom_kv_digits_key(<<"$_digits[">> = Key) ->
+    custom_kv_digits_key_eval_error(Key);
+is_custom_kv_digits_key(_) -> 'false'.
+
+-spec custom_kv_digits_key_eval_error(ne_binary()) ->
+                                             {'error', {ne_binary(), ne_binary()}}.
+custom_kv_digits_key_eval_error(Key) ->
+    {'error', {Key, <<"invalid format for digits lookup key">>}}.
 
 -spec set_dtmf_collection(api_binary(), call()) -> call().
 -spec set_dtmf_collection(api_binary(), ne_binary(), call()) -> call().

--- a/core/kazoo_json/src/kz_json.erl
+++ b/core/kazoo_json/src/kz_json.erl
@@ -244,7 +244,6 @@ from_list(L) when is_list(L) -> ?JSON_WRAPPER(L).
 -spec recursive_from_list(json_proplist() | json_array()) -> object() | json_array().
 -spec recursive_from_list(json_proplist() | json_array(), json_proplist()) ->
                                  json_proplist() | json_array().
-recursive_from_list([]) -> from_list([]);
 recursive_from_list(L) when is_list(L) ->
     %% If no keys are defined, it is a JSON array
     case props:get_keys(L) of
@@ -255,6 +254,8 @@ recursive_from_list(L) when is_list(L) ->
 recursive_from_list([], Acc) -> lists:reverse(Acc);
 recursive_from_list([{K,V}|T], Acc) when is_list(V) ->
     recursive_from_list(T, [{K, recursive_from_list(V)} | Acc]);
+recursive_from_list([V|T], Acc) when is_list(V) ->
+    recursive_from_list(T, [recursive_from_list(V) | Acc]);
 recursive_from_list([H|T], Acc) ->
     recursive_from_list(T, [H | Acc]).
 

--- a/core/kazoo_json/src/kz_json.erl
+++ b/core/kazoo_json/src/kz_json.erl
@@ -71,6 +71,7 @@
         ]).
 
 -export([from_list/1, merge_jobjs/2]).
+-export([recursive_from_list/1]).
 
 -export([load_fixture_from_file/2, load_fixture_from_file/3]).
 
@@ -239,6 +240,23 @@ are_identical(JObj1, JObj2) ->
 -spec from_list(json_proplist()) -> object().
 from_list([]) -> new();
 from_list(L) when is_list(L) -> ?JSON_WRAPPER(L).
+
+-spec recursive_from_list(json_proplist() | json_array()) -> object() | json_array().
+-spec recursive_from_list(json_proplist() | json_array(), json_proplist()) ->
+                                 json_proplist() | json_array().
+recursive_from_list([]) -> from_list([]);
+recursive_from_list(L) when is_list(L) ->
+    %% If no keys are defined, it is a JSON array
+    case props:get_keys(L) of
+        [] -> recursive_from_list(L, []);
+        _ -> ?JSON_WRAPPER(recursive_from_list(L, []))
+    end.
+
+recursive_from_list([], Acc) -> lists:reverse(Acc);
+recursive_from_list([{K,V}|T], Acc) when is_list(V) ->
+    recursive_from_list(T, [{K, recursive_from_list(V)} | Acc]);
+recursive_from_list([H|T], Acc) ->
+    recursive_from_list(T, [H | Acc]).
 
 %% only a top-level merge
 %% merges JObj1 into JObj2

--- a/core/kazoo_json/test/kz_json_test.erl
+++ b/core/kazoo_json/test/kz_json_test.erl
@@ -271,6 +271,15 @@ recursive_to_proplist_test_() ->
     ,?_assertEqual(?P13, kz_json:recursive_to_proplist(?D7))
     ].
 
+recursive_from_list_test_() ->
+    [?_assertEqual(?D1, kz_json:recursive_from_list(?P8))
+    ,?_assertEqual(?D2, kz_json:recursive_from_list(?P9))
+    ,?_assertEqual(?D3, kz_json:recursive_from_list(?P10))
+    ,?_assertEqual(?D4, kz_json:recursive_from_list(?P11))
+    ,?_assertEqual(?D6, kz_json:recursive_from_list(?P12))
+    ,?_assertEqual(?D7, kz_json:recursive_from_list(?P13))
+    ].
+
 delete_key_test_() ->
     [?_assertEqual(?EMPTY_JSON_OBJECT, kz_json:delete_key(<<"foo">>, ?EMPTY_JSON_OBJECT))
     ,?_assertEqual(?EMPTY_JSON_OBJECT, kz_json:delete_key(<<"foo">>, ?EMPTY_JSON_OBJECT, 'prune'))

--- a/core/kazoo_translator/src/convertors/kzt_kazoo.erl
+++ b/core/kazoo_translator/src/convertors/kzt_kazoo.erl
@@ -91,5 +91,5 @@ req_params(Call) ->
       ,{<<"Transcription-Text">>, kzt_util:get_transcription_text(Call)}
       ,{<<"Transcription-Status">>, kzt_util:get_transcription_status(Call)}
       ,{<<"Transcription-Url">>, kzt_util:get_transcription_url(Call)}
-      | kz_json:recursive_to_proplist(kapps_call:custom_kvs(Call))
+       | kz_json:recursive_to_proplist(kapps_call:custom_kvs(Call))
       ]).

--- a/core/kazoo_translator/src/convertors/kzt_kazoo.erl
+++ b/core/kazoo_translator/src/convertors/kzt_kazoo.erl
@@ -91,4 +91,5 @@ req_params(Call) ->
       ,{<<"Transcription-Text">>, kzt_util:get_transcription_text(Call)}
       ,{<<"Transcription-Status">>, kzt_util:get_transcription_status(Call)}
       ,{<<"Transcription-Url">>, kzt_util:get_transcription_url(Call)}
+      | kz_json:recursive_to_proplist(kapps_call:custom_kvs(Call))
       ]).


### PR DESCRIPTION
Long lost follow up to both #1328 and #1255.

Addressed concerns about cross-app dependencies by moving custom-KV-related code into kapps_call.
Moved to a generic variable replacer in cf_exe.
Schema doc is empty template since variables (the properties of module's data) are freeform.
