### PR TITLE
Send fax failure notification in more circumstances

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -10502,6 +10502,7 @@
                         "teletype_fax_inbound_error_to_email",
                         "teletype_fax_inbound_to_email",
                         "teletype_fax_outbound_error_to_email",
+                        "teletype_fax_outbound_smtp_error_to_email",
                         "teletype_fax_outbound_to_email",
                         "teletype_first_occurrence",
                         "teletype_low_balance",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.json
@@ -13,6 +13,7 @@
                 "teletype_fax_inbound_error_to_email",
                 "teletype_fax_inbound_to_email",
                 "teletype_fax_outbound_error_to_email",
+                "teletype_fax_outbound_smtp_error_to_email",
                 "teletype_fax_outbound_to_email",
                 "teletype_first_occurrence",
                 "teletype_low_balance",

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -39,7 +39,7 @@
                ,from :: api_ne_binary()
                ,to :: api_ne_binary()
                ,doc :: kz_json:object()
-               ,filename :: file:filename_all()
+               ,filename :: api_ne_binary()
                ,content_type :: api_ne_binary()
                ,peer_ip :: peer()
                ,owner_id :: api_binary()

--- a/applications/teletype/src/templates/teletype_fax_outbound_smtp_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_smtp_error_to_email.erl
@@ -1,0 +1,99 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%   Max Lay
+%%%-------------------------------------------------------------------
+-module(teletype_fax_outbound_smtp_error_to_email).
+
+-export([init/0
+        ,handle_fax_outbound_smtp_error/1
+        ]).
+
+-include("../teletype.hrl").
+
+-define(TEMPLATE_ID, <<"fax_outbound_smtp_error_to_email">>).
+-define(MOD_CONFIG_CAT, <<(?NOTIFY_CONFIG_CAT)/binary, ".", (?TEMPLATE_ID)/binary>>).
+-define(FAX_CONFIG_CAT, <<(?NOTIFY_CONFIG_CAT)/binary, ".fax">>).
+
+-define(TEMPLATE_MACROS, kz_json:from_list([])).
+
+-define(TEMPLATE_TEXT, <<"Error sending fax to faxbox: {{error}}">>).
+-define(TEMPLATE_HTML, <<"<html><body>Error sending fax to faxbox: {{error}}</body></html>">>).
+-define(TEMPLATE_SUBJECT, <<"Error Sending Fax">>).
+-define(TEMPLATE_CATEGORY, <<"fax">>).
+-define(TEMPLATE_NAME, <<"Outbound Fax SMTP Error to Email">>).
+
+-define(TEMPLATE_FROM, teletype_util:default_from_address(?MOD_CONFIG_CAT)).
+-define(TEMPLATE_CC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
+-define(TEMPLATE_BCC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
+-define(TEMPLATE_REPLY_TO, teletype_util:default_reply_to(?MOD_CONFIG_CAT)).
+
+-spec init() -> 'ok'.
+init() ->
+    kz_util:put_callid(?MODULE),
+    teletype_templates:init(?TEMPLATE_ID, [{'macros', ?TEMPLATE_MACROS}
+                                          ,{'text', ?TEMPLATE_TEXT}
+                                          ,{'html', ?TEMPLATE_HTML}
+                                          ,{'subject', ?TEMPLATE_SUBJECT}
+                                          ,{'category', ?TEMPLATE_CATEGORY}
+                                          ,{'friendly_name', ?TEMPLATE_NAME}
+                                          ,{'from', ?TEMPLATE_FROM}
+                                          ,{'cc', ?TEMPLATE_CC}
+                                          ,{'bcc', ?TEMPLATE_BCC}
+                                          ,{'reply_to', ?TEMPLATE_REPLY_TO}
+                                          ]),
+    teletype_bindings:bind(<<"outbound_smtp_fax_error">>, ?MODULE, 'handle_fax_outbound_smtp_error').
+
+-spec handle_fax_outbound_smtp_error(kz_json:object()) -> 'ok'.
+handle_fax_outbound_smtp_error(JObj) ->
+    'true' = kapi_notifications:fax_outbound_smtp_error_v(JObj),
+    kz_util:put_callid(JObj),
+
+    lager:debug("processing fax outbound error to email"),
+
+    %% Gather data for template
+    DataJObj = kz_json:normalize(JObj),
+    AccountId = kz_json:get_value(<<"account_id">>, DataJObj),
+
+    case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
+        'false' -> lager:debug("notification handling not configured for this account");
+        'true' -> process_req(DataJObj)
+    end.
+
+-spec process_req(kz_json:object()) -> 'ok'.
+process_req(DataJObj) ->
+    Errors=[Error | _] = kz_json:get_value(<<"errors">>, DataJObj),
+    Macros = [{<<"errors">>, Errors}
+             ,{<<"error">>, Error}
+             ,{<<"to_email">>, kz_json:get_value(<<"fax_to_email">>, DataJObj)}
+             ,{<<"from_email">>, kz_json:get_value(<<"fax_from_email">>, DataJObj)}
+             ,{<<"account_id">>, kz_json:get_value(<<"account_id">>, DataJObj)}
+             ],
+
+    RenderedTemplates = teletype_templates:render(?TEMPLATE_ID, Macros, DataJObj),
+
+    {'ok', TemplateMetaJObj} = teletype_templates:fetch_notification(?TEMPLATE_ID, teletype_util:find_account_id(DataJObj)),
+
+    Subject = teletype_util:render_subject(
+                kz_json:find(<<"subject">>, [DataJObj, TemplateMetaJObj], ?TEMPLATE_SUBJECT)
+                                          ,Macros
+               ),
+
+    EmailsJObj =
+        case teletype_util:is_preview(DataJObj) of
+            'true' -> DataJObj;
+            'false' ->
+                kz_json:set_value(<<"to">>, [kz_json:get_value(<<"fax_from_email">>, DataJObj)], DataJObj)
+        end,
+
+    Emails = teletype_util:find_addresses(EmailsJObj
+                                         ,TemplateMetaJObj
+                                         ,?MOD_CONFIG_CAT
+                                         ),
+
+    case teletype_util:send_email(Emails, Subject, RenderedTemplates) of
+        'ok' -> teletype_util:send_update(DataJObj, <<"completed">>);
+        {'error', Reason} -> teletype_util:send_update(DataJObj, <<"failed">>, Reason)
+    end.

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -19,6 +19,7 @@
         ,fax_inbound_error/1, fax_inbound_error_v/1
         ,fax_outbound/1, fax_outbound_v/1
         ,fax_outbound_error/1, fax_outbound_error_v/1
+        ,fax_outbound_smtp_error/1, fax_outbound_smtp_error_v/1
         ,register/1, register_v/1
         ,deregister/1, deregister_v/1
         ,first_occurrence/1, first_occurrence_v/1
@@ -58,6 +59,7 @@
         ,publish_fax_outbound/1, publish_fax_outbound/2
         ,publish_fax_inbound_error/1, publish_fax_inbound_error/2
         ,publish_fax_outbound_error/1, publish_fax_outbound_error/2
+        ,publish_fax_outbound_smtp_error/1, publish_fax_outbound_smtp_error/2
         ,publish_register/1, publish_register/2
         ,publish_deregister/1, publish_deregister/2
         ,publish_first_occurrence/1, publish_first_occurrence/2
@@ -104,6 +106,7 @@
 -define(NOTIFY_FAX_OUTBOUND, <<"notifications.fax.outbound">>).
 -define(NOTIFY_FAX_INBOUND_ERROR, <<"notifications.fax.inbound_error">>).
 -define(NOTIFY_FAX_OUTBOUND_ERROR, <<"notifications.fax.outbound_error">>).
+-define(NOTIFY_FAX_OUTBOUND_SMTP_ERROR, <<"notifications.fax.outbound_smtp_error">>).
 -define(NOTIFY_DEREGISTER, <<"notifications.sip.deregister">>).
 -define(NOTIFY_FIRST_OCCURRENCE, <<"notifications.sip.first_occurrence">>).
 %%-define(NOTIFY_REGISTER_OVERWRITE, <<"notifications.sip.register_overwrite">>).
@@ -226,6 +229,18 @@
                                    ,{<<"Event-Name">>, <<"outbound_fax_error">>}
                                    ]).
 -define(FAX_OUTBOUND_ERROR_TYPES, []).
