### PR TITLE
knm-reserve: (and reconcile and create) fail if assign_to is not an account id

### DIFF
--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -436,10 +436,16 @@ reconcile(Nums, Options0) ->
 %%--------------------------------------------------------------------
 -spec reserve(ne_binaries(), knm_number_options:options()) -> ret().
 reserve(Nums, Options) ->
-    ret(pipe(do_get(Nums, Options)
-            ,[fun if_unassigned_then_needs_assign_to/1
-             ,fun to_reserved/1
-             ])).
+    case knm_number_options:assign_to(Options) =:= undefined of
+        true ->
+            Error = knm_errors:to_json(assign_failure, undefined, field_undefined),
+            ret(new(Options, [], Nums, Error));
+        false ->
+            ret(pipe(do_get(Nums, Options)
+                    ,[fun if_unassigned_then_needs_assign_to/1
+                     ,fun to_reserved/1
+                     ]))
+    end.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -436,15 +436,15 @@ reconcile(Nums, Options0) ->
 %%--------------------------------------------------------------------
 -spec reserve(ne_binaries(), knm_number_options:options()) -> ret().
 reserve(Nums, Options) ->
-    case knm_number_options:assign_to(Options) =:= undefined of
-        true ->
-            Error = knm_errors:to_json(assign_failure, undefined, field_undefined),
-            ret(new(Options, [], Nums, Error));
-        false ->
+    case knm_number_options:assign_to(Options) of
+        ?MATCH_ACCOUNT_RAW(_) ->
             ret(pipe(do_get(Nums, Options)
                     ,[fun if_unassigned_then_needs_assign_to/1
                      ,fun to_reserved/1
-                     ]))
+                     ]));
+        _ ->
+            Error = knm_errors:to_json(assign_failure, undefined, field_undefined),
+            ret(new(Options, [], Nums, Error))
     end.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_number_manager/test/knm_numbers_test.erl
+++ b/core/kazoo_number_manager/test/knm_numbers_test.erl
@@ -173,21 +173,33 @@ delete_test_() ->
 
 reconcile_test_() ->
     Ret0 = knm_numbers:reconcile([?NOT_NUM], []),
-    Options = [{assign_to, ?RESELLER_ACCOUNT_ID} | knm_number_options:default()],
-    Ret = knm_numbers:reconcile([?NOT_NUM, ?TEST_AVAILABLE_NUM], Options),
-    [?_assertEqual(<<"assign_failure">>
-                  ,knm_errors:error(maps:get(?NOT_NUM, maps:get(ko, Ret0)))
-                  )
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret))
-    ,?_assertMatch([_], maps:get(ok, Ret))
-    ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret)))
+    Ret1 = knm_numbers:reconcile([?NOT_NUM, ?TEST_AVAILABLE_NUM], knm_number_options:default()),
+    Ret2 = knm_numbers:reconcile([?NOT_NUM, ?TEST_AVAILABLE_NUM]
+                                ,[{assign_to, ?RESELLER_ACCOUNT_ID} | knm_number_options:default()]),
+    [?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret0))
+    ,?_assertEqual([], maps:get(ok, Ret0))
+    ,?_assertEqual(#{?NOT_NUM => not_reconcilable, ?TEST_AVAILABLE_NUM => error_assign_to_undefined()}
+                  ,maps:get(ko, Ret1))
+    ,?_assertEqual([], maps:get(ok, Ret1))
+    ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret2))
+    ,?_assertMatch([_], maps:get(ok, Ret2))
+    ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret2)))
     ,{"verify number is now in service"
-     ,?_assertEqual(?NUMBER_STATE_IN_SERVICE, knm_phone_number:state(pn_x(1, Ret)))
+     ,?_assertEqual(?NUMBER_STATE_IN_SERVICE, knm_phone_number:state(pn_x(1, Ret2)))
      }
     ,{"verify number is indeed owned by account"
-     ,?_assertEqual(?RESELLER_ACCOUNT_ID, knm_phone_number:assigned_to(pn_x(1, Ret)))
+     ,?_assertEqual(?RESELLER_ACCOUNT_ID, knm_phone_number:assigned_to(pn_x(1, Ret2)))
      }
     ].
+
+
+error_assign_to_undefined() ->
+    kz_json:from_list(
+      [{<<"code">>, 400}
+      ,{<<"error">>, <<"assign_failure">>}
+      ,{<<"cause">>, <<"field_undefined">>}
+      ,{<<"message">>, <<"invalid account to assign to">>}
+      ]).
 
 
 reserve_test_() ->
@@ -203,12 +215,7 @@ reserve_test_() ->
     ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret2))
     ,?_assertMatch([_], maps:get(ok, Ret2))
     ,?_assertEqual(#{?NOT_NUM => not_reconcilable
-                    ,?TEST_IN_SERVICE_NUM => kz_json:from_list(
-                                               [{<<"code">>, 400}
-                                               ,{<<"error">>, <<"assign_failure">>}
-                                               ,{<<"cause">>, <<"field_undefined">>}
-                                               ,{<<"message">>, <<"invalid account to assign to">>}
-                                               ])
+                    ,?TEST_IN_SERVICE_NUM => error_assign_to_undefined()
                     }, maps:get(ko, Ret2b))
     ,?_assertEqual([], maps:get(ok, Ret2b))
     ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret3))

