### PR TITLE
move hangup to tail of ecallmgr execution queue - 4.0

### DIFF
--- a/applications/callflow/src/cf_exe.erl
+++ b/applications/callflow/src/cf_exe.erl
@@ -63,7 +63,7 @@
                ,cf_module_pid :: {pid(), reference()} | 'undefined'
                ,cf_module_old_pid :: {pid(), reference()} | 'undefined'
                ,status = <<"sane">> :: ne_binary()
-               ,queue :: ne_binary()
+               ,queue :: api_ne_binary()
                ,self = self()
                ,stop_on_destroy = 'true' :: boolean()
                ,destroyed = 'false' :: boolean()
@@ -847,5 +847,6 @@ hangup_call(Call) ->
     Cmd = [{<<"Event-Name">>, <<"command">>}
           ,{<<"Event-Category">>, <<"call">>}
           ,{<<"Application-Name">>, <<"hangup">>}
+          ,{<<"Insert-At">>, <<"tail">>}
           ],
     send_command(Cmd, kapps_call:control_queue_direct(Call), kapps_call:call_id_direct(Call)).


### PR DESCRIPTION
* move hangup to tail of ecallmgr execution queue giving time for other actions in ecallmgr execution queue to complete
