### PR TITLE
Part 1/2 of KAZOO-5093: store enough information in number doc

### DIFF
--- a/core/kazoo_number_manager/doc/carriers.md
+++ b/core/kazoo_number_manager/doc/carriers.md
@@ -50,7 +50,7 @@ Returns a boolean for whether this carrier's numbers should be queried for CNAM.
 
 ### `is_number_billable/1`
 
-The argument is the `#knm_number{}` record.
+The argument is the `#knm_phone_number{}` record.
 
 The result is a boolean, representing whether the number should be billed.
 

--- a/core/kazoo_number_manager/include/knm_phone_number.hrl
+++ b/core/kazoo_number_manager/include/knm_phone_number.hrl
@@ -27,6 +27,7 @@
 -define(PVT_DB_NAME, <<"pvt_db_name">>).
 -define(PVT_FEATURES, <<"pvt_features">>).
 -define(PVT_FEATURES_AVAILABLE, <<"pvt_features_available">>).
+-define(PVT_IS_BILLABLE, <<"pvt_is_billable">>).
 -define(PVT_MODIFIED, <<"pvt_modified">>).
 -define(PVT_MODULE_NAME, <<"pvt_module_name">>).
 -define(PVT_PORTED_IN, <<"pvt_ported_in">>).

--- a/core/kazoo_number_manager/src/carriers/knm_bandwidth.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_bandwidth.erl
@@ -183,8 +183,7 @@ acquire_and_provision_number(Number) ->
 %% Release a number from the routing table
 %% @end
 %%--------------------------------------------------------------------
--spec disconnect_number(knm_number:knm_number()) ->
-                               knm_number:knm_number().
+-spec disconnect_number(knm_number:knm_number()) -> knm_number:knm_number().
 disconnect_number(Number) -> Number.
 
 %%--------------------------------------------------------------------
@@ -192,7 +191,7 @@ disconnect_number(Number) -> Number.
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(knm_number:knm_number()) -> 'true'.
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'true'.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
@@ -81,7 +81,7 @@
 is_local() -> 'false'.
 
 %% @public
--spec is_number_billable(knm_number:knm_number()) -> 'true'.
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'true'.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -26,6 +26,8 @@
         ,blocks/1
         ,account_id/1
         ,reseller_id/1
+
+        ,is_number_billable/1
         ]).
 
 %%% For knm carriers only
@@ -403,6 +405,19 @@ account_id(Options) ->
 -spec reseller_id(options()) -> ne_binary().
 reseller_id(Options) ->
     props:get_value('reseller_id', Options).
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Returns whether carrier handles numbers local to the system.
+%% @end
+%%--------------------------------------------------------------------
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
+is_number_billable(PhoneNumber) ->
+    Carrier = knm_phone_number:module_name(PhoneNumber),
+    Module = erlang:binary_to_existing_atom(Carrier, 'utf8'),
+    Module:is_number_billable(PhoneNumber).
 
 
 %%%===================================================================

--- a/core/kazoo_number_manager/src/carriers/knm_inum.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_inum.erl
@@ -109,7 +109,7 @@ format_number_resp(AccountId, JObj) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(knm_number:knm_number()) -> boolean().
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'false'.
 
 %%--------------------------------------------------------------------
@@ -118,8 +118,7 @@ is_number_billable(_Number) -> 'false'.
 %% Acquire a given number from the carrier
 %% @end
 %%--------------------------------------------------------------------
--spec acquire_number(knm_number:knm_number()) ->
-                            knm_number:knm_number().
+-spec acquire_number(knm_number:knm_number()) -> knm_number:knm_number().
 acquire_number(Number) ->
     PhoneNumber = knm_number:phone_number(Number),
     lager:debug("acquiring number ~s", [knm_phone_number:number(PhoneNumber)]),

--- a/core/kazoo_number_manager/src/carriers/knm_local.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_local.erl
@@ -103,7 +103,7 @@ format_numbers(JObjs) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(knm_number:knm_number()) -> 'false'.
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'false'.
 
 %%--------------------------------------------------------------------
@@ -112,8 +112,7 @@ is_number_billable(_Number) -> 'false'.
 %% Acquire a given number from the carrier
 %% @end
 %%--------------------------------------------------------------------
