### PR TITLE
Remove /*...*/ comments in markdown docs

### DIFF
--- a/applications/ananke/doc/README.md
+++ b/applications/ananke/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Ananke
-Title: Ananke
-Language: en-US
-*/
 
 # Ananke *Callback features*
 

--- a/applications/blackhole/doc/README.md
+++ b/applications/blackhole/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Blackhole
-Title: Blackhole
-Language: en-US
-*/
 
 # Blackhole *Realtime HTTP Websocket Events*
 

--- a/applications/blackhole/doc/bindings.md
+++ b/applications/blackhole/doc/bindings.md
@@ -1,8 +1,3 @@
-/*
-Section: Blackhole
-Title: Blackhole Bindings
-Language: en-US
-*/
 
 # Blackhole *Realtime HTTP Websocket Events*
 

--- a/applications/blackhole/doc/haproxy.md
+++ b/applications/blackhole/doc/haproxy.md
@@ -1,8 +1,3 @@
-/*
-Section: Blackhole
-Title: Haproxy
-Language: en-US
-*/
 
 # Blackhole
 

--- a/applications/blackhole/doc/troubleshooting.md
+++ b/applications/blackhole/doc/troubleshooting.md
@@ -1,6 +1,1 @@
-/*
-Section: Blackhole
-Title: Troubleshooting
-Language: en-US
-*/
 

--- a/applications/call_inspector/doc/README.md
+++ b/applications/call_inspector/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Call Inspector
-Title: Call Inspector
-Language: en-US
-*/
 
 # Call Inspector
 

--- a/applications/callflow/doc/README.md
+++ b/applications/callflow/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Callflow
-Title: Callflow
-Language: en-US
-*/
 
 # Callflow *PBX Functionality*
 Please press 1 to continue

--- a/applications/callflow/doc/conference.md
+++ b/applications/callflow/doc/conference.md
@@ -1,9 +1,3 @@
-/*
-Section: Callflows
-Title: Conference
-Language: en-US
-Version: 3.22
-*/
 
 The Conference callflow element allows one to override parts of a Conference document.
 

--- a/applications/callflow/doc/fax_detect.md
+++ b/applications/callflow/doc/fax_detect.md
@@ -1,8 +1,3 @@
-/*
-Section: Callflow
-Title: Fax Detect
-Language: en-US
-*/
 
 # Fax Detect
 

--- a/applications/callflow/doc/language.md
+++ b/applications/callflow/doc/language.md
@@ -1,13 +1,3 @@
-/*
-Section: Callflows
-
-Title: Language
-
-Language: en-US
-
-Sponsors: CloudPBX
-
-*/
 
 Prompts and other content take optional language settings to know which to fetch. Use this callflow action to set the language for the call.
 

--- a/applications/callflow/doc/lookupcidname.md
+++ b/applications/callflow/doc/lookupcidname.md
@@ -1,9 +1,3 @@
-/*
-Section: Callflows
-Title: Look up CID name
-Language: en-US
-Version: 3.20
-*/
 
 This module looks up the Caller ID Name by matching numbers/patters with the provided lists.
 

--- a/applications/callflow/doc/preflow.md
+++ b/applications/callflow/doc/preflow.md
@@ -1,8 +1,3 @@
-/*
-Section: Callflow
-Title: Preflow
-Language: en-US
-*/
 
 # Preflow
 

--- a/applications/callflow/doc/record_call.md
+++ b/applications/callflow/doc/record_call.md
@@ -1,9 +1,3 @@
-/*
-Section: Callflows
-Title: Record Call
-Language: en-US
-Version: 3.20
-*/
 
 The `record_call` callflow enables you to record the audio of the call.
 

--- a/applications/callflow/doc/ring_group.md
+++ b/applications/callflow/doc/ring_group.md
@@ -1,9 +1,3 @@
-/*
-Section: Callflows
-Title: Ring Group
-Language: en-US
-Version: 3.20
-*/
 
 Ring group callflow element allows calling multiple endpoints with given strategy and timeout.
 

--- a/applications/callflow/doc/temporal_route.md
+++ b/applications/callflow/doc/temporal_route.md
@@ -1,8 +1,3 @@
-/*
-Section: Callflow
-Title: Temporal Route
-Language: en-US
-*/
 
 # Rule Set
 

