### PR TITLE
check the id actually is a binary in ids_in_flow

### DIFF
--- a/applications/crossbar/src/modules/cb_callflows.erl
+++ b/applications/crossbar/src/modules/cb_callflows.erl
@@ -485,9 +485,11 @@ ids_in_data({[], []}, IDs) -> IDs;
 ids_in_data({[V|Vs], [<<"id">>|Ks]}, IDs) ->
     ids_in_data({Vs, Ks}, [V | IDs]);
 ids_in_data({[V|Vs], [K|Ks]}, IDs) ->
-    case binary:matches(K, <<"_id">>) of
-        [] -> ids_in_data({Vs, Ks}, IDs);
-        _Match -> ids_in_data({Vs, Ks}, [V | IDs])
+    case binary:matches(K, <<"_id">>) =/= []
+        andalso kz_term:is_ne_binary(V)
+    of
+        'false' -> ids_in_data({Vs, Ks}, IDs);
+        'true' -> ids_in_data({Vs, Ks}, [V | IDs])
     end.
 
 -spec get_metadata(api_object(), ne_binary()) -> kz_json:object().


### PR DESCRIPTION
During collecting additional info about objects referenced in a callflow, when matching if the key has `_id` in it, also checks if the value is actually a binary. (e.g. do not consider it as id if the value is a json object, for example `{"caller_id": {"number":"123", "name": "alaki"}}`)