### PR TITLE
Use erlang-lager repo for lager

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -36,7 +36,7 @@ dep_couchbeam = git https://github.com/lazedo/couchbeam 1.3.1.2
 ## from for-GET/jesse
 dep_jesse = git https://github.com/lazedo/jesse 1.4.3
 
-dep_lager = git https://github.com/basho/lager 3.2.1
+dep_lager = git https://github.com/erlang-lager/lager 3.2.1
 dep_fs_event = git https://github.com/jamhed/fs_event 783400da08c2b55c295dbec81df0d926960c0346
 dep_fs_sync = git https://github.com/jamhed/fs_sync 2cf85cf5861221128f020c453604d509fd37cd53
 dep_inet_cidr = git https://github.com/benoitc/inet_cidr.git


### PR DESCRIPTION
Basho just announced they moved lager to https://github.com/erlang-lager/lager