### PR TITLE
KAZOO-5426 & KAZOO-5352: support ranges in ledgers + better data accumulation

### DIFF
--- a/applications/crossbar/doc/ledgers.md
+++ b/applications/crossbar/doc/ledgers.md
@@ -42,13 +42,30 @@ curl -v -X GET \
 
 ```json
 {
+    "auth_token": "{AUTH_TOKEN}",
     "data": {
-        "per-minute-voip": -825,
-        "support": -148
+        "mobile_data": {
+            "amount": -10.5,
+            "usage": {
+                "quantity": 1000,
+                "type": "debit",
+                "unit": "MB"
+            }
+        },
+        "per-minute-voip": {
+            "amount": -54.7404,
+            "usage": {
+                "quantity": 14520,
+                "type": "voice",
+                "unit": "sec"
+            }
+        }
     },
+    "node": "{NODE}",
     "request_id": "{REQUEST_ID}",
     "status": "success",
-    "auth_token": "{AUTH_TOKEN}"
+    "timestamp": "{TIMESTAMP}",
+    "version": "{VERSION}"
 }
 ```
 

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -82,6 +82,7 @@
                           ,view_options = [] :: view_options()
                           ,context :: cb_context:context()
                           ,start_key :: startkey()
+                          ,should_paginate :: boolean()
                           ,page_size :: non_neg_integer() | api_binary()
                           ,filter_fun :: filter_fun()
                           ,dbs = [] :: ne_binaries()
@@ -376,17 +377,19 @@ load_view(View, Options, Context, StartKey, PageSize) ->
     load_view(View, Options, Context, StartKey, PageSize, 'undefined').
 
 load_view(View, Options, Context, StartKey, PageSize, FilterFun) ->
-    load_view(#load_view_params{view=View
-                               ,view_options=Options
-                               ,context=cb_context:set_doc(Context, [])
-                               ,start_key=StartKey
-                               ,page_size=PageSize
-                               ,filter_fun=FilterFun
-                               ,dbs=[Db || Db <- props:get_value('databases', Options, [cb_context:account_db(Context)]),
-                                           kz_datamgr:db_exists(Db, View)
-                                    ]
-                               ,direction=view_sort_direction(Options)
-                               }).
+    load_view(
+      #load_view_params{view = View
+                       ,view_options = Options
+                       ,context = cb_context:set_doc(Context, [])
+                       ,start_key = StartKey
+                       ,should_paginate = cb_context:should_paginate(Context)
+                       ,page_size = PageSize
+                       ,filter_fun = FilterFun
+                       ,dbs = [Db || Db <- props:get_value('databases', Options, [cb_context:account_db(Context)]),
+                                     kz_datamgr:db_exists(Db, View)
+                              ]
+                       ,direction = view_sort_direction(Options)
+                       }).
 
 -spec view_sort_direction(kz_proplist()) -> direction().
 view_sort_direction(Options) ->

--- a/applications/crossbar/src/modules/cb_ledgers.erl
+++ b/applications/crossbar/src/modules/cb_ledgers.erl
@@ -274,7 +274,11 @@ maybe_impact_reseller(Context, Ledger, 'true', ResellerId) ->
 %%--------------------------------------------------------------------
 -spec read_ledgers(cb_context:context()) -> cb_context:context().
 read_ledgers(Context) ->
-    case kz_ledgers:get(cb_context:account_id(Context)) of
+    {From, To} = case cb_modules_util:range_view_options(Context) of
+                     {_CreatedFrom, _CreatedTo}=FromTo -> FromTo;
+                     _ContextWithError -> {undefined, undefined}
+                 end,
+    case kz_ledgers:get(cb_context:account_id(Context), From, To) of
         {'error', Reason} ->
             crossbar_util:response('error', kz_term:to_binary(Reason), Context);
         {'ok', Ledgers} ->

--- a/applications/crossbar/src/modules/cb_ledgers.erl
+++ b/applications/crossbar/src/modules/cb_ledgers.erl
@@ -294,7 +294,7 @@ summary_to_dollars(LedgersJObj) ->
         ])).
 
 -spec maybe_convert_units(ne_binary(), kz_transaction:units() | T) -> kz_transaction:dollars() | T when T::any().