--spec acquire_number(knm_number:knm_number()) ->
-                            knm_number:knm_number().
+-spec acquire_number(knm_number:knm_number()) -> knm_number:knm_number().
 acquire_number(Number) -> Number.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/carriers/knm_managed.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_managed.erl
@@ -108,7 +108,7 @@ format_number_resp(AccountId, JObj) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(knm_number:knm_number()) -> boolean().
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'false'.
 
 %%--------------------------------------------------------------------
@@ -117,8 +117,7 @@ is_number_billable(_Number) -> 'false'.
 %% Acquire a given number from the carrier
 %% @end
 %%--------------------------------------------------------------------
--spec acquire_number(knm_number:knm_number()) ->
-                            knm_number:knm_number().
+-spec acquire_number(knm_number:knm_number()) -> knm_number:knm_number().
 acquire_number(Number) ->
     PhoneNumber = knm_number:phone_number(Number),
     AssignTo = knm_phone_number:assigned_to(PhoneNumber),

--- a/core/kazoo_number_manager/src/carriers/knm_mdn.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_mdn.erl
@@ -49,7 +49,7 @@ find_numbers(_Prefix, _Quantity, _Options) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(knm_number:knm_number()) -> 'false'.
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'false'.
 
 %%--------------------------------------------------------------------
@@ -58,8 +58,7 @@ is_number_billable(_Number) -> 'false'.
 %% Acquire a given number from the carrier
 %% @end
 %%--------------------------------------------------------------------
--spec acquire_number(knm_number:knm_number()) ->
-                            knm_number:knm_number().
+-spec acquire_number(knm_number:knm_number()) -> knm_number:knm_number().
 acquire_number(Number) -> Number.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/carriers/knm_other.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_other.erl
@@ -109,7 +109,7 @@ check_numbers(Numbers, _Options) ->
 %% in a rate center
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(knm_number:knm_number()) -> 'true'.
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -118,8 +118,7 @@ is_number_billable(_Number) -> 'true'.
 %% Acquire a given number from the carrier
 %% @end
 %%--------------------------------------------------------------------
--spec acquire_number(knm_number:knm_number()) ->
-                            knm_number:knm_number().
+-spec acquire_number(knm_number:knm_number()) -> knm_number:knm_number().
 acquire_number(Number) ->
     Num = knm_phone_number:number(knm_number:phone_number(Number)),
     DefaultCountry = kapps_config:get(?KNM_OTHER_CONFIG_CAT, <<"default_country">>, ?KNM_DEFAULT_COUNTRY),

--- a/core/kazoo_number_manager/src/carriers/knm_reserved.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_reserved.erl
@@ -97,7 +97,7 @@ format_numbers(AuthBy, JObjs) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(knm_number:knm_number()) -> 'false'.
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'false'.
 
 %%--------------------------------------------------------------------
@@ -106,8 +106,7 @@ is_number_billable(_Number) -> 'false'.
 %% Acquire a given number from the carrier
 %% @end
 %%--------------------------------------------------------------------
--spec acquire_number(knm_number:knm_number()) ->
-                            knm_number:knm_number().
+-spec acquire_number(knm_number:knm_number()) -> knm_number:knm_number().
 acquire_number(Number) -> Number.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/carriers/knm_reserved_reseller.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_reserved_reseller.erl
@@ -97,7 +97,7 @@ format_numbers(AuthBy, JObjs) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(knm_number:knm_number()) -> 'false'.
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'false'.
 
 %%--------------------------------------------------------------------
@@ -106,8 +106,7 @@ is_number_billable(_Number) -> 'false'.
 %% Acquire a given number from the carrier
 %% @end
 %%--------------------------------------------------------------------
--spec acquire_number(knm_number:knm_number()) ->
-                            knm_number:knm_number().
+-spec acquire_number(knm_number:knm_number()) -> knm_number:knm_number().
 acquire_number(Number) -> Number.
 
 %%--------------------------------------------------------------------
@@ -117,8 +116,7 @@ acquire_number(Number) -> Number.
 %% @end
 %%--------------------------------------------------------------------
 
