### PR TITLE
Default timezone for new accounts to the parent account's timezone

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -804,10 +804,8 @@ get_timezone(JObj, Call) ->
 -spec account_timezone(kapps_call:call()) -> ne_binary().
 account_timezone(Call) ->
     case kz_account:fetch(kapps_call:account_id(Call)) of
-        {'ok', AccountJObj} ->
-            kz_account:timezone(AccountJObj, ?DEFAULT_TIMEZONE);
-        {'error', _E} ->
-            kapps_config:get(<<"accounts">>, <<"timezone">>, ?DEFAULT_TIMEZONE)
+        {'ok', AccountJObj} -> kz_account:timezone(AccountJObj);
+        {'error', _E} -> ?DEFAULT_TIMEZONE
     end.
 
 -spec start_task(fun(), list(), kapps_call:call()) -> 'ok'.

--- a/applications/crossbar/doc/ref/accounts.md
+++ b/applications/crossbar/doc/ref/accounts.md
@@ -25,7 +25,7 @@ Key | Description | Type | Default | Required
 `ringtones` | Ringtone Parameters | `object` | `{}` | `false`
 `ringtones.external` | The alert info SIP header added when the call is from internal sources | `string(0..256)` |   | `false`
 `ringtones.internal` | The alert info SIP header added when the call is from external sources | `string(0..256)` |   | `false`
-`timezone` | The default timezone | `string(5..32)` | `America/Los_Angeles` | `false`
+`timezone` | The default timezone | `string(5..32)` |   | `false`
 `voicemail` |   | `object` |   | `false`
 `voicemail.notify` |   | `object` |   | `false`
 `voicemail.notify.callback` |   | `#/definitions/notify.callback` |   | `false`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -170,7 +170,6 @@
                     "type": "object"
                 },
                 "timezone": {
-                    "default": "America/Los_Angeles",
                     "description": "The default timezone",
                     "maxLength": 32,
                     "minLength": 5,
@@ -7080,11 +7079,6 @@
                 },
                 "master_account_id": {
                     "description": "accounts master account id"
-                },
-                "timezone": {
-                    "default": "America/Los_Angeles",
-                    "description": "accounts timezone",
-                    "type": "string"
                 }
             },
             "required": [

--- a/applications/crossbar/priv/couchdb/schemas/accounts.json
+++ b/applications/crossbar/priv/couchdb/schemas/accounts.json
@@ -118,7 +118,6 @@
             "type": "object"
         },
         "timezone": {
-            "default": "America/Los_Angeles",
             "description": "The default timezone",
             "maxLength": 32,
             "minLength": 5,

--- a/applications/crossbar/priv/couchdb/schemas/system_config.accounts.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.accounts.json
@@ -15,11 +15,6 @@
         },
         "master_account_id": {
             "description": "accounts master account id"
-        },
-        "timezone": {
-            "default": "America/Los_Angeles",
-            "description": "accounts timezone",
-            "type": "string"
         }
     },
     "required": [

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -197,7 +197,8 @@ refresh(?KZ_CONFIG_DB) ->
     kz_datamgr:revise_doc_from_file(?KZ_CONFIG_DB, 'teletype', <<"views/notifications.json">>),
     kz_datamgr:revise_doc_from_file(?KZ_CONFIG_DB, 'crossbar', <<"views/system_configs.json">>),
     cleanup_invalid_notify_docs(),
-    delete_system_media_references();
+    delete_system_media_references(),
+    accounts_config_deprecate_timezone_for_default_timezone();
 refresh(?KZ_DATA_DB) ->
     kz_datamgr:revise_docs_from_folder(?KZ_DATA_DB, 'kazoo_data', <<"views">>);
 refresh(?KZ_OAUTH_DB) ->
@@ -336,6 +337,56 @@ refresh_numbers_db(<<?KNM_DB_PREFIX, Suffix/binary>>) ->
                                               ,<<"views/numbers.json">>
                                               ),
     'ok'.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Remove system_config/accounts timezone key and use only