-maybe_convert_units(<<"amount">>, Units) -> wht_util:units_to_dollars(Value);
+maybe_convert_units(<<"amount">>, Units) -> wht_util:units_to_dollars(Units);
 maybe_convert_units(_, Value) -> Value.
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_ledgers.erl
+++ b/applications/crossbar/src/modules/cb_ledgers.erl
@@ -282,12 +282,20 @@ read_ledgers(Context) ->
         {'error', Reason} ->
             crossbar_util:response('error', kz_term:to_binary(Reason), Context);
         {'ok', Ledgers} ->
-            crossbar_util:response(kz_json:map(fun ledger_resume_to_dollars/2, Ledgers), Context)
+            crossbar_util:response(summary_to_dollars(Ledgers), Context)
     end.
 
--spec ledger_resume_to_dollars(K, kz_transaction:units()) -> {K, kz_transaction:dollars()}.
-ledger_resume_to_dollars(K, V) ->
-    {K, wht_util:units_to_dollars(V)}.
+-spec summary_to_dollars(kz_json:object()) -> kz_json:object().
+summary_to_dollars(LedgersJObj) ->
+    kz_json:expand(
+      kz_json:from_list(
+        [{Path, maybe_convert_units(lists:last(Path), Value)}
+         || {Path, Value} <- kz_json:to_proplist(kz_json:flatten(LedgersJObj))
+        ])).
+
+-spec maybe_convert_units(ne_binary(), kz_transaction:units() | T) -> kz_transaction:dollars() | T when T::any().
+maybe_convert_units(<<"amount">>, Units) -> wht_util:units_to_dollars(Value);
+maybe_convert_units(_, Value) -> Value.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/modules/cb_ledgers.erl
+++ b/applications/crossbar/src/modules/cb_ledgers.erl
@@ -321,7 +321,7 @@ read_ledger(Context, Ledger) ->
             Context1
     end.
 
--spec pagination_page_size(cb_context:context()) -> pos_integer().
+-spec pagination_page_size(cb_context:context()) -> api_pos_integer().
 pagination_page_size(Context) ->
     case crossbar_doc:pagination_page_size(Context) of
         'undefined' -> 'undefined';

--- a/core/kazoo_ledgers/src/kz_ledger.erl
+++ b/core/kazoo_ledgers/src/kz_ledger.erl
@@ -34,8 +34,9 @@ get(Account, Name) ->
     case kazoo_modb:get_results(Account, ?LIST_BY_SERVICE_LEGACY, Options) of
         {'ok', []} -> {'ok', 0};
         {'error', _R}=Error -> Error;