--- a/applications/cccp/doc/README.md
+++ b/applications/cccp/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: CCCP
-Title: Calling Card Callback Platform
-Language: en-US
-*/
 
 cccp - Calling Card Callback Platform
 ====

--- a/applications/cdr/doc/README.md
+++ b/applications/cdr/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: CDR
-Title: Call Detail Records
-Language: en-US
-*/
 
 # CDR *Call Detail Records*
 For all your call detailing needs

--- a/applications/conference/doc/README.md
+++ b/applications/conference/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Conference
-Title: Conference
-Language: en-US
-*/
 
 # Conference
 This app should have been called "party line"...

--- a/applications/doodle/doc/README.md
+++ b/applications/doodle/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Doodle
-Title: Doodle
-Language: en-US
-*/
 
 # Doodle *Store and Forward SMS*
 "Stop that pigeon!"

--- a/applications/doodle/doc/configuration.md
+++ b/applications/doodle/doc/configuration.md
@@ -1,9 +1,3 @@
-/*
-Section: Doodle
-Title: Doodle
-Language: en-US
-Version: 3.20
-*/
 
 # Configure inbound listeners
 

--- a/applications/dth/doc/README.md
+++ b/applications/dth/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: DTH
-Title: DTH
-Language: en-US
-*/
 
 Getting started:
 

--- a/applications/ecallmgr/doc/README.md
+++ b/applications/ecallmgr/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: eCallMgr
-Title: Erlang Call Manager
-Language: en-US
-*/
 
 # eCallMgr *Erlang Call Manager*
 Manging your calls from Erlang

--- a/applications/ecallmgr/doc/acls.md
+++ b/applications/ecallmgr/doc/acls.md
@@ -1,8 +1,3 @@
-/*
-Section: ACLs
-Title: Managing your ACLs
-Language: en-US
-*/
 
 ACLs control whether to request username/password authentication from a source IP address or not. Kazoo maintains two lists of ACLs, one for the SBCs (typically Kamailio) and one for upstream carriers to send inbound traffic to Kazoo.
 

--- a/applications/ecallmgr/doc/config.md
+++ b/applications/ecallmgr/doc/config.md
@@ -1,9 +1,3 @@
-/*
-Section: eCallmgr
-Title: eCallmgr System Config
-Language: en-US
-Version: 3.19
-*/
 
 # System configuration options in ecallmgr
 

--- a/applications/ecallmgr/doc/maintenance.md
+++ b/applications/ecallmgr/doc/maintenance.md
@@ -1,9 +1,3 @@
-/*
-Section: eCallMgr
-Title: SUP Maintenance commands
-Language: en-US
-Version: 3.18
-*/
 
 Here's a run down of the available SUP commands for manipulating ecallmgr!
 

--- a/applications/fax/doc/README.md
+++ b/applications/fax/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Fax
-Title: Fax
-Language: en-US
-*/
 
 # Fax *Facsimile Services*
 Why is this still a thing?

--- a/applications/fax/doc/dns.md
+++ b/applications/fax/doc/dns.md
@@ -1,8 +1,3 @@
-/*
-Section: DNS
-Title: DNS
-Language: en-US
-*/
 
 # DNS configuration for smtp-to-fax
 

--- a/applications/fax/doc/gcp.md
+++ b/applications/fax/doc/gcp.md
@@ -1,8 +1,3 @@
-/*
-Section: GCP
-Title: Google Cloud Printer
-Language: en-US
-*/
 
 # Google Cloud Printer
 ## Features

--- a/applications/fax/doc/haproxy.md
+++ b/applications/fax/doc/haproxy.md
@@ -1,8 +1,3 @@
-/*
-Section: HAPROXY
-Title: HAPROXY
-Language: en-US
-*/
 
 # HAPROXY role in smtp to fax
 if you have more than one kapps node running the fax application, you may want to distribute the load from smtp among the several nodes.

