### PR TITLE
PISTON-422: fix name announcements in conferences when crossing media servers

### DIFF
--- a/applications/conference/src/conf_route_req.erl
+++ b/applications/conference/src/conf_route_req.erl
@@ -31,7 +31,7 @@ handle_req(JObj, _Props) ->
 maybe_send_route_response(JObj, Call) ->
     case find_conference(Call) of
         {'ok', Conference} ->
-            send_route_response(JObj, Call, bridged_conference(Conference));
+            send_route_response(JObj, Call, Conference);
         {'error', _} -> 'ok'
     end.
 
@@ -110,17 +110,4 @@ find_account_db(Call) ->
                        ,[Realm, _R]
                        ),
             'undefined'
-    end.
-
--spec bridged_conference(kapps_conference:conference()) -> kapps_conference:conference().
-bridged_conference(Conference) ->
-    %% We are relying on the original channel to play media
-    %% so that name announcements always work
-    case ?SUPPORT_NAME_ANNOUNCEMENT(kapps_conference:account_id(Conference)) of
-        'true' ->
-            Updaters = [fun(Conf) -> kapps_conference:set_play_entry_tone('false', Conf) end
-                       ,fun(Conf) -> kapps_conference:set_play_exit_tone('false', Conf) end
-                       ],
-            kapps_conference:update(Updaters, Conference);
-        'false' -> Conference
     end.

--- a/applications/conference/src/conf_route_req.erl
+++ b/applications/conference/src/conf_route_req.erl
@@ -77,8 +77,21 @@ join_local(Call, Conference, Participant) ->
                ],
     C = kapps_conference:update(Routines, Conference),
     conf_participant:set_conference(C, Participant),
+    maybe_set_name_pronounced(Call, Participant),
     kapps_call_command:answer(Call),
     conf_participant:join_local(Participant).
+
+-spec maybe_set_name_pronounced(kapps_call:call(), server_ref()) -> 'ok'.
+-spec maybe_set_name_pronounced(kz_json:api_json_term(), kz_json:api_json_term(), server_ref()) -> 'ok'.
+maybe_set_name_pronounced(Call, Participant) ->
+    AccountId = kapps_call:custom_sip_header(<<"X-Conf-Values-Pronounced-Name-Account-ID">>, Call),
+    MediaId = kapps_call:custom_sip_header(<<"X-Conf-Values-Pronounced-Name-Media-ID">>, Call),
+    maybe_set_name_pronounced(AccountId, MediaId, Participant).
+
+maybe_set_name_pronounced('undefined', _, _) -> 'ok';
+maybe_set_name_pronounced(_, 'undefined', _) -> 'ok';
+maybe_set_name_pronounced(AccountId, MediaId, Participant) ->
+    conf_participant:set_name_pronounced({'undefined', AccountId, MediaId}, Participant).
 
 -spec find_conference(kapps_call:call()) -> {'error', any()} |
                                             {'ok', kapps_conference:conference()}.


### PR DESCRIPTION
If a conference caller has to bridge to another media server because their original call was not on the media server running the mod_conference instance, name announcements will not work. The necessary FS channel vars (conference_enter_sound & conference_exit_sound) that mod_conference looks for will not be present on the channel on the new media server (to be expected, as FS instances can't share channel vars). So, when bridging, send some SIP headers that can be unwrapped in conf_route_req that will set the name announcements on the new channel.

Also removed the bridged_conference/1 function as it is no longer relevant since Kazoo 4 conferences use mod_conference's built-in media features.