### PR TITLE
[master] HELP-30444: check for conflict when creating db

### DIFF
--- a/core/kazoo_couch/src/kz_couch_db.erl
+++ b/core/kazoo_couch/src/kz_couch_db.erl
@@ -48,6 +48,9 @@ db_create(#server{}=Conn, DbName, Options) ->
         {error, db_exists} ->
             lager:warning("db ~s already exists", [DbName]),
             true;
+        {'error', {bad_response, {500, _Headers, Body}}=Error} ->
+            Reason = kz_json:get_value(<<"reason">>, kz_json:decode(Body)),
+            check_db_create_error(DbName, Error, Reason);
         {'error', _Error} ->
             lager:error("failed to create database ~s: ~p", [DbName, _Error]),
             'false'
@@ -66,6 +69,14 @@ do_db_create_db(#server{url=ServerUrl, options=Opts}=Server, DbName, Options, Pa
         Error ->
             Error
     end.
+
+-spec check_db_create_error(ne_binary(), any(), any()) -> boolean().
+check_db_create_error(_DbName, _Error, <<"conflict">>) ->
+    lager:warning("db ~s creation failed with HTTP error 500 and conflict reason, assuming db is created", [_DbName]),
+    'true';
+check_db_create_error(_DbName, _Error, _Reason) ->
+    lager:error("failed to create database ~s: ~p", [_DbName, _Error]),
+    'false'.
 
 -spec db_delete(server(), ne_binary()) -> boolean().
 db_delete(#server{}=Conn, DbName) ->


### PR DESCRIPTION
CouchDB returns and HTTP error 500 with payload
`{"error":"error","reason":"conflict"}`

This seems and internal error when couchdb tries to create the shard
files, but due to race condition on creating db at same time those files
are already created, so couchdb returns an undocumented error.

The `kazoo_modb:create` falsely thinks that database creation failed and
won't referesh views.

This patches `kz_couch_db` to handle that error.

Also it patches the `kazoo_modb` to retry the operation due db creation
failure.