### PR TITLE
cb_system_configs with defaults

### DIFF
--- a/applications/crossbar/doc/ref/system_configs.md
+++ b/applications/crossbar/doc/ref/system_configs.md
@@ -46,6 +46,16 @@ curl -v -X POST \
     http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}
 ```
 
+#### Patch
+
+> PATCH /v2/system_configs/{SYSTEM_CONFIG_ID}
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}
+```
+
 #### Remove
 
 > DELETE /v2/system_configs/{SYSTEM_CONFIG_ID}
@@ -72,6 +82,16 @@ curl -v -X GET \
 
 ```shell
 curl -v -X POST \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
+```
+
+#### Patch
+
+> PATCH /v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
+
+```shell
+curl -v -X PATCH \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
 ```

--- a/applications/crossbar/doc/system_configs.md
+++ b/applications/crossbar/doc/system_configs.md
@@ -2,15 +2,101 @@
 
 Manipulate documents in the `system_config` database via Crossbar.
 
+Alter system configs REST API (diffs, validation)
+
+A system configuration document is a JSON document of certain
+syntetic type (each node value must be a JSON object of type
+system_config.$config_name). REST API allows to address both
+documents and and docuemnt nodes. Default node of the
+configuration document is treated specially, see below.
+
+In order to avoid confusion configuration document nodes
+we call document sections, each such section is a JSON
+object representing a configuration object for Kazoo
+node or zone.
+
+General idea is to return (with with_defaults=true URI
+option) the effective values for configuration, therefore
+a complex mergedown is performed: document values are
+merged with document default section, and then merged
+with schema defaults.
+
+Therefore on save actions (PUT/POST/PATCH) a reverse
+operation is performed: a difference from defaults
+is calculated and stored to the document (if any).
+Thus by setting a value to schema default will effectively
+remove it from the document on save action.
+
+Documents
+---------
+
+GET always returns either an empty document or stored
+document. The document always has a default section included,
+populated with default values deduced from schema.
+
+POST expects to receive a complete configuration document.
+The document must be valid, each section of the document
+must pass the validation against system_config.$config_name
+schema. Before saving the difference with provided default
+is calculated, and then the difference with schema defaults
+is calculated, and then the result of this is stored, meaning
+if section value is equal to default section value it will
+not be stored to the document. The actual (stored) values
+are then returned as POST results.
+
+PATCH will merge provided changes with stored document,
+and then the resulting document is valid then the same
+store procedure is applied as in POST. The actual stored
+values are then returned as PATCH result.
+
+DELETE deletes the document (or wipes a section). Attempt
+to delete non-existing configuration object will generate
+an HTTP 404 error.
+
+Sections
+--------
+
+GET always returns either an empty document or stored
+values.
+
+POST expects to receive a valid configuration document
+(against schema system_config.$config_name). If the
+document is valid, then a difference is calculated
+with configuration document default section, and
+then the difference is calculated with schema defaults,
+and then the result is stored. For default section
+only the difference from schema defaults are calculated.
+The actual (stored) values are returned as result of
+POST request.
+
+PATCH will merge provided changes with stored section,
+and then the result is validated against schema. If
+result is valid, then the same procedure is applied
+as in POST. The actual (stored) values are returned
+as PATCH result.
+
+DELETE deletes the section specified. If configuration
+document doesn't exist (or secion in the document), then
+the request will fail with HTTP 404.
+
+Defaults
+--------
+
+In order to have effective configuration values one must
+provide `with_defaults=true` URI parameter for GET requests
+(either to get document or document section). With this
+parameter provided a configuration mergedown as described
+above is performed.
+
 #### About System Configs
 
 You must be `super_duper_admin` to access this resource.
 
 #### Schema
 
+The document schema is syntetic, see above.
 
-
-#### List all known configs
+#### Fetch
 
 > GET /v2/system_configs
 
