### PR TITLE
Follow up to Kazoo-5277: released numbers not fully deleting when they should

### DIFF
--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -400,7 +400,6 @@ authorized_release(PhoneNumber) ->
     Routines = [{fun set_features/2, kz_json:new()}
                ,{fun set_doc/2, kz_json:private_fields(doc(PhoneNumber))}
                ,{fun set_prev_assigned_to/2, assigned_to(PhoneNumber)}
-               ,{fun set_assigned_to/2, undefined}
                ,{fun set_state/2, ReleasedState}
                ],
     {'ok', NewPhoneNumber} = setters(PhoneNumber, Routines),


### PR DESCRIPTION
Kazoo-5277 patch solved a portion of this, but the circumstance remained that numbers that are released would still remain in the database when the should_delete option was on. The change to release/2 makes sure that permanently deleted numbers don't get passed to save_phone_numbers/1 but still do return in the ok list. Removing the set_assigned_to/2 call in knm_phone_number.erl both ensures that the now-available number matches the state of an available number that is freshly added AND ensures that the knm_phone_number:delete/1 call made on permanently deleted numbers can also delete the number from the assigned_to account.