-        {'ok', [JObj|_]} ->
-            {'ok', kz_json:get_integer_value(<<"value">>, JObj, 0)}
+        {'ok', [JObj0|_]} ->
+            [JObj] = kz_json:values(kz_json:get_value(<<"value">>, JObj0)),
+            {'ok', kz_json:get_integer_value(<<"amount">>, JObj, 0)}
     end.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -44,7 +44,12 @@ get(Account, CreatedFrom, CreatedTo) ->
                 [case kazoo_modb:get_results(MoDB, ?LIST_BY_SERVICE_LEGACY, []) of
                      {error, Reason} -> throw(Reason);
                      {ok, JObjs} ->
-                         kz_json:sum_jobjs([kz_json:get_value(<<"value">>, JObj) || JObj <- JObjs])
+                         kz_json:sum_jobjs([kz_json:get_value(<<"value">>, JObj)
+                                            || JObj <- JObjs,
+                                               [_Type, TimeStamp] <- [kz_json:get_value(<<"key">>, JObj)],
+                                               CreatedFrom =< TimeStamp,
+                                               TimeStamp =< CreatedTo
+                                           ])
                  end
                  || MoDB <- MoDBs
                 ]),

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -18,9 +18,8 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec get(ne_binary()) ->
-                 {'ok', kz_json:object()} |
-                 {'error', any()}.
+-spec get(ne_binary()) -> {'ok', kz_json:object()} |
+                          {'error', any()}.
 get(Account) ->
     Options = ['reduce'
               ,'group'
@@ -29,16 +28,12 @@ get(Account) ->
     case kazoo_modb:get_results(Account, ?TOTAL_BY_SERVICE_LEGACY, Options) of
         {'error', _R}=Error -> Error;
         {'ok', JObjs}->
-            build_result(JObjs)
+            {'ok', build_result(JObjs)}
     end.
 
--spec build_result(kz_json:objects()) -> {'ok', kz_json:object()}.
+-spec build_result(kz_json:objects()) -> kz_json:object().
 build_result(JObjs) ->
-    Data = lists:foldl(fun add_jobj/2, kz_json:new(), JObjs),
-    {'ok', Data}.
-
--spec add_jobj(kz_json:object(), kz_json:object()) -> kz_json:object().
-add_jobj(JObj, Acc) ->
-    Key = kz_json:get_value(<<"key">>, JObj),
-    Value = kz_json:get_value(<<"value">>, JObj),
-    kz_json:set_value(Key, Value, Acc).
+    kz_json:from_list(
+      [{kz_json:get_value(<<"key">>, JObj), kz_json:get_value(<<"value">>, JObj)}
+       || JObj <- JObjs
+      ]).

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -36,7 +36,9 @@ get(Account, undefined, undefined) ->
             {ok, LedgersJObj}
     end;
 
-get(Account, CreatedFrom, CreatedTo) ->
+get(Account, CreatedFrom, CreatedTo)
+  when is_integer(CreatedFrom), CreatedFrom > 0,
+       is_integer(CreatedTo), CreatedTo > 0 ->
     MoDBs = kazoo_modb:get_range(Account, CreatedFrom, CreatedTo),
     lager:debug("from:~p to:~p -> ~p", [CreatedFrom, CreatedTo, MoDBs]),
     try

--- a/core/kazoo_modb/priv/couchdb/views/ledgers.json
+++ b/core/kazoo_modb/priv/couchdb/views/ledgers.json
@@ -3,18 +3,56 @@
     "language": "javascript",
     "views": {
         "listing_by_service": {
-            "map": "function(doc) { if ( doc.pvt_deleted || doc.pvt_type != 'ledger') return; var amount = doc.pvt_amount || doc.amount  || 0; if(doc.pvt_ledger_type == 'debit') {amount *= -1} emit([doc.source.service, doc.pvt_created], amount)}"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_deleted || doc.pvt_type !== 'ledger')",
+                "    return;",
+                "  var amount = doc.pvt_amount || doc.amount || 0;",
+                "  if (doc.pvt_ledger_type === 'debit')",
+                "    amount *= -1;",
+                "  emit([doc.source.service, doc.pvt_created], amount);",
+                "}"
+            ]
         },
         "listing_by_service_legacy": {
-            "map": "function(doc) { if ( doc.pvt_deleted || (doc.pvt_type != 'ledger' && !( (doc.pvt_type == 'credit' || doc.pvt_type == 'debit') && (doc.pvt_code == 1001 || doc.pvt_code == 1002 )) )) return; var amount = doc.pvt_amount || doc.amount  || 0; var service = doc.pvt_type == 'ledger' ? doc.source.service : 'per-minute-voip';if( doc.pvt_ledger_type == 'debit' || doc.pvt_type == 'debit') {amount *= -1} emit([service, doc.pvt_created], amount)}"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_deleted || (doc.pvt_type !== 'ledger' && !( (doc.pvt_type === 'credit' || doc.pvt_type === 'debit') && (doc.pvt_code === 1001 || doc.pvt_code === 1002 )) ))",
+                "    return;",
+                "  var amount = doc.pvt_amount || doc.amount || 0;",
+                "  var service = doc.pvt_type === 'ledger' ? doc.source.service : 'per-minute-voip';",
+                "  if (doc.pvt_ledger_type === 'debit' || doc.pvt_type === 'debit')",
+                "    amount *= -1;",
+                "  emit([service, doc.pvt_created], amount);",
+                "}"
+            ]
         },
         "total_by_service": {
-            "map": "function(doc) { if ( doc.pvt_deleted || doc.pvt_type != 'ledger') return; var amount = doc.pvt_amount || doc.amount  || 0; if(doc.pvt_ledger_type == 'debit') {amount *= -1} emit(doc.source.service, amount)}",
-            "reduce": "function (key, values) { return sum(values) }"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_deleted || doc.pvt_type !== 'ledger')",
+                "    return;",
+                "  var amount = doc.pvt_amount || doc.amount || 0;",
+                "  if (doc.pvt_ledger_type === 'debit')",
+                "    amount *= -1;",
+                "  emit(doc.source.service, amount);",
+                "}"
+            ],
+            "reduce": "_sum"
         },
         "total_by_service_legacy": {
-            "map": "function(doc) { if ( doc.pvt_deleted || (doc.pvt_type != 'ledger' && !( (doc.pvt_type == 'credit' || doc.pvt_type == 'debit') && (doc.pvt_code == 1001 || doc.pvt_code == 1002 )) )) return; var amount = doc.pvt_amount || doc.amount  || 0; var service = doc.pvt_type == 'ledger' ? doc.source.service : 'per-minute-voip';if( doc.pvt_ledger_type == 'debit' || doc.pvt_type == 'debit') {amount *= -1} emit(service, amount)}",
-            "reduce": "function (key, values) { return sum(values) }"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_deleted || (doc.pvt_type !== 'ledger' && !( (doc.pvt_type === 'credit' || doc.pvt_type === 'debit') && (doc.pvt_code === 1001 || doc.pvt_code === 1002 )) ))",
+                "    return;",
+                "  var amount = doc.pvt_amount || doc.amount || 0;",
+                "  var service = doc.pvt_type === 'ledger' ? doc.source.service : 'per-minute-voip';",
+                "  if (doc.pvt_ledger_type === 'debit' || doc.pvt_type === 'debit')",
+                "    amount *= -1;",
+                "  emit(service, amount);",
+                "}"
+            ],
+            "reduce": "_sum"
         }
     }
 }

