### PR TITLE
Expect Conference-ID on conference error event

### DIFF
--- a/core/kazoo_amqp/src/api/kapi_conference.erl
+++ b/core/kazoo_amqp/src/api/kapi_conference.erl
@@ -356,7 +356,7 @@
 -define(CONFERENCE_EVENT_TYPES, []).
 
 %% Conference Error
--define(CONFERENCE_ERROR_HEADERS, [<<"Error-Message">>, <<"Request">>]).
+-define(CONFERENCE_ERROR_HEADERS, [<<"Error-Message">>, <<"Request">>, <<"Conference-ID">>]).
 -define(OPTIONAL_CONFERENCE_ERROR_HEADERS, []).
 -define(CONFERENCE_ERROR_VALUES, [{<<"Event-Category">>, <<"conference">>}
                                  ,{<<"Event-Name">>, <<"error">>}


### PR DESCRIPTION
Minor change. Makes validation via kapi_conference:search_resp_v/1 log a more sensible error (Event-Name error is not search_resp) instead of failing due to missing one of [<<"Conferences">>, <<"Conference-ID">>] keys. This was just confusing because ecallmgr_fs_conferences wanted to publish the error with Conference-ID but it was being stripped out.

tl;dr: log sanity cleanup