### PR TITLE
Fix error when merging configs in kapps_config

### DIFF
--- a/core/kazoo_config/src/kapps_config_util.erl
+++ b/core/kazoo_config/src/kapps_config_util.erl
@@ -51,7 +51,7 @@ load_config_from_reseller(Account, Config) ->
 
 -spec load_config_from_system(api_binary(), ne_binary()) -> {ok, kz_json:object()} | {error, any()}.
 load_config_from_system(_Account, Config) ->
-    kz_json:get_value(<<"default">>, maybe_new(kapps_config:get_category(Config))).
+    {'ok', kz_json:get_value(<<"default">>, maybe_new(kapps_config:get_category(Config)))}.
 
 -spec load_default_config(api_binary(), ne_binary()) -> {ok, kz_json:object()}.
 load_default_config(_Account, Config) ->


### PR DESCRIPTION
The merge fails when trying to load the system config. This corrects that.