### PR TITLE
qf-free: skip free-ing an account's numbers if something is wrong

### DIFF
--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -506,8 +506,11 @@ account_listing(AccountDb=?MATCH_ACCOUNT_ENCODED(_,_,_)) ->
             [{kz_doc:id(JObj), kz_json:get_value(<<"value">>, JObj)}
              || JObj <- JObjs
             ];
+        {'error', 'not_found'=_R} ->
+            lager:error("error listing numbers for ~s: ~p", [AccountDb, _R]),
+            [];
         {'error', _R} ->
-            lager:debug("error listing numbers for ~s: ~p", [AccountDb, _R])
+            lager:error("error listing numbers for ~s: ~p", [AccountDb, _R])
     end.
 
 

--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -509,8 +509,9 @@ account_listing(AccountDb=?MATCH_ACCOUNT_ENCODED(_,_,_)) ->
         {'error', 'not_found'=_R} ->
             lager:error("error listing numbers for ~s: ~p", [AccountDb, _R]),
             [];
-        {'error', _R} ->
-            lager:error("error listing numbers for ~s: ~p", [AccountDb, _R])
+        {'error', R} ->
+            lager:error("error listing numbers for ~s: ~p", [AccountDb, R]),
+            throw(R)
     end.
 
 


### PR DESCRIPTION
Found during failed creation of the master account