### PR TITLE
KAZOO-5268: fix backward cid in loopback

### DIFF
--- a/applications/stepswitch/src/stepswitch_local_extension.erl
+++ b/applications/stepswitch/src/stepswitch_local_extension.erl
@@ -269,7 +269,7 @@ build_local_extension(#state{number_props=Props
                             ,resource_req=JObj
                             ,queue=Q
                             }) ->
-    {CIDNum, CIDName} = local_extension_caller_id(JObj),
+    {CIDName, CIDNum} = local_extension_caller_id(JObj),
     lager:debug("set outbound caller id to ~s '~s'", [CIDNum, CIDName]),
     Number = knm_number_options:number(Props),
     AccountId = knm_number_options:account_id(Props),

--- a/core/kazoo_endpoint/src/kz_privacy.erl
+++ b/core/kazoo_endpoint/src/kz_privacy.erl
@@ -192,14 +192,14 @@ hide_mode(?HIDE_NAME, ?HIDE_NAME) ->
     lager:info("overriding caller id name to maintain privacy"),
     ?HIDE_NAME;
 hide_mode(?HIDE_NAME, _HideMode) ->
-    lager:debug("not allowing ~s privacy mode", [_HideMode]),
-    ?NO_HIDE_MODE;
+    lager:debug("ignoring ccv's caller privacy hide number, just overriding caller id name", [_HideMode]),
+    ?HIDE_NAME;
 hide_mode(?HIDE_NUMBER, ?HIDE_NUMBER) ->
     lager:info("overriding caller id number to maintain privacy"),
     ?HIDE_NUMBER;
 hide_mode(?HIDE_NUMBER, _HideMode) ->
-    lager:debug("not allowing ~s privacy mode", [_HideMode]),
-    ?NO_HIDE_MODE.
+    lager:debug("ignoring ccv's caller privacy hide name, just overriding caller id number", [_HideMode]),
+    ?HIDE_NUMBER.
 
 -spec anonymize_cid(ne_binary(), cid(), ne_binary()) -> cid().
 anonymize_cid(_AccountId, Default, ?NO_HIDE_MODE) ->


### PR DESCRIPTION
Fix backward caller id for loopback calls introduce by previous privacy PR.

Plus better log line why ignoring caller privacy hide name/number and actually hide configured cid part