### PR TITLE
KAZOO-5505: As a provisioner, I want kazoo to send an API request to …

### DIFF
--- a/applications/crossbar/src/modules_v1/cb_users_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_users_v1.erl
@@ -311,8 +311,8 @@ delete(Context, _Id) ->
     crossbar_doc:delete(Context).
 
 -spec patch(cb_context:context(), path_token()) -> cb_context:context().
-patch(Context, _Id) ->
-    crossbar_doc:save(Context).
+patch(Context, Id) ->
+    post(Context, Id).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/modules_v2/cb_devices_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_devices_v2.erl
@@ -277,8 +277,8 @@ post(Context, DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
     crossbar_util:response_202(<<"sync request sent">>, Context).
 
 -spec patch(cb_context:context(), path_token()) -> cb_context:context().
-patch(Context, _Id) ->
-    crossbar_doc:save(Context).
+patch(Context, Id) ->
+    post(Context, Id).
 
 -spec put(cb_context:context()) -> cb_context:context().
 put(Context) ->

--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -334,8 +334,8 @@ delete(Context, UserId, ?PHOTO) ->
     crossbar_doc:delete_attachment(UserId, ?PHOTO, Context).
 
 -spec patch(cb_context:context(), path_token()) -> cb_context:context().
-patch(Context, _Id) ->
-    crossbar_doc:save(Context).
+patch(Context, Id) ->
+    post(Context, Id).
 
 %%--------------------------------------------------------------------
 %% @private


### PR DESCRIPTION
…update provisioner when devices are PATCHed

This change will make sure that the processing for PATCH is same as for POST, the doc after patching goes through the same process as POST so why not during saving of the doc.