### PR TITLE
AMQP framing check

### DIFF
--- a/core/kazoo_amqp/include/kz_amqp.hrl
+++ b/core/kazoo_amqp/include/kz_amqp.hrl
@@ -154,6 +154,7 @@
                            #'exchange.declare'{} |
                            #'confirm.select'{} |
                            #'channel.flow'{} | #'channel.flow_ok'{} |
+                           basic_publish() |
                            '_' | 'undefined'.
 -type kz_amqp_commands() :: [kz_amqp_command()].
 

--- a/core/kazoo_amqp/src/amqp_util.erl
+++ b/core/kazoo_amqp/src/amqp_util.erl
@@ -448,18 +448,16 @@ basic_publish(Exchange, RoutingKey, ?NE_BINARY = Payload, ContentType, Props)
        is_binary(RoutingKey),
        is_binary(ContentType),
        is_list(Props) ->
-    BP = #'basic.publish'{
-            exchange = Exchange
+    BP = #'basic.publish'{exchange = Exchange
                          ,routing_key = RoutingKey
                          ,mandatory = ?P_GET('mandatory', Props, 'false')
                          ,immediate = ?P_GET('immediate', Props, 'false')
-           },
+                         },
 
     %% Add the message to the publish, converting to binary
     %% See http://www.rabbitmq.com/amqp-0-9-1-reference.html#class.basic
     MsgProps =
-        #'P_basic'{
-           content_type = ContentType % MIME content type
+        #'P_basic'{content_type = ContentType % MIME content type
                   ,content_encoding = ?P_GET('content_encoding', Props) % MIME encoding
                   ,headers = ?P_GET('headers', Props) % message headers
                   ,delivery_mode = ?P_GET('delivery_mode', Props) % persistent(2) or not(1)
@@ -467,7 +465,7 @@ basic_publish(Exchange, RoutingKey, ?NE_BINARY = Payload, ContentType, Props)
                   ,correlation_id = ?P_GET('correlation_id', Props) % correlation identifier
                   ,reply_to = ?P_GET('reply_to', Props) % address to reply to
 
-           %% TODO:: new rabbit wants an integer...
+                   %% TODO:: new rabbit wants an integer...
                   ,expiration = ?P_GET('expiration', Props) % expires time
 
                   ,message_id = ?P_GET('message_id', Props) % app message id
@@ -476,12 +474,11 @@ basic_publish(Exchange, RoutingKey, ?NE_BINARY = Payload, ContentType, Props)
                   ,user_id = ?P_GET('user_id', Props) % creating user
                   ,app_id = ?P_GET('app_id', Props) % creating app
                   ,cluster_id = ?P_GET('cluster_id', Props) % cluster
-          },
+                  },
 
-    AM = #'amqp_msg'{
-            payload = Payload
+    AM = #'amqp_msg'{payload = Payload
                     ,props = MsgProps
-           },
+                    },
 
     case ?P_GET('maybe_publish', Props, 'false') of
         'true' -> kz_amqp_channel:maybe_publish(BP, AM);
@@ -565,8 +562,7 @@ tasks_exchange() ->
 new_exchange(Exchange, Type) ->
     new_exchange(Exchange, Type, []).
 new_exchange(Exchange, Type, Options) ->
-    ED = #'exchange.declare'{
-            exchange = Exchange
+    ED = #'exchange.declare'{exchange = Exchange
                             ,type = Type
                             ,passive = ?P_GET('passive', Options, 'false')
                             ,durable = ?P_GET('durable', Options, 'false')
@@ -574,7 +570,7 @@ new_exchange(Exchange, Type, Options) ->
                             ,internal = ?P_GET('internal', Options, 'false')
                             ,nowait = ?P_GET('nowait', Options, 'false')
                             ,arguments = ?P_GET('arguments', Options, [])
-           },
+                            },
     kz_amqp_channel:command(ED).
 
 -spec declare_exchange(ne_binary(), ne_binary()) -> kz_amqp_exchange().
@@ -717,15 +713,14 @@ new_queue(<<"amq.", _/binary>>, Options) ->
 new_queue(<<>>, Options) ->
     new_queue(new_queue_name(), Options);
 new_queue(Queue, Options) when is_binary(Queue) ->
