### PR TITLE
bump erlang.mk to 2017.05.18 from 2016.01.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean-deps:
 	$(if $(wildcard deps/), rm -r deps/)
 
 .erlang.mk:
-	wget 'https://raw.githubusercontent.com/ninenines/erlang.mk/2016.01.12/erlang.mk' -O $(ROOT)/erlang.mk
+	wget 'https://raw.githubusercontent.com/ninenines/erlang.mk/2017.05.18/erlang.mk' -O $(ROOT)/erlang.mk
 
 deps: deps/Makefile
 	$(MAKE) -C deps/ all


### PR DESCRIPTION
Cause previous tag randomly disappeared!
c.f. https://github.com/ninenines/erlang.mk/issues/703

master: https://github.com/2600hz/kazoo/pull/3729