### PR TITLE
PISTON-425: use parent teletype config subject/to as defaults

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -169,6 +169,7 @@
     "crossbar.maximum_range": "crossbar maximum range",
     "crossbar.media.normalization_format": "crossbar.media normalization format",
     "crossbar.media.normalize_media": "crossbar.media normalize media",
+    "crossbar.notifications.inherit_default_values": "crossbar.notifications use parent notifications doc as default values, to be overridden by request data (prior to validation)",
     "crossbar.notifications.notification_timeout_ms": "crossbar.notifications notification timeout in milliseconds",
     "crossbar.onboard.default_callflow_start_exten": "crossbar.onboard default callflow start exten",
     "crossbar.onboard.default_extension_callflow": "crossbar.onboard default extension callflow",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -8973,6 +8973,11 @@
         "system_config.crossbar.notifications": {
             "description": "Schema for crossbar.notifications system_config",
             "properties": {
+                "inherit_default_values": {
+                    "default": false,
+                    "description": "crossbar.notifications use parent notifications doc as default values, to be overridden by request data (prior to validation)",
+                    "type": "boolean"
+                },
                 "notification_timeout_ms": {
                     "default": 5000,
                     "description": "crossbar.notifications notification timeout in milliseconds",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.notifications.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.notifications.json
@@ -3,6 +3,11 @@
     "_id": "system_config.crossbar.notifications",
     "description": "Schema for crossbar.notifications system_config",
     "properties": {
+        "inherit_default_values": {
+            "default": false,
+            "description": "crossbar.notifications use parent notifications doc as default values, to be overridden by request data (prior to validation)",
+            "type": "boolean"
+        },
         "notification_timeout_ms": {
             "default": 5000,
             "description": "crossbar.notifications notification timeout in milliseconds",

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -1081,29 +1081,9 @@ maybe_inherit_defaults(Context, Doc) ->
 -spec inherit_defaults(cb_context:context(), api_object()) -> cb_context:context().
 inherit_defaults(Context, 'undefined') -> Context;
 inherit_defaults(Context, InheritedDefaultsDoc) ->
-    Fields = kz_doc:get_public_keys(InheritedDefaultsDoc),
-    ReqData = inherit_defaults_fold(Fields
-                                   ,cb_context:req_data(Context)
-                                   ,InheritedDefaultsDoc),
+    PublicDefaults = kz_doc:public_fields(InheritedDefaultsDoc),
+    ReqData = kz_json:merge(PublicDefaults, cb_context:req_data(Context)),
     cb_context:set_req_data(Context, ReqData).
-
--spec inherit_defaults_fold(kz_json:keys(), kz_json:object(), kz_json:object()) ->
-                                   kz_json:object().
-inherit_defaults_fold([], ReqData, _) -> ReqData;
-inherit_defaults_fold([Field|Fields], ReqData, DefaultsDoc) ->
-    case kz_json:get_value(Field, ReqData) of
-        'undefined' ->
-            Default = kz_json:get_value(Field, DefaultsDoc),
-            ReqData1 = inherit_default(Field, Default, ReqData),
-            inherit_defaults_fold(Fields, ReqData1, DefaultsDoc);
-        _ -> inherit_defaults_fold(Fields, ReqData, DefaultsDoc)
-    end.
-
--spec inherit_default(kz_json:keys(), kz_json:api_json_term(), kz_json:object()) ->
-                             kz_json:object().
-inherit_default(_, 'undefined', JObj) -> JObj;
-inherit_default(Key, Value, JObj) ->
-    kz_json:set_value(Key, Value, JObj).
 
 -spec update_template(cb_context:context(), path_token(), kz_json:object()) ->
                              cb_context:context().

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -48,6 +48,9 @@
 -define(NOTIFICATION_TIMEOUT
        ,kapps_config:get_integer(?MOD_CONFIG_CAT, <<"notification_timeout_ms">>, 5 * ?MILLISECONDS_IN_SECOND)
        ).
+-define(INHERIT_DEFAULT_VALUES
+       ,kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"inherit_default_values">>, 'false')
+       ).
 
 -define(PVT_TYPE_SMTPLOG, <<"notify_smtp_log">>).
 
@@ -1063,9 +1066,17 @@ maybe_update(Context, Id) ->
 
 -spec update_notification(cb_context:context(), ne_binary()) -> cb_context:context().
 update_notification(Context, Id) ->
-    Context1 = set_required_field_defaults(Context, cb_context:doc(read(Context, Id))),
+    Context1 = maybe_set_required_field_defaults(Context, cb_context:doc(read(Context, Id))),
     OnSuccess = fun(C) -> on_successful_validation(Id, C) end,
     cb_context:validate_request_data(<<"notifications">>, Context1, OnSuccess).
+
+-spec maybe_set_required_field_defaults(cb_context:context(), api_object()) ->
+                                               cb_context:context().
+maybe_set_required_field_defaults(Context, Doc) ->
+    case ?INHERIT_DEFAULT_VALUES of
+        'true' -> set_required_field_defaults(Context, Doc);
+        'false' -> Context
+    end.
 
 -spec set_required_field_defaults(cb_context:context(), api_object()) ->
                                          cb_context:context().

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -1081,7 +1081,7 @@ maybe_inherit_defaults(Context, Doc) ->
 -spec inherit_defaults(cb_context:context(), api_object()) -> cb_context:context().
 inherit_defaults(Context, 'undefined') -> Context;
 inherit_defaults(Context, InheritedDefaultsDoc) ->
-    Fields = kz_json:get_public_keys(InheritedDefaultsDoc),
+    Fields = kz_doc:get_public_keys(InheritedDefaultsDoc),
     ReqData = inherit_defaults_fold(Fields
                                    ,cb_context:req_data(Context)
                                    ,InheritedDefaultsDoc),


### PR DESCRIPTION
As an extension to https://github.com/2600hz/kazoo/pull/3618, we are finding it useful to allow POST updates to .../notifications/<notification_id> to omit a couple of the required fields (subject/to) and merge them in from the notification inherited from up the account tree. They are still required as per the schema - retains compatibility with teletype logic.

We use this to provide control of the "from" of a notification, but automatically fill in "subject" (without having to explain the macros) and avoid potentially unwanted configuration of the "to".