### PR TITLE
Allow user to log in or out of ring group

### DIFF
--- a/applications/callflow/doc/ring_group_toggle.md
+++ b/applications/callflow/doc/ring_group_toggle.md
@@ -1,0 +1,17 @@
+
+# Ring Group Toggle
+
+Ring Group Toggle allows a user to log in and out of a ring group dynamically.
+
+```
+"data": {
+    "action": ACTION,
+    "callflow_id": CALLFLOW_ID
+}
+```
+
+The `ACTION` is what the callflow element should do. Possible values are `login` and `logout`.
+`login` will set the `disable_until` field to `0` on the user's endpoint for the ring group
+found in the callflow specified by `CALLFLOW_ID`. This will have the effect of logging the user
+into the ring group. `logout` will set the `disable_until` field to a time well in the future,
+having the effect of logging the user out.

--- a/applications/callflow/src/module/cf_log_in_out_ring_group.erl
+++ b/applications/callflow/src/module/cf_log_in_out_ring_group.erl
@@ -1,0 +1,91 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% Logs a user in or out of a ring group
+%%% @end
+%%% @contributors
+%%%   Max Lay
+%%%-------------------------------------------------------------------
+-module(cf_log_in_out_ring_group).
+
+-behaviour(gen_cf_action).
+
+-include("callflow.hrl").
+
+-export([handle/2]).
+
+-define(ON_VAL, 0).
+-define(DEFAULT_OFF_VAL, 66269664000).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Entry point for this module, attempts to call an endpoint as defined
+%% in the Data payload.  Returns continue if fails to connect or
+%% stop when successfull.
+%% @end
+%%--------------------------------------------------------------------
+-spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
+handle(Data, Call) ->
+    _ = kapps_call_command:answer(Call),
+    CallflowId = kz_json:get_value(<<"callflow_id">>, Data),
+    DisableUntil = case kz_json:is_true(<<"login">>, Data) of
+                       'true' -> ?ON_VAL;
+                       'false' -> ?DEFAULT_OFF_VAL
+                   end,
+    AccountDb = kapps_call:account_db(Call),
+    {'ok', Callflow} = kz_datamgr:open_doc(AccountDb, CallflowId),
+    UpdatedFlow = find_and_change_ring_group(kz_json:get_value(<<"flow">>, Callflow), Call, DisableUntil),
+    kz_datamgr:save_doc(AccountDb, kz_json:set_value(<<"flow">>, UpdatedFlow, Callflow)),
+    lager:debug("updated flow from ~p to ~p", [kz_json:encode(Callflow), kz_json:encode(UpdatedFlow)]),
+    cf_exe:continue(Call).
+
+-spec find_and_change_ring_group(kz_json:object(), kapps_call:call(), integer()) -> kz_json:object().
+find_and_change_ring_group(Module, Call, DisableUntil) ->
+    NewModule = case kz_json:get_value(<<"module">>, Module) of
+                    <<"ring_group">> -> alter_endpoints(Module, Call, DisableUntil);
+                    _ -> Module
+                end,
+    case kz_json:get_value(<<"children">>, NewModule) of
+        'undefined' -> NewModule;
+        Children -> kz_json:set_value(<<"children">>, maybe_modify_children(Children, Call, DisableUntil), NewModule)
+    end.
+
+-spec maybe_modify_children(kz_json:object(), kapps_call:call(), integer()) -> kz_json:object().
+maybe_modify_children(Children, Call, DisableUntil) ->
+    lists:foldl(fun(Key, JObj) ->
+                        SubModule = find_and_change_ring_group(kz_json:get_value(Key, JObj), Call, DisableUntil),
+                        kz_json:set_value(Key, SubModule, JObj)
+                end, Children, kz_json:get_keys(Children)).
+
+-spec alter_endpoints(kz_json:object(), kapps_call:call(), integer()) -> kz_json:object().
+alter_endpoints(Module, Call, DisableUntil) ->
+    EndpointsPath = [<<"data">>, <<"endpoints">>],
+    OldEndpoints = kz_json:get_value(EndpointsPath, Module),
+    {Found, EndPoints} = lists:foldl(fun(Endpoint, {Found, UpdatedEndpoints}) ->
+                                             {ThisFound, Res} = maybe_alter_disable_until(kz_json:get_value(<<"endpoint_type">>, Endpoint), Endpoint, Call, DisableUntil),
+                                             {Found or ThisFound, [Res | UpdatedEndpoints]}
+                                     end, {'false', []}, OldEndpoints),
+    Media = case {Found, DisableUntil} of
+                {'false', _} ->
+                    %% User not found
+                    kz_media_util:get_prompt(<<"agent-invalid_choice">>, Call);
+                {'true', ?ON_VAL} ->
+                    kz_media_util:get_prompt(<<"agent-logged_in">>, Call);
+                {'true', _} ->
+                    kz_media_util:get_prompt(<<"agent-logged_out">>, Call)
+            end,
+    kapps_call_command:play(Media, Call),
+    kz_json:set_value(EndpointsPath, EndPoints, Module).
+
+-spec maybe_alter_disable_until(ne_binary(), kz_json:object(), kapps_call:call(), integer()) -> {boolean(), kz_json:object()}.
+maybe_alter_disable_until(<<"user">>, Endpoint, Call, DisableUntil) ->
+    lager:debug("comparing owner ~p, to endpoint ~p", [kapps_call:owner_id(Call), Endpoint]),
+    case kapps_call:owner_id(Call) =:= kz_json:get_value(<<"id">>, Endpoint) of
+        'true' ->
+            {'true', kz_json:set_value([<<"disable_until">>], DisableUntil, Endpoint)};
+        'false' ->
+            {'false', Endpoint}
+    end;
+
+maybe_alter_disable_until(_EndpointType, Endpoint, _Call, _DisableUntil) ->
+    {'false', Endpoint}.

