### PR TITLE
use encoded node name in templates

### DIFF
--- a/applications/teletype/priv/templates/account_zone_change.html
+++ b/applications/teletype/priv/templates/account_zone_change.html
@@ -74,7 +74,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/account_zone_change.text
+++ b/applications/teletype/priv/templates/account_zone_change.text
@@ -20,4 +20,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/cnam_request.html
+++ b/applications/teletype/priv/templates/cnam_request.html
@@ -96,7 +96,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/cnam_request.text
+++ b/applications/teletype/priv/templates/cnam_request.text
@@ -26,4 +26,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/customer_update.html
+++ b/applications/teletype/priv/templates/customer_update.html
@@ -57,7 +57,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/customer_update.text
+++ b/applications/teletype/priv/templates/customer_update.text
@@ -14,4 +14,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/denied_emergency_bridge.html
+++ b/applications/teletype/priv/templates/denied_emergency_bridge.html
@@ -84,7 +84,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/denied_emergency_bridge.text
+++ b/applications/teletype/priv/templates/denied_emergency_bridge.text
@@ -25,4 +25,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/deregister.html
+++ b/applications/teletype/priv/templates/deregister.html
@@ -85,7 +85,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/deregister.text
+++ b/applications/teletype/priv/templates/deregister.text
@@ -27,4 +27,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/fax_inbound_error_to_email.html
+++ b/applications/teletype/priv/templates/fax_inbound_error_to_email.html
@@ -84,7 +84,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/fax_inbound_error_to_email.text
+++ b/applications/teletype/priv/templates/fax_inbound_error_to_email.text
@@ -34,4 +34,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/fax_inbound_error_to_email_filtered.html
+++ b/applications/teletype/priv/templates/fax_inbound_error_to_email_filtered.html
@@ -84,7 +84,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/fax_inbound_error_to_email_filtered.text
+++ b/applications/teletype/priv/templates/fax_inbound_error_to_email_filtered.text
@@ -34,4 +34,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/fax_inbound_to_email.html
+++ b/applications/teletype/priv/templates/fax_inbound_to_email.html
@@ -80,7 +80,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/fax_inbound_to_email.text
+++ b/applications/teletype/priv/templates/fax_inbound_to_email.text
@@ -25,4 +25,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/fax_outbound_error_to_email.html
+++ b/applications/teletype/priv/templates/fax_outbound_error_to_email.html
@@ -84,7 +84,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/fax_outbound_error_to_email.text
+++ b/applications/teletype/priv/templates/fax_outbound_error_to_email.text
@@ -32,4 +32,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/fax_outbound_to_email.html
+++ b/applications/teletype/priv/templates/fax_outbound_to_email.html
@@ -80,7 +80,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/fax_outbound_to_email.text
+++ b/applications/teletype/priv/templates/fax_outbound_to_email.text
@@ -25,4 +25,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/first_occurrence.html
+++ b/applications/teletype/priv/templates/first_occurrence.html
@@ -74,7 +74,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/first_occurrence.text
+++ b/applications/teletype/priv/templates/first_occurrence.text
@@ -22,4 +22,4 @@ Administrator User Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/low_balance.html
+++ b/applications/teletype/priv/templates/low_balance.html
@@ -69,7 +69,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/low_balance.text
+++ b/applications/teletype/priv/templates/low_balance.text
@@ -20,4 +20,4 @@ Current balance is now {{current_balance}}
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/missed_call.html
+++ b/applications/teletype/priv/templates/missed_call.html
@@ -86,7 +86,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/missed_call.text
+++ b/applications/teletype/priv/templates/missed_call.text
@@ -23,4 +23,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/new_account.html
+++ b/applications/teletype/priv/templates/new_account.html
@@ -134,7 +134,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/new_account.text
+++ b/applications/teletype/priv/templates/new_account.text
@@ -33,4 +33,4 @@ Welcome{% if admin.first_name %} {{admin.first_name}}{% else %} dear customer{% 
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/new_user.html
+++ b/applications/teletype/priv/templates/new_user.html
@@ -98,7 +98,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/new_user.text
+++ b/applications/teletype/priv/templates/new_user.text
@@ -23,4 +23,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/port_cancel.html
+++ b/applications/teletype/priv/templates/port_cancel.html
@@ -68,7 +68,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/port_cancel.text
+++ b/applications/teletype/priv/templates/port_cancel.text
@@ -19,4 +19,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/port_comment.html
+++ b/applications/teletype/priv/templates/port_comment.html
@@ -59,7 +59,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/port_comment.text
+++ b/applications/teletype/priv/templates/port_comment.text
@@ -14,4 +14,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/port_pending.html
+++ b/applications/teletype/priv/templates/port_pending.html
@@ -72,7 +72,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/port_pending.text
+++ b/applications/teletype/priv/templates/port_pending.text
@@ -20,4 +20,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/port_rejected.html
+++ b/applications/teletype/priv/templates/port_rejected.html
@@ -72,7 +72,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/port_rejected.text
+++ b/applications/teletype/priv/templates/port_rejected.text
@@ -19,4 +19,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/port_request.html
+++ b/applications/teletype/priv/templates/port_request.html
@@ -72,7 +72,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/port_request.text
+++ b/applications/teletype/priv/templates/port_request.text
@@ -19,4 +19,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/port_request_admin.html
+++ b/applications/teletype/priv/templates/port_request_admin.html
@@ -126,7 +126,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/port_request_admin.text
+++ b/applications/teletype/priv/templates/port_request_admin.text
@@ -34,4 +34,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/port_scheduled.html
+++ b/applications/teletype/priv/templates/port_scheduled.html
@@ -71,7 +71,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/port_scheduled.text
+++ b/applications/teletype/priv/templates/port_scheduled.text
@@ -20,4 +20,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/port_unconfirmed.html
+++ b/applications/teletype/priv/templates/port_unconfirmed.html
@@ -71,7 +71,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/port_unconfirmed.text
+++ b/applications/teletype/priv/templates/port_unconfirmed.text
@@ -23,4 +23,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/ported.html
+++ b/applications/teletype/priv/templates/ported.html
@@ -71,7 +71,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/ported.text
+++ b/applications/teletype/priv/templates/ported.text
@@ -22,4 +22,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/service_added.html
+++ b/applications/teletype/priv/templates/service_added.html
@@ -129,7 +129,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/service_added.text
+++ b/applications/teletype/priv/templates/service_added.text
@@ -50,4 +50,4 @@ Re-seller Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/skel.html
+++ b/applications/teletype/priv/templates/skel.html
@@ -61,7 +61,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/skel.text
+++ b/applications/teletype/priv/templates/skel.text
@@ -17,4 +17,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/system_alert.html
+++ b/applications/teletype/priv/templates/system_alert.html
@@ -208,7 +208,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/system_alert.text
+++ b/applications/teletype/priv/templates/system_alert.text
@@ -109,4 +109,4 @@ Administrator User Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/topup.html
+++ b/applications/teletype/priv/templates/topup.html
@@ -117,7 +117,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/topup.text
+++ b/applications/teletype/priv/templates/topup.text
@@ -36,4 +36,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/transaction.html
+++ b/applications/teletype/priv/templates/transaction.html
@@ -126,7 +126,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/transaction.text
+++ b/applications/teletype/priv/templates/transaction.text
@@ -46,4 +46,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/transaction_failed.html
+++ b/applications/teletype/priv/templates/transaction_failed.html
@@ -106,7 +106,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/transaction_failed.text
+++ b/applications/teletype/priv/templates/transaction_failed.text
@@ -32,4 +32,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/voicemail_full.html
+++ b/applications/teletype/priv/templates/voicemail_full.html
@@ -73,7 +73,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/voicemail_full.text
+++ b/applications/teletype/priv/templates/voicemail_full.text
@@ -20,4 +20,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/voicemail_to_email.html
+++ b/applications/teletype/priv/templates/voicemail_to_email.html
@@ -129,7 +129,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/voicemail_to_email.text
+++ b/applications/teletype/priv/templates/voicemail_to_email.text
@@ -33,4 +33,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/priv/templates/webhook_disabled.html
+++ b/applications/teletype/priv/templates/webhook_disabled.html
@@ -95,7 +95,7 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
             </table>
-            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.hostname}}</p>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
             <!--[if mso]>
             </td>
             </tr>

