### PR TITLE
[4.0] HELP-26637: add static mode to cf_dynamic

### DIFF
--- a/applications/callflow/src/module/cf_disa.erl
+++ b/applications/callflow/src/module/cf_disa.erl
@@ -136,7 +136,10 @@ collect_destination_number(Call, Data, Interdigit) ->
 try_collect_destination_number(Call, Interdigit, MaxDigits, Timeout) ->
     case kapps_call_command:collect_digits(MaxDigits, Timeout, Interdigit, Call) of
         {'ok', <<>>} -> try_collect_destination_number(Call, Interdigit, MaxDigits, Timeout);
-        {'ok', Digits} -> knm_converters:normalize(Digits)
+        {'ok', Digits} -> knm_converters:normalize(Digits);
+        {'error', _E} ->
+            lager:info("caller hungup while collecting destination number"),
+            cf_exe:stop(Call)
     end.
 
 %%--------------------------------------------------------------------

--- a/applications/callflow/src/module/cf_dynamic_cid.erl
+++ b/applications/callflow/src/module/cf_dynamic_cid.erl
@@ -24,34 +24,29 @@
 
 -define(MOD_CONFIG_CAT, <<(?CF_CONFIG_CAT)/binary, ".dynamic_cid">>).
 
--define(CONFIG_BIN(Key, Default)
-       ,kapps_config:get_binary(?MOD_CONFIG_CAT, Key, Default)
-       ).
--define(CONFIG_INT(Key, Default)
-       ,kapps_config:get_integer(?MOD_CONFIG_CAT, Key, Default)
-       ).
-
 -record(prompts
        ,{accept_tone =
-             ?CONFIG_BIN(<<"accept_prompt">>, <<"tone_stream://%(250,50,440)">>)
+             kapps_config:get_binary(?MOD_CONFIG_CAT, <<"accept_prompt">>, <<"tone_stream://%(250,50,440)">>)
         ,reject_tone =
              kz_media_util:get_prompt(
-               ?CONFIG_BIN(<<"reject_prompt">>, <<"dynamic-cid-invalid_using_default">>)
+               kapps_config:get_binary(?MOD_CONFIG_CAT, <<"reject_prompt">>, <<"dynamic-cid-invalid_using_default">>)
               )
         ,default_prompt =
              kz_media_util:get_prompt(
-               ?CONFIG_BIN(<<"default_prompt">>, <<"dynamic-cid-enter_cid">>)
+               kapps_config:get_binary(?MOD_CONFIG_CAT, <<"default_prompt">>, <<"dynamic-cid-enter_cid">>)
               )
         }).
 -type prompts() :: #prompts{}.
 
 -record(dynamic_cid
        ,{prompts = #prompts{} :: prompts()
-        ,max_digits = ?CONFIG_INT(<<"max_digits">>, 10) :: integer()
-        ,min_digits = ?CONFIG_INT(<<"min_digits">>, 10) :: integer()
-        ,whitelist = ?CONFIG_BIN(<<"whitelist_regex">>, <<"\\d+">>) :: ne_binary()
+        ,default_max_digits = kapps_config:get_integer(?MOD_CONFIG_CAT, <<"max_digits">>, 10) :: integer()
+        ,default_min_digits = kapps_config:get_integer(?MOD_CONFIG_CAT, <<"min_digits">>, 10) :: integer()
+        ,default_whitelist = kapps_config:get_binary(?MOD_CONFIG_CAT, <<"whitelist_regex">>, <<"\\d+">>) :: ne_binary()
         }
        ).
+
+-type cid() :: {ne_binary(), ne_binary()}.
 
 %%--------------------------------------------------------------------
 %% @public
@@ -72,6 +67,9 @@ handle(Data, Call, <<"list">>, ?NE_BINARY = _CaptureGroup) ->
 handle(Data, Call, <<"lists">>, ?NE_BINARY = _CaptureGroup) ->
     lager:info("using account's lists/entries view to get new cid info"),
     handle_lists(Data, Call);
+handle(Data, Call, <<"static">>, CaptureGroup) ->
+    lager:info("user chose a static caller id for this call"),
+    handle_static(Data, Call, CaptureGroup);
 handle(Data, Call, _Manual, ?NE_BINARY = CaptureGroup) ->
     lager:info("user must manually enter on keypad the caller id for this call"),
     handle_manual(Data, Call, CaptureGroup);
