### PR TITLE
KAZOO-5473: Why limit numbers lookup to Zero?

### DIFF
--- a/core/kazoo_number_manager/src/knm_telnyx_util.erl
+++ b/core/kazoo_number_manager/src/knm_telnyx_util.erl
@@ -196,7 +196,7 @@ maybe_apply_limit(JObj) ->
                      ).
 
 maybe_apply_limit(JObj, ResultField) ->
-    Limit = kz_json:get_integer_value(<<"limit">>, JObj, 0),
+    Limit = kz_json:get_integer_value(<<"limit">>, JObj, 100),
     Result = take(Limit, kz_json:get_value(ResultField, JObj, [])),
     kz_json:set_value(ResultField, Result, JObj).
 


### PR DESCRIPTION
Just a temporary correction while guys thinking: https://groups.google.com/forum/#!topic/2600hz-dev/UaIqtL_OVGY