### PR TITLE
Allow number port transition from submitted to scheduled

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -457,6 +457,7 @@
     "notify.voicemail_to_email.html_content_transfer_encoding": "notify.voicemail_to_email html content transfer encoding",
     "notify.voicemail_to_email.text_content_transfer_encoding": "notify.voicemail_to_email text content transfer encoding",
     "number_manager.allow": "Number features a number is allowed to enable or disable",
+    "number_manager.allow_port_transition_from_submitted_to_scheduled": "Should number ports be allowed to transition from submitted to scheduled?",
     "number_manager.available_module_name": "number_manager available module name",
     "number_manager.bandwidth.debug": "number_manager.bandwidth debug",
     "number_manager.bandwidth.developer_key": "number_manager.bandwidth developer key",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -10373,6 +10373,11 @@
         "system_config.number_manager": {
             "description": "Schema for number_manager system_config",
             "properties": {
+                "allow_port_transition_from_submitted_to_scheduled": {
+                    "default": false,
+                    "description": "Should number ports be allowed to transition from submitted to scheduled?",
+                    "type": "boolean"
+                },
                 "available_module_name": {
                     "default": "knm_local",
                     "description": "number_manager available module name",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.json
@@ -3,6 +3,11 @@
     "_id": "system_config.number_manager",
     "description": "Schema for number_manager system_config",
     "properties": {
+        "allow_port_transition_from_submitted_to_scheduled": {
+            "default": false,
+            "description": "Should number ports be allowed to transition from submitted to scheduled?",
+            "type": "boolean"
+        },
         "available_module_name": {
             "default": "knm_local",
             "description": "number_manager available module name",

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -187,7 +187,15 @@ transition_to_pending(JObj) ->
     transition(JObj, [?PORT_SUBMITTED], ?PORT_PENDING).
 
 transition_to_scheduled(JObj) ->
-    transition(JObj, [?PORT_PENDING], ?PORT_SCHEDULED).
+    FromSubmitted = kapps_config:get_is_true(?KNM_CONFIG_CAT
+                                            ,<<"allow_port_transition_from_submitted_to_scheduled">>
+                                            ,'false'),
+    transition(JObj, states_to_scheduled(FromSubmitted), ?PORT_SCHEDULED).
+
+states_to_scheduled(_AllowFromSubmitted='false') ->
+    [?PORT_PENDING];
+states_to_scheduled(_AllowFromSubmitted='true') ->
+    [?PORT_SUBMITTED | states_to_scheduled('false')].
 
 transition_to_complete(JObj) ->
     case transition(JObj, [?PORT_PENDING, ?PORT_SCHEDULED, ?PORT_REJECTED], ?PORT_COMPLETED) of


### PR DESCRIPTION
This is disabled by default. Can be enabled by setting "allow_port_transition_from_submitted_to_scheduled" in system_config/number_manager to true.