### PR TITLE
PROD-123: allow master account to set module name when creating num

### DIFF
--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -355,12 +355,15 @@ put(Context, ?COLLECTION) ->
     CB = fun() -> ?MODULE:put(cb_context:set_accepting_charges(Context), ?COLLECTION) end,
     set_response(Results, Context, CB);
 put(Context, Number) ->
+    ReqData = cb_context:req_data(Context),
+    ModuleName = kz_json:get_ne_value(<<"module_name">>, ReqData),
     Options = [{'auth_by', cb_context:auth_account_id(Context)}
               ,{'assign_to', cb_context:account_id(Context)}
               ,{'dry_run', not cb_context:accepting_charges(Context)}
-              ,{'public_fields', cb_context:doc(Context)}
+              ,{'public_fields', kz_json:delete_key(<<"module_name">>, ReqData)}
+              ,{'module_name', ModuleName}
               ],
-    Result = knm_number:create(Number, Options),
+    Result = knm_number:create(Number, props:filter_undefined(Options)),
     CB = fun() -> ?MODULE:put(cb_context:set_accepting_charges(Context), Number) end,
     set_response(Result, Context, CB).
 
@@ -976,12 +979,15 @@ numbers_action(Context, ?ACTIVATE, Numbers) ->
               ],
     knm_numbers:move(Numbers, cb_context:account_id(Context), Options);
 numbers_action(Context, ?HTTP_PUT, Numbers) ->
+    ReqData = cb_context:req_data(Context),
+    ModuleName = kz_json:get_ne_value(<<"module_name">>, ReqData),
     Options = [{'auth_by', cb_context:auth_account_id(Context)}
               ,{'assign_to', cb_context:account_id(Context)}
               ,{'dry_run', not cb_context:accepting_charges(Context)}
-              ,{'public_fields', cb_context:req_data(Context)}
+              ,{'public_fields', kz_json:delete_key(<<"module_name">>, ReqData)}
+              ,{'module_name', ModuleName}
               ],
