### PR TITLE
HELP-27660: migrate cdrs and voicemail to modb

### DIFF
--- a/applications/crossbar/priv/couchdb/account/vmboxes.json
+++ b/applications/crossbar/priv/couchdb/account/vmboxes.json
@@ -6,13 +6,56 @@
     "language": "javascript",
     "views": {
         "crossbar_listing": {
-            "map": "function(doc) { if (doc.pvt_type != 'vmbox' || doc.pvt_deleted) return; var messges_count = doc.messages ? doc.messages.length || 0 : 0; emit(doc.name, { 'id': doc._id, 'name': doc.name, 'mailbox': doc.mailbox, 'owner_id': doc.owner_id, 'messages': messges_count }); }"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'vmbox' || doc.pvt_deleted) return;",
+                "  var messges_count = doc.messages ? doc.messages.length || 0 : 0;",
+                "  emit(doc.name, {",
+                "    id: doc._id,",
+                "    name: doc.name,",
+                "    mailbox: doc.mailbox,",
+                "    owner_id: doc.owner_id,",
+                "    messages: messges_count",
+                "  });",
+                "}"
+            ]
         },
         "legacy_msg_by_timestamp": {
-            "map": "function(doc) { if (doc.pvt_type != 'vmbox' || doc.pvt_deleted) return; var messages_count = doc.messages ? doc.messages.length || 0 : 0; if (messages_count) { doc.messages.forEach(function(Message) { emit(parseInt(Message.timestamp), { 'source_id': doc._id, 'owner_id': doc.owner_id, 'mailbox': doc.mailbox, 'timezone': doc.timezone, 'metadata': { 'timestamp': parseInt(Message.timestamp), 'from': Message.from, 'to': Message.to, 'caller_id_number': Message.caller_id_number, 'caller_id_name': Message.caller_id_name, 'call_id': Message.call_id, 'folder': Message.folder, 'length': Message.length, 'media_id': Message.media_id }}) }) } else { return; } }"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'vmbox' || doc.pvt_deleted) return;",
+                "  var messages_count = doc.messages ? doc.messages.length || 0 : 0;",
+                "  if (messages_count)",
+                "    doc.messages.forEach(function(Message) {",
+                "      var timestamp = parseInt(Message.timestamp, 10);",
+                "      emit(timestamp, {",
+                "        source_id: doc._id,",
+                "        owner_id: doc.owner_id,",
+                "        mailbox: doc.mailbox,",
+                "        timezone: doc.timezone,",
+                "        metadata: {",
+                "          timestamp: timestamp,",
+                "          from: Message.from,",
+                "          to: Message.to,",
+                "          caller_id_number: Message.caller_id_number,",
+                "          caller_id_name: Message.caller_id_name,",
+                "          call_id: Message.call_id,",
+                "          folder: Message.folder,",
+                "          length: Message.length,",
+                "          media_id: Message.media_id",
+                "        }",
+                "      })",
+                "    })",
+                "}"
+            ]
         },
         "listing_by_mailbox": {
-            "map": "function(doc) { if (doc.pvt_type != 'vmbox' || doc.pvt_deleted) return; emit(parseInt(doc.mailbox, 10), null); }"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'vmbox' || doc.pvt_deleted) return;",
+                "  emit(parseInt(doc.mailbox, 10), null);",
+                "}"
+            ]
         }
     }
 }

--- a/applications/fax/src/fax_maintenance.erl
+++ b/applications/fax/src/fax_maintenance.erl
@@ -24,15 +24,15 @@
 -export([load_smtp_attachment/2]).
 -export([versions_in_use/0]).
 
--define(DEFAULT_MIGRATE_OPTIONS, []).
--define(OVERRIDE_DOCS, ['override_existing_document']).
+-define(DEFAULT_MIGRATE_OPTIONS, [{'allow_old_modb_creation', 'true'}]).
+-define(OVERRIDE_DOCS, ['override_existing_document' | ?DEFAULT_MIGRATE_OPTIONS]).
 -define(DEFAULT_BATCH_SIZE, 100).
 
 -spec migrate() -> 'ok'.
 migrate() ->
     Accounts = kapps_util:get_all_accounts(),
     Total = length(Accounts),
-    lists:foldr(fun(A, C) -> migrate_faxes_fold(A, C, Total,?DEFAULT_MIGRATE_OPTIONS) end, 1, Accounts),
+    lists:foldr(fun(A, C) -> migrate_faxes_fold(A, C, Total, ?DEFAULT_MIGRATE_OPTIONS) end, 1, Accounts),
     migrate_outbound_faxes(),
     'ok'.
 
@@ -408,7 +408,10 @@ migrate_outbound_fax(JObj) ->
     ToDB = kz_util:format_account_modb(AccountMODb, 'encoded'),
     ToId = ?MATCH_MODB_PREFIX(kz_term:to_binary(Year), kz_time:pad_month(Month),FromId),
 
-    case kazoo_modb:move_doc(FromDB, FromId, ToDB, ToId, ['override_existing_document']) of
+    Options = [{'allow_old_modb_creation', 'true'}
+              ,'override_existing_document'
+              ],
+    case kazoo_modb:move_doc(FromDB, FromId, ToDB, ToId, Options) of
         {'ok', _} -> io:format("document ~s/~s moved to ~s/~s~n", [FromDB, FromId, ToDB, ToId]);
         {'error', _E} -> io:format("error ~p moving document ~s/~s to ~s/~s~n", [_E, FromDB, FromId, ToDB, ToId])
     end.