--- a/applications/teletype/priv/templates/webhook_disabled.text
+++ b/applications/teletype/priv/templates/webhook_disabled.text
@@ -25,4 +25,4 @@ Account Information
 
 
 
-Sent from {{system.hostname}}
+Sent from {{system.encoded_node}}

--- a/applications/teletype/src/teletype.hrl
+++ b/applications/teletype/src/teletype.hrl
@@ -196,6 +196,11 @@
          ++ ?TO_MACROS
         ]).
 
+-define(COMMON_TEMPLATE_MACROS
+       ,?ACCOUNT_MACROS
+        ++ ?SYSTEM_MACROS
+       ).
+
 -record(email_receipt, {to :: ne_binaries() | ne_binary()
                        ,from :: ne_binary()
                        ,call_id :: ne_binary()

--- a/applications/teletype/src/teletype.hrl
+++ b/applications/teletype/src/teletype.hrl
@@ -157,6 +157,9 @@
 
 -define(SYSTEM_MACROS
        ,[?MACRO_VALUE(<<"system.hostname">>, <<"system_hostname">>, <<"Hostname">>, <<"Hostname of system generating the email">>)
+        ,?MACRO_VALUE(<<"system.encoded_hostname">>, <<"system_encoded_hostname">>, <<"Encoded Hostname">>, <<"Hostname of system generating the email, encoded to not reveal the real value">>)
+        ,?MACRO_VALUE(<<"system.node">>, <<"system_node">>, <<"Node">>, <<"Node name of system generating the email">>)
+        ,?MACRO_VALUE(<<"system.encoded_node">>, <<"system_encoded_node">>, <<"Encoded Node">>, <<"Node name of system generating the email, encoded to not reveal the real value">>)
         ]).
 
 -define(FAX_MACROS

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -330,7 +330,7 @@ default_content_transfer_encoding(_) -> <<"7BIT">>.
 
 -spec system_params() -> kz_proplist().
 system_params() ->
-    [{<<"hostname">>, kz_term:to_binary(net_adm:localhost())}].
+    [{<<"hostname">>, kz_nodes:node_encoded()}].
 
 -spec user_params(kzd_user:doc()) -> kz_proplist().
 user_params(UserJObj) ->

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -330,7 +330,11 @@ default_content_transfer_encoding(_) -> <<"7BIT">>.
 
 -spec system_params() -> kz_proplist().
 system_params() ->
-    [{<<"hostname">>, kz_nodes:node_encoded()}].
+    [{<<"hostname">>, kz_term:to_binary(net_adm:localhost())}
+    ,{<<"hostname">>, kz_base64url:encode(crypto:hash('md5', kz_term:to_binary(net_adm:localhost())))}
+    ,{<<"node">>, node()}
+    ,{<<"encoded_node">>, kz_nodes:node_encoded()}
+    ].
 
 -spec user_params(kzd_user:doc()) -> kz_proplist().
 user_params(UserJObj) ->

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -331,7 +331,7 @@ default_content_transfer_encoding(_) -> <<"7BIT">>.
 -spec system_params() -> kz_proplist().
 system_params() ->
     [{<<"hostname">>, kz_term:to_binary(net_adm:localhost())}
-    ,{<<"hostname">>, kz_base64url:encode(crypto:hash('md5', kz_term:to_binary(net_adm:localhost())))}
+    ,{<<"encoded_hostname">>, kz_base64url:encode(crypto:hash('md5', kz_term:to_binary(net_adm:localhost())))}
     ,{<<"node">>, node()}
     ,{<<"encoded_node">>, kz_nodes:node_encoded()}
     ].

--- a/applications/teletype/src/templates/teletype_account_zone_change.erl
+++ b/applications/teletype/src/templates/teletype_account_zone_change.erl
@@ -21,9 +21,11 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           [?MACRO_VALUE(<<"zones">>, <<"zones">>, <<"Zones">>, <<"List of account's zones">>)
-           | ?ACCOUNT_MACROS
+           | ?COMMON_TEMPLATE_MACROS
           ]
-         )).
+         )
+       ).
+
 -define(TEMPLATE_SUBJECT, <<"Account '{{account.name}}' zone have changed">>).
 -define(TEMPLATE_CATEGORY, <<"account">>).
 -define(TEMPLATE_NAME, <<"Account Zone Change">>).