@@ -89,7 +87,49 @@ handle(Data, Call, _Manual, CaptureGroup) ->
 handle_manual(Data, Call, CaptureGroup) ->
     CID = collect_cid_number(Data, Call),
     update_call(Call, CID, CaptureGroup),
+    kapps_call_command:flush_dtmf(Call),
     cf_exe:continue(Call).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handle static mode of dynamic cid
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_static(kz_json:object(), kapps_call:call(), api_binary()) -> 'ok'.
+handle_static(Data, Call, CaptureGroup) ->
+    {CIDName, CIDNumber} = get_static_cid_entry(Data, Call),
+    update_call(Call, CIDNumber, CIDName, CaptureGroup),
+    cf_exe:continue(Call).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Read CID info from a list of CID defined in database
+%% @end
+%%--------------------------------------------------------------------
+-type list_cid_entry() :: {ne_binary(), ne_binary(), ne_binary()} | {'error', kz_data:data_error()}.
+
+-spec handle_list(kz_json:object(), kapps_call:call()) -> 'ok'.
+handle_list(Data, Call) ->
+    maybe_proceed_with_call(get_list_entry(Data, Call), Data, Call).
+
+-spec handle_lists(kz_json:object(), kapps_call:call()) -> 'ok'.
+handle_lists(Data, Call) ->
+    maybe_proceed_with_call(get_lists_entry(Data, Call), Data, Call).
+
+-spec maybe_proceed_with_call(list_cid_entry(), kz_json:object(), kapps_call:call()) -> 'ok'.
+maybe_proceed_with_call({NewCallerIdName, NewCallerIdNumber, Dest}, Data, Call) ->
+    proceed_with_call(NewCallerIdName, NewCallerIdNumber, Dest, Data, Call);
+maybe_proceed_with_call(_, _, Call) ->
+    _ = kapps_call_command:answer(Call),
+    _ = kapps_call_command:prompt(<<"fault-can_not_be_completed_at_this_time">>, Call),
+    kapps_call_command:queued_hangup(Call).
+
+-spec proceed_with_call(ne_binary(), ne_binary(), binary(), kz_json:object(), kapps_call:call()) -> 'ok'.
+proceed_with_call(NewCallerIdName, NewCallerIdNumber, Dest, Data, Call) ->
+    update_call(Call, NewCallerIdNumber, NewCallerIdName, Dest),
+    Number = knm_converters:normalize(Dest),
+    maybe_route_to_callflow(Data, Call, Number).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -98,20 +138,48 @@ handle_manual(Data, Call, CaptureGroup) ->
 %% request, to and callee_number
 %% @end
 %%--------------------------------------------------------------------
--spec update_call(kapps_call:call(), api_binary(), api_binary()) -> 'ok'.
-update_call(Call, CIDNumber, DestNumber) ->
+-spec update_call(kapps_call:call(), ne_binary(), api_binary()) -> 'ok'.
+update_call(Call, CIDNumber, CaptureGroup) ->
     Updates = [{fun kapps_call:kvs_store/3, 'dynamic_cid', CIDNumber}
               ,{fun kapps_call:set_caller_id_number/2, CIDNumber}
               ],
     {'ok', C1} = cf_exe:get_call(Call),
