### PR TITLE
qf-rsa_auth: fix always-false check

### DIFF
--- a/core/kazoo_auth/c_src/kz_auth_rsa_drv.c
+++ b/core/kazoo_auth/c_src/kz_auth_rsa_drv.c
@@ -134,7 +134,7 @@ static ErlDrvSSizeT call(ErlDrvData edd, unsigned int cmd, char *buf,
   if (cmd == CUTKEY_CMD_RSA) {
     errno = CUTKEY_ERR_ARG;
     ei_decode_ei_term(buf, &index, &tuple);
-    if (!tuple.ei_type == ERL_TUPLE || tuple.arity != 3) {
+    if (tuple.ei_type != ERL_TUPLE || tuple.arity != 3) {
       goto error;
     }
     ei_decode_ei_term(buf, &index, &ref);

--- a/core/kazoo_auth/c_src/kz_auth_rsa_drv.c
+++ b/core/kazoo_auth/c_src/kz_auth_rsa_drv.c
@@ -134,7 +134,7 @@ static ErlDrvSSizeT call(ErlDrvData edd, unsigned int cmd, char *buf,
   if (cmd == CUTKEY_CMD_RSA) {
     errno = CUTKEY_ERR_ARG;
     ei_decode_ei_term(buf, &index, &tuple);
-    if (tuple.ei_type != ERL_TUPLE || tuple.arity != 3) {
+    if (!tuple.ei_type == ERL_TUPLE || tuple.arity != 3) {
       goto error;
     }
     ei_decode_ei_term(buf, &index, &ref);

--- a/core/kazoo_auth/c_src/kz_auth_rsa_drv.c
+++ b/core/kazoo_auth/c_src/kz_auth_rsa_drv.c
@@ -134,7 +134,7 @@ static ErlDrvSSizeT call(ErlDrvData edd, unsigned int cmd, char *buf,
   if (cmd == CUTKEY_CMD_RSA) {
     errno = CUTKEY_ERR_ARG;
     ei_decode_ei_term(buf, &index, &tuple);
-    if (!tuple.ei_type == ERL_TUPLE || tuple.arity != 3) {
+    if (!(tuple.ei_type == ERL_TUPLE || tuple.arity != 3)) {
       goto error;
     }
     ei_decode_ei_term(buf, &index, &ref);


### PR DESCRIPTION
Note: it's not clear to me if the intent was to `!` the first part or the whole `if`.
