### PR TITLE
qf-filter out system generated default values

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -7213,10 +7213,6 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "secret_for_user_signature",
-                "system_key"
-            ],
             "type": "object"
         },
         "system_config.blackhole": {
@@ -7957,9 +7953,7 @@
             },
             "required": [
                 "autoload_modules",
-                "ssl_ca_cert",
-                "ssl_cert",
-                "ssl_key"
+                "ssl_ca_cert"
             ],
             "type": "object"
         },
@@ -8167,7 +8161,6 @@
                 }
             },
             "required": [
-                "offline_configuration_key",
                 "{Module}"
             ],
             "type": "object"
@@ -8530,7 +8523,6 @@
             },
             "required": [
                 "connections",
-                "inbound_broker",
                 "inbound_queue_name",
                 "reschedule"
             ],
@@ -9619,7 +9611,6 @@
                     "type": "integer"
                 },
                 "proxy_password": {
-                    "default": "",
                     "description": "media proxy password",
                     "type": "string"
                 },
@@ -9641,7 +9632,6 @@
                     "type": "boolean"
                 },
                 "proxy_username": {
-                    "default": "",
                     "description": "media proxy username",
                     "type": "string"
                 },
@@ -9701,9 +9691,7 @@
             },
             "required": [
                 "call_recording",
-                "default_language",
-                "ssl_cert",
-                "ssl_key"
+                "default_language"
             ],
             "type": "object"
         },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.auth.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.auth.json
@@ -12,9 +12,5 @@
             "type": "string"
         }
     },
-    "required": [
-        "secret_for_user_signature",
-        "system_key"
-    ],
     "type": "object"
 }

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.freeswitch.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.freeswitch.json
@@ -40,7 +40,6 @@
         }
     },
     "required": [
-        "offline_configuration_key",
         "{Module}"
     ],
     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
@@ -160,9 +160,7 @@
     },
     "required": [
         "autoload_modules",
-        "ssl_ca_cert",
-        "ssl_cert",
-        "ssl_key"
+        "ssl_ca_cert"
     ],
     "type": "object"
 }

--- a/applications/crossbar/priv/couchdb/schemas/system_config.doodle.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.doodle.json
@@ -64,7 +64,6 @@
     },
     "required": [
         "connections",
-        "inbound_broker",
         "inbound_queue_name",
         "reschedule"
     ],

--- a/applications/crossbar/priv/couchdb/schemas/system_config.media.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.media.json
@@ -58,7 +58,6 @@
             "type": "integer"
         },
         "proxy_password": {
-            "default": "",
             "description": "media proxy password",
             "type": "string"
         },
@@ -80,7 +79,6 @@
             "type": "boolean"
         },
         "proxy_username": {
-            "default": "",
             "description": "media proxy username",
             "type": "string"
         },
@@ -140,9 +138,7 @@
     },
     "required": [
         "call_recording",
-        "default_language",
-        "ssl_cert",
-        "ssl_key"
+        "default_language"
     ],
     "type": "object"
 }

--- a/core/kazoo_media/src/kazoo_media.hrl
+++ b/core/kazoo_media/src/kazoo_media.hrl
@@ -26,8 +26,8 @@
                     ,{<<"authenticated_playback">>, 'false'}
                     ,{<<"authenticated_store">>, 'true'}
                     ,{<<"proxy_store_authenticate">>, 'true'}
-                    ,{<<"proxy_username">>, ""}
-                    ,{<<"proxy_password">>, ""}
+                    ,{<<"proxy_username">>, 'undefined'}
+                    ,{<<"proxy_password">>, 'undefined'}
                     ,{<<"proxy_store_acls">>, [<<"127.0.0.0/24">>]}
                     ,{<<"max_recording_time_limit">>, kz_media_util:max_recording_time_limit()}
                     ,{[<<"call_recording">>, <<"extension">>], <<"mp3">>}

--- a/core/kazoo_media/src/kz_media_store_proxy.erl
+++ b/core/kazoo_media/src/kz_media_store_proxy.erl
@@ -56,8 +56,8 @@ maybe_basic_authentication(Req) ->
 
 -spec maybe_basic_authentication(ne_binary(), ne_binary()) -> boolean().
 maybe_basic_authentication(Username, Password) ->
-    AuthUsername = kapps_config:get_string(?CONFIG_CAT, <<"proxy_username">>, ""),
-    AuthPassword = kapps_config:get_string(?CONFIG_CAT, <<"proxy_password">>, ""),
+    AuthUsername = kapps_config:get_binary(?CONFIG_CAT, <<"proxy_username">>, <<>>),
+    AuthPassword = kapps_config:get_binary(?CONFIG_CAT, <<"proxy_password">>, <<>>),
     not kz_util:is_empty(AuthUsername)
         andalso not kz_util:is_empty(AuthPassword)
         andalso Username == AuthUsername

--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -28,8 +28,8 @@
 
 -define(USE_HTTPS, kapps_config:get_is_true(?CONFIG_CAT, <<"use_https">>, 'false')).
 -define(AUTH_PLAYBACK, kapps_config:get_is_true(?CONFIG_CAT, <<"authenticated_playback">>, 'false')).
--define(AUTH_USERNAME, kapps_config:get_string(?CONFIG_CAT, <<"proxy_username">>, "")).
--define(AUTH_PASSWORD, kapps_config:get_string(?CONFIG_CAT, <<"proxy_password">>, "")).
+-define(AUTH_USERNAME, kapps_config:get_binary(?CONFIG_CAT, <<"proxy_username">>, kz_util:rand_hex_binary(8))).
+-define(AUTH_PASSWORD, kapps_config:get_binary(?CONFIG_CAT, <<"proxy_password">>, kz_util:rand_hex_binary(8))).
 -define(USE_AUTH_STORE, kapps_config:get_is_true(?CONFIG_CAT, <<"authenticated_store">>, 'true')).
 
 -define(NORMALIZE_EXE, kapps_config:get_binary(?CONFIG_CAT, <<"normalize_executable">>, <<"sox">>)).
@@ -174,7 +174,7 @@ build_url(H, P, User, Pwd) ->
                  'true' -> <<"https">>;
                  'false' -> <<"http">>
              end,
-    list_to_binary([Scheme, "://", kz_util:to_binary(User), ":", kz_util:to_binary(Pwd)
+    list_to_binary([Scheme, "://", User, ":", Pwd
                    ,"@", kz_util:to_binary(H), ":", kz_util:to_binary(P), "/"
                    ]).
 


### PR DESCRIPTION
@fenollp 
https://github.com/2600hz/kazoo/commit/026d2548d2e2718c094efae4c9f6885b11baa6e8 broke some functionality in kazoo_media. we should adapt kapps_config_usage to improve schema/swagger generation. we should not change the core code (kazoo_media in this case) to improve schema/swagger generation.

there's still some work to be done in another PR to address the cases where a `case .. of` is used like `ssl_ca_cert` in crossbar_init