### PR TITLE
[4.0] HELP-28524: prepare qs filter props for filtering in vmbox (#3349)

### DIFF
--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -1355,6 +1355,7 @@ should_filter(Val, FilterVal) ->
     try kz_json:unsafe_decode(FilterVal) of
         List when is_list(List) ->
             lists:member(Val, List);
+        Val -> 'true';
         _Data ->
             lager:debug("data is not a list: ~p", [_Data]),
             'false'


### PR DESCRIPTION
prefix filter props in query strings with metadata., so filtering messages are possible in vmboxes.

backport of (#3349)