### PR TITLE
PISTON-351: validate did ownership before saving callflows/trunks

### DIFF
--- a/applications/crossbar/src/modules/cb_callflows.erl
+++ b/applications/crossbar/src/modules/cb_callflows.erl
@@ -381,39 +381,61 @@ on_successful_validation(CallflowId, Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+-type assigned_tuple() :: {ne_binary(), ne_binaries()}.
+-type assigned_tuples() :: [assigned_tuple()].
+
 -spec validate_number_ownership(cb_context:context()) -> cb_context:context().
--spec validate_number_ownership(ne_binaries(), cb_context:context()) ->
-                                       cb_context:context().
--spec validate_number_ownership(knm_number:knm_number()
-                               ,ne_binaries()
-                               ,cb_context:context()) -> cb_context:context().
 validate_number_ownership(Context) ->
     NewNums = kz_json:get_value(<<"numbers">>, cb_context:doc(Context), []),
 
-    Assigned =  [Num
+    Assigned =  [knm_converters:normalize(Num)
                  || Num <- NewNums,
-                    Num =/= <<"undefined">>
+                    Num =/= <<"undefined">>,
+                    knm_converters:is_reconcilable(Num)
                 ],
 
-    validate_number_ownership(Assigned, Context).
+    AssignedTo = all_assigned_to_fold(Assigned, []),
+    validate_parent(AssignedTo, Context).
 
-validate_number_ownership([], Context) -> Context;
-validate_number_ownership([Number|Numbers], Context) ->
-    case knm_number:get(Number) of
-        {'ok', NumberObj} ->
-            validate_number_ownership(NumberObj, Numbers, Context);
-        _ -> validate_number_ownership(Numbers, Context)
+-spec all_assigned_to_fold(ne_binaries(), assigned_tuples()) ->
+                                  assigned_tuples().
+all_assigned_to_fold([], Acc) -> Acc;
+all_assigned_to_fold([Number|_]=Numbers, Acc) ->
+    Db = knm_converters:to_db(Number),
+    {SamePrefix, DiffPrefix} = lists:partition(fun(Number1) ->
+                                                       knm_converters:to_db(Number1) =:= Db
+                                               end
+                                              ,Numbers),
+    case kz_datamgr:get_results(Db, <<"numbers/assigned_to">>) of
+        {'ok', Results} ->
+            Acc1 = assigned_to_fold(SamePrefix, Results, Acc),
+            all_assigned_to_fold(DiffPrefix, Acc1);
+        _ -> Acc
     end.
 
-validate_number_ownership(NumberObj, Numbers, Context) ->
+-spec assigned_to_fold(ne_binaries(), kz_json:objects(), assigned_tuples()) ->
+                              assigned_tuples().
+assigned_to_fold([], _, Acc) -> Acc;
+assigned_to_fold([Number|Numbers], ViewJObjs, Acc) ->
+    case kz_json:find_value(<<"id">>, Number, ViewJObjs) of
+        'undefined' -> assigned_to_fold(Numbers, ViewJObjs, Acc);
+        JObj ->
+            AssignedTo = hd(kz_json:get_value(<<"key">>, JObj)),
+            NumbersForAssignedTo = props:get_value(AssignedTo, Acc, []),
+            NumbersForAssignedTo1 = [Number | NumbersForAssignedTo],
+            Acc1 = props:set_value(AssignedTo, NumbersForAssignedTo1, Acc),
+            assigned_to_fold(Numbers, ViewJObjs, Acc1)
+    end.
+
+-spec validate_parent(assigned_tuples(), cb_context:context()) ->
+                             cb_context:context().
+validate_parent([], Context) -> Context;
+validate_parent([{AssignedTo, Numbers}|AssignedTuples], Context) ->
     AuthBy = cb_context:auth_account_id(Context),
-    PhoneNumber = knm_number:phone_number(NumberObj),
-    AssignedTo = knm_phone_number:assigned_to(PhoneNumber),
     case kz_util:is_in_account_hierarchy(AuthBy, AssignedTo, 'true') of
-        'true' -> validate_number_ownership(Numbers, Context);
+        'true' -> validate_parent(AssignedTuples, Context);
         'false' ->
-            Number = knm_phone_number:number(PhoneNumber),
-            Message = <<"unauthorized to add/modify ", Number/binary>>,
+            Message = <<"unauthorized to add/modify ", (hd(Numbers))/binary>>,
             cb_context:add_system_error(403, 'forbidden', Message, Context)
     end.
 

--- a/applications/crossbar/src/modules/cb_callflows.erl
+++ b/applications/crossbar/src/modules/cb_callflows.erl
@@ -361,12 +361,11 @@ add_pattern_conflict(Context, JObj) ->
 -spec validate_callflow_schema(api_binary(), cb_context:context()) -> cb_context:context().
 validate_callflow_schema(CallflowId, Context) ->
     OnSuccess = fun(C) ->
-                        C1 = validate_callflow_elements(on_successful_validation(CallflowId, C)),
-                        C2 = validate_uniqueness(CallflowId, C1),
+                        C1 = validate_uniqueness(CallflowId, on_successful_validation(CallflowId, C)),
 
-                        Doc = cb_context:doc(C2),
+                        Doc = cb_context:doc(C1),
                         Nums = kz_json:get_list_value(<<"numbers">>, Doc, []),
-                        cb_modules_util:validate_number_ownership(Nums, C2)
+                        cb_modules_util:validate_number_ownership(Nums, C1)
                 end,
     cb_context:validate_request_data(<<"callflows">>, Context, OnSuccess).
 

--- a/applications/crossbar/src/modules/cb_callflows.erl
+++ b/applications/crossbar/src/modules/cb_callflows.erl
@@ -433,7 +433,7 @@ track_assignment('post', Context) ->
                     knm_converters:is_reconcilable(Num, AccountId)
                 ],
 
-    Updates = cb_modules_util:apply_assignment_updates(Unassigned ++ Assigned),
+    Updates = cb_modules_util:apply_assignment_updates(Unassigned ++ Assigned, Context),
     cb_modules_util:log_assignment_updates(Updates);
 track_assignment('put', Context) ->
     NewNums = kz_json:get_value(<<"numbers">>, cb_context:doc(Context), []),
@@ -443,7 +443,7 @@ track_assignment('put', Context) ->
                     knm_converters:is_reconcilable(Num, AccountId)
                 ],
 
