### PR TITLE
PISTON-442: use PresenceId for default CallId in acdc_util:presence_update/3

### DIFF
--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -875,17 +875,13 @@ handle_cast({'presence_update', PresenceState}, #state{acct_id=AcctId
                                                       ,agent_id=AgentId
                                                       }=State) ->
     lager:debug("no custom presence id, using ~s for ~s", [AgentId, PresenceState]),
-    acdc_util:presence_update(AcctId, AgentId, PresenceState
-                             ,kz_term:to_hex_binary(crypto:hash(md5, AgentId))
-                             ),
+    acdc_util:presence_update(AcctId, AgentId, PresenceState),
     {'noreply', State};
 handle_cast({'presence_update', PresenceState}, #state{acct_id=AcctId
                                                       ,agent_presence_id=PresenceId
                                                       }=State) ->
     lager:debug("custom presence id, using ~s for ~s", [PresenceId, PresenceState]),
-    acdc_util:presence_update(AcctId, PresenceId, PresenceState
-                             ,kz_term:to_hex_binary(crypto:hash(md5, PresenceId))
-                             ),
+    acdc_util:presence_update(AcctId, PresenceId, PresenceState),
     {'noreply', State};
 
 handle_cast({'update_status', Status}, #state{agent_id=AgentId

--- a/applications/acdc/src/acdc_util.erl
+++ b/applications/acdc/src/acdc_util.erl
@@ -49,9 +49,9 @@ agent_presence_update(AcctId, AgentId) ->
     end.
 
 -spec presence_update(ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
--spec presence_update(ne_binary(), ne_binary(), ne_binary(), api_binary()) -> 'ok'.
+-spec presence_update(ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 presence_update(AcctId, PresenceId, State) ->
-    presence_update(AcctId, PresenceId, State, 'undefined').
+    presence_update(AcctId, PresenceId, State, kz_term:to_hex_binary(crypto:hash('md5', PresenceId))).
 presence_update(AcctId, PresenceId, State, CallId) ->
     {'ok', AcctDoc} = kz_account:fetch(AcctId),
     To = <<PresenceId/binary, "@", (kz_json:get_value(<<"realm">>, AcctDoc))/binary>>,


### PR DESCRIPTION
Fix compatibility with changes made to kapi_presence:update_routing_key/1