### PR TITLE
KAZOO-5396: hon_trie_lru - progressively load rates

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -344,6 +344,8 @@
     "hotornot.rate_version": "If defined, use rates with this version",
     "hotornot.sort_by_weight": "sort rates by weight (true) or cost (false)",
     "hotornot.trie_build_timeout_ms": "build timeout (ms) for trie",
+    "hotornot.trie_lru_expires_s": "How long an entry in the LRU trie can remain",
+    "hotornot.trie_module": "Which trie module to use",
     "hotornot.use_trie": "whether to use the trie to store rates in the VM",
     "jonny5.default_inbound_trunks": "jonny5 default inbound trunks",
     "jonny5.default_twoway_trunks": "jonny5 default twoway trunks",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -9924,6 +9924,16 @@
                     "description": "build timeout (ms) for trie",
                     "type": "integer"
                 },
+                "trie_lru_expires_s": {
+                    "default": 86400,
+                    "description": "How long an entry in the LRU trie can remain",
+                    "type": "integer"
+                },
+                "trie_module": {
+                    "default": "hon_trie",
+                    "description": "Which trie module to use",
+                    "type": "string"
+                },
                 "use_trie": {
                     "default": false,
                     "description": "whether to use the trie to store rates in the VM",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.hotornot.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.hotornot.json
@@ -61,6 +61,16 @@
             "description": "build timeout (ms) for trie",
             "type": "integer"
         },