--- a/applications/fax/src/fax_maintenance.erl
+++ b/applications/fax/src/fax_maintenance.erl
@@ -408,10 +408,7 @@ migrate_outbound_fax(JObj) ->
     ToDB = kz_util:format_account_modb(AccountMODb, 'encoded'),
     ToId = ?MATCH_MODB_PREFIX(kz_term:to_binary(Year), kz_time:pad_month(Month),FromId),
 
-    Options = [{'allow_old_modb_creation', 'true'}
-              ,'override_existing_document'
-              ],
-    case kazoo_modb:move_doc(FromDB, FromId, ToDB, ToId, Options) of
+    case kazoo_modb:move_doc(FromDB, FromId, ToDB, ToId, ?OVERRIDE_DOCS) of
         {'ok', _} -> io:format("document ~s/~s moved to ~s/~s~n", [FromDB, FromId, ToDB, ToId]);
         {'error', _E} -> io:format("error ~p moving document ~s/~s to ~s/~s~n", [_E, FromDB, FromId, ToDB, ToId])
     end.

--- a/core/kazoo_documents/src/kzd_box_message.erl
+++ b/core/kazoo_documents/src/kzd_box_message.erl
@@ -63,13 +63,6 @@
 -define(PVT_TYPE, <<"mailbox_message">>).
 -define(PVT_LEGACY_TYPE, <<"private_media">>).
 
--define(MSG_ID(Year, Month, Id),
-        <<(kz_term:to_binary(Year))/binary
-          ,(kz_time:pad_month(Month))/binary
-          ,"-"
-          ,(Id)/binary
-        >>).
-
 %%--------------------------------------------------------------------
 %% @public
 %% @doc Generate a mailbox message doc with the given properties
@@ -105,7 +98,7 @@ new(AccountId, Props) ->
     MediaId = props:get_value(<<"Media-ID">>, Props, kz_binary:rand_hex(16)),
 
     Db = kazoo_modb:get_modb(AccountId, Year, Month),
-    MsgId = ?MSG_ID(Year, Month, MediaId),
+    MsgId = kazoo_modb_util:modb_id(Year, Month, MediaId),
 
     Name = create_message_name(props:get_value(<<"Box-Num">>, Props)
                               ,props:get_value(<<"Timezone">>, Props)

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -335,9 +335,8 @@ maybe_create_destination_db(FromDb, FromId, ToDb, Options) ->
     ShouldCreate = props:get_is_true('create_db', Options, 'true'),
     lager:info("destination modb ~p not found, maybe creating...", [ToDb]),
     case ShouldCreate
-        andalso (kz_datamgr:db_exists(FromDb)
-                 andalso kz_datamgr:open_doc(FromDb, FromId)
-                )
+        andalso kz_datamgr:db_exists(FromDb)
+        andalso kz_datamgr:open_doc(FromDb, FromId)
     of
         'false' when ShouldCreate ->
             lager:info("source modb ~s does not exist, not creating destination modb ~s", [FromDb, ToDb]),

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -234,6 +234,10 @@ save_fun('true') -> fun kz_datamgr:ensure_saved/3.
 %%--------------------------------------------------------------------
 %% @public
 %% @doc
+%% Move a document from source to destination with attachments,
+%% optionally applies a transform function on the document
+%% Note: Caller is responsible to format both source and destination
+%% databases!
 %% @end
 %%--------------------------------------------------------------------
 -spec move_doc(ne_binary(), kazoo_data:docid(), ne_binary(), kazoo_data:docid()) ->
@@ -279,6 +283,10 @@ move_doc(FromDb, FromId, ToDb, ToId, Options, _Reason, Retry) ->
 %%--------------------------------------------------------------------
 %% @public
 %% @doc
+%% Copy a document from source to destination with attachments,
+%% optionally applies a transform function on the document
+%% Note: Caller is responsible to format both source and destination
+%% databases!
 %% @end
 %%--------------------------------------------------------------------
 -spec copy_doc(ne_binary(), kazoo_data:docid(), ne_binary(), kazoo_data:docid()) ->
@@ -328,7 +336,7 @@ maybe_create_destination_db(FromDb, FromId, ToDb, Options) ->
     lager:info("destination modb ~p not found, maybe creating...", [ToDb]),
     case ShouldCreate
         andalso (kz_datamgr:db_exists(FromDb)
-                 andalso open_doc(FromDb, FromId)
+                 andalso kz_datamgr:open_doc(FromDb, FromId)
                 )
     of
         'false' when ShouldCreate ->

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -29,6 +29,7 @@
 -type view_option() :: {'year', kz_year()} |
                        {'month', kz_month()} |
                        {'create_db', boolean()} |
+                       {'allow_old_modb_creation', boolean()} |
                        kz_datamgr:view_option().
 -type view_options() :: [view_option()].
 
@@ -77,6 +78,7 @@ strip_modb_options(ViewOptions) ->
 is_modb_option({'year', _}) -> 'true';
 is_modb_option({'month', _}) -> 'true';
 is_modb_option({'create_db', _}) -> 'true';
+is_modb_option({'allow_old_modb_creation', _}) -> 'true';
 is_modb_option({'ensure_saved', _}) -> 'true';
 is_modb_option({'max_retries', _}) -> 'true';
 is_modb_option(_) -> 'false'.
@@ -88,7 +90,7 @@ get_results_missing_db(Account, View, ViewOptions, Retry) ->
     ShouldCreate = props:get_is_true('create_db', ViewOptions, 'true'),
     lager:info("modb ~p not found, maybe creating...", [AccountMODb]),
     case ShouldCreate
-        andalso maybe_create_current_modb(AccountMODb)
+        andalso maybe_create_current_modb(AccountMODb, ViewOptions)
     of
         'true' -> get_results(Account, View, ViewOptions, 'not_found', Retry-1);
         'too_old' ->
@@ -207,7 +209,7 @@ couch_save(AccountMODb, Doc, Options, _Reason, Retry) ->
             ShouldCreate = props:get_is_true('create_db', Options, 'true'),
             lager:info("modb ~p not found, maybe creating...", [AccountMODb]),
             case ShouldCreate
-                andalso maybe_create_current_modb(AccountMODb)
+                andalso maybe_create_current_modb(AccountMODb, Options)
             of
                 'true' ->
                     couch_save(AccountMODb, Doc, Options, 'not_found', Retry-1);
@@ -250,16 +252,18 @@ move_doc(FromDb, FromId, ToDb, ToId, Options) ->
 -spec move_doc(ne_binary(), kazoo_data:docid(), ne_binary(), kazoo_data:docid(), kz_proplist(), atom(), integer()) ->
                       {'ok', kz_json:object()} |
                       {'error', atom()}.
+move_doc(FromDb, {_, FromId}, ToDb, ToId, Options, Reason, Retry) when Retry =< 0 ->
+    move_doc(FromDb, FromId, ToDb, ToId, Options, Reason, Retry);
 move_doc(_FromDb, _FromId, _ToDb, _ToId, _Options, Reason, Retry) when Retry =< 0 ->
     lager:error("max retries to move doc from ~s/~s to ~s/~s : ~p"
-               ,[_FromDb, _FromId, _ToDb, _ToId]
+               ,[_FromDb, _FromId, _ToDb, _ToId, Reason]
                ),
     {'error', Reason};
 move_doc(FromDb, FromId, ToDb, ToId, Options, _Reason, Retry) ->
-    case kz_datamgr:move_doc(FromDb, {<<"fax">>, FromId}, ToDb, ToId, strip_modb_options(Options)) of
+    case kz_datamgr:move_doc(FromDb, FromId, ToDb, ToId, strip_modb_options(Options)) of
         {'ok', _}=OK -> OK;
         {'error', 'not_found'} ->
-            case maybe_create_destination_db(FromDb, ToDb, Options) of
+            case maybe_create_destination_db(FromDb, FromId, ToDb, Options) of
                 'true' -> move_doc(FromDb, FromId, ToDb, ToId, Options, 'not_found', Retry-1);
                 'source_not_exists' -> {'error', 'not_found'};
                 'too_old' -> {'error', 'not_found'};
@@ -299,10 +303,10 @@ copy_doc(_FromDb, _FromId, _ToDb, _ToId, _Options, Reason, Retry) when Retry =< 
                ),
     {'error', Reason};
 copy_doc(FromDb, FromId, ToDb, ToId, Options, _Reason, Retry) ->
