### PR TITLE
Account for reponses for sites and peer ids requests with wnm_bandwidth2

### DIFF
--- a/core/whistle_number_manager-1.0.0/src/carriers/wnm_bandwidth2.erl
+++ b/core/whistle_number_manager-1.0.0/src/carriers/wnm_bandwidth2.erl
@@ -403,8 +403,12 @@ rate_center_to_json(Xml) ->
 verify_response(Xml) ->
     NPAPath = "count(//TelephoneNumberDetailList/TelephoneNumberDetail)",
     TollFreePath = "count(//TelephoneNumberList/TelephoneNumber)",
+    SitesPath = "count(//SitesResponse/Sites/Site)",
+    PeersPath = "count(//TNSipPeersResponse/SipPeers/SipPeer)",
     case validate_xpath_value(xmerl_xpath:string(NPAPath, Xml))
              orelse validate_xpath_value(xmerl_xpath:string(TollFreePath, Xml))
+             orelse validate_xpath_value(xmerl_xpath:string(SitesPath, Xml))
+             orelse validate_xpath_value(xmerl_xpath:string(PeersPath, Xml))
              orelse validate_xpath_value(wh_util:get_xml_value("//OrderStatus/text()", Xml))
     of
         'true' ->


### PR DESCRIPTION
Backport of PR #2897 

Error when calling `wnm_bandwidth2:sites/0` and `wnm_bandwidth2:peers/1` with `account_id`, `api_username`, and `api_password` set in `system_config/number_manager.bandwidth2`