--- a/applications/fax/doc/postfix.md
+++ b/applications/fax/doc/postfix.md
@@ -1,8 +1,3 @@
-/*
-Section: POSTFIX
-Title: Postfix
-Language: en-US
-*/
 
 # Postfix role in smtp-to-fax
 although you can expose kazoo fax on port 25 or use haproxy, we recommend to use postfix to filter email spam before delivering to haproxy/kazoo

--- a/applications/fax/doc/smtp.md
+++ b/applications/fax/doc/smtp.md
@@ -1,8 +1,3 @@
-/*
-Section: SMTP
-Title: SMTP Integration
-Language: en-US
-*/
 
 # SMTP Integration
 kazoo will generate an smtp domain address for each faxbox on its creation.

--- a/applications/fax/doc/user.md
+++ b/applications/fax/doc/user.md
@@ -1,8 +1,3 @@
-/*
-Section: USER
-Title: User utilities
-Language: en-US
-*/
 
 # Internet fax for Office 2010
 * Create a fax.reg file with the contents below replacing xxx.fax.kazoo.io with the smtp address of faxbox.

--- a/applications/frontier/doc/README.md
+++ b/applications/frontier/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Frontier
-Title: Frontier
-Language: en-US
-*/
 
 # Frontier *The Guard of your SIP kingdom*
 Provides Kamailio with information on account and device-level access-lists and incoming packet rate limits.

--- a/applications/hotornot/doc/README.md
+++ b/applications/hotornot/doc/README.md
@@ -1,7 +1,2 @@
-/*
-Section: Hot or Not
-Title: Hot or Not
-Language: en-US
-*/
 
 # Hot or Not *Call rating*

--- a/applications/jonny5/doc/README.md
+++ b/applications/jonny5/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Jonny5
-Title: Jonny5
-Language: en-US
-*/
 
 # Overview
 

--- a/applications/konami/doc/README.md
+++ b/applications/konami/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Konami
-Title: Konami
-Language: en-US
-*/
 
 # Konami *In-Call Feature Codes*
 up up down down left right left right B A

--- a/applications/konami/doc/hold.md
+++ b/applications/konami/doc/hold.md
@@ -1,9 +1,3 @@
-/*
-Section: Konami
-Title: Hold
-Language: en-US
-Version: 3.22
-*/
 
 Some phones do not support putting the other line on hold or making it easy to set custom music to play while on hold. The Konami *hold* module permits both.
 

--- a/applications/konami/doc/move.md
+++ b/applications/konami/doc/move.md
@@ -1,9 +1,3 @@
-/*
-Section: Konami
-Title: Move
-Language: en-US
-Version: 3.19
-*/
 
 When a user is talking on one of their endpoints (say their Kazoo Mobile phone) and they move locations to have access to their IP Desk phone, it is helpful to move the call from the mobile phone to the deskphone with the other party unware of the change.
 

--- a/applications/konami/doc/resume.md
+++ b/applications/konami/doc/resume.md
@@ -1,8 +1,3 @@
-/*
-Section: Konami
-Title: Resume
-Language: en-US
-*/
 
 Some Konami actions put the other leg on hold (say for a transfer). The *resume* module allows the initiating party to reconnect with the on-hold party (cancelling whatever metaflow module had initiated the hold).
 

--- a/applications/konami/doc/transfer.md
+++ b/applications/konami/doc/transfer.md
@@ -1,8 +1,3 @@
-/*
-Section: Konami
-Title: Transfers
-Language: en-US
-*/
 
 # In-Call Attended Transfer
 

--- a/applications/media_mgr/doc/README.md
+++ b/applications/media_mgr/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Media Manager
-Title: Media Manager
-Language: en-US
-*/
 
 # Media Manager
 Single play stream

--- a/applications/milliwatt/doc/README.md
+++ b/applications/milliwatt/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Milliwatt
-Title: Milliwatt
-Language: en-US
-*/
 
 # Milliwatt *Echo and tone for monitoring*
 Beeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeep

--- a/applications/notify/doc/README.md
+++ b/applications/notify/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Notify
-Title: Notify
-Language: en-US
-*/
 
 # Notify
 

--- a/applications/omnipresence/doc/README.md
+++ b/applications/omnipresence/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Omnipresence
-Title: Omnipresence
-Language: en-US
-*/
 
 # Omnipresence *It knows*
 _the call is from inside the house_