-    case kz_datamgr:copy_doc(FromDb, {<<"fax">>, FromId}, ToDb, ToId, strip_modb_options(Options)) of
+    case kz_datamgr:copy_doc(FromDb, FromId, ToDb, ToId, strip_modb_options(Options)) of
         {'ok', _}=OK -> OK;
         {'error', 'not_found'} ->
-            case maybe_create_destination_db(FromDb, ToDb, Options) of
+            case maybe_create_destination_db(FromDb, FromId, ToDb, Options) of
                 'true' -> copy_doc(FromDb, FromId, ToDb, ToId, Options, 'not_found', Retry-1);
                 'source_not_exists' -> {'error', 'not_found'};
                 'too_old' -> {'error', 'not_found'};
@@ -315,15 +319,17 @@ copy_doc(FromDb, FromId, ToDb, ToId, Options, _Reason, Retry) ->
         {'error', _}=Error -> Error
     end.
 
--spec maybe_create_destination_db(ne_binary(), ne_binary(), kz_proplist()) ->
+-spec maybe_create_destination_db(ne_binary(), ne_binary(), ne_binary(), kz_proplist()) ->
                                          'source_not_exists' |
                                          'too_old'|
                                          boolean().
-maybe_create_destination_db(FromDb, ToDb, Options) ->
+maybe_create_destination_db(FromDb, FromId, ToDb, Options) ->
     ShouldCreate = props:get_is_true('create_db', Options, 'true'),
     lager:info("destination modb ~p not found, maybe creating...", [ToDb]),
     case ShouldCreate
-        andalso kz_datamgr:db_exists(FromDb)
+        andalso (kz_datamgr:db_exists(FromDb)
+                 andalso open_doc(FromDb, FromId)
+                )
     of
         'false' when ShouldCreate ->
             lager:info("source modb ~s does not exist, not creating destination modb ~s", [FromDb, ToDb]),
@@ -331,8 +337,11 @@ maybe_create_destination_db(FromDb, ToDb, Options) ->
         'false' ->
             lager:info("create_db is false, not creating modb ~s ...", [ToDb]),
             'source_not_exists';
-        'true' ->
-            maybe_create_current_modb(ToDb)
+        {'ok', _} ->
+            maybe_create_current_modb(ToDb, Options);
+        {'error', _} ->
+            lager:info("source document ~s/~p does not exist, not creating destination modb ~s", [FromDb, FromId, ToDb]),
+            'source_not_exists'
     end.
 
 %%--------------------------------------------------------------------