@@ -20,279 +106,430 @@ curl -v -X GET \
     http://{SERVER}:8000/v2/system_configs
 ```
 
+request response:
 ```json
 {
-    "auth_token": "{AUTH_TOKEN}",
-    "data": [
-        "notification.port_request_admin",
-        "notification.port_request",
-        "notification.port_rejected",
-        "notification.port_pending",
-        "notification.port_comment",
-        "notification.port_cancel",
-        "notification.password_recovery",
-        "notification.new_user",
-        "notification.new_account",
-        "notification.low_balance",
-        "notification.first_occurrence",
-        "notification.fax_outbound_to_email",
-        "notification.fax_outbound_error_to_email",
-        "notification.fax_inbound_to_email",
-        "notification.fax_inbound_error_to_email",
-        "notification.deregister",
-        "notification.denied_emergency_bridge",
-        "notification.customer_update",
-        "notification.cnam_request",
-        "modb",
-        "metaflows",
-        "media",
-        "konami",
-        "kazoo.pdf",
-        "kazoo_couch",
-        "kapps_maintenance",
-        "kapps_controller",
-        "hangups",
-        "fax",
-        "ecallmgr",
-        "doodle",
-        "datamgr",
-        "crossbar.token_restrictions",
-        "crossbar.resources",
-        "crossbar.port_requests",
-        "crossbar.phone_numbers",
-        "crossbar.notifications",
-        "crossbar.media",
-        "crossbar.contact_list",
-        "crossbar.cdrs",
-        "crossbar.callflows",
-        "crossbar.accounts",
-        "crossbar",
-        "callflow",
-        "braintree",
-        "blip",
-        "bli",
-        "blackhole",
-        "accounts",
-        "8b23cfb3383612cda8383047c20001a7"
-    ],
-    "next_start_key": "notification.port_scheduled",
-    "page_size": 50,
-    "request_id": "{REQUEST_ID}",
-    "revision": "{REVISION}",
-    "status": "success"
+  "next_start_key": "notification.ported",
+  "page_size": 50,
+  "data": [
+    "notification.port_unconfirmed",
+    "notification.port_scheduled",
+    "notification.port_request_admin",
+    "notification.port_request",
+    "notification.port_rejected",
+    "notification.port_pending",
+    "notification.port_comment",
+    "notification.port_cancel",
+    "notification.password_recovery",
+    "notification.new_user",
+    "notification.new_account",
+    "notification.low_balance",
+    "notification.first_occurrence",
+    "notification.fax_outbound_to_email",
+    "notification.fax_outbound_error_to_email",
+    "notification.fax_inbound_to_email",
+    "notification.fax_inbound_error_to_email_filtered",
+    "notification.fax_inbound_error_to_email",
+    "notification.deregister",
+    "notification.denied_emergency_bridge",
+    "notification.customer_update",
+    "notification.cnam_request",
+    "notification.account_zone_change",
+    "modb",
+    "milliwatt",
+    "media",
+    "kazoo_endpoint",
+    "kazoo_couch",
+    "kapps_controller",
+    "hangups",
+    "fax",
+    "ecallmgr",
+    "datamgr",
+    "crossbar.resources",
+    "crossbar.media",
+    "crossbar.local_resources",
+    "crossbar.callflows",
+    "crossbar.auth",
+    "crossbar.accounts",
+    "crossbar",
+    "conferences",
+    "cdr",
+    "callflow.park",
+    "callflow",
+    "call_command",
+    "braintree",
+    "blackhole",
+    "auth",
+    "alerts",
+    "accounts"
+  ],
+  "timestamp": "2017-03-29T23:51:00",
+  "version": "4.0.0",
+  "node": "{NODE}",
+  "request_id": "4b9bb77a555a0130d5d862964ba3c834",
+  "status": "success",
+  "auth_token": {AUTH_TOKEN}
 }
 ```
 
-
-#### Delete the whole config
-
-> DELETE /v2/system_configs/{SYSTEM_CONFIG_ID}
-
-Note: use `?hard=true` to permanently delete the document.
-
-```shell
-curl -v -X DELETE \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/system_configs/bli
-```
-
-```json
-{
-    "auth_token": "{AUTH_TOKEN}",
-    "request_id": "{REQUEST_ID}",
-    "revision": "{REVISION}",
-    "status": "success"
-}
-```
-
-
-#### Get config for all nodes
+#### Fetch
 
 > GET /v2/system_configs/{SYSTEM_CONFIG_ID}
 
 ```shell
 curl -v -X GET \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/system_configs/blip
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}
 ```
 
+request body:
+```json
+```
+
+response body:
 ```json
 {
-    "auth_token": "{AUTH_TOKEN}",
     "data": {
         "default": {
-            "blop": ""
-            "k": [
-                "value1"
-            ]
+            "acl_request_timeout_fudge_ms": 100,
+            "acl_request_timeout_ms": 2000
         },
-        "kazoo_apps@termina.tor": {
-            "T": 42
-        },
+        "id": "sysconf"
     },
-    "request_id": "{REQUEST_ID}",
-    "revision": "{REVISION}",
-    "status": "success"
+    "timestamp": "2017-03-29T23:15:46",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "aa044445a32ff469970873e49992efb7",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
 }
 ```
 
-
-#### Update config for many nodes
-
-> POST /v2/system_configs/{SYSTEM_CONFIG_ID}
-
-```shell
-curl -v -X POST \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -d '{"data": {"default": {"key": "my string", "blop": null}}}' \
-    http://{SERVER}:8000/v2/system_configs/blip
-```
-
-```json
-{
-    "auth_token": "{AUTH_TOKEN}",
-    "data": {
-        "default": {
-            "k": [
-                "value1"
-            ],
-            "key": "my string"
-        },
-        "kazoo_apps@termina.tor": {
-            "T": 42
-        },
-    },
-    "request_id": "{REQUEST_ID}",
-    "revision": "{REVISION}",
-    "status": "success"
-}
-```
-
-
-#### Create a new config
+#### Create
 
 > PUT /v2/system_configs/{SYSTEM_CONFIG_ID}
 
 ```shell
 curl -v -X PUT \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -d '{"data": {"default": {"bla": "1"}, "hi@oh.com": {"digit": 23}}}' \
