### PR TITLE
keep the original caller id for DISA and preserve CID for prepend

### DIFF
--- a/applications/callflow/src/module/cf_disa.erl
+++ b/applications/callflow/src/module/cf_disa.erl
@@ -107,9 +107,6 @@ maybe_route_to_callflow(Data, Call, Retries, Interdigit, Number) ->
                        ,list_to_binary([Number, "@", kapps_call:request_realm(Call)])
                        }
                       ,{fun kapps_call:set_to/2, list_to_binary([Number, "@", kapps_call:to_realm(Call)])}
-                      ,fun(C) when NoMatch -> update_cid(C);
-                          (C) -> C
-                       end
                       ],
             {'ok', C} = cf_exe:get_call(Call),
             cf_exe:set_call(kapps_call:exec(Updates, C)),
@@ -143,15 +140,6 @@ try_collect_destination_number(Call, Interdigit, MaxDigits, Timeout) ->
         {'ok', Digits} -> knm_converters:normalize(Digits)
     end.
 
-
--spec update_cid(kapps_call:call()) -> kapps_call:call().
-update_cid(Call) ->
-    {CIDNum, CIDName} = kz_attributes:caller_id(<<"external">>, Call),
-    Updates = [{fun kapps_call:set_caller_id_number/2, CIDNum}
-              ,{fun kapps_call:set_caller_id_name/2, CIDName}
-              ],
-    kapps_call:exec(Updates, Call).
-
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
@@ -174,7 +162,11 @@ maybe_restrict_call(Data, Call, Number, Flow) ->
 maybe_update_caller_id(Data, Call) ->
     case kz_json:is_true(<<"use_account_caller_id">>, Data, ?DEFAULT_USE_ACCOUNT_CALLER_ID) of
         'true'  -> set_caller_id(Call);
-        'false' -> Call
+        'false' ->
+            lager:debug("keep the original caller id"),
+            Updates = [fun(C) -> kapps_call:kvs_store('dynamic_cid', kapps_call:caller_id_number(C), C) end
+                      ],
+            cf_exe:update_call(Call, Updates)
     end.
 
 -spec start_preconnect_audio(kz_json:object(), kapps_call:call()) -> 'ok'.
@@ -225,64 +217,21 @@ play_ringing(Data, Call) ->
 -spec set_caller_id(kapps_call:call()) -> kapps_call:call().
 set_caller_id(Call) ->
     AccountId = kapps_call:account_id(Call),
-    {Number, Name} = maybe_get_account_cid(AccountId, Call),
-    lager:info("setting the caller id number to ~s from account ~s", [Number, AccountId]),
+    {Number, Name} = kz_attributes:get_account_external_cid(Call),
+
+    lager:info("setting the caller id number to ~s and caller id name to ~s from account ~s"
+              ,[Number, Name, AccountId]),
+
+    Props = [{<<"Caller-ID-Number">>, Number}
+            ,{<<"Caller-ID-Name">>, Name}
+            ],
+
     Updates = [fun(C) -> kapps_call:kvs_store('dynamic_cid', Number, C) end
-              ,fun(C) ->
-                       C1 = kapps_call:set_caller_id_number(Number, C),
-                       kapps_call:set_caller_id_name(Name, C1)
-               end
-              ,fun(C) ->
-                       Props = [{<<"Caller-ID-Number">>, Number}
-                               ,{<<"Caller-ID-Name">>, Name}
-                               ],
-                       kapps_call:set_custom_channel_vars(Props, C)
-               end
+              ,fun(C) -> kapps_call:set_caller_id_number(Number, C) end
+              ,fun(C) -> kapps_call:set_caller_id_name(Name, C) end
+              ,fun(C) -> kapps_call:set_custom_channel_vars(Props, C) end
               ],
