### PR TITLE
Konami unable to bind bug

### DIFF
--- a/core/kazoo_amqp/src/api/kapi_metaflow.erl
+++ b/core/kazoo_amqp/src/api/kapi_metaflow.erl
@@ -93,7 +93,7 @@
                                         ,<<"Endpoint-ID">>, <<"Listen-On">>
                                         ]).
 -define(METAFLOW_BIND_VALUES, [{<<"Event-Category">>, <<"metaflow">>}
-                              ,{<<"Event-Name">>, <<"bind">>}
+                              ,{<<"Event-Name">>, <<"bindings">>}
                               ,{<<"Binding-Digit">>, ?ANY_DIGIT}
                               ,{<<"Listen-On">>, [<<"both">>, <<"self">>, <<"peer">>, <<"aleg">>, <<"bleg">>]}
                               ]).


### PR DESCRIPTION
konami_listener expects to get Event-Name as bindings instead of bind