### PR TITLE
Fax attachment was being checked before saving

### DIFF
--- a/applications/fax/src/fax_util.erl
+++ b/applications/fax/src/fax_util.erl
@@ -113,13 +113,11 @@ save_fax_attachment(JObj, _FileContents, _CT, _Name, 0) ->
     {'error', <<"max retry saving attachment">>};
 save_fax_attachment(JObj, FileContents, CT, Name, Count) ->
     DocId = kz_doc:id(JObj),
+    _ = attempt_save(JObj, FileContents, CT, Name),
     case check_fax_attachment(DocId, Name) of
         {'ok', J} -> save_fax_doc_completed(J);
         {'missing', J} ->
             lager:warning("missing fax attachment on fax id ~s",[DocId]),
-
-            _ = attempt_save(JObj, FileContents, CT, Name),
-
             timer:sleep(?RETRY_SAVE_ATTACHMENT_DELAY),
             save_fax_attachment(J, FileContents, CT, Name, Count-1);
         {'error', _R} ->


### PR DESCRIPTION
When trying to save a fax attachement it was first checked if there was an attachement if not than it was saved by always outputting a warning in the logs, this change will first save the attachment and than will check if it exists or not and if not than output an error and try to save again.