### PR TITLE
binding_fix: add needed clause to handle found failure

### DIFF
--- a/core/kazoo_bindings/src/kazoo_bindings.erl
+++ b/core/kazoo_bindings/src/kazoo_bindings.erl
@@ -227,6 +227,8 @@ matches([<<"#">>, <<"*">>], []) -> 'false';
 matches([<<"#">>, <<"*">>], [<<>>]) -> 'false';
 matches([<<"#">>, <<"*">>], [_]) -> 'true'; % match one item:  #.* matches foo
 
+matches([<<"#">>, <<"#">> | Bs], Rs) ->
+    matches([<<"#">> | Bs], Rs);
 matches([<<"#">> | Bs], []) -> % sadly, #.# would match foo, foo.bar, foo.bar.baz, etc
     matches(Bs, []);           % so keep checking by stipping of the first #
 
@@ -239,10 +241,15 @@ matches([_|_], [<<>>]) -> 'false';
 matches([<<"*">> | Bs], [_|Rs]) ->
     matches(Bs, Rs); % so ignore what the routing segment is and continue
 
+matches([<<"#">>, B | Bs], [B, B | Rs]) ->
+    matches(Bs, Rs)
+        orelse matches([<<"#">>|Bs], [B | Rs]);
+
 %% # can match 0 or more segments
 matches([<<"#">>, B | Bs], [B | Rs]) ->
-    %% Since the segment in B could be repeated later in the Routing Key, we need to bifurcate here
-    %% but we'll short circuit if this was indeed the end of the # matching
+    %% Since the segment in B could be repeated later in the Routing Key,
+    %% we need to bifurcate here but we'll short circuit if this was indeed
+    %% the end of the # matching
     %% see binding_matches(<<"#.A.*">>,<<"A.a.A.a">>)
 
     case lists:member(B, Rs) of


### PR DESCRIPTION
The long and short of it is that when you have a # and repeated
segments, the code was being too greedy with the # matching.

In matching <<"*.u.*.7.7.#">> against <<"i.u.e.7.7.7.a">>, the code
would match away 'a' and '7' but would also strip a '7' from the
routing key.

Uncomment dbg_test and run it with the above binding and routing keys
to see it in action.