### PR TITLE
Fix wrong server sending invalid conference config

### DIFF
--- a/applications/conference/src/conference_sup.erl
+++ b/applications/conference/src/conference_sup.erl
@@ -17,6 +17,7 @@
 -export([init/1]).
 
 -define(CHILDREN, [?SUPER('conf_participant_sup')
+                  ,?WORKER('conference_config_shared_listener')
                   ,?WORKER('conference_shared_listener')
                   ,?WORKER('conference_listener')
                   ]).


### PR DESCRIPTION
When the server not hosting the initial participant's conf_participant proc is the one to receive the config req for the conference profile information, it will return an error "no participant worker found for conference '<conference_id>'".
With this patch, if the server cannot find the participant worker (and therefore the conference data), it will nack the AMQP config_req and let another server handle it.