### PR TITLE
Update connectivity.json

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/connectivity.json
+++ b/applications/crossbar/priv/couchdb/schemas/connectivity.json
@@ -164,10 +164,6 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": [
-                                    "cid_name",
-                                    "cid_number"
-                                ],
                                 "type": "object"
                             },
                             "delay": {


### PR DESCRIPTION
Cannot add PBX in MonsterUI PBX Connector with the caller_id required.