### PR TITLE
HELP-26661: remove default time_limit

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1669,7 +1669,6 @@
                     "type": "integer"
                 },
                 "time_limit": {
-                    "default": 3600,
                     "description": "Time limit, in seconds, for the recording",
                     "maximum": 3600,
                     "minimum": 5,

--- a/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
@@ -49,7 +49,6 @@
             "type": "integer"
         },
         "time_limit": {
-            "default": 3600,
             "description": "Time limit, in seconds, for the recording",
             "maximum": 3600,
             "minimum": 5,


### PR DESCRIPTION
when adding a "stop" action, time_limit can/should be unset from the
client to avoid validation errors. If we include a default, time_limit
will be set and, if the schema changes, the value could become invalid
through no fault of the user.