### PR TITLE
Add Billing-Number custom sip header

### DIFF
--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -269,6 +269,7 @@ update_ccvs(Call) ->
               [{<<"Hold-Media">>, kz_attributes:moh_attributes(<<"media_id">>, Call)}
               ,{<<"Caller-ID-Name">>, CIDName}
               ,{<<"Caller-ID-Number">>, CIDNumber}
+              ,{<<"X-Billing-Number">>, CIDNumber}
                | get_incoming_security(Call)
               ]),
     kapps_call:set_custom_channel_vars(Props, Call).

--- a/applications/ecallmgr/src/ecallmgr.hrl
+++ b/applications/ecallmgr/src/ecallmgr.hrl
@@ -303,6 +303,7 @@
                               ,{<<"Conference-Exit-Sound">>, <<"conference_exit_sound">>}
                               ,{<<"SIP-Refer-To">>, <<"sip_refer_to">>}
                               ,{<<"SIP-Referred-By">>, <<"sip_h_Referred-By">>}
+                              ,{<<"X-Billing-Number">>, <<"sip_h_X-Billing-Number">>}
                               ]).
 
 %% [{FreeSWITCH-App-Name, Kazoo-App-Name}]


### PR DESCRIPTION
We require this field to bill our calls. This allows us to report calls by extension at the carrier side.