### PR TITLE
KAZOO-5212: forward a vm message to another vmbox from callflow

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -958,7 +958,7 @@ forward_message(AttachmentName, Length, Message, SrcBoxId, #mailbox{mailbox_numb
     NewMsgProps = props:filter_undefined(
                     [{<<"Box-Id">>, BoxId}
                     ,{<<"Owner-Id">>, OwnerId}
-                    ,{<<"Length">>, Length}
+                    ,{<<"Length">>, Length + kz_json:get_integer_value(<<"length">>, Message, 0)}
                     ,{<<"Transcribe-Voicemail">>, MaybeTranscribe}
                     ,{<<"After-Notify-Action">>, Action}
                     ,{<<"Attachment-Name">>, AttachmentName}

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -868,7 +868,7 @@ forward_message(Message, SrcBoxId, DestBox, Call) ->
         {'ok', 'append'} ->
             compose_forward_message(Message, SrcBoxId, DestBox, Call);
         {'ok', 'forward'} ->
-            forward_message('undefined', 'undefined', Message, SrcBoxId, DestBox, Call);
+            forward_message('undefined', 0, Message, SrcBoxId, DestBox, Call);
         {'error', _R} ->
             lager:info("error during forward message playback: ~p", [_R])
     end.
@@ -946,7 +946,7 @@ record_forward(AttachmentName, Message, SrcBoxId, #mailbox{media_extension=Ext
             lager:info("error while attempting to record a foward message: ~p", [_R])
     end.
 
--spec forward_message(api_ne_binary(), api_pos_integer(), kz_json:object(), ne_binary(), mailbox(), kapps_call:call()) -> 'ok'.
+-spec forward_message(api_ne_binary(), non_neg_integer(), kz_json:object(), ne_binary(), mailbox(), kapps_call:call()) -> 'ok'.
 forward_message(AttachmentName, Length, Message, SrcBoxId, #mailbox{mailbox_number=BoxNum
                                                                    ,mailbox_id=BoxId
                                                                    ,timezone=Timezone
@@ -1461,7 +1461,7 @@ collect_pin(Interdigit, Call, NoopId) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec new_message(ne_binary(), pos_integer(), mailbox(), kapps_call:call()) -> any().
+-spec new_message(ne_binary(), non_neg_integer(), mailbox(), kapps_call:call()) -> any().
 new_message(_, Length, #mailbox{min_message_length=MinLength}, _)
   when Length < MinLength ->
     lager:info("attachment length is ~B and must be larger than ~B to be stored", [Length, MinLength]);

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -828,9 +828,9 @@ play_messages([H|T]=Messages, PrevMessages, Count, #mailbox{timezone=Timezone
         {'ok', 'forward'} ->
             lager:info("caller chose to forward the message"),
             forward_message(H, Box, Call),
-            _ = kvm_message:set_folder(?VM_FOLDER_SAVED, H, AccountId),
+            {_, NMessage} = kvm_message:set_folder(?VM_FOLDER_SAVED, H, AccountId),
             _ = kapps_call_command:prompt(<<"vm-saved">>, Call),
-            play_messages(T, PrevMessages, Count, Box, Call);
+            play_messages(T, [NMessage|PrevMessages], Count, Box, Call);
         {'error', _} ->
             lager:info("error during message playback")
     end;
@@ -870,6 +870,7 @@ forward_message(_Message, _SrcBoxId, #mailbox{exists='false'}, _Call) ->
     lager:info("unable to find destination mailbox, returning to message menu...");
 forward_message(Message, SrcBoxId, DestBox, Call) ->
     case forward_message_menu(DestBox, Call) of
+        {'ok', 'return'} -> 'ok';
         {'ok', 'append'} ->
             compose_forward_message(Message, SrcBoxId, DestBox, Call);
         {'ok', 'forward'} ->

--- a/applications/crossbar/src/modules/cb_media.erl
+++ b/applications/crossbar/src/modules/cb_media.erl
@@ -345,12 +345,11 @@ normalize_upload(Context, MediaId, FileJObj, UploadContentType) ->
                            ,MediaId
                            ,NewFileJObj
              );
-        {'error', Reason} ->
-            lager:warning("failed to convert to ~s: ~s", [ToExt, Reason]),
-
+        {'error', _R} ->
+            lager:warning("failed to convert to ~s: ~p", [ToExt, _R]),
+            Reason = <<"failed to communicate with conversion utility">>,
             validate_upload(cb_context:set_doc(Context
                                               ,kz_json:set_value(<<"normalization_error">>, Reason, cb_context:doc(Context))
-
                                               )
                            ,MediaId
                            ,FileJObj

--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -131,6 +131,7 @@
         ]).
 
 -export([write_file/2, write_file/3
+        ,rename_file/2
         ,delete_file/1
         ,make_dir/1
         ]).
@@ -1632,6 +1633,14 @@ write_file(Filename, Bytes, Modes) ->
         'ok' -> 'ok';
         {'error', _}=_E ->
             lager:error("writing file ~s (~p) failed : ~p", [Filename, Modes, _E])
+    end.
+
+-spec rename_file(file:filename_all(), file:filename_all()) -> 'ok'.
+rename_file(FromFilename, ToFilename) ->
+    case file:rename(FromFilename, ToFilename) of
+        'ok' -> 'ok';
+        {'error', _}=_E ->
+            lager:error("moving file ~s into ~s failed : ~p", [FromFilename, ToFilename, _E])
     end.
 
 %% @public

--- a/core/kazoo_documents/src/kzd_box_message.erl
+++ b/core/kazoo_documents/src/kzd_box_message.erl
@@ -8,7 +8,7 @@
 %%%-------------------------------------------------------------------
 -module(kzd_box_message).
 
--export([new/2, build_metadata_object/4
+-export([new/2, build_metadata_object/6
         ,count_folder/2
         ,create_message_name/3
         ,type/0
@@ -163,16 +163,16 @@ message_name(BoxNum, {{Y,M,D},{H,I,S}}, TZ) ->
 %% @doc Build message metadata
 %% @end
 %%--------------------------------------------------------------------
--spec build_metadata_object(pos_integer(), kapps_call:call(), ne_binary(), gregorian_seconds()) ->
+-spec build_metadata_object(pos_integer(), kapps_call:call(), ne_binary(), ne_binary(), ne_binary(), gregorian_seconds()) ->
                                    doc().
-build_metadata_object(Length, Call, MediaId, Timestamp) ->
+build_metadata_object(Length, Call, MediaId, CIDNumber, CIDName, Timestamp) ->
     kz_json:from_list(
       props:filter_undefined(
         [{?KEY_META_TIMESTAMP, Timestamp}
         ,{?KEY_META_FROM, kapps_call:from(Call)}
         ,{?KEY_META_TO, kapps_call:to(Call)}
-        ,{?KEY_META_CID_NUMBER, kapps_call:caller_id_number(Call)}
-        ,{?KEY_META_CID_NAME, kapps_call:caller_id_name(Call)}
+        ,{?KEY_META_CID_NUMBER, CIDNumber}
+        ,{?KEY_META_CID_NAME, CIDName}
         ,{?KEY_META_CALL_ID, kapps_call:call_id(Call)}
         ,{?VM_KEY_FOLDER, ?VM_FOLDER_NEW}
         ,{?KEY_META_LENGTH, Length}

--- a/core/kazoo_documents/src/kzd_box_message.erl
+++ b/core/kazoo_documents/src/kzd_box_message.erl
@@ -8,7 +8,7 @@
 %%%-------------------------------------------------------------------
 -module(kzd_box_message).
 
--export([new/2, build_metadata_object/6
+-export([new/2, build_metadata_object/4
         ,count_folder/2
         ,create_message_name/3
         ,type/0
@@ -108,11 +108,12 @@ new(AccountId, Props) ->
     Name = create_message_name(props:get_value(<<"Box-Num">>, Props)
                               ,props:get_value(<<"Timezone">>, Props)
                               ,UtcSeconds),
+    Description = props:get_value(<<"Description">>, Props, <<"voicemail message with media">>),
 
     DocProps = props:filter_undefined(
                  [{<<"_id">>, MsgId}
                  ,{?KEY_NAME, Name}
-                 ,{?KEY_DESC, <<"mailbox message media">>}
+                 ,{?KEY_DESC, Description}
                  ,{?KEY_SOURCE_TYPE, ?KEY_VOICEMAIL}
                  ,{?KEY_SOURCE_ID, props:get_value(<<"Box-Id">>, Props)}
                  ,{?KEY_MEDIA_SOURCE, <<"recording">>}
@@ -162,16 +163,16 @@ message_name(BoxNum, {{Y,M,D},{H,I,S}}, TZ) ->
 %% @doc Build message metadata
 %% @end
 %%--------------------------------------------------------------------
--spec build_metadata_object(pos_integer(), kapps_call:call(), ne_binary(), ne_binary(), ne_binary(), gregorian_seconds()) ->
+-spec build_metadata_object(pos_integer(), kapps_call:call(), ne_binary(), gregorian_seconds()) ->
                                    doc().
-build_metadata_object(Length, Call, MediaId, CIDNumber, CIDName, Timestamp) ->
+build_metadata_object(Length, Call, MediaId, Timestamp) ->
     kz_json:from_list(
       props:filter_undefined(
         [{?KEY_META_TIMESTAMP, Timestamp}
         ,{?KEY_META_FROM, kapps_call:from(Call)}
         ,{?KEY_META_TO, kapps_call:to(Call)}
-        ,{?KEY_META_CID_NUMBER, CIDNumber}
-        ,{?KEY_META_CID_NAME, CIDName}
+        ,{?KEY_META_CID_NUMBER, kapps_call:caller_id_number(Call)}
+        ,{?KEY_META_CID_NAME, kapps_call:caller_id_name(Call)}
         ,{?KEY_META_CALL_ID, kapps_call:call_id(Call)}
         ,{?VM_KEY_FOLDER, ?VM_FOLDER_NEW}
         ,{?KEY_META_LENGTH, Length}

--- a/core/kazoo_documents/src/kzd_box_message.erl
+++ b/core/kazoo_documents/src/kzd_box_message.erl
@@ -290,7 +290,7 @@ to_sip(JObj, Default) ->
 set_to_sip(To, Metadata) ->
     kz_json:set_value(?KEY_META_TO, To, Metadata).
 
--spec utc_seconds(doc()) -> pos_integer().
+-spec utc_seconds(doc()) -> non_neg_integer().
 utc_seconds(JObj) ->
     kz_json:get_integer_value(?KEY_UTC_SEC, JObj, 0).
 

--- a/core/kazoo_voicemail/src/kazoo_voicemail_maintenance.erl
+++ b/core/kazoo_voicemail/src/kazoo_voicemail_maintenance.erl
@@ -149,7 +149,7 @@ rebuild_message_metadata(JObj, AttachmentName) ->
                ,{fun kapps_call:set_caller_id_name/2, CIDName}
                ],
     Call = kapps_call:exec(Routines, kapps_call:new()),
-    Metadata = kzd_box_message:build_metadata_object(Length, Call, MediaId, Timestamp),
+    Metadata = kzd_box_message:build_metadata_object(Length, Call, MediaId, CIDNumber, CIDName, Timestamp),
     kzd_box_message:set_metadata(Metadata, JObj).
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_voicemail/src/kazoo_voicemail_maintenance.erl
+++ b/core/kazoo_voicemail/src/kazoo_voicemail_maintenance.erl
@@ -145,9 +145,11 @@ rebuild_message_metadata(JObj, AttachmentName) ->
     Routines = [{fun kapps_call:set_to/2, <<CIDNumber/binary, "@nodomain">>}
                ,{fun kapps_call:set_from/2, <<CIDNumber/binary, "@nodomain">>}
                ,{fun kapps_call:set_call_id/2, kz_util:rand_hex_binary(12)}
+               ,{fun kapps_call:set_caller_id_number/2, CIDNumber}
+               ,{fun kapps_call:set_caller_id_name/2, CIDName}
                ],
     Call = kapps_call:exec(Routines, kapps_call:new()),
-    Metadata = kzd_box_message:build_metadata_object(Length, Call, MediaId, CIDNumber, CIDName, Timestamp),
+    Metadata = kzd_box_message:build_metadata_object(Length, Call, MediaId, Timestamp),
     kzd_box_message:set_metadata(Metadata, JObj).
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_voicemail/src/kazoo_voicemail_maintenance.erl
+++ b/core/kazoo_voicemail/src/kazoo_voicemail_maintenance.erl
@@ -176,7 +176,7 @@ renotify(Account, MessageId) ->
              )
     end.
 
--spec log_renotify_result(ne_binary(), ne_binary(), any()) -> 'ok'.
+-spec log_renotify_result(ne_binary(), ne_binary(), kz_amqp_worker:request_return()) -> 'ok'.
 log_renotify_result(MessageId, BoxId, {'ok', JObj}) ->
     ?LOG("re-notify sent message ~s from mailbox ~s: ~s"
         ,[MessageId, BoxId, kz_json:encode(JObj)]

--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -379,8 +379,10 @@ create_message_doc(Call, Metadata, Props) ->
 -spec maybe_add_metadata(kapps_call:call(), kz_json:object(), api_object(), kz_proplist()) -> kz_json:object().
 maybe_add_metadata(Call, JObj, 'undefined', Props) ->
     Length = props:get_value(<<"Length">>, Props),
+    CIDNumber = kvm_util:get_caller_id_number(Call),
+    CIDName = kvm_util:get_caller_id_name(Call),
     Timestamp = kz_util:current_tstamp(),
-    Metadata = kzd_box_message:build_metadata_object(Length, Call, kz_doc:id(JObj), Timestamp),
+    Metadata = kzd_box_message:build_metadata_object(Length, Call, kz_doc:id(JObj), CIDNumber, CIDName, Timestamp),
     kzd_box_message:set_metadata(Metadata, JObj);
 maybe_add_metadata(_Call, JObj, Metadata, _Props) ->
     MediaId = kz_doc:id(JObj),

--- a/core/kazoo_voicemail/src/kvm_messages.erl
+++ b/core/kazoo_voicemail/src/kvm_messages.erl
@@ -101,7 +101,7 @@ count_by_owner(AccountId, OwnerId) ->
             {0, 0}
     end.
 
--spec sum_owner_mailboxes(kz_json:objects(), ne_binaries(), count_result()) -> count_result().
+-spec sum_owner_mailboxes(kz_json:object(), ne_binaries(), count_result()) -> count_result().
 sum_owner_mailboxes(_, [], Results) -> Results;
 sum_owner_mailboxes(FolderQuantities, [BoxId|BoxIds], {New, Saved}) ->
     {BoxNew, BoxSaved} = normalize_count_none_deleted(BoxId, FolderQuantities),

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -173,6 +173,7 @@ get_change_vmbox_funs(AccountId, NewBoxId, NBoxJ, OldBoxId) ->
     ,fun(DocJ) -> kzd_box_message:change_message_name(NBoxJ, DocJ) end
     ,fun(DocJ) -> kzd_box_message:change_to_sip_field(AccountId, NBoxJ, DocJ) end
     ,fun(DocJ) -> kzd_box_message:add_message_history(OldBoxId, DocJ) end
+    ,fun(DocJ) -> kz_json:set_value(<<"timestamp">>, kz_util:current_tstamp(), DocJ) end
     ].
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -219,7 +219,7 @@ get_caller_id_number(Call) ->
                                   {'timeout', kz_json:objects()} |
                                   {'error', any()}.
 publish_saved_notify(MediaId, BoxId, Call, Length, Props) ->
-    MaybeTranscribe = props:get_value(<<"Transcribe-Voicemail">>, Props),
+    MaybeTranscribe = props:get_value(<<"Transcribe-Voicemail">>, Props, 'false'),
     Transcription = maybe_transcribe(kapps_call:account_id(Call), MediaId, MaybeTranscribe),
 
     NotifyProp = [{<<"From-User">>, kapps_call:from_user(Call)}

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -216,9 +216,7 @@ get_caller_id_number(Call) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec publish_saved_notify(ne_binary(), ne_binary(), kapps_call:call(), pos_integer(), kz_proplist()) ->
-                                  {'ok', kz_json:objects()} |
-                                  {'timeout', kz_json:objects()} |
-                                  {'error', any()}.
+                                  kz_amqp_worker:request_return().
 publish_saved_notify(MediaId, BoxId, Call, Length, Props) ->
     MaybeTranscribe = props:get_value(<<"Transcribe-Voicemail">>, Props, 'false'),
     Transcription = maybe_transcribe(kapps_call:account_id(Call), MediaId, MaybeTranscribe),


### PR DESCRIPTION
~~DO NOT MERGE THIS YET!~~ It's ready

with ability to prepend a message

* add an option to message_menu for forwarding a message
* present a forwarding menu to user if they wish to prepend a message
* if forwarding without a prepend, just call `copy_to_vmboxes` and if it was successful, send mwi update for both vmboxes/owners
* if forwarding with a prepend message, try to record and join the desire message and save it as new message to destination vmbox then send mwi update to both vmboxes/owners

* depends on https://github.com/2600hz/kazoo-sounds/pull/4 for prompts necessary for forwarding

~~DO NOT MERGE THIS YET!~~ It's ready