### PR TITLE
[4.0] fix issue in delete method when there is no qs

### DIFF
--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -443,18 +443,22 @@ filter_messages([Mess|Messages], <<_/binary>> = Filter, Context, Selected)
        Filter =:= ?VM_FOLDER_SAVED;
        Filter =:= ?VM_FOLDER_DELETED ->
     Id = kzd_box_message:media_id(Mess),
-    QsFiltered = should_filter_by_qs(Mess, crossbar_doc:has_qs_filter(Context), Context),
-    case kzd_box_message:folder(Mess) of
-        Filter when not QsFiltered -> filter_messages(Messages, Filter, Context, [Id|Selected]);
-        _ -> filter_messages(Messages, Filter, Context, Selected)
+    QsFiltered = filtered_by_qs(Mess, crossbar_doc:has_qs_filter(Context), Context),
+    case QsFiltered
+        orelse kzd_box_message:folder(Mess) =:= Filter
+    of
+        'true' -> filter_messages(Messages, Filter, Context, [Id|Selected]);
+        'false' -> filter_messages(Messages, Filter, Context, Selected)
     end;
 %% Filter by Ids
 filter_messages(_, [], _Context, Selected) -> Selected;
 filter_messages([Mess|Messages], Filters, Context, Selected) ->
     Id = kzd_box_message:media_id(Mess),
-    QsFiltered = should_filter_by_qs(Mess, crossbar_doc:has_qs_filter(Context), Context),
-    case lists:member(Id, Filters) of
-        'true' when not QsFiltered -> filter_messages(Messages, Filters, Context, [Id|Selected]);
+    QsFiltered = filtered_by_qs(Mess, crossbar_doc:has_qs_filter(Context), Context),
+    case QsFiltered
+        orelse lists:member(Id, Filters)
+    of
+        'true' -> filter_messages(Messages, Filters, Context, [Id|Selected]);
         'false' -> filter_messages(Messages, Filters, Context, Selected)
     end.
 
@@ -937,9 +941,9 @@ generate_media_name(CallerId, GregorianSeconds, Ext, Timezone) ->
     Date = kz_util:pretty_print_datetime(LocalTime),
     list_to_binary([CallerId, "_", Date, Ext]).
 
--spec should_filter_by_qs(kz_json:object(), boolean(), cb_context:context()) -> boolean().
-should_filter_by_qs(_, 'false', _Context) -> 'true';
-should_filter_by_qs(JObj, 'true', Context) ->
+-spec filtered_by_qs(kz_json:object(), boolean(), cb_context:context()) -> boolean().
+filtered_by_qs(_, 'false', _Context) -> 'false';
+filtered_by_qs(JObj, 'true', Context) ->
     crossbar_doc:filtered_doc_by_qs(JObj, Context).
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Fix issue during testing VM delete method, when there is no query string but message id is member of list of messages that should be deleted

(backport of #3136 )