### PR TITLE
MWI function fix

### DIFF
--- a/applications/omnipresence/src/omnip_subscriptions.erl
+++ b/applications/omnipresence/src/omnip_subscriptions.erl
@@ -453,7 +453,7 @@ subscribe(#omnip_subscription{user=_U
                              ,call_id=CallId
                              ,stalker=Stalker
                              ,contact=Contact
-                             ,normalized_user=User
+                             ,username=Username
                              ,realm=Realm
                              ,event=Event
                              }=S) ->
@@ -471,11 +471,11 @@ subscribe(#omnip_subscription{user=_U
                                ,{#omnip_subscription.stalker, Stalker}
                                ,{#omnip_subscription.contact, Contact}
                                ]),
-            gen_server:cast(self(), {'after', {'resubscribe', {Event, User, Realm, CallId}}});
+            gen_server:cast(self(), {'after', {'resubscribe', {Event, Username, Realm, CallId}}});
         {'error', 'not_found'} ->
             lager:debug("subscribe ~s/~s/~s expires in ~ps", [_U, _F, CallId, E1]),
             ets:insert(table_id(), S),
-            gen_server:cast(self(), {'after', {'subscribe', {Event, User, Realm, CallId}}})
+            gen_server:cast(self(), {'after', {'subscribe', {Event, Username, Realm, CallId}}})
     end.
 
 -spec notify(kz_json:object()) -> 'ok' | {'error', any()}.
@@ -526,15 +526,15 @@ exec([Fun|Funs], Reason, Msg) ->
     exec(Funs, Reason, Msg).
 
 -spec maybe_probe(atom(), msg()) -> 'ok'.
-maybe_probe(_, {<<"message-summary">> = Package, User, Realm, _}) ->
-    omnip_util:request_probe(Package, User, Realm);
-maybe_probe(_, {<<"dialog">>, <<"*", _/binary>> = User, Realm, _}) ->
+maybe_probe(_, {<<"message-summary">> = Package, Username, Realm, _}) ->
+    omnip_util:request_probe(Package, Username, Realm);
+maybe_probe(_, {<<"dialog">>, <<"*", _/binary>> = Username, Realm, _}) ->
     case kapps_util:get_account_by_realm(Realm) of
         {'ok', Account} ->
             VM = ?VM_NUMBER(kz_util:format_account_id(Account)),
             S = size(VM),
-            case User of
-                <<VM:S/binary, New/binary>> -> omnip_util:request_probe(<<"message-summary">>, New);
+            case Username of
+                <<VM:S/binary, New/binary>> -> omnip_util:request_probe(<<"message-summary">>, New, Realm);
                 _ -> 'ok'
             end;
         _ -> 'ok'


### PR DESCRIPTION
`omnip_util:request_probe(Package, Username, Realm)`  was being called with value `user` instead of `username` which contains `username@realm` so the function was changed to `omnip_util:request_probe(Package, User)`