--- a/core/kazoo_number_manager/test/knm_numbers_test.erl
+++ b/core/kazoo_number_manager/test/knm_numbers_test.erl
@@ -206,16 +206,19 @@ reserve_test_() ->
     ,{"verify number was indeed reserved"
      ,?_assertEqual(?NUMBER_STATE_RESERVED, knm_phone_number:state(pn_x(1, Ret1)))
      }
+    ,?_assertEqual(?RESELLER_ACCOUNT_ID, knm_phone_number:assigned_to(pn_x(1, Ret1)))
     ,?_assertEqual([?RESELLER_ACCOUNT_ID], knm_phone_number:reserve_history(pn_x(1, Ret1)))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret2)))
     ,?_assertEqual([?RESELLER_ACCOUNT_ID], knm_phone_number:reserve_history(pn_x(1, Ret2)))
     ,{"verify number is now reserved"
      ,?_assertEqual(?NUMBER_STATE_RESERVED, knm_phone_number:state(pn_x(1, Ret2)))
      }
+    ,?_assertEqual(?RESELLER_ACCOUNT_ID, knm_phone_number:assigned_to(pn_x(1, Ret2)))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret3)))
     ,{"verify number was indeed reserved"
      ,?_assertEqual(?NUMBER_STATE_RESERVED, knm_phone_number:state(pn_x(1, Ret3)))
      }
+    ,?_assertEqual(?CHILD_ACCOUNT_ID, knm_phone_number:assigned_to(pn_x(1, Ret3)))
     ,?_assertEqual([?CHILD_ACCOUNT_ID, ?RESELLER_ACCOUNT_ID], knm_phone_number:reserve_history(pn_x(1, Ret3)))
     ].
 
@@ -249,6 +252,7 @@ release_test_() ->
     ,{"Verify number went from in_service to reserved"
      ,?_assertEqual(?NUMBER_STATE_RESERVED, knm_phone_number:state(pn_x(1, Ret1)))
      }
+    ,?_assertEqual(?MASTER_ACCOUNT_ID, knm_phone_number:assigned_to(pn_x(1, Ret1)))
     ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret2))
     ,?_assertMatch([_], maps:get(ok, Ret2))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret2)))

--- a/core/kazoo_number_manager/test/knm_numbers_test.erl
+++ b/core/kazoo_number_manager/test/knm_numbers_test.erl
@@ -202,7 +202,14 @@ reserve_test_() ->
     ,?_assertMatch([_], maps:get(ok, Ret1))
     ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret2))
     ,?_assertMatch([_], maps:get(ok, Ret2))
-    ,?_assertEqual([?NOT_NUM, ?TEST_IN_SERVICE_NUM], lists:reverse(lists:usort(maps:keys(maps:get(ko, Ret2b)))))
+    ,?_assertEqual(#{?NOT_NUM => not_reconcilable
+                    ,?TEST_IN_SERVICE_NUM => kz_json:from_list(
+                                               [{<<"code">>, 400}
+                                               ,{<<"error">>, <<"assign_failure">>}
+                                               ,{<<"cause">>, <<"field_undefined">>}
+                                               ,{<<"message">>, <<"invalid account to assign to">>}
+                                               ])
+                    }, maps:get(ko, Ret2b))
     ,?_assertEqual([], maps:get(ok, Ret2b))
     ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret3))
     ,?_assertMatch([_], maps:get(ok, Ret3))

--- a/core/kazoo_number_manager/test/knm_numbers_test.erl
+++ b/core/kazoo_number_manager/test/knm_numbers_test.erl
@@ -194,12 +194,16 @@ reserve_test_() ->
     AssignToChild = [{assign_to, ?CHILD_ACCOUNT_ID} | knm_number_options:default()],
     Ret1 = knm_numbers:reserve([?NOT_NUM, ?TEST_AVAILABLE_NUM]
                               ,[{assign_to,?RESELLER_ACCOUNT_ID}, {auth_by,?MASTER_ACCOUNT_ID}]),
-    Ret2 = knm_numbers:reserve([?NOT_NUM, ?TEST_IN_SERVICE_NUM], knm_number_options:default()),
+    Ret2b = knm_numbers:reserve([?NOT_NUM, ?TEST_IN_SERVICE_NUM], knm_number_options:default()),
+    Ret2 = knm_numbers:reserve([?NOT_NUM, ?TEST_IN_SERVICE_NUM]
+                              ,[{assign_to,?RESELLER_ACCOUNT_ID} | knm_number_options:default()]),
     Ret3 = knm_numbers:reserve([?NOT_NUM, ?TEST_IN_SERVICE_NUM], AssignToChild),
     [?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret1))
     ,?_assertMatch([_], maps:get(ok, Ret1))
     ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret2))
     ,?_assertMatch([_], maps:get(ok, Ret2))
+    ,?_assertEqual([?NOT_NUM, ?TEST_IN_SERVICE_NUM], lists:reverse(lists:usort(maps:keys(maps:get(ko, Ret2b)))))
+    ,?_assertEqual([], maps:get(ok, Ret2b))
     ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret3))
     ,?_assertMatch([_], maps:get(ok, Ret3))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret1)))


### PR DESCRIPTION
4.0 version coming up