+
+-define(FAX_OUTBOUND_SMTP_ERROR_HEADERS, [<<"Fax-From-Email">>
+                                         ,<<"Errors">>
+                                         ,<<"Account-ID">>
+                                         ]).
+-define(OPTIONAL_FAX_OUTBOUND_SMTP_ERROR_HEADERS, [<<"Fax-To-Email">>
+                                                       | ?DEFAULT_OPTIONAL_HEADERS
+                                                  ]).
+-define(FAX_OUTBOUND_SMTP_ERROR_VALUES, [{<<"Event-Category">>, <<"notification">>}
+                                        ,{<<"Event-Name">>, <<"outbound_smtp_fax_error">>}
+                                        ]).
+-define(FAX_OUTBOUND_SMTP_ERROR_TYPES, []).
 
 %% Notify Deregister
 -define(DEREGISTER_HEADERS, [<<"Username">>, <<"Realm">>, <<"Account-ID">>]).
@@ -561,6 +576,8 @@ headers(<<"fax_outbound_to_email">>) ->
     ?FAX_OUTBOUND_HEADERS ++ ?OPTIONAL_FAX_OUTBOUND_HEADERS;
 headers(<<"fax_outbound_error_to_email">>) ->
     ?FAX_OUTBOUND_ERROR_HEADERS ++ ?OPTIONAL_FAX_OUTBOUND_ERROR_HEADERS;