--- a/applications/teletype/src/templates/teletype_cnam_request.erl
+++ b/applications/teletype/src/templates/teletype_cnam_request.erl
@@ -24,9 +24,11 @@
           ,?MACRO_VALUE(<<"request.number_state">>, <<"request_number_state">>, <<"Number State">>, <<"Number state">>)
           ,?MACRO_VALUE(<<"request.local_number">>, <<"request_local_number">>, <<"Local Number">>, <<"Is a local number">>)
           ,?MACRO_VALUE(<<"request.acquired_for">>, <<"request_acquired_for">>, <<"Acquired For">>, <<"Who authorized the request">>)
-           | ?ACCOUNT_MACROS ++ ?USER_MACROS
+           | ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
           ]
-         )).
+         )
+       ).
 
 -define(TEMPLATE_SUBJECT, <<"Caller name update request for {{request.number}}">>).
 -define(TEMPLATE_CATEGORY, <<"account">>).

--- a/applications/teletype/src/templates/teletype_customer_update.erl
+++ b/applications/teletype/src/templates/teletype_customer_update.erl
@@ -26,7 +26,9 @@
           [?MACRO_VALUE(<<"user.first_name">>, <<"first_name">>, <<"First Name">>, <<"First Name">>)
           ,?MACRO_VALUE(<<"user.last_name">>, <<"last_name">>, <<"Last Name">>, <<"Last Name">>)
            | ?USER_MACROS
-          ])
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Customer update">>).

