### PR TITLE
Ignore the cdr conflict

### DIFF
--- a/applications/cdr/src/cdr_util.erl
+++ b/applications/cdr/src/cdr_util.erl
@@ -44,6 +44,7 @@ save_cdr(AccountMOD, Doc) ->
 do_save_cdr(AccountMODb, Doc) ->
     case kazoo_modb:save_doc(AccountMODb, Doc, [{'max_retries', 3}]) of
         {'ok', _}-> 'ok';
+        {'error', 'conflict'} -> 'ok';
         {'error', _E} ->
             lager:debug("failed to save cdr ~s : ~p", [kz_doc:id(Doc), _E]),
             {'error', max_save_retries}


### PR DESCRIPTION
Ignore the confict if the cdr is tried to be saved again, 

If the cdr is tried to save again the conflict error is ignored and the value is given as retries error which causes a error log to be generated in cdr_util