-    http://{SERVER}:8000/v2/system_configs/candle_jack
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}
 ```
 
+See POST
+
+#### Change
+
+> POST /v2/system_configs/{SYSTEM_CONFIG_ID}
+
+```shell
+curl -v -X POST \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}
+```
+
+request body:
 ```json
 {
-    "auth_token": "{AUTH_TOKEN}",
     "data": {
         "default": {
-            "bla": "1"
+            "acl_request_timeout_fudge_ms": 100,
+            "acl_request_timeout_ms": 2000
         },
-        "hi@oh.com": {
-            "digit": 23
-        },
-        "id": "candle_jack"
-    },
-    "request_id": "{REQUEST_ID}",
-    "revision": "{REVISION}",
-    "status": "success"
+        "id": "sysconf",
+        "node": {
+            "acl_request_timeout_fudge_ms": 101
+        }
+    }
 }
 ```
 
-##### Successful creation
-
+response body:
 ```json
 {
-    "auth_token": "{AUTH_TOKEN}",
     "data": {
-        "name": ""
+        "node": {
+            "acl_request_timeout_fudge_ms": 101
+        },
+        "id": "sysconf"
     },
-    "request_id": "{REQUEST_ID}",
     "revision": "{REVISION}",
-    "status": "success"
+    "timestamp": "2017-03-29T23:15:46",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "34496796b71921c4908d54ffcfba815e",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
 }
 ```
 
-##### Error: old soft-deleted document still exists
+#### Patch
 
-Note: to avoid conflicts use hard deletes.
-However, soft deletes leave you the possibility to rollback to a previous version.
+> PATCH /v2/system_configs/{SYSTEM_CONFIG_ID}
 
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}
+```
+
+request body:
 ```json
 {
-    "auth_token": "{AUTH_TOKEN}",
     "data": {
-        "message": "conflicting documents"
-    },
-    "error": "409",
-    "message": "datastore_conflict",
-    "request_id": "{REQUEST_ID}",
-    "status": "error"
+        "node": {
+            "acl_request_timeout_fudge_ms": 102
+        }
+    }
 }
 ```
 
