### PR TITLE
Stop trunkstore process on bridge

### DIFF
--- a/applications/trunkstore/src/ts_from_offnet.erl
+++ b/applications/trunkstore/src/ts_from_offnet.erl
@@ -151,6 +151,7 @@ send_privacy(State) ->
 -spec wait_for_bridge(ts_callflow:state(), api_integer()) -> 'ok'.
 wait_for_bridge(State, Timeout) ->
     case ts_callflow:wait_for_bridge(State, Timeout) of
+        {'bridged', _} -> lager:info("channel bridged, we're done");
         {'hangup', _} -> 'ok';
         {'error', State1} ->
             lager:info("error waiting for bridge, try failover"),

--- a/applications/trunkstore/src/ts_from_onnet.erl
+++ b/applications/trunkstore/src/ts_from_onnet.erl
@@ -194,6 +194,7 @@ send_offnet(State, Command) ->
 
 wait_for_bridge(State, CtlQ, Timeout) ->
     case ts_callflow:wait_for_bridge(State, Timeout) of
+        {'done', _} -> lager:info("channel bridged, we're done here");
         {'hangup', _} -> ts_callflow:send_hangup(State);
         {'error', #ts_callflow_state{aleg_callid='undefined'}} -> 'ok';
         {'error', #ts_callflow_state{aleg_callid=CallId}=State1} ->


### PR DESCRIPTION
There doesn't seem to be a need for the trunkstore process to stay
alive once the bridge has started (CHANNEL_BRIDGE received). If
received, the process will cleanup and terminate.