### PR TITLE
qf-attachments allow url as a function

### DIFF
--- a/applications/fax/src/fax_request.erl
+++ b/applications/fax/src/fax_request.erl
@@ -471,9 +471,9 @@ store_attachment(#state{call=Call
                        ,storage=#fax_storage{attachment_id=AttachmentId}
                        ,fax_doc=FaxDoc
                        }=State) ->
-    FaxUrl = kz_media_url:store(FaxDoc, AttachmentId),
+    FaxUrlFun = fun() -> kz_media_url:store(FaxDoc, AttachmentId) end,
     FaxFile = get_fs_filename(State),
-    case kapps_call_command:store_file(FaxFile, FaxUrl, Call) of
+    case kapps_call_command:store_file(FaxFile, FaxUrlFun, Call) of
         'ok' ->
             notify_success(FaxResultObj, State),
             {'stop', 'normal', State};

--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -3024,19 +3024,16 @@ store_file(Filename, Url, Tries, Timeout, Call) ->
     API = fun() -> [{<<"Command">>, <<"send_http">>}
                    ,{<<"Args">>, kz_json:from_list(store_file_args(Filename, Url))}
                    ,{<<"FreeSWITCH-Node">>, kapps_call:switch_nodename(Call)}
-                     | kz_api:default_headers(AppName, AppVersion)
+                    | kz_api:default_headers(AppName, AppVersion)
                    ]
           end,
     do_store_file(Tries, Timeout, API, Msg, Call).
 