+response body:
+```json
+{
+    "data": {
+        "node": {
+            "acl_request_timeout_fudge_ms": 102
+        },
+        "id": "sysconf"
+    },
+    "revision": "{REVISION}",
+    "timestamp": "2017-03-29T23:15:46",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "8c8b81cc498d7cb12af17c6e501a3bd6",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
+}
+```
 
-#### Delete node specific config
+#### Fetch
 
-> DELETE /v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
+> GET /v2/system_configs/{SYSTEM_CONFIG_ID}?with_defaults=true
+
+```shell
+curl -v -X GET \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}
+```
+
+request body:
+```json
+```
+
+response body:
+```json
+{
+    "data": {
+        "node": {
+            "acl_request_timeout_fudge_ms": 102,
+            "acl_request_timeout_ms": 2000
+        },
+        "default": {
+            "acl_request_timeout_fudge_ms": 100,
+            "acl_request_timeout_ms": 2000
+        },
+        "id": "sysconf"
+    },
+    "timestamp": "2017-03-29T23:15:46",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "9dc532fbc603ff2c89a8b28b8d4b9bf5",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
+}
+```
+
+#### Remove
+
+> DELETE /v2/system_configs/{SYSTEM_CONFIG_ID}
 
 ```shell
 curl -v -X DELETE \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/system_configs/blip/kazoo_apps@termina.tor
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}
 ```
 
+request body:
+```json
+```
+
+response body:
 ```json
 {
-    "auth_token": "{AUTH_TOKEN}",
-    "request_id": "{REQUEST_ID}",
+    "data": {
+        "node": {
+            "acl_request_timeout_fudge_ms": 102
+        },
+        "id": "sysconf"
+    },
     "revision": "{REVISION}",
-    "status": "success"
+    "timestamp": "2017-03-29T23:15:47",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "69d9cce540246c6d733aab7806a85fab",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
 }
 ```
 
-
-#### Get node-specific config
+#### Fetch
 
 > GET /v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
 
 ```shell
 curl -v -X GET \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/system_configs/blip/kazoo_apps@termina.tor
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
 ```
 
+request body:
+```json
+```
+
+response body:
 ```json
 {
-    "auth_token": "{AUTH_TOKEN}",
     "data": {
-        "T": 42
+        "id": "sysconf\/node"
     },
-    "request_id": "{REQUEST_ID}",
-    "revision": "{REVISION}",
-    "status": "success"
+    "timestamp": "2017-03-29T23:15:47",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "796768266b9bae69dbd2379f4dcd02fe",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
 }
 ```
 
-
-#### Update node-specific config
+#### Change
 
 > POST /v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
 
 ```shell
 curl -v -X POST \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -d '{"data": {"T": 42}}' \
-    http://{SERVER}:8000/v2/system_configs/blip/kazoo_apps@termina.tor
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
 ```
 
+request body:
 ```json
 {
-    "auth_token": "{AUTH_TOKEN}",
     "data": {
-        "T": 42
-    },
-    "request_id": "{REQUEST_ID}",
-    "revision": "{REVISION}",
-    "status": "success"
+        "id": "sysconf\/node",
+        "acl_request_timeout_fudge_ms": 101
+    }
 }
 ```
