### PR TITLE
[master] HELP-29570: use kazoo_modb for most modb ops

### DIFF
--- a/applications/acdc/src/acdc_maintenance.erl
+++ b/applications/acdc/src/acdc_maintenance.erl
@@ -194,15 +194,20 @@ refresh() ->
 -spec refresh_account(ne_binary()) -> 'ok'.
 refresh_account(Acct) ->
     MoDB = acdc_stats_util:db_name(Acct),
-    refresh_account(MoDB, kz_datamgr:db_create(MoDB)),
+    refresh_account(MoDB, kazoo_modb:maybe_create(MoDB)),
     lager:debug("refreshed: ~s", [MoDB]).
 
 refresh_account(MoDB, 'true') ->
     lager:debug("created ~s", [MoDB]),
     kz_datamgr:revise_views_from_folder(MoDB, 'acdc');
 refresh_account(MoDB, 'false') ->
-    lager:debug("exists ~s", [MoDB]),
-    kz_datamgr:revise_views_from_folder(MoDB, 'acdc').
+    case kz_datamgr:db_exists(MoDB) of
+        'true' ->
+            lager:debug("exists ~s", [MoDB]),
+            kz_datamgr:revise_views_from_folder(MoDB, 'acdc');
+        'false' ->
+            lager:debug("modb ~s was not created", [MoDB])
+    end.
 
 -spec migrate() -> 'ok'.
 migrate() ->

--- a/applications/acdc/src/acdc_stats.erl
+++ b/applications/acdc/src/acdc_stats.erl
@@ -335,8 +335,6 @@ find_call(CallId) ->
 
 -record(state, {archive_ref :: reference()
                ,cleanup_ref :: reference()
-               ,call_table_id :: ets:tid()
-               ,status_table_id :: ets:tid()
                }).
 -type state() :: #state{}.
 