--spec do_store_file(pos_integer(), kz_timeout(), kz_proplist() | function()
+-spec do_store_file(pos_integer(), kz_timeout(), function()
                    ,ne_binary(), kapps_call:call()) ->
                            'ok' | {'error', any()}.
 do_store_file(Tries, Timeout, API, Msg, Call) ->
-    Payload = case is_function(API, 0) of
-                  'true' -> API();
-                  'false' -> API
-              end,
+    Payload = API(),
     case kz_amqp_worker:call(Payload, fun kapi_switch:publish_command/1, fun kapi_switch:fs_reply_v/1, Timeout) of
         {'ok', JObj} ->
             case kz_json:get_ne_binary_value(<<"Result">>, JObj) of

--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -2989,25 +2989,29 @@ wait_for_unparked_call(Call, Timeout) ->
             end
     end.
 
--spec store_file_args(ne_binary(), ne_binary()) -> kz_proplist().
-store_file_args(Filename, Url) ->
+-spec store_file_args(ne_binary(), ne_binary() | function()) -> kz_proplist().
+store_file_args(Filename, UrlFun) ->
+    Url = case is_function(UrlFun, 0) of
+              'true' -> UrlFun();
+              'false' -> UrlFun
+          end,
     [{<<"File-Name">>, Filename}
     ,{<<"Url">>, Url}
     ,{<<"Http-Method">>, <<"put">>}
     ].
 
--spec store_file(ne_binary(), ne_binary(), kapps_call:call()) -> 'ok' | {'error', any()}.
+-spec store_file(ne_binary(), ne_binary() | function(), kapps_call:call()) -> 'ok' | {'error', any()}.
 store_file(Filename, Url, Call) ->
     App = kz_util:calling_app(),
     store_file(Filename, Url, storage_retries(App), storage_timeout(App), Call).
 
--spec store_file(ne_binary(), ne_binary(), pos_integer(), kapps_call:call()) ->
+-spec store_file(ne_binary(), ne_binary() | function(), pos_integer(), kapps_call:call()) ->
                         'ok' | {'error', any()}.
 store_file(Filename, Url, Tries, Call) ->
     App = kz_util:calling_app(),
     store_file(Filename, Url, Tries, storage_timeout(App), Call).
 
--spec store_file(ne_binary(), ne_binary(), pos_integer(), kz_timeout(), kapps_call:call()) ->
+-spec store_file(ne_binary(), ne_binary() | function(), pos_integer(), kz_timeout(), kapps_call:call()) ->
                         'ok' | {'error', any()}.
 store_file(Filename, Url, Tries, Timeout, Call) ->
     Msg = case kapps_call:kvs_fetch('alert_msg', Call) of
@@ -3017,18 +3021,23 @@ store_file(Filename, Url, Tries, Timeout, Call) ->
               ErrorMsg -> ErrorMsg
           end,
     {AppName, AppVersion} = kz_util:calling_app_version(),
-    API = [{<<"Command">>, <<"send_http">>}
-          ,{<<"Args">>, kz_json:from_list(store_file_args(Filename, Url))}
-          ,{<<"FreeSWITCH-Node">>, kapps_call:switch_nodename(Call)}
-           | kz_api:default_headers(AppName, AppVersion)
-          ],
+    API = fun() -> [{<<"Command">>, <<"send_http">>}
+                   ,{<<"Args">>, kz_json:from_list(store_file_args(Filename, Url))}
+                   ,{<<"FreeSWITCH-Node">>, kapps_call:switch_nodename(Call)}
+                     | kz_api:default_headers(AppName, AppVersion)
+                   ]
+          end,
     do_store_file(Tries, Timeout, API, Msg, Call).
 
--spec do_store_file(pos_integer(), kz_timeout(), kz_proplist()
+-spec do_store_file(pos_integer(), kz_timeout(), kz_proplist() | function()
                    ,ne_binary(), kapps_call:call()) ->
                            'ok' | {'error', any()}.
 do_store_file(Tries, Timeout, API, Msg, Call) ->
-    case kz_amqp_worker:call(API, fun kapi_switch:publish_command/1, fun kapi_switch:fs_reply_v/1, Timeout) of
+    Payload = case is_function(API, 0) of
+                  'true' -> API();
+                  'false' -> API
+              end,
+    case kz_amqp_worker:call(Payload, fun kapi_switch:publish_command/1, fun kapi_switch:fs_reply_v/1, Timeout) of
         {'ok', JObj} ->
             case kz_json:get_ne_binary_value(<<"Result">>, JObj) of
                 <<"success">> -> 'ok';
@@ -3057,7 +3066,7 @@ do_store_file(Tries, Timeout, API, Msg, Call) ->
             retry_store_file(Tries - 1, Timeout, API, Msg, kz_util:to_binary(Error), Call)
     end.
 
--spec retry_store_file(integer(), kz_timeout(), kz_proplist()
+-spec retry_store_file(integer(), kz_timeout(), kz_proplist() | function()
                       ,ne_binary(), ne_binary(), kapps_call:call()) ->
                               'ok' | {'error', any()}.
 retry_store_file(0, _Timeout, _API, Msg, Error, Call) ->

--- a/core/kazoo_media/src/kz_media_recording.erl
+++ b/core/kazoo_media/src/kz_media_recording.erl
@@ -551,8 +551,7 @@ save_recording(#state{call=Call, media=Media}=State, _) ->
             lager:warning("error storing metadata : ~p", [Err]),
             gen_server:cast(self(), 'store_failed');
         Rev ->
-            StoreUrl = store_url(State, Rev),
-            lager:info("store url: ~s", [StoreUrl]),
+            StoreUrl = fun()-> store_url(State, Rev) end,
             store_recording(Media, StoreUrl, Call)
     end.
 
@@ -568,7 +567,7 @@ start_recording(Call, MediaName, TimeLimit, MediaDocId, SampleRate, RecordMinSec
     kapps_call_command:start_record_call(Props, TimeLimit, Call),
     gen_server:cast(self(), 'recording_started').
 
--spec store_recording({ne_binary(), ne_binary()}, ne_binary(), kapps_call:call()) -> 'ok'.
+-spec store_recording({ne_binary(), ne_binary()}, ne_binary() | function(), kapps_call:call()) -> 'ok'.
 store_recording({DirName, MediaName}, StoreUrl, Call) ->
     Filename = filename:join(DirName, MediaName),
     case kapps_call_command:store_file(Filename, StoreUrl, Call) of

--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -298,7 +298,7 @@ create_message_doc(AccountId, Props) ->
     MsgJObj = kzd_box_message:new(AccountId, Props),
     {'ok', SavedJObj} = kz_datamgr:save_doc(kz_doc:account_db(MsgJObj), MsgJObj),
 
-    MediaUrl = fun() -> 
+    MediaUrl = fun() ->
                        kz_media_url:store(SavedJObj
                                          ,props:get_value(<<"Attachment-Name">>, Props)
                                          )

--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -293,14 +293,16 @@ media_url(AccountId, Message) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec create_message_doc(ne_binary(), kz_proplist()) -> {ne_binary(), ne_binary()}.
+-spec create_message_doc(ne_binary(), kz_proplist()) -> {ne_binary(), ne_binary() | function()}.
 create_message_doc(AccountId, Props) ->
     MsgJObj = kzd_box_message:new(AccountId, Props),
     {'ok', SavedJObj} = kz_datamgr:save_doc(kz_doc:account_db(MsgJObj), MsgJObj),
 
-    MediaUrl = kz_media_url:store(SavedJObj
-                                 ,props:get_value(<<"Attachment-Name">>, Props)
-                                 ),
+    MediaUrl = fun() -> 
+                       kz_media_url:store(SavedJObj
+                                         ,props:get_value(<<"Attachment-Name">>, Props)
+                                         )
+               end,
 
     {kz_doc:id(MsgJObj), MediaUrl}.
 
@@ -309,7 +311,7 @@ create_message_doc(AccountId, Props) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec store_recording(ne_binary(), ne_binary(), kapps_call:call()) ->
+-spec store_recording(ne_binary(), ne_binary() | function(), kapps_call:call()) ->
                              'ok' |
                              {'error', kapps_call:call()}.
 store_recording(AttachmentName, Url, Call) ->


### PR DESCRIPTION
bigcouch may return error when storing attachments and when retried it can be a 409

