### PR TITLE
Count M:F/A across the project or within an application

### DIFF
--- a/core/kazoo_ast/README.org
+++ b/core/kazoo_ast/README.org
@@ -27,3 +27,13 @@ Similar to `cb_api_endpoints`, the next step is to make this an escript that run
 This module looks in all Kazoo Erlang application modules for calls to kapps_config (docs in the `system_config` database) getters. Similar to `cf_data_usage`, `kapps_config_usage` will create schemas if missing, update existing schemas, guess types, and include defaults if appropriate.
 
 It also builds schemas for account config documents (account-overrides of system_config parameters).
+*** code_usage
+
+This module looks across the project for function call usage. It counts M:F/A and M:F(Args) instances (counting the length of Args to get arity) in the AST. The printer then takes an optional argument to print the Top hits.
+
+#+BEGIN_EXAMPLE
+`code_usage:tabulate()`: print the top 25 M:F/A across the project
+`code_usage:tabulate(50)`: print the top 50 M:F/A across the project
+`code_usage:tabulate(crossbar)`: print the top 25 M:F/A in Crossbar
+`code_usage:tabulate(crossbar, 50)`: print the top 50 M:F/A in Crossbar
+#+END_EXAMPLE

--- a/core/kazoo_ast/src/code_usage.erl
+++ b/core/kazoo_ast/src/code_usage.erl
@@ -1,0 +1,75 @@
+-module(code_usage).
+
+-export([process/0, process/1
+        ,tabulate/0, tabulate/1
+        ]).
+
+-include_lib("kazoo_ast/include/kz_ast.hrl").
+
+-define(DEFAULT_TOP, 25).
+
+-spec tabulate() -> 'ok'.
+-spec tabulate(atom() | pos_integer()) -> 'ok'.
+-spec tabulate(atom(), pos_integer()) -> 'ok'.
+tabulate() ->
+    print_usage(process(), ?DEFAULT_TOP).
+
+tabulate(App) when is_atom(App) ->
+    tabulate(App, ?DEFAULT_TOP);
+tabulate(Top) when is_integer(Top)
+                   andalso Top > 0 ->
+    print_usage(process(), Top).
+
+tabulate(App, Top) when is_atom(App)
+                        andalso is_integer(Top)
+                        andalso Top > 0 ->
+    print_usage(process(App), Top).
+
+-define(PRINT(Args), io:format("~6.6s | ~s~n", Args)).
+
+print_usage(Dict, Top) ->
+    Sorted = sort_and_truncate_dict(Dict, Top),
+    ?PRINT(["Count", "M:F/A"]),
+    [?PRINT([integer_to_list(Count), MFA])
+     || {MFA, Count} <- Sorted
+    ],
+    'ok'.
+
+sort_and_truncate_dict(Dict, Top) ->
+    Sorted = lists:keysort(2, dict:to_list(Dict)),
+    {TopL, _} = lists:split(Top, lists:reverse(Sorted)),
+    TopL.
+
+-define(OPTIONS, [{'expression', fun count_mfa/2}
+                 ,{'module', fun print_dot/2}
+                 ,{'accumulator', dict:new()}
+                 ]).
+
+-spec process() -> map().
+process() ->
+    io:format("process mfa counts: "),
+    Usage = kazoo_ast:walk_project(?OPTIONS),
+    io:format(" done~n", []),
+    Usage.
+
+-spec process(atom()) -> map().
+process(App) ->
+    io:format("process mfa counts in ~s: ", [App]),
+    Usage = kazoo_ast:walk_app(App, ?OPTIONS),
+    io:format(" done~n", []),
+    Usage.
+
+print_dot(_M, Acc) ->
+    io:format(".", []),
+    Acc.
+
+count_mfa(?MOD_FUN_ARGS(M, F, Args), Acc) ->
+    A = length(Args),
+    count_mfa(M, F, A, Acc);
+count_mfa(?MFA(M, F, A), Acc) ->
+    count_mfa(M, F, A, Acc);
+count_mfa(_Expr, Acc) -> Acc.
+
+count_mfa(M, F, A, Dict) ->
+    MFA = io_lib:format("~s:~s/~p", [M, F, A]),
+    dict:update_counter(MFA, 1, Dict).

--- a/core/kazoo_ast/src/code_usage.erl
+++ b/core/kazoo_ast/src/code_usage.erl
@@ -45,14 +45,14 @@ sort_and_truncate_dict(Dict, Top) ->
                  ,{'accumulator', dict:new()}
                  ]).
 
--spec process() -> map().
+-spec process() -> dict:dict().
 process() ->
     io:format("process mfa counts: "),
     Usage = kazoo_ast:walk_project(?OPTIONS),
     io:format(" done~n", []),
     Usage.
 
--spec process(atom()) -> map().
+-spec process(atom()) -> dict:dict().
 process(App) ->
     io:format("process mfa counts in ~s: ", [App]),
     Usage = kazoo_ast:walk_app(App, ?OPTIONS),


### PR DESCRIPTION
For now, just counts literal usage of the M:F/A (no dynamic M or F). Could be nice to add more functions that analyze the counts, or unwrap Kazoo M:F/A until an Erlang/OTP module is encountered. Could also look at other code analysis tooling to see what they look for and adapt here.