+
+response body:
+```json
+{
+    "data": {
+        "acl_request_timeout_fudge_ms": 101,
+        "id": "sysconf\/node"
+    },
+    "revision": "{REVISION}",
+    "timestamp": "2017-03-29T23:15:47",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "1e37f7cd29533fca6232552e4ba2324e",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
+}
+```
+
+#### Patch
+
+> PATCH /v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
+```
+
+request body:
+```json
+{
+    "data": {
+        "acl_request_timeout_fudge_ms": 102
+    }
+}
+```
+
+response body:
+```json
+{
+    "data": {
+        "acl_request_timeout_fudge_ms": 102,
+        "id": "sysconf\/node"
+    },
+    "revision": "{REVISION}",
+    "timestamp": "2017-03-29T23:15:47",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "67862fe74310955f4a53db3fa8473e35",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
+}
+```
+
+#### Fetch with defaults
+
+> GET /v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
+
+```shell
+curl -v -X GET \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}?with_defaults=true
+```
+
+request body:
+```json
+```
+
+response body:
+```json
+{
+    "data": {
+        "acl_request_timeout_fudge_ms": 102,
+        "acl_request_timeout_ms": 2000,
+        "id": "sysconf\/node"
+    },
+    "timestamp": "2017-03-29T23:15:47",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "a0e221dc821d5d49a32555155344ea10",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
+}
+```
+
+#### Remove
+
+> DELETE /v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
+
+```shell
+curl -v -X DELETE \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/system_configs/{SYSTEM_CONFIG_ID}/{NODE}
+```
+
+request body:
+```json
+```
+
+response body:
+{
+    "data": {
+        "id": "sysconf\/node"
+    },
+    "revision": "{REVISION}",
+    "timestamp": "2017-03-29T23:15:47",
+    "version": "4.0.0",
+    "node": "{NODE}",
+    "request_id": "2dfd98b331aa180d8f07f9ee7488dbe3",
+    "status": "success",
+    "auth_token": "{AUTH_TOKEN}"
+}
+```json

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -22227,6 +22227,13 @@
                     }
                 ]
             },
