### PR TITLE
restart kz_media_file_cache if working has terminated or is missing

### DIFF
--- a/core/kazoo_media/src/kz_media_continuous_proxy.erl
+++ b/core/kazoo_media/src/kz_media_continuous_proxy.erl
@@ -70,7 +70,8 @@ handle(Req0, {Meta, Bin}) ->
     lager:debug("media: ~s content-type: ~s size: ~b", [MediaName, ContentType, Size]),
 
     Req2 = case ContentType of
-               CT when CT =:= <<"audio/mpeg">>; CT =:= <<"audio/mp3">> ->
+               CT when CT =:= <<"audio/mpeg">> orelse
+                   CT =:= <<"audio/mp3">> ->
                    Req1 = set_resp_headers(Req0, ChunkSize, ContentType, MediaName, Url),
                    cowboy_req:set_resp_body_fun(Size
                                                ,fun(Socket, Transport) ->

--- a/core/kazoo_media/src/kz_media_continuous_proxy.erl
+++ b/core/kazoo_media/src/kz_media_continuous_proxy.erl
@@ -70,8 +70,8 @@ handle(Req0, {Meta, Bin}) ->
     lager:debug("media: ~s content-type: ~s size: ~b", [MediaName, ContentType, Size]),
 
     Req2 = case ContentType of
-               CT when CT =:= <<"audio/mpeg">> orelse
-                   CT =:= <<"audio/mp3">> ->
+               CT when CT =:= <<"audio/mpeg">>
+                   orelse CT =:= <<"audio/mp3">> ->
                    Req1 = set_resp_headers(Req0, ChunkSize, ContentType, MediaName, Url),
                    cowboy_req:set_resp_body_fun(Size
                                                ,fun(Socket, Transport) ->

--- a/core/kazoo_media/src/kz_media_continuous_proxy.erl
+++ b/core/kazoo_media/src/kz_media_continuous_proxy.erl
@@ -70,7 +70,7 @@ handle(Req0, {Meta, Bin}) ->
     lager:debug("media: ~s content-type: ~s size: ~b", [MediaName, ContentType, Size]),
 
     Req2 = case ContentType of
-               CT when CT =:= <<"audio/mpeg">> orelse CT =:= <<"audio/mp3">> ->
+               CT when CT =:= <<"audio/mpeg">>; CT =:= <<"audio/mp3">> ->
                    Req1 = set_resp_headers(Req0, ChunkSize, ContentType, MediaName, Url),
                    cowboy_req:set_resp_body_fun(Size
                                                ,fun(Socket, Transport) ->

--- a/core/kazoo_media/src/kz_media_continuous_proxy.erl
+++ b/core/kazoo_media/src/kz_media_continuous_proxy.erl
@@ -71,7 +71,7 @@ handle(Req0, {Meta, Bin}) ->
 
     Req2 = case ContentType of
                CT when CT =:= <<"audio/mpeg">>
-                   orelse CT =:= <<"audio/mp3">> ->
+                  orelse CT =:= <<"audio/mp3">> ->
                    Req1 = set_resp_headers(Req0, ChunkSize, ContentType, MediaName, Url),
                    cowboy_req:set_resp_body_fun(Size
                                                ,fun(Socket, Transport) ->

--- a/core/kazoo_media/src/kz_media_single_proxy.erl
+++ b/core/kazoo_media/src/kz_media_single_proxy.erl
@@ -51,9 +51,15 @@ init_from_doc(Url, Req) ->
         {'ok', Pid} ->
             {'ok', Req, kz_media_file_cache:single(Pid)};
         {'error', _} ->
-            lager:debug("missing file server: 404"),
-            {'ok', Req1} = cowboy_req:reply(404, Req),
-            {'shutdown', Req1, 'ok'}
+            lager:debug("starting file server ~s/~s/~s", [Db, Id, Attachment]),
+            case kz_media_cache_sup:start_file_server(Db, Id, Attachment) of
+                {'ok', Pid} ->
+                    {'ok', Req, kz_media_file_cache:single(Pid)};
+                {'error', Error} ->
+                    lager:debug("start server failed ~s/~s/~s: ~p", [Db, Id, Attachment, Error]),
+                    {'ok', Req1} = cowboy_req:reply(404, Req),
+                    {'shutdown', Req1, 'ok'}
+            end
     catch
         _E:_R ->
             kz_util:log_stacktrace(),

--- a/core/kazoo_media/src/kz_media_single_proxy.erl
+++ b/core/kazoo_media/src/kz_media_single_proxy.erl
@@ -79,8 +79,8 @@ handle(Req0, {Meta, Bin}) ->
     Url = kz_json:get_value(<<"url">>, Meta, <<>>),
 
     Req2 = case ContentType of
-               CT when CT =:= <<"audio/mpeg">> orelse
-                   CT =:= <<"audio/mp3">> ->
+               CT when CT =:= <<"audio/mpeg">>
+                   orelse CT =:= <<"audio/mp3">> ->
                    Req1 = set_resp_headers(Req0, ChunkSize, ContentType, MediaName, Url),
                    cowboy_req:set_resp_body_fun(Size
                                                ,fun(Socket, Transport) ->

--- a/core/kazoo_media/src/kz_media_single_proxy.erl
+++ b/core/kazoo_media/src/kz_media_single_proxy.erl
@@ -79,7 +79,7 @@ handle(Req0, {Meta, Bin}) ->
     Url = kz_json:get_value(<<"url">>, Meta, <<>>),
 
     Req2 = case ContentType of
-               CT when CT =:= <<"audio/mpeg">> orelse CT =:= <<"audio/mp3">> ->
+               CT when CT =:= <<"audio/mpeg">>; CT =:= <<"audio/mp3">> ->
                    Req1 = set_resp_headers(Req0, ChunkSize, ContentType, MediaName, Url),
                    cowboy_req:set_resp_body_fun(Size
                                                ,fun(Socket, Transport) ->

--- a/core/kazoo_media/src/kz_media_single_proxy.erl
+++ b/core/kazoo_media/src/kz_media_single_proxy.erl
@@ -79,7 +79,8 @@ handle(Req0, {Meta, Bin}) ->
     Url = kz_json:get_value(<<"url">>, Meta, <<>>),
 
     Req2 = case ContentType of
-               CT when CT =:= <<"audio/mpeg">>; CT =:= <<"audio/mp3">> ->
+               CT when CT =:= <<"audio/mpeg">> orelse
+                   CT =:= <<"audio/mp3">> ->
                    Req1 = set_resp_headers(Req0, ChunkSize, ContentType, MediaName, Url),
                    cowboy_req:set_resp_body_fun(Size
                                                ,fun(Socket, Transport) ->

--- a/core/kazoo_media/src/kz_media_single_proxy.erl
+++ b/core/kazoo_media/src/kz_media_single_proxy.erl
@@ -80,7 +80,7 @@ handle(Req0, {Meta, Bin}) ->
 
     Req2 = case ContentType of
                CT when CT =:= <<"audio/mpeg">>
-                   orelse CT =:= <<"audio/mp3">> ->
+                  orelse CT =:= <<"audio/mp3">> ->
                    Req1 = set_resp_headers(Req0, ChunkSize, ContentType, MediaName, Url),
                    cowboy_req:set_resp_body_fun(Size
                                                ,fun(Socket, Transport) ->


### PR DESCRIPTION
We are running kazoo 3.19, so I made the original change in that branch. Since the logic appeared the same, I was told to make the change in the current active branch.

We are experiencing a problem with prompts not playing after the freeswitch cache times out. Freeswitch then goes to whistle to retrieve the file but the whistle_media_file_cache worker had terminated. The wh_media_single_prozy then returned a 404, which caused the prompt to fail to play.

This change restarts the whistle_media_file_cache worker if it is stopped.