--- a/applications/teletype/src/templates/teletype_denied_emergency_bridge.erl
+++ b/applications/teletype/src/templates/teletype_denied_emergency_bridge.erl
@@ -24,8 +24,9 @@
           ,?MACRO_VALUE(<<"call.emergency_caller_id_name">>, <<"emergency_caller_id_name">>, <<"Emergency Caller ID Name">>, <<"Emergency Caller ID Name">>)
           ,?MACRO_VALUE(<<"call.emergency_caller_id_number">>, <<"emergency_caller_id_number">>, <<"Emergency Caller ID Number">>, <<"Emergency Caller ID Number">>)
           ,?MACRO_VALUE(<<"call.call_id">>, <<"call_id">>, <<"Call ID">>, <<"Call ID">>)
-           | ?ACCOUNT_MACROS
-          ])
+           | ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Blocked emergency call from account '{{account.name}}'">>).

--- a/applications/teletype/src/templates/teletype_deregister.erl
+++ b/applications/teletype/src/templates/teletype_deregister.erl
@@ -35,8 +35,9 @@
           ,?MACRO_VALUE(<<"last_registration.contact">>, <<"last_registration_contact">>, <<"SIP Contact">>, <<"SIP Contact">>)
           ,?MACRO_VALUE(<<"last_registration.expires">>, <<"last_registration_expires">>, <<"Expires">>, <<"Expires">>)
           ,?MACRO_VALUE(<<"last_registration.authorizing_id">>, <<"last_registration_authorizing_id">>, <<"Authorizing ID">>, <<"Authorizing ID">>)
-           | ?ACCOUNT_MACROS
-          ])
+           | ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Loss of Registration for '{{last_registration.username}}'">>).

--- a/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
@@ -25,7 +25,9 @@
           ++ ?FAX_MACROS
           ++ ?DEFAULT_CALL_MACROS
           ++ ?USER_MACROS
-         )).
+          ++ ?COMMON_TEMPLATE_MACROS
+         )
+       ).
 
 -define(TEMPLATE_SUBJECT, <<"Error receiving fax from {% firstof caller_id.name fax.remote_station_id %} ({% firstof fax.remote_station_id caller_id.number \"Unknown Number\" %})">>).
 -define(TEMPLATE_CATEGORY, <<"fax">>).

--- a/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
@@ -23,7 +23,9 @@
           ?FAX_MACROS
           ++ ?DEFAULT_CALL_MACROS
           ++ ?USER_MACROS
-         )).
+          ++ ?COMMON_TEMPLATE_MACROS
+         )
+       ).
 
 -define(TEMPLATE_SUBJECT, <<"New fax from {{caller_id.name}} ({{caller_id.number}})">>).
 -define(TEMPLATE_CATEGORY, <<"fax">>).

--- a/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
@@ -24,7 +24,9 @@
           ++ ?FAX_MACROS
           ++ ?DEFAULT_CALL_MACROS
           ++ ?USER_MACROS
-         )).
+          ++ ?COMMON_TEMPLATE_MACROS
+         )
+       ).
 
 -define(TEMPLATE_SUBJECT, <<"Error sending Fax to {{callee_id.name}} ({% firstof fax.remote_station_id callee_id.number \"Unknown Number\" %})">>).
 -define(TEMPLATE_CATEGORY, <<"fax">>).

--- a/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
@@ -23,7 +23,9 @@
           ?FAX_MACROS
           ++ ?DEFAULT_CALL_MACROS
           ++ ?USER_MACROS
