### PR TITLE
KAZOO-5335: Teletype customer_update enhancement

### DIFF
--- a/applications/crossbar/doc/notifications.md
+++ b/applications/crossbar/doc/notifications.md
@@ -586,3 +586,32 @@ You can send a message with changed subject, html and plain text templates by pr
     }
 }
 ```
+
+To send an update to a customer from your kapp, you can build payload including you apps data (see <<"DataBag">> field) and send it over amqp using predefined particular template (see <<"Template-ID">> field) or your own hardcoded templates (see <<"HTML">> and <<"Text">> fields):
+
+```
+-spec send_account_update(ne_binary()) -> 'ok'.
+send_account_update(AccountId) ->
+    case kz_amqp_worker:call(build_customer_update_payload(AccountId)
+                            ,fun kapi_notifications:publish_customer_update/1
+                            ,fun kapi_notifications:customer_update_v/1
+                            )
+    of
+        {'ok', _Resp} ->
+            lager:debug("published customer_update notification");
+        {'error', _E} ->
+            lager:debug("failed to publish_customer update notification: ~p", [_E])
+    end.
+
+-spec build_customer_update_payload(cb_context:context()) -> kz_proplist().
+build_customer_update_payload(AccountId) ->
+    props:filter_empty(
+      [{<<"Account-ID">>, kz_services:find_reseller_id(AccountId)}
+      ,{<<"Recipient-ID">>, AccountId}
+      ,{<<"Template-ID">>, <<"customer_update_billing_period">>}
+      ,{<<"DataBag">>, {[{<<"field1">>,<<"value1">>},{<<"field2">>,{[{<<"subfield1">>,<<"subvalue1">>},{<<"subfield2">>,<<"subvalue2">>}]}}]}}
+      ,{<<"HTML">>, base64:encode(<<"Dear {{user.first_name}} {{user.last_name}}. <br /> DataBag test: {{databag.field2.subfield1}} <br /> Kind regards,">>)}
+      ,{<<"Text">>, <<"Oh Dear {{user.first_name}} {{user.last_name}}.\n\nDataBag test: {{databag.field2.subfield2}}\n\nBest regards,">>}
+       | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+      ]).
+```

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -383,6 +383,9 @@ post(Context, ?CUSTOMER_UPDATE, ?MESSAGE) ->
             crossbar_util:response('error', <<"Failed to send message">>, Context)
     end;
 
+post(Context, <<"customer_update_", _/binary>>, ?PREVIEW) ->
+    post(Context, ?CUSTOMER_UPDATE, ?PREVIEW);
+
 post(Context, Id, ?PREVIEW) ->
     Notification = cb_context:doc(Context),
     Preview = build_preview_payload(Context, Notification),
@@ -425,7 +428,8 @@ build_customer_update_payload(Context) ->
 -spec build_preview_payload(cb_context:context(), kz_json:object()) -> kz_proplist().
 build_preview_payload(Context, Notification) ->
     props:filter_empty(
-      [{<<"To">>, kz_json:get_value(<<"to">>, Notification)}
+      [{<<"Template-ID">>, kz_json:get_value(<<"id">>, Notification)}
+      ,{<<"To">>, kz_json:get_value(<<"to">>, Notification)}
       ,{<<"From">>, kz_json:get_value(<<"from">>, Notification)}
       ,{<<"Cc">>, kz_json:get_value(<<"cc">>, Notification)}
       ,{<<"Bcc">>, kz_json:get_value(<<"bcc">>, Notification)}

--- a/applications/teletype/src/templates/teletype_customer_update.erl
+++ b/applications/teletype/src/templates/teletype_customer_update.erl
@@ -32,6 +32,7 @@
 -define(TEMPLATE_SUBJECT, <<"Customer update">>).
 -define(TEMPLATE_CATEGORY, <<"user">>).
 -define(TEMPLATE_NAME, <<"Customer update">>).
+-define(THIRD_PARTY_DATA, <<"databag">>).
 
 -define(TEMPLATE_TO, ?CONFIGURED_EMAILS(?EMAIL_ORIGINAL)).
 -define(TEMPLATE_FROM, teletype_util:default_from_address(?MOD_CONFIG_CAT)).
@@ -110,8 +111,9 @@ select_users_to_update(Users, DataJObj) ->
 send_update_to_user(UserJObj, DataJObj) ->
     Macros = [{<<"system">>, teletype_util:system_params()}
              ,{<<"account">>, teletype_util:account_params(DataJObj)}
-              | build_macro_data(UserJObj, DataJObj)
-             ],
+             ]
+        ++ build_macro_data(UserJObj, DataJObj)
+        ++ [{?THIRD_PARTY_DATA, kz_json:get_value(?THIRD_PARTY_DATA, DataJObj, kz_json:new())}],
 
     RenderedTemplates = teletype_templates:render(?TEMPLATE_ID, Macros, DataJObj, 'true'),
     {'ok', TemplateMetaJObj} = teletype_templates:fetch_notification(?TEMPLATE_ID, teletype_util:find_account_id(DataJObj)),

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -522,6 +522,7 @@
 -define(OPTIONAL_CUSTOMER_UPDATE_HEADERS, [<<"Recipient-ID">>
                                           ,<<"User-Type">>
                                           ,<<"DataBag">>
+                                          ,<<"Template-ID">>
                                                | ?DEFAULT_OPTIONAL_HEADERS
                                           ]).
 -define(CUSTOMER_UPDATE_VALUES, [{<<"Event-Category">>, <<"notification">>}

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -521,6 +521,7 @@
 -define(CUSTOMER_UPDATE_HEADERS, [<<"Account-ID">>]).
 -define(OPTIONAL_CUSTOMER_UPDATE_HEADERS, [<<"Recipient-ID">>
                                           ,<<"User-Type">>
+                                          ,<<"DataBag">>
                                                | ?DEFAULT_OPTIONAL_HEADERS
                                           ]).
 -define(CUSTOMER_UPDATE_VALUES, [{<<"Event-Category">>, <<"notification">>}


### PR DESCRIPTION
As a kapp developer I would like to be able to send different updates form my app to customer(s) with the information generated in my kapp.

In order to do that I need to be able to:

- manage multiple templates for notification emails of customer_update type, e.g. "new billing period approaching", "Happy New Year", etc;
- provide these templates with data generated by my kapp during template compilation;
- use existing customer_update mechanism in order to not to create teletype modules again and again