### PR TITLE
URI-encode prompt ids for uploading media

### DIFF
--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -449,7 +449,7 @@ prompt_id(<<"/system_media/", PromptId/binary>>, Lang) ->
 prompt_id(PromptId, 'undefined') -> PromptId;
 prompt_id(PromptId, <<>>) -> PromptId;
 prompt_id(PromptId, Lang) ->
-    <<Lang/binary, "/", PromptId/binary>>.
+    kz_util:uri_encode(<<Lang/binary, "/", PromptId/binary>>).
 
 -spec get_prompt(ne_binary()) -> api_binary().
 -spec get_prompt(ne_binary(), api_binary() | kapps_call:call()) ->


### PR DESCRIPTION
Restore uri-encoding that can be found in 3.22. Without it, doc ids contain the '/' and cb_media APIs cannot retrieve the doc contents (return 404s).