--- a/applications/callflow/src/module/cf_ring_group.erl
+++ b/applications/callflow/src/module/cf_ring_group.erl
@@ -134,8 +134,8 @@ start_builder(EndpointId, Member, Call) ->
       end
      ).
 
--spec member_active(kz_json:object()) -> boolean().
-member_active(Member) ->
+-spec is_member_active(kz_json:object()) -> boolean().
+is_member_active(Member) ->
     DisableUntil = kz_json:get_value(<<"disable_until">>, Member, 0),
     calendar:datetime_to_gregorian_seconds(calendar:universal_time()) > DisableUntil.
 
@@ -148,7 +148,7 @@ member_active(Member) ->
 -spec resolve_endpoint_ids(kz_json:object(), kapps_call:call()) -> endpoints().
 resolve_endpoint_ids(Data, Call) ->
     Members = kz_json:get_value(<<"endpoints">>, Data, []),
-    FilteredMembers = lists:filter(fun member_active/1, Members),
+    FilteredMembers = lists:filter(fun is_member_active/1, Members),
     lager:debug("filtered members of ring group ~p", [FilteredMembers]),
     ResolvedEndpoints = resolve_endpoint_ids(FilteredMembers, [], Data, Call),
 

--- a/applications/callflow/src/module/cf_ring_group.erl
+++ b/applications/callflow/src/module/cf_ring_group.erl
@@ -134,6 +134,11 @@ start_builder(EndpointId, Member, Call) ->
       end
      ).
 
+-spec member_active(kz_json:object()) -> boolean().
+member_active(Member) ->
+    DisableUntil = kz_json:get_value(<<"disable_until">>, Member, 0),
+    calendar:datetime_to_gregorian_seconds(calendar:universal_time()) > DisableUntil.
+
 -type endpoint() :: {ne_binary(), kz_json:object()}.
 -type endpoints() :: [endpoint()].
 
@@ -143,7 +148,9 @@ start_builder(EndpointId, Member, Call) ->
 -spec resolve_endpoint_ids(kz_json:object(), kapps_call:call()) -> endpoints().
 resolve_endpoint_ids(Data, Call) ->
     Members = kz_json:get_value(<<"endpoints">>, Data, []),