-    lager:info("setting the caller id number to ~s (from ~s)", [CIDNumber, kapps_call:caller_id_number(Call)]),
-    maybe_strip_features_code(kapps_call:exec(Updates, C1), DestNumber).
+    lager:info("setting the caller id number to ~s (from ~s)"
+              ,[CIDNumber, kapps_call:caller_id_number(Call)]
+              ),
+    maybe_strip_features_code(kapps_call:exec(Updates, C1), CaptureGroup).
 
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Same as update_call/3, but also sets caller id name
+%% @end
+%%--------------------------------------------------------------------
+-spec update_call(kapps_call:call(), ne_binary(), ne_binary(), api_binary()) -> 'ok'.
+update_call(Call, CIDNumber, CIDName, CaptureGroup) ->
+    Updates = [{fun kapps_call:kvs_store/3, 'dynamic_cid', CIDNumber}
+              ,{fun kapps_call:set_caller_id_number/2, CIDNumber}
+              ,{fun kapps_call:set_caller_id_name/2, CIDName}
+              ],
+    {'ok', C1} = cf_exe:get_call(Call),
+    lager:info("setting the cid to <~s> ~s (from <~s> ~s)"
+              ,[CIDName
+               ,CIDNumber
+               ,kapps_call:caller_id_name(Call)
+               ,kapps_call:caller_id_number(Call)
+               ]
+              ),
+    maybe_strip_features_code(kapps_call:exec(Updates, C1), CaptureGroup).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc If CaptureGroup exists correct request, to and callee_id_number
+%% @end
+%%--------------------------------------------------------------------
 -spec maybe_strip_features_code(kapps_call:call(), api_binary()) -> kapps_call:call().
 maybe_strip_features_code(Call, 'undefined') ->
     cf_exe:set_call(Call);
-maybe_strip_features_code(Call, DestNumber) ->
-    Norm = knm_converters:normalize(DestNumber),
+maybe_strip_features_code(Call, CaptureGroup) ->
+    Norm = knm_converters:normalize(CaptureGroup),
     Request = list_to_binary([Norm, "@", kapps_call:request_realm(Call)]),
     To = list_to_binary([Norm, "@", kapps_call:to_realm(Call)]),
 
@@ -125,58 +193,13 @@ maybe_strip_features_code(Call, DestNumber) ->
 
 %%--------------------------------------------------------------------
 %% @private
-%% @doc Read CID info from a list of CID defined in database
+%% @doc Lookup callflow and continue with the call
 %% @end
 %%--------------------------------------------------------------------
--type cid_entry() :: {binary(), binary(), binary()} | {'error', kz_data:data_error()}.
-
--spec handle_list(kz_json:object(), kapps_call:call()) -> 'ok'.
-handle_list(Data, Call) ->
-    maybe_proceed_with_call(get_list_entry(Data, Call), Data, Call).
-
--spec handle_lists(kz_json:object(), kapps_call:call()) -> 'ok'.
-handle_lists(Data, Call) ->
-    maybe_proceed_with_call(get_lists_entry(Data, Call), Data, Call).
-
--spec maybe_proceed_with_call(cid_entry(), kz_json:object(), kapps_call:call()) -> 'ok'.
-maybe_proceed_with_call({<<>>, <<>>, _}, _, Call) ->
-    lager:debug("empty cid entry, hanging up"),
-    _ = kapps_call_command:answer(Call),
-    _ = kapps_call_command:prompt(<<"menu-invalid_entry">>, Call),
-    kapps_call_command:queued_hangup(Call);
-maybe_proceed_with_call({NewCallerIdName, NewCallerIdNumber, Dest}, Data, Call) ->
-    proceed_with_call(NewCallerIdName, NewCallerIdNumber, Dest, Data, Call);
-maybe_proceed_with_call(_, _, Call) ->
-    _ = kapps_call_command:answer(Call),
-    _ = kapps_call_command:prompt(<<"fault-can_not_be_completed_at_this_time">>, Call),
-    kapps_call_command:queued_hangup(Call).
-
--spec proceed_with_call(ne_binary(), ne_binary(), binary(), kz_json:object(), kapps_call:call()) -> 'ok'.
-proceed_with_call(NewCallerIdName, NewCallerIdNumber, Dest, Data, Call) ->
-    lager:info("caller id number is about to be changed from: ~p to: ~p ", [kapps_call:caller_id_number(Call), NewCallerIdNumber]),
-    Updates = [{fun kapps_call:kvs_store/3, 'dynamic_cid', NewCallerIdNumber}
-              ,{fun kapps_call:set_caller_id_number/2, NewCallerIdNumber}
-              ,{fun kapps_call:set_caller_id_name/2, NewCallerIdName}
-              ],
-    cf_exe:set_call(kapps_call:exec(Updates, Call)),
-    Number = knm_converters:normalize(Dest),
-    lager:info("send the call onto real destination of: ~s", [Number]),
-    maybe_route_to_callflow(Data, Call, Number).
-
 -spec maybe_route_to_callflow(kz_json:object(), kapps_call:call(), ne_binary()) -> 'ok'.
 maybe_route_to_callflow(Data, Call, Number) ->
     case cf_flow:lookup(Number, kapps_call:account_id(Call)) of
         {'ok', Flow, 'true'} ->
