### PR TITLE
konami listener typo for metaflow exchange

### DIFF
--- a/applications/konami/src/konami_listener.erl
+++ b/applications/konami/src/konami_listener.erl
@@ -35,7 +35,7 @@
                   ,{'route', []}
                   ]).
 -define(RESPONDERS, [{{?MODULE, 'handle_metaflow'}
-                     ,[{<<"metaflow">>, <<"bindings">>}]
+                     ,[{<<"metaflow">>, <<"bind">>}]
                      }
                     ,{{?MODULE, 'handle_channel_create'}
                      ,[{<<"call_event">>, <<"CHANNEL_CREATE">>}]


### PR DESCRIPTION
(HT Paolo Consolaro)

In commit ab0e0e6b1b275a58ad65dee8a5b31e243bac588d Luis Azedo introduced the
"metaflow" exchange in AMQP. But a typo prevents konami to properly react to
this exchange bindings as published, I think, by:

      grep METAFLOW_BIND_ROUTING_KEY ./core/kazoo/src/api/kapi_metaflow.erl
      ...
      -define(METAFLOW_BIND_ROUTING_KEY(AccountId, CallId), <<"metaflow.bind.", ...