### PR TITLE
HELP-28312: include active port in numbers by default

### DIFF
--- a/applications/crossbar/priv/couchdb/views/port_requests.json
+++ b/applications/crossbar/priv/couchdb/views/port_requests.json
@@ -27,7 +27,7 @@
             "map": [
                 "function(doc) {",
                 "  if (doc.pvt_type !== 'port_request' || doc.pvt_deleted) return;",
-                "  if (doc.pvt_port_state === 'unconfirmed' || doc.pvt_port_state === 'canceled')",
+                "  if (doc.pvt_port_state === 'unconfirmed' || doc.pvt_port_state === 'canceled' || doc.pvt_port_state == 'completed')",
                 "    return;",
                 "  for (var i in doc.numbers) {",
                 "    var number = doc.numbers[i];",

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -514,8 +514,9 @@ fix_available(NumJObj) ->
     NewJObj = kz_json:set_value(<<"features_available">>, Allowed, JObj),
     kz_json:from_list([{Num, NewJObj}]).
 
+-spec should_include_ports(cb_context:context()) -> boolean().
 should_include_ports(Context) ->
-    kz_term:is_true(cb_context:req_value(Context, <<"include_ports">>)).
+    kz_term:is_true(cb_context:req_value(Context, <<"include_ports">>, 'true')).
 
 %% @private
 -spec maybe_add_port_request_numbers(cb_context:context()) -> kz_json:object().
@@ -543,7 +544,7 @@ maybe_add_port_request_numbers(Context, 'true') ->
 %% @private
 -spec maybe_filter_port_number(kz_json:object(), cb_context:context(), boolean()) ->
                                       boolean().
-maybe_filter_port_number(_Port, _Context, 'false') -> 'false';
+maybe_filter_port_number(_Port, _Context, 'false') -> 'true';
 maybe_filter_port_number(Port, Context, 'true') ->
     crossbar_doc:filtered_doc_by_qs(kz_json:get_value(<<"value">>, Port), Context).
 


### PR DESCRIPTION
Conflicts:
	applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl