### PR TITLE
Update presence on call_forward toggle via phone or crossbar

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -45,6 +45,8 @@
         ,event_listener_name/2
         ]).
 
+-export([update_presence/2]).
+
 -include("callflow.hrl").
 -include_lib("kazoo_json/include/kazoo_json.hrl").
 
@@ -869,3 +871,10 @@ vm_count(JObj) ->
 vm_count_by_owner(_AccountDb, 'undefined') -> {0, 0};
 vm_count_by_owner(<<_/binary>> = AccountDb, <<_/binary>> = OwnerId) ->
     kvm_messages:count_by_owner(AccountDb, OwnerId).
+
+-spec update_presence(kapps_call:call(), ne_binary()) -> any().
+update_presence(Call, State) ->
+    lager:debug("updating presence to ~s", [State]),
+    PresenceId = kz_attributes:presence_id(Call),
+    _ = kz_datamgr:update_doc(kapps_call:account_db(Call), ?MANUAL_PRESENCE_DOC, [{PresenceId, State}]),
+    kapps_call_command:presence(State, PresenceId, kz_term:to_hex_binary(crypto:hash(md5, PresenceId))).

--- a/applications/crossbar/doc/accounts.md
+++ b/applications/crossbar/doc/accounts.md
@@ -36,6 +36,7 @@ Key | Description | Type | Default | Required
 `ringtones.external` | The alert info SIP header added when the call is from internal sources | `string(0..256)` |   | `false`
 `ringtones.internal` | The alert info SIP header added when the call is from external sources | `string(0..256)` |   | `false`
 `timezone` | The default timezone | `string(5..32)` |   | `false`
