### PR TITLE
[4.0] KAZOO-4601: branch on a variable's value

### DIFF
--- a/applications/callflow/doc/cf_branch_variable.md
+++ b/applications/callflow/doc/cf_branch_variable.md
@@ -1,0 +1,78 @@
+### Callflow Branch on a Variable's Value
+
+#### Overview
+
+The `branch_variable` callflow enables you to branch based on value of some field inside one of the a call CCVs, user's document, device's documten or an account's document.
+
+##### Callflow fields
+
+Key | Description | Type | Default | Required
+--- | ----------- | ---- | ------- | --------
+`scope` | specifies where the variable is defined | `string` | `"cunstom_channel_vars"` | `false`
+`variable` | specifies the name of variable/property that should be looked up | `string` or a json path | | `true`
+
+#### Description
+
+The purpose of this callflow is to branch on value of some property so it may have children named after possible values of the property, e.g. branch on boolean value of a property with the name `"call_forward"`. For this, there should be three children on the callflow: `"true"`, `"false"` (and `"_"` for the case when property is not defined anywhere and it's value is unknown).
+
+##### Scope
+
+The place that the variable can be defined is configurable by `scope`. By default if the scope is not defined or if it sets to `"custom_channel_vars"`, call's CCVs would be looking for the variable's value.
+
+Supported places for defining the variable:
+
+* `"accounts"`: in the account's document
+* `"custom_channel_vars"`: in the Call's Custom Channel Variables
+* `"device"`: in the device's documents
+* `"merged"`: in the endpoint object (the merge of device, user and account)
+* `"user"`: in the user's documents
+
+##### Variable
+
+Variable is the name of the variable or property that should be look for in the specified scope. It must be a valid JSON key, e.g. a single string or a list of string which is a path to deep nested JSON objects.
+
+For example, if you set `scope` to `merged`, this module tries to use endpoint which has the merged value of user, device and account document. The endpoint has `record_call` attribute which is JSON object:
+
+```json
+...
+{
+	"record_call": {
+		"action": "start",
+		"record_call": true
+	}
+}
+...
+```
+
+If you want to record the calls based on the merged value inside the endpoint then the variable should be set to `["record_call", "record_call"]`. This will result the value `'true'`' of the inner attribute of the JSON object been fetched.
+
+#### Example
+
+If you want to conditinally record outbound calls in `no_match` callflow depending on a property sets for users inside their documents:
+
+```json
+...
+{
+	"data": {
+    	"scope": "user",
+    	"variable": "x_user_record_outbound"
+ 	},
+ 	"children":{
+		"true": { },
+    	"false": { },
+		"_" : { }
+ 	}
+}
+...
+```
+
+The name of the property that is been looked is set on the `"variable"`. Property name of the each children is the value of the variable the has been found.
+
+`"true"`
+:  If the variable is set to the `true`
+
+`"false"`
+:  If the variable is set to `false`
+
+`"_"`
+:  If the variable is not defined or has a different value

--- a/applications/callflow/doc/cf_dynamic_cid.md
+++ b/applications/callflow/doc/cf_dynamic_cid.md
@@ -2,25 +2,33 @@
 
 #### About Dynamic CID
 
-The Dynamic CID callflow enables you to dynamically change the Caller ID (CID). There are two methods for doing that:
+The Dynamic CID callflow enables you to dynamically change the Caller ID (CID). There are different methods for doing that:
 
-* **manual:** dial the new Caller ID on the keypad when prompted, this way you can set the Caller ID number only
-* **list:** setting Caller ID name and number based on the configurtion on the specified document in the database
+* **manual:** dial the new Caller ID on the keypad when prompted, this way you can set the Caller ID number only. This works with and without a capture group
+* **list:** setting Caller ID name and number based on the configurtion on the specified document in the database. This requires a capture group
 * **lists:** almost the same as list mode but you can use account's lists feature to configure entries
+* **static** set the caller id to a value in a `caller_id.name` and `caller_id.number` property in the data object. This works with and without a capture group
 
 ##### Callflow fields
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
-`action` | Method to use for changing the Caller ID. Valid value are `manual` and `list` | `string` | `"manual"` | `true`
-`id` | The id of document in database that holds the new Caller ID when action is set to `list` | `string` | | `true` if action is `list`
-`media_id` | The id of the media prompt to play when collecting Caller ID from user if action is set to `manual` | `string` | `"dynamic-cid-enter_cid"` | `false`
+`action` | Method to use for changing the Caller ID. Valid value are `manual` and `list` | `string` | `"manual"` | `false`
+`caller_id` | caller id for `static` action | `object` | | `false`
+`caller_id.name` | caller id name for `static` action | `string` | | `false`
+`caller_id.number` | caller id number for `static` action | `string` | | `false`
+`enforce_call_restriction` | in `list`  and `lists` action mode, should call be restricted by number classification | `boolean` | `true` | `false`
+`id` | The id of document in database that holds the new Caller ID when action is set to `list` | `string` | | `false`
 `interdigit_timeout` | The amount of time (in milliseconds) to wait for the caller to press the next digit after pressing a digit | `integer` | 2000 | `false`
+`max_digits` | maximum digits length to ollect for `manual` action | `integer` | 10 | `false`
+`media_id` | The id of the media prompt to play when collecting Caller ID from user if action is set to `manual` | `string` | `"dynamic-cid-enter_cid"` | `false`
+`min_digits` | minumum digits length to collect for `manual` action | `integer` | 10 | `false`
+`whitelist_regex` | the regex that will run over collected digits for number verification | `string` | `"\\d+"` | `false`
 
 #### Manual action mode
 
-In this method user is prompted to dial the new Caller ID number. The lenght of the dialed new Caller ID is checked to be
-in the default(or configured) boundry and it also matched against the default(or configured) regex, if these checks are passed the call will proceed.
+In this method user is prompted to dial a new Caller ID number. The lenght of the dialed new Caller ID is checked to be
+in the default(or configured) boundry and it is also matched against the default(or configured) regex, if these checks are passed the call will proceed.
 
 > **Notes** You can only set the Caller ID number with this method.
 
@@ -128,30 +136,48 @@ Almost the same as list mode but you can use account's lists feature to configur
 
 - Create a list
 
-````ssh
+```shell
 curl -v -X POST \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     -d '{"data":{"name":"Dynamic CID","description":"List of new callerid name and number entries ","list_type":"dynamic_cid"}}' \
     http://{SERVER}/v2/accounts/{ACCOUNT_ID}/lists
-````
+```
 
 > `list_type` field is optional here and used just for easier filtering `dynamic_cid` list among the others
 
 - Create entries
 
-````ssh
+```shell
 curl -v -X POST \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     -d '{"data":{"cid_key":"01","cid_name":"My Office CID","cid_number":"+78124906700"}}' \
     http://{SERVER}/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}/entries
-````
+```
 
 - Create callflow dynamic_cid feature code
 
-````ssh
+```shell
 curl -v -X POST \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     -d '{"data":{"flow":{"children":{},"data":{"action":"lists","id":"{LIST_ID}"},"module":"dynamic_cid"},"numbers":[],"patterns":["^\\*69([0-9]{2,})$"],"featurecode":{"number":"69","name":"dynamic_cid"}}}'
     http://{SERVER}/v2/accounts/{ACCOUNT_ID}/callflows
-````
+```
 
+#### Static action mode
+
+In this method the new Caller ID number and name would be set to `caller_id` value sets in the callflow Data object.
+
+###### Example Callflow Data
+
+```json
+{
+    "data": {
+        "action": "static",
+        "caller_id": {
+            "name": "CALL_ME",
+            "number": "5555555555"
+        }
+    },
+    "module": "dynamic_cid"
+}
+```

--- a/applications/callflow/src/module/cf_branch_variable.erl
+++ b/applications/callflow/src/module/cf_branch_variable.erl
@@ -2,15 +2,19 @@
 %%% @copyright (C) 2013-2016, 2600Hz INC
 %%% @doc
 %%%
-%%% Try branch to variable's value
+%%% Try to branch based on the value of a variable.
 %%%
 %%% "data":{
 %%%   "variable":{{var_name}}
+%%%   //optional
+%%%   "scope": "[custome_channel_vars|device|user|account|_]",
 %%% }
 %%%
 %%% @end
 %%% @contributors
 %%%   KAZOO-3596: Sponsored by GTNetwork LLC, implemented by SIPLABS LLC
+%%%   KAZOO-4601: SIPLABS LLC (Maksim Krzhemenevskiy)
+%%%   Hesaam Farhang
 %%%-------------------------------------------------------------------
 -module(cf_branch_variable).
 
@@ -20,9 +24,7 @@
 
 -export([handle/2]).
 
--spec name_mapping() -> kz_proplist().
-name_mapping() ->
-    [{<<"call_priority">>, <<"Call-Priority">>}].
+-type variable_key() :: api_ne_binary() | api_ne_binaries().
 
 %%--------------------------------------------------------------------
 %% @public
@@ -32,14 +34,146 @@ name_mapping() ->
 %%--------------------------------------------------------------------
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
-    Name = props:get_value(kz_json:get_value(<<"variable">>, Data), name_mapping()),
+    Scope = kz_json:get_ne_binary_value(<<"scope">>, Data, <<"custom_channel_vars">>),
+    Variable = normalize_variable(kz_json:get_ne_value(<<"variable">>, Data)),
+    lager:info("looking for variable '~p' value in scope '~s' to find next callflow branch", [Variable, Scope]),
+    ChildName = find_child_in_scope(Scope, Variable, Call),
+    maybe_branch_to_named_child(ChildName, Call).
+
+-spec maybe_branch_to_named_child(variable_key(), kapps_call:call()) -> kapps_call:call().
+maybe_branch_to_named_child('undefined', Call) ->
+    lager:info("trying '_'"),
+    cf_exe:continue(Call);
+maybe_branch_to_named_child(ChildName, Call) ->
+    lager:info("trying '~s'", [ChildName]),
+    cf_exe:continue(ChildName, Call).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Try to find callflow branch name out of variable's value in the Scope.
+%% If scope sets to other values than custome_channel_vars, account,
+%% user and device, it search in merged attributes in endpoint.
+%% @end
+%%--------------------------------------------------------------------
+-spec find_child_in_scope(ne_binary(), variable_key(), kapps_call:call()) -> api_binary().
+find_child_in_scope(_Scope, 'undefined', _Call) ->
+    lager:warning("no variable is specified"),
+    'undefined';
+find_child_in_scope(<<"custom_channel_vars">>, Variable, Call) ->
+    ChildName = kz_json:get_ne_value(Variable, kz_json:normalize(kapps_call:custom_channel_vars(Call))),
+    find_child_in_branch(ChildName, Call);
+find_child_in_scope(<<"account">>, Variable, Call) ->
+    find_child_in_doc(kapps_call:account_id(Call), Variable, Call);
+find_child_in_scope(Scope, Variable, Call) when Scope =:= <<"user">>;
+                                                Scope =:= <<"device">> ->
+    case kapps_call:authorizing_type(Call) of
+        <<"device">> when Scope =:= <<"user">>->
+            find_child_in_doc(device_owner(Call), Variable, Call);
+        <<"device">> when Scope =:= <<"device">>->
+            find_child_in_doc(kapps_call:authorizing_id(Call), Variable, Call);
+        _AuthType ->
+            lager:debug("unsupported authorizing type: ~s", [_AuthType]),
+            'undefined'
+    end;
+find_child_in_scope(<<"merged">>, Variable, Call) ->
     {'branch_keys', Keys} = cf_exe:get_branch_keys(Call),
-    Value = kapps_call:custom_channel_var(Name, Call),
-    case lists:member(Value, Keys) of
-        'true' ->
-            lager:info("trying '~s'", [Value]),
-            cf_exe:continue(Value, Call);
-        'false' ->
-            lager:info("trying '_'"),
-            cf_exe:continue(Call)
+    CCVsChild = kz_json:get_ne_value(Variable, kz_json:normalize(kapps_call:custom_channel_vars(Call))),
+    case kz_endpoint:get(Call) of
+        {'ok', JObj} ->
+            EndPointChildName = kz_json:get_ne_value(Variable, JObj),
+            case find_child_in_branch(EndPointChildName, Call, Keys) of
+                'undefined' ->
+                    find_child_in_branch(CCVsChild, Call, Keys);
+                ChildName -> ChildName
+            end;
+        _Else ->
+            lager:debug("failed to lookup endpoint"),
+            'undefined'
     end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Open the document DocId to find the value of the variable which is the
+%% name of the callflow branch.
+%% @end
+%%--------------------------------------------------------------------
+-spec find_child_in_doc(api_binary(), ne_binary(), kapps_call:call()) -> api_binary().
+find_child_in_doc('undefined', _Variable, _Call) ->
+    lager:debug("could not find document for current scope"),
+    'undefined';
+find_child_in_doc(DocId, Variable, Call) ->
+    case kz_datamgr:open_cache_doc(kapps_call:account_db(Call), DocId) of
+        {'ok', JObj} ->
+            find_child_in_branch(kz_json:get_ne_value(Variable, JObj), Call);
+        _Else ->
+            lager:debug("failed to open device doc ~s in account ~s", [DocId, kapps_call:account_id(Call)]),
+            'undefined'
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Look into the defined children in the callflow to see if the child name
+%% that was found is there, if yes we found the child, otherwise
+%% fall back to the default children '_'.
+%% @end
+%%--------------------------------------------------------------------
+-spec find_child_in_branch(any(), kapps_call:call()) -> api_binary().
+find_child_in_branch(ChildName, Call) ->
+    {'branch_keys', Keys} = cf_exe:get_branch_keys(Call),
+    find_child_in_branch(ChildName, Call, Keys).
+
+-spec find_child_in_branch(any(), kapps_call:call(), kz_json:paths()) -> api_binary().
+find_child_in_branch('undefined', _Call, _Keys) -> 'undefined';
+find_child_in_branch(?NE_BINARY = ChildName, _Call, Keys) ->
+    case lists:member(ChildName, Keys) of
+        'true' -> ChildName;
+        'false' -> 'undefined'
+    end;
+find_child_in_branch(ChildName, Call, Keys) ->
+    try kz_util:to_binary(ChildName) of
+        Bin ->
+            find_child_in_branch(Bin, Call, Keys)
+    catch
+        _:_ ->
+            lager:info("failed to convert none binary value ~p to binary", [ChildName]),
+            'undefined'
+    end.
+
+%% Utility Funcations
+
+-spec device_owner(kapps_call:call()) -> ne_binary().
+device_owner(Call) ->
+    DeviceId = kapps_call:authorizing_id(Call),
+    case kz_datamgr:open_cache_doc(kapps_call:account_db(Call), DeviceId) of
+        {'ok', JObj} -> kz_device:owner_id(JObj);
+        _Else ->
+            lager:debug("failed to open device doc ~s in account ~s", [DeviceId, kapps_call:account_id(Call)]),
+            'undefined'
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Normalize variable. Variable is a json path, so we should accept
+%% binary, or a path and ignore others,
+%% So if ones wants to look into a deep json object, path [<<"v1">>, <<"v2">>]
+%% can be used to get the value.
+%% @end
+%%--------------------------------------------------------------------
+-spec normalize_variable(variable_key() | kz_json:object()) -> variable_key().
+normalize_variable('undefined') ->
+    'undefined';
+normalize_variable(?NE_BINARY = Variable) ->
+    kz_json:normalize_key(Variable);
+normalize_variable(Variable) when is_list(Variable) ->
+    lists:reverse([kz_json:normalize_key(V)
+                   || V <- Variable,
+                      not kz_util:is_empty(V)
+                  ]
+                 );
+normalize_variable(_JObj) ->
+    lager:debug("unsupported variable name"),
+    'undefined'.

--- a/applications/callflow/src/module/cf_dynamic_cid.erl
+++ b/applications/callflow/src/module/cf_dynamic_cid.erl
@@ -278,7 +278,7 @@ collect_cid_number(Data, Call) ->
 
     Min = kz_json:get_ne_value(<<"min_digits">>, Data, DefaultMin),
     Max = kz_json:get_ne_value(<<"max_digits">>, Data, DefaultMax),
-    Regex = kz_json:get_ne_value(<<"min_digits">>, Data, DefaultRegex),
+    Regex = kz_json:get_ne_value(<<"whitelist_regex">>, Data, DefaultRegex),
 
     Interdigit = kz_json:get_integer_value(<<"interdigit_timeout">>
                                           ,Data
@@ -360,7 +360,7 @@ find_key_and_dest(ListJObj, Data, Call) ->
 
 -spec find_key_and_dest(kz_json:object(), kapps_call:call()) -> {binary(), binary()}.
 find_key_and_dest(ListJObj, Call) ->
-    LengthDigits = kz_json:get_integer_value(<<"length">>, ListJObj),
+    LengthDigits = kz_json:get_integer_value(<<"length">>, ListJObj, 2),
     lager:debug("digit length to limit lookup key in number: ~p", [LengthDigits]),
     CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
     <<CIDKey:LengthDigits/binary, Dest/binary>> = CaptureGroup,

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -768,8 +768,23 @@
         "callflows.branch_variable": {
             "description": "Validator for the branch_variable callflow's data object",
             "properties": {
+                "scope": {
+                    "default": "custom_channel_vars",
+                    "description": "specifies where the variable is defined",
+                    "enum": [
+                        "account",
+                        "custom_channel_vars",
+                        "device",
+                        "merged",
+                        "user"
+                    ],
+                    "type": "string"
+                },
                 "variable": {
-                    "description": ""
+                    "default": "",
+                    "description": "specifies the name of variable/property that should be looked up",
+                    "required": true,
+                    "type": "string"
                 }
             },
             "required": true,

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1129,6 +1129,9 @@
                 },
                 "min_digits": {
                     "description": ""
+                },
+                "whitelist_regex": {
+                    "description": ""
                 }
             },
             "required": true,

--- a/applications/crossbar/priv/couchdb/schemas/callflows.branch_variable.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.branch_variable.json
@@ -3,8 +3,23 @@
     "_id": "callflows.branch_variable",
     "description": "Validator for the branch_variable callflow's data object",
     "properties": {
+        "scope": {
+            "default": "custom_channel_vars",
+            "description": "specifies where the variable is defined",
+            "enum": [
+                "account",
+                "custom_channel_vars",
+                "device",
+                "merged",
+                "user"
+            ],
+            "type": "string"
+        },
         "variable": {
-            "description": ""
+            "default": "",
+            "description": "specifies the name of variable/property that should be looked up",
+            "required": true,
+            "type": "string"
         }
     },
     "required": true,

--- a/applications/crossbar/priv/couchdb/schemas/callflows.dynamic_cid.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.dynamic_cid.json
@@ -32,6 +32,9 @@
         },
         "min_digits": {
             "description": ""
+        },
+        "whitelist_regex": {
+            "description": ""
         }
     },
     "required": true,


### PR DESCRIPTION
Re-work of PR #1732

Change the current cf_branch_variable module to add more places that a variable can be look up. Use case is if someone wants to branch based on value of a specific variable in users/device/account documents.

Default location to define the name of the variable is in "custom_channel_vars" which is because of preserving the current behavior if the scope is not defined.

(backport of #3077 and #3120 )