### PR TITLE
also format jsons when compiling tests

### DIFF
--- a/make/kz.mk
+++ b/make/kz.mk
@@ -68,7 +68,7 @@ json:
 	@$(ROOT)/scripts/format-json.sh $(JSON)
 
 
-compile-test: clean-test $(COMPILE_MOAR) test/$(PROJECT).app
+compile-test: clean-test $(COMPILE_MOAR) test/$(PROJECT).app json
 
 test/$(PROJECT).app: ERLC_OPTS += -DTEST
 test/$(PROJECT).app: $(TEST_SOURCES)


### PR DESCRIPTION
With this change, `compile-test` now mirrors the behavior of `compile`.