### PR TITLE
KAZOO-5540: rewrite called number

### DIFF
--- a/applications/callflow/doc/number_rewrite.md
+++ b/applications/callflow/doc/number_rewrite.md
@@ -1,0 +1,52 @@
+## Number Rewrite
+
+### About Number Rewrite
+
+The `number_rewrite` callflow enables you to rewrite the number called by user.
+
+### Schema
+
+Validator for the Record Call callflow action
+
+Key | Description | Type | Default | Required
+--- | ----------- | ---- | ------- | --------
+`number` | The final destination number to call | `string` |   | `false`
+
+## Callflow Json
+
+```json
+{
+   "_id": "04c5fb047c8845e2a59c108a2dbeab8c",
+   "_rev": "3-bb7b16b570cf38826f992ba528dc9880",
+   "flow": {
+       "data": {
+           "number": "+1844xxxxxxx"
+       },
+       "module": "number_rewrite",
+       "children": {
+           "_": {
+               "data": {
+                   "caller_id_type": "external",
+                   "ignore_early_media": false,
+                   "outbound_flags": [
+                   ],
+                   "use_local_resources": true
+               },
+               "module": "offnet",
+               "children": {
+               }
+           }
+       }
+   },
+   "numbers": [
+       "611"
+   ],
+   "patterns": [
+   ],
+   "contact_list": {
+       "exclude": true
+   }
+}
+```
+
+The above callflow when called to 611 will send the users call to configured number +1844xxxxxxx

--- a/applications/callflow/doc/ref/number_rewrite.md
+++ b/applications/callflow/doc/ref/number_rewrite.md
@@ -1,0 +1,15 @@
+## Number Rewrite
+
+### About Number Rewrite
+
+#### Schema
+
+Validator for the number rewrite data object
+
+
+
+Key | Description | Type | Default | Required
+--- | ----------- | ---- | ------- | --------
+`number` | The final destination number to call | `string` |   | `false`
+
+

--- a/applications/callflow/src/module/cf_number_rewrite.erl
+++ b/applications/callflow/src/module/cf_number_rewrite.erl
@@ -1,0 +1,51 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%% "data":{
+%%%   "number": "+1844xxxxxxx"
+%%% }
+%%% @end
+%%%-------------------------------------------------------------------
+-module(cf_number_rewrite).
+
+-behaviour(gen_cf_action).
+
+-include("callflow.hrl").
+
+-export([handle/2]).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Get the new number that needs to be changed from the data section
+%% @end
+%%--------------------------------------------------------------------
+-spec handle(kz_json:object(), kapps_call:call()) -> any().
+handle(Data, Call) ->
+    Number =  kz_json:get_binary_value(<<"number">>, Data),
+
+    lager:debug("updating called number to ~s", [Number]),
+
+    Updates = [fun(C) -> set_request(C, Number) end
+              ,fun(C) -> set_callee_number(C, Number) end
+              ],
+
+    {'ok', Call1} = cf_exe:get_call(Call),
+    cf_exe:set_call(kapps_call:exec(Updates, Call1)),
+    cf_exe:continue(Call1).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% modify the number called
+%% @end
+%%--------------------------------------------------------------------
+-spec set_request(kapps_call:call(), ne_binary()) -> kapps_call:call().
+set_request(Call, Number) ->
+    Realm = kapps_call:request_realm(Call),
+    Request = <<Number/binary, "@", Realm/binary>>,
+    kapps_call:set_request(Request, Call).
+
+-spec set_callee_number(kapps_call:call(), ne_binary()) -> kapps_call:call().
+set_callee_number(Call, Number) ->
+    kapps_call:set_callee_id_number(Number, Call).

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1740,6 +1740,16 @@
             ],
             "type": "object"
         },
+        "callflows.number_rewrite": {
+            "description": "Validator for the number rewrite data object",
+            "properties": {
+                "number": {
+                    "description": "The final destination number to call",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "callflows.offnet": {
             "description": "Validator for the offnet callflow's data object",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/callflows.number_rewrite.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.number_rewrite.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "callflows.number_rewrite",
+    "description": "Validator for the number rewrite data object",
+    "properties": {
+        "number": {
+            "description": "The final destination number to call",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
Rewrite the called number can have multiple uses when a number needs to routed according to a certain pattern to a certain number

e.g. 611 can route to reseller's main number. The ui can create the callflow needed while provisioning an account, the number is not hard programmed to only accept reseller's number as that type of restrictions can be added by ui according to different use cases.