--- a/core/kazoo_modb/priv/couchdb/views/ledgers.json
+++ b/core/kazoo_modb/priv/couchdb/views/ledgers.json
@@ -20,10 +20,13 @@
                 "  if (doc.pvt_deleted || (doc.pvt_type !== 'ledger' && !( (doc.pvt_type === 'credit' || doc.pvt_type === 'debit') && (doc.pvt_code === 1001 || doc.pvt_code === 1002 )) ))",
                 "    return;",
                 "  var amount = doc.pvt_amount || doc.amount || 0;",
+                "  var usage = doc.pvt_usage || doc.usage || {};",
                 "  var service = doc.pvt_type === 'ledger' ? doc.source.service : 'per-minute-voip';",
                 "  if (doc.pvt_ledger_type === 'debit' || doc.pvt_type === 'debit')",
                 "    amount *= -1;",
-                "  emit([service, doc.pvt_created], amount);",
+                "  var o = {};",
+                "  o[service] = {amount:amount, usage:usage};",
+                "  emit([service, doc.pvt_created], o);",
                 "}"
             ]
         },

--- a/core/kazoo_modb/priv/couchdb/views/transactions.json
+++ b/core/kazoo_modb/priv/couchdb/views/transactions.json
@@ -10,7 +10,17 @@
             "map": "function(doc) { if ( (doc.pvt_type != 'credit' && doc.pvt_type != 'debit') || doc.pvt_deleted) return; emit(doc.pvt_created, doc._id); }"
         },
         "credit_remaining": {
-            "map": "function(doc) { if ( (doc.pvt_type != 'credit' && doc.pvt_type != 'debit' && doc.pvt_type != 'ledger') || doc.pvt_deleted) return; var modifier = (doc.pvt_type == 'credit' ? 1 : doc.pvt_type == 'debit' ? -1 : doc.pvt_ledger_type == 'debit' ? -1 : doc.pvt_ledger_type == 'credit' ? 1 : 0), amount = doc.pvt_amount || doc.amount || 0; emit(null, amount * modifier); }",
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_deleted || (doc.pvt_type !== 'credit' && doc.pvt_type !== 'debit' && doc.pvt_type !== 'ledger'))",
+                "    return;",
+                "  var is_credit = doc.pvt_type === 'credit' || doc.pvt_ledger_type === 'credit';",
+                "  var is_debit  = doc.pvt_type ===  'debit' || doc.pvt_ledger_type ===  'debit';",
+                "  var modifier = is_credit ? 1 : is_debit ? -1 : 0;",
+                "  var amount = doc.pvt_amount || doc.amount || 0;",
+                "  emit(null, amount * modifier);",
+                "}"
+            ],
             "reduce": "_sum"
         },
         "per_minute_cost": {

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -93,6 +93,7 @@
         ]).
 
 -export([sum/2, sum/3]).
+-export([sum_jobjs/1, sum_jobjs/2]).
 -export_type([sumer/0]).
 
 -export([order_by/3]).
@@ -433,6 +434,26 @@ sum(?JSON_WRAPPER(_)=JObj1, Value, Sumer, Keys)
     Syek = lists:reverse(Keys),
     V = get_value(Syek, JObj1),
     set_value(Syek, Sumer(V, Value), JObj1).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Sum two (deep) JSON objects.