+            "patch": {
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/system_config_id"
+                    }
+                ]
+            },
             "post": {
                 "parameters": [
                     {
@@ -22254,6 +22261,16 @@
                 ]
             },
             "get": {
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/system_config_id"
+                    },
+                    {
+                        "$ref": "#/parameters/node"
+                    }
+                ]
+            },
+            "patch": {
                 "parameters": [
                     {
                         "$ref": "#/parameters/system_config_id"

--- a/applications/crossbar/src/crossbar_init.erl
+++ b/applications/crossbar/src/crossbar_init.erl
@@ -53,9 +53,9 @@ start_link() ->
     kz_util:put_callid(?LOG_SYSTEM_ID),
 
     _ = [
-     lager:error("System config ~s validation error:~p", [Config, Error])
-     || {Config, Error} <- kapps_maintenance:validate_system_configs()
-    ],
+         lager:error("System config ~s validation error:~p", [Config, Error])
+         || {Config, Error} <- kapps_maintenance:validate_system_configs()
+        ],
 
     Dispatch = cowboy_router:compile(crossbar_routes()),
 

--- a/applications/crossbar/src/crossbar_init.erl
+++ b/applications/crossbar/src/crossbar_init.erl
@@ -52,7 +52,7 @@ api_version_constraint(NotVersion) ->
 start_link() ->
     kz_util:put_callid(?LOG_SYSTEM_ID),
 
-    [
+    _ = [
      lager:error("System config ~s validation error:~p", [Config, Error])
      || {Config, Error} <- kapps_maintenance:validate_system_configs()
     ],

--- a/applications/crossbar/src/crossbar_init.erl
+++ b/applications/crossbar/src/crossbar_init.erl
@@ -52,6 +52,11 @@ api_version_constraint(NotVersion) ->
 start_link() ->
     kz_util:put_callid(?LOG_SYSTEM_ID),
 
+    [
+     lager:error("System config ~s validation error:~p", [Config, Error])
+     || {Config, Error} <- kapps_maintenance:validate_system_configs()
+    ],
+
     Dispatch = cowboy_router:compile(crossbar_routes()),
 
     maybe_start_plaintext(Dispatch),

--- a/core/kazoo_config/src/kapps_config_doc.erl
+++ b/core/kazoo_config/src/kapps_config_doc.erl
@@ -1,0 +1,122 @@
+-module(kapps_config_doc).
+-include_lib("kazoo/include/kz_types.hrl").
+-include_lib("kazoo/include/kz_databases.hrl").
+-compile({no_auto_import,[get_keys/1]}).
+-export([
+         get_keys/1
+        ,get_config/1
+        ,get_node/2
+        ,apply_default_values/3
+        ,apply_default_node/1, apply_schema_defaults/2, apply_schema_defaults_to_default/2
+        ,schema_defaults/1
+        ,config_with_defaults/1, config_with_default_node/1
+        ,diff_from_default/2
+        ,default_config/2, stored_config/2, build_default/2
+        ,default_node/2, stored_node/2, diff_node_from_default/3
+        ,list_configs/0
+        ]).
+
+-define(DEFAULT, <<"default">>).
+
+-spec maybe_new({ok, kz_json:object()}) -> kz_json:object().
+maybe_new({ok, JObj}) -> JObj;
+maybe_new(_) -> kz_json:new().
+
+-spec get_keys(kz_json:object()) -> [ne_binary()].
+get_keys(Config) ->
+    kz_json:get_keys(kz_doc:public_fields(Config)) -- [?DEFAULT].
+
+-spec get_config(ne_binary()) -> kz_json:object().
+get_config(Id) ->
+    kz_doc:public_fields(maybe_new(kapps_config:get_category(Id))).
+
+-spec get_node(kz_json:object(), ne_binary()) -> kz_json:object().
+get_node(Config, Node) ->
+    kz_json:get_value(Node, Config, kz_json:new()).
+
+-spec apply_default_values(kz_json:object(), ne_binary(), kz_json:object()) -> kz_json:object().
+apply_default_values(Config, Node, Default) ->
+    NodeValue = get_node(Config, Node),
+    kz_json:set_value(Node, kz_json:merge_recursive(Default, NodeValue), Config).
+
+-spec apply_default_node(kz_json:object()) -> kz_json:object().
+apply_default_node(Config) ->
+    Default = kz_json:get_value(?DEFAULT, Config, kz_json:new()),
+    lists:foldl(fun(K,A) -> apply_default_values(A, K, Default) end, Config, get_keys(Config)).
+
+-spec apply_schema_defaults(ne_binary(), kz_json:object()) -> kz_json:object().
+apply_schema_defaults(Id, Config) ->
+    Default = schema_defaults(Id),
+    lists:foldl(fun(K,A) -> apply_default_values(A, K, Default) end, Config, [?DEFAULT|get_keys(Config)]).
+
+-spec apply_schema_defaults_to_default(ne_binary(), kz_json:object()) -> kz_json:object().
+apply_schema_defaults_to_default(Id, Config) ->
+    apply_default_values(Config, ?DEFAULT, schema_defaults(Id)).
+
+-spec schema_defaults(ne_binary()) -> kz_json:object().
+schema_defaults(Id) ->
+    kz_json_schema:default_object(kapps_config_util:system_schema(Id)).
+
+-spec maybe_insert_default_node(kz_json:object()) -> kz_json:object().
+maybe_insert_default_node(Config) ->
+    case kz_json:get_value(?DEFAULT, Config) of
+        undefined -> kz_json:set_value(?DEFAULT, kz_json:new(), Config);
+        _Else -> Config
+    end.
+
+-spec config_with_defaults(ne_binary()) -> kz_json:object().
+config_with_defaults(Id) ->
+    apply_schema_defaults(Id, maybe_insert_default_node(apply_default_node(get_config(Id)))).
+
+-spec default_config(ne_binary(), [ne_binary()]) -> kz_json:object().
+default_config(Id, Keys) ->
+    DefaultNode = schema_defaults(Id),
+    lists:foldl(fun(Key,A) -> kz_json:set_value(Key, DefaultNode, A) end, kz_json:new(), [?DEFAULT|Keys]).
+
+-spec stored_config(ne_binary(), kz_json:object()) -> kz_json:object().
+stored_config(Id, Keys) ->
+    Config = config_with_default_node(Id),
+    Default = kz_json:get_value(?DEFAULT, Config, kz_json:new()),
+    lists:foldl(fun(K,A) -> apply_default_values(A, K, Default) end, Config, Keys).
+
+-spec config_with_default_node(ne_binary()) -> kz_json:object().
+config_with_default_node(Id) ->
+    Config = get_config(Id),
+    apply_default_values(Config, ?DEFAULT, schema_defaults(Id)).
+
+-spec diff_from_default(ne_binary(), kz_json:object()) -> kz_json:object().
+diff_from_default(Id, JObj) ->
+    kz_json:diff(JObj, build_default(Id, JObj)).
+
+-spec build_default(ne_binary(), kz_json:object()) -> kz_json:object().
+build_default(Id, JObj) ->
+    Default = kz_json:get_value(?DEFAULT, JObj, kz_json:new()),
+    Config = lists:foldl(fun(K,A) -> apply_default_values(A, K, Default) end, kz_json:new(), get_keys(JObj)),
+    apply_schema_defaults(Id, Config).
+
+%% ----------------------------------------------------------
+%% Node API
+%% ----------------------------------------------------------
+
+-spec default_node(ne_binary(), ne_binary()) -> kz_json:object().
+default_node(Id, ?DEFAULT) ->
+    schema_defaults(Id);
+default_node(Id, _Node) ->
+    stored_node(Id, ?DEFAULT).
+
+-spec stored_node(ne_binary(), ne_binary()) -> kz_json:object().
+stored_node(Id, Node) ->
+    get_node(stored_config(Id, [Node]), Node).
+
+-spec diff_node_from_default(ne_binary(), ne_binary(), kz_json:object()) -> kz_json:object().
+diff_node_from_default(Id, ?DEFAULT, JObj) ->
+    kz_json:diff(JObj, schema_defaults(Id));
+diff_node_from_default(Id, _Node, JObj) ->
+    kz_json:diff(JObj, stored_node(Id, ?DEFAULT)).
+
+-spec list_configs() -> [ne_binary()].
+list_configs() ->
+    case kz_datamgr:get_results(?KZ_CONFIG_DB, <<"system_configs/crossbar_listing">>, []) of
+        {ok, List} -> [ kz_json:get_value(<<"id">>, JSON) || JSON <- List ];
+        _ -> []
+    end.

--- a/core/kazoo_config/src/kapps_config_doc.erl
+++ b/core/kazoo_config/src/kapps_config_doc.erl
@@ -73,7 +73,7 @@ default_config(Id, Keys) ->
     DefaultNode = schema_defaults(Id),
     lists:foldl(fun(Key,A) -> kz_json:set_value(Key, DefaultNode, A) end, kz_json:new(), [?DEFAULT|Keys]).
 
--spec stored_config(ne_binary(), kz_json:object()) -> kz_json:object().
+-spec stored_config(ne_binary(), kz_json:keys()) -> kz_json:object().
 stored_config(Id, Keys) ->
     Config = config_with_default_node(Id),
     Default = kz_json:get_value(?DEFAULT, Config, kz_json:new()),

--- a/core/kazoo_config/src/kapps_config_util.erl
+++ b/core/kazoo_config/src/kapps_config_util.erl
@@ -7,6 +7,7 @@
         ,system_schema_name/1
         ,account_schema/1
         ,system_schema/1
+        ,system_config_document_schema/1
         ]).
 
 -spec doc_id(ne_binary()) -> ne_binary().
@@ -80,3 +81,14 @@ account_schema(Config) when is_binary(Config) ->
     Name = account_schema_name(Config),
     {'ok', Schema} = kz_json_schema:load(Name),
     Schema.
+
+-spec system_config_document_schema(ne_binary()) -> kz_json:object().
+system_config_document_schema(Id) ->
+    Flat = [
+            {<<"$schema">>,<<"http://json-schema.org/draft-04/schema#">>}
+           ,{<<"id">>, <<"system_config">>}
+           ,{[<<"patternProperties">>, <<".+">>, <<"$ref">>], system_schema_name(Id)}
+           ,{[<<"patternProperties">>, <<".+">>, <<"type">>], <<"object">>}
+           ,{<<"type">>, <<"object">>}
+           ],
+    kz_json:expand(kz_json:from_list(Flat)).

--- a/core/kazoo_config/src/kapps_config_util.erl
+++ b/core/kazoo_config/src/kapps_config_util.erl
@@ -85,10 +85,10 @@ account_schema(Config) when is_binary(Config) ->
 -spec system_config_document_schema(ne_binary()) -> kz_json:object().
 system_config_document_schema(Id) ->
     Flat = [
-            {<<"$schema">>,<<"http://json-schema.org/draft-04/schema#">>}
-           ,{<<"id">>, <<"system_config">>}
+            {[<<"$schema">>],<<"http://json-schema.org/draft-04/schema#">>}
+           ,{[<<"id">>], <<"system_config">>}
            ,{[<<"patternProperties">>, <<".+">>, <<"$ref">>], system_schema_name(Id)}
            ,{[<<"patternProperties">>, <<".+">>, <<"type">>], <<"object">>}
-           ,{<<"type">>, <<"object">>}
+           ,{[<<"type">>], <<"object">>}
            ],
     kz_json:expand(kz_json:from_list(Flat)).

--- a/core/kazoo_json/include/kazoo_json.hrl
+++ b/core/kazoo_json/include/kazoo_json.hrl
@@ -42,7 +42,7 @@
 -type path() :: keys() | key() | pos_integer() | [pos_integer()].
 -type paths() :: [path()].
 
--type json_proplist() :: [{key(), json_term()}] | [].
+-type json_proplist() :: [{key()|keys(), json_term()}] | [].
 -type json_proplists() :: [json_proplist()].
 
 -type encode_option() :: 'uescape'

--- a/core/kazoo_json/include/kazoo_json.hrl
+++ b/core/kazoo_json/include/kazoo_json.hrl
@@ -42,7 +42,7 @@
 -type path() :: keys() | key() | pos_integer() | [pos_integer()].
 -type paths() :: [path()].
 
--type json_proplist() :: [{key()|keys(), json_term()}] | [].
+-type json_proplist() :: [{key(), json_term()}] | [].
 -type json_proplists() :: [json_proplist()].
 
 -type encode_option() :: 'uescape'


### PR DESCRIPTION
A system configuration document is a JSON document of certain
syntetic type (each node value must be a JSON object of type
system_config.$config_name). REST API allows to address both
documents and and docuemnt nodes. Default node of the
configuration document is treated specially, see below.

In order to avoid confusion configuration document nodes
we call document sections, each such section is a JSON
object representing a configuration object for Kazoo
node or zone.

General idea is to return (with with_defaults=true URI
option) the effective values for configuration, therefore
a complex mergedown is performed: document values are
merged with document default section, and then merged
with schema defaults.

Therefore on save actions (PUT/POST/PATCH) a reverse
operation is performed: a difference from defaults
is calculated and stored to the document (if any).
Thus by setting a value to schema default will effectively
remove it from the document on save action.

Documents
---------

GET always returns either an empty document or stored
document. The document always has a default section included,
populated with default values deduced from schema.

POST expects to receive a complete configuration document.
The document must be valid, each section of the document
must pass the validation against system_config.$config_name
schema. Before saving the difference with provided default
is calculated, and then the difference with schema defaults
is calculated, and then the result of this is stored, meaning
if section value is equal to default section value it will
not be stored to the document. The actual (stored) values
are then returned as POST results.

PATCH will merge provided changes with stored document,
and then the resulting document is valid then the same
store procedure is applied as in POST. The actual stored
values are then returned as PATCH result.

DELETE deletes the document (or wipes a section). Attempt
to delete non-existing configuration object will generate
an HTTP 404 error.

Sections
--------

GET always returns either an empty document or stored
values.

POST expects to receive a valid configuration document
(against schema system_config.$config_name). If the
document is valid, then a difference is calculated
with configuration document default section, and
then the difference is calculated with schema defaults,
and then the result is stored. For default section
only the difference from schema defaults are calculated.
The actual (stored) values are returned as result of
POST request.

PATCH will merge provided changes with stored section,
and then the result is validated against schema. If
result is valid, then the same procedure is applied
as in POST. The actual (stored) values are returned
as PATCH result.

DELETE deletes the section specified. If configuration
document doesn't exist (or secion in the document), then
the request will fail with HTTP 404.

Defaults
--------

In order to have effective configuration values one must
provide `with_defaults=true` URI parameter for GET requests
(either to get document or document section). With this
parameter provided a configuration mergedown as described
above is performed.
