### PR TITLE
Bandwidth sites results have an xpath that is different from the rest

### DIFF
--- a/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
@@ -502,9 +502,11 @@ verify_response(Xml) ->
     NPAPath = "count(//TelephoneNumberDetailList/TelephoneNumberDetail)",
     TollFreePath = "count(//TelephoneNumberList/TelephoneNumber)",
     SitesPath = "count(//SitesResponse/Sites/Site)",
+    PeersPath = "count(//TNSipPeersResponse/SipPeers/SipPeer)",
     case validate_xpath_value(xmerl_xpath:string(NPAPath, Xml))
         orelse validate_xpath_value(xmerl_xpath:string(TollFreePath, Xml))
         orelse validate_xpath_value(xmerl_xpath:string(SitesPath, Xml))
+        orelse validate_xpath_value(xmerl_xpath:string(PeersPath, Xml))
         orelse validate_xpath_value(kz_util:get_xml_value("//OrderStatus/text()", Xml))
     of
         'true' ->

--- a/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
@@ -501,8 +501,10 @@ rate_center_to_json(Xml) ->
 verify_response(Xml) ->
     NPAPath = "count(//TelephoneNumberDetailList/TelephoneNumberDetail)",
     TollFreePath = "count(//TelephoneNumberList/TelephoneNumber)",
+    SitesPath = "count(//SitesResponse/Sites/Site)",
     case validate_xpath_value(xmerl_xpath:string(NPAPath, Xml))
         orelse validate_xpath_value(xmerl_xpath:string(TollFreePath, Xml))
+        orelse validate_xpath_value(xmerl_xpath:string(SitesPath, Xml))
         orelse validate_xpath_value(kz_util:get_xml_value("//OrderStatus/text()", Xml))
     of
         'true' ->


### PR DESCRIPTION
It could be that I'm not calling `knm_bandwidth2:sites()` incorrectly, but when I call it with `account_id`, `api_username`, and `api_password` set in `system_config/number_manager.bandwidth2`, I get an error:

`** exception error: no match of right hand side value {error,<<"Number not found">>}`

After adding the lines for verifying the response for the sites request, the method returns successfully. 