@@ -390,20 +399,23 @@ get_modb(Account, Year, Month) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec maybe_create_current_modb(ne_binary()) -> 'too_old' | boolean().
-maybe_create_current_modb(?MATCH_MODB_SUFFIX_RAW(_AccountId, Year, Month) = AccountMODb) ->
+-spec maybe_create_current_modb(ne_binary(), kz_proplist()) -> 'too_old' | boolean().
+maybe_create_current_modb(?MATCH_MODB_SUFFIX_RAW(_AccountId, Year, Month) = AccountMODb, Options) ->
     {Y, M, _} = erlang:date(),
+    ShouldCreateOld = props:get_is_true('allow_old_modb_creation', Options, 'false'),
     case {kz_term:to_binary(Y), kz_time:pad_month(M)} of
         {Year, Month} ->
+            maybe_create(AccountMODb);
+        {_Year, _Month} when ShouldCreateOld ->
             maybe_create(AccountMODb);
         {_Year, _Month} ->
             lager:info("modb ~p is not for the current month, skip creating", [AccountMODb]),
             'too_old'
     end;
-maybe_create_current_modb(?MATCH_MODB_SUFFIX_ENCODED(_, _, _) = AccountMODb) ->
-    maybe_create_current_modb(kz_util:format_account_modb(AccountMODb, 'raw'));
-maybe_create_current_modb(?MATCH_MODB_SUFFIX_UNENCODED(_, _, _) = AccountMODb) ->
-    maybe_create_current_modb(kz_util:format_account_modb(AccountMODb, 'raw')).
+maybe_create_current_modb(?MATCH_MODB_SUFFIX_ENCODED(_, _, _) = AccountMODb, Options) ->
+    maybe_create_current_modb(kz_util:format_account_modb(AccountMODb, 'raw'), Options);
+maybe_create_current_modb(?MATCH_MODB_SUFFIX_UNENCODED(_, _, _) = AccountMODb, Options) ->
+    maybe_create_current_modb(kz_util:format_account_modb(AccountMODb, 'raw'), Options).
 
 -spec maybe_create(ne_binary()) -> boolean().
 maybe_create(?MATCH_MODB_SUFFIX_RAW(AccountId, _, _) = AccountMODb) ->

