### PR TITLE
Track/sychronize call position between queue mgrs

### DIFF
--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -372,7 +372,7 @@ connect_req({'member_hungup', JObj}, #state{queue_proc=Srv
 
             webseq:evt(?WSD_ID, self(), CallId, <<"member call finish - abandon">>),
 
-            acdc_queue_listener:finish_member_call(Srv, JObj),
+            acdc_queue_listener:cancel_member_call(Srv, JObj),
             acdc_stats:call_abandoned(AccountId, QueueId, CallId, ?ABANDON_HANGUP),
             {'next_state', 'ready', clear_member_call(State), 'hibernate'};
         'false' ->

--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -14,6 +14,7 @@
 %%% @contributors
 %%%   James Aimonetti
 %%%   KAZOO-3596: Sponsored by GTNetwork LLC, implemented by SIPLABS LLC
+%%%   Daniel Finke
 %%%-------------------------------------------------------------------
 -module(acdc_queue_listener).
 -behaviour(gen_listener).
@@ -355,6 +356,7 @@ handle_cast({'timeout_member_call', JObj}, #state{delivery=Delivery
 
     maybe_timeout_agent(AgentId, QueueId, Call, JObj),
 
+    publish_queue_member_remove(AccountId, QueueId, kapps_call:call_id(Call)),
     acdc_queue_shared:ack(Pid, Delivery),
     send_member_call_failure(Q, AccountId, QueueId, kapps_call:call_id(Call), MyId, AgentId),
 
@@ -378,6 +380,7 @@ handle_cast({'exit_member_call'}, #state{delivery=Delivery
 
     acdc_util:unbind_from_call_events(Call),
     lager:debug("unbound from call events for ~s", [kapps_call:call_id(Call)]),
+    publish_queue_member_remove(AccountId, QueueId, kapps_call:call_id(Call)),
     acdc_queue_shared:ack(Pid, Delivery),
     send_member_call_failure(Q, AccountId, QueueId, kapps_call:call_id(Call), MyId, AgentId, <<"Caller exited the queue via DTMF">>),
 
@@ -395,6 +398,7 @@ handle_cast({'exit_member_call_empty'}, #state{delivery=Delivery
 
     acdc_util:unbind_from_call_events(Call),
     lager:debug("unbound from call events for ~s", [kapps_call:call_id(Call)]),
+    publish_queue_member_remove(AccountId, QueueId, kapps_call:call_id(Call)),
     acdc_queue_shared:ack(Pid, Delivery),
     send_member_call_failure(Q, AccountId, QueueId, kapps_call:call_id(Call), MyId, AgentId, <<"No agents left in queue">>),
 
@@ -449,12 +453,15 @@ handle_cast({'cancel_member_call'}, #state{delivery=Delivery
 handle_cast({'cancel_member_call', _RejectJObj}, #state{delivery='undefined'}=State) ->
     lager:debug("cancel a member_call that I don't have delivery info for"),
     {'noreply', State};
-handle_cast({'cancel_member_call', _RejectJObj}, #state{delivery=Delivery
+handle_cast({'cancel_member_call', _RejectJObj}, #state{queue_id=QueueId
+                                                       ,account_id=AccountId
+                                                       ,delivery=Delivery
                                                        ,call=Call
                                                        ,shared_pid=Pid
                                                        }=State) ->
     lager:debug("agent failed to handle the call, nack"),
 
+    publish_queue_member_remove(AccountId, QueueId, kapps_call:call_id(Call)),
     _ = maybe_nack(Call, Delivery, Pid),
     {'noreply', clear_call_state(State), 'hibernate'};
 handle_cast({'cancel_member_call', _MemberCallJObj, Delivery}, #state{shared_pid=Pid}=State) ->
@@ -601,6 +608,15 @@ send_member_call_failure(Q, AccountId, QueueId, CallId, MyId, AgentId, Reason) -
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
     publish(Q, Resp, fun kapi_acdc_queue:publish_member_call_failure/2).
+
+-spec publish_queue_member_remove(ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
+publish_queue_member_remove(AccountId, QueueId, CallId) ->
+    Prop = [{<<"Account-ID">>, AccountId}
+            ,{<<"Queue-ID">>, QueueId}
+            ,{<<"Call-ID">>, CallId}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_acdc_queue:publish_queue_member_remove(Prop).
 
 send_sync_req(MyQ, MyId, AccountId, QueueId, Type) ->
     Resp = props:filter_undefined(

--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -612,8 +612,8 @@ send_member_call_failure(Q, AccountId, QueueId, CallId, MyId, AgentId, Reason) -
 -spec publish_queue_member_remove(ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 publish_queue_member_remove(AccountId, QueueId, CallId) ->
     Prop = [{<<"Account-ID">>, AccountId}
-            ,{<<"Queue-ID">>, QueueId}
-            ,{<<"Call-ID">>, CallId}
+           ,{<<"Queue-ID">>, QueueId}
+           ,{<<"Call-ID">>, CallId}
             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
     kapi_acdc_queue:publish_queue_member_remove(Prop).

--- a/applications/acdc/src/acdc_queue_manager.hrl
+++ b/applications/acdc/src/acdc_queue_manager.hrl
@@ -1,0 +1,23 @@
+-ifndef(ACDC_QUEUE_MANAGER_HRL).
+
+%% rr :: Round Robin
+%% mi :: Most Idle
+-type queue_strategy() :: 'rr' | 'mi'.
+
+-record(state, {ignored_member_calls = dict:new() :: dict:dict()
+                ,account_id :: api_binary()
+                ,queue_id :: api_binary()
+                ,supervisor :: pid()
+                ,strategy = 'rr' :: queue_strategy() % round-robin | most-idle
+                ,strategy_state :: queue_strategy_state() % based on the strategy
+                ,known_agents = dict:new() :: dict:dict() % how many agent processes are available {AgentId, Count}
+                ,enter_when_empty = 'true' :: boolean() % allow caller into queue if no agents are logged in
+                ,moh :: api_binary()
+                ,current_member_calls = [] :: list() % ordered list of current members waiting
+               }).
+-type mgr_state() :: #state{}.
+
+-type queue_strategy_state() :: queue:queue() | ne_binaries().
+
+-define(ACDC_QUEUE_MANAGER_HRL, 'true').
+-endif.

--- a/applications/acdc/src/acdc_queue_manager.hrl
+++ b/applications/acdc/src/acdc_queue_manager.hrl
@@ -5,15 +5,15 @@
 -type queue_strategy() :: 'rr' | 'mi'.
 
 -record(state, {ignored_member_calls = dict:new() :: dict:dict()
-                ,account_id :: api_binary()
-                ,queue_id :: api_binary()
-                ,supervisor :: pid()
-                ,strategy = 'rr' :: queue_strategy() % round-robin | most-idle
-                ,strategy_state :: queue_strategy_state() % based on the strategy
-                ,known_agents = dict:new() :: dict:dict() % how many agent processes are available {AgentId, Count}
-                ,enter_when_empty = 'true' :: boolean() % allow caller into queue if no agents are logged in
-                ,moh :: api_binary()
-                ,current_member_calls = [] :: list() % ordered list of current members waiting
+               ,account_id :: api_binary()
+               ,queue_id :: api_binary()
+               ,supervisor :: pid()
+               ,strategy = 'rr' :: queue_strategy() % round-robin | most-idle
+               ,strategy_state :: queue_strategy_state() % based on the strategy
+               ,known_agents = dict:new() :: dict:dict() % how many agent processes are available {AgentId, Count}
+               ,enter_when_empty = 'true' :: boolean() % allow caller into queue if no agents are logged in
+               ,moh :: api_binary()
+               ,current_member_calls = [] :: list() % ordered list of current members waiting
                }).
 -type mgr_state() :: #state{}.
 

--- a/applications/acdc/src/acdc_stats.erl
+++ b/applications/acdc/src/acdc_stats.erl
@@ -6,6 +6,7 @@
 %%% @contributors
 %%%   James Aimonetti
 %%%   KAZOO-3596: Sponsored by GTNetwork LLC, implemented by SIPLABS LLC
+%%%   Daniel Finke
 %%%-------------------------------------------------------------------
 -module(acdc_stats).
 -behaviour(gen_listener).

--- a/applications/acdc/src/kapi_acdc_queue.erl
+++ b/applications/acdc/src/kapi_acdc_queue.erl
@@ -562,8 +562,8 @@ queue_member_routing_key(AcctId, QID) ->
 -define(QUEUE_MEMBER_ADD_TYPES, []).
 
 -spec queue_member_add(api_terms()) ->
-                          {'ok', iolist()} |
-                          {'error', string()}.
+                              {'ok', iolist()} |
+                              {'error', string()}.
 queue_member_add(Prop) when is_list(Prop) ->
     case queue_member_add_v(Prop) of
         'true' -> kz_api:build_message(Prop, ?QUEUE_MEMBER_ADD_HEADERS, ?OPTIONAL_QUEUE_MEMBER_ADD_HEADERS);


### PR DESCRIPTION
Prerequisite patch to some other features/bug fixes/improvements in acdc.
Ensures an ordered(-ish) list of calls in a queue is shared amongst queue mgrs.