### PR TITLE
KAZOO-5260_4oh: fix number release of unknown carrier

### DIFF
--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -325,7 +325,7 @@ disconnect(Number) ->
     try apply(Module, disconnect_number, [Number]) of
         Result -> Result
     catch
-        'error':'undef' ->
+        'error':_ ->
             lager:debug("non-existant carrier module ~p, allowing disconnect", [Module]),
             Number
     end.

--- a/core/kazoo_number_manager/src/knm.hrl
+++ b/core/kazoo_number_manager/src/knm.hrl
@@ -52,6 +52,7 @@
 -define(TEST_CREATE_NUM, <<"+15559871234">>).
 -define(TEST_AVAILABLE_NUM, <<"+15551239876">>).
 -define(TEST_IN_SERVICE_NUM, <<"+15551233322">>).
+-define(TEST_IN_SERVICE_BAD_CARRIER_NUM, <<"+15551233337">>).
 -define(TEST_IN_SERVICE_WITH_HISTORY_NUM, <<"+15551255693">>).
 -define(TEST_CREATE_TOLL, <<"+18887771111">>).
 -define(TEST_EXISTING_TOLL, <<"+18005551212">>).
@@ -104,6 +105,24 @@
           ,{?PVT_ASSIGNED_TO, ?RESELLER_ACCOUNT_ID}
           ,{?PVT_RESERVE_HISTORY, [?RESELLER_ACCOUNT_ID]}
           ,{?PVT_MODULE_NAME, ?CARRIER_LOCAL}