@@ -780,11 +778,17 @@ miss_to_doc(#agent_miss{agent_id=AgentId
 -spec init_db(ne_binary()) -> 'ok'.
 init_db(AccountId) ->
     DbName = acdc_stats_util:db_name(AccountId),
-    maybe_created_db(DbName, kz_datamgr:db_create(DbName)).
+    maybe_created_db(DbName, kazoo_modb:maybe_create(DbName)).
 
 -spec maybe_created_db(ne_binary(), boolean()) -> 'ok'.
 maybe_created_db(DbName, 'false') ->
-    lager:debug("database ~s already created", [DbName]);
+    case kz_datamgr:db_exists(DbName) of
+        'true' ->
+            lager:debug("database ~s already created, refreshing view", [DbName]),
+            kz_datamgr:revise_views_from_folder(DbName, 'acdc');
+        'false' ->
+            lager:debug("modb ~s was not created", [DbName])
+    end;
 maybe_created_db(DbName, 'true') ->
     lager:debug("created db ~s, adding views", [DbName]),
     kz_datamgr:revise_views_from_folder(DbName, 'acdc').

--- a/applications/cdr/src/cdr.hrl
+++ b/applications/cdr/src/cdr.hrl
@@ -8,8 +8,6 @@
 -define(APP_VERSION, <<"4.0.0">>).
 -define(CONFIG_CAT, ?APP_NAME).
 
--define(MAX_RETRIES, 3).
-
 -type account_id() :: ne_binary().
 -type account_db() :: ne_binary().
 

--- a/applications/cdr/src/cdr_channel_destroy.erl
+++ b/applications/cdr/src/cdr_channel_destroy.erl
@@ -191,7 +191,7 @@ set_interaction(_AccountId, _Timestamp, JObj) ->
 save_cdr(_, _, JObj) ->
     CDRDb = kz_doc:account_db(JObj),
     case cdr_util:save_cdr(CDRDb, kz_json:normalize_jobj(JObj)) of
-        {'error', 'max_retries'} ->
+        {'error', 'max_save_retries'} ->
             lager:error("write failed to ~s, too many retries", [CDRDb]);
         'ok' -> 'ok'
     end.

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -585,9 +585,7 @@ get_cdr_ids(Db, View, ViewOptions) ->
 maybe_add_design_doc(Db) ->
     case kz_datamgr:lookup_doc_rev(Db, <<"_design/cdrs">>) of
         {'ok', _} -> 'ok';
-        {'error', 'not_found'} ->
-            lager:warning("adding cdr views to modb: ~s", [Db]),
-            kz_datamgr:revise_doc_from_file(Db, 'kazoo_modb', <<"views/cdrs.json">>)
+        {'error', 'not_found'} -> kazoo_modb:refresh_views(Db)
     end.
 
 -spec load_chunked_cdrs(ne_binary(), ne_binaries(), payload()) -> payload().

--- a/applications/crossbar/src/modules/cb_sms.erl
+++ b/applications/crossbar/src/modules/cb_sms.erl
@@ -109,7 +109,12 @@ validate_sms(Context, Id, ?HTTP_DELETE) ->
 %%--------------------------------------------------------------------
 -spec put(cb_context:context()) -> cb_context:context().
 put(Context) ->
-    crossbar_doc:save(Context).
+    Doc = cb_context:doc(Context),
+    case kazoo_modb:save_doc(cb_context:account_db(Context), Doc) of
+        {'ok', Saved} -> crossbar_util:response(Saved, Context);
+        {'error', Error} ->
+            crossbar_doc:handle_datamgr_errors(Error, kz_doc:id(Doc), Context)
+    end.
 
 %%--------------------------------------------------------------------
 %% @public
@@ -157,7 +162,6 @@ on_successful_validation(Context) ->
     JObj = cb_context:doc(Context),
     AccountId = cb_context:account_id(Context),
     AccountDb = cb_context:account_modb(Context),
-    kazoo_modb:maybe_create(AccountDb),
     ResellerId = cb_context:reseller_id(Context),
     Realm = kz_util:get_account_realm(AccountId),
 

--- a/applications/doodle/src/doodle_util.erl
+++ b/applications/doodle/src/doodle_util.erl
@@ -131,7 +131,7 @@ save_sms(JObj, DocId, Call) ->
                       kapps_call:call().
 save_sms(JObj, ?MATCH_MODB_PREFIX(Year,Month,_) = DocId, Doc, Call) ->
     AccountId = kapps_call:account_id(Call),
-    AccountDb = kazoo_modb:get_modb(AccountId, Year, Month),
+    AccountMODB = kazoo_modb:get_modb(AccountId, Year, Month),
     OwnerId = kapps_call:owner_id(Call),
     AuthType = kapps_call:authorizing_type(Call),
     AuthId = kapps_call:authorizing_id(Call),
@@ -155,7 +155,7 @@ save_sms(JObj, ?MATCH_MODB_PREFIX(Year,Month,_) = DocId, Doc, Call) ->
               ,{<<"pvt_type">>, <<"sms">>}
               ,{<<"account_id">>, AccountId}
               ,{<<"pvt_account_id">>, AccountId}
-              ,{<<"pvt_account_db">>, AccountDb}
+              ,{<<"pvt_account_db">>, AccountMODB}
               ,{<<"owner_id">>, OwnerId}
               ,{<<"pvt_owner_id">>, OwnerId}
               ,{<<"authorization_type">>, AuthType}
@@ -185,8 +185,7 @@ save_sms(JObj, ?MATCH_MODB_PREFIX(Year,Month,_) = DocId, Doc, Call) ->
               ,{<<"_rev">>, Rev}
               ]),
     JObjDoc = kz_json:set_values(Props, Doc),
-    kazoo_modb:maybe_create(AccountDb),
-    case kz_datamgr:save_doc(AccountDb, JObjDoc, Opts) of
+    case kazoo_modb:save_doc(AccountMODB, JObjDoc, Opts) of
         {'ok', Saved} ->
             kapps_call:kvs_store(<<"_rev">>, kz_doc:revision(Saved), Call);
         {'error', E} ->