-    knm_numbers:create(Numbers, Options);
+    knm_numbers:create(Numbers, props:filter_undefined(Options));
 numbers_action(Context, ?HTTP_POST, Numbers) ->
     Options = [{'auth_by', cb_context:auth_account_id(Context)}
               ,{'assign_to', cb_context:account_id(Context)}

--- a/core/kazoo_number_manager/src/knm_number_options.erl
+++ b/core/kazoo_number_manager/src/knm_number_options.erl
@@ -47,7 +47,7 @@
                   {'auth_by', ne_binary()} |
                   {'dry_run', boolean()} |
                   {'batch_run', boolean()} |
-                  {mdn_run, boolean()} |
+                  {'mdn_run', boolean()} |
                   {'module_name', ne_binary()} |
                   {'ported_in', boolean()} |
                   {'public_fields', kz_json:object()} |
@@ -141,7 +141,7 @@ auth_by(Options) ->
 auth_by(Options, Default) ->
     props:get_binary_value('auth_by', Options, Default).
 
--spec public_fields(options()) -> api_object().
+-spec public_fields(options()) -> kz_json:object().
 public_fields(Options) ->
     props:get_value('public_fields', Options, kz_json:new()).
 

--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -262,21 +262,27 @@ do_get_pn(Nums, Options, Error) ->
 %%--------------------------------------------------------------------
 -spec create(ne_binaries(), knm_number_options:options()) -> ret().
 create(Nums, Options) ->
+    create(Nums, Options, knm_number_options:assign_to(Options)).
+
+-spec create(ne_binaries(), knm_number_options:options(), api_ne_binary()) -> ret().
+create(Nums, Options, AccountId=?MATCH_ACCOUNT_RAW(_)) ->
     T0 = do_get_pn(Nums, Options, knm_errors:to_json(not_reconcilable)),
     case take_not_founds(T0) of
         {#{ok := []}, []} -> T0;
         {T1, NotFounds} ->
-            case options_for_create(Nums, Options) of
-                #{}=Ret -> Ret;
-                NewOptions ->
-                    ret(pipe(maybe_create(NotFounds, options(NewOptions, T1))
-                            ,[fun maybe_set_ported_in/1
-                             ,fun knm_number:new/1
-                             ,fun knm_number_states:to_options_state/1
-                             ,fun save_numbers/1
-                             ]))
-            end
-    end.
+            ToState = knm_number:state_for_create(AccountId, Options),
+            lager:debug("picked state ~s for ~s for ~p", [ToState, AccountId, Nums]),
+            NewOptions = [{'state', ToState} | pick_module(Options)],
+            ret(pipe(maybe_create(NotFounds, options(NewOptions, T1))
+                    ,[fun maybe_set_ported_in/1
+                     ,fun knm_number:new/1
+                     ,fun knm_number_states:to_options_state/1
+                     ,fun save_numbers/1
+                     ]))
+    end;
+create(Nums, Options, _) ->
+    Error = knm_errors:to_json(assign_failure, undefined, field_undefined),
+    ret(new(Options, [], Nums, Error)).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -638,43 +644,11 @@ maybe_set_ported_in(T=#{todo := PNs, options := Options}) ->
     end.
 
 %% @private
-%% Generates options for number creation, can return error if the correct options
-%% are not passed
--spec options_for_create(ne_binaries(), knm_number_options:options()) ->
-                                knm_number_options:options() |
-                                ret().
-options_for_create(Nums, Options0) ->
-    Fs = [fun state_create_option/2
-         ,fun module_name_create_option/2
-         ],
-    lists:foldl(fun(_F, #{}=Ret) -> Ret;
-                   (F, AccOptions) -> F(Nums, AccOptions)
-                end
-               ,Options0
-               ,Fs
-               ).
-
-%% @private
--spec state_create_option(ne_binaries(), knm_number_options:options()) ->
-                                 knm_number_options:options() |
-                                 ret().
-state_create_option(Nums, Options) ->
-    case knm_number_options:assign_to(Options) of
-        ?MATCH_ACCOUNT_RAW(AccountId) ->
-            ToState = knm_number:state_for_create(AccountId, Options),
-            lager:debug("picked state ~s for ~s for ~p", [ToState, AccountId, Nums]),
-            [{'state', ToState} | Options];
-        _ ->
-            Error = knm_errors:to_json(assign_failure, undefined, field_undefined),
-            ret(new(Options, [], Nums, Error))
-    end.
-
-%% @private
--spec module_name_create_option(ne_binaries(), knm_number_options:options()) -> knm_number_options:options().
-module_name_create_option(_Nums, Options) ->
+-spec pick_module(knm_number_options:options()) -> knm_number_options:options().
+pick_module(Options) ->
     AuthBy = knm_number_options:auth_by(Options),
     case kz_term:is_not_empty(AuthBy)
-        andalso {props:get_ne_binary_value('module_name', Options), kapps_util:get_master_account_id()}
+        andalso {knm_number_options:module_name(Options), kapps_util:get_master_account_id()}
     of
         'false' -> Options;
         {?CARRIER_LOCAL, _} -> Options;

--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -645,6 +645,20 @@ maybe_set_ported_in(T=#{todo := PNs, options := Options}) ->
 
 %% @private
 -spec pick_module(knm_number_options:options()) -> knm_number_options:options().
+-ifdef(TEST).
+pick_module(Options) ->
+    AuthBy = knm_number_options:auth_by(Options),
+    case kz_term:is_not_empty(AuthBy)
+        andalso {knm_number_options:module_name(Options), {'ok', ?MASTER_ACCOUNT_ID}}
+    of
+        'false' -> Options;
+        {?CARRIER_LOCAL, _} -> Options;
+        {?CARRIER_MDN, _} -> Options;
+        {?CARRIER_OTHER, _} -> Options; %% cb_jobs_listener
+        {_, {'ok', AuthBy}} -> Options;
+        {_, _} -> props:delete('module_name', Options)
+    end.
+-else.
 pick_module(Options) ->
     AuthBy = knm_number_options:auth_by(Options),
     case kz_term:is_not_empty(AuthBy)
@@ -657,6 +671,7 @@ pick_module(Options) ->
         {_, {'ok', AuthBy}} -> Options;
         {_, _} -> props:delete('module_name', Options)
     end.
+-endif.
 
 -spec maybe_create(ne_binaries(), t_pn()) -> t_pn().
 maybe_create(NotFounds, T) ->

--- a/core/kazoo_number_manager/test/knm_create_new_number_test.erl
+++ b/core/kazoo_number_manager/test/knm_create_new_number_test.erl
@@ -50,6 +50,7 @@ create_new_number_test_() ->
 reseller_new_number_test_() ->
     Props = [{'auth_by', ?RESELLER_ACCOUNT_ID}
             ,{'assign_to', ?RESELLER_ACCOUNT_ID}
+            ,{'module_name', <<"knm_bandwidth2">>}
             ,{'dry_run', 'false'}
             ,{<<"auth_by_account">>
              ,kz_account:set_allow_number_additions(?RESELLER_ACCOUNT_DOC, 'true')
@@ -72,7 +73,7 @@ reseller_new_number_test_() ->
     ,{"Verify the reseller account is listed in reserve history"
      ,?_assertEqual([?RESELLER_ACCOUNT_ID], knm_phone_number:reserve_history(PN))
      }
-    ,{"Verify the local carrier module is being used"
+    ,{"Verify the local carrier module is being used (Also checks only master account can set module_name)"
      ,?_assertEqual(?CARRIER_LOCAL, knm_phone_number:module_name(PN))
      }
     ].
@@ -279,6 +280,22 @@ create_non_existing_mobile_number_test_() ->
      ,?_assertEqual(true, kz_json:are_equal(MobileField
                                            ,kz_json:get_value(<<"mobile">>, knm_number:to_public_json(N))
                                            ))
+     }
+    ].
+
+create_number_with_module_name_test_() ->
+    Props = [{'auth_by', ?MASTER_ACCOUNT_ID}
+            ,{'assign_to', ?RESELLER_ACCOUNT_ID}
+            ,{'dry_run', 'false'}
+            ,{'module_name', <<"knm_bandwidth2">>}
+            ,{<<"auth_by_account">>
+             ,kz_account:set_allow_number_additions(?RESELLER_ACCOUNT_DOC, 'true')
+             }
+            ],
+    {'ok', N} = knm_number:create(?TEST_CREATE_NUM, Props),
+    PN = knm_number:phone_number(N),
+    [{"Verify the bandwidth2 carrier module is being used (and only master account can set module name)"
+     ,?_assertEqual(<<"knm_bandwidth2">>, knm_phone_number:module_name(PN))
      }
     ].
 

--- a/core/kazoo_number_manager/test/knm_create_new_number_test.erl
+++ b/core/kazoo_number_manager/test/knm_create_new_number_test.erl
@@ -50,7 +50,6 @@ create_new_number_test_() ->
 reseller_new_number_test_() ->
     Props = [{'auth_by', ?RESELLER_ACCOUNT_ID}
             ,{'assign_to', ?RESELLER_ACCOUNT_ID}
-            ,{'module_name', <<"knm_bandwidth2">>}
             ,{'dry_run', 'false'}
             ,{<<"auth_by_account">>
              ,kz_account:set_allow_number_additions(?RESELLER_ACCOUNT_DOC, 'true')
@@ -73,7 +72,7 @@ reseller_new_number_test_() ->
     ,{"Verify the reseller account is listed in reserve history"
      ,?_assertEqual([?RESELLER_ACCOUNT_ID], knm_phone_number:reserve_history(PN))
      }
-    ,{"Verify the local carrier module is being used (Also checks only master account can set module_name)"
+    ,{"Verify the local carrier module is being used"
      ,?_assertEqual(?CARRIER_LOCAL, knm_phone_number:module_name(PN))
      }
     ].
@@ -293,9 +292,14 @@ create_number_with_module_name_test_() ->
              }
             ],
     {'ok', N} = knm_number:create(?TEST_CREATE_NUM, Props),
+    {'ok', N2} = knm_number:create(?TEST_CREATE_NUM, props:set_value('auth_by', ?RESELLER_ACCOUNT_ID, Props)),
     PN = knm_number:phone_number(N),
-    [{"Verify the bandwidth2 carrier module is being used (and only master account can set module name)"
+    PN2 = knm_number:phone_number(N2),
+    [{"Verify that only master account can set module module"
      ,?_assertEqual(<<"knm_bandwidth2">>, knm_phone_number:module_name(PN))
+     }
+    ,{"Verify the local module is being used if any other account than the master tries to set module name"
+     ,?_assertEqual(?CARRIER_LOCAL, knm_phone_number:module_name(PN2))
      }
     ].
 


### PR DESCRIPTION
When creating a number the API should honor a carrier module name, defaulting to local if not present or the authorizing user does not belong to the master account.
