### PR TITLE
qf-extfeat_4oh: allow setting external features by default

### DIFF
--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -860,6 +860,9 @@ features_denied(#knm_phone_number{number = ?TEST_TELNYX_NUM}) ->
     [?FEATURE_PORT
     ,?FEATURE_FAILOVER
     ];
+features_denied(#knm_phone_number{number = ?BW_EXISTING_DID}) ->
+    [?FEATURE_E911
+    ];
 features_denied(#knm_phone_number{features_denied = Features}) -> Features.
 -else.
 features_denied(#knm_phone_number{features_denied = Features}) -> Features.

--- a/core/kazoo_number_manager/src/providers/knm_providers.erl
+++ b/core/kazoo_number_manager/src/providers/knm_providers.erl
@@ -45,7 +45,7 @@
         kapps_config:get(?KNM_CONFIG_CAT, ?KEY_FEATURES_ALLOW, Default)).
 
 -define(FEATURES_ALLOWED_SYSTEM,
-        ?FEATURES_ALLOWED_SYSTEM(?KAZOO_NUMBER_FEATURES)).
+        ?FEATURES_ALLOWED_SYSTEM(?KAZOO_NUMBER_FEATURES ++ ?EXTERNAL_NUMBER_FEATURES)).
 
 
 -record(feature_parameters, {is_local = false :: boolean()

--- a/core/kazoo_number_manager/test/knm_number_test.erl
+++ b/core/kazoo_number_manager/test/knm_number_test.erl
@@ -120,7 +120,34 @@ is_mdn_for_mdn_run_test_() ->
     ].
 
 
-attempt_setting_e911_on_disallowed_number_test_() ->
+attempt_setting_e911_on_disallowed_local_number_test_() ->
+    JObj = kz_json:from_list(
+             [{?FEATURE_E911
+              ,kz_json:from_list(
+                 [{?E911_STREET1, <<"140 Geary St.">>}
+                 ,{?E911_STREET2, <<"3rd floor">>}
+                 ,{?E911_CITY, <<"San Francisco">>}
+                 ,{?E911_STATE, <<"CA">>}
+                 ,{?E911_ZIP, <<"94108">>}
+                 ])
+              }
+             ]),
+    Options = [{auth_by, ?RESELLER_ACCOUNT_ID}
+              ,{public_fields, JObj}
+              ],
+    Updates = [{fun knm_phone_number:reset_doc/2, JObj}],
+    Num = ?TEST_IN_SERVICE_NUM,
+    {ok, N} = knm_number:get(Num),
+    PN = knm_number:phone_number(N),
+    [{"Verify feature is not set"
+     ,?_assertEqual(undefined, knm_phone_number:feature(PN, ?FEATURE_E911))
+     }
+    ,{"Verify feature cannot be set"
+     ,?_assertThrow({error, unauthorized}, knm_number:update_phone_number(N, Updates, Options))
+     }
+    ].
+
+attempt_setting_e911_on_explicitly_disallowed_number_test_() ->
     JObj = kz_json:from_list(
              [{?FEATURE_E911
               ,kz_json:from_list(


### PR DESCRIPTION
no mergy-mergy