### PR TITLE
[4.0] properly return an error when exception raised in account creation

### DIFF
--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -318,15 +318,15 @@ put(Context, PathAccountId) ->
             case cb_context:is_context(C) of
                 'true' -> delete(C, NewAccountId);
                 'false' ->
-                    C = cb_context:add_system_error('unspecified_fault', Context),
-                    delete(C, NewAccountId)
+                    _ = delete(Context, NewAccountId),
+                    cb_context:add_system_error('unspecified_fault', <<"internal error, unable to create the account">>, Context)
             end;
         _E:_R ->
             ST = erlang:get_stacktrace(),
             lager:debug("unexpected failure when creating account: ~s: ~p", [_E, _R]),
             kz_util:log_stacktrace(ST),
-            C = cb_context:add_system_error('unspecified_fault', Context),
-            delete(C, NewAccountId)
+            _ = delete(Context, NewAccountId),
+            cb_context:add_system_error('unspecified_fault', <<"internal error, unable to create the account">>, Context)
     end.
 
 put(Context, AccountId, ?RESELLER) ->


### PR DESCRIPTION
When account creation failed, we don't return an error to UI, so UI doesn't know that account has not created, which result in UI continues to make other request to put limits, callflow an etc to the non-existent account.

backport of (#3388)