### PR TITLE
Repeat service reconciles: Remove unused/bad return type

### DIFF
--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -1439,8 +1439,7 @@ get_reseller_id(Parent, Ancestors, JObj) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec maybe_save('false' | services()) -> 'false' |
-                                          services() |
-                                          {'error', 'no_change'}.
+                                          services().
 maybe_save('false') -> 'false';
 maybe_save(#kz_services{jobj=JObj
                        ,updates=UpdatedQuantities
@@ -1452,7 +1451,7 @@ maybe_save(#kz_services{jobj=JObj
             save(Services);
         'false' ->
             lager:debug("no service quantity changes"),
-            {'error', 'no_change'}
+            Services
     end.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
The {'error', 'no_change'} return value of maybe_save isn't used, but causes an error such as in https://github.com/2600hz/kazoo/blob/master/core/kazoo_number_manager/src/knm_services.erl#L135. The return value is used as if it were a services record. Making the change in kz_services:maybe_save/1 because nothing uses the error tuple.