### PR TITLE
Revert "metaflow.callflow: should "id" field be the mandatory one?"

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -5398,9 +5398,6 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "id"
-            ],
             "type": "object"
         },
         "metaflow.hangup": {


### PR DESCRIPTION
Reverts 2600hz/kazoo#3503 in order to satisfy circleci