### PR TITLE
Telnyx E911 sandbox provisioning

### DIFF
--- a/core/kazoo_number_manager/src/providers/knm_telnyx_e911.erl
+++ b/core/kazoo_number_manager/src/providers/knm_telnyx_e911.erl
@@ -18,6 +18,11 @@
 
 -define(ADDRESS_ID, <<"address_id">>).
 
+-define(MOD_CONFIG_CAT, <<(?KNM_CONFIG_CAT)/binary, ".telnyx">>).
+
+-define(IS_SANDBOX_PROVISIONING_TRUE,
+        kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"sandbox_provisioning">>, 'false')).
+
 %%--------------------------------------------------------------------
 %% @public
 %% @doc
@@ -76,7 +81,8 @@ feature(Number) ->
 -spec maybe_update_e911(knm_number:knm_number(), boolean()) -> knm_number:knm_number().
 maybe_update_e911(Number) ->
     IsDryRun = knm_phone_number:dry_run(knm_number:phone_number(Number)),
-    maybe_update_e911(Number, IsDryRun).
+    maybe_update_e911(Number, (IsDryRun
+                               orelse ?IS_SANDBOX_PROVISIONING_TRUE)).
 
 maybe_update_e911(Number, 'true') ->
     CurrentE911 = feature(Number),


### PR DESCRIPTION
Telnyx config "sandbox_provisioning" flag doesn't influences 911 provisioning behaviour.
Detailed conversation could be found over here: https://github.com/2600hz/kazoo/pull/3081