-    Updates = cb_modules_util:apply_assignment_updates(Assigned),
+    Updates = cb_modules_util:apply_assignment_updates(Assigned, Context),
     cb_modules_util:log_assignment_updates(Updates);
 track_assignment('delete', Context) ->
     Nums = kz_json:get_value(<<"numbers">>, cb_context:doc(Context), []),
@@ -452,7 +452,7 @@ track_assignment('delete', Context) ->
                    || Num <- Nums,
                       knm_converters:is_reconcilable(Num, AccountId)
                   ],
-    Updates = cb_modules_util:apply_assignment_updates(Unassigned),
+    Updates = cb_modules_util:apply_assignment_updates(Unassigned, Context),
     cb_modules_util:log_assignment_updates(Updates).
 
 -spec filter_callflow_list(api_binary(), kz_json:objects()) -> kz_json:objects().

--- a/applications/crossbar/src/modules/cb_callflows.erl
+++ b/applications/crossbar/src/modules/cb_callflows.erl
@@ -361,7 +361,9 @@ add_pattern_conflict(Context, JObj) ->
 -spec validate_callflow_schema(api_binary(), cb_context:context()) -> cb_context:context().
 validate_callflow_schema(CallflowId, Context) ->
     OnSuccess = fun(C) ->
-                        validate_uniqueness(CallflowId, on_successful_validation(CallflowId, C))
+                        C1 = validate_callflow_elements(on_successful_validation(CallflowId, C)),
+                        C2 = validate_uniqueness(CallflowId, C1),
+                        validate_number_ownership(C2)
                 end,
     cb_context:validate_request_data(<<"callflows">>, Context, OnSuccess).
 