+headers(<<"fax_outbound_smtp_error">>) ->
+    ?FAX_OUTBOUND_SMTP_ERROR_HEADERS ++ ?OPTIONAL_FAX_OUTBOUND_SMTP_ERROR_HEADERS;
 headers(<<"low_balance">>) ->
     ?LOW_BALANCE_HEADERS ++ ?OPTIONAL_LOW_BALANCE_HEADERS;
 headers(<<"new_account">>) ->
@@ -738,6 +755,24 @@ fax_outbound_error(JObj) -> fax_outbound_error(kz_json:to_proplist(JObj)).
 fax_outbound_error_v(Prop) when is_list(Prop) ->
     kz_api:validate(Prop, ?FAX_OUTBOUND_ERROR_HEADERS, ?FAX_OUTBOUND_ERROR_VALUES, ?FAX_OUTBOUND_ERROR_TYPES);
 fax_outbound_error_v(JObj) -> fax_outbound_error_v(kz_json:to_proplist(JObj)).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Takes proplist, creates JSON string or error
+%% @end
+%%--------------------------------------------------------------------
+-spec fax_outbound_smtp_error(api_terms()) -> api_formatter_return().
+fax_outbound_smtp_error(Prop) when is_list(Prop) ->
+    case fax_outbound_smtp_error_v(Prop) of
+        'true' -> kz_api:build_message(Prop, ?FAX_OUTBOUND_SMTP_ERROR_HEADERS, ?OPTIONAL_FAX_OUTBOUND_SMTP_ERROR_HEADERS);
+        'false' -> {'error', "Proplist failed validation for outbound_smtp_fax_error"}
+    end;
+fax_outbound_smtp_error(JObj) -> fax_outbound_smtp_error(kz_json:to_proplist(JObj)).
+
+-spec fax_outbound_smtp_error_v(api_terms()) -> boolean().
+fax_outbound_smtp_error_v(Prop) when is_list(Prop) ->
+    kz_api:validate(Prop, ?FAX_OUTBOUND_SMTP_ERROR_HEADERS, ?FAX_OUTBOUND_SMTP_ERROR_VALUES, ?FAX_OUTBOUND_SMTP_ERROR_TYPES);
+fax_outbound_smtp_error_v(JObj) -> fax_outbound_smtp_error_v(kz_json:to_proplist(JObj)).
 
 %%--------------------------------------------------------------------
 %% @doc Register (unregister is a key word) - see wiki
