### PR TITLE
cf_park doesn't use cache; neither should parked_calls

### DIFF
--- a/applications/crossbar/src/modules/cb_parked_calls.erl
+++ b/applications/crossbar/src/modules/cb_parked_calls.erl
@@ -30,7 +30,12 @@ resource_exists() -> 'true'.
 
 -spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
-    Ctx1 = crossbar_doc:load(?DB_DOC_NAME, Context, [{'expected_type', ?DB_DOC_NAME}]),
+    Ctx1 = crossbar_doc:load(?DB_DOC_NAME
+                            ,Context
+                            ,[{'expected_type', ?DB_DOC_NAME}
+                             ,{'use_cache', 'false'}
+                             ]
+                            ),
 
     case cb_context:doc(Ctx1) of
         'undefined' ->


### PR DESCRIPTION
makes sure crossbar returns the freshest parked calls object available