### PR TITLE
PISTON-459: if all resources have Bypass-Media, still set bypass_media=true

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_bridge.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_bridge.erl
@@ -159,19 +159,15 @@ handle_bypass_media(DP, _Node, _UUID, #channel{profile=ChannelProfile}, JObj) ->
 
 -spec maybe_bypass_endpoint_media(kz_json:objects(), ne_binary(), ne_binary(), kz_proplist()) -> kz_proplist().
 maybe_bypass_endpoint_media(Endpoints, BridgeProfile, ChannelProfile, DP) ->
-    BypassOnAll = lists:foldl(fun(EP, 'none') ->
-                                      case bypass_endpoint_media_enabled(EP, BridgeProfile, ChannelProfile) of
-                                          'true' -> 'true';
-                                          'false' -> 'none'
-                                      end;
-                                 (EP, BypassOnAll1) ->
-                                      BypassOnAll1
-                                          andalso bypass_endpoint_media_enabled(EP, BridgeProfile, ChannelProfile)
-                              end, 'none', Endpoints),
-    case BypassOnAll of
+    ShouldBypass = lists:all(fun(Endpoint) ->
+                                     bypass_endpoint_media_enabled(Endpoint
+                                                                  ,BridgeProfile
+                                                                  ,ChannelProfile
+                                                                  )
+                             end, Endpoints),
+    case ShouldBypass of
         'true' -> [{"application", "set bypass_media=true"}|DP];
-        'false' -> DP;
-        'none' -> DP
+        'false' -> DP
     end.
 
 -spec bypass_endpoint_media_enabled(kz_json:object(), ne_binary(), ne_binary()) -> boolean().

--- a/applications/ecallmgr/src/ecallmgr_fs_bridge.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_bridge.erl
@@ -172,7 +172,7 @@ maybe_bypass_endpoint_media(Endpoints, BridgeProfile, ChannelProfile, DP) ->
 
 -spec bypass_endpoint_media_enabled(kz_json:object(), ne_binary(), ne_binary()) -> boolean().
 bypass_endpoint_media_enabled(Endpoint, BridgeProfile, ChannelProfile) ->
-    EndpointProfile = kz_json:get_value(<<"SIP-Interface">>, Endpoint, BridgeProfile),
+    EndpointProfile = kz_json:get_ne_binary_value(<<"SIP-Interface">>, Endpoint, BridgeProfile),
     kz_json:is_true(<<"Bypass-Media">>, Endpoint)
         andalso EndpointProfile =:= ChannelProfile.
 


### PR DESCRIPTION
Previous version of this function would only enable bypass_media if there was a single endpoint and Bypass-Media was enabled on it. New version enables bypass_media as long as _all_ endpoints have Bypass-Media set to true.