-    QD = #'queue.declare'{
-            queue = Queue
+    QD = #'queue.declare'{queue = Queue
                          ,passive = ?P_GET('passive', Options, 'false')
                          ,durable = ?P_GET('durable', Options, 'false')
                          ,exclusive = ?P_GET('exclusive', Options, 'false')
                          ,auto_delete = ?P_GET('auto_delete', Options, 'true')
                          ,nowait = ?P_GET('nowait', Options, 'false')
                          ,arguments = queue_arguments(?P_GET('arguments', Options, []))
-           },
+                         },
 
     %% can be queue | message_count | consumer_count | all
     Return = ?P_GET('return_field', Options, 'queue'),
@@ -841,12 +836,11 @@ queue_delete(Queue) -> queue_delete(Queue, []).
 queue_delete(Queue, _Prop) when not is_binary(Queue) ->
     {'error', 'invalid_queue_name'};
 queue_delete(Queue, Prop) ->
-    QD = #'queue.delete'{
-            queue=Queue
+    QD = #'queue.delete'{queue=Queue
                         ,if_unused = ?P_GET('if_unused', Prop, 'false')
                         ,if_empty = ?P_GET('if_empty', Prop, 'false')
                         ,nowait = ?P_GET('nowait', Prop, 'true')
-           },
+                        },
     kz_amqp_channel:command(QD).
 
 %%------------------------------------------------------------------------------
@@ -983,13 +977,12 @@ bind_q_to_exchange(Queue, _Routing, _Exchange) when not is_binary(Queue) ->
 bind_q_to_exchange(Queue, Routing, Exchange) ->
     bind_q_to_exchange(Queue, Routing, Exchange, []).
 bind_q_to_exchange(Queue, Routing, Exchange, Options) ->
-    QB = #'queue.bind'{
-            queue = Queue %% what queue does the binding attach to?
+    QB = #'queue.bind'{queue = Queue %% what queue does the binding attach to?
                       ,exchange = Exchange %% what exchange does the binding attach to?
                       ,routing_key = Routing %% how does an exchange know a message should go to a bound queue?
                       ,nowait = ?P_GET('nowait', Options, 'false')
                       ,arguments = []
-           },
+                      },
     kz_amqp_channel:command(QB).
 
 %%------------------------------------------------------------------------------
@@ -1094,12 +1087,12 @@ unbind_q_from_tasks(Queue, Routing) ->
 -spec unbind_q_from_exchange(ne_binary(), ne_binary(), ne_binary()) ->
                                     'ok' | {'error', any()}.
 unbind_q_from_exchange(Queue, Routing, Exchange) ->
-    kz_amqp_channel:command(
-      #'queue.unbind'{queue = Queue
-                     ,exchange = Exchange
-                     ,routing_key = Routing
-                     ,arguments = []
-                     }).
+    UB = #'queue.unbind'{queue = Queue
+                        ,exchange = Exchange
+                        ,routing_key = Routing
+                        ,arguments = []
+                        },
+    kz_amqp_channel:command(UB).
 
 %%------------------------------------------------------------------------------
 %% @public
@@ -1112,14 +1105,13 @@ unbind_q_from_exchange(Queue, Routing, Exchange) ->
 -spec basic_consume(ne_binary(), kz_proplist()) -> 'ok' | {'error', any()}.
 basic_consume(Queue) -> basic_consume(Queue, []).
 basic_consume(Queue, Options) ->
-    BC = #'basic.consume'{
-            queue = Queue
+    BC = #'basic.consume'{queue = Queue
                          ,consumer_tag = <<>>
                          ,no_local = ?P_GET('no_local', Options, 'false')
                          ,no_ack = ?P_GET('no_ack', Options, 'true')
                          ,exclusive = ?P_GET('exclusive', Options, 'true')
                          ,nowait = ?P_GET('nowait', Options, 'false')
-           },
+                         },
     kz_amqp_channel:command(BC).
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
When AMQP methods have fields that violate their constraints (like a routing key over 255 characters, for instance), the connection is taken down which is obviously disruptive to the system and a bit of overkill. Before we send the method to the amqp_client code, let's assert that it can be encoded properly for sending to the broker (via the amqp_client library).