-         )).
+          ++ ?COMMON_TEMPLATE_MACROS
+         )
+       ).
 
 -define(TEMPLATE_SUBJECT, <<"Fax has been sended to {{callee_id.name}} ({{callee_id.number}})">>).
 -define(TEMPLATE_CATEGORY, <<"fax">>).

--- a/applications/teletype/src/templates/teletype_first_occurrence.erl
+++ b/applications/teletype/src/templates/teletype_first_occurrence.erl
@@ -20,8 +20,10 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           [?MACRO_VALUE(<<"event">>, <<"event">>, <<"Event">>, <<"Event">>)
-           | ?USER_MACROS ++ ?ACCOUNT_MACROS ++ ?SYSTEM_MACROS
-          ])
+           | ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"First {{event}} on account '{{account.name}}'">>).

--- a/applications/teletype/src/templates/teletype_low_balance.erl
+++ b/applications/teletype/src/templates/teletype_low_balance.erl
@@ -21,8 +21,9 @@
        ,kz_json:from_list(
           [?MACRO_VALUE(<<"current_balance">>, <<"current_balance">>, <<"Current Balance">>, <<"Account's Current Credit Balance">>)
           ,?MACRO_VALUE(<<"threshold">>, <<"threshold">>, <<"Threshold">>, <<"Account's Low Credit Balance Threshold">>)
-           | ?ACCOUNT_MACROS
-          ])
+           | ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Account '{{account.name}}' is running out of credit">>).

--- a/applications/teletype/src/templates/teletype_missed_call.erl
+++ b/applications/teletype/src/templates/teletype_missed_call.erl
@@ -20,8 +20,11 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           [?MACRO_VALUE(<<"missed_call.reason">>, <<"missed_call_reasom">>, <<"Missed Call Reason">>, <<"Reason why the call is terminated without been bridged or left a voicemail message">>)
-           | ?DEFAULT_CALL_MACROS ++ ?ACCOUNT_MACROS ++ ?USER_MACROS
-          ])
+           | ?DEFAULT_CALL_MACROS
+           ++ ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Missed call from {{caller_id.name}} ({{caller_id.number}})">>).

--- a/applications/teletype/src/templates/teletype_new_account.erl
+++ b/applications/teletype/src/templates/teletype_new_account.erl
@@ -23,8 +23,9 @@
           ,?MACRO_VALUE(<<"admin.last_name">>, <<"last_name">>, <<"Last Name">>, <<"Admin user last name">>)
           ,?MACRO_VALUE(<<"admin.email">>, <<"email">>, <<"email">>, <<"Admin user email">>)
           ,?MACRO_VALUE(<<"admin.timezone">>, <<"timezone">>, <<"timezone">>, <<"Admin user timezone">>)
-           | ?ACCOUNT_MACROS
-          ])
+           | ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Your new VoIP services account '{{account.name}}' has been created">>).

--- a/applications/teletype/src/templates/teletype_new_user.erl
+++ b/applications/teletype/src/templates/teletype_new_user.erl
@@ -20,8 +20,10 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           [?MACRO_VALUE(<<"user.password">>, <<"password">>, <<"Password">>, <<"Password">>)
-           | ?USER_MACROS ++ ?ACCOUNT_MACROS
-          ])
+           | ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Your new VoIP services user profile has been created">>).

--- a/applications/teletype/src/templates/teletype_password_recovery.erl
+++ b/applications/teletype/src/templates/teletype_password_recovery.erl
@@ -20,8 +20,10 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           [?MACRO_VALUE(<<"link">>, <<"link">>, <<"Password Reset Link">>, <<"Link to reset password">>)
-           | ?ACCOUNT_MACROS ++ ?USER_MACROS
-          ])
+           | ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Reset your VoIP services user password">>).

--- a/applications/teletype/src/templates/teletype_port_cancel.erl
+++ b/applications/teletype/src/templates/teletype_port_cancel.erl
@@ -20,7 +20,7 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           ?PORT_REQUEST_MACROS
-          ++ ?ACCOUNT_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
          )
        ).
 

--- a/applications/teletype/src/templates/teletype_port_comment.erl
+++ b/applications/teletype/src/templates/teletype_port_comment.erl
@@ -20,7 +20,8 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           ?PORT_REQUEST_MACROS
-          ++ ?ACCOUNT_MACROS ++ ?USER_MACROS
+          ++ ?USER_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
          )
        ).
 

