### PR TITLE
remove maintenance code duplicating notify's maintenance code

### DIFF
--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -312,7 +312,6 @@ refresh(?KZ_ACCOUNTS_DB) ->
     Views = [kapps_util:get_view_json('kazoo_apps', ?MAINTENANCE_VIEW_FILE)
             ,kapps_util:get_view_json('kazoo_apps', ?ACCOUNTS_AGG_VIEW_FILE)
             ,kapps_util:get_view_json('kazoo_apps', ?SEARCH_VIEW_FILE)
-            ,kapps_util:get_view_json('notify', ?ACCOUNTS_AGG_NOTIFY_VIEW_FILE)
             ],
     kapps_util:update_views(?KZ_ACCOUNTS_DB, Views, 'true'),
     'ok';


### PR DESCRIPTION
Reported by @swysor  after crash:

```
<9847.5234.0> (21/21) refreshing database 'system_config'
archiving to /tmp/system_config.json
   archived 83 docs
<9847.5234.0> (20/21) refreshing database 'system_data'
<9847.5234.0> (19/21) refreshing database 'offnet'
<9847.5234.0> (18/21) refreshing database 'accounts'
Stderr Command failed: {'EXIT',{badarg,[{erlang,list_to_binary,[[{error,bad_name},"/couchdb/",<<"views/notify.json">>]],[]},{kapps_util,get_view_json,2,[{file,"src/kapps_util.erl"},{line,530}]},{kapps_maintenance,refresh,1,[{file,"src/kapps_maintenance.erl"},{line,315}]},{kapps_maintenance,refresh,3,[{file,"src/kapps_maintenance.erl"},{line,244}]},{kapps_maintenance,migrate,2,[{file,"src/kapps_maintenance.erl"},{line,141}]},{kapps_maintenance,migrate,1,[{file,"src/kapps_maintenance.erl"},{line,126}]},{rpc,'-handle_call_call/6-fun-0-',5,[{file,"rpc.erl"},{line,206}]}]}}
```