--- a/core/kazoo_modb/src/kazoo_modb_migrate_maintenance.erl
+++ b/core/kazoo_modb/src/kazoo_modb_migrate_maintenance.erl
@@ -1,0 +1,343 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz INC
+%%% @doc
+%%% The Great Kazoo Migration (TM)
+%%% @end
+%%%-------------------------------------------------------------------
+-module(kazoo_modb_migrate_maintenance).
+
+-export([migrate/0
+        ,migrate_account/1
+        ]).
+
+-include("kazoo_modb.hrl").
+
+-type update_funs() :: [fun((kz_json:object()) -> kz_json:object())].
+
+-spec migrate() -> 'ok'.
+migrate() ->
+    AccountIds = kz_term:shuffle_list(kapps_util:get_all_accounts('raw')),
+    Total = length(AccountIds),
+    io:format("Start migrating items to MODB from ~b databases~n~n", [Total]),
+    lists:foldl(fun(A, C) -> migrate_account_fold(A, C, Total) end, 1, AccountIds),
+    'ok'.
+
+-spec migrate_account_fold(ne_binary(), non_neg_integer(), non_neg_integer()) -> non_neg_integer().
+migrate_account_fold(AccountId, Current, Total) ->
+    io:format("(~p/~p) migrating items within account '~s'~n", [Current, Total, AccountId]),
+    _ = migrate_account(AccountId),
+    Current + 1.
+
+-spec migrate_account(ne_binary()) -> 'ok'.
+migrate_account(Account) ->
+    AccountId = get_account_id(Account),
+    lists:foreach(fun(Fun) -> Fun(AccountId) end
+                 ,[fun migrate_voicemails/1
+                  ,fun migrate_cdrs/1
+                  ]
+                 ).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+-spec get_account_id(ne_binary()) -> ne_binary().
+get_account_id(?MATCH_ACCOUNT_RAW(AccountId)) -> AccountId;
+get_account_id(?MATCH_ACCOUNT_UNENCODED(A, B, Rest)) -> ?MATCH_ACCOUNT_RAW(A, B, Rest);
+get_account_id(?MATCH_ACCOUNT_ENCODED(A, B, Rest)) -> ?MATCH_ACCOUNT_RAW(A, B, Rest);
+get_account_id(?MATCH_MODB_SUFFIX_RAW(AccountId, _, _)) -> AccountId;
+get_account_id(?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, _, _)) -> ?MATCH_ACCOUNT_RAW(A, B, Rest);
+get_account_id(?MATCH_MODB_SUFFIX_UNENCODED(A, B, Rest, _, _)) -> ?MATCH_ACCOUNT_RAW(A, B, Rest).
+
+-spec get_view_count(ne_binary(), ne_binary()) -> non_neg_integer().
+get_view_count(AccountId, View) ->
+    get_view_count(AccountId, View, 2).
+
+-spec get_view_count(ne_binary(), ne_binary(), integer()) -> non_neg_integer().
+get_view_count(_AccountId, _View, Retry) when Retry < 0 ->
+    io:format("[~s] failed to fetch view ~s count~n", [_AccountId, _View]),
+    0;
+get_view_count(AccountId, View, Retry) ->
+    AccountDb = kz_util:format_account_db(AccountId),
+    case kz_datamgr:get_results_count(AccountDb, View, []) of
+        {'ok', Total} -> Total;
+        {'error', 'not_found'} ->
+            kapps_maintenance:refresh(AccountDb),
+            get_view_count(AccountDb, View, Retry-1);
+        {'error', _} ->
+            get_view_count(AccountDb, View, Retry-1)
+    end.
+
+%%%===================================================================
+%%% Voicemail Migration
+%%%===================================================================
+-spec migrate_voicemails(ne_binary()) -> 'ok'.
+migrate_voicemails(AccountId) ->
+    Total = get_view_count(AccountId, <<"vmboxes/legacy_msg_by_timestamp">>),
+    migrate_voicemails(AccountId, Total).
+
+-spec migrate_voicemails(ne_binary(), non_neg_integer()) -> 'ok'.
+migrate_voicemails(_AccountId, 0) ->
+    io:format("[~s] no voicemail messages found~n", [_AccountId]);
+migrate_voicemails(AccountId, Total) ->
+    Limit = kz_datamgr:max_bulk_read(),
+    io:format("[~s] start migrating total ~b voicemail messages with batch size ~b~n", [AccountId, Total, Limit]),
+    Stats = #{total => Total
+             ,processed => 0
+             ,moved => 0
+             ,result => #{}
+             },
+    migrate_voicemails(AccountId, Stats, [{'limit', 5}]).
+
+-spec migrate_voicemails(ne_binary(), map(), kz_proplist()) -> 'ok'.
+migrate_voicemails(AccountId, #{total := Total, processed := Processed, moved := Moved}=Stats, ViewOptions) ->
+    AccountDb = kz_util:format_account_db(AccountId),
+    case kz_datamgr:get_results(AccountDb, <<"vmboxes/legacy_msg_by_timestamp">>, ViewOptions) of
+        {'ok', []} ->
+            io:format("[~s] voicemail message migration finished, (~b/~b) messages has been moved~n"
+                     ,[AccountId, Moved, Total]
+                     );
+        {'ok', ViewResults} ->
+            Length = length(ViewResults),
+            io:format("[~s] processing ~b messages~n", [AccountId, Length]),
+            MoveFun = fun(JObj, Map) ->
+                          move_vm_to_modb(AccountId, kz_json:get_value(<<"value">>, JObj), Map)
+                      end,
+            ProcessMap = lists:foldl(MoveFun, Stats, ViewResults),
+            update_mailboxes(AccountId, maps:get(result, ProcessMap)),
+
+            NewProcessed = Processed + Length,
+            Remaining = Total - NewProcessed,
+            io:format("[~s] finished processing ~b messages, ~b remain~n", [AccountId, Length, Remaining]),
+            timer:sleep(1000),
+            NewSkip = case Remaining of
+                          0 -> Total;
+                          Remaining when Remaining < NewProcessed -> Remaining;
+                          _ -> NewProcessed
+                      end,
+            migrate_voicemails(AccountId
+                              ,Stats#{processed := NewProcessed
+                                     ,moved := maps:get(moved, ProcessMap)
+                                     ,result := #{}
+                                     }
+                              ,props:set_value('skip', NewSkip, ViewOptions)
+                              );
+        {'error', _R} ->
+            io:format("[~s] failed to fetch voicemail messages: ~p~n", [AccountId, _R])
+    end.
+
+-spec move_vm_to_modb(ne_binary(), kz_json:object(), map()) -> map().
+move_vm_to_modb(AccountId, LegacyVMJObj, #{total := Total
+                                          ,processed := Processed
+                                          ,moved := Moved
+                                          ,result := Result
+                                          }=Map) ->
+    AccountDb = kz_util:format_account_db(AccountId),
+    BoxId = kz_json:get_value(<<"source_id">>, LegacyVMJObj),
+    {ToDb, ToId, TransformFuns} = transform_vm_doc_funs(AccountDb, LegacyVMJObj),
+
+    FromId = kz_json:get_value([<<"metadata">>, <<"media_id">>], LegacyVMJObj),
+
+    io:format("[~s] (~b/~b) moving voicemail ~s to ~s := "
+             ,[AccountId, Processed + 1, Total, FromId, ToId]
+             ),
+
+    Opts = [{'transform', fun(_, B) -> lists:foldl(fun(F, J) -> F(J) end, B, TransformFuns) end}
+           ,{'create_db', 'true'}
+           ,{'allow_old_modb_creation', 'true'}
+           ,{'max_retries', 3}
+           ],
+
+    case kazoo_modb:move_doc(AccountDb, {kzd_box_message:type(), FromId}, ToDb, ToId, Opts) of
+        {'ok', _} ->
+            io:format("done~n"),
+            Map#{result := maps:update_with(BoxId
+                                           ,fun(Old) -> sets:add_element(FromId, Old) end
+                                           ,sets:new()
+                                           ,Result
+                                           )
+                ,moved := Moved + 1
+                ,processed := Processed + 1
+                };
+        {'error', _Reason} ->
+            io:format("failed ~p~n", [_Reason]),
+            Map#{processed := Processed + 1}
+    end.
+
+-spec transform_vm_doc_funs(ne_binary(), kz_json:object()) -> {ne_binary(), ne_binary(), update_funs()}.
+transform_vm_doc_funs(AccountDb, LegacyVMJObj) ->
+    Metadata = kz_json:get_value(<<"metadata">>, LegacyVMJObj),
+    Timestamp = kz_json:get_integer_value(<<"timestamp">>, Metadata),
+    OldId = kz_json:get_value(<<"media_id">>, Metadata),
+    OldCallId = kz_json:get_value(<<"call_id">>, Metadata),
+
+    {{Year, Month, _}, _} = calendar:gregorian_seconds_to_datetime(Timestamp),
+
+    NewId = kazoo_modb_util:modb_id(Year, Month, OldId),
+    NewCallId = kazoo_modb_util:modb_id(Year, Month, OldCallId),
+    NewDb = kazoo_modb:get_modb(AccountDb, Year, Month),
+
+    NewMetadata = kz_json:set_values(
+                    [{<<"media_id">>, NewId}
+                    ,{<<"call_id">>, NewCallId}
+                    ], Metadata),
+    {NewDb
+    ,NewId
+    ,[fun(J) -> kz_json:set_value(<<"metadata">>, NewMetadata, J) end
+     ,fun(J) -> kz_doc:set_type(J, kzd_box_message:type()) end
+     ,fun(J) -> kz_doc:set_account_db(J, NewDb) end
+     ]
+    }.
+
+-spec update_mailboxes(ne_binary(), map()) -> 'ok'.
+update_mailboxes(AccountId, Map) ->
+    BoxIds = maps:keys(Map),
+    io:format("BoxIds ~p~n", [BoxIds]),
+
+    AccountDb = kz_util:format_account_db(AccountId),
+    case kz_term:is_not_empty(BoxIds)
+        andalso kz_datamgr:open_docs(AccountDb, BoxIds) of
+        false -> ok;
+        {'ok', BoxJObjs} ->
+            NewBoxJObjs = update_mailbox_jobjs(BoxJObjs, Map),
+            case kz_datamgr:save_docs(AccountDb, NewBoxJObjs) of
+                {'ok', _} -> 'ok';
+                {'error', _Reason} ->
+                    io:format("[~s] failed to update mailbox message arrays: ~p~n", [AccountId, _Reason])
+            end;
+        {'error', _Reason} ->
+            io:format("[~s] failed to open mailboxs for updating message arrays: ~p~n", [AccountId, _Reason])
+    end.
+
+-spec update_mailbox_jobjs(kz_json:objects(), map()) -> kz_json:objects().
+update_mailbox_jobjs(BoxJObjs, Map) ->
+    [update_message_array(kz_json:get_value(<<"doc">>, J), maps:get(kz_doc:id(J), Map))
+     || J <- BoxJObjs
+    ].
+
+-spec update_message_array(kz_json:object(), sets:set()) -> kz_json:object().
+update_message_array(BoxJObj, ResultSet) ->
+    io:format("Moved ~p~n", [sets:to_list(ResultSet)]),
+    Messages = kz_json:get_value(<<"messages">>, BoxJObj),
+    Fun = fun(Msg, Acc) ->
+                  case sets:is_element(kz_json:get_value(<<"media_id">>, Msg), ResultSet) of
+                      true -> Acc;
+                      false -> [Msg|Acc]
+                  end
+          end,
+    NewMessages = lists:foldl(Fun, [], Messages),
+    kz_json:set_value(<<"messages">>, NewMessages, BoxJObj).
+
+%%%===================================================================
+%%% Voicemail Migration
+%%%===================================================================
+
+-spec migrate_cdrs(ne_binary()) -> 'ok'.
+migrate_cdrs(AccountId) ->
+    Total = get_view_count(AccountId, <<"cdrs/crossbar_listing">>),
+    migrate_cdrs(AccountId, Total).
+
+-spec migrate_cdrs(ne_binary(), non_neg_integer()) -> 'ok'.
+migrate_cdrs(_AccountId, 0) ->
+    io:format("[~s] no cdrs found~n", [_AccountId]);
+migrate_cdrs(AccountId, Total) ->
+    Limit = kz_datamgr:max_bulk_read(),
+    io:format("[~s] start migrating total ~b cdrs with batch size ~b~n", [AccountId, Total, Limit]),
+    Stats = #{total => Total
+             ,processed => 0
+             ,moved => 0
+             },
+    migrate_cdrs(AccountId, Stats, [{'limit', 5}, include_docs]).
+
+-spec migrate_cdrs(ne_binary(), map(), kz_proplist()) -> 'ok'.
+migrate_cdrs(AccountId, #{total := Total, processed := Processed, moved := Moved}=Stats, ViewOptions) ->
+    AccountDb = kz_util:format_account_db(AccountId),
+    case kz_datamgr:get_results(AccountDb, <<"cdrs/crossbar_listing">>, ViewOptions) of
+        {'ok', []} ->
+            io:format("[~s] cdrs migration finished, (~b/~b) doc has been moved~n"
+                     ,[AccountId, Moved, Total]
+                     );
+        {'ok', ViewResults} ->
+            Length = length(ViewResults),
+            io:format("[~s] processing ~b cdrs~n", [AccountId, Length]),
+
+            MovedIds = move_cdrs_to_modb(AccountId, ViewResults),
+            case kz_term:is_not_empty(MovedIds)
+                andalso kz_datamgr:del_docs(AccountDb, MovedIds) of
+                false -> ok;
+                {'ok', _} -> 'ok';
+                {'error', _Reason} ->
+                    io:format("[~s] failed to remove moved cdrs from account db: ~p~n", [AccountId, _Reason])
+            end,
+
+            NewProcessed = Processed + Length,
+            Remaining = Total - NewProcessed,
+            io:format("[~s] finished processing ~b cdrs, ~b remain~n", [AccountId, Length, Remaining]),
+
+            timer:sleep(1000),
+            NewSkip = case Remaining of
+                          0 -> Total;
+                          Remaining when Remaining < NewProcessed -> Remaining;
+                          _ -> NewProcessed
+                      end,
+            migrate_cdrs(AccountId
+                        ,Stats#{processed := NewProcessed
+                               ,moved := Moved + length(MovedIds)
+                               }
+                        ,props:set_value('skip', NewSkip, ViewOptions)
+                        );
+
+        {'error', _R} ->
+            io:format("[~s] failed to fetch cdrs: ~p~n", [AccountId, _R])
+    end.
+
+-spec move_cdrs_to_modb(ne_binary(), kz_json:objects()) -> ne_binaries().
+move_cdrs_to_modb(AccountId, ViewResults) ->
+    Mapped = map_tranform_cdrs(AccountId, ViewResults, maps:new()),
+    maps:fold(fun do_move_cdrs/3, [], Mapped).
+
+-spec map_tranform_cdrs(ne_binary(), kz_json:objects(), map()) -> map().
+map_tranform_cdrs(_AccountId, [], Map) -> Map;
+map_tranform_cdrs(AccountId, [VR|VRs], Map) ->
+    AccountDb = kz_util:format_account_db(AccountId),
+    Doc = kz_json:get_value(<<"doc">>, VR),
+    OldId = kz_doc:id(Doc),
+    Created = kz_doc:created(Doc),
+
+    {{Year, Month, _}, _} = calendar:gregorian_seconds_to_datetime(Created),
+
+    NewId = kazoo_modb_util:modb_id(Year, Month, OldId),
+    NewDb = kazoo_modb:get_modb(AccountDb, Year, Month),
+
+    TransformFuns = [fun(J) -> kz_doc:set_id(J, NewId) end
+                    ,fun(J) -> kz_doc:delete_revision(J) end
+                    ,fun(J) -> kz_doc:set_account_db(J, NewDb) end
+                    ],
+    NewDoc = lists:foldl(TransformFuns, Doc, TransformFuns),
+
+    NewMap = maps:update_with(NewDb, fun(Old) -> [NewDoc|Old] end, [], Map),
+    map_tranform_cdrs(AccountId, VRs, NewMap).
+
+-spec do_move_cdrs(ne_binary(), kz_json:object(), ne_binaries()) -> ne_binaries().
+do_move_cdrs(MODB, Docs, MovedAcc) ->
+    _AccountId = kz_util:format_account_id(MODB),
+    case kz_datamgr:save_docs(MODB, Docs) of
+        {ok, SavedJObj} -> check_for_failure(SavedJObj, MovedAcc);
+        {error, _Reason} ->
+            io:format("[~s] failed to move cdrs in batch: ~p~n", [_AccountId, _Reason]),
+            MovedAcc
+    end.
+
+-spec check_for_failure(kz_json:objects(), ne_binaries()) -> ne_binaries().
+check_for_failure(JObjs, MovedAcc) ->
+    lists:map(
+      fun(J) ->
+          case kz_json:get_value(<<"error">>, J) of
+              'undefined' ->
+                  ?MATCH_MODB_PREFIX(_Year, _Month, OldId) = kz_doc:id(J),
+                  [OldId|MovedAcc];
+              _ -> MovedAcc
+          end
+      end
+      ,JObjs
+    ).

