### PR TITLE
ts_bridged: handle return when channel is bridged

### DIFF
--- a/applications/trunkstore/src/ts_from_onnet.erl
+++ b/applications/trunkstore/src/ts_from_onnet.erl
@@ -194,7 +194,6 @@ send_offnet(State, Command) ->
 
 wait_for_bridge(State, CtlQ, Timeout) ->
     case ts_callflow:wait_for_bridge(State, Timeout) of
-        {'done', _} -> lager:info("channel bridged, we're done here");
         {'bridged', _} -> lager:info("channel bridged, we're done here");
         {'hangup', _} -> ts_callflow:send_hangup(State);
         {'error', #ts_callflow_state{aleg_callid='undefined'}} -> 'ok';

--- a/applications/trunkstore/src/ts_from_onnet.erl
+++ b/applications/trunkstore/src/ts_from_onnet.erl
@@ -195,6 +195,7 @@ send_offnet(State, Command) ->
 wait_for_bridge(State, CtlQ, Timeout) ->
     case ts_callflow:wait_for_bridge(State, Timeout) of
         {'done', _} -> lager:info("channel bridged, we're done here");
+        {'bridged', _} -> lager:info("channel bridged, we're done here");
         {'hangup', _} -> ts_callflow:send_hangup(State);
         {'error', #ts_callflow_state{aleg_callid='undefined'}} -> 'ok';
         {'error', #ts_callflow_state{aleg_callid=CallId}=State1} ->


### PR DESCRIPTION
@k-anderson fixed. I guess I named the variable in `ts_callflow` `Done` and matched on `{done, _}` instead of the actual tagged tuple `{bridged, _}`.