+        "trie_lru_expires_s": {
+            "default": 86400,
+            "description": "How long an entry in the LRU trie can remain",
+            "type": "integer"
+        },
+        "trie_module": {
+            "default": "hon_trie",
+            "description": "Which trie module to use",
+            "type": "string"
+        },
         "use_trie": {
             "default": false,
             "description": "whether to use the trie to store rates in the VM",

--- a/applications/hotornot/src/hon_trie_lru.erl
+++ b/applications/hotornot/src/hon_trie_lru.erl
@@ -1,0 +1,179 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2011-2017, 2600Hz INC
+%%% @doc
+%%% (Words * Bytes/Word) div (Prefixes) ~= Bytes per Prefix
+%%% (1127494 * 8) div 78009 = 115
+%%%
+%%% Processing:
+%%% timer:tc(hon_trie, match_did, [<<"53341341354">>]).
+%%%  {132,...}
+%%% timer:tc(hon_util, candidate_rates, [<<"53341341354">>]).
+%%%  {16989,...}
+%%%
+%%% Progressively load rates instead of seeding from the database
+%%%
+%%% @end
+%%% @contributors
+%%%   James Aimonetti
+%%%-------------------------------------------------------------------
+-module(hon_trie_lru).
+-behaviour(gen_server).
+
+-export([start_link/1, start_link/2
+        ,stop/1
+        ,cache_rates/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("hotornot.hrl").
+
+-define(STATE_READY(Trie, RatedeckDb, CheckRef), {'ready', Trie, RatedeckDb, CheckRef}).
+
+-define(CHECK_MSG(ExpiresS), {'check_trie', ExpiresS}).
+
+-type state() :: ?STATE_READY(trie:trie(), ne_binary(), reference()).
+-type rate_entry() :: {ne_binary(), gregorian_seconds()}.
+-type rate_entries() :: [rate_entry()].
+
+-spec start_link(ne_binary()) -> {'ok', pid()}.
+-spec start_link(ne_binary(), pos_integer()) -> {'ok', pid()}.
+start_link(RatedeckDb) ->
+    start_link(RatedeckDb, hotornot_config:lru_expires_s()).
+
+start_link(RatedeckDb, ExpiresS) ->
+    ProcName = hon_trie:trie_proc_name(RatedeckDb),
+    gen_server:start_link({'local', ProcName}, ?MODULE, [RatedeckDb, ExpiresS], []).
+
+-spec stop(ne_binary()) -> 'ok'.
+stop(<<_/binary>>=RatedeckId) ->
+    ProcName = hon_trie:trie_proc_name(RatedeckId),
+    case whereis(ProcName) of
+        'undefined' -> 'ok';
+        Pid -> catch gen_server:call(Pid, 'stop')
+    end.
+
+-spec cache_rates(ne_binary(), kzd_rate:docs()) -> 'ok'.
+cache_rates(RatedeckId, Rates) ->
+    ProcName = hon_trie:trie_proc_name(RatedeckId),
+    gen_server:call(ProcName, {'cache_rates', Rates}).
+
+-spec init([ne_binary() | pos_integer()]) -> {'ok', state()}.
+init([RatedeckDb, ExpiresS]) ->
+    kz_util:put_callid(hon_trie:trie_proc_name(RatedeckDb)),
+    lager:info("starting LRU for ~s", [RatedeckDb]),
+    {'ok', ?STATE_READY(trie:new(), RatedeckDb, start_expires_check_timer(ExpiresS))}.
+
+-spec start_expires_check_timer(pos_integer()) -> reference().
+-ifdef(PROPER).
+start_expires_check_timer(ExpiresS) ->
+    erlang:start_timer(1 * ?MILLISECONDS_IN_SECOND, self(), ?CHECK_MSG(ExpiresS)).
+-else.
+start_expires_check_timer(ExpiresS) ->
+    Check = (ExpiresS div 2) * ?MILLISECONDS_IN_SECOND,
+    erlang:start_timer(Check, self(), ?CHECK_MSG(ExpiresS)).
+-endif.
+
+-spec handle_call(any(), pid_ref(), state()) ->
+                         {'noreply', state()} |
+                         {'reply', match_return(), state()}.
+handle_call({'match_did', DID}, _From, ?STATE_READY(Trie, RatedeckDb, CheckRef)) ->
+    {UpdatedTrie, Resp} = match_did_in_trie(DID, Trie),
+    {'reply', Resp, ?STATE_READY(UpdatedTrie, RatedeckDb, CheckRef)};
+handle_call({'cache_rates', Rates}, _From, ?STATE_READY(Trie, RatedeckDb, CheckRef)) ->
+    UpdatedTrie = handle_caching_of_rates(Trie, Rates),
+    {'reply', 'ok', ?STATE_READY(UpdatedTrie, RatedeckDb, CheckRef)};
+handle_call('stop', _From, State) ->
+    lager:debug("requested to stop by ~p", [_From]),
+    {'stop', 'normal', State};
+handle_call(_Req, _From, State) ->
+    {'noreply', State}.
+
+-spec handle_cast(any(), state()) -> {'noreply', state()}.
+handle_cast(_Req, State) ->
+    lager:debug("unhandled cast ~p", [_Req]),
+    {'noreply', State}.
+
+-spec handle_info(any(), state()) -> {'noreply', state()}.
+handle_info({'timeout', CheckRef, ?CHECK_MSG(ExpiresS)}
+           ,?STATE_READY(Trie, RatedeckDb, CheckRef)
+           ) ->
+    UpdatedTrie = check_expired_entries(Trie, ExpiresS),
+    {'noreply', ?STATE_READY(UpdatedTrie, RatedeckDb, start_expires_check_timer(ExpiresS))};
+handle_info(_Msg, State) ->
+    lager:debug("unhandled message ~p: ~p",[_Msg, State]),
+    {'noreply', State}.
+
+-spec check_expired_entries(trie:trie(), pos_integer()) -> trie:trie().
+check_expired_entries(Trie, ExpiresS) ->
+    OldestMs = kz_time:now_ms() - (ExpiresS * 1000),
+    {UpdatedTrie, OldestMs} =
+        trie:foldl(fun check_if_expired/3
+                  ,{Trie, OldestMs}
+                  ,Trie
+                  ),
+    UpdatedTrie.
+
+-spec check_if_expired(prefix(), [{ne_binary(), pos_integer()}], {pid(), pos_integer()}) ->
+                              {pid(), pos_integer()}.
+check_if_expired(Prefix, Rates, {Trie, OldestTimestamp}=Acc) ->
+    case expired_rates(Rates, OldestTimestamp) of
+        [] -> Acc;
+        [_|_]=_OldRates ->
+            {trie:erase(Prefix, Trie), OldestTimestamp}
+    end.
+
+-spec expired_rates([{ne_binary(), pos_integer()}], pos_integer()) ->
+                           [] | [{ne_binary(), pos_integer()}].
+expired_rates(Rates, OldestTimestamp) ->
+    [RateId
+     || {RateId, LastUsed} <- Rates,
+        LastUsed < OldestTimestamp
+    ].
+
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, ?STATE_READY(_, _, _)) ->
+    lager:info("terminating: ~p", [_Reason]).
+
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_Vsn, State, _Extra) ->
+    {'ok', State}.
+
+-spec match_did_in_trie(string(), trie:trie()) -> {trie:trie(), match_return()}.
+match_did_in_trie(DID, Trie) ->
+    case trie:find_prefix_longest(DID, Trie) of
+        'error' ->
+            {Trie, {'error', 'not_found'}};
+        {'ok', Prefix, RateIds} ->
+            UpdatedTrie = bump_prefix_timestamp(Trie, Prefix, RateIds),
+            {UpdatedTrie, {'ok', {Prefix, [Id || {Id, _Created} <- RateIds]}}}
+    end.
+
+-spec bump_prefix_timestamp(trie:trie(), string(), rate_entries()) -> trie:trie().
+bump_prefix_timestamp(Trie, Prefix, RateIds) ->
+    BumpedRateIds = [{Id, kz_time:now_ms()}
+                     || {Id, _LastAccessed} <- RateIds
+                    ],
+    trie:store(Prefix, BumpedRateIds, Trie).
+
+-spec handle_caching_of_rates(trie:trie(), kzd_rate:docs()) -> trie:trie().
+handle_caching_of_rates(Trie, Rates) ->
+    lists:foldl(fun cache_rate/2, Trie, Rates).
+
+-spec cache_rate(kzd_rate:doc(), trie:trie()) -> trie:trie().
+cache_rate(Rate, Trie) ->
+    Id = kz_doc:id(Rate),
+    Prefix = kz_term:to_list(kzd_rate:prefix(Rate)),
+    NowMs = kz_time:now_ms(),
+    lager:debug("caching ~s for prefix ~s at ~p into ~p~n", [Id, Prefix, NowMs, Trie]),
+    trie:update(Prefix
+               ,fun(Rates) -> props:insert_value(Id, NowMs, Rates) end
+               ,[{Id, NowMs}]
+               ,Trie
+               ).

--- a/applications/hotornot/src/hotornot.hrl
+++ b/applications/hotornot/src/hotornot.hrl
@@ -12,6 +12,9 @@
 -define(CACHE_NAME, 'hotornot_cache').
 
 -type trunking_options() :: ne_binaries().
+-type prefix() :: string().
+-type match_return() :: {'error', any()} |
+                        {'ok', {prefix(), ne_binaries()}}.
 
 -define(HOTORNOT_HRL, 'true').
 -endif.

--- a/applications/hotornot/src/hotornot_config.erl
+++ b/applications/hotornot/src/hotornot_config.erl
@@ -17,7 +17,10 @@
         ,should_account_filter_by_resource/1
 
         ,should_use_trie/0, use_trie/0, dont_use_trie/0
+        ,trie_module/0, use_trie_lru/0
         ,trie_build_timeout_ms/0
+        ,lru_expires_s/0
+
         ]).
 
 -include("hotornot.hrl").
