### PR TITLE
Don't set iss if it defined when creating a jwt token

### DIFF
--- a/core/kazoo_auth/src/kz_auth_jwt.erl
+++ b/core/kazoo_auth/src/kz_auth_jwt.erl
@@ -162,9 +162,12 @@ encode(Alg, InClaimsSet, {KeyId, Key}) ->
            ,{<<"kid">>, KeyId}
            ],
     Header = kz_base64url:encode(kz_json:encode(kz_json:from_list(Head))),
-    ClaimsSet = [{<<"iss">>, <<"kazoo">>}
-                 | InClaimsSet
-                ],
+    ClaimsSet = case props:get_value(<<"iss">>, InClaimsSet) of
+                    'undefined' -> [{<<"iss">>, <<"kazoo">>}
+                                    | InClaimsSet
+                                   ];
+                    <<_:8, _/binary>> -> InClaimsSet
+                end,
     Claims = kz_base64url:encode(kz_json:encode(kz_json:from_list(ClaimsSet))),
     Payload = <<Header/binary, ".", Claims/binary>>,
     case sign(Alg, Payload, Key) of


### PR DESCRIPTION
Hi. We are integrating kazoo with salesforce and salesforce requires property "iss" to set to a provided value as described at https://help.salesforce.com/articleView?id=remoteaccess_oauth_jwt_flow.htm&type=0
We disscussed this with @k-anderson and he agreed that it would be better to use core module. He asked to create a pull request to provide support even it brakes RFC.