### PR TITLE
Fix erlang build timeout for circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,17 +17,8 @@ dependencies:
   cache_directories:
     - ~/.kerl
   pre:
-    - |
-      if [[ ! -d ~/.kerl/$OTP_VERSION ]]; then
-        if [[ ! -d ~/.kerl ]]; then
-          mkdir ~/.kerl
-          curl -fsSLo ~/.kerl/kerl https://raw.githubusercontent.com/kerl/kerl/master/kerl
-          chmod +x ~/.kerl/kerl
-          ~/.kerl/kerl update releases
-        fi
-        ~/.kerl/kerl build $OTP_VERSION $OTP_VERSION
-        ~/.kerl/kerl install $OTP_VERSION ~/.kerl/$OTP_VERSION
-      fi
+      - bash ./scripts/circleci-build-erlang.sh:
+          timeout: 3600
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - ~/.kerl
   pre:
       - bash ./scripts/circleci-build-erlang.sh:
-          timeout: 3600
+          timeout: 1800
 
 test:
   pre:

--- a/scripts/circleci-build-erlang.sh
+++ b/scripts/circleci-build-erlang.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -x
+set -e
+if [[ ! -d ~/.kerl/$OTP_VERSION ]]; then
+    if [[ ! -d ~/.kerl ]]; then
+        mkdir ~/.kerl
+        curl -fsSLo ~/.kerl/kerl https://raw.githubusercontent.com/kerl/kerl/master/kerl
+        chmod +x ~/.kerl/kerl
+        ~/.kerl/kerl update releases
+    fi
+    ~/.kerl/kerl build $OTP_VERSION $OTP_VERSION
+    ~/.kerl/kerl install $OTP_VERSION ~/.kerl/$OTP_VERSION
+fi

--- a/scripts/circleci-build-erlang.sh
+++ b/scripts/circleci-build-erlang.sh
@@ -6,8 +6,8 @@ if [[ ! -d ~/.kerl/$OTP_VERSION ]]; then
         mkdir ~/.kerl
         curl -fsSLo ~/.kerl/kerl https://raw.githubusercontent.com/kerl/kerl/master/kerl
         chmod +x ~/.kerl/kerl
-        ~/.kerl/kerl update releases
     fi
+    ~/.kerl/kerl update releases
     ~/.kerl/kerl build $OTP_VERSION $OTP_VERSION
     ~/.kerl/kerl install $OTP_VERSION ~/.kerl/$OTP_VERSION
 fi


### PR DESCRIPTION
Without "timeout" option kerl build killed with error "took more than 10 minutes since last output".
This happens when erlang build first time (~20 minutes). After this it taken from cache and dont spend so much time.