### PR TITLE
Validation of crossbar module typo fix

### DIFF
--- a/applications/crossbar/src/crossbar_bindings.erl
+++ b/applications/crossbar/src/crossbar_bindings.erl
@@ -181,7 +181,7 @@ modules_loaded() ->
 
 -spec is_cb_module(ne_binary() | atom()) -> boolean().
 is_cb_module(<<"cb_", _/binary>>) -> 'true';
-is_cb_module(<<"crossbar_", _binary>>) -> 'true';
+is_cb_module(<<"crossbar_", _/binary>>) -> 'true';
 is_cb_module(<<_/binary>>) -> 'false';
 is_cb_module(Mod) ->
     is_cb_module(kz_util:to_binary(Mod)).


### PR DESCRIPTION
Typo which didn't validate any module as crossbar module when crossbar appended in front of the module name