-    ResolvedEndpoints = resolve_endpoint_ids(Members, [], Data, Call),
+    FilteredMembers = lists:filter(fun member_active/1, Members),
+    lager:debug("filtered members of ring group ~p", [FilteredMembers]),
+    ResolvedEndpoints = resolve_endpoint_ids(FilteredMembers, [], Data, Call),
 
     FilteredEndpoints = [{Weight, {Id, kz_json:set_value(<<"source">>, kz_term:to_binary(?MODULE), Member)}}
                          || {Type, Id, Weight, Member} <- ResolvedEndpoints,

--- a/applications/callflow/src/module/cf_ring_group_toggle.erl
+++ b/applications/callflow/src/module/cf_ring_group_toggle.erl
@@ -5,7 +5,7 @@
 %%% @contributors
 %%%   Max Lay
 %%%-------------------------------------------------------------------
--module(cf_log_in_out_ring_group).
+-module(cf_ring_group_toggle).
 
 -behaviour(gen_cf_action).
 
@@ -13,8 +13,12 @@
 
 -export([handle/2]).
 
+%% 0000 00:00:00
 -define(ON_VAL, 0).
+%% 2100 00:00:00
 -define(DEFAULT_OFF_VAL, 66269664000).
+
+-define(MAX_SAVE_RETRIES, 3).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -27,35 +31,51 @@
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
     _ = kapps_call_command:answer(Call),
-    CallflowId = kz_json:get_value(<<"callflow_id">>, Data),
-    DisableUntil = case kz_json:is_true(<<"login">>, Data) of
-                       'true' -> ?ON_VAL;
-                       'false' -> ?DEFAULT_OFF_VAL
+    CallflowId = kz_json:get_ne_binary_value(<<"callflow_id">>, Data),
+    DisableUntil = case kz_json:get_ne_binary_value(<<"action">>, Data) of
+                       <<"login">> -> ?ON_VAL;
+                       <<"logout">> -> ?DEFAULT_OFF_VAL
                    end,
     AccountDb = kapps_call:account_db(Call),
-    {'ok', Callflow} = kz_datamgr:open_doc(AccountDb, CallflowId),
-    UpdatedFlow = find_and_change_ring_group(kz_json:get_value(<<"flow">>, Callflow), Call, DisableUntil),
-    kz_datamgr:save_doc(AccountDb, kz_json:set_value(<<"flow">>, UpdatedFlow, Callflow)),
-    lager:debug("updated flow from ~p to ~p", [kz_json:encode(Callflow), kz_json:encode(UpdatedFlow)]),
+    {'ok', Callflow} = kz_datamgr:open_cache_doc(AccountDb, CallflowId),
+    UpdatedFlow = find_and_change_ring_group(kzd_callflow:flow(Callflow), Call, DisableUntil),
+    save_callflow(AccountDb, kzd_callflow:set_flow(UpdatedFlow, Callflow)),
     cf_exe:continue(Call).
 
+save_callflow(AccountDb, Callflow) ->
+    save_callflow(AccountDb, Callflow, ?MAX_SAVE_RETRIES).
+save_callflow(_AccountDb, Callflow, -1) ->
+    lager:error("failed to update callflow to ~p", [kz_json:encode(Callflow)]);
+save_callflow(AccountDb, Callflow, Retries) ->
+    case kz_datamgr:save_doc(AccountDb, Callflow) of
+        {'error', 'conflict'} ->
+            save_callflow(AccountDb, Callflow, Retries);
+        {'error', _} ->
+            save_callflow(AccountDb, Callflow, Retries - 1);
+        {'ok', _} ->
+            lager:debug("updated flow to ~p", [kz_json:encode(Callflow)])
+    end.
+
 -spec find_and_change_ring_group(kz_json:object(), kapps_call:call(), integer()) -> kz_json:object().
-find_and_change_ring_group(Module, Call, DisableUntil) ->
-    NewModule = case kz_json:get_value(<<"module">>, Module) of
-                    <<"ring_group">> -> alter_endpoints(Module, Call, DisableUntil);
-                    _ -> Module
+find_and_change_ring_group(Action, Call, DisableUntil) ->
+    NewAction = case kz_json:get_binary_value(<<"module">>, Action) of
+                    <<"ring_group">> -> alter_endpoints(Action, Call, DisableUntil);
+                    _ -> Action
                 end,
-    case kz_json:get_value(<<"children">>, NewModule) of
-        'undefined' -> NewModule;
-        Children -> kz_json:set_value(<<"children">>, maybe_modify_children(Children, Call, DisableUntil), NewModule)
+    case kz_json:get_value(<<"children">>, NewAction) of
+        'undefined' -> NewAction;
+        Children -> kz_json:set_value(<<"children">>, maybe_modify_children(Children, Call, DisableUntil), NewAction)
     end.
 
 -spec maybe_modify_children(kz_json:object(), kapps_call:call(), integer()) -> kz_json:object().
 maybe_modify_children(Children, Call, DisableUntil) ->
-    lists:foldl(fun(Key, JObj) ->
-                        SubModule = find_and_change_ring_group(kz_json:get_value(Key, JObj), Call, DisableUntil),
-                        kz_json:set_value(Key, SubModule, JObj)
-                end, Children, kz_json:get_keys(Children)).
+    kz_json:foldl(fun(Branch, ChildAction, JObj) ->
+        SubModule = find_and_change_ring_group(ChildAction, Call, DisableUntil),
+        kz_json:set_value(Branch, SubModule, JObj)
+    end
+    ,Children
+    ,Children
+    ).
 
 -spec alter_endpoints(kz_json:object(), kapps_call:call(), integer()) -> kz_json:object().
 alter_endpoints(Module, Call, DisableUntil) ->
@@ -80,7 +100,7 @@ alter_endpoints(Module, Call, DisableUntil) ->
 -spec maybe_alter_disable_until(ne_binary(), kz_json:object(), kapps_call:call(), integer()) -> {boolean(), kz_json:object()}.
 maybe_alter_disable_until(<<"user">>, Endpoint, Call, DisableUntil) ->
     lager:debug("comparing owner ~p, to endpoint ~p", [kapps_call:owner_id(Call), Endpoint]),
-    case kapps_call:owner_id(Call) =:= kz_json:get_value(<<"id">>, Endpoint) of
+    case kapps_call:owner_id(Call) =:= kz_json:get_binary_value(<<"id">>, Endpoint) of
         'true' ->
             {'true', kz_json:set_value([<<"disable_until">>], DisableUntil, Endpoint)};
         'false' ->

--- a/applications/callflow/src/module/cf_ring_group_toggle.erl
+++ b/applications/callflow/src/module/cf_ring_group_toggle.erl
@@ -70,12 +70,12 @@ find_and_change_ring_group(Action, Call, DisableUntil) ->
 -spec maybe_modify_children(kz_json:object(), kapps_call:call(), integer()) -> kz_json:object().
 maybe_modify_children(Children, Call, DisableUntil) ->
     kz_json:foldl(fun(Branch, ChildAction, JObj) ->
-        SubModule = find_and_change_ring_group(ChildAction, Call, DisableUntil),
-        kz_json:set_value(Branch, SubModule, JObj)
-    end
-    ,Children
-    ,Children
-    ).
+                          SubModule = find_and_change_ring_group(ChildAction, Call, DisableUntil),
+                          kz_json:set_value(Branch, SubModule, JObj)
+                  end
+                 ,Children
+                 ,Children
+                 ).
 
 -spec alter_endpoints(kz_json:object(), kapps_call:call(), integer()) -> kz_json:object().
 alter_endpoints(Module, Call, DisableUntil) ->

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1533,20 +1533,6 @@
             "required": true,
             "type": "object"
         },