-    UpdatedCall = kapps_call:exec(Updates, Call),
-    cf_exe:set_call(UpdatedCall),
-    UpdatedCall.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
--spec maybe_get_account_cid(ne_binary(), kapps_call:call()) ->
-                                   {api_binary(), api_binary()}.
-maybe_get_account_cid(AccountId, Call) ->
-    Name = kapps_call:caller_id_name(Call),
-    Number = kapps_call:caller_id_number(Call),
-    case kz_account:fetch(AccountId) of
-        {'error', _} -> kz_attributes:maybe_get_assigned_number(Number, Name, Call);
-        {'ok', JObj} -> maybe_get_account_external_number(Number, Name, JObj, Call)
-    end.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
--spec maybe_get_account_external_number(ne_binary(), ne_binary(), kz_json:object(), kapps_call:call()) ->
-                                               {api_binary(), api_binary()}.
-maybe_get_account_external_number(Number, Name, Account, Call) ->
-    External = kz_json:get_ne_value([<<"caller_id">>, <<"external">>, <<"number">>], Account),
-    case is_valid_caller_id(External, Call) of
-        'true' ->
-            lager:info("valid account external caller id <~s> ~s", [Name, Number]),
-            {External, Name};
-        'false' ->
-            kz_attributes:maybe_get_account_default_number(Number, Name, Account, Call)
-    end.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
--spec is_valid_caller_id(api_binary(), kapps_call:call()) -> boolean().
-is_valid_caller_id('undefined', _) -> 'false';
-is_valid_caller_id(_, _) -> 'true'.
+    cf_exe:update_call(Call, Updates).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/callflow/src/module/cf_disa.erl
+++ b/applications/callflow/src/module/cf_disa.erl
@@ -96,7 +96,7 @@ allow_dial(Data, Call, Retries, Interdigit) ->
 
     lager:info("caller is trying to call '~s'", [Number]),
 
-    Call1 = maybe_update_caller_id(Data, Call),
+    Call1 = maybe_update_caller_id(Call, should_use_account_cid(Data)),
     maybe_route_to_callflow(Data, Call1, Retries, Interdigit, Number).
 
 maybe_route_to_callflow(Data, Call, Retries, Interdigit, Number) ->
@@ -108,8 +108,7 @@ maybe_route_to_callflow(Data, Call, Retries, Interdigit, Number) ->
                        }
                       ,{fun kapps_call:set_to/2, list_to_binary([Number, "@", kapps_call:to_realm(Call)])}
                       ],
-            {'ok', C} = cf_exe:get_call(Call),
-            cf_exe:set_call(kapps_call:exec(Updates, C)),
+            cf_exe:set_call(kapps_call:exec(Updates, Call)),
             maybe_restrict_call(Data, Call, Number, Flow);
         _ ->
             lager:info("failed to find a callflow to satisfy ~s", [Number]),
@@ -158,16 +157,13 @@ maybe_restrict_call(Data, Call, Number, Flow) ->
             cf_exe:branch(kz_json:get_value(<<"flow">>, Flow), Call)
     end.
 
--spec maybe_update_caller_id(kz_json:object(), kapps_call:call()) -> kapps_call:call().
-maybe_update_caller_id(Data, Call) ->
-    case kz_json:is_true(<<"use_account_caller_id">>, Data, ?DEFAULT_USE_ACCOUNT_CALLER_ID) of
-        'true'  -> set_caller_id(Call);
-        'false' ->
-            lager:debug("keep the original caller id"),
-            Updates = [fun(C) -> kapps_call:kvs_store('dynamic_cid', kapps_call:caller_id_number(C), C) end
-                      ],
-            cf_exe:update_call(Call, Updates)
-    end.
+-spec should_use_account_cid(kz_json:object()) -> boolean().
+should_use_account_cid(Data) ->
+    kz_json:is_true(<<"use_account_caller_id">>, Data, ?DEFAULT_USE_ACCOUNT_CALLER_ID).
+
+-spec maybe_update_caller_id(kz_json:object(), boolean()) -> kapps_call:call().
+maybe_update_caller_id(Call, 'true') -> use_account_cid(Call);
+maybe_update_caller_id(Call, 'false') -> keep_original_cid(Call).
 
 -spec start_preconnect_audio(kz_json:object(), kapps_call:call()) -> 'ok'.
 start_preconnect_audio(Data, Call) ->
