### PR TITLE
[4.0] KAZOO-5270: read crossbar ip from system_config

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -134,6 +134,7 @@
     "crossbar.freeswitch.templates_to_process": "crossbar.freeswitch templates to process",
     "crossbar.freeswitch.work_dir": "crossbar.freeswitch work dir",
     "crossbar.freeswitch.{Module}": "crossbar.freeswitch {Module}",
+    "crossbar.ip": "crossbar ip",
     "crossbar.local_resources.allow_peers": "crossbar.local_resources allow peers",
     "crossbar.magic_path_patterns": "crossbar magic path patterns",
     "crossbar.max_upload_size": "crossbar maximum upload size",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -7949,7 +7949,6 @@
             },
             "required": [
                 "autoload_modules",
-                "ip",
                 "ssl_ca_cert"
             ],
             "type": "object"

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -7826,6 +7826,10 @@
                     "description": "crossbar expiry percentage",
                     "type": "integer"
                 },
+                "ip": {
+                    "description": "crossbar ip",
+                    "type": "string"
+                },
                 "magic_path_patterns": {
                     "default": [
                         "/:version/accounts/:account_id/vmboxes/:box_id/messages/:message_id/raw",
@@ -7945,6 +7949,7 @@
             },
             "required": [
                 "autoload_modules",
+                "ip",
                 "ssl_ca_cert"
             ],
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
@@ -164,7 +164,6 @@
     },
     "required": [
         "autoload_modules",
-        "ip",
         "ssl_ca_cert"
     ],
     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
@@ -41,6 +41,10 @@
             "description": "crossbar expiry percentage",
             "type": "integer"
         },
+        "ip": {
+            "description": "crossbar ip",
+            "type": "string"
+        },
         "magic_path_patterns": {
             "default": [
                 "/:version/accounts/:account_id/vmboxes/:box_id/messages/:message_id/raw",
@@ -160,6 +164,7 @@
     },
     "required": [
         "autoload_modules",
+        "ip",
         "ssl_ca_cert"
     ],
     "type": "object"

--- a/applications/crossbar/src/crossbar_init.erl
+++ b/applications/crossbar/src/crossbar_init.erl
@@ -216,7 +216,7 @@ maybe_start_plaintext(Dispatch) ->
             end
     end.
 
--spec get_binding_ip() -> string().
+-spec get_binding_ip() -> inet:ip_address().
 get_binding_ip() ->
     Default = case is_ipv6_supported() of
                   'true' -> <<"::">>;

--- a/applications/crossbar/src/crossbar_init.erl
+++ b/applications/crossbar/src/crossbar_init.erl
@@ -192,7 +192,7 @@ maybe_start_plaintext(Dispatch) ->
             %% Name, NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts
             try
                 IP = get_binding_ip(),
-                lager:info("trying to bind to ~p:~b", [IP, Port]),
+                lager:info("trying to bind to address ~s port ~b", [inet:ntoa(IP), Port]),
                 cowboy:start_http('api_resource', Workers
                                  ,[{'ip', IP}
                                   ,{'port', Port}
@@ -263,8 +263,15 @@ start_ssl(Dispatch) ->
             ReqTimeout = kapps_config:get_integer(?CONFIG_CAT, <<"request_timeout_ms">>, 10 * ?MILLISECONDS_IN_SECOND),
             Workers = kapps_config:get_integer(?CONFIG_CAT, <<"ssl_workers">>, 100),
 
-            try cowboy:start_https('api_resource_ssl', Workers
-                                  ,SSLOpts
+            try
+                IP = get_binding_ip(),
+                lager:info("trying to bind SSL API server to address ~s port ~b"
+                          ,[inet:ntoa(IP)
+                           ,props:get_value('port', SSLOpts)
+                           ]
+                          ),
+                cowboy:start_https('api_resource_ssl', Workers
+                                  ,[{'ip', IP} | SSLOpts]
                                   ,[{'env', [{'dispatch', Dispatch}
                                             ,{'timeout', ReqTimeout}
                                             ]}


### PR DESCRIPTION
Check IP address for IPv6, if it failed check for IPv4.
Default to `::` if IPv6 is enabled, otherwise to bind to `0.0.0.0`.