### PR TITLE
reseller_bookkeeper_lookup

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -602,6 +602,7 @@
     "services.http_sync.http_url": "services http sync http url",
     "services.master_account_bookkeeper": "services master account bookkeeper",
     "services.modules": "services modules",
+    "services.reseller_bookkeeper_lookup": "allow resellers configure bookkeeper for children billing",
     "services.scan_rate": "services scan rate",
     "services.should_save_master_audit_logs": "services should save master audit logs",
     "services.support_billing_id": "services support billing id",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -11737,6 +11737,11 @@
                 "modules": {
                     "description": "services modules"
                 },
+                "reseller_bookkeeper_lookup": {
+                    "default": false,
+                    "description": "allow resellers configure bookkeeper for children billing",
+                    "type": "boolean"
+                },
                 "scan_rate": {
                     "default": 20000,
                     "description": "services scan rate",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.services.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.services.json
@@ -16,6 +16,11 @@
         "modules": {
             "description": "services modules"
         },
+        "reseller_bookkeeper_lookup": {
+            "default": false,
+            "description": "allow resellers configure bookkeeper for children billing",
+            "type": "boolean"
+        },
         "scan_rate": {
             "default": 20000,
             "description": "services scan rate",

--- a/core/kazoo_services/include/kz_service.hrl
+++ b/core/kazoo_services/include/kz_service.hrl
@@ -8,5 +8,13 @@
 -define(KZ_SERVICE_MASTER_ACCOUNT_BOOKKEEPER,
         kapps_config:get_atom(<<"services">>, <<"master_account_bookkeeper">>, 'kz_bookkeeper_local')).
 
+-define(MAYBE_RESELLER_BOOKKEEPER_LOOKUP,
+        kapps_config:get_atom(<<"services">> ,<<"reseller_bookkeeper_lookup">> ,'false')).
+
+-define(KZ_LOOKUP_BOOKKEEPER(ResellerId),
+        kz_term:to_atom(kapps_account_config:get_global(ResellerId
+                                                       ,<<"services">>
+                                                       ,<<"master_account_bookkeeper">>
+                                                       ,'kz_bookkeeper_local'))).
 -define(KZ_SERVICE_HRL, 'true').
 -endif.


### PR DESCRIPTION
Hi,
At the moment only kz_bookkeeper_local could be used to bill non master reseller's children.
This reduces the benefit of reseller tree feature.
I would like to propose a little step forward in order subresellers could also have fully featured billing solution within their Kazoo platform tenant  
Regards,
Kirill