### PR TITLE
[4.0] KAZOO-5105: span to multiple modb when fetching pivot debug logs

### DIFF
--- a/applications/crossbar/src/modules/cb_pivot.erl
+++ b/applications/crossbar/src/modules/cb_pivot.erl
@@ -97,20 +97,17 @@ validate(Context, ?DEBUG_PATH_TOKEN, CallId) ->
 %%--------------------------------------------------------------------
 -spec debug_summary(cb_context:context()) -> cb_context:context().
 debug_summary(Context) ->
-    AccountModb = get_modb(Context),
-    maybe_normalize_debug_results(
-      crossbar_doc:load_view(
-        ?CB_FIRST_ITERATION
-                            ,[]
-                            ,cb_context:setters(
-                               Context
-                                               ,[{fun cb_context:set_account_db/2, AccountModb}
-                                                ,fun fix_req_pagination/1
-                                                ]
-                              )
-                            ,fun normalize_view_results/2
-       )
-     ).
+    case modb_view_options(Context, 'undefined') of
+        {'ok', ViewOptions} ->
+            maybe_normalize_debug_results(
+              crossbar_doc:load_view(?CB_FIRST_ITERATION
+                                    ,ViewOptions
+                                    ,fix_req_pagination(Context)
+                                    ,fun normalize_view_results/2
+                                    )
+             );
+        C -> C
+    end.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -121,7 +118,7 @@ debug_summary(Context) ->
 fix_req_pagination(Context) ->
     QS = cb_context:query_string(Context),
     Size = crossbar_doc:pagination_page_size(Context),
-    cb_context:set_query_string(Context, kz_json:set_value(<<"page_size">>, Size*2 +1, QS)).
+    cb_context:set_query_string(Context, kz_json:set_value(<<"page_size">>, Size * 2 + 1, QS)).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -130,23 +127,28 @@ fix_req_pagination(Context) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec debug_read(cb_context:context(), ne_binary()) -> cb_context:context().
-debug_read(Context, CallId) ->
-    AccountModb = get_modb(Context),
+debug_read(Context, ?MATCH_MODB_PREFIX(Year, Month, CallId)) ->
+    AccountModb = kazoo_modb:get_modb(cb_context:account_id(Context), Year, Month),
     Context1 =
-        crossbar_doc:load_view(
-          ?CB_DEBUG_LIST
+        crossbar_doc:load_view(?CB_DEBUG_LIST
                               ,[{'endkey', [CallId, kz_json:new()]}
                                ,{'startkey', [CallId]}
                                ,'include_docs'
                                ]
                               ,cb_context:set_account_db(Context, AccountModb)
                               ,fun normalize_debug_read/2
-         ),
+                              ),
     case cb_context:resp_status(Context1) of
         'success' ->
             RespData = cb_context:resp_data(Context1),
             cb_context:set_resp_data(Context1, lists:reverse(RespData));
         _Status -> Context1
+    end;
+debug_read(Context, CallId) ->
+    case modb_view_options(Context, CallId) of
+        {'ok', ViewOptions} ->
+            crossbar_doc:load_view(?CB_DEBUG_LIST, ViewOptions, Context, fun normalize_debug_read/2);
+        C -> C
     end.
 
 %%--------------------------------------------------------------------
@@ -154,13 +156,31 @@ debug_read(Context, CallId) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec get_modb(cb_context:context()) -> ne_binary().
-get_modb(Context) ->
+-spec modb_view_options(cb_context:context(), api_ne_binary()) ->
+                               {'ok', crossbar_doc:view_options()} |
+                               cb_context:context().
+modb_view_options(Context, CallId) ->
     AccountId = cb_context:account_id(Context),
-    case cb_context:req_value(Context, <<"created_from">>) of
-        'undefined' -> kz_util:format_account_mod_id(AccountId);
-        From -> kz_util:format_account_mod_id(AccountId, kz_util:to_integer(From))
+    case cb_modules_util:range_view_options(Context) of
+        {CreatedFrom, CreatedTo} ->
+            MODBs = lists:reverse(kazoo_modb:get_range(AccountId, CreatedFrom, CreatedTo)),
+            {'ok', maybe_add_start_end_key(CallId, CreatedTo, CreatedFrom, MODBs)};
+        Ctx -> Ctx
     end.
