### PR TITLE
HELP-27113: update endpoint cid when emergency

### DIFF
--- a/applications/stepswitch/src/stepswitch_bridge.erl
+++ b/applications/stepswitch/src/stepswitch_bridge.erl
@@ -351,7 +351,7 @@ update_endpoint_emergency_cid(Endpoint, Number, Name) ->
                     ,{<<"Outbound-Caller-ID-Number">>, Number}
                     ],
             kz_json:set_values(Props, Endpoint)
-   end.
+    end.
 
 -spec build_bridge(state(), api_binary(), api_binary()) -> kz_proplist().
 build_bridge(#state{endpoints=Endpoints

--- a/applications/stepswitch/src/stepswitch_bridge.erl
+++ b/applications/stepswitch/src/stepswitch_bridge.erl
@@ -327,10 +327,31 @@ maybe_deny_emergency_bridge(State, 'undefined', Name) ->
                                        )
     end;
 maybe_deny_emergency_bridge(#state{control_queue=ControlQ}=State, Number, Name) ->
+    State0 = update_endpoint_emergency_cid(State, Number, Name),
     kapi_dialplan:publish_command(ControlQ
-                                 ,build_bridge(State, Number, Name)
+                                 ,build_bridge(State0, Number, Name)
                                  ),
     lager:debug("sent bridge command to ~s", [ControlQ]).
+
+-spec update_endpoint_emergency_cid(state() | kz_json:object(), ne_binary(), api_binary()) -> state().
+update_endpoint_emergency_cid(#state{endpoints=Endpoints}=State, Number, Name) ->
+    State#state{endpoints=[update_endpoint_emergency_cid(Endpoint, Number, Name)
+                           || Endpoint <- Endpoints
+                          ]};
+update_endpoint_emergency_cid(Endpoint, Number, Name) ->
+    case {kz_json:get_value(<<"Outbound-Caller-ID-Number">>, Endpoint, Number)
+         ,kz_json:get_value(<<"Outbound-Caller-ID-Name">>, Endpoint, Name)
+         }
+    of
+        {Number, Name} -> Endpoint;
+        {Number, _} -> kz_json:set_value(<<"Outbound-Caller-ID-Name">>, Name, Endpoint);
+        {_, Name} -> kz_json:set_value(<<"Outbound-Caller-ID-Number">>, Number, Endpoint);
+        {_, _} ->
+            Props = [{<<"Outbound-Caller-ID-Name">>, Name}
+                    ,{<<"Outbound-Caller-ID-Number">>, Number}
+                    ],
+            kz_json:set_values(Props, Endpoint)
+   end.
 
 -spec build_bridge(state(), api_binary(), api_binary()) -> kz_proplist().
 build_bridge(#state{endpoints=Endpoints


### PR DESCRIPTION
The stepswitch_formatters are determining that the caller id name/number is different if the caller id is corrected for an emergency call.  They they set per-leg the 'formatted' caller id based on the original, overriding the correction.  To correct, if the emergency cid is utilized copy it to the endpoints (if necessary) so that the formatters use the corrected caller id.