### PR TITLE
Qf onhold

### DIFF
--- a/applications/crossbar/src/modules/cb_websockets.erl
+++ b/applications/crossbar/src/modules/cb_websockets.erl
@@ -31,6 +31,8 @@
               ,?TO_JSON(<<"call.CHANNEL_ANSWER.*">>, <<"CHANNEL_ANSWER">>)
               ,?TO_JSON(<<"call.CHANNEL_DESTROY.*">>, <<"CHANNEL_DESTROY">>)
               ,?TO_JSON(<<"call.CHANNEL_BRIDGE.*">>, <<"CHANNEL_BRIDGE">>)
+              ,?TO_JSON(<<"call.CHANNEL_HOLD.*">>, <<"CHANNEL_HOLD">>)
+              ,?TO_JSON(<<"call.CHANNEL_UNHOLD.*">>, <<"CHANNEL_UNHOLD">>)
               ]).
 
 -define(OBJECTS,


### PR DESCRIPTION
This adds CHANNEL_HOLD and CHANNEL_UNHOLD to list of available websocket bindings in cb_websockets and also publish those events from `ecallmgr_call_events`.

But the published events doesn't have a SIP_HEADERS and CUSTOME_CHANNEL_VARS!!! thus they're not received by bonded modules(e.g., blackhole doesn't received them)

This needs to be addressed in FreeSWITCH itself due to how it treats these events.
