### PR TITLE
and-you-get-a-rel: decare a release per kapp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,14 @@ clean-release:
 
 build-release: $(RELX) clean-release rel/relx.config rel/vm.args
 	$(RELX) --config rel/relx.config -V 2 release --relname 'kazoo'
-	patch _rel/kazoo/bin/kazoo -i rel/relx.patch
+	patch _rel/'kazoo'/bin/'kazoo' -i rel/relx.patch
+build-all-release: build-release
+	for path in applications/*/; do \
+	  app=$$(echo $$path | cut -d/ -f2) ; \
+	  if [ $$app = 'skel' ]; then continue; fi ; \
+	  $(RELX) --config rel/relx.config -V 2 release --relname $$app ; \
+	  patch _rel/$$app/bin/$$app -i rel/relx.patch ; \
+	done
 build-dev-release: $(RELX) clean-release rel/relx.config-dev rel/vm.args
 	$(RELX) --dev-mode true --config rel/relx.config -V 2 release --relname 'kazoo'
 	patch _rel/kazoo/bin/kazoo -i rel/relx.patch

--- a/rel/relx.config.src
+++ b/rel/relx.config.src
@@ -4,28 +4,21 @@ Apps = [list_to_atom(App)  || "applications/"++App = Dir <- filelib:wildcard("ap
 Core = [list_to_atom(App)  ||         "core/"++App = Dir <- filelib:wildcard(        "core/*"), filelib:is_dir(Dir)],
 Deps = [list_to_atom(App)  ||         "deps/"++App = Dir <- filelib:wildcard(        "deps/*"), filelib:is_dir(Dir)],
 
-Filter = 
-case os:getenv("KAZOO_DEV") of
-    false ->
-        [
-         'rabbitmq_codegen'
-        ,'.erlang.mk'
-        ,'.settings'
-        ,'skel'
-        ,'parse_trans'
-        ,'fs_sync'
-        ,'fs_event'
-        ,'reloader'
-        ];
-    _ ->
-        [
-         'rabbitmq_codegen'
-        ,'.erlang.mk'
-        ,'.settings'
-        ,'skel'
-        ,'parse_trans'
-        ]
-end,
+ToFilterOut = [rabbitmq_codegen
+              ,'.erlang.mk'
+              ,'.settings'
+              ,skel
+              ,parse_trans
+              ]
+++ case os:getenv("KAZOO_DEV") of
+       Str when is_list(Str) ->
+           [fs_sync
+           ,fs_event
+           ,reloader
+           ];
+       false -> []
+   end,
+Preparer = fun (List) -> [{E,load} || E <- List, not lists:member(E, ToFilterOut)] end,
 Base = lists:filter(fun(A) -> not lists:member(A, Filter) end, Apps ++ Core ++ Deps),
 Based = [{A, 'load'} || A <- lists:sort(Base)],
 Included = [runtime_tools
@@ -51,7 +44,11 @@ end ++
 ,{vm_args, "rel/vm.args"}
 
 ,{release, {kazoo,"4.0.0"}
- ,Included ++ Based
+ ,Included ++ Preparer(Apps ++ Core ++ Deps)
  }
-
-].
+]
+++ [{release, {list_to_atom("kazoo_" ++ App), "4.0.0"}
+    ,Included ++ Preparer([App] ++ Core ++ Deps)
+    }
+    || App <- Apps
+   ].

--- a/rel/relx.config.src
+++ b/rel/relx.config.src
@@ -19,12 +19,10 @@ ToFilterOut = [rabbitmq_codegen
        false -> []
    end,
 Preparer = fun (List) -> [{E,load} || E <- List, not lists:member(E, ToFilterOut)] end,
-Base = lists:filter(fun(A) -> not lists:member(A, Filter) end, Apps ++ Core ++ Deps),
-Based = [{A, 'load'} || A <- lists:sort(Base)],
-Included = [runtime_tools
-           ,wx
-           ,observer
-           ],
+Base = [runtime_tools
+       ,wx
+       ,observer
+       ],
 
 Config = "/etc/kazoo/app.config", %% SHOULD rename app.config to sys.config as OTP prefers it.
 case filelib:is_regular(Config) of
@@ -43,12 +41,14 @@ end ++
 
 ,{vm_args, "rel/vm.args"}
 
+,{default_release, kazoo, "4.0.0"}
 ,{release, {kazoo,"4.0.0"}
- ,Included ++ Preparer(Apps ++ Core ++ Deps)
+ ,Base ++ Preparer(Apps ++ Core ++ Deps)
  }
 ]
-++ [{release, {list_to_atom("kazoo_" ++ App), "4.0.0"}
-    ,Included ++ Preparer([App] ++ Core ++ Deps)
+++ [{release, {App, "4.0.0"}
+    ,Base ++ Preparer([App] ++ Core ++ Deps)
     }
-    || App <- Apps
+    || App <- Apps,
+       App =/= skel
    ].


### PR DESCRIPTION
This was intended to find inter-kapps dependencies. Turns out Relx does not verify that all modules bundled in a release are reachable.
I thought this could be useful in the future so here it is.