### PR TITLE
Update build-autocomplete.escript

### DIFF
--- a/core/sup/priv/build-autocomplete.escript
+++ b/core/sup/priv/build-autocomplete.escript
@@ -16,6 +16,7 @@
                           ,"kapps_account_config"
                           ,"kapps_config"
                           ,"kapps_controller"
+                          "kz_datamgr"
                           ]).
 
 %% API

--- a/core/sup/priv/build-autocomplete.escript
+++ b/core/sup/priv/build-autocomplete.escript
@@ -16,7 +16,7 @@
                           ,"kapps_account_config"
                           ,"kapps_config"
                           ,"kapps_controller"
-                          "kz_datamgr"
+                          ,"kz_datamgr"
                           ]).
 
 %% API


### PR DESCRIPTION
Add kz_datamgr module to build sup command list escript.

I find this script useful for building a list of sup commands.  Are there any other useful modules that should be added?