--spec disconnect_number(knm_number:knm_number()) ->
-                               knm_number:knm_number().
+-spec disconnect_number(knm_number:knm_number()) -> knm_number:knm_number().
 disconnect_number(Number) -> Number.
 
 %%--------------------------------------------------------------------
@@ -126,5 +124,5 @@ disconnect_number(Number) -> Number.
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec should_lookup_cnam() -> 'true'.
+-spec should_lookup_cnam() -> boolean().
 should_lookup_cnam() -> 'true'.

--- a/core/kazoo_number_manager/src/carriers/knm_simwood.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_simwood.erl
@@ -98,7 +98,7 @@ disconnect_number(Number) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(knm_number:knm_number()) -> 'true'.
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'true'.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -91,7 +91,7 @@ disconnect_number(Number) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec should_lookup_cnam() -> 'false'.
+-spec should_lookup_cnam() -> boolean().
 should_lookup_cnam() -> 'false'.
 
 %%--------------------------------------------------------------------
@@ -100,7 +100,7 @@ should_lookup_cnam() -> 'false'.
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec is_number_billable(_) -> 'true'.
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_) -> 'true'.
 
 %%%===================================================================

--- a/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
@@ -74,7 +74,7 @@
 is_local() -> 'false'.
 
 %% @public
--spec is_number_billable(knm_number:knm_number()) -> boolean().
+-spec is_number_billable(knm_phone_number:knm_phone_number()) -> boolean().
 is_number_billable(_Number) -> 'true'.
 
 

--- a/core/kazoo_number_manager/src/converters/knm_converters.erl
+++ b/core/kazoo_number_manager/src/converters/knm_converters.erl
@@ -26,76 +26,66 @@
 
 -ifdef(TEST).
 -define(DEFAULT_CONVERTER, ?DEFAULT_CONVERTER_B).
-
 -define(RECONCILE_REGEX, ?DEFAULT_RECONCILE_REGEX).
-
 -else.
--define(DEFAULT_CONVERTER, kapps_config:get(?KNM_CONFIG_CAT, <<"converter">>, ?DEFAULT_CONVERTER_B)).
-
+-define(DEFAULT_CONVERTER,
+        kapps_config:get(?KNM_CONFIG_CAT, <<"converter">>, ?DEFAULT_CONVERTER_B)).
 -define(RECONCILE_REGEX,
         kapps_config:get_binary(?KNM_CONFIG_CAT, ?KEY_RECONCILE_REGEX, ?DEFAULT_RECONCILE_REGEX)).
-
 -endif.
 
 -define(CONVERTER_MOD, kz_util:to_atom(<<"knm_converter_", (?DEFAULT_CONVERTER)/binary>>, 'true')).
 
--define(DEFAULT_RECONCILE_REGEX, <<"^\\+?1?\\d{10}$|^\\+[2-9]\\d{7,}$|^011\\d*$|^00\\d*$">>).
+-define(DEFAULT_RECONCILE_REGEX, <<"^\\+?1?\\d{10}$|^\\+[2-9]\\d{7,}$|^011\\d*$|^00\\d*\$">>).
 -define(KEY_RECONCILE_REGEX, <<"reconcile_regex">>).
 
--define(CLASSIFIER_TOLLFREE_US
-       ,kz_json:from_list([{<<"regex">>, <<"^\\+1((?:800|888|877|866|855)\\d{7})$">>}
-                            ,{<<"friendly_name">>, <<"US TollFree">>}
-                                           ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
-                                           ])
-       ).
+-define(CLASSIFIER_TOLLFREE_US,
+        kz_json:from_list([{<<"regex">>, <<"^\\+1((?:800|888|877|866|855)\\d{7})\$">>}
+                          ,{<<"friendly_name">>, <<"US TollFree">>}
+                          ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
+                          ])).
 
--define(CLASSIFIER_TOLLFREE
-        ,kz_json:from_list([{<<"regex">>, <<"^\\+1(900\\d{7})$">>}
-                            ,{<<"friendly_name">>, <<"US Toll">>}
-                            ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
-                           ])
-       ).
+-define(CLASSIFIER_TOLLFREE,
+        kz_json:from_list([{<<"regex">>, <<"^\\+1(900\\d{7})\$">>}
+                          ,{<<"friendly_name">>, <<"US Toll">>}
+                          ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
+                          ])).
 
