### PR TITLE
metaflow.callflow: should "id" field be the mandatory one?

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/metaflow.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/metaflow.callflow.json
@@ -7,8 +7,5 @@
             "type": "string"
         }
     },
-    "required": [
-        "id"
-    ],
     "type": "object"
 }


### PR DESCRIPTION
Hi! 

Since we've got an option to look for a callflow based on captures, it seems "id" field shouldn't be strictly demanded...
https://github.com/2600hz/kazoo/blob/master/applications/konami/src/module/konami_callflow.erl#L32-L38

Regards,