### PR TITLE
Csv fix

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6240,14 +6240,14 @@
                 "rate_increment": {
                     "default": 60,
                     "description": "The time slice, in seconds, to bill in.",
-                    "minimum": 10,
+                    "minimum": 6,
                     "required": false,
                     "type": "integer"
                 },
                 "rate_minimum": {
                     "default": 60,
                     "description": "The minimum time slice, in seconds to bill a call",
-                    "minimum": 10,
+                    "minimum": 6,
                     "required": false,
                     "type": "integer"
                 },

--- a/applications/crossbar/priv/couchdb/schemas/rates.json
+++ b/applications/crossbar/priv/couchdb/schemas/rates.json
@@ -63,14 +63,14 @@
         "rate_increment": {
             "default": 60,
             "description": "The time slice, in seconds, to bill in.",
-            "minimum": 10,
+            "minimum": 6,
             "required": false,
             "type": "integer"
         },
         "rate_minimum": {
             "default": 60,
             "description": "The minimum time slice, in seconds to bill a call",
-            "minimum": 10,
+            "minimum": 6,
             "required": false,
             "type": "integer"
         },

--- a/applications/crossbar/src/modules/cb_rates.erl
+++ b/applications/crossbar/src/modules/cb_rates.erl
@@ -506,7 +506,7 @@ get_row_routes([_|_]) ->
 
 get_row_increment([_, _, _, _, _, _, _, _, Increment | _]) ->
     case kz_term:to_float(Increment) of
-        Inc when Inc < 10 -> 10;
+        Inc when Inc < 6 -> 6;
         Inc -> Inc
     end;
 get_row_increment([_|_]) ->
@@ -514,7 +514,7 @@ get_row_increment([_|_]) ->
 
 get_row_minimum([_, _, _, _, _, _, _, _, _, Minimum | _]) ->
     case kz_term:to_float(Minimum) of
-        Min when Min < 10 -> 10;
+        Min when Min < 6 -> 6;
         Min -> Min
     end;
 get_row_minimum([_|_]) ->

--- a/applications/crossbar/src/modules/cb_rates.erl
+++ b/applications/crossbar/src/modules/cb_rates.erl
@@ -462,16 +462,16 @@ get_row_description(_R) ->
     'undefined'.
 
 -spec get_row_internal_surcharge(rate_row()) -> api_float().
-get_row_internal_surcharge([_, _, _, InternalSurcharge, _, _ | _]) ->
+get_row_internal_surcharge([_, _, _, InternalSurcharge, _, _ | _]) when (InternalSurcharge /= []) ->
     kz_term:to_float(InternalSurcharge);
 get_row_internal_surcharge(_R) ->
     lager:info("internal surcharge not found on row: ~p", [_R]),
     'undefined'.
 
 -spec get_row_surcharge(rate_row()) -> api_float().
-get_row_surcharge([_, _, _, Surcharge, _, _]) ->
+get_row_surcharge([_, _, _, Surcharge, _, _]) when (Surcharge /= []) ->
     kz_term:to_float(Surcharge);
-get_row_surcharge([_, _, _, _, Surcharge, _ | _]) ->
+get_row_surcharge([_, _, _, _, Surcharge, _ | _]) when (Surcharge /= []) ->
     kz_term:to_float(Surcharge);
 get_row_surcharge([_|_]=_R) ->
     lager:info("surcharge not found on row: ~p", [_R]),
@@ -499,7 +499,7 @@ get_row_rate([_|_]=_R) ->
     lager:info("rate not found on row: ~p", [_R]),
     'undefined'.
 
-get_row_routes([_, _, _, _, _, _, _, Routes | _]) ->
+get_row_routes([_, _, _, _, _, _, _, Routes | _]) when (Routes /= []) ->
     [kz_term:to_binary(X) || X <- string:tokens(kz_term:to_list(Routes), ";")];
 get_row_routes([_|_]) ->
     'undefined'.


### PR DESCRIPTION
This allows empty csv columns when using:

Prefix, ISO, Desc, Surcharge, InternalRate, Rate
Prefix, ISO, Desc, InternalSurcharge, Surcharge, InternalRate, Rate
Prefix, ISO, Desc, InternalSurcharge, Surcharge, Internal_rate, Rate, Routes, RateIncrement, RateMinimum, Direction