--define(CLASSIFIER_EMERGENCY
-        ,kz_json:from_list([{<<"regex">>, <<"^(911)$">>}
-                            ,{<<"emergency">>, 'true'}
-                            ,{<<"friendly_name">>, <<"Emergency Dispatcher">>}
-                           ])
-       ).
+-define(CLASSIFIER_EMERGENCY,
+        kz_json:from_list([{<<"regex">>, <<"^(911)\$">>}
+                          ,{<<"emergency">>, 'true'}
+                          ,{<<"friendly_name">>, <<"Emergency Dispatcher">>}
+                          ])).
 
--define(CLASSIFIER_CARIBBEAN
-        ,kz_json:from_list([{<<"regex">>, <<"^\\+?1((?:684|264|268|242|246|441|284|345|767|809|829|849|473|671|876|664|670|787|939|869|758|784|721|868|649|340)\\d{7})$">>}
-                            ,{<<"friendly_name">>, <<"Caribbean">>}
-                            ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
-                           ])
-       ).
+-define(CLASSIFIER_CARIBBEAN,
+        kz_json:from_list([{<<"regex">>, <<"^\\+?1((?:684|264|268|242|246|441|284|345|767|809|829|849|473|671|876|664|670|787|939|869|758|784|721|868|649|340)\\d{7})\$">>}
+                          ,{<<"friendly_name">>, <<"Caribbean">>}
+                          ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
+                          ])).
 
--define(CLASSIFIER_DID_US
-        ,kz_json:from_list([{<<"regex">>, <<"^\\+?1?([2-9][0-9]{2}[2-9][0-9]{6})$">>}
-                            ,{<<"friendly_name">>, <<"US DID">>}
-                            ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
-                           ])
-       ).
+-define(CLASSIFIER_DID_US,
+        kz_json:from_list([{<<"regex">>, <<"^\\+?1?([2-9][0-9]{2}[2-9][0-9]{6})\$">>}
+                          ,{<<"friendly_name">>, <<"US DID">>}
+                          ,{<<"pretty_print">>, <<"SS(###) ### - ####">>}
+                          ])).
 
--define(CLASSIFIER_INTERNATIONAL
-        ,kz_json:from_list([{<<"regex">>, <<"^(011\\d*)$|^(00\\d*)$">>}
-                            ,{<<"friendly_name">>, <<"International">>}
-                           ])
-       ).
+-define(CLASSIFIER_INTERNATIONAL,
+        kz_json:from_list([{<<"regex">>, <<"^(011\\d*)$|^(00\\d*)\$">>}
+                          ,{<<"friendly_name">>, <<"International">>}
+                          ])).
 
--define(CLASSIFIER_UNKNOWN
-        ,kz_json:from_list([{<<"regex">>, <<"^(.*)$">>}
-                            ,{<<"friendly_name">>, <<"Unknown">>}
-                           ])
-       ).
+-define(CLASSIFIER_UNKNOWN,
+        kz_json:from_list([{<<"regex">>, <<"^(.*)\$">>}
+                          ,{<<"friendly_name">>, <<"Unknown">>}
+                          ])).
 
 -define(DEFAULT_CLASSIFIERS, [{<<"tollfree_us">>, ?CLASSIFIER_TOLLFREE_US}
-                              ,{<<"toll_us">>, ?CLASSIFIER_TOLLFREE}
-                              ,{<<"emergency">>, ?CLASSIFIER_EMERGENCY}
-                              ,{<<"caribbean">>, ?CLASSIFIER_CARIBBEAN}
-                              ,{<<"did_us">>, ?CLASSIFIER_DID_US}
-                              ,{<<"international">>, ?CLASSIFIER_INTERNATIONAL}
-                              ,{<<"unknown">>, ?CLASSIFIER_UNKNOWN}
+                             ,{<<"toll_us">>, ?CLASSIFIER_TOLLFREE}
+                             ,{<<"emergency">>, ?CLASSIFIER_EMERGENCY}
+                             ,{<<"caribbean">>, ?CLASSIFIER_CARIBBEAN}
+                             ,{<<"did_us">>, ?CLASSIFIER_DID_US}
+                             ,{<<"international">>, ?CLASSIFIER_INTERNATIONAL}
+                             ,{<<"unknown">>, ?CLASSIFIER_UNKNOWN}
                              ]).
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/converters/knm_converters.erl
+++ b/core/kazoo_number_manager/src/converters/knm_converters.erl
@@ -178,9 +178,9 @@ is_reconcilable(Number) ->
 is_reconcilable(Number, AccountId) ->
     Regex = kapps_account_config:get_global(
               AccountId
-              ,?KNM_CONFIG_CAT
-              ,?KEY_RECONCILE_REGEX
-              ,?DEFAULT_RECONCILE_REGEX
+                                           ,?KNM_CONFIG_CAT
+                                           ,?KEY_RECONCILE_REGEX
+                                           ,?DEFAULT_RECONCILE_REGEX
              ),
     Num = normalize(Number, AccountId),
     is_reconcilable_by_regex(Num, Regex).