--- a/applications/fax/src/fax_maintenance.erl
+++ b/applications/fax/src/fax_maintenance.erl
@@ -186,8 +186,7 @@ migrate_fax_to_modb(AccountDb, DocId, JObj, Options) ->
               ,DocId/binary
             >>,
     io:format("moving doc ~s/~s to ~s/~s~n",[AccountDb, DocId, AccountMODb, FaxId]),
-    kazoo_modb:maybe_create(AccountMODb),
-    case kz_datamgr:move_doc(AccountDb, DocId, FaxMODb, FaxId, Options) of
+    case kazoo_modb:move_doc(AccountDb, DocId, FaxMODb, FaxId, Options) of
         {'ok', _JObj} -> io:format("document ~s moved to ~s~n",[DocId, FaxId]);
         {'error', Error} -> io:format("error ~p moving document ~s to ~s~n",[Error, DocId, FaxId])
     end.
@@ -406,12 +405,10 @@ migrate_outbound_fax(JObj) ->
     AccountId = kz_doc:account_id(JObj),
     AccountMODb = kazoo_modb:get_modb(AccountId, Year, Month),
 
-    kazoo_modb:maybe_create(AccountMODb),
-
     ToDB = kz_util:format_account_modb(AccountMODb, 'encoded'),
     ToId = ?MATCH_MODB_PREFIX(kz_term:to_binary(Year), kz_time:pad_month(Month),FromId),
 
-    case kz_datamgr:move_doc(FromDB, FromId, ToDB, ToId, ['override_existing_document']) of
+    case kazoo_modb:move_doc(FromDB, FromId, ToDB, ToId, ['override_existing_document']) of
         {'ok', _} -> io:format("document ~s/~s moved to ~s/~s~n", [FromDB, FromId, ToDB, ToId]);
         {'error', _E} -> io:format("error ~p moving document ~s/~s to ~s/~s~n", [_E, FromDB, FromId, ToDB, ToId])
     end.

--- a/applications/webhooks/src/webhooks_util.erl
+++ b/applications/webhooks/src/webhooks_util.erl
@@ -478,7 +478,7 @@ init_webhooks(Accts, Year, Month) ->
 init_webhook(Acct, Year, Month) ->
     Db = kz_util:format_account_id(kz_json:get_value(<<"key">>, Acct), Year, Month),
     kazoo_modb:maybe_create(Db),
-    lager:debug("updated account_mod ~s", [Db]).
+    lager:debug("updated account_modb ~s", [Db]).
 
 -spec note_failed_attempt(ne_binary(), ne_binary()) -> 'ok'.
 note_failed_attempt(AccountId, HookId) ->

--- a/core/kazoo_bindings/src/kazoo_bindings.erl
+++ b/core/kazoo_bindings/src/kazoo_bindings.erl
@@ -731,8 +731,7 @@ map_processor(Routing, Payload, Options) when not is_list(Payload) ->
 map_processor(Routing, Payload, Options) ->
     RoutingParts = routing_parts(Routing),
     lists:foldl(fun(Binding, Acc) ->
-                        io:format("~n Binding ~p Routing ~p ~n Options ~p~n~n", [Binding, Routing, Options]),
-                        map_processor_fold(Binding, Acc, Map, Routing, RoutingParts, Options)
+                        map_processor_fold(Binding, Acc, Payload, Routing, RoutingParts, Options)
                 end
                ,[]
                ,kazoo_bindings_rt:candidates(Options, Routing)

--- a/core/kazoo_bindings/src/kazoo_bindings.erl
+++ b/core/kazoo_bindings/src/kazoo_bindings.erl
@@ -731,7 +731,8 @@ map_processor(Routing, Payload, Options) when not is_list(Payload) ->
 map_processor(Routing, Payload, Options) ->
     RoutingParts = routing_parts(Routing),
     lists:foldl(fun(Binding, Acc) ->
-                        map_processor_fold(Binding, Acc, Payload, Routing, RoutingParts, Options)
+                        io:format("~n Binding ~p Routing ~p ~n Options ~p~n~n", [Binding, Routing, Options]),
+                        map_processor_fold(Binding, Acc, Map, Routing, RoutingParts, Options)
                 end
                ,[]
                ,kazoo_bindings_rt:candidates(Options, Routing)

--- a/core/kazoo_media/src/kz_media_recording.erl
+++ b/core/kazoo_media/src/kz_media_recording.erl
@@ -465,8 +465,7 @@ store_recording_meta(#state{call=Call
                      ]))
                                            ,Db
                 ),
