### PR TITLE
User Item name and Quantity for Qpaque billing

### DIFF
--- a/applications/crossbar/priv/couchdb/account/services.json
+++ b/applications/crossbar/priv/couchdb/account/services.json
@@ -7,7 +7,7 @@
             "reduce": "_sum"
         },
         "opaque_billing": {
-            "map": "function(doc) { if(!doc.billing || doc.pvt_deleted) return; for (index in doc.billing) emit( index, doc.billing[index] ); }",
+            "map": "function(doc) { if(!doc.billing || doc.pvt_deleted) return; for (index in doc.billing)  if (doc.billing[index].item) { emit( doc.billing[index].item, doc.billing[index].quantity ); } else { emit( index, doc.billing[index] ); } }",
             "reduce": "_sum"
         },
         "users": {


### PR DESCRIPTION
At the moment opaque billing keeps track of items with just index numbers, this change will allow future `billing` object to have item name and quantity

````json
"billing": [
            {
             "item":"feature1",
             "quantity":5
             },
            {
             "item":"service1",
             "quantity":2
             }
]
````