### PR TITLE
Load token restrictions per request

### DIFF
--- a/applications/crossbar/src/crossbar_auth.erl
+++ b/applications/crossbar/src/crossbar_auth.erl
@@ -66,7 +66,6 @@ create_auth_token(Context, AuthModule, JObj) ->
                ,{<<"method">>, Method}
                ,{<<"exp">>, Expiration}
                ,{<<"mfa_resp">>, kz_json:get_ne_value(<<"multi_factor_response">>, Data)}
-               ,{<<"restrictions">>, crossbar_util:get_token_restrictions(AuthModule, AccountId, OwnerId)}
                 | kz_json:to_proplist(kz_json:get_value(<<"Claims">>, JObj, kz_json:new()))
                ]),
     case maybe_create_token(Claims, Method) of

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -943,7 +943,6 @@ create_auth_token(Context, AuthModule, JObj) ->
               ,{<<"owner_id">>, OwnerId}
               ,{<<"as">>, kz_json:get_value(<<"as">>, Data)}
               ,{<<"api_key">>, kz_json:get_value(<<"api_key">>, Data)}
-              ,{<<"restrictions">>, get_token_restrictions(AuthModule, AccountId, OwnerId)}
               ,{<<"method">>, kz_term:to_binary(AuthModule)}
               ]),
     JObjToken = kz_doc:update_pvt_parameters(kz_json:from_list(Token)

--- a/applications/crossbar/src/modules/cb_token_restrictions.erl
+++ b/applications/crossbar/src/modules/cb_token_restrictions.erl
@@ -160,12 +160,14 @@ get_auth_restrictions(AuthDoc) ->
     kz_json:get_json_value(<<"restrictions">>, AuthDoc).
 -else.
 -spec get_auth_restrictions(api_object()) -> api_object().
-get_auth_restrictions('undefined') -> 'undefined';
+get_auth_restrictions('undefined') ->
+    ?LOG_DEBUG("no auth doc to check"),
+    'undefined';
 get_auth_restrictions(AuthDoc) ->
     AuthModule = kz_json:get_atom_value(<<"method">>, AuthDoc),
     AccountId = kz_json:get_ne_binary_value(<<"account_id">>, AuthDoc),
     OwnerId = kz_json:get_ne_binary_value(<<"owner_id">>, AuthDoc),
-
+    ?LOG_DEBUG("checking for restrictions for ~s in ~s using ~s method", [OwnerId, AccountId, AuthModule]),
     crossbar_util:get_token_restrictions(AuthModule, AccountId, OwnerId).
 -endif.
 

--- a/applications/crossbar/src/modules/cb_token_restrictions.erl
+++ b/applications/crossbar/src/modules/cb_token_restrictions.erl
@@ -155,6 +155,10 @@ maybe_deny_access(Context) ->
             maybe_deny_access(Context, Restrictions)
     end.
 
+-ifdef(TEST).
+get_auth_restrictions(AuthDoc) ->
+    kz_json:get_json_value(<<"restrictions">>, AuthDoc).
+-else.
 -spec get_auth_restrictions(api_object()) -> api_object().
 get_auth_restrictions('undefined') -> 'undefined';
 get_auth_restrictions(AuthDoc) ->
@@ -163,7 +167,7 @@ get_auth_restrictions(AuthDoc) ->
     OwnerId = kz_json:get_ne_binary_value(<<"owner_id">>, AuthDoc),
 
     crossbar_util:get_token_restrictions(AuthModule, AccountId, OwnerId).
-
+-endif.
 
 -spec maybe_deny_access(cb_context:context(), kz_json:object()) -> boolean().
 maybe_deny_access(Context, Restrictions) ->
@@ -194,10 +198,8 @@ match_endpoint(Context, Restrictions) ->
 -spec match_request_endpoint(api_object(), ne_binary()) ->
                                     api_objects().
 match_request_endpoint(Restrictions, ?CATCH_ALL = ReqEndpoint) ->
-    ?LOG_DEBUG("trying to match ~s in ~p", [ReqEndpoint, Restrictions]),
     kz_json:get_list_value(ReqEndpoint, Restrictions);
 match_request_endpoint(Restrictions, ReqEndpoint) ->
-    ?LOG_DEBUG("trying to match ~s in ~p", [ReqEndpoint, Restrictions]),
     case kz_json:get_list_value(ReqEndpoint, Restrictions) of
         'undefined' -> match_request_endpoint(Restrictions, ?CATCH_ALL);
         EndpointRestrictions -> EndpointRestrictions


### PR DESCRIPTION
Instead of loading the restrictions into the auth doc (and ballooning the size on large restriction rule sets), load them from the restrictions doc on each request and compare.