@@ -205,10 +205,10 @@ is_reconcilable_by_regex(Num, Regex) ->
 -define(CLASSIFIERS, kz_json:from_list(?DEFAULT_CLASSIFIERS)).
 -else.
 -define(CLASSIFIERS
-        ,kapps_config:get(?KNM_CONFIG_CAT
-                           ,<<"classifiers">>
-                           ,kz_json:from_list(?DEFAULT_CLASSIFIERS)
-                          )
+       ,kapps_config:get(?KNM_CONFIG_CAT
+                        ,<<"classifiers">>
+                        ,kz_json:from_list(?DEFAULT_CLASSIFIERS)
+                        )
        ).
 -endif.
 
@@ -226,8 +226,8 @@ classify(Number) ->
 -spec available_classifiers() -> kz_json:object().
 available_classifiers() ->
     kz_json:foldl(fun correct_depreciated_classifiers/3
-                  ,kz_json:new()
-                  ,?CLASSIFIERS
+                 ,kz_json:new()
+                 ,?CLASSIFIERS
                  ).
 
 %%--------------------------------------------------------------------
@@ -287,10 +287,10 @@ get_classifier_regex(JObj) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec correct_depreciated_classifiers(kz_json:path(), kz_json:json_term(), kz_json:object()) ->
-                                             kz_json:object().
+                                                 kz_json:object().
 correct_depreciated_classifiers(Classifier, ?NE_BINARY = Regex, JObj) ->
     J = kz_json:from_list([{<<"regex">>, Regex}
-                           ,{<<"friendly_name">>, Classifier}
+                          ,{<<"friendly_name">>, Classifier}
                           ]),
     kz_json:set_value(Classifier, J, JObj);
 correct_depreciated_classifiers(Classifier, J, JObj) ->

--- a/core/kazoo_number_manager/src/knm_gen_carrier.erl
+++ b/core/kazoo_number_manager/src/knm_gen_carrier.erl
@@ -27,7 +27,7 @@
 -callback should_lookup_cnam() ->
     boolean().
 
--callback is_number_billable(knm_number:knm_number()) ->
+-callback is_number_billable(knm_phone_number:knm_phone_number()) ->
     boolean().
 
 -callback is_local() ->

--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -44,6 +44,7 @@
         ,doc/1, update_doc/2
         ,modified/1, set_modified/2
         ,created/1, set_created/2
+        ,is_billable/1
         ]).
 
 -export([list_attachments/2]).
@@ -74,6 +75,7 @@
                           ,doc = kz_json:new() :: kz_json:object()
                           ,modified :: gregorian_seconds()
                           ,created :: gregorian_seconds()
+                          ,is_billable = 'false' :: boolean()
                           }).
 -opaque knm_phone_number() :: #knm_phone_number{}.
 
