### PR TITLE
HELP-26680: filter empty text elements

### DIFF
--- a/core/kazoo_translator/src/kzt.hrl
+++ b/core/kazoo_translator/src/kzt.hrl
@@ -9,7 +9,7 @@
 -type usurp_return() :: {'usurp', kapps_call:call()}.
 -type request_return() :: {'request', kapps_call:call()}.
 -type error_return() :: {'error', kapps_call:call()} |
-                        {'error', kazpps_call:call(), list()}.
+                        {'error', kapps_call:call(), list()}.
 
 -type exec_element_return() ::
         ok_return() |

--- a/core/kazoo_xml/src/kz_xml.erl
+++ b/core/kazoo_xml/src/kz_xml.erl
@@ -11,6 +11,7 @@
 -export([elements/1, elements/2
         ,texts_to_binary/1, texts_to_binary/2
         ,attributes_to_proplist/1
+        ,filter_empty_text/1
         ]).
 
 -include_lib("kazoo/include/kz_types.hrl").
@@ -41,3 +42,13 @@ texts_to_binary(Vs, Size) when is_list(Vs), is_integer(Size), Size > 0 ->
 -spec attributes_to_proplist(xml_attribs()) -> kz_proplist().
 attributes_to_proplist(L) ->
     [{K, V} || #xmlAttribute{name=K, value=V} <- L].
+
+-spec filter_empty_text(xml_els() | xml_texts()) -> xml_els() | xml_texts().
+filter_empty_text([_|_]=Els) ->
+    [El || El <- Els,
+           not is_empty_text(El)
+    ].
+
+-spec is_empty_text(xml_text() | xml_el()) -> boolean().
+is_empty_text(#xmlText{value=" "}) -> 'true';
+is_empty_text(_El) -> 'false'.


### PR DESCRIPTION
Use xmerl's {space, normalize} to reduce #xmlText{} with just
whitespace to " ". Added function to remove those #xmlText{} elements.

Additionally, there was an unintentional pattern match when matching a
single <Number> element. The attributes of the Dial and Number
elements were being bound with the same name. Differentiated those to
make sure the single Number clause is used.