+%% default_timezone
+%% @end
+%%--------------------------------------------------------------------
+-spec accounts_config_deprecate_timezone_for_default_timezone() -> 'ok'.
+accounts_config_deprecate_timezone_for_default_timezone() ->
+    case kz_datamgr:open_cache_doc(?KZ_CONFIG_DB, <<"accounts">>) of
+        {'ok', Doc} ->
+            PublicFields = kz_doc:public_fields(Doc),
+            Keys = kz_json:get_keys(PublicFields),
+            %% No update if no keys
+            case Keys =:= [] of
+                'true' -> 'ok';
+                'false' ->
+                    %% Remove timezone key
+                    Doc1 = deprecate_timezone_for_default_timezone(
+                             kz_json:get_keys(PublicFields)
+                             ,PublicFields),
+                    %% Overwrite doc with new keys
+                    kz_datamgr:save_doc(?KZ_CONFIG_DB
+                      ,kz_json:set_values(kz_json:to_proplist(Doc1)
+                                          ,Doc))
+            end;
+        {'error', E} ->
+            lager:warning("unable to fetch system_config/accounts: ~p", [E])
+    end.
+
+-spec deprecate_timezone_for_default_timezone(kz_json:keys(), kz_json:object()) -> 'ok'.
+deprecate_timezone_for_default_timezone([], Doc) -> Doc;
+deprecate_timezone_for_default_timezone([Node|Nodes], Doc) ->
+    case kz_json:is_json_object(Node, Doc) of
+        'true' ->
+            Timezone = kz_json:get_value([Node, <<"timezone">>], Doc),
+            DefaultTimezone = kz_json:get_value([Node, <<"default_timezone">>], Doc),
+            %% If timezone has been set, but not default_timezone, use the former's value
+            Doc1 = case Timezone =/= 'undefined'
+                       andalso DefaultTimezone =:= 'undefined'
+                   of
+                       'true' -> kz_json:set_value(<<"default_timezone">>, Timezone, Doc);
+                       'false' -> Doc
+                   end,
+            deprecate_timezone_for_default_timezone(Nodes
+              ,kz_json:delete_key([Node, <<"timezone">>], Doc1));
+        'false' ->
+            deprecate_timezone_for_default_timezone(Nodes, Doc)
+    end.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -356,13 +356,12 @@ accounts_config_deprecate_timezone_for_default_timezone() ->
                 'true' -> 'ok';
                 'false' ->
                     %% Remove timezone key
-                    Doc1 = deprecate_timezone_for_default_timezone(
-                             kz_json:get_keys(PublicFields)
-                             ,PublicFields),
+                    Doc1 = deprecate_timezone_for_default_timezone(kz_json:get_keys(PublicFields)
+                                                                  ,PublicFields
+                                                                  ),
                     %% Overwrite doc with new keys
                     kz_datamgr:save_doc(?KZ_CONFIG_DB
-                      ,kz_json:set_values(kz_json:to_proplist(Doc1)
-                                          ,Doc))
+                                       ,kz_json:set_values(kz_json:to_proplist(Doc1), Doc))
             end;
         {'error', E} ->
             lager:warning("unable to fetch system_config/accounts: ~p", [E])
@@ -383,7 +382,7 @@ deprecate_timezone_for_default_timezone([Node|Nodes], Doc) ->
                        'false' -> Doc
                    end,
             deprecate_timezone_for_default_timezone(Nodes
-              ,kz_json:delete_key([Node, <<"timezone">>], Doc1));
+                                                   ,kz_json:delete_key([Node, <<"timezone">>], Doc1));
         'false' ->
             deprecate_timezone_for_default_timezone(Nodes, Doc)
     end.


### PR DESCRIPTION
also deprecate system_config/accounts/timezone and use default_timezone instead

The value in timezone will be copied to default_timezone if the latter is undefined.
The core of this change is to make new accounts default to the timezone of the parent account. Removed the default value from the accounts.json schema as it would be merged in prior to the parent timezone check (note that timezone can still be included in the JSON of a new account). As well, we ensure that the timezones fetched by cf_util match. For accounts whose timezone key is blank, kz_account:timezone/1 will deal with fetching the parent or eventually failing back to the system default or even "Los_Angeles". Hence the removal of kz_account:timezone/2 on applications/callflow/src/cf_util.erl#L808 - kz_account:timezone/2 would use the second argument instead of trying the parent first.