--- a/applications/omnipresence/doc/maintenance.md
+++ b/applications/omnipresence/doc/maintenance.md
@@ -1,9 +1,3 @@
-/*
-Section: Omnipresence
-Title: Maintenance
-Language: en-US
-Version: 3.16
-*/
 
 ## Current Subscriptions
 

--- a/applications/pivot/doc/README.md
+++ b/applications/pivot/doc/README.md
@@ -1,9 +1,3 @@
-/*
-Section: Pivot
-Title: Pivot
-Language: en-US
-Version: 3.18
-*/
 
 # Overview
 

--- a/applications/pivot/doc/issues.md
+++ b/applications/pivot/doc/issues.md
@@ -1,8 +1,3 @@
-/*
-Section: Pivot
-Title: Issues
-Language: en-US
-*/
 
 * Default data submitted on request: CallerName, Direction, ApiVerson, CallStatus, To, From, AccountSid, CallSid
 * Play

--- a/applications/pivot/doc/kazoo/README.md
+++ b/applications/pivot/doc/kazoo/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Pivot
-Title: Build your callflows on-demand
-Language: en-US
-*/
 
 # Overview
 

--- a/applications/pivot/doc/kazoo/bridging.md
+++ b/applications/pivot/doc/kazoo/bridging.md
@@ -1,9 +1,3 @@
-/*
-Section: Pivot
-Title: Bridging
-Language: en-US
-Version: 3.18
-*/
 
 # Overview
 

--- a/applications/pivot/doc/kazoo/collect.md
+++ b/applications/pivot/doc/kazoo/collect.md
@@ -1,8 +1,3 @@
-/*
-Section: Pivot
-Title: DTMF Collection
-Language: en-US
-*/
 
 # Overview
 

--- a/applications/pivot/doc/kazoo/conferencing.md
+++ b/applications/pivot/doc/kazoo/conferencing.md
@@ -1,9 +1,3 @@
-/*
-Section: Pivot
-Title: Conferencing
-Language: en-US
-Version: 3.18
-*/
 
 # Overview
 

--- a/applications/pivot/doc/kazoo/dtmf.md
+++ b/applications/pivot/doc/kazoo/dtmf.md
@@ -1,9 +1,3 @@
-/*
-Section: Pivot
-Title: DTMF
-Language: en-US
-Version: 3.18
-*/
 
 # Overview
 

--- a/applications/pivot/doc/kazoo/hangups.md
+++ b/applications/pivot/doc/kazoo/hangups.md
@@ -1,9 +1,3 @@
-/*
-Section: Pivot
-Title: Hangups
-Language: en-US
-Version: 3.18
-*/
 
 # Overview
 

--- a/applications/pivot/doc/kazoo/play.md
+++ b/applications/pivot/doc/kazoo/play.md
@@ -1,8 +1,3 @@
-/*
-Section: Pivot
-Title: Playing Files
-Language: en-US
-*/
 
 # Overview
 

--- a/applications/pivot/doc/kazoo/presence.md
+++ b/applications/pivot/doc/kazoo/presence.md
@@ -1,9 +1,3 @@
-/*
-Section: Pivot
-Title: Presence
-Language: en-US
-Version: 3.18
-*/
 
 # Overview
 

--- a/applications/pivot/doc/kazoo/recording.md
+++ b/applications/pivot/doc/kazoo/recording.md
@@ -1,9 +1,3 @@
-/*
-Section: Pivot
-Title: Recording
-Language: en-US
-Version: 3.18
-*/
 
 # Overview
 

--- a/applications/pivot/doc/kazoo/say.md
+++ b/applications/pivot/doc/kazoo/say.md
@@ -1,8 +1,3 @@
-/*
-Section: Pivot
-Title: Saying Text
-Language: en-US
-*/
 
 # Overview
 

--- a/applications/pivot/doc/twiml/README.md
+++ b/applications/pivot/doc/twiml/README.md
@@ -1,9 +1,3 @@
-/*
-Section: Pivot
-Title: Pivot
-Language: en-US
-Version: 3.18
-*/
 
 # Overview
 