-        "callflows.log_in_out_ring_group": {
-            "description": "Skeleton JSON schema",
-            "properties": {
-                "callflow_id": {
-                    "description": ""
-                },
-                "login": {
-                    "description": "",
-                    "type": "boolean"
-                }
-            },
-            "required": true,
-            "type": "object"
-        },
         "callflows.lookupcidname": {
             "description": "Validator for the Lookup callflow element",
             "properties": {
@@ -2140,6 +2126,27 @@
                     "description": "How long to ring the ring group before continuing, in seconds",
                     "required": false,
                     "type": "integer"
+                }
+            },
+            "required": true,
+            "type": "object"
+        },
+        "callflows.ring_group_toggle": {
+            "description": "Validator for the ring_group_toggle callflow's data object",
+            "properties": {
+                "action": {
+                    "description": "What the module should do. Options are 'login' and 'logout'",
+                    "enum": [
+                        "login",
+                        "logout"
+                    ],
+                    "required": true,
+                    "type": "string"
+                },
+                "callflow_id": {
+                    "description": "The callflow containing the ring group to log in and out of",
+                    "required": true,
+                    "type": "string"
                 }
             },
             "required": true,

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1533,6 +1533,20 @@
             "required": true,
             "type": "object"
         },
+        "callflows.log_in_out_ring_group": {
+            "description": "Validator for the log_in_out_ring_group callflow's data object",
+            "properties": {
+                "callflow_id": {
+                    "description": ""
+                },
+                "login": {
+                    "description": "",
+                    "type": "boolean"
+                }
+            },
+            "required": true,
+            "type": "object"
+        },
         "callflows.lookupcidname": {
             "description": "Validator for the Lookup callflow element",
             "properties": {

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1534,7 +1534,7 @@
             "type": "object"
         },
         "callflows.log_in_out_ring_group": {
-            "description": "Validator for the log_in_out_ring_group callflow's data object",
+            "description": "Skeleton JSON schema",
             "properties": {
                 "callflow_id": {
                     "description": ""

--- a/applications/crossbar/priv/couchdb/schemas/callflows.ring_group_toggle.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.ring_group_toggle.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "_id": "callflows.ring_group_toggle",
+    "description": "Validator for the ring_group_toggle callflow's data object",
+    "properties": {
+        "action": {
+            "description": "What the module should do. Options are 'login' and 'logout'",
+            "enum": [
+                "login",
+                "logout"
+            ],
+            "required": true,
+            "type": "string"
+        },
+        "callflow_id": {
+            "description": "The callflow containing the ring group to log in and out of",
+            "required": true,
+            "type": "string"
+        }
+    },
+    "required": true,
+    "type": "object"
+}


### PR DESCRIPTION
This pull request includes two changes.
The first is to allow endpoints in a ring group to log out of the group until a certain time.
The second is a callflow module that allows a user to log in and out of a ring group.

The works as follows:

1. The user sets up two callflows containing the log_in_out_ring_group element, one to log in ("login": true) and one to log out ("login": false) for a ring group. They could be on the same callflow with a menu. This callflow is linked to the ring group by the "callflow_id" field.
2. The user dials into the logout callflow. Kazoo recursively searches the callflow for ring groups which contain the user. The endpoints for the user are disabled until a long time in the future. The user is told that they are logged out.