### PR TITLE
PISTON-460: truncate DTMF after terminators in early DTMF before cf_collect_dtmf

### DIFF
--- a/applications/callflow/src/module/cf_collect_dtmf.erl
+++ b/applications/callflow/src/module/cf_collect_dtmf.erl
@@ -36,8 +36,9 @@ handle(Data, Call) ->
             'undefined' -> <<>>;
             <<_/binary>> = D -> D
         end,
+    AlreadyCollected1 = truncate_after_terminator(AlreadyCollected, terminators(Data)),
 
-    maybe_collect_more_digits(Data, kapps_call:set_dtmf_collection('undefined', Call), AlreadyCollected).
+    maybe_collect_more_digits(Data, kapps_call:set_dtmf_collection('undefined', Call), AlreadyCollected1).
 
 -spec maybe_collect_more_digits(kz_json:object(), kapps_call:call(), binary()) -> 'ok'.
 maybe_collect_more_digits(Data, Call, AlreadyCollected) ->
@@ -77,6 +78,10 @@ collect_more_digits(Data, Call, AlreadyCollected, MaxDigits) ->
         {'error', _E} ->
             lager:debug("failed to collect DTMF: ~p", [_E])
     end.
+
+-spec truncate_after_terminator(binary(), ne_binaries()) -> binary().
+truncate_after_terminator(AlreadyCollected, Terminators) ->
+    hd(binary:split(AlreadyCollected, Terminators, ['global'])).
 
 -spec collection_name(kz_json:object()) -> ne_binary().
 collection_name(Data) ->

--- a/applications/callflow/src/module/cf_collect_dtmf.erl
+++ b/applications/callflow/src/module/cf_collect_dtmf.erl
@@ -81,7 +81,7 @@ collect_more_digits(Data, Call, AlreadyCollected, MaxDigits) ->
 
 -spec truncate_after_terminator(binary(), ne_binaries()) -> binary().
 truncate_after_terminator(AlreadyCollected, Terminators) ->
-    hd(binary:split(AlreadyCollected, Terminators, ['global'])).
+    hd(binary:split(AlreadyCollected, Terminators)).
 
 -spec collection_name(kz_json:object()) -> ne_binary().
 collection_name(Data) ->


### PR DESCRIPTION
While cf_collect_dtmf was already checking whether the max number of DTMF digits were entered early via kapps_call:get_dtmf_collection/1, it wasn't checking if the digits contained terminators.

We were getting odd cases where despite '#' being a terminator, it was appearing in the collected DTMF after this module. The culprit was the passing the length check without honouring the terminator.

After this PR, if a terminator is found in early DTMF, it is ignored, and subsequent digits are truncated.