### PR TITLE
PISTON-461: Callflow module for flushing early DTMF collection

### DIFF
--- a/applications/callflow/doc/flush_dtmf.md
+++ b/applications/callflow/doc/flush_dtmf.md
@@ -10,6 +10,6 @@ Validator for the flush_dtmf callflow's data object
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
-`collection_name` | Flush collected DTMF in a named key | `string` |   | `false`
+`collection_name` | Flush collected DTMF in a named key | `string` | `default` | `false`
 
 

--- a/applications/callflow/doc/flush_dtmf.md
+++ b/applications/callflow/doc/flush_dtmf.md
@@ -1,0 +1,15 @@
+## Flush Dtmf
+
+### About Flush Dtmf
+
+#### Schema
+
+Validator for the flush_dtmf callflow's data object
+
+
+
+Key | Description | Type | Default | Required
+--- | ----------- | ---- | ------- | --------
+`collection_name` | Flush collected DTMF in a named key | `string` |   | `false`
+
+

--- a/applications/callflow/doc/flush_dtmf.md
+++ b/applications/callflow/doc/flush_dtmf.md
@@ -10,6 +10,7 @@ Validator for the flush_dtmf callflow's data object
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
-`collection_name` | Flush collected DTMF in a named key | `string` | `default` | `false`
+`collection_name` | Flush collected DTMF in a named key | `string()` | `default` | `false`
+
 
 

--- a/applications/callflow/doc/ref/flush_dtmf.md
+++ b/applications/callflow/doc/ref/flush_dtmf.md
@@ -10,6 +10,6 @@ Validator for the flush_dtmf callflow's data object
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
-`collection_name` | Flush collected DTMF in a named key | `string` |   | `false`
+`collection_name` | Flush collected DTMF in a named key | `string` | `default` | `false`
 
 

--- a/applications/callflow/doc/ref/flush_dtmf.md
+++ b/applications/callflow/doc/ref/flush_dtmf.md
@@ -1,0 +1,15 @@
+## Flush Dtmf
+
+### About Flush Dtmf
+
+#### Schema
+
+Validator for the flush_dtmf callflow's data object
+
+
+
+Key | Description | Type | Default | Required
+--- | ----------- | ---- | ------- | --------
+`collection_name` | Flush collected DTMF in a named key | `string` |   | `false`
+
+

--- a/applications/callflow/doc/ref/flush_dtmf.md
+++ b/applications/callflow/doc/ref/flush_dtmf.md
@@ -10,6 +10,7 @@ Validator for the flush_dtmf callflow's data object
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
-`collection_name` | Flush collected DTMF in a named key | `string` | `default` | `false`
+`collection_name` | Flush collected DTMF in a named key | `string()` | `default` | `false`
+
 
 

--- a/applications/callflow/src/module/cf_flush_dtmf.erl
+++ b/applications/callflow/src/module/cf_flush_dtmf.erl
@@ -1,0 +1,35 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017 Voxter Communications
+%%% @doc
+%%% Flush DTMF collection on a call
+%%% "data":{
+%%%   "collection_name":"your_name_here" // the collection to flush
+%%% }
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(cf_flush_dtmf).
+
+-behaviour(gen_cf_action).
+
+-include("callflow.hrl").
+
+-export([handle/2]).
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Entry point for this module
+%% @end
+%%--------------------------------------------------------------------
+-spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
+handle(Data, Call) ->
+    Collection = collection_name(Data),
+    cf_exe:continue(kapps_call:set_dtmf_collection('undefined', Collection, Call)).
+
+-spec collection_name(kz_json:object()) -> ne_binary().
+collection_name(Data) ->
+    case kz_json:get_value(<<"collection_name">>, Data) of
+        <<_/binary>> = Name -> Name;
+        'undefined' -> <<"default">>
+    end.

--- a/applications/callflow/src/module/cf_flush_dtmf.erl
+++ b/applications/callflow/src/module/cf_flush_dtmf.erl
@@ -29,7 +29,4 @@ handle(Data, Call) ->
 
 -spec collection_name(kz_json:object()) -> ne_binary().
 collection_name(Data) ->
-    case kz_json:get_ne_binary_value(<<"collection_name">>, Data) of
-        <<_/binary>> = Name -> Name;
-        'undefined' -> <<"default">>
-    end.
+    kz_json:get_ne_binary_value(<<"collection_name">>, Data, <<"default">>).

--- a/applications/callflow/src/module/cf_flush_dtmf.erl
+++ b/applications/callflow/src/module/cf_flush_dtmf.erl
@@ -29,7 +29,7 @@ handle(Data, Call) ->
 
 -spec collection_name(kz_json:object()) -> ne_binary().
 collection_name(Data) ->
-    case kz_json:get_value(<<"collection_name">>, Data) of
+    case kz_json:get_ne_binary_value(<<"collection_name">>, Data) of
         <<_/binary>> = Name -> Name;
         'undefined' -> <<"default">>
     end.

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1607,6 +1607,7 @@
             "description": "Validator for the flush_dtmf callflow's data object",
             "properties": {
                 "collection_name": {
+                    "default": "default",
                     "description": "Flush collected DTMF in a named key",
                     "type": "string"
                 }

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1603,6 +1603,16 @@
             },
             "type": "object"
         },
+        "callflows.flush_dtmf": {
+            "description": "Validator for the flush_dtmf callflow's data object",
+            "properties": {
+                "collection_name": {
+                    "description": "Flush collected DTMF in a named key",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "callflows.group": {
             "description": "Validator for the group callflow's data object",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/callflows.flush_dtmf.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.flush_dtmf.json
@@ -4,6 +4,7 @@
     "description": "Validator for the flush_dtmf callflow's data object",
     "properties": {
         "collection_name": {
+            "default": "default",
             "description": "Flush collected DTMF in a named key",
             "type": "string"
         }

--- a/applications/crossbar/priv/couchdb/schemas/callflows.flush_dtmf.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.flush_dtmf.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "callflows.flush_dtmf",
+    "description": "Validator for the flush_dtmf callflow's data object",
+    "properties": {
+        "collection_name": {
+            "description": "Flush collected DTMF in a named key",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
When a callflow looks like:
- cf_play
- cf_play
- cf_collect_dtmf

If a caller presses a digit during the first cf_play, it cancels playback and gets added to the kapps_call dtmf_collection. Then the next media file starts playing.
There isn't a way to allow a caller to just skip the first cf_play without accumulating that DTMF. The solution is this:

- cf_play
- cf_flush_dtmf
- cf_play
- cf_collect_dtmf