### PR TITLE
PISTON-421: allow teletype to use system-level templates as fallback

### DIFF
--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -744,8 +744,9 @@ read_account(Context, Id, LoadFrom) ->
             maybe_read_from_parent(Context, Id, LoadFrom, cb_context:reseller_id(Context));
         {_Code, 'success'} ->
             lager:debug("loaded ~s from account database ~s", [Id, cb_context:account_db(Context)]),
-            NewRespData = note_account_override(cb_context:resp_data(Context1)),
-            cb_context:set_resp_data(Context1, NewRespData);
+            Context2 = maybe_merge_ancestor_attachments(Context1, Id),
+            NewRespData = note_account_override(cb_context:resp_data(Context2)),
+            cb_context:set_resp_data(Context2, NewRespData);
         {_Code, _Status} ->
             lager:debug("failed to load ~s: ~p", [Id, _Code]),
             Context1
@@ -836,6 +837,82 @@ maybe_hard_delete(Context, Id) ->
         {'error', _E} ->
             lager:debug("error deleting ~s from ~s: ~p", [Id, cb_context:account_db(Context), _E])
     end.
+
+-spec maybe_merge_ancestor_attachments(cb_context:context(), ne_binary()) ->
+                                              cb_context:context().
+maybe_merge_ancestor_attachments(Context, Id) ->
+    case kz_doc:attachments(cb_context:doc(Context)) of
+        'undefined' -> merge_ancestor_attachments(Context, Id);
+        _ -> Context
+    end.
+
+-spec merge_ancestor_attachments(cb_context:context(), ne_binary()) -> cb_context:context().
+-spec merge_ancestor_attachments(cb_context:context(), ne_binary(), ne_binary(), ne_binary()) ->
+                                        cb_context:context().
+merge_ancestor_attachments(Context, Id) ->
+    AccountId = cb_context:account_id(Context),
+    ResellerId = case cb_context:fetch(Context, 'initial_reseller_id') of
+                     'undefined' -> kz_services:find_reseller_id(AccountId);
+                     ResellerId1 -> ResellerId1
+                 end,
+    Context1 = cb_context:store(Context, 'initial_reseller_id', ResellerId),
+    merge_ancestor_attachments(Context1, Id, AccountId, ResellerId).
+
+%% Last attempt was reseller, now try ?KZ_CONFIG_DB
+merge_ancestor_attachments(Context, Id, AccountId, AccountId) ->
+    lager:debug("trying attachments in ~s", [?KZ_CONFIG_DB]),
+    case kz_doc:attachments(cb_context:doc(read_system(Context, Id))) of
+        'undefined' ->
+            lager:error("the ~s ~s template is missing", [?KZ_CONFIG_DB, Id]),
+            Context;
+        Attachments ->
+            lager:debug("found attachments in ~s", [?KZ_CONFIG_DB]),
+            Doc = kz_json:set_value(<<"_attachments">>, Attachments, cb_context:doc(Context)),
+            cb_context:setters(Context
+                              ,[{fun cb_context:store/3, 'db_doc', Doc}
+                               ,{fun cb_context:set_doc/2, Doc}
+                               ,{fun cb_context:store/3, 'attachments_db', ?KZ_CONFIG_DB}])
+    end;
+%% Not yet at reseller, try parent account
+merge_ancestor_attachments(Context, Id, AccountId, ResellerId) ->
+    AccountContext = masquerade(Context, AccountId),
+    AccountContext1 = crossbar_doc:load(AccountId, AccountContext, ?TYPE_CHECK_OPTION(kz_account:type())),
+    AccountJObj = cb_context:doc(AccountContext1),
+    case kz_account:parent_account_id(AccountJObj) of
+        'undefined' ->
+            lager:error("where was the parent account for ~s?", [AccountId]),
+            Context;
+        ParentAccountId ->
+            lager:debug("trying attachments in account ~s", [ParentAccountId]),
+            try_parent_attachments(Context, Id, AccountId, ParentAccountId, ResellerId)
+    end.
+
+-spec try_parent_attachments(cb_context:context(), ne_binary(), ne_binary(), ne_binary(), ne_binary()) ->
+                                    cb_context:context().
+try_parent_attachments(Context, Id, AccountId, ParentAccountId, ResellerId) ->
+    ParentNotificationContext = crossbar_doc:load(Id
+                                                 ,masquerade(Context, ParentAccountId)
+                                                 ,?TYPE_CHECK_OPTION(kz_notification:pvt_type())),
+    Doc = cb_context:doc(ParentNotificationContext),
+    case kz_doc:attachments(Doc) of
+        'undefined' -> merge_ancestor_attachments(Context, Id, ParentAccountId, ResellerId);
+        Attachments ->
+            lager:debug("found attachments in account ~s", [ParentAccountId]),
+            Doc = kz_json:set_value(<<"_attachments">>, Attachments, cb_context:doc(Context)),
+            AttachmentsDb = kz_util:format_account_id(ParentAccountId, 'encoded'),
+            cb_context:setters(Context
+                              ,[{fun cb_context:store/3, 'db_doc', Doc}
+                               ,{fun cb_context:set_doc/2, Doc}
+                               ,{fun cb_context:store/3, 'attachments_db', AttachmentsDb}])
+    end.
+
+-spec masquerade(cb_context:context(), ne_binary()) -> cb_context:context().
+masquerade(Context, AccountId) ->
+    AccountDb = kz_util:format_account_id(AccountId, 'encoded'),
+    cb_context:setters(Context
+                      ,[{fun cb_context:set_account_id/2, AccountId}
+                       ,{fun cb_context:set_account_db/2, AccountDb}
+                       ]).
 
 -spec maybe_note_notification_preference(cb_context:context()) -> 'ok'.
 -spec maybe_note_notification_preference(ne_binary(), kz_json:object()) -> 'ok'.
