### PR TITLE
Add previously failing test and update jesse dep location

### DIFF
--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -896,4 +896,4 @@ fix_path(Path) ->
 -spec fix_el(kz_json:key() | non_neg_integer()) -> kz_json:key() | non_neg_integer().
 fix_el(I) when is_integer(I) -> I+1;
 fix_el(El) -> El.
-    
+

--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -33,7 +33,7 @@
 -define(DEFAULT_OPTIONS, [{'schema_loader_fun', fun load/1}
                          ,{'allowed_errors', 'infinity'}
                          ,{'extra_validator', fun kz_json_schema_extensions:extra_validator/2}
-                         ,{'setter_fun', fun kz_json:set_value/3}
+                         ,{'setter_fun', fun set_value/3}
                          ,{'validator_options', ['use_defaults'
                                                 ,'apply_defaults_to_empty_objects'
                                                 ]}
@@ -882,3 +882,18 @@ filter(JObj, Schema) ->
                                  ,kz_json:flatten(JObj)
                                  ),
     kz_json:expand(FilteredFlat).
+
+set_value(Path, Value, JObj) ->
+    FixedPath = fix_path(Path),
+    kz_json:set_value(FixedPath, Value, JObj).
+
+-spec fix_path(kz_json:path()) -> kz_json:path().
+fix_path(Path) ->
+    [fix_el(El) || El <- Path].
+
+%% JSON array indicies are 0-indexed, Erlang's are 1-indexed
+%% If an indicie is found, convert (incr) from JSON- to Erlang-based indicie
+-spec fix_el(kz_json:key() | non_neg_integer()) -> kz_json:key() | non_neg_integer().
+fix_el(I) when is_integer(I) -> I+1;
+fix_el(El) -> El.
+    

--- a/core/kazoo_schemas/test/kz_json_schema_test.erl
+++ b/core/kazoo_schemas/test/kz_json_schema_test.erl
@@ -187,6 +187,7 @@ did_duplication_test() ->
     {'ok', Schema} = kz_json_schema:fload(<<"connectivity">>),
 
     {'ok', Valid} = kz_json_schema:validate(Schema, JObj),
+
     ?assertEqual(name_and_did(JObj), name_and_did(Valid)).
 
 name_and_did(JObj) ->

--- a/core/kazoo_schemas/test/kz_json_schema_test.erl
+++ b/core/kazoo_schemas/test/kz_json_schema_test.erl
@@ -164,3 +164,32 @@ flatten_sms_schema_test() ->
                            {[<<"outbound">>,<<"options">>,<<"description">>], <<"sms options">>},
                            {[<<"outbound">>,<<"options">>,<<"type">>],<<"object">>}]
                          })].
+
+did_duplication_test() ->
+    SrvA = kz_json:from_list([{<<"DIDs">>,kz_json:new()}
+                             ,{<<"auth">>, kz_json:from_list([{<<"auth_method">>, <<"password">>}])}
+                             ,{<<"server_name">>,<<"AAA1">>}
+                             ]
+                            ),
+    SrvB = kz_json:from_list([{<<"DIDs">>,kz_json:new()}
+                             ,{<<"auth">>, kz_json:from_list([{<<"auth_method">>, <<"password">>}])}
+                             ,{<<"server_name">>,<<"BBB1">>}
+                             ]
+                            ),
+    SrvC = kz_json:from_list([{<<"DIDs">>,{[{<<"+78121111111">>,kz_json:new()}]}}
+                             ,{<<"auth">>, kz_json:from_list([{<<"auth_method">>, <<"password">>}])}
+                             ,{<<"server_name">>,<<"CCC1">>}
+                             ]
+                            ),
+
+    JObj = kz_json:from_list([{<<"servers">>, [SrvA, SrvB, SrvC]}]),
+
+    {'ok', Schema} = kz_json_schema:fload(<<"connectivity">>),
+
+    {'ok', Valid} = kz_json_schema:validate(Schema, JObj),
+    ?assertEqual(name_and_did(JObj), name_and_did(Valid)).
+
+name_and_did(JObj) ->
+    [{kz_json:get_value(<<"server_name">>, Server), kz_json:get_value(<<"DIDs">>, Server)}
+     || Server <- kz_json:get_value(<<"servers">>, JObj)
+    ].

--- a/core/kazoo_schemas/test/kz_json_schema_test.erl
+++ b/core/kazoo_schemas/test/kz_json_schema_test.erl
@@ -191,6 +191,8 @@ did_duplication_test() ->
     ?assertEqual(name_and_did(JObj), name_and_did(Valid)).
 
 name_and_did(JObj) ->
-    [{kz_json:get_value(<<"server_name">>, Server), kz_json:get_value(<<"DIDs">>, Server)}
+    [{kz_json:get_value(<<"server_name">>, Server)
+     ,kz_json:is_empty(kz_json:get_json_value(<<"DIDs">>, Server))
+     }
      || Server <- kz_json:get_value(<<"servers">>, JObj)
     ].

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -63,10 +63,8 @@ dep_couchbeam = git https://github.com/2600hz/couchbeam 1.4.1a
 ### https://github.com/benoitc/couchbeam/pull/164
 ### https://github.com/benoitc/couchbeam/pull/165
 
-##dep_jesse = git https://github.com/for-GET/jesse 1.4.0
-## pull request pending
-## https://github.com/for-GET/jesse/pull/42
-dep_jesse = git https://github.com/2600hz/jesse 1.5-rc5
+##dep_jesse = git https://github.com/2600hz/jesse 1.5-rc5
+dep_jesse = git https://github.com/for-GET/jesse 1.5.0-rc2
 
 dep_lager = git https://github.com/erlang-lager/lager 3.2.1
 dep_trie = git https://github.com/okeuday/trie v1.5.4

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -63,8 +63,8 @@ dep_couchbeam = git https://github.com/2600hz/couchbeam 1.4.1a
 ### https://github.com/benoitc/couchbeam/pull/164
 ### https://github.com/benoitc/couchbeam/pull/165
 
-##dep_jesse = git https://github.com/2600hz/jesse 1.5-rc5
-dep_jesse = git https://github.com/for-GET/jesse 1.5.0-rc2
+dep_jesse = git https://github.com/2600hz/jesse 1.5-rc6
+##dep_jesse = git https://github.com/for-GET/jesse 1.5.0-rc2
 
 dep_lager = git https://github.com/erlang-lager/lager 3.2.1
 dep_trie = git https://github.com/okeuday/trie v1.5.4


### PR DESCRIPTION
With the 2600Hz branch of jesse, the supplied test would fail. Pointing to the 1.5 rc2 in the for-GET repo causes the test to pass successfully.