### PR TITLE
Primary Amqp server fix

### DIFF
--- a/core/kazoo_amqp/include/kz_amqp.hrl
+++ b/core/kazoo_amqp/include/kz_amqp.hrl
@@ -220,6 +220,7 @@
                              ,timestamp=os:timestamp() :: kz_now() | '_'
                              ,zone='local' :: atom() | '$1' | '_'
                              ,manager=self() :: pid() | '_'
+                             ,started = os:timestamp() :: kz_now() | '$2' | '_'
                              ,tags = [] :: list() | '_'
                              ,hidden = 'false' :: boolean() | '$3' | '_'
                              }).

--- a/core/kazoo_amqp/src/kz_amqp_connections.erl
+++ b/core/kazoo_amqp/src/kz_amqp_connections.erl
@@ -201,14 +201,15 @@ primary_broker() ->
                                   ,zone='local'
                                   ,hidden='false'
                                   ,broker='$1'
+                                  ,started='$2'
                                   ,_='_'
                                   },
-    case lists:sort([Broker
-                     || [Broker] <- ets:match(?TAB, Pattern)
-                    ])
+    case lists:keysort(2, [{Broker, Started}
+                           || [Broker, Started] <- ets:match(?TAB, Pattern)
+                          ])
     of
         [] -> 'undefined';
-        [Broker|_] -> Broker
+        [{Broker, _}|_] -> Broker
     end.
 
 -spec federated_brokers() -> ne_binaries().


### PR DESCRIPTION
make decision as which server is primary based on on its connection pid, where the first added amqp server will have a lower connection pid which does not changes after a connection has been added, and the server are added in accordance to their addition in config file.