@@ -944,14 +1021,6 @@ attachment_filename(Id, Accept) ->
     ,$., kz_mime:to_extension(Accept)
     ].
 
--spec read_system_attachment(cb_context:context(), ne_binary(), ne_binary()) -> cb_context:context().
-read_system_attachment(Context, DocId, Name) ->
-    crossbar_doc:load_attachment(DocId
-                                ,Name
-                                ,?TYPE_CHECK_OPTION(kz_notification:pvt_type())
-                                ,cb_context:set_account_db(Context, ?KZ_CONFIG_DB)
-                                ).
-
 -spec read_account_attachment(cb_context:context(), ne_binary(), ne_binary()) -> cb_context:context().
 read_account_attachment(Context, DocId, Name) ->
     Context1 = crossbar_doc:load_attachment(DocId, Name, ?TYPE_CHECK_OPTION(kz_notification:pvt_type()), Context),
@@ -960,14 +1029,27 @@ read_account_attachment(Context, DocId, Name) ->
          }
     of
         {404, 'error'} ->
-            lager:debug("~s not found in account, reading from master", [DocId]),
-            read_system_attachment(Context, DocId, Name);
+            lager:debug("~s not found in account, checking for ancestor attachments", [DocId]),
+            maybe_read_other_account_attachment(Context, DocId, Name);
         {_Code, 'success'} ->
             lager:debug("loaded ~s from account database", [DocId]),
             Context1;
         {_Code, _Status} ->
             lager:debug("failed to load ~s: ~p", [DocId, _Code]),
             Context1
+    end.
+
+-spec maybe_read_other_account_attachment(cb_context:context(), ne_binary(), ne_binary()) ->
+                                                 cb_context:context().
+maybe_read_other_account_attachment(Context, DocId, Name) ->
+    case cb_context:fetch(Context, 'attachments_db') of
+        'undefined' -> Context;
+        AttachmentsDb ->
+            lager:debug("attachments_db ~s is specified, load from it", [AttachmentsDb]),
+            crossbar_doc:load_attachment(DocId
+                                        ,Name
+                                        ,?TYPE_CHECK_OPTION(kz_notification:pvt_type())
+                                        ,cb_context:set_account_db(Context, AttachmentsDb))
     end.
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -871,13 +871,8 @@ merge_ancestor_attachments(Context, Id, AccountId, AccountId) ->
     end;
 %% Not yet at reseller, try parent account
 merge_ancestor_attachments(Context, Id, AccountId, ResellerId) ->
-    AccountContext = masquerade(Context, AccountId),
-    AccountContext1 = crossbar_doc:load(AccountId, AccountContext, ?TYPE_CHECK_OPTION(kz_account:type())),
-    AccountJObj = cb_context:doc(AccountContext1),
-    case kz_account:parent_account_id(AccountJObj) of
-        'undefined' ->
-            lager:error("where was the parent account for ~s?", [AccountId]),
-            Context;
+    case get_parent_account_id(AccountId) of
+        'undefined' -> Context;
         ParentAccountId ->
             lager:debug("trying attachments in account ~s", [ParentAccountId]),
             try_parent_attachments(Context, Id, AccountId, ParentAccountId, ResellerId)

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -851,12 +851,8 @@ maybe_merge_ancestor_attachments(Context, Id) ->
                                         cb_context:context().
 merge_ancestor_attachments(Context, Id) ->
     AccountId = cb_context:account_id(Context),
-    ResellerId = case cb_context:fetch(Context, 'initial_reseller_id') of
-                     'undefined' -> kz_services:find_reseller_id(AccountId);
-                     ResellerId1 -> ResellerId1
-                 end,
-    Context1 = cb_context:store(Context, 'initial_reseller_id', ResellerId),
-    merge_ancestor_attachments(Context1, Id, AccountId, ResellerId).
+    ResellerId = kz_services:find_reseller_id(AccountId),
+    merge_ancestor_attachments(Context, Id, AccountId, ResellerId).
 
 %% Last attempt was reseller, now try ?KZ_CONFIG_DB
 merge_ancestor_attachments(Context, Id, AccountId, AccountId) ->

--- a/applications/teletype/src/teletype_templates.erl
+++ b/applications/teletype/src/teletype_templates.erl
@@ -177,10 +177,8 @@ templates_source(TemplateId, AccountId, ResellerId) ->
         {'error', _E} -> 'undefined'
     end.
 
--spec templates_source_has_attachments(ne_binary()
-                                      ,ne_binary()
-                                      ,ne_binary()
-                                      ,kz_json:object()) -> api_binary().
+-spec templates_source_has_attachments(ne_binary(), ne_binary(), ne_binary(), kz_json:object()) ->
+                                              api_binary().
 templates_source_has_attachments(TemplateId, AccountId, ResellerId, Template) ->
     case kz_doc:attachments(Template) of
         'undefined' -> parent_templates_source(TemplateId, AccountId, ResellerId);


### PR DESCRIPTION
It seems useful to allow accounts to modify the notification docs for a teletype notification while using the system level template. This allows us to make a change to the template in system_config and have it apply to any accounts that have overridden fields such as "from" in the notification doc but not provided their own template. (That's our use case)
This is currently possible by doing a POST to /v[12]/accounts/<account_id>/notifications/<notification_id> with just the metadata fields and no attachment. Without the modifications in this PR, the notification doesn't work when a POST is done this way. With them, if a notification doc doesn't have attachments going up the tree, it will fall back to the system_config template attachments.