@@ -77,12 +80,23 @@ should_use_trie() ->
 -spec use_trie() -> 'ok'.
 use_trie() ->
     {'ok', _} = kapps_config:set_default(?APP_NAME, <<"use_trie">>, 'true'),
+    {'ok', _} = kapps_config:set_default(?APP_NAME, <<"trie_module">>, 'hon_trie'),
     'ok'.
 
 -spec dont_use_trie() -> 'ok'.
 dont_use_trie() ->
     {'ok', _} = kapps_config:set_default(?APP_NAME, <<"use_trie">>, 'false'),
     'ok'.
+
+-spec use_trie_lru() -> 'ok'.
+use_trie_lru() ->
+    use_trie(),
+    {'ok', _} = kapps_config:set_default(?APP_NAME, <<"trie_module">>, 'hon_trie_lru'),
+    'ok'.
+
+-spec trie_module() -> atom().
+trie_module() ->
+    kapps_config:get_atom(?APP_NAME, <<"trie_module">>, 'hon_trie').
 
 -spec trie_build_timeout_ms() -> pos_integer().
 trie_build_timeout_ms() ->
@@ -100,3 +114,11 @@ set_rate_version(Version) ->
 -spec should_account_filter_by_resource(ne_binary()) -> boolean().
 should_account_filter_by_resource(AccountId) ->
     kapps_account_config:get_from_reseller(AccountId, ?APP_NAME, <<"filter_by_resource_id">>, 'false').