+`update_presence_on_call_forward` | Determines if the presence state for a phone should be altered when call_forward is toggled on a user | `boolean` |   | `false`
 `voicemail` |   | `object` |   | `false`
 `voicemail.notify` |   | `object` |   | `false`
 `voicemail.notify.callback` |   | [#/definitions/notify.callback](#notifycallback) |   | `false`

--- a/applications/crossbar/doc/ref/accounts.md
+++ b/applications/crossbar/doc/ref/accounts.md
@@ -28,6 +28,7 @@ Key | Description | Type | Default | Required
 `ringtones.external` | The alert info SIP header added when the call is from internal sources | `string(0..256)` |   | `false`
 `ringtones.internal` | The alert info SIP header added when the call is from external sources | `string(0..256)` |   | `false`
 `timezone` | The default timezone | `string(5..32)` |   | `false`
+`update_presence_on_call_forward` | Determines if the presence state for a phone should be altered when call_forward is toggled on a user | `boolean` |   | `false`
 `voicemail` |   | `object` |   | `false`
 `voicemail.notify` |   | `object` |   | `false`
 `voicemail.notify.callback` |   | [#/definitions/notify.callback](#notifycallback) |   | `false`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -175,6 +175,10 @@
                     "minLength": 5,
                     "type": "string"
                 },
+                "update_presence_on_call_forward": {
+                    "description": "Determines if the presence state for a phone should be altered when call_forward is toggled on a user",
+                    "type": "boolean"
+                },
                 "voicemail": {
                     "properties": {
                         "notify": {

--- a/applications/crossbar/priv/couchdb/schemas/accounts.json
+++ b/applications/crossbar/priv/couchdb/schemas/accounts.json
@@ -123,6 +123,10 @@
             "minLength": 5,
             "type": "string"
         },
+        "update_presence_on_call_forward": {
+            "description": "Determines if the presence state for a phone should be altered when call_forward is toggled on a user",
+            "type": "boolean"
+        },
         "voicemail": {
             "properties": {
                 "notify": {

--- a/core/kazoo_documents/src/kz_account.erl
+++ b/core/kazoo_documents/src/kz_account.erl
@@ -45,6 +45,7 @@
         ,sent_initial_registration/1, set_initial_registration_sent/2
         ,sent_initial_call/1, set_initial_call_sent/2
         ,home_zone/1, home_zone/2, set_home_zone/2
+        ,update_presence_on_call_forward/1, update_presence_on_call_forward/2, set_update_presence_on_call_forward/2
         ]).
 
 -include("kz_documents.hrl").
@@ -77,6 +78,7 @@
 -define(TOPUP_THRESHOLD, [<<"topup">>, <<"threshold">>]).
 -define(SENT_INITIAL_REGISTRATION, [<<"notifications">>, <<"first_occurrence">>, <<"sent_initial_registration">>]).
 -define(SENT_INITIAL_CALL, [<<"notifications">>, <<"first_occurrence">>, <<"sent_initial_call">>]).
+-define(UPDATE_PRESENCE_ON_CALL_FORWARD, <<"update_presence_on_call_forward">>).
 
 -define(PVT_TYPE, <<"account">>).
 
@@ -711,3 +713,28 @@ fax_settings(JObj) ->
         'undefined' -> kz_json:set_value(?FAX_TIMEZONE_KEY, timezone(JObj), FaxSettings);
         _ -> FaxSettings
     end.
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Should the presence state for users under this account change when
+%% callforwarding is toggled?
+%% @end
+%%--------------------------------------------------------------------
+-spec update_presence_on_call_forward(doc()) -> api_object().
+-spec update_presence_on_call_forward(doc(), Default) -> kz_json:object() | Default.
+update_presence_on_call_forward(JObj) ->
+    update_presence_on_call_forward(JObj, 'false').
+update_presence_on_call_forward(JObj, Default) ->
+    kz_json:is_true(?UPDATE_PRESENCE_ON_CALL_FORWARD, JObj, Default).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @see update_presence_on_call_forward/1
+%% @end
+%%--------------------------------------------------------------------
+-spec set_update_presence_on_call_forward(doc(), boolean()) -> doc().
+set_update_presence_on_call_forward(JObj, Should) ->
+    kz_json:set_value(?UPDATE_PRESENCE_ON_CALL_FORWARD, Should, JObj).

--- a/core/kazoo_documents/src/kzd_user.erl
+++ b/core/kazoo_documents/src/kzd_user.erl
@@ -21,6 +21,7 @@
         ,fax_settings/1
         ,name/1, first_name/1, last_name/1
         ,priv_level/1, priv_level/2
+        ,call_forward_enabled/1, call_forward_enabled/2
         ]).
 
 -include("kz_documents.hrl").
@@ -36,6 +37,7 @@
 -define(KEY_FIRST_NAME, <<"first_name">>).
 -define(KEY_LAST_NAME, <<"last_name">>).
 -define(KEY_PRIV_LEVEL, <<"priv_level">>).
+-define(KEY_CALL_FORWARD_ENABLED, [<<"call_forward">>, <<"enabled">>]).
 
 -define(PVT_TYPE, <<"user">>).
 
@@ -311,3 +313,10 @@ priv_level(Doc) ->
     priv_level(Doc, <<"user">>).
 priv_level(Doc, Default) ->
     kz_json:get_binary_value(?KEY_PRIV_LEVEL, Doc, Default).
+
+-spec call_forward_enabled(doc()) -> api_binary().
+-spec call_forward_enabled(doc(), Default) -> ne_binary() | Default.
+call_forward_enabled(Doc) ->
+    call_forward_enabled(Doc, 'false').
+call_forward_enabled(Doc, Default) ->
+    kz_json:is_true(?KEY_CALL_FORWARD_ENABLED, Doc, Default).


### PR DESCRIPTION
When a user sets call forwarding to on the BLF should show busy. 
When a user sets call forwarding to off the BLF should show available.
This is configurable on the account level, defaulting to off.

I would have preferred to have implemented this in a separate app listening to user document changes to reduce code duplication, but I don't know of a way to figure out if a field was toggled this way.