+
+-spec maybe_add_start_end_key(api_binary(), gregorian_seconds(), gregorian_seconds(), ne_binaries()) ->
+                                     crossbar_doc:view_options().
+maybe_add_start_end_key('undefined', _CreatedTo, _CreatedFrom, MODBs) ->
+    [{'databases', MODBs}
+    ,'descending'
+    ];
+maybe_add_start_end_key(CallId, CreatedTo, CreatedFrom, MODBs) ->
+    [{'databases', MODBs}
+    ,{'startkey', [CallId, CreatedTo]}
+    ,{'endkey', [CallId, CreatedFrom]}
+    ,'include_docs'
+    ,'descending'
+    ].
 
 %%--------------------------------------------------------------------
 %% @private
@@ -193,18 +213,16 @@ maybe_normalize_debug_results(Context) ->
 -spec normalize_debug_results(cb_context:context(), kz_proplist()) -> kz_json:objects().
 normalize_debug_results(Context) ->
     Dict =
-        lists:foldl(
-          fun normalize_debug_results_fold/2
+        lists:foldl(fun normalize_debug_results_fold/2
                    ,dict:new()
                    ,lists:reverse(cb_context:resp_data(Context))
-         ),
+                   ),
     RespData = normalize_debug_results(Context, dict:to_list(Dict)),
-    cb_context:setters(
-      Context
+    cb_context:setters(Context
                       ,[{fun cb_context:set_resp_data/2, RespData}
                        ,fun fix_page_size/1
                        ]
-     ).
+                      ).
 
 normalize_debug_results(Context, List) ->
     Size = kz_util:to_integer((crossbar_doc:pagination_page_size(Context)-1)/2),
@@ -225,10 +243,11 @@ normalize_debug_results(Context, List) ->
 -spec normalize_debug_results_fold(kz_json:object(), dict:dict()) -> dict:dict().
 normalize_debug_results_fold(JObj, Dict) ->
     CallId = kz_json:get_value(<<"call_id">>, JObj),
+    NewJObj = kz_json:set_value(<<"debug_id">>, debug_id(JObj), JObj),
     case dict:find(CallId, Dict) of
-        'error' -> dict:store(CallId, JObj, Dict);
+        'error' -> dict:store(CallId, NewJObj, Dict);
         {'ok', Value} ->
-            dict:store(CallId, kz_json:merge_jobjs(Value, JObj), Dict)
+            dict:store(CallId, kz_json:merge_jobjs(Value, NewJObj), Dict)
     end.
 
 %%--------------------------------------------------------------------
@@ -241,10 +260,9 @@ fix_page_size(Context) ->
     RespEnv = cb_context:resp_envelope(Context),
     RespData = cb_context:resp_data(Context),
     Size = erlang:length(RespData),
-    cb_context:set_resp_envelope(
-      Context
+    cb_context:set_resp_envelope(Context
                                 ,kz_json:set_value(<<"page_size">>, Size, RespEnv)
-     ).
+                                ).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -264,12 +282,12 @@ normalize_debug_read(JObj, Acc) ->
 leak_pvt_field(JObj) ->
     Routines = [fun leak_pvt_created/2
                ,fun leak_pvt_node/2
+               ,fun set_debug_id/2
                ],
-    lists:foldl(
-      fun(F, Acc) -> F(JObj, Acc) end
+    lists:foldl(fun(F, Acc) -> F(JObj, Acc) end
                ,JObj
                ,Routines
-     ).
+               ).
 
 -spec leak_pvt_created(kz_json:object(), kz_json:object()) -> kz_json:object().
 leak_pvt_created(JObj, Acc) ->
@@ -279,3 +297,14 @@ leak_pvt_created(JObj, Acc) ->
 leak_pvt_node(JObj, Acc) ->
     Node = kz_json:get_value([<<"pvt_node">>], JObj),
     kz_json:set_value(<<"node">>, Node, Acc).
+
+-spec set_debug_id(kz_json:object(), kz_json:objects()) -> kz_json:object().
+set_debug_id(JObj, Acc) ->
+    kz_json:set_value(<<"debug_id">>, debug_id(JObj), Acc).
+
+-spec debug_id(kz_json:object()) -> ne_binary().
+debug_id(JObj) ->
+    Created = kz_json:get_first_defined([<<"created">>, <<"pvt_created">>], JObj),
+    CallId = kz_json:get_value(<<"call_id">>, JObj),
+    {{Year, Month, _}, _} = calendar:gregorian_seconds_to_datetime(Created),
+    ?MATCH_MODB_PREFIX(kz_util:to_binary(Year), kz_util:pad_month(Month), CallId).


### PR DESCRIPTION
Also set debug_id for each log to fetch the debug details for old logs

backport of (#3433)