### PR TITLE
skip keys that are function calls

### DIFF
--- a/core/kazoo_ast/src/cf_data_usage.erl
+++ b/core/kazoo_ast/src/cf_data_usage.erl
@@ -314,6 +314,10 @@ process_mfa(#usage{data_var_name=DataName}=Acc
            ,'kz_json', 'set_value', [_Key, _Value, ?VAR(DataName)]
            ) ->
     Acc;
+process_mfa(#usage{}=Acc
+           ,'kz_json', _F, [{call, _, _, _}=_Key|_]
+           ) ->
+    Acc;
 process_mfa(#usage{data_var_name=DataName
                   ,usages=Usages
                   }=Acc


### PR DESCRIPTION
cf_data_usage looks for kz_json:get_value(K,V) pattern,
in case K is a function call (e.g. kz_json:get_value(fun(), V) it fails because of missing clause,
and here is a fix for this clause.