@@ -214,24 +210,40 @@ play_ringing(Data, Call) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec set_caller_id(kapps_call:call()) -> kapps_call:call().
-set_caller_id(Call) ->
+-spec use_account_cid(kapps_call:call()) -> kapps_call:call().
+use_account_cid(Call) ->
     AccountId = kapps_call:account_id(Call),
     {Number, Name} = kz_attributes:get_account_external_cid(Call),
 
-    lager:info("setting the caller id number to ~s and caller id name to ~s from account ~s"
-              ,[Number, Name, AccountId]),
+    lager:info("setting the caller id to <~s> ~s from account ~s", [Name, Number, AccountId]),
 
-    Props = [{<<"Caller-ID-Number">>, Number}
+    set_cid(Number, Name, Call).
+
+-spec keep_original_cid(kapps_call:call()) -> kapps_call:call().
+keep_original_cid(Call) ->
+    Number = kapps_call:caller_id_number(Call),
+    Name = kapps_call:caller_id_name(Call),
+
+    lager:info("keep the original caller id <~s> ~s", [Name, Number]),
+
+    set_cid(Number, Name, Call).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec set_cid(ne_binary(), ne_binary(), kapps_call:call()) -> kapps_call:call().
+set_cid(Number, Name, Call) ->
+    Props = [{<<"Retain-CID">>, 'true'}
+            ,{<<"Caller-ID-Number">>, Number}
             ,{<<"Caller-ID-Name">>, Name}
             ],
-
-    Updates = [fun(C) -> kapps_call:kvs_store('dynamic_cid', Number, C) end
-              ,fun(C) -> kapps_call:set_caller_id_number(Number, C) end
+    Updates = [fun(C) -> kapps_call:set_caller_id_number(Number, C) end
               ,fun(C) -> kapps_call:set_caller_id_name(Name, C) end
               ,fun(C) -> kapps_call:set_custom_channel_vars(Props, C) end
               ],
-    cf_exe:update_call(Call, Updates).
+    kapps_call:exec(Updates, Call).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/callflow/src/module/cf_prepend_cid.erl
+++ b/applications/callflow/src/module/cf_prepend_cid.erl
@@ -29,6 +29,7 @@ handle(<<"reset">>, _Data, Call) ->
     Name   = kapps_call:kvs_fetch(<<"original_cid_name">>, kapps_call:caller_id_name(Call), Call),
     Number = kapps_call:kvs_fetch(<<"original_cid_number">>, kapps_call:caller_id_number(Call), Call),
 
+    lager:info("reset prepend cid resulted in cid number ~s and cid name ~s", [Number, Name]),
     set_values(Name, Number, Call);
 
 handle(<<"prepend">>, Data, Call) ->
@@ -39,16 +40,16 @@ handle(<<"prepend">>, Data, Call) ->
     OrigNum  = kapps_call:kvs_fetch(<<"original_cid_number">>, kapps_call:caller_id_number(Call), Call),
 
     {Name, Number} = case kz_json:get_value(<<"apply_to">>, Data, <<"original">>) of
-                         <<"original">> -> {
-                             <<NamePre/binary, OrigName/binary>>
-                                           ,<<NumberPre/binary, OrigNum/binary>>
-                            };
-
-                         <<"current">> -> {
-                             <<NamePre/binary, (kapps_call:caller_id_name(Call))/binary>>
-                                          ,<<NumberPre/binary, (kapps_call:caller_id_number(Call))/binary>>
-                            }
+                         <<"original">> ->
+                             {<<NamePre/binary, OrigName/binary>>
+                             ,<<NumberPre/binary, OrigNum/binary>>
+                             };
+                         <<"current">> ->
+                             {<<NamePre/binary, (kapps_call:caller_id_name(Call))/binary>>
+                             ,<<NumberPre/binary, (kapps_call:caller_id_number(Call))/binary>>
+                             }
                      end,
+    lager:info("prepend cid resulted in cid number ~s and cid name ~s", [Number, Name]),
     set_values(Name, Number, Call).
 
 -spec maybe_set_orig_name(kapps_call:call()) -> kapps_call:call().
@@ -67,8 +68,8 @@ maybe_set_orig_number(Call) ->
 
 -spec set_values(binary(), binary(), kapps_call:call()) -> any().
 set_values(Name, Number, Call) ->
-    Call1 = kapps_call:exec([
-                             fun(C) -> kapps_call:set_caller_id_name(Name, C) end
+    Call1 = kapps_call:exec([fun(C) -> kapps_call:kvs_store('dynamic_cid', Number, C) end
+                            ,fun(C) -> kapps_call:set_caller_id_name(Name, C) end
                             ,fun(C) -> kapps_call:set_caller_id_number(Number, C) end
                             ], Call),
     cf_exe:set_call(Call1),

--- a/applications/callflow/src/module/cf_prepend_cid.erl
+++ b/applications/callflow/src/module/cf_prepend_cid.erl
@@ -68,9 +68,14 @@ maybe_set_orig_number(Call) ->
 
 -spec set_values(binary(), binary(), kapps_call:call()) -> any().
 set_values(Name, Number, Call) ->
-    Call1 = kapps_call:exec([fun(C) -> kapps_call:kvs_store('dynamic_cid', Number, C) end
-                            ,fun(C) -> kapps_call:set_caller_id_name(Name, C) end
-                            ,fun(C) -> kapps_call:set_caller_id_number(Number, C) end
-                            ], Call),
+    Props = [{<<"Retain-CID">>, 'true'}
+            ,{<<"Caller-ID-Number">>, Number}
+            ,{<<"Caller-ID-Name">>, Name}
+            ],
+    Updates = [fun(C) -> kapps_call:set_caller_id_number(Number, C) end
+              ,fun(C) -> kapps_call:set_caller_id_name(Name, C) end
+              ,fun(C) -> kapps_call:set_custom_channel_vars(Props, C) end
+              ],
+    Call1 = kapps_call:exec(Updates, Call),
     cf_exe:set_call(Call1),
     cf_exe:continue(Call1).

--- a/core/kazoo_endpoint/src/kz_attributes.erl
+++ b/core/kazoo_endpoint/src/kz_attributes.erl
@@ -19,6 +19,7 @@
         ,owned_by_docs/2, owned_by_docs/3
         ]).
 -export([owner_ids/2]).
+-export([get_account_external_cid/1]).
 -export([maybe_get_assigned_number/3]).
 -export([maybe_get_account_default_number/4]).
 
@@ -234,6 +235,16 @@ ensure_valid_caller_id(Number, Name, Call) ->
             maybe_get_account_cid(Number, Name, Call)
     end.
 
+-spec get_account_external_cid(kapps_call:call()) ->
+                                      {api_binary(), api_binary()}.
+get_account_external_cid(Call) ->
+    Number = kapps_call:caller_id_number(Call),
+    Name = kapps_call:caller_id_name(Call),
+
+    lager:info("current cid number ~s and name ~s", [Number, Name]),
+
+    maybe_get_account_cid(Number, Name, Call).
+
 -spec maybe_get_account_cid(ne_binary(), ne_binary(), kapps_call:call()) ->
                                    {api_binary(), api_binary()}.
 maybe_get_account_cid(Number, Name, Call) ->
@@ -248,7 +259,7 @@ maybe_get_account_external_number(Number, Name, Account, Call) ->
     External = kz_json:get_ne_value([<<"caller_id">>, <<"external">>, <<"number">>], Account),
     case is_valid_caller_id(External, Call) of
         'true' ->
-            lager:info("determined valid account external caller id is <~s> ~s", [Name, Number]),
+            lager:info("determined valid account external caller id is <~s> ~s", [Name, External]),
             {External, Name};
         'false' ->
             maybe_get_account_default_number(Number, Name, Account, Call)
@@ -260,7 +271,7 @@ maybe_get_account_default_number(Number, Name, Account, Call) ->
     Default = kz_json:get_ne_value([<<"caller_id">>, <<"default">>, <<"number">>], Account),
     case is_valid_caller_id(Default, Call) of
         'true' ->
-            lager:info("determined valid account default caller id is <~s> ~s", [Name, Number]),
+            lager:info("determined valid account default caller id is <~s> ~s", [Name, Default]),
             {Default, Name};
         'false' ->
             maybe_get_assigned_number(Number, Name, Call)

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -972,15 +972,12 @@ get_clid(Endpoint, Properties, Call, Type) ->
         'true' -> #clid{};
         'false' ->
             {Number, Name} = kz_attributes:caller_id(Type, Call),
-            DynamicCID = kz_util:is_true(kapps_call:kvs_fetch('dynamic_cid', Call)),
             CallerNumber = case kapps_call:caller_id_number(Call) of
                                Number -> 'undefined';
-                               NewNumber when DynamicCID -> NewNumber;
                                _Number -> Number
                            end,
             CallerName = case kapps_call:caller_id_name(Call) of
                              Name -> 'undefined';
-                             NewName when DynamicCID -> NewName;
                              _Name -> Name
                          end,
             {CalleeNumber, CalleeName} = kz_attributes:callee_id(Endpoint, Call),

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -173,11 +173,12 @@ maybe_cached_hotdesk_ids(Props, JObj, AccountDb) ->
                         end, Props, OwnerIds)
     end.
 
--spec maybe_format_endpoint(kz_json:object(), api_object()) -> kz_json:object().
-maybe_format_endpoint(Endpoint, 'undefined') ->
+-spec maybe_format_endpoint(kz_json:object(), boolean()) -> kz_json:object().
+maybe_format_endpoint(Endpoint, 'true') ->
     lager:debug("no formatters defined"),
     Endpoint;
-maybe_format_endpoint(Endpoint, Formatters) ->
+maybe_format_endpoint(Endpoint, 'false') ->
+    Formatters = kz_json:get_value(<<"formatters">>, Endpoint),
     Formatted = kz_formatters:apply(Endpoint, Formatters, 'outbound'),
     lager:debug("with ~p formatted ~p", [Formatters, Endpoint]),
     lager:debug("formatted as ~p", [Formatted]),
@@ -971,12 +972,15 @@ get_clid(Endpoint, Properties, Call, Type) ->
         'true' -> #clid{};
         'false' ->
             {Number, Name} = kz_attributes:caller_id(Type, Call),
+            DynamicCID = kz_util:is_true(kapps_call:kvs_fetch('dynamic_cid', Call)),
             CallerNumber = case kapps_call:caller_id_number(Call) of
                                Number -> 'undefined';
+                               NewNumber when DynamicCID -> NewNumber;
                                _Number -> Number
                            end,
             CallerName = case kapps_call:caller_id_name(Call) of
                              Name -> 'undefined';
+                             NewName when DynamicCID -> NewName;
                              _Name -> Name
                          end,
             {CalleeNumber, CalleeName} = kz_attributes:callee_id(Endpoint, Call),
@@ -1057,7 +1061,7 @@ create_sip_endpoint(Endpoint, Properties, #clid{}=Clid, Call) ->
                       ,{<<"Metaflows">>, kz_json:get_value(<<"metaflows">>, Endpoint)}
                        | maybe_get_t38(Endpoint, Call)
                       ])),
-    maybe_format_endpoint(SIPEndpoint, kz_json:get_value(<<"formatters">>, Endpoint)).
+    maybe_format_endpoint(SIPEndpoint, kz_util:is_empty(kz_json:get_value(<<"formatters">>, Endpoint))).
 
 -spec maybe_get_t38(kz_json:object(), kapps_call:call()) -> kz_proplist().
 maybe_get_t38(Endpoint, Call) ->


### PR DESCRIPTION
* keep the origrinal caller id in disa & add some log lines
* move get account cid to kz_attributes to keep cid hunting in sync
* log correct number that is about to set
* HELP-26318 preserve already set CID in endpoint, and keep the CID in prepend in from PR #2857