--- a/applications/teletype/src/templates/teletype_port_pending.erl
+++ b/applications/teletype/src/templates/teletype_port_pending.erl
@@ -20,7 +20,7 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           ?PORT_REQUEST_MACROS
-          ++ ?ACCOUNT_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
          )
        ).
 

--- a/applications/teletype/src/templates/teletype_port_rejected.erl
+++ b/applications/teletype/src/templates/teletype_port_rejected.erl
@@ -20,7 +20,7 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           ?PORT_REQUEST_MACROS
-          ++ ?ACCOUNT_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
          )
        ).
 

--- a/applications/teletype/src/templates/teletype_port_request.erl
+++ b/applications/teletype/src/templates/teletype_port_request.erl
@@ -17,7 +17,12 @@
 -define(TEMPLATE_ID, <<"port_request">>).
 -define(MOD_CONFIG_CAT, <<(?NOTIFY_CONFIG_CAT)/binary, ".", (?TEMPLATE_ID)/binary>>).
 
--define(TEMPLATE_MACROS, kz_json:from_list(?PORT_REQUEST_MACROS ++ ?ACCOUNT_MACROS)).
+-define(TEMPLATE_MACROS
+       ,kz_json:from_list(
+          ?PORT_REQUEST_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
+         )
+       ).
 
 -define(TEMPLATE_SUBJECT, <<"Number port request for account '{{account.name}}'">>).
 -define(TEMPLATE_CATEGORY, <<"port_request">>).

--- a/applications/teletype/src/templates/teletype_port_request_admin.erl
+++ b/applications/teletype/src/templates/teletype_port_request_admin.erl
@@ -20,7 +20,7 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           ?PORT_REQUEST_MACROS
-          ++ ?ACCOUNT_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
          )
        ).
 

--- a/applications/teletype/src/templates/teletype_port_scheduled.erl
+++ b/applications/teletype/src/templates/teletype_port_scheduled.erl
@@ -20,7 +20,7 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           ?PORT_REQUEST_MACROS
-          ++ ?ACCOUNT_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
          )
        ).
 

--- a/applications/teletype/src/templates/teletype_port_unconfirmed.erl
+++ b/applications/teletype/src/templates/teletype_port_unconfirmed.erl
@@ -20,7 +20,7 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           ?PORT_REQUEST_MACROS
-          ++ ?ACCOUNT_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
          )
        ).
 

--- a/applications/teletype/src/templates/teletype_ported.erl
+++ b/applications/teletype/src/templates/teletype_ported.erl
@@ -18,7 +18,10 @@
 -define(MOD_CONFIG_CAT, <<(?NOTIFY_CONFIG_CAT)/binary, ".", (?TEMPLATE_ID)/binary>>).
 
 -define(TEMPLATE_MACROS
-       ,kz_json:from_list(?PORT_REQUEST_MACROS ++ ?ACCOUNT_MACROS)
+       ,kz_json:from_list(
+          ?PORT_REQUEST_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Number port request '{{port_request.name}}' completed">>).

--- a/applications/teletype/src/templates/teletype_service_added.erl
+++ b/applications/teletype/src/templates/teletype_service_added.erl
@@ -25,8 +25,10 @@
           ,?MACRO_VALUE(<<"sub_account.language">>, <<"sub_account_language">>, <<"Sub-Account Language">>, <<"Sub-Account Language">>)
           ,?MACRO_VALUE(<<"sub_account.timezone">>, <<"sub_account_timezone">>, <<"Sub-Account Timezone">>, <<"Sub-Account Timezone">>)
           ,?MACRO_VALUE(<<"service_changes">>, <<"service_changes">>, <<"Sub-Account Service Changes object">>, <<"Sub-Account Service Changes object">>)
-           | ?ACCOUNT_MACROS ++ ?USER_MACROS
-          ])
+           | ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"New VoIP services were added to sub-account '{{sub_account.name}}'">>).

--- a/applications/teletype/src/templates/teletype_system_alert.erl
+++ b/applications/teletype/src/templates/teletype_system_alert.erl
@@ -20,8 +20,10 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           [?MACRO_VALUE(<<"message">>, <<"message">>, <<"Message">>, <<"System message">>)
-           | ?ACCOUNT_MACROS ++ ?USER_MACROS
-          ])
+           | ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"System Alert: '{{request.level}}' from '{{request.node}}'">>).