@@ -372,6 +374,48 @@ on_successful_validation('undefined', Context) ->
                       );
 on_successful_validation(CallflowId, Context) ->
     crossbar_doc:load_merge(CallflowId, Context, ?TYPE_CHECK_OPTION(kzd_callflow:type())).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec validate_number_ownership(cb_context:context()) -> cb_context:context().
+-spec validate_number_ownership(ne_binaries(), cb_context:context()) ->
+                                       cb_context:context().
+-spec validate_number_ownership(knm_number:knm_number()
+                               ,ne_binaries()
+                               ,cb_context:context()) -> cb_context:context().
+validate_number_ownership(Context) ->
+    NewNums = kz_json:get_value(<<"numbers">>, cb_context:doc(Context), []),
+
+    Assigned =  [Num
+                 || Num <- NewNums,
+                    Num =/= <<"undefined">>
+                ],
+
+    validate_number_ownership(Assigned, Context).
+
+validate_number_ownership([], Context) -> Context;
+validate_number_ownership([Number|Numbers], Context) ->
+    case knm_number:get(Number) of
+        {'ok', NumberObj} ->
+            validate_number_ownership(NumberObj, Numbers, Context);
+        _ -> validate_number_ownership(Numbers, Context)
+    end.
+
+validate_number_ownership(NumberObj, Numbers, Context) ->
+    AuthBy = cb_context:auth_account_id(Context),
+    PhoneNumber = knm_number:phone_number(NumberObj),
+    AssignedTo = knm_phone_number:assigned_to(PhoneNumber),
+    case kz_util:is_in_account_hierarchy(AuthBy, AssignedTo, 'true') of
+        'true' -> validate_number_ownership(Numbers, Context);
+        'false' ->
+            Number = knm_phone_number:number(PhoneNumber),
+            Message = <<"unauthorized to add/modify ", Number/binary>>,
+            cb_context:add_system_error(403, 'forbidden', Message, Context)
+    end.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/modules/cb_connectivity.erl
+++ b/applications/crossbar/src/modules/cb_connectivity.erl
@@ -166,13 +166,13 @@ track_assignment('post', Context) ->
                      not (lists:member(Num, NewNums))
                  ],
 
-    Updates = cb_modules_util:apply_assignment_updates(Assigned ++ Unassigned),
+    Updates = cb_modules_util:apply_assignment_updates(Assigned ++ Unassigned, Context),
     cb_modules_util:log_assignment_updates(Updates);
 track_assignment('delete', Context) ->
     Nums = get_numbers(cb_context:doc(Context)),
     Unassigned = [{Num, 'undefined'} || Num <- Nums],
 
-    Updates = cb_modules_util:apply_assignment_updates(Unassigned),
+    Updates = cb_modules_util:apply_assignment_updates(Unassigned, Context),
     cb_modules_util:log_assignment_updates(Updates).
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_connectivity.erl
+++ b/applications/crossbar/src/modules/cb_connectivity.erl
@@ -198,7 +198,9 @@ get_numbers_fold(Server, Acc) ->
 %%--------------------------------------------------------------------
 -spec create(cb_context:context()) -> cb_context:context().
 create(Context) ->
-    OnSuccess = fun(C) -> on_successful_validation('undefined', C) end,
+    OnSuccess = fun(C) ->
+                        validate_number_ownership(on_successful_validation('undefined', C))
+                end,
     cb_context:validate_request_data(<<"connectivity">>, Context, OnSuccess).
 
 %%--------------------------------------------------------------------
@@ -220,7 +222,9 @@ read(Id, Context) ->
 %%--------------------------------------------------------------------
 -spec update(ne_binary(), cb_context:context()) -> cb_context:context().
 update(Id, Context) ->
-    OnSuccess = fun(C) -> on_successful_validation(Id, C) end,
+    OnSuccess = fun(C) ->
+                        validate_number_ownership(on_successful_validation(Id, C))
+                end,
     cb_context:validate_request_data(<<"connectivity">>, Context, OnSuccess).
 
 %%--------------------------------------------------------------------
