### PR TITLE
Json Pretty Print

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -145,10 +145,11 @@ rest_init(Req0, Opts) ->
             {'ok', Req9, Context2};
         {Context1, Req8} ->
             {Req9, Context2} = api_util:get_auth_token(Req8, Context1),
-            Event = api_util:create_event_name(Context2, <<"init">>),
-            {Context3, _} = crossbar_bindings:fold(Event, {Context2, Opts}),
+            {Req10, Context3} = api_util:get_pretty_print(Req9, Context2),
+            Event = api_util:create_event_name(Context3, <<"init">>),
+            {Context4, _} = crossbar_bindings:fold(Event, {Context3, Opts}),
             lager:info("~s: ~s?~s from ~s", [Method, Path, QS, ClientIP]),
-            {'ok', cowboy_req:set_resp_header(<<"x-request-id">>, ReqId, Req9), Context3}
+            {'ok', cowboy_req:set_resp_header(<<"x-request-id">>, ReqId, Req10), Context4}
     end.
 
 -spec metrics() -> {non_neg_integer(), non_neg_integer()}.

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -19,6 +19,7 @@
         ,get_req_data/2
         ,get_http_verb/2
         ,get_auth_token/2
+        ,get_pretty_print/2
         ,is_authentic/2
         ,is_permitted/2
         ,is_known_content_type/2
@@ -798,6 +799,30 @@ get_authorization_token_type(Token) -> {Token, 'unknown'}.
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
+%% This function will try to find pretty print option inside the headers
+%% if not found will look into the request to find the options
+%% otherwise will result in false
+%% @end
+%%--------------------------------------------------------------------
+-spec get_pretty_print(cowboy_req:req(), cb_context:context()) ->
+                              {cowboy_req:req(), cb_context:context()}.
+get_pretty_print(Req0, Context) ->
+    case cowboy_req:header(<<"x-pretty-print">>, Req0) of
+        {'undefined', Req1} ->
+            case cb_context:req_value(Context, <<"pretty_print">>) of
+                'undefined' -> {Req1, cb_context:set_pretty_print(Context, 'false')};
+                Value ->
+                    lager:debug("using pretty print value from inside the request"),
+                    {Req1, cb_context:set_pretty_print(Context, kz_util:is_true(Value))}
+            end;
+        {Value, Req1} ->
+            lager:debug("found pretty print options inside header"),
+            {Req1, cb_context:set_pretty_print(Context, kz_util:is_true(Value))}
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
 %% This function will use event bindings to determine if the client is
 %% authorized for this request
 %% @end
@@ -1114,7 +1139,8 @@ finish_request(_Req, Context) ->
                                  {ne_binary() | iolist(), cowboy_req:req()}.
 create_resp_content(Req0, Context) ->
     Resp = create_resp_envelope(Context),
-    try kz_json:encode(Resp) of
+    Options = get_encode_options(Context),
+    try kz_json:encode(Resp, Options) of
         JSON ->
             case cb_context:req_value(Context, <<"jsonp">>) of
                 'undefined' ->
@@ -1148,6 +1174,13 @@ create_resp_file(Req, Context) ->
                   Res
           end,
     {{Len, Fun}, Req}.
+
+-spec get_encode_options(cb_context:context()) -> kz_json:encode_options().
+get_encode_options(Context) ->
+    case cb_context:pretty_print(Context) of
+        'true' ->  ['pretty'];
+        'false' -> []
+    end.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -62,6 +62,7 @@
         ,doc/1, set_doc/2, update_doc/2
         ,load_merge_bypass/1, set_load_merge_bypass/2
         ,start/1, set_start/2
+        ,pretty_print/1
         ,resp_file/1, set_resp_file/2
         ,resp_data/1, set_resp_data/2
         ,resp_status/1, set_resp_status/2
@@ -92,6 +93,7 @@
         ,validation_errors/1, set_validation_errors/2
 
         ,host_url/1, set_host_url/2
+        ,set_pretty_print/2
         ,set_raw_host/2
         ,set_port/2
         ,set_raw_path/2
