### PR TITLE
qfm: add missing description on system_config entry

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -465,6 +465,7 @@
     "number_manager.force_port_out_outbound": "number_manager force port out outbound",
     "number_manager.locality.url": "number_manager.locality url",
     "number_manager.maximum_search_quantity": "maximum number of returned DIDs in search query",
+    "number_manager.number_search_timeout_ms": "number manager number search timeout in milliseconds",
     "number_manager.other.default_country": "number_manager.other default country",
     "number_manager.other.endpoints": "number_manager.other endpoints",
     "number_manager.other.phonebook_url": "number_manager.other phonebook url",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -10298,6 +10298,11 @@
                     "description": "maximum number of returned DIDs in search query",
                     "type": "integer"
                 },
+                "number_search_timeout_ms": {
+                    "default": 5000,
+                    "description": "number manager number search timeout in milliseconds",
+                    "type": "integer"
+                },
                 "porting_module_name": {
                     "default": "knm_local",
                     "description": "number manager porting module name",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.json
@@ -103,6 +103,11 @@
             "description": "maximum number of returned DIDs in search query",
             "type": "integer"
         },
+        "number_search_timeout_ms": {
+            "default": 5000,
+            "description": "number manager number search timeout in milliseconds",
+            "type": "integer"
+        },
         "porting_module_name": {
             "default": "knm_local",
             "description": "number manager porting module name",


### PR DESCRIPTION
@onnet Hey would you happen to know why CircleCI does not run your PRs?

Examples: https://github.com/2600hz/kazoo/pull/3078 https://github.com/2600hz/kazoo/pull/3081