@@ -1229,6 +1264,7 @@ skel_v(JObj) -> skel_v(kz_json:to_proplist(JObj)).
                        'new_fax' |
                        'inbound_fax_error' |
                        'outbound_fax_error' |
+                       'outbound_smtp_fax_error' |
                        'fax_error' |
                        'register' |
                        'deregister' |
@@ -1290,6 +1326,9 @@ bind_to_q(Q, ['inbound_fax_error'|T]) ->
     bind_to_q(Q, T);
 bind_to_q(Q, ['outbound_fax_error'|T]) ->
     'ok' = amqp_util:bind_q_to_notifications(Q, ?NOTIFY_FAX_OUTBOUND_ERROR),
+    bind_to_q(Q, T);
+bind_to_q(Q, ['outbound_smtp_fax_error'|T]) ->
+    'ok' = amqp_util:bind_q_to_notifications(Q, ?NOTIFY_FAX_OUTBOUND_SMTP_ERROR),
     bind_to_q(Q, T);
 bind_to_q(Q, ['fax_error'|T]) ->
     'ok' = amqp_util:bind_q_to_notifications(Q, ?NOTIFY_FAX_INBOUND_ERROR),
@@ -1404,6 +1443,9 @@ unbind_q_from(Q, ['inbound_fax_error'|T]) ->
     unbind_q_from(Q, T);
 unbind_q_from(Q, ['outbound_fax_error'|T]) ->
     'ok' = amqp_util:unbind_q_from_notifications(Q,?NOTIFY_FAX_OUTBOUND_ERROR),
+    unbind_q_from(Q, T);
+unbind_q_from(Q, ['outbound_smtp_fax_error'|T]) ->
+    'ok' = amqp_util:unbind_q_from_notifications(Q,?NOTIFY_FAX_OUTBOUND_SMTP_ERROR),
     unbind_q_from(Q, T);
 unbind_q_from(Q, ['fax_error'|T]) ->
     'ok' = amqp_util:unbind_q_from_notifications(Q,?NOTIFY_FAX_OUTBOUND_ERROR),
@@ -1547,6 +1589,13 @@ publish_fax_outbound_error(JObj) -> publish_fax_outbound_error(JObj, ?DEFAULT_CO
 publish_fax_outbound_error(Fax, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Fax, ?FAX_OUTBOUND_ERROR_VALUES, fun fax_outbound_error/1),
     amqp_util:notifications_publish(?NOTIFY_FAX_OUTBOUND_ERROR, Payload, ContentType).
+
+-spec publish_fax_outbound_smtp_error(api_terms()) -> 'ok'.
+-spec publish_fax_outbound_smtp_error(api_terms(), ne_binary()) -> 'ok'.
+publish_fax_outbound_smtp_error(JObj) -> publish_fax_outbound_smtp_error(JObj, ?DEFAULT_CONTENT_TYPE).
+publish_fax_outbound_smtp_error(Fax, ContentType) ->
+    {'ok', Payload} = kz_api:prepare_api_payload(Fax, ?FAX_OUTBOUND_SMTP_ERROR_VALUES, fun fax_outbound_smtp_error/1),
+    amqp_util:notifications_publish(?NOTIFY_FAX_OUTBOUND_SMTP_ERROR, Payload, ContentType).
 
 -spec publish_register(api_terms()) -> 'ok'.
 -spec publish_register(api_terms(), ne_binary()) -> 'ok'.


### PR DESCRIPTION
Currently no failure message is sent by teletype if a fax fails for the following reasons:
- sender not authorised
- no attachment
- the number is invalid

In each case the sender should be notified by return email to explain why their fax has failed.