+
+-spec lru_expires_s() -> non_neg_integer().
+-ifdef(TEST).
+lru_expires_s() -> ?SECONDS_IN_DAY.
+-else.
+lru_expires_s() ->
+    kapps_config:get_integer(?APP_NAME, <<"trie_lru_expires_s">>, ?SECONDS_IN_DAY).
+-endif.

--- a/applications/hotornot/test/hon_trie_lru_pqc.erl
+++ b/applications/hotornot/test/hon_trie_lru_pqc.erl
@@ -1,0 +1,236 @@
+%% invoke with `proper:quickcheck(hon_trie_lru_pqc:correct())` or `correct_parallel`
+-module(hon_trie_lru_pqc).
+
+-ifdef(PROPER).
+-include_lib("proper/include/proper.hrl").
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include_lib("kazoo_json/include/kazoo_json.hrl").
+-include_lib("kazoo/include/kz_databases.hrl").
+
+-behaviour(proper_statem).
+
+-export([command/1
+        ,initial_state/0
+        ,next_state/3
+        ,postcondition/3
+        ,precondition/2
+
+        ,correct/0
+        ,correct_parallel/0
+        ]).
+
+-define(EXPIRES_S, 2). % expire after 2 seconds
+-record(model, {cache = []
+               ,now_ms = 0
+               ,next_purge = ?EXPIRES_S * 1000
+               }
+       ).
+
+correct() ->
+    ?FORALL(Cmds
+           ,commands(?MODULE)
+           ,?TRAPEXIT(
+               begin
+                   hon_trie_lru:stop(?KZ_RATES_DB),
+                   {'ok', _Pid} = hon_trie_lru:start_link(?KZ_RATES_DB, ?EXPIRES_S),
+                   {History, State, Result} = run_commands(?MODULE, Cmds),
+                   hon_trie_lru:stop(?KZ_RATES_DB),
+
+                   ?WHENFAIL(?debugFmt("~nLRU: ~p~n Final State: ~p~nRecreate:~n~s~nZip:~n~s~n"
+                                      ,[_Pid, State, recreate_steps(Cmds), print_zip(zip(Cmds, History))]
+                                      )
+                            ,aggregate(command_names(Cmds), Result =:= 'ok')
+                            )
+               end
+              )
+           ).
+
+recreate_steps(Steps) ->
+    string:join([recreate_step(Step) || Step <- Steps], ",").
+
+recreate_step({'set', _Var, {'call', M, F, As}}) ->
+    io_lib:format("~s:~s(~s)~n", [M, F, args_to_list(As)]).
+
+args_to_list(Args) ->
+    string:join([io_lib:format("~p", [A]) || A <- Args], ", ").
+
+print_zip(Zip) ->
+    [print_zip_item(Item) || Item <- Zip].
+
+print_zip_item({{set, _Var, {call, M, F, As}}
+               ,{#model{cache=Cache, now_ms=NowMs}, Result}
+               }) ->
+    io_lib:format("~6b: cache: ~p calling ~s:~s(~s) results in ~p~n"
+                 ,[NowMs, Cache, M, F, args_to_list(As), Result]
+                 ).
+
+correct_parallel() ->
+    ?FORALL(Cmds
+           ,parallel_commands(?MODULE)
+           ,?TRAPEXIT(
+               begin
+                   hon_trie_lru:stop(?KZ_RATES_DB),
+                   {'ok', _Pid} = hon_trie_lru:start_link(?KZ_RATES_DB, ?EXPIRES_S),
+                   {Sequential, Parallel, Result} = run_parallel_commands(?MODULE, Cmds),
+                   hon_trie_lru:stop(?KZ_RATES_DB),
+
+                   ?WHENFAIL(?debugFmt("Failing Cmds: ~p\nS: ~p\nP: ~p\n"
+                                      ,[Cmds, Sequential, Parallel]
+                                      )
+                            ,aggregate(command_names(Cmds), Result =:= 'ok')
+                            )
+               end
+              )
+           ).
+
+-type cache() :: [{ne_binary(), {ne_binary(), gregorian_seconds()}}].
+initial_state() ->
+    #model{}.
+
+command(#model{}) ->
+    Ms = ?EXPIRES_S * ?MILLISECONDS_IN_SECOND,
+    oneof([{'call', 'hon_trie', 'match_did', [phone_number(), 'undefined', ?KZ_RATES_DB]}
+          ,{'call', 'hon_trie_lru', 'cache_rates', [?KZ_RATES_DB, [rate_doc()]]}
+          ,{'call', 'timer', 'sleep', [range(Ms-100,Ms+100)]}
+          ]).
+
+next_state(#model{now_ms=NowMs
+                 ,next_purge=NextPurge
+                 ,cache=Cache
+                 }=Model
+          ,V
+          ,Call
+          ) when NextPurge < NowMs ->
+    next_state(Model#model{cache=expire_rates(Cache, NowMs)
+                          ,next_purge=NextPurge + (?EXPIRES_S * 1000)
+                          }
+              ,V
+              ,Call
+              );
+next_state(#model{cache=Cache
+                 ,now_ms=NowMs
+                 }=Model
+          ,_V
+          ,{'call', 'hon_trie', 'match_did', [PhoneNumber, _AccountId, _RatedeckId]}
+          ) ->
+    case find_prefix(Cache, PhoneNumber) of
+        'error' -> Model;
+        {'ok', Prefix, RateIds} ->
+            Model#model{cache=bump_matched(Cache, NowMs, Prefix, RateIds)}
+    end;
+next_state(#model{cache=Cache
+                 ,now_ms=NowMs
+                 }=Model
+          ,_V
+          ,{'call', 'hon_trie_lru', 'cache_rates', [_RatedeckId, RateDocs]}
+          ) ->
+    {UpdatedCache, NowMs} = cache_rates(Cache, NowMs, RateDocs),
+    Model#model{cache=UpdatedCache};
+next_state(#model{now_ms=ThenMs}=Model
+          ,_V
+          ,{'call', 'timer', 'sleep', [SleepMs]}
+          ) ->
+    NowMs = ThenMs + SleepMs,
+    Model#model{now_ms=NowMs}.
+
+precondition(_Model, _Call) -> 'true'.
+
+postcondition(#model{cache=Cache}
+             ,{'call', 'hon_trie', 'match_did', [PhoneNumber, _AccountId, _RatedeckId]}
+             ,{'error', 'not_found'}
+             ) ->
+    find_prefix(Cache, PhoneNumber) =:= 'error';
+postcondition(#model{cache=Cache}
+             ,{'call', 'hon_trie', 'match_did', [PhoneNumber, _AccountId, _RatedeckId]}
+             ,{'ok', RateDocs}
+             ) ->
+    case find_prefix(Cache, PhoneNumber) of
+        'error' -> 'false';
+        {'ok', _Prefix, RateIds} ->
+            length(RateDocs) =:= length(RateIds)
+                andalso lists:all(fun(RateId) -> props:is_defined(RateId, RateIds) end, RateDocs)
+    end;
+postcondition(#model{}
+             ,{'call', 'hon_trie_lru', 'cache_rates', [_RatedeckId, _Rates]}
+             ,'ok'
+             ) ->
+    'true';
+postcondition(#model{}
+             ,{'call', 'timer', 'sleep', [_Wait]}
+             ,'ok'
+             ) ->
+    'true'.
+
+%% Generators
+phone_number() ->
+    oneof(["14158867900"
+          ,"14168867900"
+          ,"14268867900"
+          ,"15158867900"
+          ]).
+
+rate_doc() ->
+    oneof([?JSON_WRAPPER([{<<"prefix">>, <<"1">>}, {<<"id">>, <<"1">>}])
+          ,?JSON_WRAPPER([{<<"prefix">>, <<"14">>}, {<<"id">>, <<"14">>}])
+          ,?JSON_WRAPPER([{<<"prefix">>, <<"141">>}, {<<"id">>, <<"141">>}])
+          ,?JSON_WRAPPER([{<<"prefix">>, <<"1415">>}, {<<"id">>, <<"1415">>}])
+          ]).
+
+%% Helpers
+cache_rates(Cache, NowMs, RateDocs) ->
+    lists:foldl(fun cache_rate/2, {Cache, NowMs}, RateDocs).
+
+cache_rate(Rate, {Cache, NowMs}) ->
+    Id = kz_doc:id(Rate),
+    Prefix = kz_term:to_list(kzd_rate:prefix(Rate)),
+
+    Rates = props:get_value(Prefix, Cache, []),
+    NewRates = props:insert_value(Id, NowMs, Rates),
+    {props:set_value(Prefix, NewRates, Cache)
+    ,NowMs
+    }.
+
+expire_rates(Cache, NowMs) ->
+    OldestTimestamp = NowMs - (?EXPIRES_S * ?MILLISECONDS_IN_SECOND),
+    {NewCache, _} = lists:foldl(fun expire_rate/2, {[], OldestTimestamp}, Cache),
+    NewCache.
+
+expire_rate({Prefix, Rates}, {Cache, OldestTimestamp}) ->
+    case [RateId || {RateId, LastUsed} <- Rates,
+                    LastUsed < OldestTimestamp
+         ]
+    of
+        [] -> {props:set_value(Prefix, Rates, Cache), OldestTimestamp};
+        [_|_]=_OldRates -> {Cache, OldestTimestamp}
+    end.
+
+bump_matched(Cache, NowMs, Prefix, RateIds) ->
+    BumpedRateIds = [{Id, NowMs}
+                     || {Id, _LastAccessed} <- RateIds
+                    ],
+    props:set_value(Prefix, BumpedRateIds, Cache).
+
+-spec find_prefix(cache(), string()) ->
+                         'error' |
+                         {'ok', string(), any()}.
+find_prefix(Cache, PhoneNumber) ->
+    PNBin = kz_term:to_binary(PhoneNumber),
+    case lists:foldl(fun longest_prefix/2, {PNBin, <<>>, 0, []}, Cache) of
+        {_, <<>>, 0, []} -> 'error';
+        {_, Prefix, _Len, Rates} ->
+            {'ok', kz_term:to_list(Prefix), Rates}
+    end.
+
+longest_prefix({Prefix, Rates}
+              ,{PhoneNumber, _MatchingPrefix, MatchingLength, _MatchingRates}=Acc
+              ) ->
+    PrefixBin = kz_term:to_binary(Prefix),
+    case binary:match(PhoneNumber, PrefixBin) of
+        {0, PrefixLength} when PrefixLength > MatchingLength ->
+            {PhoneNumber, Prefix, PrefixLength, Rates};
+        _ -> Acc
+    end.
+
+-endif.


### PR DESCRIPTION
This allows you to progressively load rates instead of loading the
whole ratedeck in one shot. Minimizes memory usage as rarely-used
rates aren't kept in memory while oft-used rates stay in-memory for
fast matching.