### PR TITLE
json_merge: provides a nice merge function

### DIFF
--- a/core/kazoo_json/src/kz_json.erl
+++ b/core/kazoo_json/src/kz_json.erl
@@ -68,6 +68,8 @@
 -export([merge_recursive/1
         ,merge_recursive/2
         ,merge_recursive/3
+        ,merge/2, merge/3
+        ,merge_left/2, merge_right/2
         ]).
 
 -export([from_list/1, merge_jobjs/2]).
@@ -240,6 +242,51 @@ are_identical(JObj1, JObj2) ->
 -spec from_list(json_proplist()) -> object().
 from_list([]) -> new();
 from_list(L) when is_list(L) -> ?JSON_WRAPPER(L).
+
+%% Lifted from Jesper's post on the ML (Nov 2016) on merging maps
+-spec merge(object(), object()) -> object().
+merge(JObj1, JObj2) ->
+    merge(fun merge_left/2, JObj1, JObj2).
+
+-type merge_arg_2() :: {'left' | 'right', json_term()} | {'both', json_term(), json_term()}.
+-type merge_fun_result() :: 'undefined' | {'ok', json_term()}.
+-type merge_fun() :: fun((key(), merge_arg_2()) -> merge_fun_result()).
+-spec merge(merge_fun(), object(), object()) -> object().
+merge(F, ?JSON_WRAPPER(PropsA), ?JSON_WRAPPER(PropsB)) ->
+    ListA = lists:sort(PropsA),
+    ListB = lists:sort(PropsB),
+    merge(F, ListA, ListB, []).
+
+merge(_F, [], [], Acc) ->
+    from_list(Acc);
+merge(F, [{KX, VX}|Xs], [], Acc) ->
+    merge(F, Xs, [], f(KX, F(KX, {'left', VX}), Acc));
+merge(F, [], [{KY, VY}|Ys], Acc) ->
+    merge(F, Ys, [], f(KY, F(KY, {'right', VY}), Acc));
+merge(F, [{KX, VX}|Xs]=Left, [{KY, VY}|Ys]=Right, Acc) ->
+    if
+        KX < KY -> merge(F, Xs, Right, f(KX, F(KX, {'left', VX}), Acc));
+        KX > KY -> merge(F, Left, Ys, f(KY, F(KY, {'right', VY}), Acc));
+        KX =:= KY -> merge(F, Xs, Ys, f(KX, F(KX, {'both', VX, VY}), Acc))
+    end.
+
+-spec f(key(), merge_fun_result(), list()) -> list().
+f(_K, 'undefined', Acc) -> Acc;
+f(K, {'ok', R}, Acc) -> [{K, R} | Acc].
+
+-spec merge_left(key(), merge_arg_2()) -> merge_fun_result().
+merge_left(_K, {'left', V}) -> {'ok', V};
+merge_left(_K, {'right', V}) -> {'ok', V};
+merge_left(_K, {'both', ?JSON_WRAPPER(_)=Left, ?JSON_WRAPPER(_)=Right}) ->
+    {'ok', merge(fun merge_left/2, Left, Right)};
+merge_left(_K, {'both', Left, _Right}) -> {'ok', Left}.
+
+-spec merge_right(key(), merge_arg_2()) -> merge_fun_result().
+merge_right(_K, {'left', V}) -> {'ok', V};
+merge_right(_K, {'right', V}) -> {'ok', V};
+merge_right(_K, {'both', ?JSON_WRAPPER(_)=Left, ?JSON_WRAPPER(_)=Right}) ->
+    {'ok', merge(fun merge_right/2, Left, Right)};
+merge_right(_K, {'both', _Left, Right}) -> {'ok', Right}.
 
 %% only a top-level merge
 %% merges JObj1 into JObj2

--- a/core/kazoo_json/test/kz_json_test.erl
+++ b/core/kazoo_json/test/kz_json_test.erl
@@ -108,13 +108,25 @@ prop_to_proplist() ->
 -define(SP, kz_json:decode(<<"{\"plan\":{\"phone_numbers\":{\"did_us\":{\"discounts\":{\"cumulative\":{\"rate\":1}}}}}}">>)).
 -define(O, kz_json:decode(<<"{\"phone_numbers\":{\"did_us\":{\"discounts\":{\"cumulative\":{\"rate\":20}}}}}">>)).
 
-merge_overrides_test_() ->
+merge_recursive_overrides_test_() ->
     AP = kz_json:merge_recursive(?SP, kz_json:from_list([{<<"plan">>, ?O}])),
 
     Key = [<<"plan">>, <<"phone_numbers">>, <<"did_us">>, <<"discounts">>, <<"cumulative">>, <<"rate">>],
 
     [?_assertEqual(1, kz_json:get_value(Key, ?SP))
     ,?_assertEqual(20, kz_json:get_value(Key, AP))
+    ].
+
+merge_overrides_test_() ->
+    %% default merges left onto right
+    Left = kz_json:merge(fun kz_json:merge_left/2, ?SP, kz_json:from_list([{<<"plan">>, ?O}])),
+    Right = kz_json:merge(fun kz_json:merge_right/2, ?SP, kz_json:from_list([{<<"plan">>, ?O}])),
+
+    Key = [<<"plan">>, <<"phone_numbers">>, <<"did_us">>, <<"discounts">>, <<"cumulative">>, <<"rate">>],
+
+    [?_assertEqual(1, kz_json:get_value(Key, ?SP))
+    ,?_assertEqual(20, kz_json:get_value(Key, Right))
+    ,?_assertEqual(1, kz_json:get_value(Key, Left))
     ].
 
 is_empty_test_() ->


### PR DESCRIPTION
as described on the Erlang ML today by Jesper (for merging maps), this
applies nicely to merging JSON objects as well.

This provides two merge functions, merge_left/2 and merge_right/2,
that will prefer the left or right value (except in cases where the
values are JSON objects themselves - recursively merge them).