### PR TITLE
Add call to Module:TaskName/3 when reache end of CSV file.

### DIFF
--- a/core/kazoo_tasks/src/kz_csv.erl
+++ b/core/kazoo_tasks/src/kz_csv.erl
@@ -146,7 +146,8 @@ associator(CSVHeader, OrderedFields, Verifier) ->
             [{find_position(Header, OrderedFields, 1), I}
              || {I,Header} <- lists:zip(lists:seq(1, length(CSVHeader)), CSVHeader)
             ]),
-    fun (Row0) ->
+    fun ('eof') -> {'true', ['eof']};
+        (Row0) ->
             Row = pad_row_to(Max, Row0),
             ReOrdered =
                 [ begin
@@ -170,7 +171,8 @@ associator(CSVHeader, OrderedFields, Verifier) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec row_to_iolist(row()) -> iodata().
+-spec row_to_iolist(row() | 'eof') -> iodata().
+row_to_iolist('eof') -> <<>>;
 row_to_iolist([Cell]) -> cell_to_binary(Cell);
 row_to_iolist(Row=[_|_]) ->
     kz_util:iolist_join($,, [cell_to_binary(Cell) || Cell <- Row]).


### PR DESCRIPTION
When CSV file is over `kz_task_worker:loop/2` will try call `Module:TaskName/3` with args (kz_proplist(), task_iterator(), 'eof'). Return values from this call is ignored, after that `teardown/3` is called.

With this you can process lines in "bulk" mode.
Example: you get rows from CSV file and store them in `task_iterator()` on each 1000th row you insert accumulated rows in DB with one request. When you get call `Module:TaskName/3` with 'eof' you can insert rest of accumulated rows.

Also little rewrite actions on return values. Now you can return 'ok', {'ok', ItertorData} when prcessing input data from CSV (kz_task_worker).
Fixed datd which go into task_iterator() in `kz_task_noinput_worker`