### PR TITLE
Revert KAZOO-5107 change as that actually /broke/ it in the way the ticket describes

### DIFF
--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1439,7 +1439,7 @@ maybe_retain_caller_id({_Endpoint, _Call, 'undefined', _JObj}=Acc) ->
 maybe_retain_caller_id({Endpoint, Call, CallFwd, JObj}) ->
     {Endpoint, Call, CallFwd
     ,case kapps_call:inception(Call) =:= 'undefined'
-         andalso kz_json:is_true(<<"keep_caller_id">>, CallFwd)
+         orelse kz_json:is_true(<<"keep_caller_id">>, CallFwd)
      of
          'true' ->
              lager:info("call forwarding will retain caller id"),

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1438,9 +1438,7 @@ maybe_retain_caller_id({_Endpoint, _Call, 'undefined', _JObj}=Acc) ->
     Acc;
 maybe_retain_caller_id({Endpoint, Call, CallFwd, JObj}) ->
     {Endpoint, Call, CallFwd
-    ,case kapps_call:inception(Call) =:= 'undefined'
-         orelse kz_json:is_true(<<"keep_caller_id">>, CallFwd)
-     of
+    ,case kz_json:is_true(<<"keep_caller_id">>, CallFwd) of
          'true' ->
              lager:info("call forwarding will retain caller id"),
              kz_json:set_value(<<"Retain-CID">>, <<"true">>, JObj);


### PR DESCRIPTION
The change to andalso in KAZOO-5107 actually causes the caller ID to never appear for forwarded external callers. We just ran into this after a recent merge and reverting the change fixes the issue. Not directly reverting commit so as to keep lager line english update ;)