@@ -263,6 +265,9 @@ resp_envelope(#cb_context{resp_envelope=E}) -> E.
 allow_methods(#cb_context{allow_methods=AMs}) -> AMs.
 allowed_methods(#cb_context{allowed_methods=AMs}) -> AMs.
 method(#cb_context{method=M}) -> M.
+
+-spec pretty_print(context()) -> boolean().
+pretty_print(#cb_context{pretty_print = PrettyPrint}) -> PrettyPrint.
 
 -spec path_token(binary()) -> binary().
 path_token(Token) ->
@@ -478,6 +483,10 @@ set_host_url(#cb_context{}=Context, Value) ->
 
 -spec host_url(context()) -> binary().
 host_url(#cb_context{host_url = Value}) -> Value.
+
+-spec set_pretty_print(context(), boolean()) -> context().
+set_pretty_print(#cb_context{}=Context, Value) ->
+    Context#cb_context{pretty_print = Value}.
 
 set_raw_host(#cb_context{}=Context, Value) ->
     Context#cb_context{raw_host = Value}.

--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -145,6 +145,7 @@
                     ,reseller_id :: api_binary()
                     ,db_name :: api_binary() | ne_binaries()
                     ,doc :: api_object() | kz_json:objects()
+                    ,pretty_print = 'false' :: boolean()
                     ,resp_expires = {{1999,1,1},{0,0,0}} :: kz_datetime()
                     ,resp_etag :: 'automatic' | string() | api_binary()
                     ,resp_status = 'error' :: crossbar_status()

--- a/core/kazoo_json/include/kazoo_json.hrl
+++ b/core/kazoo_json/include/kazoo_json.hrl
@@ -43,5 +43,14 @@
 -type json_terms() :: [json_term()].
 -type api_json_term() :: json_term() | 'undefined'.
 
+-type encode_option() :: 'uescape'
+                       | 'pretty'
+                       | 'force_utf8'
+                       | 'escape_forward_slashes'
+                       | {bytes_per_iter, non_neg_integer()}
+                       | {bytes_per_red, non_neg_integer()}.
+
+-type encode_options() :: [encode_option()].
+
 -define(KAZOO_JSON_HRL, 'true').
 -endif.

--- a/core/kazoo_json/src/kz_json.erl
+++ b/core/kazoo_json/src/kz_json.erl
@@ -85,7 +85,7 @@
         ,is_private_key/1
         ]).
 
--export([encode/1]).
+-export([encode/1, encode/2]).
 -export([decode/1, decode/2]).
 -export([unsafe_decode/1, unsafe_decode/2]).
 
@@ -105,7 +105,10 @@
 new() -> ?JSON_WRAPPER([]).
 
 -spec encode(json_term()) -> text().
-encode(JObj) -> jiffy:encode(JObj).
+-spec encode(json_term(), encode_options()) -> text().
+encode(JObj) -> encode(JObj, []).
+
+encode(JObj, Options) -> jiffy:encode(JObj, Options).
 
 -spec unsafe_decode(iolist() | ne_binary()) -> json_term().
 -spec unsafe_decode(iolist() | ne_binary(), ne_binary()) -> json_term().

--- a/core/kazoo_json/src/kz_json.hrl
+++ b/core/kazoo_json/src/kz_json.hrl
@@ -43,5 +43,14 @@
 -type json_terms() :: [json_term()].
 -type api_json_term() :: json_term() | 'undefined'.
 
+-type encode_option() :: 'uescape'
+                       | 'pretty'
+                       | 'force_utf8'
+                       | 'escape_forward_slashes'
+                       | {bytes_per_iter, non_neg_integer()}
+                       | {bytes_per_red, non_neg_integer()}.
+
+-type encode_options() :: [encode_option()].
+
 -define(KZ_JSON_HRL, 'true').
 -endif.


### PR DESCRIPTION
added pretty printing option for json output

User is able to get the json returned formatted using Header value 'x-pretty-print: true' or inside url or body of the request, 

v1/url?pretty_print=true


