### PR TITLE
Fix wrong server sending invalid conference config

### DIFF
--- a/applications/conference/src/conf_participant.erl
+++ b/applications/conference/src/conf_participant.erl
@@ -13,6 +13,7 @@
 %% API
 -export([start_link/1]).
 -export([relay_amqp/2]).
+-export([handle_conference_bootstrap_req/2]).
 -export([handle_conference_error/2]).
 
 -export([consume_call_events/1]).
@@ -48,8 +49,11 @@
 
 -define(RESPONDERS, [{{?MODULE, 'relay_amqp'}
                      ,[{<<"call_event">>, <<"*">>}]
-                     },
-                     {{?MODULE, 'handle_conference_event'}
+                     }
+                    ,{{?MODULE, 'handle_conference_bootstrap_req'}
+                     ,[{<<"conference">>, <<"bootstrap_req">>}]
+                     }
+                    ,{{?MODULE, 'handle_conference_event'}
                      ,[{<<"conference">>, <<"event">>}]
                      }
                     ,{{?MODULE, 'handle_conference_error'}
@@ -165,6 +169,12 @@ relay_amqp(JObj, Props) ->
             dtmf(Srv, Digit)
     end.
 
+-spec handle_conference_bootstrap_req(kz_json:object(), kz_proplist()) -> 'ok'.
+handle_conference_bootstrap_req(JObj, Props) ->
+    'true' = kapi_conference:bootstrap_req_v(JObj),
+    Srv = props:get_value('server', Props),
+    gen_listener:cast(Srv, {'handle_bootstrap_req', JObj}).
+
 -spec handle_conference_error(kz_json:object(), kz_proplist()) -> 'ok'.
 handle_conference_error(JObj, Props) ->
     'true' = kapi_conference:conference_error_v(JObj),
@@ -235,6 +245,14 @@ handle_call(_Request, _, P) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec handle_cast(any(), participant()) -> handle_cast_ret_state(participant()).
+handle_cast({'handle_bootstrap_req', JObj}, #participant{conference=Conference}=P) ->
+    ServerId = kz_api:server_id(JObj),
+    Resp = [{<<"Conference">>, kapps_conference:to_json(Conference)}
+           ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_conference:publish_bootstrap_resp(ServerId, Resp),
+    {'noreply', P};
 handle_cast('hungup', Participant) ->
     {'stop', {'shutdown', 'hungup'}, Participant};
 handle_cast({'gen_listener', {'created_queue', Q}}, #participant{conference='undefined'
@@ -262,7 +280,9 @@ handle_cast({'set_conference', Conference}, Participant=#participant{call=Call})
     ConferenceId = kapps_conference:id(Conference),
     CallId = kapps_call:call_id(Call),
     lager:debug("received conference data for conference ~s", [ConferenceId]),
-    gen_listener:add_binding(self(), 'conference', [{ 'restrict_to', [{'event', {ConferenceId,CallId}}] }]),
+    gen_listener:add_binding(self(), 'conference', [{ 'restrict_to', [{'event', {ConferenceId,CallId}}
+                                                                     ,{'bootstrap', ConferenceId}
+                                                                     ] }]),
     {'noreply', Participant#participant{conference=Conference}};
 handle_cast({'set_discovery_event', DE}, #participant{}=Participant) ->
     {'noreply', Participant#participant{discovery_event=DE}};

--- a/core/kazoo_amqp/include/kz_amqp.hrl
+++ b/core/kazoo_amqp/include/kz_amqp.hrl
@@ -23,6 +23,7 @@
 -define(KEY_CONFERENCE_DISCOVERY, <<"conference.discovery">>).
 -define(KEY_CONFERENCE_COMMAND, <<"conference.command.">>).
 -define(KEY_CONFERENCE_EVENT, <<"conference.event.">>).
+-define(KEY_CONFERENCE_BOOTSTRAP, <<"conference.bootstrap.">>).
 -define(KEY_CONFERENCE_CONFIG, <<"conference.config.">>).
 
 %% To listen for auth requests, bind your queue in the CallMgr Exchange with the <<"auth.req">> routing key.

--- a/core/kazoo_amqp/src/amqp_util.erl
+++ b/core/kazoo_amqp/src/amqp_util.erl
@@ -351,7 +351,7 @@ offnet_resource_publish(Payload, ContentType) ->
 monitor_publish(Payload, ContentType, RoutingKey) ->
     basic_publish(?EXCHANGE_MONITOR, RoutingKey, Payload, ContentType).
 
--type conf_routing_type() :: 'discovery' | 'event' | 'command' | 'config'.
+-type conf_routing_type() :: 'discovery' | 'event' | 'command' | 'bootstrap' | 'config'.
 -spec conference_publish(amqp_payload(), conf_routing_type()) -> 'ok'.
 -spec conference_publish(amqp_payload(), conf_routing_type(), api_binary()) -> 'ok'.
 -spec conference_publish(amqp_payload(), conf_routing_type(), api_binary(), kz_proplist()) -> 'ok'.
@@ -361,6 +361,8 @@ conference_publish(Payload, 'discovery') ->
     conference_publish(Payload, 'discovery', <<"*">>);
 conference_publish(Payload, 'event') ->
     conference_publish(Payload, 'event', <<"*">>);
+conference_publish(Payload, 'bootstrap') ->
+    conference_publish(Payload, 'bootstrap', <<"*">>);
 conference_publish(Payload, 'config') ->
     conference_publish(Payload, 'config', <<"*">>);
 conference_publish(Payload, 'command') ->
@@ -368,6 +370,8 @@ conference_publish(Payload, 'command') ->
 
 conference_publish(Payload, 'discovery', ConfId) ->
     conference_publish(Payload, 'discovery', ConfId, []);
+conference_publish(Payload, 'bootstrap', ConfId) ->
+    conference_publish(Payload, 'bootstrap', ConfId, []);
 conference_publish(Payload, 'config', ConfId) ->
     conference_publish(Payload, 'config', ConfId, []);
 conference_publish(Payload, 'event', ConfId) ->
@@ -377,6 +381,8 @@ conference_publish(Payload, 'command', ConfId) ->
 
 conference_publish(Payload, 'discovery', ConfId, Options) ->
     conference_publish(Payload, 'discovery', ConfId, Options, ?DEFAULT_CONTENT_TYPE);
+conference_publish(Payload, 'bootstrap', ConfId, Options) ->
+    conference_publish(Payload, 'bootstrap', ConfId, Options, ?DEFAULT_CONTENT_TYPE);
 conference_publish(Payload, 'config', ConfId, Options) ->
     conference_publish(Payload, 'config', ConfId, Options, ?DEFAULT_CONTENT_TYPE);
 conference_publish(Payload, 'event', ConfId, Options) ->
@@ -386,6 +392,8 @@ conference_publish(Payload, 'command', ConfId, Options) ->
 
 conference_publish(Payload, 'discovery', _, Options, ContentType) ->
     basic_publish(?EXCHANGE_CONFERENCE, ?KEY_CONFERENCE_DISCOVERY, Payload, ContentType, Options);
+conference_publish(Payload, 'bootstrap', ConfId, Options, ContentType) ->
+    basic_publish(?EXCHANGE_CONFERENCE, <<?KEY_CONFERENCE_BOOTSTRAP/binary, ConfId/binary>>, Payload, ContentType, Options);
 conference_publish(Payload, 'config', ConfProfile, Options, ContentType) ->
     basic_publish(?EXCHANGE_CONFERENCE, <<?KEY_CONFERENCE_CONFIG/binary, ConfProfile/binary>>, Payload, ContentType, Options);
 conference_publish(Payload, 'event', ConfId, Options, ContentType) ->
@@ -948,6 +956,8 @@ bind_q_to_conference(Queue, 'command') ->
     bind_q_to_conference(Queue, 'command', <<"*">>);
 bind_q_to_conference(Queue, 'event') ->
     bind_q_to_conference(Queue, 'event', <<"*">>);
+bind_q_to_conference(Queue, 'bootstrap') ->
+    bind_q_to_conference(Queue, 'bootstrap', <<"*">>);
 bind_q_to_conference(Queue, 'config') ->
     bind_q_to_conference(Queue, 'config', <<"*">>).
 
@@ -957,6 +967,8 @@ bind_q_to_conference(Queue, 'event', EventKey) ->
     bind_q_to_exchange(Queue, <<?KEY_CONFERENCE_EVENT/binary, EventKey/binary>>, ?EXCHANGE_CONFERENCE);
 bind_q_to_conference(Queue, 'command', ConfId) ->
     bind_q_to_exchange(Queue, <<?KEY_CONFERENCE_COMMAND/binary, ConfId/binary>>, ?EXCHANGE_CONFERENCE);
+bind_q_to_conference(Queue, 'bootstrap', ConfId) ->
+    bind_q_to_exchange(Queue, <<?KEY_CONFERENCE_BOOTSTRAP/binary, ConfId/binary>>, ?EXCHANGE_CONFERENCE);
 bind_q_to_conference(Queue, 'config', ConfProfile) ->
     bind_q_to_exchange(Queue, <<?KEY_CONFERENCE_CONFIG/binary, ConfProfile/binary>>, ?EXCHANGE_CONFERENCE).
 
@@ -1006,6 +1018,8 @@ unbind_q_from_conference(Queue, 'discovery') ->
     unbind_q_from_conference(Queue, 'discovery', 'undefined');
 unbind_q_from_conference(Queue, 'command') ->
     unbind_q_from_conference(Queue, 'command', <<"*">>);
+unbind_q_from_conference(Queue, 'bootstrap') ->
+    unbind_q_from_conference(Queue, 'bootstrap', <<"*">>);
 unbind_q_from_conference(Queue, 'config') ->
     unbind_q_from_conference(Queue, 'config', 'undefined');
 unbind_q_from_conference(Queue, 'event') ->
@@ -1015,6 +1029,8 @@ unbind_q_from_conference(Queue, 'discovery', _) ->
     unbind_q_from_exchange(Queue, ?KEY_CONFERENCE_DISCOVERY, ?EXCHANGE_CONFERENCE);
 unbind_q_from_conference(Queue, 'event', ConfId) ->
     unbind_q_from_conference(Queue, 'event', ConfId, <<"*">>);
+unbind_q_from_conference(Queue, 'bootstrap', ConfId) ->
+    unbind_q_from_exchange(Queue, <<?KEY_CONFERENCE_BOOTSTRAP/binary, ConfId/binary>>, ?EXCHANGE_CONFERENCE);
 unbind_q_from_conference(Queue, 'config', ConfProfile) ->
     unbind_q_from_exchange(Queue, <<?KEY_CONFERENCE_CONFIG/binary, ConfProfile/binary>>, ?EXCHANGE_CONFERENCE);
 unbind_q_from_conference(Queue, 'command', ConfId) ->

--- a/core/kazoo_amqp/src/api/kapi_conference.erl
+++ b/core/kazoo_amqp/src/api/kapi_conference.erl
@@ -37,6 +37,8 @@
 -export([participant_volume_out/1, participant_volume_out_v/1]).
 -export([participant_event/1, participant_event_v/1]).
 -export([conference_error/1, conference_error_v/1]).
+-export([bootstrap_req/1, bootstrap_req_v/1
+        ,bootstrap_resp/1, bootstrap_resp_v/1]).
 -export([config_req/1, config_req_v/1
         ,config_resp/1, config_resp_v/1
         ]).
@@ -72,6 +74,8 @@
 -export([publish_command/2, publish_command/3]).
 -export([publish_event/1, publish_event/2]).
 -export([publish_targeted_command/2, publish_targeted_command/3]).
+-export([publish_bootstrap_req/1, publish_bootstrap_req/2
+        ,publish_bootstrap_resp/2, publish_bootstrap_resp/3]).
 -export([publish_config_req/1, publish_config_req/2
         ,publish_config_resp/2, publish_config_resp/3
         ]).
@@ -362,6 +366,20 @@
                                  ,{<<"Event-Name">>, <<"error">>}
                                  ]).
 -define(CONFERENCE_ERROR_TYPES, []).
+
+-define(BOOTSTRAP_REQ_HEADERS, [<<"Conference-ID">>]).
+-define(OPTIONAL_BOOTSTRAP_REQ_HEADERS, []).
+-define(BOOTSTRAP_REQ_VALUES, [{<<"Event-Category">>, <<"conference">>}
+                              ,{<<"Event-Name">>, <<"bootstrap_req">>}
+                              ]).
+-define(BOOTSTRAP_REQ_TYPES, []).
+
+-define(BOOTSTRAP_RESP_HEADERS, [<<"Conference">>]).
+-define(OPTIONAL_BOOTSTRAP_RESP_HEADERS, []).
+-define(BOOTSTRAP_RESP_VALUES, [{<<"Event-Category">>, <<"conference">>}
+                               ,{<<"Event-Name">>, <<"bootstrap_resp">>}
+                               ]).
+-define(BOOTSTRAP_RESP_TYPES, []).
 
 -define(CONFIG_REQ_HEADERS, [<<"Request">>, <<"Profile">>]).
 -define(OPTIONAL_CONFIG_REQ_HEADERS, [<<"Controls">>]).
@@ -941,6 +959,42 @@ conference_error_v(JObj) -> conference_error_v(kz_json:to_proplist(JObj)).
 %% Takes proplist, creates JSON string or error
 %% @end
 %%--------------------------------------------------------------------
+-spec bootstrap_req(api_terms()) -> {'ok', iolist()} | {'error', string()}.
+bootstrap_req(Prop) when is_list(Prop) ->
+    case bootstrap_req_v(Prop) of
+        'true' -> kz_api:build_message(Prop, ?BOOTSTRAP_REQ_HEADERS, ?OPTIONAL_BOOTSTRAP_REQ_HEADERS);
+        'false' -> {'error', "Proplist failed validation for bootstrap req"}
+    end;
+bootstrap_req(JObj) -> bootstrap_req(kz_json:to_proplist(JObj)).
+
+-spec bootstrap_req_v(api_terms()) -> boolean().
+bootstrap_req_v(Prop) when is_list(Prop) ->
+    kz_api:validate(Prop, ?BOOTSTRAP_REQ_HEADERS, ?BOOTSTRAP_REQ_VALUES, ?BOOTSTRAP_REQ_TYPES);
+bootstrap_req_v(JObj) -> bootstrap_req_v(kz_json:to_proplist(JObj)).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Takes proplist, creates JSON string or error
+%% @end
+%%--------------------------------------------------------------------
+-spec bootstrap_resp(api_terms()) -> {'ok', iolist()} | {'error', string()}.
+bootstrap_resp(Prop) when is_list(Prop) ->
+    case bootstrap_resp_v(Prop) of
+        'true' -> kz_api:build_message(Prop, ?BOOTSTRAP_RESP_HEADERS, ?OPTIONAL_BOOTSTRAP_RESP_HEADERS);
+        'false' -> {'error', "Proplist failed validation for bootstrap resp"}
+    end;
+bootstrap_resp(JObj) -> bootstrap_resp(kz_json:to_proplist(JObj)).
+
+-spec bootstrap_resp_v(api_terms()) -> boolean().
+bootstrap_resp_v(Prop) when is_list(Prop) ->
+    kz_api:validate(Prop, ?BOOTSTRAP_RESP_HEADERS, ?BOOTSTRAP_RESP_VALUES, ?BOOTSTRAP_RESP_TYPES);
+bootstrap_resp_v(JObj) -> bootstrap_resp_v(kz_json:to_proplist(JObj)).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Takes proplist, creates JSON string or error
+%% @end
+%%--------------------------------------------------------------------
 -spec config_req(api_terms()) -> {'ok', iolist()} | {'error', string()}.
 config_req(Prop) when is_list(Prop) ->
     case config_req_v(Prop) of
@@ -994,6 +1048,9 @@ bind_to_q(Q, ['command'|T], Props) ->
 bind_to_q(Q, ['event'|T], Props) ->
     'ok' = amqp_util:bind_q_to_conference(Q, 'event'),
     bind_to_q(Q, T, Props);
+bind_to_q(Q, [{'bootstrap', ConfId}|T], Props) ->
+    'ok' = amqp_util:bind_q_to_conference(Q, 'bootstrap', ConfId),
+    bind_to_q(Q, T, Props);
 bind_to_q(Q, ['config'|T], Props) ->
     Profile = props:get_value('profile', Props, <<"*">>),
     'ok' = amqp_util:bind_q_to_conference(Q, 'config', Profile),
@@ -1034,6 +1091,9 @@ unbind_from_q(Q, ['command'|T], Props) ->
 unbind_from_q(Q, ['event'|T], Props) ->
     'ok' = amqp_util:unbind_q_from_conference(Q, 'event'),
     unbind_from_q(Q, T, Props);
+unbind_from_q(Q, [{'bootstrap', ConfId}|T], Props) ->
+    'ok' = amqp_util:unbind_q_from_conference(Q, 'bootstrap', ConfId),
+    unbind_from_q(Q, T, Props);
 unbind_from_q(Q, ['config'|T], Props) ->
     Profile = props:get_value('profile', Props, <<"*">>),
     'ok' = amqp_util:unbind_q_from_conference(Q, 'config', Profile),
@@ -1048,7 +1108,7 @@ unbind_from_q(Q, [{'event', ConfIdOrProps}|T], Props) ->
 
 unbind_from_q(Q, [{'command', ConfId}|T], Props) ->
     'ok' = amqp_util:bind_q_to_conference(Q, 'command', ConfId),
-    bind_to_q(Q, T, Props);
+    unbind_from_q(Q, T, Props);
 unbind_from_q(_Q, [], _) -> 'ok'.
 
 %%--------------------------------------------------------------------
@@ -1445,6 +1505,36 @@ publish_targeted_command(Focus, Req, ContentType) ->
             Queue = focus_queue_name(Focus),
             amqp_util:targeted_publish(Queue, Payload, ContentType)
     end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Publish to the conference exchange
+%% @end
+%%--------------------------------------------------------------------
+-spec publish_bootstrap_req(api_terms()) -> 'ok'.
+-spec publish_bootstrap_req(api_terms(), ne_binary()) -> 'ok'.
+publish_bootstrap_req(JObj) ->
+    publish_bootstrap_req(JObj, ?DEFAULT_CONTENT_TYPE).
+publish_bootstrap_req(Req, ContentType) ->
+    ConfId = conference_id(Req),
+    {'ok', Payload} = kz_api:prepare_api_payload(Req, ?BOOTSTRAP_REQ_VALUES, fun bootstrap_req/1),
+    amqp_util:conference_publish(Payload, 'bootstrap', ConfId, [], ContentType).
+
+conference_id(Props) when is_list(Props) -> props:get_value(<<"Conference-ID">>, Props);
+conference_id(JObj) -> kz_json:get_value(<<"Conference-ID">>, JObj).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Publish to the conference exchange
+%% @end
+%%--------------------------------------------------------------------
+-spec publish_bootstrap_resp(ne_binary(), api_terms()) -> 'ok'.
+-spec publish_bootstrap_resp(ne_binary(), api_terms(), ne_binary()) -> 'ok'.
+publish_bootstrap_resp(Queue, JObj) ->
+    publish_bootstrap_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+publish_bootstrap_resp(Queue, Req, ContentType) ->
+    {'ok', Payload} = kz_api:prepare_api_payload(Req, ?BOOTSTRAP_RESP_VALUES, fun bootstrap_resp/1),
+    amqp_util:targeted_publish(Queue, Payload, ContentType).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/core/kazoo_amqp/src/api/kapi_conference.erl
+++ b/core/kazoo_amqp/src/api/kapi_conference.erl
@@ -1107,7 +1107,7 @@ unbind_from_q(Q, [{'event', ConfIdOrProps}|T], Props) ->
     unbind_from_q(Q, T, Props);
 
 unbind_from_q(Q, [{'command', ConfId}|T], Props) ->
-    'ok' = amqp_util:bind_q_to_conference(Q, 'command', ConfId),
+    'ok' = amqp_util:unbind_q_from_conference(Q, 'command', ConfId),
     unbind_from_q(Q, T, Props);
 unbind_from_q(_Q, [], _) -> 'ok'.
 


### PR DESCRIPTION
Reopening with alternative approach. Publish bootstrap_req and have the initial conf_participant reply with conference data. We can't use search_req to acquire the data from ecallmgr_fs_conferences as the conference hasn't been created yet (when looking for the "Profile" for the conference).

Also note a quick fix in this PR for bad unbind on L1110-1111 of kapi_conference.erl.