-    kazoo_modb:maybe_create(Db),
-    case kz_datamgr:ensure_saved(Db, MediaDoc) of
+    case kazoo_modb:save_doc(Db, MediaDoc, [{ensure_saved, true}]) of
         {'ok', JObj} -> kz_doc:revision(JObj);
         {'error', _}= Err -> Err
     end.

--- a/core/kazoo_modb/src/kazoo_modb_view.erl
+++ b/core/kazoo_modb/src/kazoo_modb_view.erl
@@ -60,7 +60,7 @@ fold_query({Db, View, CouchOpts, Mapper}, {Limit, LastKey, Res}) when is_integer
 -spec limited_query(integer(), ne_binary(), ne_binary(), kz_datamgr:view_options()) -> kz_json:objects().
 limited_query(Limit, _, _, _) when Limit =< 0 -> [];
 limited_query(Limit, Db, View, CouchOpts) ->
-    case kz_datamgr:get_results(Db, View, [{limit, Limit} | CouchOpts]) of
+    case kazoo_modb:get_results(Db, View, [{limit, Limit} | CouchOpts]) of
         {ok, JObjs} -> JObjs;
         {error, not_found} -> [];
         {error, Error} -> throw(Error)
@@ -101,7 +101,7 @@ get_ordered(AccountId, View, Start, End, Mapper, CouchOptions) when Start < End 
 
 -spec unlimited_query(ne_binary(), ne_binary(), kz_datamgr:view_options()) -> kz_json:objects().
 unlimited_query(Db, View, CouchOpts) ->
-    case kz_datamgr:get_results(Db, View, CouchOpts) of
+    case kazoo_modb:get_results(Db, View, CouchOpts) of
         {ok, JObjs} -> JObjs;
         {error, not_found} -> [];
         {error, Error} -> throw(Error)

--- a/core/kazoo_services/src/kz_services_modb.erl
+++ b/core/kazoo_services/src/kz_services_modb.erl
@@ -20,7 +20,7 @@
 -spec start_link() -> startlink_ret().
 start_link() ->
     _Pid = kz_util:spawn(fun kazoo_modb:add_routine/1, [?MODULE]),
-    io:format("started add_rountine in ~p~n", [_Pid]),
+    io:format("started services modb add_rountine in ~p~n", [_Pid]),
     'ignore'.
 
 -spec modb(ne_binary()) -> 'ok'.

--- a/core/kazoo_voicemail/src/kvm_messages.erl
+++ b/core/kazoo_voicemail/src/kvm_messages.erl
@@ -311,7 +311,7 @@ get_view_results([], _View, _ViewOpts, NormFun, ViewResults) ->
         not kz_term:is_empty(JObj)
     ];
 get_view_results([Db | Dbs], View, ViewOpts, NormFun, Acc) ->
-    case kz_datamgr:get_results(Db, View, ViewOpts) of
+    case kazoo_modb:get_results(Db, View, ViewOpts) of
         {'ok', []} -> get_view_results(Dbs, View, ViewOpts, NormFun, Acc);
         {'ok', Msgs} -> get_view_results(Dbs, View, ViewOpts, NormFun, Msgs ++ Acc);
         {'error', _}=_E ->


### PR DESCRIPTION
* make sure we use `kazoo_modb` function for `get_results`, `save_doc`, `copy_doc`, `move_doc` every place that we operate on MODB. This cause if modb is not created yet, creates it and properly refresh modb views
* add functions for move and copy doc to kazoo_modb