-            lager:info("callflow ~s satisfies request", [kz_json:get_value(<<"_id">>, Flow)]),
-            Updates = [{fun kapps_call:set_request/2
-                       ,list_to_binary([Number, "@", kapps_call:request_realm(Call)])
-                       }
-                      ,{fun kapps_call:set_to/2
-                       ,list_to_binary([Number, "@", kapps_call:to_realm(Call)])
-                       }
-                      ],
-            {'ok', C} = cf_exe:get_call(Call),
-            cf_exe:set_call(kapps_call:exec(Updates, C)),
             maybe_restrict_call(Data, Call, Number, Flow);
         _ ->
             lager:info("failed to find a callflow to satisfy ~s", [Number]),
@@ -248,10 +271,14 @@ collect_cid_number(Data, Call) ->
                 Else -> Else
             end,
 
-    Min = DynamicCID#dynamic_cid.min_digits,
-    Max = DynamicCID#dynamic_cid.max_digits,
-    Regex = DynamicCID#dynamic_cid.whitelist,
+    DefaultMin = DynamicCID#dynamic_cid.default_min_digits,
+    DefaultMax = DynamicCID#dynamic_cid.default_max_digits,
+    DefaultRegex = DynamicCID#dynamic_cid.default_whitelist,
     DefaultCID = kapps_call:caller_id_number(Call),
