### PR TITLE
KAZOO-5421: HELP-28880: make is_notice_enabled a system parameter

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -688,6 +688,7 @@
     "tasks.unfinished_port_request_lifetime_s": "tasks unfinished port request lifetime in seconds",
     "tasks.wait_after_row_ms": "tasks wait after row in milliseconds",
     "teletype.iterate_over_bcc": "teletype iterate over bcc",
+    "teletype.notice_enabled_by_default": "Specify if template is considered enabled by default when teletype tries to process that notification",
     "teletype.render_farm_workers": "teletype render farm workers",
     "token_buckets.inactivity_timeout_s": "token_buckets inactivity timeout in seconds",
     "token_buckets.max_bucket_tokens": "token_buckets maximum bucket tokens",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -12132,6 +12132,11 @@
                     "description": "teletype iterate over bcc",
                     "type": "boolean"
                 },
+                "notice_enabled_by_default": {
+                    "default": true,
+                    "description": "Specify if template is considered enabled by default when teletype tries to process that notification",
+                    "type": "boolean"
+                },
                 "render_farm_workers": {
                     "default": 50,
                     "description": "teletype render farm workers",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.teletype.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.teletype.json
@@ -8,6 +8,11 @@
             "description": "teletype iterate over bcc",
             "type": "boolean"
         },
+        "notice_enabled_by_default": {
+            "default": true,
+            "description": "Specify if template is considered enabled by default when teletype tries to process that notification",
+            "type": "boolean"
+        },
         "render_farm_workers": {
             "default": 50,
             "description": "teletype render farm workers",

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -46,6 +46,10 @@
                                   ,{?TEXT_HTML, 2}
                                   ]).
 
+-define(NOTICE_ENABLED_BY_DEFAULT,
+        kapps_config:get_is_true(?APP_NAME, <<"notice_enabled_by_default">>, 'true')
+       ).
+
 -spec send_email(email_map(), ne_binary(), rendered_templates()) ->
                         'ok' | {'error', any()}.
 -spec send_email(email_map(), ne_binary(), rendered_templates(), attachments()) ->
@@ -629,7 +633,7 @@ is_account_notice_enabled(AccountId, TemplateKey, ResellerAccountId) ->
     case kz_datamgr:open_cache_doc(AccountDb, TemplateId) of
         {'ok', TemplateJObj} ->
             lager:debug("account ~s has ~s, checking if enabled", [AccountId, TemplateId]),
-            kz_notification:is_enabled(TemplateJObj);
+            kz_notification:is_enabled(TemplateJObj, ?NOTICE_ENABLED_BY_DEFAULT);
         _Otherwise when AccountId =/= ResellerAccountId ->
             lager:debug("account ~s is mute, checking parent", [AccountId]),
             is_account_notice_enabled(
@@ -647,7 +651,7 @@ is_notice_enabled_default(TemplateKey) ->
     case kz_datamgr:open_cache_doc(?KZ_CONFIG_DB, TemplateId) of
         {'ok', TemplateJObj} ->
             lager:debug("system has ~s, checking if enabled", [TemplateId]),
-            kz_notification:is_enabled(TemplateJObj);
+            kz_notification:is_enabled(TemplateJObj, ?NOTICE_ENABLED_BY_DEFAULT);
         _Otherwise ->
             lager:debug("system is mute, ~s not enabled", [TemplateId]),
             'false'


### PR DESCRIPTION
Parametrize  `kz_notification:is_enabled/2` default value in `teletype_util:is_notice_enabled`.
Set it to `true` by default.