### PR TITLE
QF Crossbar log & kz_network_utils:verify_cidr/2

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -69,11 +69,11 @@ get_profile_id(Req) ->
     end.
 
 -spec get_client_ip(inet:ip_address(), cowboy_req:req()) ->
-                           ne_binary().
+                           inet:ip_address().
 get_client_ip(Peer, Req) ->
     case cowboy_req:header(<<"x-forwarded-for">>, Req) of
-        {'undefined', _} -> kz_network_utils:iptuple_to_binary(Peer);
-        {ForwardIP, _} -> maybe_allow_proxy_req(kz_network_utils:iptuple_to_binary(Peer), ForwardIP)
+        {'undefined', _} -> Peer;
+        {ForwardIP, _} -> maybe_allow_proxy_req(Peer, ForwardIP)
     end.
 
 -spec maybe_trace(cowboy_req:req()) -> 'ok'.
@@ -115,6 +115,7 @@ rest_init(Req0, Opts) ->
     {Version, Req7} = find_version(Path, Req6),
 
     ClientIP = get_client_ip(Peer, Req7),
+    MappedClientIP = kz_network_utils:maybe_mapped_ipv4(ClientIP),
 
     {Headers, _} = cowboy_req:headers(Req7),
 
@@ -129,7 +130,7 @@ rest_init(Req0, Opts) ->
               ,{fun cb_context:set_resp_status/2, 'fatal'}
               ,{fun cb_context:set_resp_error_msg/2, <<"init failed">>}
               ,{fun cb_context:set_resp_error_code/2, 500}
-              ,{fun cb_context:set_client_ip/2, ClientIP}
+              ,{fun cb_context:set_client_ip/2, kz_network_utils:iptuple_to_binary(ClientIP)}
               ,{fun cb_context:set_profile_id/2, ProfileId}
               ,{fun cb_context:set_api_version/2, Version}
               ,{fun cb_context:set_magic_pathed/2, props:is_defined('magic_path', Opts)}
@@ -148,7 +149,17 @@ rest_init(Req0, Opts) ->
             {Req10, Context3} = api_util:get_pretty_print(Req9, Context2),
             Event = api_util:create_event_name(Context3, <<"init">>),
             {Context4, _} = crossbar_bindings:fold(Event, {Context3, Opts}),
-            lager:info("~s: ~s?~s from ~s", [Method, Path, QS, ClientIP]),
+            case MappedClientIP of
+                'undefined' ->
+                    lager:info("~s: ~s?~s from ~s", [Method ,Path, QS
+                                                    ,kz_network_utils:iptuple_to_binary(ClientIP)
+                                                    ]);
+                _ ->
+                    lager:info("~s: ~s?~s from ~s (~s)", [Method ,Path, QS
+                                                         ,kz_network_utils:iptuple_to_binary(MappedClientIP)
+                                                         ,kz_network_utils:iptuple_to_binary(ClientIP)
+                                                         ])
+            end,
             {'ok', cowboy_req:set_resp_header(<<"x-request-id">>, ReqId, Req10), Context4}
     end.
 
@@ -173,15 +184,17 @@ find_version(Path) ->
         [Ver | _] -> to_version(Ver)
     end.
 
--spec maybe_allow_proxy_req(ne_binary(), ne_binary()) -> ne_binary().
+-spec maybe_allow_proxy_req(inet:ip_address(), ne_binary()) -> inet:ip_address().
 maybe_allow_proxy_req(Peer, ForwardIP) ->
-    case is_proxied(Peer) of
+    BinaryPeer = kz_network_utils:iptuple_to_binary(Peer),
+    case is_proxied(BinaryPeer) of
         'true' ->
-            lager:info("request is from expected reverse proxy: ~s", [ForwardIP]),
-            kz_term:to_binary(ForwardIP);
+            lager:info("request is from reverse proxy: ~s, client address: ~s", [BinaryPeer, ForwardIP]),
+            {'ok', ForwardPeer} = inet:parse_address(kz_term:to_list(ForwardIP)),
+            ForwardPeer;
         'false' ->
             lager:warning("request with \"X-Forwarded-For: ~s\" header, but peer (~s) is not allowed as proxy"
-                         ,[ForwardIP, Peer]
+                         ,[ForwardIP, BinaryPeer]
                          ),
             Peer
     end.

--- a/core/kazoo/src/kz_network_utils.erl
+++ b/core/kazoo/src/kz_network_utils.erl
@@ -29,6 +29,7 @@
         ,srvtuple_to_binary/1
         ,naptrtuple_to_binary/1
         ,mxtuple_to_binary/1