+%% Default sumer function only sums numbers. For other kinds of values,
+%% the value from JObj1 is kept untouched. If it is undefined it's the one from JObj2.
+%% @end
+%%--------------------------------------------------------------------
+-spec sum_jobjs(objects()) -> object().
+sum_jobjs(JObjs) -> sum_jobjs(JObjs, fun default_sumer/2).
+
+-spec sum_jobjs(object(), sumer()) -> object().
+sum_jobjs([?JSON_WRAPPER(_)=JObj], Sumer)
+  when is_function(Sumer, 2) ->
+    JObj;
+sum_jobjs([FirstJObj|JObjs], Sumer)
+  when is_function(Sumer, 2) ->
+    F = fun (JObj, Carry) -> sum(Carry, JObj, fun default_sumer/2) end,
+    lists:foldl(F, FirstJObj, JObjs).
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -446,7 +446,7 @@ sum(?JSON_WRAPPER(_)=JObj1, Value, Sumer, Keys)
 -spec sum_jobjs(objects()) -> object().
 sum_jobjs(JObjs) -> sum_jobjs(JObjs, fun default_sumer/2).
 
--spec sum_jobjs(object(), sumer()) -> object().
+-spec sum_jobjs(objects(), sumer()) -> object().
 sum_jobjs([], Sumer)
   when is_function(Sumer, 2) -> new();
 sum_jobjs([?JSON_WRAPPER(_)=JObj], Sumer)

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -438,18 +438,19 @@ sum(?JSON_WRAPPER(_)=JObj1, Value, Sumer, Keys)
 %%--------------------------------------------------------------------
 %% @public
 %% @doc
-%% Sum two (deep) JSON objects.
+%% Sum (deep) JSON objects.
 %% Default sumer function only sums numbers. For other kinds of values,
-%% the value from JObj1 is kept untouched. If it is undefined it's the one from JObj2.
+%% the value from JObj1 is kept untouched. If it is undefined it takes the value from the other JObjs.
 %% @end
 %%--------------------------------------------------------------------
 -spec sum_jobjs(objects()) -> object().
 sum_jobjs(JObjs) -> sum_jobjs(JObjs, fun default_sumer/2).
 
 -spec sum_jobjs(object(), sumer()) -> object().
+sum_jobjs([], Sumer)
+  when is_function(Sumer, 2) -> new();
 sum_jobjs([?JSON_WRAPPER(_)=JObj], Sumer)
-  when is_function(Sumer, 2) ->
-    JObj;
+  when is_function(Sumer, 2) -> JObj;
 sum_jobjs([FirstJObj|JObjs], Sumer)
   when is_function(Sumer, 2) ->
     F = fun (JObj, Carry) -> sum(Carry, JObj, fun default_sumer/2) end,

--- a/core/kazoo_stdlib/test/kz_json_test.erl
+++ b/core/kazoo_stdlib/test/kz_json_test.erl
@@ -637,6 +637,7 @@ sum_test_() ->
     ,?_assertEqual(?CHARGES_DOUBLE, kz_json:sum(?CHARGES_SIMPLE, ?CHARGES_SIMPLE))
     ,?_assertEqual(?CHARGES_DOUBLE, kz_json:sum_jobjs([?CHARGES_SIMPLE, ?CHARGES_SIMPLE]))
     ,?_assertEqual(E, kz_json:sum_jobjs([E, E]))
+    ,?_assertEqual(kz_json:new(), kz_json:sum_jobjs([]))
     ,?_assertEqual(A42Bhi, kz_json:sum_jobjs([A40, A2Bhi]))
     ,?_assertEqual(A42Bhi, kz_json:sum_jobjs([A2Bhi, A40]))
     ,?_assert(kz_json:are_equal(?AMOUNT, kz_json:sum_jobjs(?AMOUNTS)))

--- a/core/kazoo_stdlib/test/kz_json_test.erl
+++ b/core/kazoo_stdlib/test/kz_json_test.erl
@@ -612,6 +612,12 @@ are_equal_test_() ->
 -define(CHARGES_DOUBLE,
         kz_json:decode(<<"{\"phone_numbers\":{\"did_us\":{\"category\":\"phone_numbers\",\"item\":\"did_us\",\"name\":\"US DID\",\"quantity\":2,\"rate\":2.0,\"single_discount\":true,\"single_discount_rate\":0.0,\"cumulative_discount\":2,\"cumulative_discount_rate\":1.0,\"activation_charge\":4.0,\"minimum\":0,\"exceptions\":[],\"activation_charges\":4.0}},\"activation_charges\":4.0}">>)).
 
