### PR TITLE
KAZOO-5125: fix proxy username password missmatch

### DIFF
--- a/core/kazoo_media/src/kz_media_store_proxy.erl
+++ b/core/kazoo_media/src/kz_media_store_proxy.erl
@@ -60,8 +60,8 @@ maybe_basic_authentication(Username, Password) ->
     AuthPassword = kapps_config:get_string(?CONFIG_CAT, <<"proxy_password">>, ""),
     not kz_util:is_empty(AuthUsername)
         andalso not kz_util:is_empty(AuthPassword)
-        andalso Username == AuthUsername
-        andalso Password == AuthPassword.
+        andalso kz_util:to_list(Username) == AuthUsername
+        andalso kz_util:to_list(Password) == AuthPassword.
 
 -spec maybe_acl_authentication(cowboy_req:req()) -> boolean().
 maybe_acl_authentication(Req) ->


### PR DESCRIPTION
binary was being matched with a string which always resulted in username password mistmatch