### PR TITLE
qf-vmargs_4oh: remove ERL option that disables writting crash dumps

### DIFF
--- a/rel/args
+++ b/rel/args
@@ -13,9 +13,6 @@
 # Start a pool of asynchronous IO threads
 +A 25
 
-# Comment this line out if you want the Erlang shell
-+Bd
-
 # Treat error_logger:warning_msg/2 as warnings instead of errors (default)
 +W w
 

--- a/rel/args
+++ b/rel/args
@@ -25,5 +25,8 @@
 # Increase number of concurrent ports / sockets
 ##-env ERL_MAX_PORTS 4096
 
+# When crashing, write dump with highest priority
+-env ERL_CRASH_DUMP_NICE 1
+
 -s lager
 -s kazoo_apps_app


### PR DESCRIPTION
master: https://github.com/2600hz/kazoo/pull/3499