--- a/applications/pusher/doc/pusher.md
+++ b/applications/pusher/doc/pusher.md
@@ -1,8 +1,3 @@
-/*
-Section: Pusher
-Title: Pusher
-Language: en-US
-*/
 
 # Pusher
 pusher app allows kazoo to send a push message to a device when the device is the target of a bridge call and is not registered, so that the device can "wake up", register and receive the call.

--- a/applications/registrar/doc/README.md
+++ b/applications/registrar/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Registrar
-Title: Registrar
-Language: en-US
-*/
 
 # Registrar *The star registration application*
 Papers, please.

--- a/applications/reorder/doc/README.md
+++ b/applications/reorder/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Reorder
-Title: Reorder
-Language: en-US
-*/
 
 # Reorder *Misconfigured Number Replies*
 404

--- a/applications/skel/doc/README.md
+++ b/applications/skel/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Skel
-Title: Skel
-Language: en-US
-*/
 
 # Overview
 

--- a/applications/spyvsspy/doc/README.md
+++ b/applications/spyvsspy/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Spy vs Spy
-Title: Spy vs Spy
-Language: en-US
-*/
 
 # Spy vs Spy *Call Eavesdropping*
 **BOOM**

--- a/applications/stats/doc/README.md
+++ b/applications/stats/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Stats
-Title: Stats
-Language: en-US
-*/
 
 Events counts are collected by kazoo_stats.erl running on every kazoo
 cluster node and are regularly sent via the targeted/statistics amqp queue to

--- a/applications/stepswitch/doc/README.md
+++ b/applications/stepswitch/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Stepswitch
-Title: Stepswitch
-Language: en-US
-*/
 
 # Stepswitch *VoIP line finder*
 click, click, click, clack

--- a/applications/stepswitch/doc/rules.md
+++ b/applications/stepswitch/doc/rules.md
@@ -1,9 +1,3 @@
-/*
-Section: Stepswitch
-Title: Rules
-Language: en-US
-Version: 3.18
-*/
 
 # Rules fields
 

--- a/applications/sysconf/doc/README.md
+++ b/applications/sysconf/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: System Config
-Title: System Config
-Language: en-US
-*/
 
 Kazoo configuration, for the most part, lives in the `system_config` database (with a few exceptions for BigCouch, RabbitMQ, and basic Kazoo settings).
 

--- a/applications/tasks/doc/README.md
+++ b/applications/tasks/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Tasks
-Title: Tasks
-Language: en-US
-*/
 
 # Kazoo Tasks
 

--- a/applications/teletype/doc/README.md
+++ b/applications/teletype/doc/README.md
@@ -1,9 +1,3 @@
-/*
-Section: Teletype
-Title: Index
-Language: en-US
-Version: 3.19
-*/
 
 # Overview
 

--- a/applications/teletype/doc/maintenance.md
+++ b/applications/teletype/doc/maintenance.md
@@ -1,9 +1,3 @@
-/*
-Section: Teletype
-Title: Maintenance
-Language: en-US
-Version: 3.19
-*/
 
 # Overview
 

--- a/applications/trunkstore/doc/README.md
+++ b/applications/trunkstore/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: Trunkstore
-Title: Trunkstore
-Language: en-US
-*/
 
 # Trunkstore *Lightweight trunking services*
 Keep on trunk'n

--- a/applications/webhooks/doc/README.md
+++ b/applications/webhooks/doc/README.md
@@ -1,8 +1,3 @@
-/*
-Section: WebHooks
-Title: WebHooks
-Language: en-US
-*/
 
 # WebHooks *Event driven HTTP callbacks*
 Smee: I've just had an apostrophe.

--- a/applications/webhooks/doc/maintenance.md
+++ b/applications/webhooks/doc/maintenance.md
@@ -1,9 +1,3 @@
-/*
-Section: WebHooks
-Title: Maintenance
-Language: en-US
-Version: 3.21
-*/
 
 ## See what hooks are active
 


### PR DESCRIPTION
Used the following to find/remove:
grep --include="*.md" -Pzlr '(?s)/\*.*\n.*\*/' applications/ | xargs sed -i '/^\/\*/,/\*\//d'