### PR TITLE
[4.0] KAZOO-5278: create the number when adding a mobile device

### DIFF
--- a/applications/crossbar/src/modules_v2/cb_devices_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_devices_v2.erl
@@ -859,10 +859,7 @@ remove_if_mobile(MDN, Context) ->
                     %% hard removing number
                     lager:debug("hard removing old mdn ~s with mobile properties ~s"
                                ,[Normalized, kz_json:encode(Mobile)]),
-                    Options = [{'auth_by', ?KNM_DEFAULT_AUTH_BY}
-                              ,{'dry_run', 'false'}
-                              ],
-                    _ = knm_number:delete(Normalized, Options),
+                    _ = knm_number:delete(Normalized, knm_number_options:default()),
                     Context
             end;
         {'error', _R} ->

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -22,6 +22,8 @@
         ,put/2, put/3
         ,post/2
         ,delete/2
+
+        ,set_response/2
         ]).
 
 -include("crossbar.hrl").
@@ -905,6 +907,7 @@ validate_delete(Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+-spec set_response(result(), cb_context:context()) -> cb_context:context().
 set_response(Result, Context) ->
     set_response(Result, Context, fun() -> Context end).
 

--- a/core/kazoo_number_manager/src/knm.hrl
+++ b/core/kazoo_number_manager/src/knm.hrl
@@ -83,6 +83,7 @@
        ,kz_json:from_list(
           [{<<"_id">>, ?TEST_AVAILABLE_NUM}
           ,{<<"_rev">>, <<"10-7dd6a1523e81a4e3c2689140ed3a8e69">>}
+          ,{<<"my_key">>, <<"my string">>}
           ,{?PVT_MODIFIED, 63565934349}
           ,{?PVT_FEATURES, kz_json:new()}
           ,{?PVT_ASSIGNED_TO, ?RESELLER_ACCOUNT_ID}

--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -304,8 +304,11 @@ move(Num, MoveTo) ->
 
 move(Num, ?MATCH_ACCOUNT_RAW(MoveTo), Options0) ->
     Options = [{'assign_to', MoveTo} | Options0],
+    Updates = knm_number_options:to_phone_number_setters(Options),
     case get(Num, Options) of
-        {'ok', Number} -> attempt(fun move_to/1, [Number]);
+        {'ok', Number} ->
+            {'ok', PN} = knm_phone_number:setters(phone_number(Number), Updates),
+            attempt(fun move_to/1, [set_phone_number(Number, PN)]);
         {'error', 'not_found'} -> maybe_from_discovery(Num, Options);
         {'error', _R}=E -> E
     end.

--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -321,7 +321,7 @@ maybe_from_discovery(Num, Options) ->
 
 -spec from_not_found(ne_binary(), knm_number_options:options()) -> knm_number_return().
 from_not_found(Num, Options) ->
-    PN = knm_phone_number:new(Num, Options),
+    PN = knm_phone_number:new(Num, [{'state', ?NUMBER_STATE_IN_SERVICE} | Options]),
     Number = set_phone_number(new(), PN),
     attempt(fun move_to/1, [Number]).
 

--- a/core/kazoo_number_manager/src/knm_number_options.erl
+++ b/core/kazoo_number_manager/src/knm_number_options.erl
@@ -79,7 +79,7 @@ default() ->
 to_phone_number_setters(Options) ->
     [case Option of
          'public_fields' ->
-             {fun knm_phone_number:update_doc/2, Value};
+             {fun knm_phone_number:reset_doc/2, Value};
          _ ->
              FName = kz_util:to_atom("set_" ++ atom_to_list(Option)),
              {fun knm_phone_number:FName/2, Value}
@@ -201,9 +201,9 @@ transfer_media_id(Props) when is_list(Props) ->
 -ifdef(TEST).
 
 to_phone_number_setters_test_() ->
-    A_1 = kz_json:from_list([{<<"a">>, 1}
-                            ]),
-    [?_assertEqual([{fun knm_phone_number:update_doc/2, A_1}]
+    A_1 = kz_json:from_list([{<<"a">>, 1}]),
+    M_1 = ?CARRIER_LOCAL,
+    [?_assertEqual([{fun knm_phone_number:reset_doc/2, A_1}]
                   ,to_phone_number_setters([{'public_fields', A_1}])
                   )
     ,?_assertEqual([{fun knm_phone_number:set_auth_by/2, ?KNM_DEFAULT_AUTH_BY}
@@ -216,6 +216,13 @@ to_phone_number_setters_test_() ->
                                            ,{'dry_run', [[[]]]}
                                            ])
                   )
+     %%FIXME: decide if below should turn into _assertEqual.
+    ,?_assertNotEqual([fun knm_phone_number:set_module_name/2, M_1]
+                     ,to_phone_number_setters([{module_name, M_1}
+                                              ,{module_name, <<"blaaa">>}
+                                              ,{module_name, ?CARRIER_MDN}
+                                              ])
+                     )
     ].
 
 -endif.

--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -206,7 +206,7 @@ save(#knm_phone_number{dry_run='true'}=PhoneNumber) ->
     lager:debug("dry_run-ing btw"),
     PhoneNumber;
 save(#knm_phone_number{is_dirty = false}=PhoneNumber) ->
-    lager:debug("not dirty: skipping save"),
+    lager:debug("not dirty, skipping save"),
     PhoneNumber;
 save(PhoneNumber) ->
     Routines = [fun save_to_number_db/1
@@ -1151,6 +1151,9 @@ is_in_account_hierarchy(AuthBy, AccountId) ->
 -ifdef(TEST).
 save_to_number_db(PhoneNumber) -> PhoneNumber.
 -else.
+save_to_number_db(#knm_phone_number{state = ?NUMBER_STATE_DELETED}=PhoneNumber) ->
+    lager:debug("deleted, skip saving ~s", [number(PhoneNumber)]),
+    PhoneNumber;
 save_to_number_db(PhoneNumber) ->
     NumberDb = number_db(PhoneNumber),
     JObj = to_json(PhoneNumber),
@@ -1194,8 +1197,7 @@ assign(PhoneNumber) ->
 
 -spec assign(knm_phone_number(), ne_binary()) -> knm_phone_number().
 -ifdef(TEST).
-assign(PhoneNumber, _AssignedTo) ->
-    PhoneNumber.
+assign(PhoneNumber, _AssignedTo) -> PhoneNumber.
 -else.
 assign(PhoneNumber, AssignedTo) ->
     AccountDb = kz_util:format_account_db(AssignedTo),

--- a/core/kazoo_number_manager/src/knm_search.erl
+++ b/core/kazoo_number_manager/src/knm_search.erl
@@ -430,7 +430,7 @@ discovery(Num, Options) ->
 
 -spec local_discovery(ne_binary(), knm_carriers:options()) -> knm_number:knm_number_return().
 -ifdef(TEST).
-local_discovery(?TEST_CREATE_NUM, _Options) -> {'error', 'not_found'}.
+local_discovery(_Num, _Options) -> {'error', 'not_found'}.
 -else.
 local_discovery(Num, Options) ->
     case ets:match_object(?ETS_DISCOVERY_CACHE, {'_', {Num, '_', ?NUMBER_STATE_DISCOVERY, '_'}}) of
@@ -441,7 +441,7 @@ local_discovery(Num, Options) ->
 
 -spec remote_discovery(ne_binary(), knm_carriers:options()) -> knm_number:knm_number_return().
 -ifdef(TEST).
-remote_discovery(?TEST_CREATE_NUM, _Options) -> {'error', 'not_found'}.
+remote_discovery(_Num, _Options) -> {'error', 'not_found'}.
 -else.
 remote_discovery(Number, Options) ->
     Payload = [{<<"Number">>, Number}

--- a/core/kazoo_number_manager/src/knm_search.erl
+++ b/core/kazoo_number_manager/src/knm_search.erl
@@ -335,6 +335,7 @@ next(Options) ->
 %% Create a number in a discovery state.
 %% @end
 %%--------------------------------------------------------------------
+-ifndef(TEST).
 -spec create_discovery(ne_binary(), module(), kz_json:object(), knm_carriers:options()) -> knm_number:knm_number().
 create_discovery(DID=?NE_BINARY, Carrier, Data, Options0) ->
     Options = [{'state', ?NUMBER_STATE_DISCOVERY}
@@ -351,7 +352,7 @@ create_discovery(DID=?NE_BINARY, Carrier, Data, Options0) ->
 create_discovery(JObj, Options) ->
     PhoneNumber = knm_phone_number:from_json_with_options(JObj, Options),
     knm_number:set_phone_number(knm_number:new(), PhoneNumber).
-
+-endif.
 
 -spec quantity(options()) -> pos_integer().
 quantity(Options) ->
@@ -428,13 +429,20 @@ discovery(Num, Options) ->
     end.
 
 -spec local_discovery(ne_binary(), knm_carriers:options()) -> knm_number:knm_number_return().
+-ifdef(TEST).
+local_discovery(?TEST_CREATE_NUM, _Options) -> {'error', 'not_found'}.
+-else.
 local_discovery(Num, Options) ->
     case ets:match_object(?ETS_DISCOVERY_CACHE, {'_', {Num, '_', ?NUMBER_STATE_DISCOVERY, '_'}}) of
         [] -> {'error', 'not_found'};
         [{_QID, {Num, Carrier, _, Data}} | _] -> {'ok', create_discovery(Num, Carrier, Data, Options)}
     end.
+-endif.
 
 -spec remote_discovery(ne_binary(), knm_carriers:options()) -> knm_number:knm_number_return().
+-ifdef(TEST).
+remote_discovery(?TEST_CREATE_NUM, _Options) -> {'error', 'not_found'}.
+-else.
 remote_discovery(Number, Options) ->
     Payload = [{<<"Number">>, Number}
               ,{<<"Account-ID">>, account_id(Options)}
@@ -450,6 +458,7 @@ remote_discovery(Number, Options) ->
             lager:debug("error requesting number from amqp : ~p", [_Error]),
             {'error', 'not_found'}
     end.
+-endif.
 
 %%%===================================================================
 %%% Internal functions

--- a/core/kazoo_number_manager/test/knm_create_new_number_test.erl
+++ b/core/kazoo_number_manager/test/knm_create_new_number_test.erl
@@ -219,6 +219,48 @@ create_dry_run_test_() ->
      }
     ].
 
+move_non_existing_mobile_number_test_() ->
+    MobileField =
+        kz_json:from_list(
+          [{<<"provider">>, <<"tower-of-power">>}
+          ,{<<"authorizing">>, kz_json:from_list([{<<"account-id">>, ?MASTER_ACCOUNT_ID}])}
+          ,{<<"device-id">>, kz_util:rand_hex_binary(32)}
+          ]),
+    PublicFields = kz_json:from_list([{<<"mobile">>, MobileField}]),
+    Props = [{'auth_by', ?MASTER_ACCOUNT_ID}
+            ,{'dry_run', 'false'}
+            ,{'public_fields', PublicFields}
+            ,{'module_name', ?CARRIER_MDN}
+            ,{<<"auth_by_account">>
+             ,kz_account:set_allow_number_additions(?RESELLER_ACCOUNT_DOC, 'true')
+             }
+            ],
+    {'ok', N} = knm_number:move(?TEST_CREATE_NUM, ?RESELLER_ACCOUNT_ID, Props),
+    PN = knm_number:phone_number(N),
+    [{"Verify phone number is assigned to reseller account"
+     ,?_assertEqual(?RESELLER_ACCOUNT_ID, knm_phone_number:assigned_to(PN))
+     }
+    ,{"Verify new phone number was authorized by master account"
+     ,?_assertEqual(?MASTER_ACCOUNT_ID, knm_phone_number:auth_by(PN))
+     }
+    ,{"Verify new phone number database is properly set"
+     ,?_assertEqual(<<"numbers%2F%2B1555">>, knm_phone_number:number_db(PN))
+     }
+    ,{"Verify new phone number is in service state"
+     ,?_assertEqual(?NUMBER_STATE_IN_SERVICE, knm_phone_number:state(PN))
+     }
+    ,{"Verify reserve history is empty"
+     ,?_assertEqual([], knm_phone_number:reserve_history(PN))
+     }
+    ,{"Verify the mdn carrier module is being used"
+     ,?_assertEqual(?CARRIER_MDN, knm_phone_number:module_name(PN))
+     }
+    ,{"Verify the mobile public fields is exists"
+     ,?_assertEqual('false', kz_json:is_empty(
+                               kz_json:get_value(<<"mobile">>, knm_number:to_public_json(N))
+                              ))}
+    ].
+
 create_checks_test_() ->
     create_available_checks()
         ++ load_existing_checks().

--- a/core/kazoo_number_manager/test/knm_create_new_number_test.erl
+++ b/core/kazoo_number_manager/test/knm_create_new_number_test.erl
@@ -256,9 +256,10 @@ move_non_existing_mobile_number_test_() ->
      ,?_assertEqual(?CARRIER_MDN, knm_phone_number:module_name(PN))
      }
     ,{"Verify the mobile public fields is exists"
-     ,?_assertEqual('false', kz_json:is_empty(
-                               kz_json:get_value(<<"mobile">>, knm_number:to_public_json(N))
-                              ))}
+     ,?_assertEqual(true, kz_json:are_equal(MobileField
+                                           ,kz_json:get_value(<<"mobile">>, knm_number:to_public_json(N))
+                                           ))
+     }
     ].
 
 create_checks_test_() ->

--- a/core/kazoo_number_manager/test/knm_move_number_test.erl
+++ b/core/kazoo_number_manager/test/knm_move_number_test.erl
@@ -24,7 +24,7 @@ move_to_child() ->
     }.
 
 move_changing_public_fields_test_() ->
-	Key = <<"my_key">>,
+    Key = <<"my_key">>,
     Fields = [{<<"a">>, <<"bla">>}
              ,{Key, 42}
              ],

--- a/core/kazoo_number_manager/test/knm_move_number_test.erl
+++ b/core/kazoo_number_manager/test/knm_move_number_test.erl
@@ -22,3 +22,35 @@ move_to_child() ->
     {"verify assigned_to is child account"
     ,?_assertEqual(?CHILD_ACCOUNT_ID, knm_phone_number:assigned_to(PhoneNumber))
     }.
+
+move_changing_public_fields_test_() ->
+	Key = <<"my_key">>,
+    Fields = [{<<"a">>, <<"bla">>}
+             ,{Key, 42}
+             ],
+    Options = [{public_fields, kz_json:from_list(Fields)}
+               |knm_number_options:default()
+              ],
+    {ok, N0} = knm_number:get(?TEST_AVAILABLE_NUM),
+    {ok, N} = knm_number:move(?TEST_AVAILABLE_NUM, ?RESELLER_ACCOUNT_ID, Options),
+    [{"verify a public key is set"
+     ,?_assertEqual(<<"my string">>
+                   ,kz_json:get_value(Key, knm_number:to_public_json(N0))
+                   )
+     }
+    ,{"verify that key got updated"
+     ,?_assertEqual(42
+                   ,kz_json:get_value(Key, knm_number:to_public_json(N))
+                   )
+     }
+    ,{"verify another key was added"
+     ,?_assertEqual(<<"bla">>
+                   ,kz_json:get_value(<<"a">>, knm_number:to_public_json(N))
+                   )
+     }
+    ,{"verify that that other key is really new"
+     ,?_assertEqual(undefined
+                   ,kz_json:get_value(<<"a">>, knm_number:to_public_json(N0))
+                   )
+     }
+    ].


### PR DESCRIPTION
create number in func add_mobile_mdn in cb_devices

(backport of #3127)