### PR TITLE
KAZOO-5273: return false if number is empty in fax_util

### DIFF
--- a/applications/fax/src/fax_util.erl
+++ b/applications/fax/src/fax_util.erl
@@ -187,6 +187,7 @@ filter_numbers(Number) ->
 
 -spec is_valid_caller_id(api_binary(), ne_binary()) -> boolean().
 is_valid_caller_id('undefined', _) -> 'false';
+is_valid_caller_id(<<>>, _) -> 'false';
 is_valid_caller_id(Number, AccountId) ->
     case knm_number:lookup_account(Number) of
         {'ok', AccountId, _} -> 'true';


### PR DESCRIPTION
Handle a case when number is empty during validating caller _id in fax_util