### PR TITLE
kz_json:diff, expand, flatten/2

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -876,7 +876,7 @@ accept_override(Context) ->
 
 -spec flatten_jobj(cb_context:context()) -> iolist().
 flatten_jobj(Context) ->
-    JObj = kz_json:flatten(cb_context:resp_data(Context)),
+    JObj = kz_json:flatten(cb_context:resp_data(Context), binary_join),
     Routines = [fun check_integrity/1
                ,fun create_csv_header/1
                ,fun json_objs_to_csv/1

--- a/core/kazoo_json/test/kz_json_test.erl
+++ b/core/kazoo_json/test/kz_json_test.erl
@@ -586,6 +586,6 @@ flatten_expand_diff_test() ->
     X2 = kz_json:set_value(k20, v20, X),
     Delta = kz_json:set_value(k20, v20, X),
     [
-        ?_assertEqual(kz_json:expand(kz_json:flatten(X2)), X2)
-        ,?_assertEqual(kz_json:diff(X, X2), Delta)
+     ?_assertEqual(kz_json:expand(kz_json:flatten(X2)), X2)
+    ,?_assertEqual(kz_json:diff(X, X2), Delta)
     ].

--- a/core/kazoo_json/test/kz_json_test.erl
+++ b/core/kazoo_json/test/kz_json_test.erl
@@ -580,3 +580,12 @@ from_list_recursive_test() ->
     ,?_assertEqual(kz_json:get_ne_binary_value(Key2, JObj1), kz_json:get_ne_binary_value(Key2, JObj2))
     ,?_assertEqual(true, kz_json:are_equal(JObj1, JObj2))
     ].
+
+flatten_expand_diff_test() ->
+    X = kz_json:set_value([k10, k11, k12], v10, kz_json:new()),
+    X2 = kz_json:set_value(k20, v20, X),
+    Delta = kz_json:set_value(k20, v20, X),
+    [
+        ?_assertEqual(kz_json:expand(kz_json:flatten(X2)), X2)
+        ,?_assertEqual(kz_json:diff(X, X2), Delta)
+    ].


### PR DESCRIPTION
- calculate difference between json objects
- new api for flatten (second argument determines the way to join keys)
- new function expand to convert from flatten representation