+
+    Min = kz_json:get_ne_value(<<"min_digits">>, Data, DefaultMin),
+    Max = kz_json:get_ne_value(<<"max_digits">>, Data, DefaultMax),
+    Regex = kz_json:get_ne_value(<<"min_digits">>, Data, DefaultRegex),
 
     Interdigit = kz_json:get_integer_value(<<"interdigit_timeout">>
                                           ,Data
@@ -274,6 +301,9 @@ collect_cid_number(Data, Call) ->
                     _ = kapps_call_command:play(Prompts#prompts.reject_tone, Call),
                     DefaultCID
             end;
+        {'error', 'channel_hungup'} ->
+            lager:info("caller hungup while collecting caller id number"),
+            cf_exe:stop(Call);
         {'error', _} ->
             _ = kapps_call_command:play(Prompts#prompts.reject_tone, Call),
             DefaultCID
@@ -282,10 +312,27 @@ collect_cid_number(Data, Call) ->
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
+%% Get static CID from callflow data
+%% @end
+%%--------------------------------------------------------------------
+-spec get_static_cid_entry(kz_json:object(), kapps_call:call()) -> cid().
+get_static_cid_entry(Data, Call) ->
+    case kz_json:get_ne_value(<<"caller_id">>, Data) of
+        'undefined' ->
+            maybe_set_default_cid('undefined', 'undefined', Call);
+        NewCallerId ->
+            Name = kz_json:get_ne_binary_value(<<"name">>, NewCallerId),
+            Number = kz_json:get_ne_binary_value(<<"number">>, NewCallerId),
+            maybe_set_default_cid(Name, Number, Call)
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
 %% Pull in document from database with the callerid switching information inside
 %% @end
 %%--------------------------------------------------------------------
--spec get_list_entry(kz_json:object(), kapps_call:call()) -> cid_entry().
+-spec get_list_entry(kz_json:object(), kapps_call:call()) -> list_cid_entry().
 get_list_entry(Data, Call) ->
     ListId = kz_json:get_ne_value(<<"id">>, Data),
     AccountDb = kapps_call:account_db(Call),
@@ -293,7 +340,7 @@ get_list_entry(Data, Call) ->
     case kz_datamgr:open_cache_doc(AccountDb, ListId) of
         {'ok', ListJObj} ->
             {CIDKey, DestNumber} = find_key_and_dest(ListJObj, Data, Call),
-            {NewCallerIdName, NewCallerIdNumber} = get_new_caller_id(CIDKey, ListJObj),
+            {NewCallerIdName, NewCallerIdNumber} = get_new_caller_id(CIDKey, ListJObj, Call),
             {NewCallerIdName, NewCallerIdNumber, DestNumber};
         {'error', _Reason}=E ->
             lager:info("failed to load match list document ~s: ~p", [ListId, _Reason]),
@@ -319,17 +366,19 @@ find_key_and_dest(ListJObj, Call) ->
     <<CIDKey:LengthDigits/binary, Dest/binary>> = CaptureGroup,
     {CIDKey, Dest}.
 
--spec get_new_caller_id(binary(), kz_json:object()) -> {binary(), binary()}.
-get_new_caller_id(CIDKey, ListJObj) ->
+-spec get_new_caller_id(binary(), kz_json:object(), kapps_call:call()) -> cid().
+get_new_caller_id(CIDKey, ListJObj, Call) ->
     JObj = kz_json:get_ne_value(<<"entries">>, ListJObj, kz_json:new()),
     case kz_json:get_value(CIDKey, JObj) of
-        'undefined' -> {<<>>, <<>>};
+        'undefined' ->
+            maybe_set_default_cid('undefined', 'undefined', Call);
         NewCallerId ->
-            {kz_json:get_binary_value(<<"name">>, NewCallerId, <<>>)
-            ,kz_json:get_binary_value(<<"number">>, NewCallerId, <<>>)}
+            Name = kz_json:get_ne_binary_value(<<"name">>, NewCallerId),
+            Number = kz_json:get_ne_binary_value(<<"number">>, NewCallerId),
+            maybe_set_default_cid(Name, Number, Call)
     end.
 
--spec get_lists_entry(kz_json:object(), kapps_call:call()) -> cid_entry().
+-spec get_lists_entry(kz_json:object(), kapps_call:call()) -> list_cid_entry().
 get_lists_entry(Data, Call) ->
     ListId = kz_json:get_ne_value(<<"id">>, Data),
     AccountDb = kapps_call:account_db(Call),
@@ -337,25 +386,60 @@ get_lists_entry(Data, Call) ->
         {'ok', Entries} ->
             CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
             <<CIDKey:2/binary, Dest/binary>> = CaptureGroup,
-            {NewCallerIdName, NewCallerIdNumber} = cid_key_lookup(CIDKey, Entries),
+            {NewCallerIdName, NewCallerIdNumber} = cid_key_lookup(CIDKey, Entries, Call),
             {NewCallerIdName, NewCallerIdNumber, Dest};
         {'error', Reason} = E ->
             lager:info("failed to load match list document ~s: ~p", [ListId, Reason]),
             E
     end.
 
--spec cid_key_lookup(binary(), kz_json:objects()) -> {binary(), binary()}.
-cid_key_lookup(CIDKey, Entries) ->
+-spec cid_key_lookup(binary(), kz_json:objects(), kapps_call:call()) -> cid().
+cid_key_lookup(CIDKey, Entries, Call) ->
     case lists:foldl(fun(Entry, Acc) -> cidkey_wanted(CIDKey, Entry, Acc) end, [], Entries) of
-        [{NewCallerIdName, NewCallerIdNumber}|_] -> {NewCallerIdName, NewCallerIdNumber};
-        _ -> {<<>>, <<>>}
+        [{NewCallerIdName, NewCallerIdNumber}|_] ->
+            maybe_set_default_cid(NewCallerIdName, NewCallerIdNumber, Call);
+        _ ->
+            maybe_set_default_cid('undefined', 'undefined', Call)
     end.
 
 -spec cidkey_wanted(binary(), kz_json:object(), proplist()) -> proplist().
 cidkey_wanted(CIDKey, Entry, Acc) ->
     case kz_json:get_binary_value([<<"value">>, <<"cid_key">>], Entry) == CIDKey of
-        'true' -> Acc ++ [{kz_json:get_binary_value([<<"value">>, <<"cid_name">>], Entry, <<>>)
-                          ,kz_json:get_binary_value([<<"value">>, <<"cid_number">>], Entry, <<>>)
+        'true' -> Acc ++ [{kz_json:get_ne_binary_value([<<"value">>, <<"cid_name">>], Entry)
+                          ,kz_json:get_ne_binary_value([<<"value">>, <<"cid_number">>], Entry)
                           }];
         'false' -> Acc
     end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Play reject prompt if any of the caller id are empty
+%% @end
+%%--------------------------------------------------------------------
+-spec maybe_set_default_cid(api_ne_binary(), api_ne_binary(), kapps_call:call()) -> cid().
+maybe_set_default_cid('undefined', 'undefined', Call) ->
+    lager:debug("empty cid entry, set to default value"),
+    play_reject_prompt(Call),
+    {kapps_call:caller_id_name(Call), kapps_call:caller_id_number(Call)};
+maybe_set_default_cid('undefined', Number, Call) ->
+    lager:debug("empty cid name, set to default value"),
+    {kapps_call:caller_id_name(Call), Number};
+maybe_set_default_cid(Name, 'undefined', Call) ->
+    lager:debug("empty cid number, set to default value"),
+    play_reject_prompt(Call),
+    {Name, kapps_call:caller_id_number(Call)};
+maybe_set_default_cid(Name, Number, _Call) ->
+    {Name, Number}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc play reject prompts when caller id number is empty or invalid
+%% @end
+%%--------------------------------------------------------------------
+-spec play_reject_prompt(kapps_call:call()) -> 'ok'.
+play_reject_prompt(Call) ->
+    _ = kapps_call_command:play(
+          kz_media_util:get_prompt(
+            kapps_config:get_binary(?MOD_CONFIG_CAT, <<"reject_prompt">>, <<"dynamic-cid-invalid_using_default">>)
+           ), Call),
+    'ok'.

--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -46,6 +46,7 @@
     "callflow.default_pin_length": "callflow default pin length",
     "callflow.default_use_account_caller_id": "callflow default use account caller id",
     "callflow.delete_after_notify": "callflow delete after notify",
+    "callflow.dynamic_cid.reject_prompt": "callflow.dynamic_cid reject prompt",
     "callflow.ensure_valid_caller_id": "callflow ensure valid caller id",
     "callflow.extension": "callflow extension",
     "callflow.fax_detect_duration_s": "callflow fax detect duration in seconds",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1088,6 +1088,9 @@
                 "action": {
                     "description": ""
                 },
+                "caller_id": {
+                    "description": ""
+                },
                 "enforce_call_restriction": {
                     "default": true,
                     "description": "",
@@ -1103,7 +1106,13 @@
                     "description": "",
                     "type": "integer"
                 },
+                "max_digits": {
+                    "description": ""
+                },
                 "media_id": {
+                    "description": ""
+                },
+                "min_digits": {
                     "description": ""
                 }
             },
@@ -7537,6 +7546,17 @@
                     "default": 3,
                     "description": "callflow.call_forward minimum callfwd number length",
                     "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.callflow.dynamic_cid": {
+            "description": "Schema for callflow.dynamic_cid system_config",
+            "properties": {
+                "reject_prompt": {
+                    "default": "dynamic-cid-invalid_using_default",
+                    "description": "callflow.dynamic_cid reject prompt",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/callflows.dynamic_cid.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.dynamic_cid.json
@@ -6,6 +6,9 @@
         "action": {
             "description": ""
         },
+        "caller_id": {
+            "description": ""
+        },
         "enforce_call_restriction": {
             "default": true,
             "description": "",
@@ -21,7 +24,13 @@
             "description": "",
             "type": "integer"
         },
+        "max_digits": {
+            "description": ""
+        },
         "media_id": {
+            "description": ""
+        },
+        "min_digits": {
             "description": ""
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.dynamic_cid.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.dynamic_cid.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.callflow.dynamic_cid",
+    "description": "Schema for callflow.dynamic_cid system_config",
+    "properties": {
+        "reject_prompt": {
+            "default": "dynamic-cid-invalid_using_default",
+            "description": "callflow.dynamic_cid reject prompt",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
* Add a new mode to cf_dynamic which allows users to set a static caller id.

* Inform user if the cid would be set to the default:
Better response to user if the caller id number are missing and is about to
set to default value, instead of hanging up.

* Read manual mode options from callflow data, default to system_config

* Handle channel hungup during collect digits in disa and dynamic cid