### PR TITLE
Create admin user

### DIFF
--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -493,7 +493,7 @@ db_exists(Database, ShouldRetry) ->
 validate_account(JObj, Context) ->
     Payload = [cb_context:setters(Context
                                  ,[{fun cb_context:set_req_data/2, JObj}
-                                  ,{fun cb_context:set_req_nouns/2, [{?KZ_ACCOUNTS_DB, []}]}
+                                  ,{fun cb_context:set_req_nouns/2, [{<<"accounts">>, []}]}
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
                                   ,{fun cb_context:set_resp_status/2, 'fatal'}
                                   ])
@@ -518,9 +518,12 @@ validate_account(JObj, Context) ->
 validate_user(JObj, Context) ->
     Payload = [cb_context:setters(Context
                                  ,[{fun cb_context:set_req_data/2, JObj}
-                                  ,{fun cb_context:set_req_nouns/2, [{?KZ_ACCOUNTS_DB, []}]}
+                                  ,{fun cb_context:set_req_nouns/2, [{<<"users">>, []}
+                                                                    ,{<<"accounts">>, [cb_context:account_id(Context)]}
+                                                                    ]}
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
                                   ,{fun cb_context:set_resp_status/2, 'fatal'}
+                                  ,{fun cb_context:set_doc/2, 'undefined'}
                                   ]
                                  )
               ],

--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -496,6 +496,7 @@ validate_account(JObj, Context) ->
                                   ,{fun cb_context:set_req_nouns/2, [{<<"accounts">>, []}]}
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
                                   ,{fun cb_context:set_resp_status/2, 'fatal'}
+                                  ,{fun cb_context:set_api_version/2, ?VERSION_2}
                                   ])
               ],
     Context1 = crossbar_bindings:fold(<<"v2_resource.validate.accounts">>, Payload),
@@ -524,6 +525,7 @@ validate_user(JObj, Context) ->
                                   ,{fun cb_context:set_req_verb/2, ?HTTP_PUT}
                                   ,{fun cb_context:set_resp_status/2, 'fatal'}
                                   ,{fun cb_context:set_doc/2, 'undefined'}
+                                  ,{fun cb_context:set_resp_data/2, 'undefined'}
                                   ]
                                  )
               ],


### PR DESCRIPTION
With changes to how PATCH worked, the _rev from the account creation step would be set on the admin user doc. This clears out the 'doc' portion of the context so the user's doc doesn't pick up account-related pvt fields.