@@ -245,6 +249,48 @@ on_successful_validation('undefined', Context) ->
     cb_context:set_doc(Context, kz_doc:set_type(cb_context:doc(Context), <<"sys_info">>));
 on_successful_validation(Id, Context) ->
     crossbar_doc:load_merge(Id, Context, ?TYPE_CHECK_OPTION(<<"sys_info">>)).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec validate_number_ownership(cb_context:context()) -> cb_context:context().
+-spec validate_number_ownership(ne_binaries(), cb_context:context()) ->
+                                       cb_context:context().
+-spec validate_number_ownership(knm_number:knm_number()
+                               ,ne_binaries()
+                               ,cb_context:context()) -> cb_context:context().
+validate_number_ownership(Context) ->
+    NewNums = get_numbers(cb_context:doc(Context)),
+
+    Assigned =  [Num
+                 || Num <- NewNums,
+                    Num =/= <<"undefined">>
+                ],
+
+    validate_number_ownership(Assigned, Context).
+
+validate_number_ownership([], Context) -> Context;
+validate_number_ownership([Number|Numbers], Context) ->
+    case knm_number:get(Number) of
+        {'ok', NumberObj} ->
+            validate_number_ownership(NumberObj, Numbers, Context);
+        _ -> validate_number_ownership(Numbers, Context)
+    end.
+
+validate_number_ownership(NumberObj, Numbers, Context) ->
+    AuthBy = cb_context:auth_account_id(Context),
+    PhoneNumber = knm_number:phone_number(NumberObj),
+    AssignedTo = knm_phone_number:assigned_to(PhoneNumber),
+    case kz_util:is_in_account_hierarchy(AuthBy, AssignedTo, 'true') of
+        'true' -> validate_number_ownership(Numbers, Context);
+        'false' ->
+            Number = knm_phone_number:number(PhoneNumber),
+            Message = <<"unauthorized to add/modify ", Number/binary>>,
+            cb_context:add_system_error(403, 'forbidden', Message, Context)
+    end.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/modules/cb_connectivity.erl
+++ b/applications/crossbar/src/modules/cb_connectivity.erl
@@ -256,39 +256,60 @@ on_successful_validation(Id, Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+-type assigned_tuple() :: {ne_binary(), ne_binaries()}.
+-type assigned_tuples() :: [assigned_tuple()].
+
 -spec validate_number_ownership(cb_context:context()) -> cb_context:context().
--spec validate_number_ownership(ne_binaries(), cb_context:context()) ->
-                                       cb_context:context().
--spec validate_number_ownership(knm_number:knm_number()
-                               ,ne_binaries()
-                               ,cb_context:context()) -> cb_context:context().
 validate_number_ownership(Context) ->
     NewNums = get_numbers(cb_context:doc(Context)),
 
-    Assigned =  [Num
+    Assigned =  [knm_converters:normalize(Num)
                  || Num <- NewNums,
-                    Num =/= <<"undefined">>
+                    knm_converters:is_reconcilable(Num)
                 ],
 
-    validate_number_ownership(Assigned, Context).
+    AssignedTo = all_assigned_to_fold(Assigned, []),
+    validate_parent(AssignedTo, Context).
 
-validate_number_ownership([], Context) -> Context;
-validate_number_ownership([Number|Numbers], Context) ->
-    case knm_number:get(Number) of
-        {'ok', NumberObj} ->
-            validate_number_ownership(NumberObj, Numbers, Context);
-        _ -> validate_number_ownership(Numbers, Context)
+-spec all_assigned_to_fold(ne_binaries(), assigned_tuples()) ->
+                                  assigned_tuples().
+all_assigned_to_fold([], Acc) -> Acc;
+all_assigned_to_fold([Number|_]=Numbers, Acc) ->
+    Db = knm_converters:to_db(Number),
+    {SamePrefix, DiffPrefix} = lists:partition(fun(Number1) ->
+                                                       knm_converters:to_db(Number1) =:= Db
+                                               end
+                                              ,Numbers),
+    case kz_datamgr:get_results(Db, <<"numbers/assigned_to">>) of
+        {'ok', Results} ->
+            Acc1 = assigned_to_fold(SamePrefix, Results, Acc),
+            all_assigned_to_fold(DiffPrefix, Acc1);
+        _ -> Acc
     end.
 
-validate_number_ownership(NumberObj, Numbers, Context) ->
+-spec assigned_to_fold(ne_binaries(), kz_json:objects(), assigned_tuples()) ->
+                              assigned_tuples().
+assigned_to_fold([], _, Acc) -> Acc;
+assigned_to_fold([Number|Numbers], ViewJObjs, Acc) ->
+    case kz_json:find_value(<<"id">>, Number, ViewJObjs) of
+        'undefined' -> assigned_to_fold(Numbers, ViewJObjs, Acc);
+        JObj ->
+            AssignedTo = hd(kz_json:get_value(<<"key">>, JObj)),
+            NumbersForAssignedTo = props:get_value(AssignedTo, Acc, []),
+            NumbersForAssignedTo1 = [Number | NumbersForAssignedTo],
+            Acc1 = props:set_value(AssignedTo, NumbersForAssignedTo1, Acc),
+            assigned_to_fold(Numbers, ViewJObjs, Acc1)
+    end.
+
+-spec validate_parent(assigned_tuples(), cb_context:context()) ->
+                             cb_context:context().
+validate_parent([], Context) -> Context;
+validate_parent([{AssignedTo, Numbers}|AssignedTuples], Context) ->
     AuthBy = cb_context:auth_account_id(Context),
-    PhoneNumber = knm_number:phone_number(NumberObj),
-    AssignedTo = knm_phone_number:assigned_to(PhoneNumber),
     case kz_util:is_in_account_hierarchy(AuthBy, AssignedTo, 'true') of
-        'true' -> validate_number_ownership(Numbers, Context);
+        'true' -> validate_parent(AssignedTuples, Context);
         'false' ->
-            Number = knm_phone_number:number(PhoneNumber),
-            Message = <<"unauthorized to add/modify ", Number/binary>>,
+            Message = <<"unauthorized to add/modify ", (hd(Numbers))/binary>>,
             cb_context:add_system_error(403, 'forbidden', Message, Context)
     end.
 

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -575,11 +575,9 @@ remove_plaintext_password(Context) ->
 -spec validate_number_ownership([{knm_numbers:num(), knm_numbers:ko()}], ne_binaries(), cb_context:context()) ->
                                        cb_context:context().
 validate_number_ownership(Numbers, Context) ->
-    Filtered = [knm_converters:normalize(Num)
-                || Num <- Numbers,
-                   knm_converters:is_reconcilable(Num)
-               ],
-    validate_number_ownership(Filtered, [], Context).
+    Options = [{'auth_by', cb_context:auth_account_id(Context)}],
+    #{ko := KOs} = knm_numbers:get(Numbers, Options),
+    validate_number_ownership(maps:to_list(KOs), [], Context).
 
 validate_number_ownership([], [], Context) -> Context;
 validate_number_ownership([], Unauthorized, Context) ->
@@ -587,15 +585,14 @@ validate_number_ownership([], Unauthorized, Context) ->
     Numbers = kz_binary:join(Unauthorized, <<", ">>),
     Message = <<Prefix/binary, Numbers/binary>>,
     cb_context:add_system_error(403, 'forbidden', Message, Context);
-validate_number_ownership([Number|Numbers], Unauthorized, Context) ->
-    Options = [{'auth_by', cb_context:auth_account_id(Context)}],
-    case knm_number:get(Number, Options) of
-        {'error', 'not_found'} ->
-            validate_number_ownership(Numbers, Unauthorized, Context);
-        {'error', _} ->
-            validate_number_ownership(Numbers, [Number | Unauthorized], Context);
-        _ ->
-            validate_number_ownership(Numbers, Unauthorized, Context)
+validate_number_ownership([{_, Reason}|KOs], Unauthorized, Context) when is_atom(Reason) ->
+    %% Ignoring atom reasons, i.e. 'not_found' or 'not_reconcilable'
+    validate_number_ownership(KOs, Unauthorized, Context);
+validate_number_ownership([{Number, ReasonJObj}|KOs], Unauthorized, Context) ->
+    case knm_errors:error(ReasonJObj) of
+        <<"forbidden">> ->
+            validate_number_ownership(KOs, [Number|Unauthorized], Context);
+        _ -> validate_number_ownership(KOs, Unauthorized, Context)
     end.
 
 -type assignment_to_apply() :: {ne_binary(), api_binary()}.

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -669,8 +669,9 @@ format_assignment_results(#{ok := OKs
 
 -spec format_assignment_oks(knm_number:knm_numbers()) -> assignment_updates().
 format_assignment_oks(Numbers) ->
-    [{knm_phone_number:number(knm_number:phone_number(Number)), {'ok', Number}}
-     || Number <- Numbers
+    [{knm_phone_number:number(PN), {'ok', Number}}
+     || Number <- Numbers,
+        PN <- [knm_number:phone_number(Number)]
     ].
 
 -spec format_assignment_kos(knm_numbers:kos()) -> assignment_updates().

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -572,7 +572,7 @@ remove_plaintext_password(Context) ->
 %%--------------------------------------------------------------------
 -spec validate_number_ownership(ne_binaries(), cb_context:context()) ->
                                        cb_context:context().
--spec validate_number_ownership(ne_binaries(), ne_binaries(), cb_context:context()) ->
+-spec validate_number_ownership([{knm_numbers:num(), knm_numbers:ko()}], ne_binaries(), cb_context:context()) ->
                                        cb_context:context().
 validate_number_ownership(Numbers, Context) ->
     Filtered = [knm_converters:normalize(Num)

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -630,8 +630,7 @@ maybe_assign_to_app(DID, Assign, AccountId) ->
             PhoneNumber = knm_number:phone_number(Number),
             AssignedTo = knm_phone_number:assigned_to(PhoneNumber),
             maybe_assign_to_app(DID, Assign, AccountId, AssignedTo);
-        {'error', _}=E -> {DID, E};
-        {'dry_run', _, _} -> {DID, {'error', 'dry_run'}}
+        {'error', _}=E -> {DID, E}
     end.
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -614,7 +614,6 @@ apply_assignment_updates(Updates, Context) ->
     {PRUpdates, NumUpdates} = lists:foldl(fun split_port_requests/2, {[], []}, Updates),
     PortAssignResults = assign_to_port_number(PRUpdates),
     AssignResults = maybe_assign_to_app(NumUpdates, AccountId),
-    lager:debug("AssignResults ~p", [AssignResults]),
     PortAssignResults ++ AssignResults.
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -579,8 +579,8 @@ validate_number_ownership(Numbers, Context) ->
         [] -> Context;
         Unauthorized ->
             Prefix = <<"unauthorized to use ">>,
-            Numbers = kz_binary:join(Unauthorized, <<", ">>),
-            Message = <<Prefix/binary, Numbers/binary>>,
+            NumbersStr = kz_binary:join(Unauthorized, <<", ">>),
+            Message = <<Prefix/binary, NumbersStr/binary>>,
             cb_context:add_system_error(403, 'forbidden', Message, Context)
     end.
 

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -683,8 +683,7 @@ format_assignment_kos(KOs) ->
 format_assignment_kos_fold(Number, Reason, Updates) when is_atom(Reason) ->
     [{Number, {'error', Reason}} | Updates];
 format_assignment_kos_fold(Number, ReasonJObj, Updates) ->
-    Error = knm_errors:error(ReasonJObj),
-    [{Number, {'error', Error}} | Updates].
+    [{Number, {'error', ReasonJObj}} | Updates].
 
 -spec log_assignment_updates(assignment_updates()) -> 'ok'.
 log_assignment_updates(Updates) ->

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -662,7 +662,7 @@ group_by_assign_to(NumUpdates) ->
 
 group_by_assign_to([], Groups) -> Groups;
 group_by_assign_to([{DID, Assign}|NumUpdates], Groups) ->
-    DIDs = maps:get(Groups, Assign, []),
+    DIDs = maps:get(Assign, Groups, []),
     Groups1 = Groups#{Assign => [DID|DIDs]},
     group_by_assign_to(NumUpdates, Groups1).
 

--- a/core/kazoo_number_manager/src/knm_number_states.erl
+++ b/core/kazoo_number_manager/src/knm_number_states.erl
@@ -233,24 +233,9 @@ in_service_from_in_service_authorize(T0=#{todo := Ns}) ->
     lists:foldl(F, T0, Ns);
 in_service_from_in_service_authorize(Number) ->
     PhoneNumber = knm_number:phone_number(Number),
-    AssignTo = knm_phone_number:assign_to(PhoneNumber),
-    AssignedTo = knm_phone_number:assigned_to(PhoneNumber),
-    AuthBy = knm_phone_number:auth_by(PhoneNumber),
-    Sudo = ?KNM_DEFAULT_AUTH_BY =:= AuthBy,
-    case Sudo
-        %% Assign to self or parent
-        %% Allowed when account is parent of owner or owner
-        orelse (?ACCT_HIERARCHY(AssignTo, AuthBy, 'true')
-                andalso ?ACCT_HIERARCHY(AuthBy, AssignedTo, 'true'))
-        %% Assign to another child
-        %% Allowed when account is parent of owner
-        orelse ?ACCT_HIERARCHY(AuthBy, AssignedTo, 'false')
-    of
-        false -> knm_errors:unauthorized();
-        true ->
-            Sudo
-                andalso lager:info("bypassing auth"),
-            Number
+    case knm_phone_number:is_authorized(PhoneNumber) of
+        'true' -> Number;
+        'false' -> knm_errors:unauthorized()
     end.
 
 -spec not_assigning_to_self(kn()) -> kn();

--- a/core/kazoo_number_manager/src/knm_number_states.erl
+++ b/core/kazoo_number_manager/src/knm_number_states.erl
@@ -221,22 +221,9 @@ in_service_from_reserved_authorize(Number) ->
             Number
     end.
 
--spec in_service_from_in_service_authorize(kn()) -> kn();
-                                          (t()) -> t().
-in_service_from_in_service_authorize(T0=#{todo := Ns}) ->
-    F = fun (N, T) ->
-                case knm_number:attempt(fun in_service_from_in_service_authorize/1, [N]) of
-                    {ok, NewN} -> knm_numbers:ok(NewN, T);
-                    {error, R} -> knm_numbers:ko(N, R, T)
-                end
-        end,
-    lists:foldl(F, T0, Ns);
-in_service_from_in_service_authorize(Number) ->
-    PhoneNumber = knm_number:phone_number(Number),
-    case knm_phone_number:is_authorized(PhoneNumber) of
-        'true' -> Number;
-        'false' -> knm_errors:unauthorized()
-    end.
+-spec in_service_from_in_service_authorize(t()) -> t().
+in_service_from_in_service_authorize(T) ->
+    knm_numbers:do_in_wrap(fun knm_phone_number:is_authorized/1, T).
 
 -spec not_assigning_to_self(kn()) -> kn();
                            (t()) -> t().


### PR DESCRIPTION
Ensure that number docs can't be modified by cb_callflows or cb_connectivity if the authorizing account does have rights to do so.
We noticed that it was possible to update fields in a numbers document that shouldn't be allowed simply by permitting the update of in_service numbers by setting assign_to to an account that /would/ allow those doc updates. This is handled in the knm_number_states change.
cb_callflows and cb_connectivity have validation functions to prevent the callflow from saving if the additional functions (track_assignment and reconciliation) shouldn't be allowed.