### PR TITLE
Fix create number with auth_by system

### DIFF
--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -249,6 +249,8 @@ ensure_can_create(Num, Options) ->
 -endif.
 
 -spec allow_number_additions(knm_number_options:options(), ne_binary()) -> boolean().
+allow_number_additions(_Options, ?KNM_DEFAULT_AUTH_BY) ->
+    'true';
 allow_number_additions(_Options, _AccountId) ->
     {'ok', JObj} = ?LOAD_ACCOUNT(_Options, _AccountId),
     kz_account:allow_number_additions(JObj).


### PR DESCRIPTION
Creating a number authorised by system currently crashes with the following stacktrace:

```
02:23:28.322 warning kzs_util.86 unknown type for database account%2Fsy%2Fst%2Fem
02:23:28.322 error kz_util.108 stacktrace:
02:23:28.323 error kz_util.120 st: kzs_util:db_classification/1 at (87)
02:23:28.323 error kz_util.120 st: kzs_plan:get_dataplan/1 at (70)
02:23:28.323 error kz_util.120 st: kzs_plan:plan/2 at (47)
02:23:28.323 error kz_util.120 st: kz_datamgr:open_doc/3 at (631)
02:23:28.323 error kz_util.120 st: kzs_cache:open_cache_doc/3 at (52)
02:23:28.323 error kz_util.120 st: knm_number:allow_number_additions/2 at (253)
02:23:28.323 error kz_util.120 st: knm_number:allowed_creation_states/2 at (171)
02:23:28.326 error kazoo_bindings.692 excepted: error: {badmatch,{error,not_found}}
02:23:28.326 error kz_util.108 stacktrace:
02:23:28.326 error kz_util.120 st: knm_number:allow_number_additions/2 at (253)
02:23:28.326 error kz_util.120 st: knm_number:allowed_creation_states/2 at (171)
02:23:28.326 error kz_util.120 st: knm_number:state_for_create/1 at (157)
02:23:28.326 error kz_util.120 st: knm_numbers:create/2 at (307)
02:23:28.326 error kz_util.120 st: knm_number:create/2 at (143)
02:23:28.326 error kz_util.120 st: cb_purchase_numbers:create_number_kazoo/2 at (291)
02:23:28.326 error kz_util.120 st: lists:foreach/2 at (1338)
```

This fixes that issue.