### PR TITLE
Update cb_rates.erl

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6240,14 +6240,14 @@
                 "rate_increment": {
                     "default": 60,
                     "description": "The time slice, in seconds, to bill in.",
-                    "minimum": 10,
+                    "minimum": 6,
                     "required": false,
                     "type": "integer"
                 },
                 "rate_minimum": {
                     "default": 60,
                     "description": "The minimum time slice, in seconds to bill a call",
-                    "minimum": 10,
+                    "minimum": 6,
                     "required": false,
                     "type": "integer"
                 },

--- a/applications/crossbar/priv/couchdb/schemas/rates.json
+++ b/applications/crossbar/priv/couchdb/schemas/rates.json
@@ -63,14 +63,14 @@
         "rate_increment": {
             "default": 60,
             "description": "The time slice, in seconds, to bill in.",
-            "minimum": 10,
+            "minimum": 6,
             "required": false,
             "type": "integer"
         },
         "rate_minimum": {
             "default": 60,
             "description": "The minimum time slice, in seconds to bill a call",
-            "minimum": 10,
+            "minimum": 6,
             "required": false,
             "type": "integer"
         },

--- a/applications/crossbar/src/modules/cb_rates.erl
+++ b/applications/crossbar/src/modules/cb_rates.erl
@@ -506,7 +506,7 @@ get_row_routes([_|_]) ->
 
 get_row_increment([_, _, _, _, _, _, _, _, Increment | _]) ->
     case kz_term:to_float(Increment) of
-        Inc when Inc < 10 -> 10;
+        Inc when Inc < 6 -> 6;
         Inc -> Inc
     end;
 get_row_increment([_|_]) ->
@@ -514,7 +514,7 @@ get_row_increment([_|_]) ->
 
 get_row_minimum([_, _, _, _, _, _, _, _, _, Minimum | _]) ->
     case kz_term:to_float(Minimum) of
-        Min when Min < 10 -> 10;
+        Min when Min < 6 -> 6;
         Min -> Min
     end;
 get_row_minimum([_|_]) ->


### PR DESCRIPTION
Need to reduce the minimum increments for 6sec/6sec billing.  Not sure why these are here.  Perhaps you can consider removing them completely.