### PR TITLE
restart file cache if missing

### DIFF
--- a/core/whistle_media-1.0.0/src/wh_media_single_proxy.erl
+++ b/core/whistle_media-1.0.0/src/wh_media_single_proxy.erl
@@ -49,9 +49,15 @@ init_from_doc(Db, Id, Attachment, Req) ->
         {'ok', Pid} ->
             {'ok', Req, wh_media_file_cache:single(Pid)};
         {'error', _} ->
-            lager:debug("missing file server: 404"),
-            {'ok', Req1} = cowboy_req:reply(404, Req),
-            {'shutdown', Req1, 'ok'}
+            lager:debug("starting file server ~s/~s/~s", [Db, Id, Attachment]),
+            case wh_media_cache_sup:start_file_server(Db, Id, Attachment) of
+                {'ok', Pid} ->
+                    {'ok', Req, wh_media_file_cache:single(Pid)};
+                {'error', Error} ->
+                    lager:debug("start server failed ~s/~s/~s: ~p", [Db, Id, Attachment, Error]),
+                    {'ok', Req1} = cowboy_req:reply(500, Req),
+                    {'shutdown', Req1, 'ok'}
+            end
     catch
         _E:_R ->
             lager:debug("exception thrown: ~s: ~p", [_E, _R]),


### PR DESCRIPTION
We experienced a problem with prompts not playing after freeswitch cache timed out, then went to whistle to retrieve the file but the whistle_media_file_cache worker had terminated. It then returned a 404.

This change restarts the whistle_media_file_cache if it is stopped.