### PR TITLE
Revert "metaflow.callflow: should "id" field be the mandatory one?"

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/metaflow.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/metaflow.callflow.json
@@ -7,5 +7,8 @@
             "type": "string"
         }
     },
+    "required": [
+        "id"
+    ],
     "type": "object"
 }


### PR DESCRIPTION
Reverts 2600hz/kazoo#3503