+          ,{?PVT_STATE, ?NUMBER_STATE_IN_SERVICE}
+          ,{?PVT_DB_NAME, <<"numbers%2F%2B1555">>}
+          ,{?PVT_CREATED, 63565934344}
+          ,{?PVT_AUTH_BY, ?MASTER_ACCOUNT_ID}
+          ,{?PVT_USED_BY, <<"callflow">>}
+          ]
+         )
+       ).
+
+-define(IN_SERVICE_BAD_CARRIER_NUMBER
+       ,kz_json:from_list(
+          [{<<"_id">>, ?TEST_IN_SERVICE_BAD_CARRIER_NUM}
+          ,{<<"_rev">>, <<"3-7dd6a1523e81a4e3c2689140ed3a8e69">>}
+          ,{?PVT_MODIFIED, 63565934349}
+          ,{?PVT_FEATURES, kz_json:new()}
+          ,{?PVT_ASSIGNED_TO, ?RESELLER_ACCOUNT_ID}
+          ,{?PVT_RESERVE_HISTORY, [?RESELLER_ACCOUNT_ID]}
+          ,{?PVT_MODULE_NAME, <<"wnm_pacwest">>}
           ,{?PVT_STATE, ?NUMBER_STATE_IN_SERVICE}
           ,{?PVT_DB_NAME, <<"numbers%2F%2B1555">>}
           ,{?PVT_CREATED, 63565934344}

--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -139,6 +139,8 @@ fetch(?TEST_CREATE_NUM, _Options) ->
     {'error', 'not_found'};
 fetch(?TEST_AVAILABLE_NUM, Options) ->
     handle_fetched_result(?AVAILABLE_NUMBER, Options);
+fetch(?TEST_IN_SERVICE_BAD_CARRIER_NUM, Options) ->
+    handle_fetched_result(?IN_SERVICE_BAD_CARRIER_NUMBER, Options);
 fetch(?TEST_IN_SERVICE_NUM, Options) ->
     handle_fetched_result(?IN_SERVICE_NUMBER, Options);
 fetch(?TEST_IN_SERVICE_WITH_HISTORY_NUM, Options) ->

--- a/core/kazoo_number_manager/test/knm_release_number_test.erl
+++ b/core/kazoo_number_manager/test/knm_release_number_test.erl
@@ -4,35 +4,23 @@
 %%% @end
 %%% @contributors
 %%%   James Aimonetti
+%%%   Pierre Fenoll
 %%%-------------------------------------------------------------------
 -module(knm_release_number_test).
 
 -include_lib("eunit/include/eunit.hrl").
 -include("knm.hrl").
 
-release_number_test_() ->
-    Tests = [fun release_unknown_number/1
-            ,fun release_available_number/1
-            ,fun release_in_service_number/1
-            ,fun release_with_history/1
-            ,fun release_for_hard_delete/1
-            ],
-    lists:foldl(fun(F, Acc) ->
-                        F(Acc)
-                end, [], Tests
-               ).
-
-release_unknown_number(Tests) ->
+release_unknown_number_test_() ->
     [{"verfiy missing numbers return errors"
      ,?_assertMatch(
          {'error', 'not_found'}
                    ,knm_number:release(?TEST_CREATE_NUM)
         )
      }
-     | Tests
     ].
 
-release_available_number(Tests) ->
+release_available_number_test_() ->
     {'error', Error} = knm_number:release(?TEST_AVAILABLE_NUM),
 
     [{"Verify error code for releasing available number"
@@ -41,10 +29,9 @@ release_available_number(Tests) ->
     ,{"Verify error for releasing available number"
      ,?_assertEqual(<<"invalid_state_transition">>, knm_errors:error(Error))
      }
-     | Tests
     ].
 
-release_in_service_number(Tests) ->
+release_in_service_number_test_() ->
     {'ok', Released} = knm_number:release(?TEST_IN_SERVICE_NUM),
     PhoneNumber = knm_number:phone_number(Released),
     [{"verify number state is changed"
@@ -53,10 +40,9 @@ release_in_service_number(Tests) ->
     ,{"verify reserve history is empty now"
      ,?_assertEqual([], knm_phone_number:reserve_history(PhoneNumber))
      }
-     | Tests
     ].
 
-release_with_history(Tests) ->
+release_with_history_test_() ->
     {'ok', Unwound} = knm_number:release(?TEST_IN_SERVICE_WITH_HISTORY_NUM),
     PhoneNumber = knm_number:phone_number(Unwound),
     [{"verify number state is moved to RESERVED"
@@ -68,14 +54,12 @@ release_with_history(Tests) ->
     ,{"verify number is assigned to prev account"
      ,?_assertEqual(?MASTER_ACCOUNT_ID, knm_phone_number:assigned_to(PhoneNumber))
      }
-     | Tests
     ].
 
-release_for_hard_delete(Tests) ->
+release_for_hard_delete_test_() ->
     {'ok', Deleted} = knm_number:release(?TEST_IN_SERVICE_NUM, [{'should_delete', 'true'}]),
     PhoneNumber = knm_number:phone_number(Deleted),
     [{"verify number state is moved to DELETED"
      ,?_assertEqual(?NUMBER_STATE_DELETED, knm_phone_number:state(PhoneNumber))
      }
-     | Tests
     ].

--- a/core/kazoo_number_manager/test/knm_release_number_test.erl
+++ b/core/kazoo_number_manager/test/knm_release_number_test.erl
@@ -31,6 +31,17 @@ release_available_number_test_() ->
      }
     ].
 
+release_in_service_bad_carrier_number_test_() ->
+    {'ok', Released} = knm_number:release(?TEST_IN_SERVICE_BAD_CARRIER_NUM),
+    PhoneNumber = knm_number:phone_number(Released),
+    [{"verify number state is changed"
+     ,?_assertEqual(?NUMBER_STATE_AVAILABLE, knm_phone_number:state(PhoneNumber))
+     }
+    ,{"verify reserve history is empty now"
+     ,?_assertEqual([], knm_phone_number:reserve_history(PhoneNumber))
+     }
+    ].
+
 release_in_service_number_test_() ->
     {'ok', Released} = knm_number:release(?TEST_IN_SERVICE_NUM),
     PhoneNumber = knm_number:phone_number(Released),


### PR DESCRIPTION
Note: the catch-all was added so that binary_to_existing_atom failure is caught.