### PR TITLE
s3 allow international hosts

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6774,6 +6774,9 @@
                         "bucket": {
                             "type": "string"
                         },
+                        "host": {
+                            "type": "string"
+                        },
                         "key": {
                             "type": "string"
                         },

--- a/applications/crossbar/priv/couchdb/schemas/storage.attachment.aws.json
+++ b/applications/crossbar/priv/couchdb/schemas/storage.attachment.aws.json
@@ -16,6 +16,9 @@
                 "bucket": {
                     "type": "string"
                 },
+                "host": {
+                    "type": "string"
+                },
                 "key": {
                     "type": "string"
                 },


### PR DESCRIPTION
s3_bucket_after_host is changed to true as while working with s3 some bucket names gives ssl errors as s3 uses wildcard cert for buckets, the commit changes the bucket name to be appended to the back of the host name and it saves us from the invalid cert issue. The other way to get arround the issue is to use http but i guess this is a good way as it does not break anything and is secure. 

The change to hostname is added which will allow user to use any other bucket besides amazon's us-east which is being used as a default.