### PR TITLE
Missing originate_uuid event breaks existing apps (noticed on acdc)

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -764,8 +764,8 @@ publish_originate_uuid(ServerId, UUID, JObj, CtrlQueue) ->
 
 -spec maybe_send_originate_uuid(created_uuid(), pid(), state()) -> 'ok'.
 maybe_send_originate_uuid({_, UUID}, Pid, #state{server_id=ServerId
-                                                   ,originate_req=JObj
-                                                   }) ->
+                                                ,originate_req=JObj
+                                                }) ->
     CtlQ = gen_listener:queue_name(Pid),
     publish_originate_uuid(ServerId, UUID, JObj, CtlQ).
 

--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -768,6 +768,8 @@ maybe_send_originate_uuid({'fs', UUID}, Pid, #state{server_id=ServerId
                                                    }) ->
     CtlQ = gen_listener:queue_name(Pid),
     publish_originate_uuid(ServerId, UUID, JObj, CtlQ);
+maybe_send_originate_uuid({'api', UUID}, Pid, State) ->
+    maybe_send_originate_uuid({'fs', UUID}, Pid, State);
 maybe_send_originate_uuid(_, _, _) -> 'ok'.
 
 -spec find_originate_timeout(kz_json:object()) -> pos_integer().

--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -763,14 +763,11 @@ publish_originate_uuid(ServerId, UUID, JObj, CtrlQueue) ->
     kapi_resource:publish_originate_uuid(ServerId, Resp).
 
 -spec maybe_send_originate_uuid(created_uuid(), pid(), state()) -> 'ok'.
-maybe_send_originate_uuid({'fs', UUID}, Pid, #state{server_id=ServerId
+maybe_send_originate_uuid({_, UUID}, Pid, #state{server_id=ServerId
                                                    ,originate_req=JObj
                                                    }) ->
     CtlQ = gen_listener:queue_name(Pid),
-    publish_originate_uuid(ServerId, UUID, JObj, CtlQ);
-maybe_send_originate_uuid({'api', UUID}, Pid, State) ->
-    maybe_send_originate_uuid({'fs', UUID}, Pid, State);
-maybe_send_originate_uuid(_, _, _) -> 'ok'.
+    publish_originate_uuid(ServerId, UUID, JObj, CtlQ).
 
 -spec find_originate_timeout(kz_json:object()) -> pos_integer().
 find_originate_timeout(JObj) ->


### PR DESCRIPTION
Prior to this patch the originate_uuid event is not fired for uuids generated as part of an originate_req. However, they are used in existing applications and, in particular, event control queues exist for the missed uuids. Without this patch, commands such as hangup on those calls cannot reach FS.