@@ -320,6 +322,7 @@ to_json(#knm_phone_number{doc=JObj}=N) ->
         ,{?PVT_REGION, region(N)}
         ,{?PVT_MODIFIED, modified(N)}
         ,{?PVT_CREATED, created(N)}
+        ,{?PVT_IS_BILLABLE, is_billable(N)}
         ,{?PVT_TYPE, <<"number">>}
          | kz_json:to_proplist(
              kz_json:delete_key(<<"id">>, kz_json:public_fields(JObj))
@@ -637,11 +640,15 @@ set_module_name(N0, ?CARRIER_LOCAL=Name) ->
             LocalFeature -> LocalFeature
         end,
     N = set_feature(N0, ?FEATURE_LOCAL, Feature),
-    N#knm_phone_number{module_name=Name};
+    N#knm_phone_number{module_name = Name
+                      ,is_billable = 'false'
+                      };
 set_module_name(N, <<"wnm_", Name/binary>>) ->
     set_module_name(N, <<"knm_", Name/binary>>);
 set_module_name(N, Name=?NE_BINARY) ->
-    N#knm_phone_number{module_name=Name}.
+    N#knm_phone_number{module_name = Name
+                      ,is_billable = knm_carriers:is_number_billable(N)
+                      }.
 
 %%--------------------------------------------------------------------
 %% @public
@@ -777,6 +784,14 @@ created(#knm_phone_number{created=Created}) -> Created.
 set_created(PN, Created)
   when is_integer(Created), Created > 0 ->
     PN#knm_phone_number{created=Created}.
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec is_billable(knm_phone_number()) -> boolean().
+is_billable(#knm_phone_number{is_billable = IsBillable}) -> IsBillable.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_number_manager/src/knm_services.erl
+++ b/core/kazoo_number_manager/src/knm_services.erl
@@ -129,8 +129,8 @@ update_services(Number, _, 'true') ->
     Number;
 update_services(Number, 'true', _) ->
     lager:debug("somewhat dry_run-ing btw"),
-    JObj = knm_phone_number:to_json(knm_number:phone_number(Number)),
-    Services = kz_service_phone_numbers:reconcile(fetch_services(Number), [JObj]),
+    PhoneNumber = knm_number:phone_number(Number),
+    Services = kz_service_phone_numbers:reconcile(fetch_services(Number), [PhoneNumber]),
     knm_number:set_services(Number, Services);
 update_services(Number, 'false', _) ->
     PhoneNumber = knm_number:phone_number(Number),
@@ -162,8 +162,7 @@ activate_phone_number(Number) ->
 activate_phone_number(Number, BillingId) ->
     Services = fetch_services(Number),
     Num = knm_phone_number:number(knm_number:phone_number(Number)),
-    Units = kz_service_phone_numbers:
-        phone_number_activation_charge(Services, Num),
+    Units = kz_service_phone_numbers:phone_number_activation_charge(Services, Num),
     activate_phone_number(Number, BillingId, Units).
 
 activate_phone_number(Number, _BillingId, 0) ->

--- a/core/kazoo_services/src/services/kz_service_phone_numbers.erl
+++ b/core/kazoo_services/src/services/kz_service_phone_numbers.erl
@@ -26,7 +26,6 @@
 %%--------------------------------------------------------------------
 -spec reconcile(kz_services:services()) -> kz_services:services().
 -spec reconcile(kz_services:services(), kz_json:objects()) -> kz_services:services().
-
 reconcile(Services) ->
     AccountId = kz_services:account_id(Services),
     AccountDb = kz_util:format_account_id(AccountId, 'encoded'),

--- a/core/kazoo_services/src/services/kz_service_phone_numbers.erl
+++ b/core/kazoo_services/src/services/kz_service_phone_numbers.erl
@@ -37,10 +37,10 @@ reconcile(Services) ->
             lager:debug("unable to get current phone numbers in service: ~p", [_R]),
             Services;
         {'ok', JObjs} ->
-            PNs = [knm_phone_number:from_json(kz_json:get_value(<<"doc">>, JObj))
-                   || JObj <- JObjs
-                  ],
-            reconcile(Services, PNs)
+            reconcile(Services
+                     ,[knm_phone_number:from_json(kz_json:get_value(<<"doc">>, JObj))
+                       || JObj <- JObjs
+                      ])
     end.
 
 reconcile(Services, PNs) ->


### PR DESCRIPTION
... so that a reduce view can be written (as part of PR 2/2) that would return the cumulated quantities.

I'm far from a services expert so please take a look: is all the data needed to compute quantities now stored on the number document?

Note: classifiers need not be in the number doc. They will be part of the reduce view.

Note: depends on #2700. Will need rebase to please Circle.