### PR TITLE
KAZOO-5262: Make number search timeout configurable

### DIFF
--- a/core/kazoo_number_manager/src/knm_search.erl
+++ b/core/kazoo_number_manager/src/knm_search.erl
@@ -57,6 +57,8 @@
 
 -define(POLLING_INTERVAL, 5000).
 
+-define(NUMBER_SEARCH_TIMEOUT, kapps_config:get_integer(?KNM_CONFIG_CAT, <<"number_search_timeout_ms">>, 5000)).
+
 -define(EOT, '$end_of_table').
 
 -type state() :: #{}.
@@ -309,8 +311,8 @@ wait_for_search(N, Options) ->
         _Other ->
             lager:debug("unexpected search result ~p", [_Other]),
             wait_for_search(N - 1, Options)
-    after 5000 ->
-            lager:debug("timeout (~B) collecting responses from search providers", [5000]),
+    after ?NUMBER_SEARCH_TIMEOUT ->
+            lager:debug("timeout (~B) collecting responses from search providers", [?NUMBER_SEARCH_TIMEOUT]),
             wait_for_search(N - 1, Options)
     end.
 


### PR DESCRIPTION
I'm testing Telnyx as a number provider atm.
Sometimes Telnyx processes its number lookup slightly longer than 5 seconds.
Because of 5000 number search hardcoded timeout, Kazoo provides empty result...