+-define(AMOUNTS,
+        kz_json:decode(<<"[{\"mobile_data\":{\"amount\":-10.5,\"usage\":{\"type\":\"debit\",\"unit\":\"MB\",\"quantity\":9482}}},{\"per_minute_voip\":{\"amount\":-155,\"usage\":{\"type\":\"voice\",\"unit\":\"sec\",\"quantity\":2120}}},{\"per_minute_voip\":{\"amount\":37,\"usage\":{\"type\":\"voice\",\"unit\":\"sec\",\"quantity\":480}}}]">>)).
+
+-define(AMOUNT,
+       kz_json:decode(<<"{\"mobile_data\":{\"amount\":-10.5,\"usage\":{\"type\":\"debit\",\"unit\":\"MB\",\"quantity\":9482}},\"per_minute_voip\":{\"amount\":-118,\"usage\":{\"type\":\"voice\",\"unit\":\"sec\",\"quantity\":2600}}}">>)).
+
 sum_test_() ->
     E = kz_json:new(),
     A42 = kz_json:from_list([{<<"a">>, 42}]),
@@ -633,6 +639,7 @@ sum_test_() ->
     ,?_assertEqual(E, kz_json:sum_jobjs([E, E]))
     ,?_assertEqual(A42Bhi, kz_json:sum_jobjs([A40, A2Bhi]))
     ,?_assertEqual(A42Bhi, kz_json:sum_jobjs([A2Bhi, A40]))
+    ,?_assert(kz_json:are_equal(?AMOUNT, kz_json:sum_jobjs(?AMOUNTS)))
     ].
 
 order_by_test_() ->

--- a/core/kazoo_stdlib/test/kz_json_test.erl
+++ b/core/kazoo_stdlib/test/kz_json_test.erl
@@ -616,7 +616,7 @@ are_equal_test_() ->
         kz_json:decode(<<"[{\"mobile_data\":{\"amount\":-10.5,\"usage\":{\"type\":\"debit\",\"unit\":\"MB\",\"quantity\":9482}}},{\"per_minute_voip\":{\"amount\":-155,\"usage\":{\"type\":\"voice\",\"unit\":\"sec\",\"quantity\":2120}}},{\"per_minute_voip\":{\"amount\":37,\"usage\":{\"type\":\"voice\",\"unit\":\"sec\",\"quantity\":480}}}]">>)).
 
 -define(AMOUNT,
-       kz_json:decode(<<"{\"mobile_data\":{\"amount\":-10.5,\"usage\":{\"type\":\"debit\",\"unit\":\"MB\",\"quantity\":9482}},\"per_minute_voip\":{\"amount\":-118,\"usage\":{\"type\":\"voice\",\"unit\":\"sec\",\"quantity\":2600}}}">>)).
+        kz_json:decode(<<"{\"mobile_data\":{\"amount\":-10.5,\"usage\":{\"type\":\"debit\",\"unit\":\"MB\",\"quantity\":9482}},\"per_minute_voip\":{\"amount\":-118,\"usage\":{\"type\":\"voice\",\"unit\":\"sec\",\"quantity\":2600}}}">>)).
 
 sum_test_() ->
     E = kz_json:new(),

--- a/core/kazoo_stdlib/test/kz_json_test.erl
+++ b/core/kazoo_stdlib/test/kz_json_test.erl
@@ -629,6 +629,10 @@ sum_test_() ->
     ,?_assertEqual(A42Bhi, kz_json:sum(A40, A2Bhi))
     ,?_assertEqual(A42Bhi, kz_json:sum(A2Bhi, A40))
     ,?_assertEqual(?CHARGES_DOUBLE, kz_json:sum(?CHARGES_SIMPLE, ?CHARGES_SIMPLE))
+    ,?_assertEqual(?CHARGES_DOUBLE, kz_json:sum_jobjs([?CHARGES_SIMPLE, ?CHARGES_SIMPLE]))
+    ,?_assertEqual(E, kz_json:sum_jobjs([E, E]))
+    ,?_assertEqual(A42Bhi, kz_json:sum_jobjs([A40, A2Bhi]))
+    ,?_assertEqual(A42Bhi, kz_json:sum_jobjs([A2Bhi, A40]))
     ].
 
 order_by_test_() ->


### PR DESCRIPTION
1. Accumulates total credits/debits for any ledger on /ledger, within the given or default time range (changes to kz_ledgers)
1. Fixes multi-databases modb crossbar view queries (see crossbar_doc's introduction of the should_paginate boolean)
