### PR TITLE
With nested multipart emails, fax_smtp fails if one part doesn't have attachments

### DIFF
--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -791,10 +791,8 @@ process_part(CT, Body, State) ->
 -spec maybe_ignore_no_valid_attachment(state()) -> state().
 maybe_ignore_no_valid_attachment(#state{filename='undefined'}=State) -> State;
 maybe_ignore_no_valid_attachment(#state{errors=Errors}=State) ->
-    NewErrors = lists:filter(fun(?ERROR_NO_VALID_ATTACHMENT) -> 'false';
-                                (_) -> 'true'
-                             end
-                            ,Errors),
+    NewErrors = [Error || Error <- Errors
+                         ,Error =/= ?ERROR_NO_VALID_ATTACHMENT],
     State#state{errors=NewErrors}.
 
 -spec is_allowed_content_type(ne_binary()) -> boolean().

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -792,7 +792,7 @@ process_part(CT, Body, State) ->
 maybe_ignore_no_valid_attachment(#state{filename='undefined'}=State) -> State;
 maybe_ignore_no_valid_attachment(#state{errors=Errors}=State) ->
     NewErrors = [Error || Error <- Errors
-                         ,Error =/= ?ERROR_NO_VALID_ATTACHMENT],
+                              ,Error =/= ?ERROR_NO_VALID_ATTACHMENT],
     State#state{errors=NewErrors}.
 
 -spec is_allowed_content_type(ne_binary()) -> boolean().

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -34,6 +34,8 @@
 -define(DEFAULT_IMAGE_SIZE_CMD_FMT, <<"echo -n `identify -format \"%[fx:w]x%[fx:h]\" ~s`">>).
 -define(IMAGE_SIZE_CMD_FMT, kapps_config:get_binary(?CONFIG_CAT, <<"image_size_cmd_format">>, ?DEFAULT_IMAGE_SIZE_CMD_FMT)).
 
+-define(ERROR_NO_VALID_ATTACHMENT, <<"no valid attachment">>).
+
 -record(state, {
           options = [] :: list()
                ,from :: binary()
@@ -712,7 +714,7 @@ process_message(_Type, _SubType, _Headers, _Parameters, _Body, State) ->
 process_parts([], #state{filename='undefined'
                         ,errors=Errors
                         }=State) ->
-    {'ok', State#state{errors=[<<"no valid attachment">> | Errors]}};
+    {'ok', State#state{errors=[?ERROR_NO_VALID_ATTACHMENT | Errors]}};
 process_parts([], State) ->
     {'ok', State};
 process_parts([{Type, SubType, _Headers, Parameters, BodyPart}
@@ -724,7 +726,7 @@ process_parts([{Type, SubType, _Headers, Parameters, BodyPart}
                             ,BodyPart
                             ,State
                             ),
-    process_parts(Parts, NewState).
+    process_parts(Parts, maybe_ignore_no_valid_attachment(NewState)).
 
 -spec maybe_process_part(ne_binary(), kz_proplist(), binary() | mimemail:mimetuple(), state()) ->
                                 {'ok', state()}.
@@ -783,6 +785,17 @@ process_part(CT, Body, State) ->
     {'ok', State#state{filename=Filename
                       ,content_type=CT
                       }}.
+
+%% If the filename is no longer undefined, but the "no valid attachment" error
+%% was triggered by an undefined filename at one point, remove it
+-spec maybe_ignore_no_valid_attachment(state()) -> state().
+maybe_ignore_no_valid_attachment(#state{filename='undefined'}=State) -> State;
+maybe_ignore_no_valid_attachment(#state{errors=Errors}=State) ->
+    NewErrors = lists:filter(fun(?ERROR_NO_VALID_ATTACHMENT) -> 'false';
+                                (_) -> 'true'
+                             end
+                            ,Errors),
+    State#state{errors=NewErrors}.
 
 -spec is_allowed_content_type(ne_binary()) -> boolean().
 is_allowed_content_type(CT) ->


### PR DESCRIPTION
When an email for fax has nested multipart parts and one of the parts of the parent multipart doesn't have an attachment, fax_smtp will fail because of the error "no valid attachment". It should succeed, as there is a valid attachment in the other part. This patch filters out the "no valid attachment" error upon finding a valid attachment in the other part.

Below is an example of the fax_smtp log lines (with a couple extra) to illustrate the format of the email:
```
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:177 (<0.10060.2>) Message decoded successfully!
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:692 (<0.10060.2>) processing multipart/mixed
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:702 (<0.10060.2>) processing multiple parts, first is multipart/alternative
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:736 (<0.10060.2>) processing multipart/alternative
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:746 (<0.10060.2>) processing multiple parts, first is text/plain
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:778 (<0.10060.2>) ignoring part text/plain
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:778 (<0.10060.2>) ignoring part text/html
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:718 (<0.10060.2>) no valid attachment
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:784 (<0.10060.2>) part is application/pdf
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:787 (<0.10060.2>) filename <<"/tmp/email_attachment_63644735578.pdf">>
Oct 26 21:12:58 hostname 2600hz[22454]: |91e795f2a9515c8b8c7ee9a2dde8ccb4|fax_smtp:704 (<0.10060.2>) done processing parts
```