### PR TITLE
add type to cb_limits_v2 POST

### DIFF
--- a/applications/crossbar/src/modules_v2/cb_limits_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_limits_v2.erl
@@ -139,7 +139,7 @@ post(Context) ->
         fun() ->
                 crossbar_doc:save(Context)
         end,
-    crossbar_services:maybe_dry_run(Context, Callback).
+    crossbar_services:maybe_dry_run(Context, Callback, ?PVT_TYPE).
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
Otherwise I'm getting the next error:
Mar  2 09:57:56 sip 2600hz[2689]: |209a757fe601449e655c7fb47adb8596|kazoo_bindings:719 (<0.3915.0>) unable to find function clause for props:get_value(<<"type">>, undefined, undefined) in src/props.erl:103
Mar  2 09:57:56 sip 2600hz[2689]: |209a757fe601449e655c7fb47adb8596|kazoo_bindings:725 (<0.3915.0>) as part of cb_limits_v2:post/1
Mar  2 09:57:56 sip 2600hz[2689]: |209a757fe601449e655c7fb47adb8596|kazoo_bindings:726 (<0.3915.0>) st: {props,get_ne_binary_value,3,[{file,"src/props.erl"},{line,212}]}
Mar  2 09:57:56 sip 2600hz[2689]: |209a757fe601449e655c7fb47adb8596|kazoo_bindings:726 (<0.3915.0>) st: {crossbar_services,maybe_dry_run,3,[{file,"src/crossbar_services.erl"},{line,35}]}
Mar  2 09:57:56 sip 2600hz[2689]: |209a757fe601449e655c7fb47adb8596|kazoo_bindings:726 (<0.3915.0>) st: {kazoo_bindings,fold_bind_results,5,[{file,"src/kazoo_bindings.erl"},{line,646}]}
Mar  2 09:57:56 sip 2600hz[2689]: |209a757fe601449e655c7fb47adb8596|kazoo_bindings:726 (<0.3915.0>) st: {lists,foldl,3,[{file,"lists.erl"},{line,1262}]}
Mar  2 09:57:56 sip 2600hz[2689]: |209a757fe601449e655c7fb47adb8596|kazoo_bindings:726 (<0.3915.0>) st: {kazoo_bindings,fold_processor,3,[{file,"src/kazoo_bindings.erl"},{line,793}]}
Mar  2 09:57:56 sip 2600hz[2689]: |209a757fe601449e655c7fb47adb8596|kazoo_bindings:726 (<0.3915.0>) st: {api_util,execute_request,5,[{file,"src/api_util.erl"},{line,1085}]}
Mar  2 09:57:56 sip 2600hz[2689]: |209a757fe601449e655c7fb47adb8596|kazoo_bindings:726 (<0.3915.0>) st: {api_resource,from_json,2,[{file,"src/api_resource.erl"},{line,693}]}