### PR TITLE
qf-portreq: introduce and use validate_request_data_only/2,3,4

### DIFF
--- a/applications/crossbar/doc/port_requests.md
+++ b/applications/crossbar/doc/port_requests.md
@@ -846,7 +846,8 @@ curl -v -X GET \
     "auth_token": "{AUTH_TOKEN}",
     "data": [
         {
-            "{PORT_REQUEST_ID}": {
+            "id": "{PORT_REQUEST_ID}",
+            "transition": {
                 "authorization": {
                     "account": {
                         "id": "{AUTH_ACCOUNT_ID}",

--- a/applications/crossbar/doc/port_requests.md
+++ b/applications/crossbar/doc/port_requests.md
@@ -329,7 +329,7 @@ curl -v -X GET \
                         "+12025559042": {}
                     },
                     "port_state": "scheduled",
-                    "schedule_at": {
+                    "schedule_on": {
                         "date_time": "2017-06-24 12:00",
                         "timezone": "America/New_York"
                     },
@@ -1087,10 +1087,13 @@ curl -v -X PATCH \
 
 > PATCH /v2/accounts/{ACCOUNT_ID}/port_requests/{PORT_REQUEST_ID}/scheduled
 
+Note: `schedule_on` is a required field for this state transition.
+Note: `scheduled_date` is an automatically added timestamp computed from the value of the `schedule_on` object.
+
 ```shell
 curl -v -X PATCH \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -d '{"data": {"scheduled_date": {"timezone":"America/Los_Angeles", "date_time":"2017-06-24 12:00"}}}' \
+    -d '{"data": {"schedule_on": {"timezone":"America/Los_Angeles", "date_time":"2017-06-24 12:00"}}}' \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/{PORT_REQUEST_ID}/scheduled
 ```
 
@@ -1105,7 +1108,7 @@ curl -v -X PATCH \
             "+12025559000": {}
         },
         "port_state": "scheduled",
-        "schedule_at": {
+        "schedule_on": {
             "date_time": "2017-06-24 12:00",
             "timezone": "America/Los_Angeles"
         },

--- a/applications/crossbar/doc/port_requests.md
+++ b/applications/crossbar/doc/port_requests.md
@@ -844,27 +844,29 @@ curl -v -X GET \
 ```json
 {
     "auth_token": "{AUTH_TOKEN}",
-    "data": {
-        "{PORT_REQUEST_ID}": {
-            "authorization": {
-                "account": {
-                    "id": "{AUTH_ACCOUNT_ID}",
-                    "name": "{AUTH_ACCOUNT_NAME}"
+    "data": [
+        {
+            "{PORT_REQUEST_ID}": {
+                "authorization": {
+                    "account": {
+                        "id": "{AUTH_ACCOUNT_ID}",
+                        "name": "{AUTH_ACCOUNT_NAME}"
+                    },
+                    "user": {
+                        "id": "0d46906ff1eb36bff4d09b5b32fc14be",
+                        "first_name": "John",
+                        "last_name": "Doe"
+                    }
                 },
-                "user": {
-                    "id": "0d46906ff1eb36bff4d09b5b32fc14be",
-                    "first_name": "John",
-                    "last_name": "Doe"
-                }
-            },
-            "reason": "this was approved by Jane Doe",
-            "timestamp": 63664096014,
-            "transition": {
-                "new": "submitted",
-                "previous": "unconfirmed"
-            },
-            "type": "transition"
-        }
+                "reason": "this was approved by Jane Doe",
+                "timestamp": 63664096014,
+                "transition": {
+                    "new": "submitted",
+                    "previous": "unconfirmed"
+                },
+                "type": "transition"
+            }
+        ]
     },
     "node": "{NODE}",
     "request_id": "{REQUEST_ID}",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -22071,7 +22071,7 @@
             "description": "Schema for a port request to be transitioned to the 'scheduled' state",
             "properties": {
                 "schedule_on": {
-                    "description": "Time at which to perform the porting, either as a gregorian timestamp or as datetime",
+                    "description": "date-time at which to perform the porting",
                     "properties": {
                         "date_time": {
                             "pattern": "^2\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d$",
@@ -22664,11 +22664,12 @@
                         "date_time"
                     ],
                     "type": "object"
+                },
+                "scheduled_date": {
+                    "description": "Gregorian timestamp at which to perform the porting",
+                    "type": "integer"
                 }
             },
-            "required": [
-                "schedule_on"
-            ],
             "type": "object"
         },
         "profile": {

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -22070,7 +22070,7 @@
         "port_requests.to_scheduled": {
             "description": "Schema for a port request to be transitioned to the 'scheduled' state",
             "properties": {
-                "scheduled_date": {
+                "schedule_on": {
                     "description": "Time at which to perform the porting, either as a gregorian timestamp or as datetime",
                     "properties": {
                         "date_time": {
@@ -22663,14 +22663,11 @@
                         "timezone",
                         "date_time"
                     ],
-                    "type": [
-                        "integer",
-                        "object"
-                    ]
+                    "type": "object"
                 }
             },
             "required": [
-                "scheduled_date"
+                "schedule_on"
             ],
             "type": "object"
         },

--- a/applications/crossbar/priv/couchdb/schemas/port_requests.to_scheduled.json.src
+++ b/applications/crossbar/priv/couchdb/schemas/port_requests.to_scheduled.json.src
@@ -2,9 +2,21 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "port_requests.to_scheduled",
     "description": "Schema for a port request to be transitioned to the 'scheduled' state",
+    "oneOf": [
+        {
+            "required": [
+                "scheduled_date"
+            ]
+        },
+        {
+            "required": [
+                "schedule_on"
+            ]
+        }
+    ],
     "properties": {
         "schedule_on": {
-            "description": "Time at which to perform the porting, either as a gregorian timestamp or as datetime",
+            "description": "date-time at which to perform the porting",
             "properties": {
                 "date_time": {
                     "pattern": "^2\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d$",
@@ -21,10 +33,11 @@
                 "date_time"
             ],
             "type": "object"
+        },
+        "scheduled_date": {
+            "description": "Gregorian timestamp at which to perform the porting",
+            "type": "integer"
         }
     },
-    "required": [
-        "schedule_on"
-    ],
     "type": "object"
 }

--- a/applications/crossbar/priv/couchdb/schemas/port_requests.to_scheduled.json.src
+++ b/applications/crossbar/priv/couchdb/schemas/port_requests.to_scheduled.json.src
@@ -3,7 +3,7 @@
     "_id": "port_requests.to_scheduled",
     "description": "Schema for a port request to be transitioned to the 'scheduled' state",
     "properties": {
-        "scheduled_date": {
+        "schedule_on": {
             "description": "Time at which to perform the porting, either as a gregorian timestamp or as datetime",
             "properties": {
                 "date_time": {
@@ -20,14 +20,11 @@
                 "timezone",
                 "date_time"
             ],
-            "type": [
-                "integer",
-                "object"
-            ]
+            "type": "object"
         }
     },
     "required": [
-        "scheduled_date"
+        "schedule_on"
     ],
     "type": "object"
 }

--- a/applications/crossbar/priv/couchdb/views/port_requests.json
+++ b/applications/crossbar/priv/couchdb/views/port_requests.json
@@ -58,10 +58,10 @@
         "listing_submitted": {
             "map": [
                 "function(doc) {",
-                "  if (doc.pvt_type != 'port_request' || doc.pvt_deleted) return;",
-                "  if (doc.pvt_port_state != 'submitted') return;",
+                "  if (doc.pvt_type !== 'port_request' || doc.pvt_deleted) return;",
+                "  if (doc.pvt_port_state !== 'submitted') return;",
                 "  if (doc.pvt_sent === true) return;",
-                "  emit(doc._id, null);",
+                "  emit([doc.pvt_account_id, doc._id], null);",
                 "}"
             ]
         },

--- a/applications/crossbar/priv/port-request-scheduled-schema.escript
+++ b/applications/crossbar/priv/port-request-scheduled-schema.escript
@@ -14,7 +14,7 @@
 main(_) ->
     {ok, SchemaBin} = file:read_file(?IN),
     SchemaJObj = kz_json:decode(SchemaBin),
-    TZEnumPath = [<<"properties">>, <<"scheduled_date">>, <<"properties">>, <<"timezone">>, <<"enum">>],
+    TZEnumPath = [<<"properties">>, <<"schedule_on">>, <<"properties">>, <<"timezone">>, <<"enum">>],
     [<<"America/Los_Angeles">>] = kz_json:get_list_value(TZEnumPath, SchemaJObj),
     Enum = unique_values(?tz_index),
     NewSchemaJObj = kz_json:set_value(TZEnumPath, lists:sort(sets:to_list(Enum)), SchemaJObj),

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -725,7 +725,8 @@ validate_request_data(SchemaId, Context, OnSuccess, OnFailure) ->
 
 -spec copy_req_data_to_doc(context()) -> context().
 copy_req_data_to_doc(Context) ->
-    set_doc(Context, req_data(Context)).
+    NewDoc = kz_json:merge_jobjs(kz_doc:private_fields(doc(Context)), req_data(Context)),
+    set_doc(Context, NewDoc).
 
 -spec validate_request_data_only(ne_binary(), context()) -> context().
 -spec validate_request_data_only(ne_binary(), context(), after_fun()) -> context().

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -722,6 +722,7 @@ validate_request_data(SchemaId, Context, OnSuccess, OnFailure) ->
     OnPassing = fun copy_req_data_to_doc/1,
     do_validate_request_data(SchemaId, Context, OnSuccess, OnFailure, OnPassing).
 
+-spec copy_req_data_to_doc(context()) -> context().
 copy_req_data_to_doc(Context) ->
     set_doc(Context, req_data(Context)).
 
@@ -749,7 +750,7 @@ do_validate_request_data(SchemaId, Context, OnSuccess, OnFailure, OnPassing) ->
 
 -spec do_validate_request_data(ne_binary() | api_object(), context(), on_passing()) -> context().
 do_validate_request_data(undefined, Context, _) ->
-    lager:error("why validate then?"),
+    lager:error("schema id or schema JSON not defined, continuing anyway"),
     passed(Context);
 do_validate_request_data(?NE_BINARY=SchemaId, Context, OnPassing) ->
     Strict = fetch(Context, ensure_valid_schema, ?SHOULD_ENSURE_SCHEMA_IS_VALID),

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -16,9 +16,7 @@
         ,has_errors/1
         ,add_system_error/2, add_system_error/3, add_system_error/4
         ,add_validation_error/4
-        ,do_validate_request_data/5
         ,validate_request_data/2, validate_request_data/3, validate_request_data/4
-        ,validate_request_data_only/2, validate_request_data_only/3, validate_request_data_only/4
         ,add_content_types_provided/2
         ,add_content_types_accepted/2
         ,add_attachment_content_type/3
@@ -727,17 +725,6 @@ validate_request_data(SchemaId, Context, OnSuccess, OnFailure) ->
 copy_req_data_to_doc(Context) ->
     NewDoc = kz_json:merge_jobjs(kz_doc:private_fields(doc(Context)), req_data(Context)),
     set_doc(Context, NewDoc).
-
--spec validate_request_data_only(ne_binary(), context()) -> context().
--spec validate_request_data_only(ne_binary(), context(), after_fun()) -> context().
--spec validate_request_data_only(ne_binary(), context(), after_fun(), after_fun()) -> context().
-
-validate_request_data_only(SchemaId, Context) ->
-    validate_request_data_only(SchemaId, Context, undefined).
-validate_request_data_only(SchemaId, Context, OnSuccess) ->
-    validate_request_data_only(SchemaId, Context, OnSuccess, undefined).
-validate_request_data_only(SchemaId, Context, OnSuccess, OnFailure) ->
-    do_validate_request_data(SchemaId, Context, OnSuccess, OnFailure, fun kz_term:identity/1).
 
 -type on_passing() :: fun((context()) -> context()).
 -spec do_validate_request_data(ne_binary(), context(), after_fun(), after_fun(), on_passing()) -> context().

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -724,10 +724,7 @@ validate_request_data(Schema=?NE_BINARY, Context) ->
     end;
 validate_request_data(SchemaJObj, Context) ->
     Strict = kapps_config:get_is_true(?CONFIG_CAT, <<"schema_strict_validation">>, 'false'),
-    try kz_json_schema:validate(SchemaJObj
-                               ,kz_doc:public_fields(req_data(Context))
-                               )
-    of
+    try kz_json_schema:validate(SchemaJObj, kz_doc:public_fields(req_data(Context))) of
         {'ok', JObj} ->
             passed(set_doc(Context, JObj));
         {'error', Errors} when Strict ->
@@ -768,10 +765,7 @@ failed(Context, Errors) ->
                        ,{fun set_resp_status/2, 'error'}
                        ]
                       ),
-    lists:foldl(fun failed_error/2
-               ,Context1
-               ,Errors
-               ).
+    lists:foldl(fun failed_error/2, Context1, Errors).
 
 -spec failed_error(jesse_error:error_reason(), context()) -> context().
 failed_error(Error, Context) ->

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -713,7 +713,9 @@ response(#cb_context{resp_error_code=Code
                                    context().
 -spec validate_request_data(ne_binary() | api_object(), context(), after_fun()) ->
                                    context().
--spec validate_request_data(ne_binary() | api_object(), context(), after_fun(), boolean()) ->
+-spec validate_request_data(ne_binary() | api_object(), context(), after_fun(), after_fun()) ->
+                                   context().
+-spec validate_request_data(ne_binary() | api_object(), context(), after_fun(), after_fun(), boolean()) ->
                                    context().
 validate_request_data(SchemaId, Context) ->
     validate_request_data(SchemaId, Context, 'undefined').

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -809,10 +809,14 @@ failed_error(Error, Context) ->
                       }.
 
 -spec passed(context()) -> context().
-passed(#cb_context{req_data=Data}=Context) ->
-    case kz_doc:id(Data) of
-        'undefined' -> Context;
-        Id -> set_doc(Context, kz_doc:set_id(doc(Context), Id))
+passed(Context) ->
+    Context1 = case error =:= resp_status(Context) of
+                   true -> Context;
+                   false -> set_resp_status(Context, success)
+               end,
+    case kz_doc:id(req_data(Context1)) of
+        'undefined' -> Context1;
+        Id -> set_doc(Context1, kz_doc:set_id(doc(Context1), Id))
     end.
 
 -spec find_schema(ne_binary()) -> api_object().

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -723,7 +723,10 @@ validate_request_data(SchemaId, Context, OnSuccess, OnFailure) ->
 
 -spec copy_req_data_to_doc(context()) -> context().
 copy_req_data_to_doc(Context) ->
-    NewDoc = kz_json:merge_jobjs(kz_doc:private_fields(doc(Context)), req_data(Context)),
+    NewDoc = case doc(Context) of
+                 undefined -> req_data(Context);
+                 Doc -> kz_json:merge_jobjs(kz_doc:private_fields(Doc), req_data(Context))
+             end,
     set_doc(Context, NewDoc).
 
 -type on_passing() :: fun((context()) -> context()).

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -707,6 +707,7 @@ response(#cb_context{resp_error_code=Code
 -spec validate_request_data(ne_binary() | api_object(), context(), after_fun(), after_fun()) ->
                                    context().
 validate_request_data('undefined', Context) ->
+    lager:error("why validate then?"),
     passed(Context);
 validate_request_data(Schema=?NE_BINARY, Context) ->
     DefaultStrict = kapps_config:get_is_true(?CONFIG_CAT, <<"ensure_valid_schema">>, 'true'),
@@ -716,6 +717,7 @@ validate_request_data(Schema=?NE_BINARY, Context) ->
             Msg = <<"schema ", Schema/binary, " not found.">>,
             system_error(Context, Msg);
         'undefined' ->
+            lager:error("schema ~s not found, continuing anyway", [Schema]),
             passed(set_doc(Context, req_data(Context)));
         SchemaJObj ->
             validate_request_data(SchemaJObj, Context)

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -16,6 +16,7 @@
         ,has_errors/1
         ,add_system_error/2, add_system_error/3, add_system_error/4
         ,add_validation_error/4
+        ,do_validate_request_data/5
         ,validate_request_data/2, validate_request_data/3, validate_request_data/4
         ,validate_request_data_only/2, validate_request_data_only/3, validate_request_data_only/4
         ,add_content_types_provided/2

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -12,7 +12,7 @@
 -export([load/2, load/3
         ,load_merge/2, load_merge/3, load_merge/4
         ,merge/3
-        ,patch_and_validate/3
+        ,patch_and_validate/3, patch_and_validate/4
         ,load_view/3, load_view/4, load_view/5, load_view/6
         ,load_attachment/4, load_docs/2
         ,save/1, save/2, save/3
@@ -318,12 +318,17 @@ merge(DataJObj, JObj, Context) ->
 
 -spec patch_and_validate(ne_binary(), cb_context:context(), validate_fun()) ->
                                 cb_context:context().
--spec patch_and_validate_doc(ne_binary(), cb_context:context(), validate_fun(), crossbar_status()) ->
-                                    cb_context:context().
+-spec patch_and_validate(ne_binary(), cb_context:context(), validate_fun(), load_options()) ->
+                                cb_context:context().
 patch_and_validate(Id, Context, ValidateFun) ->
-    Context1 = load(Id, Context, ?TYPE_CHECK_OPTION_ANY),
+    patch_and_validate(Id, Context, ValidateFun, ?TYPE_CHECK_OPTION_ANY).
+
+patch_and_validate(Id, Context, ValidateFun, LoadOptions) ->
+    Context1 = load(Id, Context, LoadOptions),
     patch_and_validate_doc(Id, Context1, ValidateFun, cb_context:resp_status(Context1)).
 
+-spec patch_and_validate_doc(ne_binary(), cb_context:context(), validate_fun(), crossbar_status()) ->
+                                    cb_context:context().
 patch_and_validate_doc(Id, Context, ValidateFun, 'success') ->
     PatchedJObj = patch_the_doc(cb_context:req_data(Context), cb_context:doc(Context)),
     Context1 = cb_context:set_req_data(Context, PatchedJObj),

--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -492,7 +492,7 @@ create_account(Context) ->
             Errors = cb_context:resp_data(Context1),
             io:format("failed to create account: '~s'~n", [kz_json:encode(Errors)]),
             AccountId = kz_doc:id(cb_context:req_data(Context)),
-            kz_datamgr:db_delete(kz_util:format_account_id(AccountId, 'encoded')),
+            kz_datamgr:db_delete(kz_util:format_account_db(AccountId)),
             {'error', Errors}
     end.
 
@@ -509,9 +509,7 @@ create_user(Context) ->
     Context1 = crossbar_bindings:fold(<<"v1_resource.execute.put.users">>, [Context]),
     case cb_context:resp_status(Context1) of
         'success' ->
-            io:format("created new account admin user '~s'~n"
-                     ,[kz_doc:id(cb_context:doc(Context1))]
-                     ),
+            io:format("created new account admin user '~s'~n", [kz_doc:id(cb_context:doc(Context1))]),
             {'ok', Context1};
         _Status ->
             Errors = cb_context:resp_data(Context1),

--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -432,7 +432,7 @@ validate_account(JObj, Context) ->
                                  ,[{fun cb_context:set_req_data/2, JObj}
                                   ,{fun cb_context:set_req_nouns/2, [{?KZ_ACCOUNTS_DB, []}]}
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
-                                  ,{fun cb_context:set_resp_status/2, 'fatal'}
+                                  ,{fun cb_context:set_resp_status/2, success}
                                   ])
               ],
     Context1 = crossbar_bindings:fold(<<"v1_resource.validate.accounts">>, Payload),

--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -432,7 +432,6 @@ validate_account(JObj, Context) ->
                                  ,[{fun cb_context:set_req_data/2, JObj}
                                   ,{fun cb_context:set_req_nouns/2, [{?KZ_ACCOUNTS_DB, []}]}
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
-                                  ,{fun cb_context:set_resp_status/2, success}
                                   ])
               ],
     Context1 = crossbar_bindings:fold(<<"v1_resource.validate.accounts">>, Payload),
@@ -458,7 +457,6 @@ validate_user(JObj, Context) ->
                                  ,[{fun cb_context:set_req_data/2, JObj}
                                   ,{fun cb_context:set_req_nouns/2, [{?KZ_ACCOUNTS_DB, []}]}
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
-                                  ,{fun cb_context:set_resp_status/2, success}
                                   ]
                                  )
               ],

--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -432,6 +432,7 @@ validate_account(JObj, Context) ->
                                  ,[{fun cb_context:set_req_data/2, JObj}
                                   ,{fun cb_context:set_req_nouns/2, [{?KZ_ACCOUNTS_DB, []}]}
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
+                                  ,{fun cb_context:set_resp_status/2, 'fatal'}
                                   ])
               ],
     Context1 = crossbar_bindings:fold(<<"v1_resource.validate.accounts">>, Payload),
@@ -457,6 +458,7 @@ validate_user(JObj, Context) ->
                                  ,[{fun cb_context:set_req_data/2, JObj}
                                   ,{fun cb_context:set_req_nouns/2, [{?KZ_ACCOUNTS_DB, []}]}
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
+                                  ,{fun cb_context:set_resp_status/2, 'fatal'}
                                   ]
                                  )
               ],

--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -416,7 +416,7 @@ create_account(AccountName, Realm, Username, Password) ->
 -spec update_system_config(ne_binary()) -> 'ok'.
 update_system_config(AccountId) ->
     kapps_config:set(?KZ_SYSTEM_CONFIG_ACCOUNT, <<"master_account_id">>, AccountId),
-    io:format("updating master account id in system_config.~s~n", [?KZ_SYSTEM_CONFIG_ACCOUNT]).
+    io:format("updated master account id in system_config.~s~n", [?KZ_SYSTEM_CONFIG_ACCOUNT]).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -458,11 +458,11 @@ validate_user(JObj, Context) ->
                                  ,[{fun cb_context:set_req_data/2, JObj}
                                   ,{fun cb_context:set_req_nouns/2, [{?KZ_ACCOUNTS_DB, []}]}
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
-                                  ,{fun cb_context:set_resp_status/2, 'fatal'}
+                                  ,{fun cb_context:set_resp_status/2, success}
                                   ]
                                  )
               ],
-    Context1 = crossbar_bindings:fold(<<"v1_resource.validate.users">>, Payload),
+    Context1 = crossbar_bindings:fold(<<"v2_resource.validate.users">>, Payload),
     case cb_context:resp_status(Context1) of
         'success' -> {'ok', Context1};
         _Status ->

--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -1277,7 +1277,7 @@ create_new_account_db(Context) ->
             lager:debug("created account definition"),
 
             _ = load_initial_views(C),
-            lager:debug("laoded initial views"),
+            lager:debug("loaded initial views"),
 
             _ = crossbar_bindings:map(<<"account.created">>, C),
             lager:debug("alerted listeners of new account"),

--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -60,6 +60,13 @@
 -define(REMOVE_SPACES, [<<"realm">>]).
 -define(MOVE, <<"move">>).
 
+-define(ACCOUNT_REALM_SUFFIX
+       ,kapps_config:get_binary(?ACCOUNTS_CONFIG_CAT, <<"account_realm_suffix">>, <<"sip.2600hz.com">>)).
+-define(RANDOM_REALM_STRENGTH
+       ,kapps_config:get_integer(?ACCOUNTS_CONFIG_CAT, <<"random_realm_strength">>, 3)).
+-define(ALLOW_DIRECT_CLIENTS
+       ,kapps_config:get_is_true(?KZ_ACCOUNTS_DB, 'allow_subaccounts_for_direct', 'true')).
+
 -spec init() -> 'ok'.
 init() ->
     Bindings = [{<<"*.allowed_methods.accounts">>, 'allowed_methods'}
@@ -441,13 +448,13 @@ move_account(Context, AccountId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec prepare_context(api_binary(), cb_context:context()) -> cb_context:context().
+-spec prepare_context(api_ne_binary(), cb_context:context()) -> cb_context:context().
 -spec prepare_context(cb_context:context(), ne_binary(), ne_binary()) -> cb_context:context().
 prepare_context('undefined', Context) ->
     cb_context:set_account_db(Context, ?KZ_ACCOUNTS_DB);
 prepare_context(Account, Context) ->
-    AccountId = kz_util:format_account_id(Account, 'raw'),
-    AccountDb = kz_util:format_account_id(Account, 'encoded'),
+    AccountId = kz_util:format_account_id(Account),
+    AccountDb = kz_util:format_account_db(Account),
     prepare_context(Context, AccountId, AccountDb).
 
 prepare_context(Context, AccountId, AccountDb) ->
@@ -461,8 +468,7 @@ prepare_context(Context, AccountId, AccountDb) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec validate_request(api_binary(), cb_context:context()) ->
-                              cb_context:context().
+-spec validate_request(api_binary(), cb_context:context()) -> cb_context:context().
 validate_request(AccountId, Context) ->
     ValidateFuns = [fun ensure_account_has_realm/2
                    ,fun ensure_account_has_timezone/2
@@ -473,10 +479,7 @@ validate_request(AccountId, Context) ->
                    ,fun validate_account_schema/2
                    ,fun disallow_direct_clients/2
                    ],
-    lists:foldl(fun(F, C) -> F(AccountId, C) end
-               ,Context
-               ,ValidateFuns
-               ).
+    lists:foldl(fun(F, C) -> F(AccountId, C) end, Context, ValidateFuns).
 
 -spec ensure_account_has_realm(api_binary(), cb_context:context()) -> cb_context:context().
 ensure_account_has_realm(_AccountId, Context) ->
@@ -495,6 +498,7 @@ ensure_account_has_realm(_AccountId, Context) ->
 ensure_account_has_timezone(_AccountId, Context) ->
     JObj = cb_context:req_data(Context),
     Timezone = kz_json:get_value(<<"timezone">>, JObj, get_timezone_from_parent(Context)),
+    lager:debug("selected timezone: ~s", [Timezone]),
     cb_context:set_req_data(Context, kz_account:set_timezone(JObj, Timezone)).
 
 -spec get_timezone_from_parent(cb_context:context()) -> ne_binary().
@@ -506,16 +510,11 @@ get_timezone_from_parent(Context) ->
 
 -spec random_realm() -> ne_binary().
 random_realm() ->
-    RealmSuffix = kapps_config:get_binary(?ACCOUNTS_CONFIG_CAT, <<"account_realm_suffix">>, <<"sip.2600hz.com">>),
-    Strength = kapps_config:get_integer(?ACCOUNTS_CONFIG_CAT, <<"random_realm_strength">>, 3),
-    list_to_binary([kz_binary:rand_hex(Strength), ".", RealmSuffix]).
+    <<(kz_binary:rand_hex(?RANDOM_REALM_STRENGTH))/binary, ".", (?ACCOUNT_REALM_SUFFIX)/binary>>.
 
 -spec remove_spaces(api_binary(), cb_context:context()) -> cb_context:context().
 remove_spaces(_AccountId, Context) ->
-    ReqData = lists:foldl(fun remove_spaces_fold/2
-                         ,cb_context:req_data(Context)
-                         ,?REMOVE_SPACES
-                         ),
+    ReqData = lists:foldl(fun remove_spaces_fold/2, cb_context:req_data(Context), ?REMOVE_SPACES),
     cb_context:set_req_data(Context, ReqData).
 
 -spec remove_spaces_fold(kz_json:path(), kz_json:object()) -> kz_json:object().
@@ -540,39 +539,39 @@ cleanup_leaky_keys(_AccountId, Context) ->
 validate_realm_is_unique(AccountId, Context) ->
     Realm = kz_account:realm(cb_context:req_data(Context)),
     case is_unique_realm(AccountId, Realm) of
-        'true' -> Context;
+        'true' ->
+            lager:debug("realm ~s is indeed unique", [Realm]),
+            Context;
         'false' ->
-            cb_context:add_validation_error(
-              [<<"realm">>]
-                                           ,<<"unique">>
-                                           ,kz_json:from_list(
-                                              [{<<"message">>, <<"Account realm already in use">>}
-                                              ,{<<"cause">>, Realm}
-                                              ])
-                                           ,Context
-             )
+            Msg = kz_json:from_list(
+                    [{<<"message">>, <<"Account realm already in use">>}
+                    ,{<<"cause">>, Realm}
+                    ]),
+            cb_context:add_validation_error([<<"realm">>], <<"unique">>, Msg, Context)
     end.
 
 -spec validate_account_name_is_unique(api_binary(), cb_context:context()) -> cb_context:context().
 validate_account_name_is_unique(AccountId, Context) ->
     Name = kz_account:name(cb_context:req_data(Context)),
     case maybe_is_unique_account_name(AccountId, Name) of
-        'true' -> Context;
+        'true' ->
+            lager:debug("name ~s is indeed unique", [Name]),
+            Context;
         'false' ->
-            cb_context:add_validation_error(
-              [<<"name">>]
-                                           ,<<"unique">>
-                                           ,kz_json:from_list(
-                                              [{<<"message">>, <<"Account name already in use">>}
-                                              ,{<<"cause">>, Name}
-                                              ])
-                                           ,Context
-             )
+            Msg = kz_json:from_list(
+                    [{<<"message">>, <<"Account name already in use">>}
+                    ,{<<"cause">>, Name}
+                    ]),
+            cb_context:add_validation_error([<<"name">>], <<"unique">>, Msg, Context)
     end.
 
 -spec validate_account_schema(api_binary(), cb_context:context()) -> cb_context:context().
 validate_account_schema(AccountId, Context) ->
-    OnSuccess = fun(C) -> on_successful_validation(AccountId, C) end,
+    lager:debug("validating payload"),
+    OnSuccess = fun(C) ->
+                        lager:debug("account payload is valid"),
+                        on_successful_validation(AccountId, C)
+                end,
     cb_context:validate_request_data(<<"accounts">>, Context, OnSuccess).
 
 -spec on_successful_validation(api_binary(), cb_context:context()) -> cb_context:context().
@@ -591,38 +590,37 @@ on_successful_validation(AccountId, Context) ->
 maybe_import_enabled(Context) ->
     case cb_context:auth_account_id(Context) =:= cb_context:account_id(Context) of
         'true' ->
-            cb_context:set_doc(Context
-                              ,kz_json:delete_key(<<"enabled">>, cb_context:doc(Context))
-                              );
+            NewDoc = kz_json:delete_key(<<"enabled">>, cb_context:doc(Context)),
+            cb_context:set_doc(Context, NewDoc);
         'false' ->
+            lager:debug("this should be success: ~p", [cb_context:resp_status(Context)]),
             maybe_import_enabled(Context, cb_context:resp_status(Context))
     end.
 
 maybe_import_enabled(Context, 'success') ->
-    AuthId = cb_context:auth_account_id(Context),
-    JObj = cb_context:doc(Context),
-    case lists:member(AuthId, kz_account:tree(JObj)) of
-        'false' ->
-            cb_context:set_doc(Context, kz_json:delete_key(<<"enabled">>, JObj));
-        'true' ->
-            maybe_import_enabled(Context, JObj, kz_json:get_value(<<"enabled">>, JObj))
+    AuthAccountId = cb_context:auth_account_id(Context),
+    Doc = cb_context:doc(Context),
+    Enabled = kz_json:get_value(<<"enabled">>, Doc),
+    NewDoc = kz_json:delete_key(<<"enabled">>, Doc),
+    lager:debug("import enabled: ~p", [Enabled]),
+    case lists:member(AuthAccountId, kz_account:tree(Doc)) of
+        'false' -> cb_context:set_doc(Context, NewDoc);
+        'true' -> maybe_import_enabled(Context, NewDoc, Enabled)
     end.
 
-maybe_import_enabled(Context, _JObj, 'undefined') -> Context;
-maybe_import_enabled(Context, JObj, IsEnabled) ->
-    JObj1 =
-        case kz_term:is_true(IsEnabled) of
-            'true' -> kz_account:enable(JObj);
-            'false' -> kz_account:disable(JObj)
-        end,
-    cb_context:set_doc(Context
-                      ,kz_json:delete_key(<<"enabled">>, JObj1)
-                      ).
+maybe_import_enabled(Context, _, 'undefined') -> Context;
+maybe_import_enabled(Context, Doc, IsEnabled) ->
+    NewDoc = case kz_term:is_true(IsEnabled) of
+                 'true' -> kz_account:enable(Doc);
+                 'false' -> kz_account:disable(Doc)
+             end,
+    cb_context:set_doc(Context, NewDoc).
 
 -spec disallow_direct_clients(api_binary(), cb_context:context()) -> cb_context:context().
 disallow_direct_clients(AccountId, Context) ->
-    AllowDirect = kapps_config:get_is_true(?KZ_ACCOUNTS_DB, 'allow_subaccounts_for_direct', 'true'),
-    maybe_disallow_direct_clients(AccountId, Context, AllowDirect).
+    ShouldAllow = ?ALLOW_DIRECT_CLIENTS,
+    lager:debug("will allow direct clients: ~s", [ShouldAllow]),
+    maybe_disallow_direct_clients(AccountId, Context, ShouldAllow).
 
 -spec maybe_disallow_direct_clients(api_binary(), cb_context:context(), boolean()) ->
                                            cb_context:context().
@@ -638,15 +636,11 @@ maybe_disallow_direct_clients(_AccountId, Context, 'false') ->
         'true' -> Context;
         'false' ->
             lager:debug("direct account ~p is disallowed from creating sub-accounts", [AuthAccountId]),
-            cb_context:add_validation_error(
-              [<<"account">>]
-                                           ,<<"forbidden">>
-                                           ,kz_json:from_list(
-                                              [{<<"message">>, <<"Direct account is not allowed to create sub-accounts">>}
-                                              ,{<<"cause">>, AuthAccountId}
-                                              ])
-                                           ,Context
-             )
+            Msg = kz_json:from_list(
+                    [{<<"message">>, <<"Direct account is not allowed to create sub-accounts">>}
+                    ,{<<"cause">>, AuthAccountId}
+                    ]),
+            cb_context:add_validation_error([<<"account">>], <<"forbidden">>, Msg, Context)
     end.
 
 %%--------------------------------------------------------------------
@@ -664,10 +658,10 @@ validate_delete_request(AccountId, Context) ->
                 'false' -> cb_context:set_resp_status(Context, 'success');
                 'true' ->
                     lager:debug("pervent deleting account ~s due to has active port request", [AccountId]),
-                    cb_context:add_system_error('account_has_active_port'
-                                               ,kz_json:from_list([{<<"message">>
-                                                                   ,<<"Account has active port request">>}])
-                                               ,Context)
+                    Msg = kz_json:from_list(
+                            [{<<"message">>, <<"Account has active port request">>}
+                            ]),
+                    cb_context:add_system_error('account_has_active_port', Msg, Context)
             end
     end.
 
@@ -1100,12 +1094,8 @@ extract_tree(AccountId, JObjs) ->
 -spec find_accounts_from_tree(ne_binaries(), kz_json:objects(), cb_context:context()) -> kz_json:objects().
 -spec find_accounts_from_tree(ne_binaries(), kz_json:objects(), ne_binary(), kz_json:objects()) -> kz_json:objects().
 find_accounts_from_tree(Tree, JObjs, Context) ->
-    find_accounts_from_tree(
-      lists:reverse(Tree)
-                           ,JObjs
-                           ,cb_context:auth_account_id(Context)
-                           ,[]
-     ).
+    AuthAccountId = cb_context:auth_account_id(Context),
+    find_accounts_from_tree(lists:reverse(Tree), JObjs, AuthAccountId, []).
 
 find_accounts_from_tree([], _, _, Acc) -> Acc;
 find_accounts_from_tree([AuthAccountId|_], JObjs, AuthAccountId, Acc) ->
@@ -1115,12 +1105,8 @@ find_accounts_from_tree([AuthAccountId|_], JObjs, AuthAccountId, Acc) ->
 find_accounts_from_tree([AccountId|Tree], JObjs, AuthAccountId, Acc) ->
     JObj = kz_json:find_value(<<"id">>, AccountId, JObjs),
     Value = kz_json:get_value(<<"value">>, JObj),
-    find_accounts_from_tree(
-      Tree
-                           ,JObjs
-                           ,AuthAccountId
-                           ,[account_from_tree(Value)|Acc]
-     ).
+    NewAcc = [account_from_tree(Value)|Acc],
+    find_accounts_from_tree(Tree, JObjs, AuthAccountId, NewAcc).
 
 -spec account_from_tree(kz_json:object()) -> kz_json:object().
 account_from_tree(JObj) ->
@@ -1538,14 +1524,11 @@ support_depreciated_billing_id(BillingId, AccountId, Context) ->
             Context
     catch
         'throw':{Error, Reason} ->
-            cb_context:add_validation_error(<<"billing_id">>
-                                           ,<<"not_found">>
-                                           ,kz_json:from_list(
-                                              [{<<"message">>, kz_term:to_binary(Error)}
-                                              ,{<<"cause">>, AccountId}
-                                              ])
-                                           ,Reason
-                                           )
+            Msg = kz_json:from_list(
+                    [{<<"message">>, kz_term:to_binary(Error)}
+                    ,{<<"cause">>, AccountId}
+                    ]),
+            cb_context:add_validation_error(<<"billing_id">>, <<"not_found">>, Msg, Reason)
     end.
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -362,7 +362,7 @@ maybe_update_scheduled_date(Context, PortId) ->
             TZ = kz_json:get_ne_binary_value([Key, <<"timezone">>], ReqData),
             Datetime = kz_json:get_ne_binary_value([Key, <<"date_time">>], ReqData),
             Scheduled = date_as_configured_timezone(Datetime, TZ),
-            lager:debug("date ~s (~s) translated to ~p (~s)", [Datetime, Scheduled, TZ]),
+            lager:debug("date ~s (~s) translated to ~p", [Datetime, TZ, Scheduled]),
             Values = [{Key, Scheduled}
                      ,{<<"schedule_at">>, DateJObj}
                      ],

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -1211,7 +1211,7 @@ send_port_notification(Context, Id, ?PORT_CANCELED=State) ->
 send_port_notification(Context, Id, State, Fun) ->
     try
         Fun(Context, Id),
-        lager:debug("port ~s notification sent", [State]),
+        lager:debug("port ~s notification sent for ~s", [State, Id]),
         Context
     catch
         _E:_R ->

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -349,7 +349,7 @@ patch(Context, Id, ?PORT_CANCELED) ->
 -spec maybe_patch_to_scheduled(cb_context:context(), path_token()) -> cb_context:context().
 maybe_patch_to_scheduled(Context, Id) ->
     OnSuccess = fun (C) -> maybe_update_scheduled_date(C, Id) end,
-    cb_context:validate_request_data(<<"port_requests.to_scheduled">>, Context, OnSuccess).
+    cb_context:validate_request_data_only(<<"port_requests.to_scheduled">>, Context, OnSuccess).
 
 -spec maybe_update_scheduled_date(cb_context:context(), ne_binary()) -> cb_context:context().
 maybe_update_scheduled_date(Context, PortId) ->

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -746,9 +746,9 @@ last_submitted(Context) ->
     case success =:= cb_context:resp_status(Context) of
         false -> Context;
         true ->
-            [RespData] = cb_context:resp_data(Context),
             Timelines = [{kz_doc:id(Doc), LastSubmitted}
-                         || Doc <- kz_json:get_list_value(<<"port_requests">>, RespData),
+                         || [RespData] <- [cb_context:resp_data(Context)],
+                            Doc <- kz_json:get_list_value(<<"port_requests">>, RespData),
                             Timeline <- [prepare_timeline(Context, Doc)],
                             [LastSubmitted|_] <- [lists:reverse(transitions_to_submitted(Timeline))]
                         ],

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -30,6 +30,9 @@
 -include("crossbar.hrl").
 -include_lib("kazoo_number_manager/include/knm_port_request.hrl").
 
+-define(SCHEMA, <<"port_requests">>).
+-define(SCHEMA_TO_SCHEDULED, <<(?SCHEMA)/binary, ".to_scheduled">>).
+
 -define(TEMPLATE_DOC_ID, <<"notify.loa">>).
 -define(TEMPLATE_ATTACHMENT_ID, <<"template">>).
 
@@ -303,29 +306,27 @@ get(Context, Id, ?PATH_TOKEN_LOA) ->
 -spec put(cb_context:context()) -> cb_context:context().
 -spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context) ->
-    crossbar_doc:save(update_port_request_for_save(Context)).
-
--spec update_port_request_for_save(cb_context:context()) -> cb_context:context().
--spec update_port_request_for_save(cb_context:context(), kz_json:object()) -> cb_context:context().
-update_port_request_for_save(Context) ->
-    update_port_request_for_save(Context, cb_context:doc(Context)).
-update_port_request_for_save(Context, Doc) ->
-    NewDoc1 = maybe_set_scheduled_date_from_schedule_on(Doc),
-    NewDoc = kz_account:set_tree(NewDoc1, kz_account:tree(cb_context:account_doc(Context))),
-    cb_context:setters(Context
-                      ,[{fun cb_context:set_account_db/2, ?KZ_PORT_REQUESTS_DB}
-                       ,{fun cb_context:set_doc/2, NewDoc}
-                       ]
-                      ).
+    save(Context).
 
 put(Context, Id, ?PORT_ATTACHMENT) ->
     [{Filename, FileJObj}] = cb_context:req_files(Context),
     Contents = kz_json:get_value(<<"contents">>, FileJObj),
     CT = kz_json:get_value([<<"headers">>, <<"content_type">>], FileJObj),
-    Opts = [{'content_type', CT} | ?TYPE_CHECK_OPTION(<<"port_request">>)],
+    Opts = [{'content_type', CT} | ?TYPE_CHECK_OPTION(?TYPE_PORT_REQUEST)],
     AName = cb_modules_util:attachment_name(Filename, CT),
     Context1 = cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB),
     crossbar_doc:save_attachment(Id, AName, Contents, Context1, Opts).
+
+-spec save(cb_context:context()) -> cb_context:context().
+save(Context) ->
+    NewDoc1 = maybe_set_scheduled_date_from_schedule_on(cb_context:doc(Context)),
+    NewDoc = kz_account:set_tree(NewDoc1, kz_account:tree(cb_context:account_doc(Context))),
+    Context1 = cb_context:setters(Context
+                                 ,[{fun cb_context:set_account_db/2, ?KZ_PORT_REQUESTS_DB}
+                                  ,{fun cb_context:set_doc/2, NewDoc}
+                                  ]
+                                 ),
+    crossbar_doc:save(Context1).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -333,24 +334,32 @@ put(Context, Id, ?PORT_ATTACHMENT) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec patch(cb_context:context(), path_token(), path_token()) -> cb_context:context().
-patch(Context, Id, ?PORT_SUBMITTED) ->
-    Callback = fun() -> patch_then_notify(Context, Id, ?PORT_SUBMITTED) end,
+patch(Context, Id, NewState=?PORT_SUBMITTED) ->
+    Callback = fun() -> save_then_maybe_notify(Context, Id, NewState) end,
     crossbar_services:maybe_dry_run(Context, Callback);
-patch(Context, Id, ?PORT_PENDING) ->
-    patch_then_notify(Context, Id, ?PORT_PENDING);
-patch(Context, Id, ?PORT_SCHEDULED) ->
-    maybe_patch_to_scheduled(Context, Id);
-patch(Context, Id, ?PORT_COMPLETED) ->
-    patch_then_notify(Context, Id, ?PORT_COMPLETED);
-patch(Context, Id, ?PORT_REJECTED) ->
-    patch_then_notify(Context, Id, ?PORT_REJECTED);
-patch(Context, Id, ?PORT_CANCELED) ->
-    patch_then_notify(Context, Id, ?PORT_CANCELED).
+patch(Context, Id, NewState=?PORT_PENDING) ->
+    save_then_maybe_notify(Context, Id, NewState);
+patch(Context, Id, NewState=?PORT_SCHEDULED) ->
+    OnSuccess = fun (C) -> save_then_maybe_notify(C, Id, NewState) end,
+    cb_context:validate_request_data(?SCHEMA_TO_SCHEDULED, Context, OnSuccess);
+patch(Context, Id, NewState=?PORT_COMPLETED) ->
+    save_then_maybe_notify(Context, Id, NewState);
+patch(Context, Id, NewState=?PORT_REJECTED) ->
+    save_then_maybe_notify(Context, Id, NewState);
+patch(Context, Id, NewState=?PORT_CANCELED) ->
+    save_then_maybe_notify(Context, Id, NewState).
 
--spec maybe_patch_to_scheduled(cb_context:context(), path_token()) -> cb_context:context().
-maybe_patch_to_scheduled(Context, PortId) ->
-    OnSuccess = fun (C) -> patch_then_notify(C, PortId, ?PORT_SCHEDULED) end,
-    cb_context:validate_request_data_only(<<"port_requests.to_scheduled">>, Context, OnSuccess).
+-spec save_then_maybe_notify(cb_context:context(), ne_binary(), ne_binary()) -> cb_context:context().
+save_then_maybe_notify(Context, PortId, NewState) ->
+    Context1 = save(Context),
+    case success =:= cb_context:resp_status(Context1) of
+        false -> Context1;
+        true ->
+            RespData1 = knm_port_request:public_fields(cb_context:doc(Context1)),
+            RespData = filter_private_comments(Context1, RespData1),
+            Context2 = cb_context:set_resp_data(Context1, RespData),
+            send_port_notification(Context2, PortId, NewState)
+    end.
 
 -spec maybe_set_scheduled_date_from_schedule_on(kz_json:object()) -> kz_json:object().
 maybe_set_scheduled_date_from_schedule_on(Doc) ->
@@ -373,30 +382,6 @@ date_as_configured_timezone(<<YYYY:4/binary, $-, MM:2/binary, $-, DD:2/binary, $
     Time = {kz_term:to_integer(HH), kz_term:to_integer(Mm), 0},
     kz_time:to_gregorian_seconds({Date, Time}, FromTimezone).
 
-%% @private
--spec patch_then_notify(cb_context:context(), path_token(), path_token()) -> cb_context:context().
-patch_then_notify(Context, PortId, PortState) ->
-    Context1 = do_patch(Context),
-    case success =:= cb_context:resp_status(Context1) of
-        false -> Context1;
-        true ->
-            send_port_notification(Context1, PortId, PortState)
-    end.
-
-%% @private
--spec do_patch(cb_context:context()) -> cb_context:context().
-do_patch(Context) ->
-    UpdatedDoc = kz_json:merge(cb_context:doc(Context), kz_doc:public_fields(cb_context:req_data(Context))),
-
-    Context1  = crossbar_doc:save(update_port_request_for_save(Context, UpdatedDoc)),
-    RespData1 = knm_port_request:public_fields(cb_context:doc(Context1)),
-    RespData2 = filter_private_comments(Context1, RespData1),
-
-    case cb_context:resp_status(Context1) of
-        'success' -> cb_context:set_resp_data(Context1, RespData2);
-        _Status -> Context1
-    end.
-
 %%--------------------------------------------------------------------
 %% @public
 %% @doc
@@ -407,7 +392,7 @@ do_patch(Context) ->
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
 -spec post(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 post(Context, Id) ->
-    Context1 = crossbar_doc:save(update_port_request_for_save(Context)),
+    Context1 = save(Context),
     case cb_context:resp_status(Context1) of
         'success' ->
             _ = maybe_send_port_comment_notification(Context1, Id),
@@ -421,20 +406,14 @@ post(Context, Id, ?PORT_ATTACHMENT, AttachmentId) ->
     [{_Filename, FileJObj}] = cb_context:req_files(Context),
     Contents = kz_json:get_value(<<"contents">>, FileJObj),
     CT = kz_json:get_value([<<"headers">>, <<"content_type">>], FileJObj),
-    Opts = [{'content_type', CT} | ?TYPE_CHECK_OPTION(<<"port_request">>)],
-
+    Options = [{'content_type', CT} | ?TYPE_CHECK_OPTION(?TYPE_PORT_REQUEST)],
     case kz_doc:attachment(cb_context:doc(Context), AttachmentId) of
         'undefined' -> lager:debug("no attachment named ~s", [AttachmentId]);
         _AttachmentMeta ->
             lager:debug("deleting old attachment ~s", [AttachmentId]),
             kz_datamgr:delete_attachment(cb_context:account_db(Context), Id, AttachmentId)
     end,
-    crossbar_doc:save_attachment(Id
-                                ,AttachmentId
-                                ,Contents
-                                ,Context
-                                ,Opts
-                                ).
+    crossbar_doc:save_attachment(Id, AttachmentId, Contents, Context, Options).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -458,7 +437,7 @@ delete(Context, Id, ?PORT_ATTACHMENT, AttachmentName) ->
 -spec load_port_request(cb_context:context(), ne_binary()) -> cb_context:context().
 load_port_request(Context, Id) ->
     Context1 = cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB),
-    crossbar_doc:load(Id, Context1, ?TYPE_CHECK_OPTION(<<"port_request">>)).
+    crossbar_doc:load(Id, Context1, ?TYPE_CHECK_OPTION(?TYPE_PORT_REQUEST)).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -508,18 +487,29 @@ validate_port_request(Context, Id, ?HTTP_POST) ->
 validate_port_request(Context, Id, ?HTTP_DELETE) ->
     is_deletable(load_port_request(Context, Id)).
 
-validate_port_request(Context, Id, ?PORT_SUBMITTED, ?HTTP_PATCH) ->
-    maybe_move_state(Context, Id, ?PORT_SUBMITTED);
-validate_port_request(Context, Id, ?PORT_PENDING, ?HTTP_PATCH) ->
-    maybe_move_state(Context, Id, ?PORT_PENDING);
-validate_port_request(Context, Id, ?PORT_SCHEDULED, ?HTTP_PATCH) ->
-    maybe_move_state(Context, Id, ?PORT_SCHEDULED);
-validate_port_request(Context, Id, ?PORT_COMPLETED, ?HTTP_PATCH) ->
-    maybe_move_state(Context, Id, ?PORT_COMPLETED);
-validate_port_request(Context, Id, ?PORT_REJECTED, ?HTTP_PATCH) ->
-    maybe_move_state(Context, Id, ?PORT_REJECTED);
-validate_port_request(Context, Id, ?PORT_CANCELED, ?HTTP_PATCH) ->
-    maybe_move_state(Context, Id, ?PORT_CANCELED).
+validate_port_request(Context, Id, ToState=?PORT_SUBMITTED, ?HTTP_PATCH) ->
+    patch_then_validate_then_maybe_transition(Context, Id, ToState);
+validate_port_request(Context, Id, ToState=?PORT_PENDING, ?HTTP_PATCH) ->
+    patch_then_validate_then_maybe_transition(Context, Id, ToState);
+validate_port_request(Context, Id, ToState=?PORT_SCHEDULED, ?HTTP_PATCH) ->
+    patch_then_validate_then_maybe_transition(Context, Id, ToState);
+validate_port_request(Context, Id, ToState=?PORT_COMPLETED, ?HTTP_PATCH) ->
+    patch_then_validate_then_maybe_transition(Context, Id, ToState);
+validate_port_request(Context, Id, ToState=?PORT_REJECTED, ?HTTP_PATCH) ->
+    patch_then_validate_then_maybe_transition(Context, Id, ToState);
+validate_port_request(Context, Id, ToState=?PORT_CANCELED, ?HTTP_PATCH) ->
+    patch_then_validate_then_maybe_transition(Context, Id, ToState).
+
+-spec patch_then_validate_then_maybe_transition(cb_context:context(), ne_binary(), ne_binary()) ->
+                                                       cb_context:context().
+patch_then_validate_then_maybe_transition(Context, PortId, ToState) ->
+    ValidateFun = fun (_PortId, C) ->
+                          OnSuccess = fun (OtherC) -> maybe_move_state(OtherC, ToState) end,
+                          cb_context:validate_request_data(?SCHEMA, C, OnSuccess)
+                  end,
+    Context1 = cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB),
+    LoadOptions = ?TYPE_CHECK_OPTION(?TYPE_PORT_REQUEST),
+    crossbar_doc:patch_and_validate(PortId, Context1, ValidateFun, LoadOptions).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -573,7 +563,7 @@ is_deletable(Context, _PortState) ->
 -spec create(cb_context:context()) -> cb_context:context().
 create(Context) ->
     OnSuccess = fun(C) -> on_successful_validation(C, 'undefined') end,
-    cb_context:validate_request_data(<<"port_requests">>, Context, OnSuccess).
+    cb_context:validate_request_data(?SCHEMA, Context, OnSuccess).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -612,7 +602,7 @@ authority(AccountId) ->
 -spec update(cb_context:context(), ne_binary()) -> cb_context:context().
 update(Context, Id) ->
     OnSuccess = fun(C) -> on_successful_validation(C, Id) end,
-    cb_context:validate_request_data(<<"port_requests">>, Context, OnSuccess).
+    cb_context:validate_request_data(?SCHEMA, Context, OnSuccess).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -890,7 +880,7 @@ on_successful_validation(Context, 'undefined') ->
 on_successful_validation(Context, Id) ->
     Context1 = crossbar_doc:load_merge(Id
                                       ,cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB)
-                                      ,?TYPE_CHECK_OPTION(<<"port_request">>)
+                                      ,?TYPE_CHECK_OPTION(?TYPE_PORT_REQUEST)
                                       ),
     on_successful_validation(Context1, Id, can_update_port_request(Context1)).
 
@@ -1059,7 +1049,7 @@ load_attachment(Id, AttachmentId, Context) ->
 load_attachment(AttachmentId, Context) ->
     Context1 = crossbar_doc:load_attachment(cb_context:doc(Context)
                                            ,AttachmentId
-                                           ,?TYPE_CHECK_OPTION(<<"port_request">>)
+                                           ,?TYPE_CHECK_OPTION(?TYPE_PORT_REQUEST)
                                            ,cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB)
                                            ),
     Headers =
@@ -1070,13 +1060,13 @@ load_attachment(AttachmentId, Context) ->
     cb_context:add_resp_headers(Context1, Headers).
 
 %% @private
--spec maybe_move_state(cb_context:context(), ne_binary(), ne_binary()) -> cb_context:context().
-maybe_move_state(Context, Id, PortState) ->
+-spec maybe_move_state(cb_context:context(), ne_binary()) -> cb_context:context().
+maybe_move_state(Context, PortState) ->
     Metadata = knm_port_request:transition_metadata(cb_context:auth_account_id(Context)
                                                    ,cb_context:auth_user_id(Context)
                                                    ,cb_context:req_value(Context, ?REQ_TRANSITION)
                                                    ),
-    Context1 = remove_transition_reason(load_port_request(Context, Id)),
+    Context1 = remove_transition_reason(Context),
     try cb_context:resp_status(Context1) =:= 'success'
              andalso knm_port_request:maybe_transition(cb_context:doc(Context1), Metadata, PortState)
     of

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -748,12 +748,11 @@ last_submitted(Context) ->
                   ,{endkey, [AccountId, kz_json:new()]}
                   ,include_docs
                   ],
-    merge_resp_data(
-      crossbar_doc:load_view(<<"port_requests/listing_submitted">>
-                            ,ViewOptions
-                            ,cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB)
-                            ,fun (Res, Acc) -> last_submitted(Context, Res, Acc) end
-                            )).
+    crossbar_doc:load_view(<<"port_requests/listing_submitted">>
+                          ,ViewOptions
+                          ,cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB)
+                          ,fun (Res, Acc) -> last_submitted(Context, Res, Acc) end
+                          ).
 
 -spec last_submitted(cb_context:context(), kz_json:object(), kz_json:objects()) -> kz_json:objects().
 last_submitted(Context, ResultJObj, Acc) ->
@@ -762,16 +761,11 @@ last_submitted(Context, ResultJObj, Acc) ->
     case lists:reverse(transitions_to_submitted(Timeline)) of
         [] -> Acc;
         [LastSubmitted|_] ->
-            JObj = kz_json:from_list([{kz_doc:id(Doc), LastSubmitted}]),
+            JObj = kz_json:from_list(
+                     [{<<"id">>, kz_doc:id(Doc)}
+                     ,{<<"transition">>, LastSubmitted}
+                     ]),
             [JObj|Acc]
-    end.
-
--spec merge_resp_data(cb_context:context()) -> cb_context:context().
-merge_resp_data(Context) ->
-    case success =:= cb_context:resp_status(Context) of
-        false -> Context;
-        true ->
-            cb_context:set_resp_data(Context, kz_json:merge(cb_context:resp_data(Context)))
     end.
 
 -spec transitions_to_submitted(kz_json:objects()) -> kz_json:objects().

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -748,11 +748,12 @@ last_submitted(Context) ->
                   ,{endkey, [AccountId, kz_json:new()]}
                   ,include_docs
                   ],
-    crossbar_doc:load_view(<<"port_requests/listing_submitted">>
-                          ,ViewOptions
-                          ,cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB)
-                          ,fun (Res, Acc) -> last_submitted(Context, Res, Acc) end
-                          ).
+    merge_resp_data(
+      crossbar_doc:load_view(<<"port_requests/listing_submitted">>
+                            ,ViewOptions
+                            ,cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB)
+                            ,fun (Res, Acc) -> last_submitted(Context, Res, Acc) end
+                            )).
 
 -spec last_submitted(cb_context:context(), kz_json:object(), kz_json:objects()) -> kz_json:objects().
 last_submitted(Context, ResultJObj, Acc) ->
@@ -763,6 +764,14 @@ last_submitted(Context, ResultJObj, Acc) ->
         [LastSubmitted|_] ->
             JObj = kz_json:from_list([{kz_doc:id(Doc), LastSubmitted}]),
             [JObj|Acc]
+    end.
+
+-spec merge_resp_data(cb_context:context()) -> cb_context:context().
+merge_resp_data(Context) ->
+    case success =:= cb_context:resp_status(Context) of
+        false -> Context;
+        true ->
+            cb_context:set_resp_data(Context, kz_json:merge(cb_context:resp_data(Context)))
     end.
 
 -spec transitions_to_submitted(kz_json:objects()) -> kz_json:objects().

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -383,10 +383,10 @@ date_as_configured_timezone(<<YYYY:4/binary, $-, MM:2/binary, $-, DD:2/binary, $
 -spec patch_then_notify(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 patch_then_notify(Context, PortId, PortState) ->
     Context1 = do_patch(Context),
-    case cb_context:resp_status(Context1) of
-        'success' ->
-            send_port_notification(Context1, PortId, PortState);
-        _ -> Context1
+    case success =:= cb_context:resp_status(Context1) of
+        false -> Context1;
+        true ->
+            send_port_notification(Context1, PortId, PortState)
     end.
 
 %% @private
@@ -1075,11 +1075,7 @@ load_attachment(AttachmentId, Context) ->
         ],
     cb_context:add_resp_headers(Context1, Headers).
 
-%%--------------------------------------------------------------------
 %% @private
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 -spec maybe_move_state(cb_context:context(), ne_binary(), ne_binary()) -> cb_context:context().
 maybe_move_state(Context, Id, PortState) ->
     Metadata = knm_port_request:transition_metadata(cb_context:auth_account_id(Context)

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -341,7 +341,7 @@ patch(Context, Id, NewState=?PORT_PENDING) ->
     save_then_maybe_notify(Context, Id, NewState);
 patch(Context, Id, NewState=?PORT_SCHEDULED) ->
     OnSuccess = fun (C) -> save_then_maybe_notify(C, Id, NewState) end,
-    cb_context:validate_request_data_only(?SCHEMA_TO_SCHEDULED, Context, OnSuccess);
+    cb_context:validate_request_data(?SCHEMA_TO_SCHEDULED, Context, OnSuccess);
 patch(Context, Id, NewState=?PORT_COMPLETED) ->
     save_then_maybe_notify(Context, Id, NewState);
 patch(Context, Id, NewState=?PORT_REJECTED) ->
@@ -504,11 +504,8 @@ validate_port_request(Context, Id, ToState=?PORT_CANCELED, ?HTTP_PATCH) ->
                                                        cb_context:context().
 patch_then_validate_then_maybe_transition(Context, PortId, ToState) ->
     ValidateFun = fun (_PortId, C) ->
-                          ReqData = cb_context:req_data(C),
                           OnSuccess = fun (OtherC) -> maybe_move_state(OtherC, ToState) end,
-                          %% Note: patch_and_validate sets ReqData to what we want
-                          OnPassing = fun (OtherC) -> cb_context:set_doc(OtherC, ReqData) end,
-                          cb_context:do_validate_request_data(?SCHEMA, C, OnSuccess, undefined, OnPassing)
+                          cb_context:validate_request_data(?SCHEMA, C, OnSuccess)
                   end,
     Context1 = cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB),
     LoadOptions = ?TYPE_CHECK_OPTION(?TYPE_PORT_REQUEST),

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -756,14 +756,14 @@ last_submitted(Context) ->
 
 -spec last_submitted(cb_context:context(), kz_json:object(), kz_json:objects()) -> kz_json:objects().
 last_submitted(Context, ResultJObj, Acc) ->
-    [begin
-         Doc = kz_json:get_value(<<"doc">>, ResultJObj),
-         Timeline = prepare_timeline(Context, Doc),
-         [LastSubmitted|_] = lists:reverse(transitions_to_submitted(Timeline)),
-         kz_json:from_list([{kz_doc:id(Doc), LastSubmitted}])
-     end
-     | Acc
-    ].
+    Doc = kz_json:get_value(<<"doc">>, ResultJObj),
+    Timeline = prepare_timeline(Context, Doc),
+    case lists:reverse(transitions_to_submitted(Timeline)) of
+        [] -> Acc;
+        [LastSubmitted|_] ->
+            JObj = kz_json:from_list([{kz_doc:id(Doc), LastSubmitted}]),
+            [JObj|Acc]
+    end.
 
 -spec transitions_to_submitted(kz_json:objects()) -> kz_json:objects().
 transitions_to_submitted(Timeline) ->

--- a/applications/crossbar/src/modules_v1/cb_users_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_users_v1.erl
@@ -591,7 +591,7 @@ check_user_name(UserId, Context) ->
     AccountDb = cb_context:account_db(Context),
     case is_username_unique(AccountDb, UserId, UserName) of
         'true' ->
-            lager:debug("user name ~p is unique", [UserName]),
+            lager:debug("user name ~s is unique", [UserName]),
             check_emergency_caller_id(UserId, Context);
         'false' ->
             lager:error("user name ~s is already in use", [UserName]),

--- a/applications/crossbar/src/modules_v1/cb_users_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_users_v1.erl
@@ -439,7 +439,7 @@ vcard_normalize_type(T) when is_list(T) -> iolist_join(<<";">>, [vcard_normalize
 vcard_normalize_type({T, V}) -> iolist_join(<<"=">>, [T, V]);
 vcard_normalize_type(T) -> T.
 
-                                                %-spec card_field(ne_binary(), kz_json:object()) -> {vcard_type_spec(), vcard_val()}.
+%%-spec card_field(ne_binary(), kz_json:object()) -> {vcard_type_spec(), vcard_val()}.
 card_field(Key, _)
   when Key =:= <<"BEGIN">> ->
     {Key, <<"VCARD">>};
@@ -594,17 +594,12 @@ check_user_name(UserId, Context) ->
             lager:debug("user name ~p is unique", [UserName]),
             check_emergency_caller_id(UserId, Context);
         'false' ->
-            Context1 =
-                cb_context:add_validation_error(
-                  [<<"username">>]
-                                               ,<<"unique">>
-                                               ,kz_json:from_list([
-                                                                   {<<"message">>, <<"User name already in use">>}
-                                                                  ,{<<"cause">>, UserName}
-                                                                  ])
-                                               ,Context
-                 ),
-            lager:error("user name ~p is already used", [UserName]),
+            lager:error("user name ~s is already in use", [UserName]),
+            Msg = kz_json:from_list(
+                    [{<<"message">>, <<"User name already in use">>}
+                    ,{<<"cause">>, UserName}
+                    ]),
+            Context1 = cb_context:add_validation_error([<<"username">>], <<"unique">>, Msg, Context),
             check_emergency_caller_id(UserId, Context1)
     end.
 
@@ -674,15 +669,11 @@ maybe_validate_username(UserId, Context) ->
             manditory_rehash_creds(UserId, NewUsername, Context);
         %% updated user name to existing, collect any further errors...
         _Else ->
-            C = cb_context:add_validation_error(
-                  <<"username">>
-                                               ,<<"unique">>
-                                               ,kz_json:from_list([
-                                                                   {<<"message">>, <<"User name is not unique for this account">>}
-                                                                  ,{<<"cause">>, NewUsername}
-                                                                  ])
-                                               ,Context
-                 ),
+            Msg = kz_json:from_list(
+                    [{<<"message">>, <<"User name is not unique for this account">>}
+                    ,{<<"cause">>, NewUsername}
+                    ]),
+            C = cb_context:add_validation_error(<<"username">>, <<"unique">>, Msg, Context),
             manditory_rehash_creds(UserId, NewUsername, C)
     end.
 
@@ -704,28 +695,20 @@ maybe_rehash_creds(UserId, Username, Context) ->
 manditory_rehash_creds(UserId, Username, Context) ->
     case kz_json:get_ne_value(<<"password">>, cb_context:doc(Context)) of
         'undefined' ->
-            cb_context:add_validation_error(
-              <<"password">>
-                                           ,<<"required">>
-                                           ,kz_json:from_list([
-                                                               {<<"message">>, <<"The password must be provided when updating the user name">>}
-                                                              ])
-                                           ,Context
-             );
+            Msg = kz_json:from_list(
+                    [{<<"message">>, <<"The password must be provided when updating the user name">>}
+                    ]),
+            cb_context:add_validation_error(<<"password">>, <<"required">>, Msg, Context);
         Password -> rehash_creds(UserId, Username, Password, Context)
     end.
 
 -spec rehash_creds(api_binary(), api_binary(), ne_binary(), cb_context:context()) ->
                           cb_context:context().
 rehash_creds(_UserId, 'undefined', _Password, Context) ->
-    cb_context:add_validation_error(
-      <<"username">>
-                                   ,<<"required">>
-                                   ,kz_json:from_list([
-                                                       {<<"message">>, <<"The user name must be provided when updating the password">>}
-                                                      ])
-                                   ,Context
-     );
+    Msg = kz_json:from_list(
+            [{<<"message">>, <<"The user name must be provided when updating the password">>}
+            ]),
+    cb_context:add_validation_error(<<"username">>, <<"required">>, Msg, Context);
 rehash_creds(_UserId, Username, Password, Context) ->
     lager:debug("password set on doc, updating hashes for ~s", [Username]),
     {MD5, SHA1} = cb_modules_util:pass_hashes(Username, Password),

--- a/applications/teletype/src/teletype_port_utils.erl
+++ b/applications/teletype/src/teletype_port_utils.erl
@@ -187,13 +187,8 @@ fix_transfer_date(JObj) ->
 
 -spec fix_scheduled_date(kz_json:path()) -> kz_json:object().
 fix_scheduled_date(JObj) ->
-    ScheduledDate = case kz_json:get_integer_value([<<"scheduled_date">>, <<"local">>], JObj) of
-                        %% backward compatibility
-                        undefined -> kz_json:get_integer_value(<<"scheduled_date">>, JObj);
-                        Timestamp -> Timestamp
-                    end,
     kz_json:set_values([{<<"port_scheduled_date">>, kz_json:get_value(<<"scheduled_date">>, JObj)}
-                       ,{<<"scheduled_date">>, ScheduledDate}
+                       ,{<<"scheduled_date">>, kz_json:get_value([<<"scheduled_date">>, <<"local">>], JObj)}
                        ], JObj).
 
 -spec fix_ui_metadata(kz_json:path()) -> kz_json:object().

--- a/applications/teletype/src/teletype_port_utils.erl
+++ b/applications/teletype/src/teletype_port_utils.erl
@@ -135,11 +135,8 @@ fix_billing_fold(Key, Value, Acc) ->
 
 -spec fix_comments(kz_json:object()) -> kz_json:object().
 fix_comments(JObj) ->
-    case kz_json:get_value(<<"comments">>, JObj) of
-        'undefined' ->
-            kz_json:delete_key(<<"comments">>, JObj);
-        [] ->
-            kz_json:delete_key(<<"comments">>, JObj);
+    case kz_json:get_list_value(<<"comments">>, JObj, []) of
+        [] -> kz_json:delete_key(<<"comments">>, JObj);
         Comments ->
             LastComment = lists:last(Comments),
 
@@ -157,10 +154,7 @@ fix_comments(JObj) ->
 
 -spec fix_dates(kz_json:object()) -> kz_json:object().
 fix_dates(JObj) ->
-    lists:foldl(fun fix_date_fold/2
-               ,JObj
-               ,[<<"transfer_date">>, <<"scheduled_date">>]
-               ).
+    lists:foldl(fun fix_date_fold/2, JObj, [<<"transfer_date">>, <<"scheduled_date">>]).
 
 -spec fix_date_fold(kz_json:path(), kz_json:object()) -> kz_json:object().
 fix_date_fold(Key, JObj) ->

--- a/applications/teletype/src/teletype_port_utils.erl
+++ b/applications/teletype/src/teletype_port_utils.erl
@@ -125,7 +125,7 @@ fix_number_fold(Number, _Value, Acc) ->
 fix_billing(JObj) ->
     kz_json:foldl(fun fix_billing_fold/3
                  ,kz_json:delete_key(<<"bill">>, JObj)
-                 ,kz_json:get_value(<<"bill">>, JObj)
+                 ,kz_json:get_json_value(<<"bill">>, JObj, kz_json:new())
                  ).
 
 -spec fix_billing_fold(kz_json:path(), kz_json:json_term(), kz_json:object()) ->

--- a/core/kazoo_ast/src/cb_api_endpoints.erl
+++ b/core/kazoo_ast/src/cb_api_endpoints.erl
@@ -225,7 +225,8 @@ process_schema(Filename, Definitions) ->
                 end
                 || {Path,V}=KV <- kz_json:to_proplist(kz_json:flatten(JObj0)),
                    not lists:member(<<"patternProperties">>, Path),
-                   not lists:member(<<"kazoo-validation">>, Path)
+                   not lists:member(<<"kazoo-validation">>, Path),
+                   not lists:member(<<"oneOf">>, Path)
                ])),
     Name = kz_term:to_binary(filename:basename(Filename, ".json")),
     kz_json:set_value(Name, JObj, Definitions).

--- a/core/kazoo_number_manager/include/knm_port_request.hrl
+++ b/core/kazoo_number_manager/include/knm_port_request.hrl
@@ -1,5 +1,7 @@
 -ifndef(KNM_PORT_REQUEST_HRL).
 
+-define(TYPE_PORT_REQUEST, <<"port_request">>).
+
 -define(PORT_ATTACHMENT, <<"attachments">>).
 -define(PORT_CANCELED, <<"canceled">>).
 -define(PORT_COMPLETED, <<"completed">>).

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -392,17 +392,14 @@ assign_to_app(Number, NewApp, JObj) ->
 %%--------------------------------------------------------------------
 -spec send_submitted_requests() -> 'ok'.
 send_submitted_requests() ->
-    case kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB
-                               ,?VIEW_LISTING_SUBMITTED
-                               ,['include_docs']
-                               )
-    of
+    View = ?VIEW_LISTING_SUBMITTED,
+    case kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB, View, [include_docs]) of
         {'error', _R} ->
-            lager:error("failed to open view ~s ~p", [?VIEW_LISTING_SUBMITTED, _R]);
+            lager:error("failed to open view ~s ~p", [View, _R]);
         {'ok', []} -> 'ok';
         {'ok', JObjs} ->
             lists:foreach(fun send_submitted_request/1, JObjs),
-            lager:debug("sent requests")
+            lager:debug("requests sent")
     end.
 
 send_submitted_request(JObj) ->

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -180,7 +180,7 @@ normalize_number_map(N, Meta) ->
 new(PortReq, ?MATCH_ACCOUNT_RAW(AuthAccountId), AuthUserId) ->
     Normalized = normalize_numbers(PortReq),
     Metadata = transition_metadata(AuthAccountId, AuthUserId),
-    Unconf = [{?PORT_PVT_TYPE, <<"port_request">>}
+    Unconf = [{?PORT_PVT_TYPE, ?TYPE_PORT_REQUEST}
              ,{?PORT_PVT_STATE, ?PORT_UNCONFIRMED}
              ,{?PORT_PVT_TRANSITIONS, [transition_metadata_jobj(undefined, ?PORT_UNCONFIRMED, Metadata)]}
              ],


### PR DESCRIPTION
Fixes and issue where, after validating a scheduled port request, the PATCH would forget about the port request JSON and only continue with the req data.

`crossbar_doc:patch_and_validate` was not used here because `cb_port_requests` loads then checks/modifies its documents its own way and I do not want to deal with that mess.