--- a/core/kazoo_modb/src/kazoo_modb_migrate_maintenance.erl
+++ b/core/kazoo_modb/src/kazoo_modb_migrate_maintenance.erl
@@ -100,12 +100,11 @@ migrate_voicemails(AccountId, Total) ->
              ,result => #{}
              ,skip => 0
              },
-    migrate_voicemails(AccountId, Stats, [{'limit', 5}]).
+    migrate_voicemails(AccountId, Stats, [{'limit', Limit}]).
 
 -spec migrate_voicemails(ne_binary(), map(), kz_proplist()) -> 'ok'.
 migrate_voicemails(AccountId, #{total := Total, processed := Processed, moved := Moved, skip := Skip}=Stats, ViewOptions) ->
     AccountDb = kz_util:format_account_db(AccountId),
-    io:format("~nStats ~p~n ViewOptions ~p~n~n", [Stats, ViewOptions]),
     case kz_datamgr:get_results(AccountDb, <<"vmboxes/legacy_msg_by_timestamp">>, ViewOptions) of
         {'ok', []} ->
             io:format("[~s] voicemail message migration finished, (~b/~b) messages has been moved~n"
@@ -273,7 +272,7 @@ migrate_cdrs(AccountId, Total) ->
              ,moved => 0
              ,skip => 0
              },
-    migrate_cdrs(AccountId, Stats, [{'limit', 5}, include_docs]).
+    migrate_cdrs(AccountId, Stats, [{'limit', Limit}, include_docs]).
 
 -spec migrate_cdrs(ne_binary(), map(), kz_proplist()) -> 'ok'.
 migrate_cdrs(AccountId, #{total := Total, processed := Processed, moved := Moved, skip := Skip}=Stats, ViewOptions) ->

--- a/core/kazoo_modb/src/kazoo_modb_migrate_maintenance.erl
+++ b/core/kazoo_modb/src/kazoo_modb_migrate_maintenance.erl
@@ -313,7 +313,7 @@ map_tranform_cdrs(AccountId, [VR|VRs], Map) ->
                     ,fun(J) -> kz_doc:delete_revision(J) end
                     ,fun(J) -> kz_doc:set_account_db(J, NewDb) end
                     ],
-    NewDoc = lists:foldl(TransformFuns, Doc, TransformFuns),
+    NewDoc = lists:foldl(fun(F, J) -> F(J) end, Doc, TransformFuns),
 
     NewMap = maps:update_with(NewDb, fun(Old) -> [NewDoc|Old] end, [], Map),
     map_tranform_cdrs(AccountId, VRs, NewMap).

--- a/core/kazoo_modb/src/kazoo_modb_util.erl
+++ b/core/kazoo_modb/src/kazoo_modb_util.erl
@@ -13,6 +13,7 @@
 -export([prev_year_month/1, prev_year_month/2
         ,prev_year_month_mod/1
         ,split_account_mod/1
+        ,modb_id/0, modb_id/2, modb_id/3
         ]).
 
 -spec prev_year_month(ne_binary()) -> {kz_year(), kz_month()}.
@@ -63,3 +64,26 @@ split_account_mod(?MATCH_MODB_SUFFIX_ENCODED(Account,Year,Month)) ->
     ,kz_term:to_integer(Year)
     ,kz_term:to_integer(Month)
     }.
