### PR TITLE
amend auth doc with restrictions

### DIFF
--- a/applications/crossbar/doc/ref/token_restrictions.md
+++ b/applications/crossbar/doc/ref/token_restrictions.md
@@ -11,9 +11,9 @@ Schema for token restrictions
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
 `restrictions` |   | `object` |   | `false`
-`restrictions./^\w+$/` | Name of authentication method used when creating token. '_' matches any auth method | `object` |   | `true`
-`restrictions./^\w+$/./^\w+$/` | Level of user privilege. '_' matches any priv level | `object` |   | `true`
-`restrictions./^\w+$/./^\w+$/./^\w+$/` |   | `array(object)` |   | `true`
+`restrictions./^\w+$/` | Name of authentication method used when creating token. '_' matches any auth method | `object` |   | `false`
+`restrictions./^\w+$/./^\w+$/` | Level of user privilege. '_' matches any priv level | `object` |   | `false`
+`restrictions./^\w+$/./^\w+$/./^\w+$/` |   | `array(object)` |   | `false`
 `restrictions./^\w+$/./^\w+$/./^\w+$/.[].allowed_accounts` | Account allowed to match this item | `array(string)` |   | `false`
 `restrictions./^\w+$/./^\w+$/./^\w+$/.[].allowed_accounts.[]` |   | `string` |   | `false`
 `restrictions./^\w+$/./^\w+$/./^\w+$/.[].rules` | Rules applied to endpoint parameters | `object` |   | `false`