+        ,maybe_mapped_ipv4/1
         ]).
 -export([pretty_print_bytes/1]).
 
@@ -151,7 +152,8 @@ verify_cidr(IP, CIDR) when is_binary(CIDR) ->
     verify_cidr(IP, kz_term:to_list(CIDR));
 verify_cidr(IP, CIDR) ->
     Block = inet_cidr:parse(CIDR),
-    inet_cidr:contains(Block, inet:parse_address(IP)).
+    {'ok', IPTuple} = inet:parse_address(IP),
+    inet_cidr:contains(Block, IPTuple).
 
 %%     %% As per the docs... "This operation should only be used for test purposes"
 %%     %% so, ummm ya, but probably cheaper then my expand bellow followed by a list
@@ -336,6 +338,13 @@ mxtuple_to_binary({Priority, Domain}) ->
     <<(kz_term:to_binary(Priority))/binary, " "
       ,(kz_binary:strip_right(kz_term:to_binary(Domain), $.))/binary
     >>.
+
+-spec maybe_mapped_ipv4(inet:ip_address()) -> inet:ip4_address() | 'undefined'.
+maybe_mapped_ipv4({0, 0, 0, 0, 0, 16#FFFF, AB, CD}) ->
+    <<A:8, B:8>> = <<AB:16>>,
+    <<C:8, D:8>> = <<CD:16>>,
+    {A, B, C, D};
+maybe_mapped_ipv4(_) -> 'undefined'.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo/src/kz_network_utils.erl
+++ b/core/kazoo/src/kz_network_utils.erl
@@ -29,7 +29,6 @@
         ,srvtuple_to_binary/1
         ,naptrtuple_to_binary/1
         ,mxtuple_to_binary/1
-        ,maybe_mapped_ipv4/1
         ]).
 -export([pretty_print_bytes/1]).
 
@@ -310,6 +309,13 @@ iptuple_to_binary({A,B,C,D}) ->
       ,(kz_term:to_binary(C))/binary, "."
       ,(kz_term:to_binary(D))/binary
     >>;
+
+%% IPv4 mapped to IPv6
+%% https://tools.ietf.org/html/rfc4038#section-4.2
+iptuple_to_binary({0, 0, 0, 0, 0, 16#FFFF, AB, CD}) ->
+    <<A:8, B:8>> = <<AB:16>>,
+    <<C:8, D:8>> = <<CD:16>>,
+    iptuple_to_binary({A,B,C,D});
 iptuple_to_binary({_I1, _I2, _I3, _I4, _I5, _I6, _I7, _I8}=T) ->
     kz_binary:join([to_hex(I) || I <- tuple_to_list(T)], <<":">>).
 
@@ -340,13 +346,6 @@ mxtuple_to_binary({Priority, Domain}) ->
     <<(kz_term:to_binary(Priority))/binary, " "
       ,(kz_binary:strip_right(kz_term:to_binary(Domain), $.))/binary
     >>.
-
--spec maybe_mapped_ipv4(inet:ip_address()) -> inet:ip4_address() | 'undefined'.
-maybe_mapped_ipv4({0, 0, 0, 0, 0, 16#FFFF, AB, CD}) ->
-    <<A:8, B:8>> = <<AB:16>>,
-    <<C:8, D:8>> = <<CD:16>>,
-    {A, B, C, D};
-maybe_mapped_ipv4(_) -> 'undefined'.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo/src/kz_network_utils.erl
+++ b/core/kazoo/src/kz_network_utils.erl
@@ -152,8 +152,10 @@ verify_cidr(IP, CIDR) when is_binary(CIDR) ->
     verify_cidr(IP, kz_term:to_list(CIDR));
 verify_cidr(IP, CIDR) ->
     Block = inet_cidr:parse(CIDR),
-    {'ok', IPTuple} = inet:parse_address(IP),
-    inet_cidr:contains(Block, IPTuple).
+    case inet:parse_address(IP) of
+        {'ok', IPTuple} -> inet_cidr:contains(Block, IPTuple);
+        {'error', _} -> 'false'
+    end.
 
 %%     %% As per the docs... "This operation should only be used for test purposes"
 %%     %% so, ummm ya, but probably cheaper then my expand bellow followed by a list


### PR DESCRIPTION
Fix kz_network_utils:verify_cidr/2 (it never match)
Display IPv4 addres when it is mapped in IPv6 (0:0:0:0:0:ffff:0:0/96 [RFC](https://tools.ietf.org/html/rfc4038#section-4.2))