+
+%% @doc
+%% Equivalent to `modb_id/3`
+-spec modb_id() -> ne_binary().
+modb_id() ->
+    {Year, Month, _} = erlang:date(),
+    modb_id(Year, Month, kz_binary:rand_hex(16)).
+
+%% @doc
+%% Equivalent to `modb_id/3`
+-spec modb_id(ne_binary() | kz_year(), ne_binary() | kz_month()) -> ne_binary().
+modb_id(Year, Month) ->
+    modb_id(Year, Month, kz_binary:rand_hex(16)).
+
+%% @doc
+%% Format a document id prefix with year and month
+-spec modb_id(ne_binary() | kz_year(), ne_binary() | kz_month(), ne_binary()) -> ne_binary().
+modb_id(Year, Month, Id) ->
+    <<(kz_term:to_binary(Year))/binary
+      ,(kz_time:pad_month(Month))/binary
+      ,"-"
+      ,(Id)/binary
+    >>.

--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -796,7 +796,7 @@ check_for_collision(Call, JObj, SavedJObj, DieAnotherDay) ->
 
 -spec give_me_another_id(ne_binary()) -> ne_binary().
 give_me_another_id(?MATCH_MODB_PREFIX(Year, Month, _)) ->
-    ?MODB_MSG_ID(Year, Month, kz_binary:rand_hex(16)).
+    kazoo_modb_util:modb_id(Year, Month).
 
 -spec send_system_alert(kapps_call:call() | 'undefined', ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 send_system_alert('undefined', AccountId, Subject, Msg) ->

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -179,9 +179,9 @@ get_change_vmbox_funs(AccountId, NewBoxId, NBoxJ, OldBoxId, ToId) ->
     Month = kz_time:pad_month(M),
 
     NewId = case ToId of
-                'undefined' -> ?MODB_MSG_ID(Year, Month, kz_binary:rand_hex(16));
-                <<Year:4/binary, Month:2/binary, _Rest/binary>> -> ToId;
-                _OldId -> ?MODB_MSG_ID(Year, Month, kz_binary:rand_hex(16))
+                'undefined' -> kazoo_modb_util:modb_id(Year, Month, kz_binary:rand_hex(16));
+                ?MATCH_MODB_PREFIX(Year, Month,  _Rest) -> ToId;
+                _OldId -> kazoo_modb_util:modb_id(Year, Month, kz_binary:rand_hex(16))
             end,
     AccountDb = get_db(AccountId, NewId),
 

--- a/core/kazoo_voicemail/src/kz_voicemail.hrl
+++ b/core/kazoo_voicemail/src/kz_voicemail.hrl
@@ -29,12 +29,5 @@
 
 -type next_account() :: {ne_binary(), gregorian_seconds(), gregorian_seconds()}.
 
--define(MODB_MSG_ID(Year, Month, Id),
-        <<(kz_term:to_binary(Year))/binary
-          ,(kz_time:pad_month(Month))/binary
-          ,"-"
-          ,(Id)/binary
-        >>).
-
 -define(KZ_VOICEMAIL_HRL, 'true').
 -endif.

--- a/core/kazoo_voicemail/src/migrate/kvm_migrate_account.erl
+++ b/core/kazoo_voicemail/src/migrate/kvm_migrate_account.erl
@@ -249,7 +249,7 @@ update_message_array(BoxJObj, MODbFailed, Failed) ->
     Fun = fun(Msg, Acc) ->
                   Timestamp = kz_json:get_integer_value(<<"timestamp">>, Msg),
                   {{Year, Month, _}, _} = calendar:gregorian_seconds_to_datetime(Timestamp),
-                  MsgId = ?MODB_MSG_ID(Year, Month, kz_json:get_value(<<"media_id">>, Msg)),
+                  MsgId = kazoo_modb_util:modb_id(Year, Month, kz_json:get_value(<<"media_id">>, Msg)),
                   M = dict:is_key(MsgId, MODbFailed),
                   F = dict:is_key(MsgId, Failed),
 


### PR DESCRIPTION
Add maintenance command to migrate cdrs and voicemail from AccountDB to MODB.

Useful for cleaning Account DBs purposes in which it would create old modb if they're not present.