### PR TITLE
knm_service_restriction_error

### DIFF
--- a/core/kazoo_number_manager/src/knm_errors.erl
+++ b/core/kazoo_number_manager/src/knm_errors.erl
@@ -156,6 +156,8 @@ to_json('not_reconcilable', Num=?NE_BINARY, _) ->
 to_json('unauthorized', _, Cause) ->
     Message = <<"requestor is unauthorized to perform operation">>,
     build_error(403, 'forbidden', Message, Cause);
+to_json('service_restriction', Message, Cause) ->
+    build_error(402, 'service_restriction', kz_util:to_binary(Message), Cause);
 to_json('no_change_required', _, Cause) ->
     Message = <<"no change required">>,
     build_error(400, 'no_change_required', Message, Cause);

--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -906,6 +906,8 @@ attempt(Fun, Args) ->
     catch
         'throw':{'error', Reason} ->
             {'error', knm_errors:to_json(Reason)};
+        'throw':{'error', Reason, Message} when is_list(Message) ->
+            {'error', knm_errors:to_json(Reason, Message)};
         'throw':{'error', Reason, Number} ->
             {'error', knm_errors:to_json(Reason, num_to_did(Number))};
         'throw':{'error', Reason, Number, Cause} ->


### PR DESCRIPTION
cb_phone_numbers fails to response if we have not enough credit to activate number:

10:44:21.684 [error] |9dab2e56e27b4d1ce381ca9aaa8b0303-sync|knm_services:188 (<0.11238.4>) not enough credit to activate number for $3.0
10:44:21.685 [error] |9dab2e56e27b4d1ce381ca9aaa8b0303-sync|kazoo_bindings:717 (<0.11238.4>) unable to find function clause for knm_phone_number:number([110,111,116,32,101,110,111,117,103,104,32,99,114,101,100,105,116,32,116,111,
36,"3.0"]) in src/knm_phone_number.erl:568
10:44:21.685 [error] |9dab2e56e27b4d1ce381ca9aaa8b0303-sync|kazoo_bindings:723 (<0.11238.4>) as part of cb_phone_numbers_v2:put/3
10:44:21.685 [error] |9dab2e56e27b4d1ce381ca9aaa8b0303-sync|kazoo_bindings:724 (<0.11238.4>) st: {knm_number,attempt,2,[{file,"src/knm_number.erl"},{line,910}]}