### PR TITLE
Update README.md

### DIFF
--- a/applications/hotornot/doc/README.md
+++ b/applications/hotornot/doc/README.md
@@ -21,7 +21,9 @@ Each rate is a separate document:
     "ratedeck_name": "ratedeck_1",
     "iso_country_code": "US",
     "description": "USA prefix 1",
-    "direction": "outbound",
+    "direction": [
+       "outbound"
+    ],
     "rate_increment": "60",
     "rate_minimum": "60",
     "rate_nocharge_time": "0",


### PR DESCRIPTION
The example rate document didn't work with Kazoo 4.0.  'direction' has to use '[]'