--- a/applications/crossbar/doc/token_restrictions.md
+++ b/applications/crossbar/doc/token_restrictions.md
@@ -46,7 +46,24 @@ curl -v -X POST \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}
 ```
 
-Now, when someone logs into this account (via user\_auth) and who's user\_doc is of type `user` (and not `admin`), they will be unable to create sub-accounts.
+Now, when someone logs into this account (via user\_auth) and who's user\_doc is of type `user` (and not `admin`), they will be unable to create sub-accounts, and will receive an error response like this:
+
+```json
+{
+  "auth_token": "{AUTH_TOKEN}",
+  "data": {
+    "cause": "access denied by token restrictions",
+    "message": "forbidden"
+  },
+  "error": "403",
+  "message": "forbidden",
+  "node": "ghw5cA1GROHLEa43HETSKg",
+  "request_id": "{REQUEST_ID}",
+  "status": "error",
+  "timestamp": "2017-06-07T23:16:25",
+  "version": "4.0.0"
+}
+```
 
 The following sections break down what's happening here.
 

--- a/applications/crossbar/doc/token_restrictions.md
+++ b/applications/crossbar/doc/token_restrictions.md
@@ -384,9 +384,9 @@ Schema for token restrictions
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
 `restrictions` |   | `object` |   | `false`
-`restrictions./^\w+$/` | Name of authentication method used when creating token. '_' matches any auth method | `object` |   | `true`
-`restrictions./^\w+$/./^\w+$/` | Level of user privilege. '_' matches any priv level | `object` |   | `true`
-`restrictions./^\w+$/./^\w+$/./^\w+$/` |   | `array(object)` |   | `true`
+`restrictions./^\w+$/` | Name of authentication method used when creating token. '_' matches any auth method | `object` |   | `false`
+`restrictions./^\w+$/./^\w+$/` | Level of user privilege. '_' matches any priv level | `object` |   | `false`
+`restrictions./^\w+$/./^\w+$/./^\w+$/` |   | `array(object)` |   | `false`
 `restrictions./^\w+$/./^\w+$/./^\w+$/.[].allowed_accounts` | Account allowed to match this item | `array(string)` |   | `false`
 `restrictions./^\w+$/./^\w+$/./^\w+$/.[].allowed_accounts.[]` |   | `string` |   | `false`
 `restrictions./^\w+$/./^\w+$/./^\w+$/.[].rules` | Rules applied to endpoint parameters | `object` |   | `false`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -11773,9 +11773,6 @@
             "description": "Schema for token restrictions",
             "properties": {
                 "restrictions": {
-                    "required": [
-                        "^\\w+$"
-                    ],
                     "type": "object"
                 }
             },

--- a/applications/crossbar/priv/couchdb/schemas/token_restrictions.json
+++ b/applications/crossbar/priv/couchdb/schemas/token_restrictions.json
@@ -48,27 +48,15 @@
                                         },
                                         "type": "object"
                                     },
-                                    "required": [
-                                        "properties"
-                                    ],
                                     "type": "array"
                                 }
                             },
-                            "required": [
-                                "^\\w+$"
-                            ],
                             "type": "object"
                         }
                     },
-                    "required": [
-                        "^\\w+$"
-                    ],
                     "type": "object"
                 }
             },
-            "required": [
-                "^\\w+$"
-            ],
             "type": "object"
         }
     },

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -732,7 +732,7 @@ validate_request_data(SchemaJObj, Context) ->
             lager:debug("request data did not validate against ~s: ~p", [kz_doc:id(SchemaJObj)
                                                                         ,Errors
                                                                         ]),
-            failed(Context, Errors);
+            failed(set_resp_error_msg(Context, <<"validation failed">>), Errors);
         {'error', Errors} ->
             maybe_fix_js_types(Context, SchemaJObj, Errors)
     catch

--- a/applications/crossbar/src/crossbar_auth.erl
+++ b/applications/crossbar/src/crossbar_auth.erl
@@ -66,6 +66,7 @@ create_auth_token(Context, AuthModule, JObj) ->
                ,{<<"method">>, Method}
                ,{<<"exp">>, Expiration}
                ,{<<"mfa_resp">>, kz_json:get_ne_value(<<"multi_factor_response">>, Data)}
+               ,{<<"restrictions">>, crossbar_util:get_token_restrictions(AuthModule, AccountId, OwnerId)}
                 | kz_json:to_proplist(kz_json:get_value(<<"Claims">>, JObj, kz_json:new()))
                ]),
     case maybe_create_token(Claims, Method) of

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -59,6 +59,7 @@
         ,get_account_lang/1
         ,get_language/1
         ,get_language/2
+        ,get_token_restrictions/3
         ]).
 -export([get_user_timezone/2
         ,get_account_timezone/1

--- a/applications/crossbar/test/cb_token_restrictions_test.erl
+++ b/applications/crossbar/test/cb_token_restrictions_test.erl
@@ -14,42 +14,39 @@
 
 allow_all_rule_test_() ->
     Context =
-        cb_context:setters(
-          cb_context:new()
+        cb_context:setters(cb_context:new()
                           ,[{fun cb_context:set_auth_account_id/2, ?AUTH_ACCOUNT_ID}
                            ,{fun cb_context:set_account_id/2, ?ACCOUNT_ID}
                            ,{fun cb_context:set_req_verb/2, ?HTTP_GET}
                            ,{fun cb_context:set_auth_doc/2, auth_doc(?ALLOW_ALL_RULE_RESTRICTIONS)}
                            ]
-         ),
+                          ),
     Label = "Verify catch-all authorizes request",
 
     build_assertions(Label, Context, [?ALLOW_REQ, ?ALLOW_REQ, ?ALLOW_REQ, ?ALLOW_REQ]).
 
 deny_api_endpoint_test_() ->
     Context =
-        cb_context:setters(
-          cb_context:new()
+        cb_context:setters(cb_context:new()
                           ,[{fun cb_context:set_auth_account_id/2, ?AUTH_ACCOUNT_ID}
                            ,{fun cb_context:set_account_id/2, ?ACCOUNT_ID}
                            ,{fun cb_context:set_req_verb/2, ?HTTP_GET}
                            ,{fun cb_context:set_auth_doc/2, auth_doc(?DENY_API_ENDPOINT_RESTRICTIONS)}
                            ]
-         ),
+                          ),
     Label = "Verify denied access to non-existant endpoint in restrictions",
 
     build_assertions(Label, Context, [?DENY_REQ, ?DENY_REQ, ?DENY_REQ, ?DENY_REQ]).
 
 allow_api_endpoint_test_() ->
     Context =
-        cb_context:setters(
-          cb_context:new()
+        cb_context:setters(cb_context:new()
                           ,[{fun cb_context:set_auth_account_id/2, ?AUTH_ACCOUNT_ID}
                            ,{fun cb_context:set_account_id/2, ?ACCOUNT_ID}
                            ,{fun cb_context:set_req_verb/2, ?HTTP_GET}
                            ,{fun cb_context:set_auth_doc/2, auth_doc(?ALLOW_API_ENDPOINT_RESTRICTIONS)}
                            ]
-         ),
+                          ),
     Label = "Verify allowed access to api endpoint in restrictions",
 
     build_assertions(Label, Context, [?ALLOW_REQ, ?ALLOW_REQ, ?ALLOW_REQ, ?ALLOW_REQ]).
@@ -65,8 +62,7 @@ allow_accounts_test_() ->
 
 allow_accounts_assertions({Account, Expected}) ->
     Context =
-        cb_context:setters(
-          cb_context:new()
+        cb_context:setters(cb_context:new()
                           ,[{fun cb_context:set_auth_account_id/2, ?AUTH_ACCOUNT_ID}
                            ,{fun cb_context:set_account_id/2, ?ACCOUNT_ID}
                            ,{fun cb_context:set_req_verb/2, ?HTTP_GET}
@@ -74,7 +70,7 @@ allow_accounts_assertions({Account, Expected}) ->
                             ,auth_doc(?ALLOW_ACCOUNTS_RESTRICTIONS(Account))
                             }
                            ]
-         ),
+                          ),
     Label = "Verify allowed access to accounts in endpoint restrictions",
 
     build_assertions(Label, Context, [Expected, Expected, Expected, Expected]).
@@ -93,8 +89,7 @@ argument_test_() ->
 
 argument_assertions({ArgPattern, ExpectedResults}) ->
     Context =
-        cb_context:setters(
-          cb_context:new()
+        cb_context:setters(cb_context:new()
                           ,[{fun cb_context:set_auth_account_id/2, ?AUTH_ACCOUNT_ID}
                            ,{fun cb_context:set_account_id/2, ?ACCOUNT_ID}
                            ,{fun cb_context:set_req_verb/2, ?HTTP_GET}
@@ -102,7 +97,7 @@ argument_assertions({ArgPattern, ExpectedResults}) ->
                             ,auth_doc(?ARGUMENTS_RESTRICTIONS(ArgPattern))
                             }
                            ]
-         ),
+                          ),
 
     Label = "Verify argument pattern matching works",
     build_assertions(Label, Context, ExpectedResults).
@@ -117,8 +112,7 @@ http_method_test_() ->
 
 method_assertions({Verbs, Expected}) ->
     Context =
-        cb_context:setters(
-          cb_context:new()
+        cb_context:setters(cb_context:new()
                           ,[{fun cb_context:set_auth_account_id/2, ?AUTH_ACCOUNT_ID}
                            ,{fun cb_context:set_account_id/2, ?ACCOUNT_ID}
                            ,{fun cb_context:set_req_verb/2, ?HTTP_GET}
@@ -126,7 +120,7 @@ method_assertions({Verbs, Expected}) ->
                             ,auth_doc(?HTTP_VERB_RESTRICTIONS(Verbs))
                             }
                            ]
-         ),
+                          ),
 
     Label = "Verify HTTP Verb matching works",
     build_assertions(Label, Context, [Expected, Expected, Expected, Expected]).

--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -42,7 +42,7 @@
 -spec load(ne_binary() | string()) -> {'ok', kz_json:object()} |
                                       {'error', any()}.
 load(<<"./", Schema/binary>>) -> load(Schema);
-load(<<"file://", Schema/binary>>) -> load(Schema);
+load(<<"file://", Schema/binary>>) -> fload(Schema);
 load(<<_/binary>> = Schema) ->
     case kz_datamgr:open_cache_doc(?KZ_SCHEMA_DB, Schema, [{'cache_failures', ['not_found']}]) of
         {'error', _E}=E -> E;
@@ -538,12 +538,12 @@ error_to_jobj({'data_invalid'
 error_to_jobj({'data_invalid'
               ,_FailedSchemaJObj
               ,'missing_required_property'
-              ,_FailedValue
+              ,FailedValue
               ,FailedKeyPath
               }
              ,Options
              ) ->
-    validation_error(FailedKeyPath
+    validation_error(FailedKeyPath ++ [FailedValue]
                     ,<<"required">>
                     ,kz_json:from_list(
                        [{<<"message">>, <<"Field is required but missing">>}]

--- a/make/kz.mk
+++ b/make/kz.mk
@@ -92,18 +92,19 @@ test: compile-test
 test.%: compile-test
 	ERL_LIBS=$(ELIBS) erl -noshell $(TEST_PA) -eval "case eunit:test([$*], [verbose]) of ok -> init:stop(); _ -> init:stop(1) end."
 
+COVERDATA=$(PROJECT).coverdata
+COVER_REPORT_DIR=cover
+
 ## Use this one when CI
 eunit:
-	ERL_LIBS=$(ELIBS) erl -noshell $(TEST_PA) -eval "_ = cover:start(), cover:compile_beam_directory(\"ebin\"), case eunit:test([`echo ebin/*.beam | sed 's%\.beam ebin/%, %g;s%ebin/%%;s/\.beam//'`], [verbose]) of ok -> cover:export(\"$(PROJECT).coverdata\"), init:stop(); _ -> init:stop(1) end."
-
-COVERDATA=$(PROJECT).coverdata
-COVER_REPORT_DIR="cover"
+	@mkdir -p $(COVER_REPORT_DIR)
+	ERL_LIBS=$(ELIBS) erl -noshell $(TEST_PA) -eval "_ = cover:start(), cover:compile_beam_directory(\"ebin\"), case eunit:test([`echo ebin/*.beam | sed 's%\.beam ebin/%, %g;s%ebin/%%;s/\.beam//'`], [verbose]) of ok -> cover:export(\"$(COVERDATA)\"), cover:analyse_to_file([html, {outdir, \"$(COVER_REPORT_DIR)\"}]), init:stop(); _ -> init:stop(1) end."
 
 cover: $(ROOT)/make/cover.mk
 	COVER=1 $(MAKE) eunit
 
 cover-report: $(ROOT)/make/core.mk $(ROOT)/make/cover.mk eunit
-	COVER=1 $(MAKE) -f $(ROOT)/make/core.mk -f $(ROOT)/make/cover.mk cover-report
+	COVER=1 CT_RUN=1 $(MAKE) -f $(ROOT)/make/core.mk -f $(ROOT)/make/cover.mk cover-report
 
 $(ROOT)/make/cover.mk: $(ROOT)/make/core.mk
 	wget 'https://raw.githubusercontent.com/ninenines/erlang.mk/master/plugins/cover.mk' -O $(ROOT)/make/cover.mk
@@ -112,7 +113,7 @@ $(ROOT)/make/core.mk:
 	wget 'https://raw.githubusercontent.com/ninenines/erlang.mk/master/core/core.mk' -O $(ROOT)/make/core.mk
 
 proper: ERLC_OPTS += -DPROPER
-proper: compile-test test
+proper: compile-test eunit
 
 PLT ?= $(ROOT)/.kazoo.plt
 $(PLT):


### PR DESCRIPTION
The new auth doc in crossbar_auth didn't add "restrictions" to the
auth doc (as was done in other auth work in crossbar_util). This
meant token restrictions were never processed during the authorize
phase.