### PR TITLE
Teletype dual email fix

### DIFF
--- a/applications/teletype/src/templates/teletype_system_alert.erl
+++ b/applications/teletype/src/templates/teletype_system_alert.erl
@@ -65,8 +65,7 @@ handle_system_alert(JObj) ->
     end.
 
 -spec handle_req_as_http(kz_json:object(), api_binary(), boolean()) -> 'ok'.
-handle_req_as_http(JObj, 'undefined', UseEmail) ->
-    handle_req_as_email(JObj, UseEmail);
+handle_req_as_http(_JObj, 'undefined', _UseEmail) -> 'ok';
 handle_req_as_http(JObj, Url, UseEmail) ->
     Headers = [{"Content-Type", "application/json"}],
     Encoded = kz_json:encode(JObj),
@@ -76,8 +75,14 @@ handle_req_as_http(JObj, Url, UseEmail) ->
             lager:debug("JSON data successfully POSTed to '~s'", [Url]);
         _Error ->
             lager:debug("failed to POST JSON data to ~p for reason: ~p", [Url,_Error]),
-            handle_req_as_email(JObj, UseEmail)
+            maybe_send_email(JObj, UseEmail)
     end.
+
+-spec maybe_send_email(kz_json:object(), boolean()) -> 'ok'.
+maybe_send_email(JObj, 'false') ->
+    handle_req_as_email(JObj, 'true');
+maybe_send_email(_JObj, 'true') ->
+    'ok'.
 
 -spec handle_req_as_email(kz_json:object(), boolean() | kz_json:object()) -> 'ok'.
 handle_req_as_email(_JObj, 'false') ->


### PR DESCRIPTION
when there is no post url or when there's an error in the post request than the email is sent twice, so this change will send email as default as well as send post to a url but when the email is turned off and the post request fails only than send email as a backup option.