### PR TITLE
KAZOO-5293_4oh: ensure KNM options precendence is meaningful

### DIFF
--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -143,6 +143,7 @@
 
 -export([application_version/1]).
 
+-export([uniq/1]).
 -export([iolist_join/2]).
 
 -include_lib("kernel/include/inet.hrl").
@@ -1741,6 +1742,21 @@ get_app(AppName) ->
 application_version(Application) ->
     {'ok', Vsn} = application:get_key(Application, 'vsn'),
     to_binary(Vsn).
+
+
+%% @doc
+%% Like lists:usort/1 but preserves original ordering.
+%% Time: O(nlog(n)).
+%% @end
+uniq(KVs) when is_list(KVs) -> uniq(KVs, sets:new(), []).
+uniq([], _, L) -> lists:reverse(L);
+uniq([{K,_}=KV|Rest], S, L) ->
+    case sets:is_element(K, S) of
+        true -> uniq(Rest, S, L);
+        false ->
+            NewS = sets:add_element(K, S),
+            uniq(Rest, NewS, [KV|L])
+    end.
 
 
 %% @public

--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -1748,6 +1748,7 @@ application_version(Application) ->
 %% Like lists:usort/1 but preserves original ordering.
 %% Time: O(nlog(n)).
 %% @end
+-spec uniq([kz_proplist()]) -> kz_proplist().
 uniq(KVs) when is_list(KVs) -> uniq(KVs, sets:new(), []).
 uniq([], _, L) -> lists:reverse(L);
 uniq([{K,_}=KV|Rest], S, L) ->

--- a/core/kazoo/test/kz_util_test.erl
+++ b/core/kazoo/test/kz_util_test.erl
@@ -446,3 +446,14 @@ runs_in_test_() ->
     [?_assertEqual(timeout, kz_util:runs_in(1, fun timer:sleep/1, [10]))
     ,?_assertEqual({ok,ok}, kz_util:runs_in(10, fun timer:sleep/1, [1]))
     ].
+
+
+uniq_test_() ->
+    [?_assertEqual([], kz_util:uniq([]))
+    ,?_assertEqual([{module_name, <<"my_module">>}]
+                  ,kz_util:uniq([{module_name, <<"my_module">>}
+                                ,{module_name, <<"blaaa">>}
+                                ,{module_name, false}
+                                ])
+                  )
+    ].

--- a/core/kazoo_number_manager/src/knm_number_options.erl
+++ b/core/kazoo_number_manager/src/knm_number_options.erl
@@ -101,9 +101,7 @@ uniq([{K,_}=KV|Rest], S, L) ->
         false ->
             NewS = sets:add_element(K, S),
             uniq(Rest, NewS, [KV|L])
-    end;
-uniq([_|Rest], S, L) ->
-    uniq(Rest, S, L).
+    end.
 
 -spec dry_run(options()) -> boolean().
 -spec dry_run(options(), Default) -> boolean() | Default.
@@ -227,8 +225,8 @@ to_phone_number_setters_test_() ->
                    ,{fun knm_phone_number:set_dry_run/2, [[[]]]}
                    ]
                   ,to_phone_number_setters([{'auth_by', ?KNM_DEFAULT_AUTH_BY}
-                                           ,<<"coucou">>
                                            ,{'ported_in', 'false'}
+                                           ,{<<"batch_run">>, 'false'}
                                            ,{'dry_run', [[[]]]}
                                            ])
                   )

--- a/core/kazoo_number_manager/src/knm_number_options.erl
+++ b/core/kazoo_number_manager/src/knm_number_options.erl
@@ -84,24 +84,10 @@ to_phone_number_setters(Options) ->
              FName = list_to_existing_atom("set_" ++ atom_to_list(Option)),
              {fun knm_phone_number:FName/2, Value}
      end
-     || {Option, Value} <- uniq(Options),
+     || {Option, Value} <- kz_util:uniq(Options),
         is_atom(Option),
         Option =/= 'should_delete'
     ].
-
-%% @doc
-%% Like lists:usort/1 but preserves original ordering.
-%% Time: O(nlog(n)).
-%% @end
-uniq(KVs) when is_list(KVs) -> uniq(KVs, sets:new(), []).
-uniq([], _, L) -> lists:reverse(L);
-uniq([{K,_}=KV|Rest], S, L) ->
-    case sets:is_element(K, S) of
-        true -> uniq(Rest, S, L);
-        false ->
-            NewS = sets:add_element(K, S),
-            uniq(Rest, NewS, [KV|L])
-    end.
 
 -spec dry_run(options()) -> boolean().
 -spec dry_run(options(), Default) -> boolean() | Default.


### PR DESCRIPTION
cc https://github.com/2600hz/kazoo/pull/3149