--- a/applications/teletype/src/templates/teletype_template_skel.erl
+++ b/applications/teletype/src/templates/teletype_template_skel.erl
@@ -19,7 +19,8 @@
 
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
-          ?ACCOUNT_MACROS ++ ?USER_MACROS
+          ?USER_MACROS
+          ++ ?COMMON_TEMPLATE_MACROS
          )
        ).
 

--- a/applications/teletype/src/templates/teletype_topup.erl
+++ b/applications/teletype/src/templates/teletype_topup.erl
@@ -21,8 +21,8 @@
        ,kz_json:from_list(
           [?MACRO_VALUE(<<"balance">>, <<"balance">>, <<"Balance">>, <<"The Resulting Account Balance">>)
            | ?TRANSACTION_MACROS
-           ++ ?ACCOUNT_MACROS
            ++ ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
           ]
          )
        ).

--- a/applications/teletype/src/templates/teletype_transaction.erl
+++ b/applications/teletype/src/templates/teletype_transaction.erl
@@ -25,9 +25,10 @@
           ,?MACRO_VALUE(<<"plan.item">>, <<"plan_item">>, <<"Plan Item">>, <<"Plan Item">>)
           ,?MACRO_VALUE(<<"plan.activation_charge">>, <<"plan_activation_charge">>, <<"Activation Charge">>, <<"Activiation Charge">>)
            | ?TRANSACTION_MACROS
-           ++ ?ACCOUNT_MACROS
            ++ ?USER_MACROS
-          ])
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(SUCCESS_TEMPLATE_SUBJECT, <<"Receipt for your payment of account '{{account.name}}'">>).

--- a/applications/teletype/src/templates/teletype_voicemail_full.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_full.erl
@@ -24,8 +24,10 @@
           ,?MACRO_VALUE(<<"voicemail.mailbox">>, <<"mailbox">>, <<"Voicemail Box Number">>, <<"Number of the voicemail box">>)
           ,?MACRO_VALUE(<<"voicemail.max_messages">>, <<"max_messages">>, <<"Maximum Messages">>, <<"The maximum number of messages this box can hold">>)
           ,?MACRO_VALUE(<<"voicemail.message_count">>, <<"message_count">>, <<"Message Count">>, <<"The current number of messages in the voicemail box">>)
-           | ?ACCOUNT_MACROS ++ ?USER_MACROS
-          ])
+           | ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Voicemail box '{{voicemail.name}}' is full">>).

--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -27,8 +27,11 @@
           ,?MACRO_VALUE(<<"voicemail.file_name">>, <<"voicemail_file_name">>, <<"Voicemail File Name">>, <<"Name of the voicemail file">>)
           ,?MACRO_VALUE(<<"voicemail.file_type">>, <<"voicemail_file_type">>, <<"Voicemail File Type">>, <<"Type of the voicemail file">>)
           ,?MACRO_VALUE(<<"voicemail.file_size">>, <<"voicemail_file_size">>, <<"Voicemail File Size">>, <<"Size of the voicemail file in bytes">>)
-           | ?DEFAULT_CALL_MACROS ++ ?ACCOUNT_MACROS ++ ?USER_MACROS
-          ])
+           | ?DEFAULT_CALL_MACROS
+           ++ ?USER_MACROS
+           ++ ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"New voicemail from {{caller_id.name}} ({{caller_id.number}})">>).

--- a/applications/teletype/src/templates/teletype_webhook_disabled.erl
+++ b/applications/teletype/src/templates/teletype_webhook_disabled.erl
@@ -24,8 +24,9 @@
           ,?MACRO_VALUE(<<"hook.uri">>, <<"hook_uri">>, <<"Hook URI">>, <<"Hook URI">>)
           ,?MACRO_VALUE(<<"hook.event">>, <<"hook_event">>, <<"Hook Event">>, <<"Hook Event">>)
           ,?MACRO_VALUE(<<"hook.disable_reason">>, <<"hook_disable_reason">>, <<"Disable Reason">>, <<"Why the hook was disabled">>)
-           | ?ACCOUNT_MACROS
-          ])
+           | ?COMMON_TEMPLATE_MACROS
+          ]
+         )
        ).
 
 -define(TEMPLATE_SUBJECT, <<"Webhook '{{hook.name}}' auto-disabled">>).


### PR DESCRIPTION
Add node to the `system` macro in teletype with encoded version (same for hostname) to allow track the sender server without revealing the name.