### PR TITLE
fake_trial_time_left

### DIFF
--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -816,7 +816,10 @@ leak_trial_time_left(Context) ->
     leak_trial_time_left(Context, JObj, kz_account:trial_expiration(JObj)).
 
 leak_trial_time_left(Context, _JObj, 'undefined') ->
-    Context;
+    RespData = kz_json:delete_key(<<"trial_time_left">>
+                                 ,cb_context:resp_data(Context)
+                                 ),
+    cb_context:set_resp_data(Context, RespData);
 leak_trial_time_left(Context, JObj, _Expiration) ->
     RespData = kz_json:set_value(<<"trial_time_left">>
                                 ,kz_account:trial_time_left(JObj)


### PR DESCRIPTION
'trial_time_left' is the flag one can use to assume the account is in trial/evaluation state.
Posting this flag to the account doc allows to keep it and pretend the account is trial despite it is not...