### PR TITLE
Fix fax attachments and some others changes

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -13,7 +13,6 @@
 
 -export([presence_probe/2]).
 -export([presence_mwi_query/2]).
--export([notification_register/2]).
 -export([unsolicited_owner_mwi_update/2]).
 -export([unsolicited_endpoint_mwi_update/2]).
 -export([alpha_to_dialpad/1]).
@@ -165,12 +164,6 @@ manual_presence_resp(Username, Realm, JObj) ->
 -spec presence_mwi_query(kz_json:object(), kz_proplist()) -> 'ok'.
 presence_mwi_query(JObj, _Props) ->
     'true' = kapi_presence:mwi_query_v(JObj),
-    _ = kz_util:put_callid(JObj),
-    mwi_query(JObj).
-
--spec notification_register(kz_json:object(), kz_proplist()) -> 'ok'.
-notification_register(JObj, _Props) ->
-    'true' = kapi_notifications:register_v(JObj),
     _ = kz_util:put_callid(JObj),
     mwi_query(JObj).
 

--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -13,6 +13,7 @@
 
 -export([presence_probe/2]).
 -export([presence_mwi_query/2]).
+-export([notification_register/2]).
 -export([unsolicited_owner_mwi_update/2]).
 -export([unsolicited_endpoint_mwi_update/2]).
 -export([alpha_to_dialpad/1]).
@@ -164,6 +165,12 @@ manual_presence_resp(Username, Realm, JObj) ->
 -spec presence_mwi_query(kz_json:object(), kz_proplist()) -> 'ok'.
 presence_mwi_query(JObj, _Props) ->
     'true' = kapi_presence:mwi_query_v(JObj),
+    _ = kz_util:put_callid(JObj),
+    mwi_query(JObj).
+
+-spec notification_register(kz_json:object(), kz_proplist()) -> 'ok'.
+notification_register(JObj, _Props) ->
+    'true' = kapi_notifications:register_v(JObj),
     _ = kz_util:put_callid(JObj),
     mwi_query(JObj).
 

--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -711,6 +711,7 @@
     "tasks.notify_resend.cycle_delay_time_ms": "Timeout in milliseconds between each cycle",
     "tasks.notify_resend.max_doc_read": "Max number of notifications to read from database for each cycle",
     "tasks.notify_resend.max_retries": "Default max retries to re-publish",
+    "tasks.notify_resend.publish_timeout_ms": "Timeout in milliseconds for publishing notification",
     "tasks.notify_resend.reschedule_rules": "Re-schedule rules for each notification type to apply",
     "tasks.notify_resend.retry_after_fudge_s": "Constant time in seconds which would be multipy with attemtps to set retry time",
     "tasks.numbers.db_page_size": "maximum count of numbers read from db at once",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -28628,6 +28628,12 @@
                     "description": "Default max retries to re-publish",
                     "type": "integer"
                 },
+                "publish_timeout_ms": {
+                    "default": 10000,
+                    "description": "Timeout in milliseconds for publishing notification",
+                    "minimum": 1,
+                    "type": "integer"
+                },
                 "reschedule_rules": {
                     "default": {
                         "voicemail_new": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.tasks.notify_resend.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.tasks.notify_resend.json
@@ -18,6 +18,12 @@
             "description": "Default max retries to re-publish",
             "type": "integer"
         },
+        "publish_timeout_ms": {
+            "default": 10000,
+            "description": "Timeout in milliseconds for publishing notification",
+            "minimum": 1,
+            "type": "integer"
+        },
         "reschedule_rules": {
             "default": {
                 "voicemail_new": {

--- a/applications/ecallmgr/src/ecallmgr_registrar.erl
+++ b/applications/ecallmgr/src/ecallmgr_registrar.erl
@@ -1106,7 +1106,7 @@ maybe_send_register_notice(#registration{username=Username
 send_register_notice(Reg) ->
     Props = to_props(Reg)
         ++ kz_api:default_headers(?APP_NAME, ?APP_VERSION),
-    kapps_notify_publisher:cast(Props, fun kapi_notifications:publish_register/1).
+    kapi_notifications:publish_register(Props).
 
 -spec maybe_send_deregister_notice(registration()) -> 'ok'.
 maybe_send_deregister_notice(#registration{username=Username

--- a/applications/ecallmgr/src/ecallmgr_registrar.erl
+++ b/applications/ecallmgr/src/ecallmgr_registrar.erl
@@ -968,7 +968,6 @@ existing_or_new_registration(Username, Realm) ->
 -spec initial_registration(registration()) -> 'ok'.
 initial_registration(#registration{}=Reg) ->
     Routines = [fun maybe_query_authn/1
-               ,fun maybe_send_register_notice/1
                ,fun maybe_registration_notify/1
                ],
     _ = lists:foldl(fun(F, R) -> F(R) end, Reg, Routines),
@@ -1089,24 +1088,6 @@ update_registration(#registration{authorizing_id=AuthorizingId
             ],
     _ = gen_server:cast(?SERVER, {'update_registration', Id, Props}),
     Reg.
-
--spec maybe_send_register_notice(registration()) -> registration().
-maybe_send_register_notice(#registration{username=Username
-                                        ,realm=Realm
-                                        }=Reg) ->
-    case oldest_registrar() of
-        'false' -> Reg;
-        'true' ->
-            lager:debug("sending register notice for ~s@~s", [Username, Realm]),
-            _ = send_register_notice(Reg),
-            Reg
-    end.
-
--spec send_register_notice(registration()) -> 'ok'.
-send_register_notice(Reg) ->
-    Props = to_props(Reg)
-        ++ kz_api:default_headers(?APP_NAME, ?APP_VERSION),
-    kapps_notify_publisher:cast(Props, fun kapi_notifications:publish_register/1).
 
 -spec maybe_send_deregister_notice(registration()) -> 'ok'.
 maybe_send_deregister_notice(#registration{username=Username

--- a/applications/tasks/src/kz_notify_resend.erl
+++ b/applications/tasks/src/kz_notify_resend.erl
@@ -31,6 +31,7 @@
 -define(SERVER, {'via', 'kz_globals', ?NAME}).
 
 -define(MOD_CONFIG_CAT, <<(?CONFIG_CAT)/binary, ".notify_resend">>).
+-define(DEFAULT_TIMEOUT, 10 * ?MILLISECONDS_IN_SECOND).
 
 %% notify resned crawler settungs
 -define(NOTIFY_RESEND_ENABLED,
@@ -39,7 +40,8 @@
         kapps_config:get_integer(?MOD_CONFIG_CAT, <<"cycle_delay_time_ms">>, 5 * ?MILLISECONDS_IN_MINUTE)).
 -define(READ_LIMIT,
         kapps_config:get_integer(?MOD_CONFIG_CAT, <<"max_doc_read">>, 20)).
--define(PUBLISH_TIMEOUT, 2 * ?MILLISECONDS_IN_SECOND).
+-define(PUBLISH_TIMEOUT,
+        kapps_config:get_pos_integer(?MOD_CONFIG_CAT, <<"publish_timeout_ms">>, ?DEFAULT_TIMEOUT)).
 
 %% default reschedule rules
 -define(DEFAULT_RETRY_COUNT,

--- a/applications/teletype/src/teletype_bindings.erl
+++ b/applications/teletype/src/teletype_bindings.erl
@@ -36,6 +36,7 @@ flush_mod(Module) ->
 
 -spec notification(kz_json:object()) -> 'ok'.
 notification(JObj) ->
+    kz_util:put_callid(JObj),
     {EventCategory, EventName} = kz_util:get_event_type(JObj),
     RoutingKey = ?ROUTING_KEY(EventCategory, EventName),
     lager:debug("dispatching notification ~s", [RoutingKey]),

--- a/applications/teletype/src/teletype_bindings.erl
+++ b/applications/teletype/src/teletype_bindings.erl
@@ -43,15 +43,12 @@ notification(JObj) ->
     Res = kazoo_bindings:map(RoutingKey, JObj, []),
     case kazoo_bindings:succeeded(Res, fun filter_out_failed/1) of
         [] ->
-            lager:debug("notification ~s did not result in successes", [RoutingKey]),
-            teletype_util:send_update(JObj, <<"failed">>, <<"not_succeeded">>);
+            FailureMsg = build_failure_message(Res),
+            lager:debug("notification ~s did not result in successes: ~s", [RoutingKey, FailureMsg]),
+            teletype_util:send_update(JObj, <<"failed">>, FailureMsg);
         _Successes ->
             lager:debug("notification ~s result in some successes", [RoutingKey])
     end.
-
--spec filter_out_failed({boolean() | 'halt', any()} | boolean() | any()) -> boolean().
-filter_out_failed('ok') -> 'true';
-filter_out_failed(_) -> 'false'.
 
 -spec start_modules() -> 'ok'.
 start_modules() ->
@@ -63,3 +60,40 @@ start_modules([Module | Remaining]) ->
     start_modules(Remaining);
 start_modules([]) ->
     lager:info("started all teletype modules").
+
+
+-spec filter_out_failed(any()) -> boolean().
+filter_out_failed('ok') -> 'true';
+filter_out_failed(_) -> 'false'.
+
+-spec build_failure_message(any()) -> ne_binary().
+build_failure_message([{'EXIT', {'error', 'no_attachment'}}|_]) ->
+    <<"no_attachment">>;
+
+build_failure_message([{'EXIT', {'error', 'missing_data',  Missing}}|_]) ->
+    <<"missing_data: ", (kz_term:to_binary(Missing))/binary>>;
+
+build_failure_message([{'EXIT', {'error', 'failed_template',  ModuleName}}|_]) ->
+    %% teletype_templates:build_renderer, probably it's only for teletype startup
+    <<"failed_template: ", (kz_term:to_binary(ModuleName))/binary>>;
+
+build_failure_message([{'EXIT',{'error', 'template_error',  Reason}}|_]) ->
+    <<"template_error: ", (kz_term:to_binary(Reason))/binary>>;
+
+build_failure_message([{'EXIT', {'function_clause', _ST}}|_]) ->
+    <<"template_error: crashed with function_clause">>;
+
+build_failure_message([{'EXIT', {'undef', _ST}}|_]) ->
+    <<"template_error: crashed with undef">>;
+
+build_failure_message([{'EXIT', {'error', {'badmatch',  _}}}|_]) ->
+    %% Some templates (like voicemail_new) is matching agianst successful open_doc
+    %% maybe because the document or attachment is not stored yet.
+    %% Let the publisher save the payload to load later
+    <<"badmatch">>;
+
+build_failure_message([{'EXIT', {_Exp, _ST}}|_]) ->
+    <<"template_error: crashed with exception">>;
+
+build_failure_message(_) ->
+    <<"unknown_template_error">>.

--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -278,19 +278,19 @@ convert(FromFormat0, ToFormat0, Bin) ->
 run_convert_command(Cmd, FromFile, ToFile) ->
     lager:debug("running conversion command: ~s", [Cmd]),
     case os:cmd(Cmd) of
-       "success" ->
-           case file:read_file(ToFile) of
-               {'ok', PDF} ->
-                   lager:debug("convert file ~s to ~s succeeded", [FromFile, ToFile]),
-                   {'ok', PDF};
-               {'error', _R}=E ->
-                   lager:debug("unable to read converted file ~s : ~p", [ToFile, _R]),
-                   E
-           end;
-       Else ->
-           lager:debug("could not convert file ~s : ~p", [FromFile, Else]),
-           {'error', Else}
-   end.
+        "success" ->
+            case file:read_file(ToFile) of
+                {'ok', PDF} ->
+                    lager:debug("convert file ~s to ~s succeeded", [FromFile, ToFile]),
+                    {'ok', PDF};
+                {'error', _R}=E ->
+                    lager:debug("unable to read converted file ~s : ~p", [ToFile, _R]),
+                    E
+            end;
+        Else ->
+            lager:debug("could not convert file ~s : ~p", [FromFile, Else]),
+            {'error', Else}
+    end.
 
 -spec valid_format(ne_binary()) -> ne_binary().
 valid_format(<<"tiff">>) -> <<"tif">>;

--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -8,10 +8,8 @@
 %%%-------------------------------------------------------------------
 -module(teletype_fax_util).
 
--export([add_data/1, maybe_add_document_data/2
-        ,convert/3
-        ,get_fax_doc/1, maybe_get_fax_doc/1
-        ,get_attachments/2
+-export([add_data/1
+        ,add_attachments/3
         ,to_email_addresses/2
         ]).
 
@@ -22,16 +20,144 @@
 
 -spec add_data(kz_json:object()) -> kz_json:object().
 add_data(DataJObj) ->
+    IsPreview = teletype_util:is_preview(DataJObj),
     FaxBoxJObj = get_faxbox_doc(DataJObj),
     Values =
         props:filter_empty(
-          [{<<"error">>, error_data(DataJObj)}
+          [{<<"error">>, error_data(DataJObj, IsPreview)}
           ,{<<"faxbox">>, FaxBoxJObj}
           ,{<<"owner">>, get_owner_doc(DataJObj, FaxBoxJObj)}
-          ,{<<"fax">>, kz_doc:public_fields(maybe_get_fax_doc(DataJObj))}
+          ,{<<"fax">>, maybe_get_fax_doc(DataJObj, IsPreview)}
           ,{<<"timezone">>, find_timezone(DataJObj, FaxBoxJObj)}
           ]),
     kz_json:set_values(Values, DataJObj).
+
+-spec add_attachments(kz_json:object(), kz_proplist(), boolean()) -> {kz_proplist(), attachments()}.
+add_attachments(DataJObj, Macros, ShouldTerminate) ->
+    IsPreview = teletype_util:is_preview(DataJObj),
+    FaxDoc = props:get_value(<<"fax">>, Macros),
+    case maybe_fetch_attachments(FaxDoc, Macros, IsPreview) of
+        [] when IsPreview -> {Macros, []};
+        [] -> maybe_terminate(DataJObj, Macros, ShouldTerminate);
+        Attachments -> {add_document_data(Macros, Attachments), Attachments}
+    end.
+
+-spec maybe_terminate(kz_json:object(), kz_proplist(), boolean()) -> {kz_proplist(), attachments()}.
+maybe_terminate(DataJObj, _, 'true') ->
+    lager:debug("No attachments were found for this fax"),
+    teletype_util:send_update(DataJObj, <<"failed">>, <<"No attachments were found for this fax">>),
+    throw({'error', 'no_attachment'});
+maybe_terminate(_, Macros, 'false') ->
+    lager:debug("No attachments were found for this fax"),
+    {Macros, []}.
+
+-spec add_document_data(kz_proplist(), attachments()) -> kz_proplist().
+add_document_data(Macros, [{ContentType, Filename, Bin}]) ->
+    Values =
+        props:filter_undefined(
+          [{<<"media">>, Filename}
+          ,{<<"document_type">>, kz_mime:to_extension(ContentType)}
+          ,{<<"document_size">>, erlang:size(Bin)}
+          ]),
+    Fax = props:set_values(Values, props:get_value(<<"fax">>, Macros, [])),
+    props:set_value(<<"fax">>, kz_doc:public_fields(Fax), Macros).
+
+-spec to_email_addresses(kz_json:object(), ne_binary()) -> api_binaries().
+to_email_addresses(DataJObj, ModConfigCat) ->
+    Paths = [[<<"to">>, <<"email_addresses">>]
+            ,[<<"fax">>, <<"email">>, <<"send_to">>]
+            ,[<<"fax">>, <<"notifications">>, <<"email">>, <<"send_to">>]
+            ,[<<"fax_notifications">>, <<"email">>, <<"send_to">>]
+            ,[<<"notifications">>, <<"email">>, <<"send_to">>]
+            ,[<<"owner">>, <<"email">>]
+            ,[<<"owner">>, <<"username">>]
+            ],
+    Emails = kz_json:get_first_defined(Paths, DataJObj),
+    to_email_addresses(DataJObj, ModConfigCat, Emails).
+
+-spec to_email_addresses(kz_json:object(), ne_binary(), ne_binary() | api_binaries()) -> api_binaries().
+to_email_addresses(_, _, ?NE_BINARY=Email) ->
+    [Email];
+to_email_addresses(_, _, Emails)
+  when is_list(Emails)
+       andalso length(Emails) >= 1 ->
+    Emails;
+to_email_addresses(DataJObj, ModConfigCat, _) ->
+    Emails = teletype_util:find_account_rep_email(DataJObj),
+    maybe_using_default_to_addresses(Emails, ModConfigCat).
+
+-spec maybe_using_default_to_addresses(api_binaries(), ne_binary()) -> api_binaries().
+maybe_using_default_to_addresses('undefined', ModConfigCat) ->
+    lager:debug("failed to find account rep email, using defaults"),
+    case kapps_config:get_ne_binary_or_ne_binaries(ModConfigCat, <<"default_to">>) of
+        'undefined' -> 'undefined';
+        ?NE_BINARY=Email -> [Email];
+        Emails when is_list(Emails) -> Emails
+    end;
+maybe_using_default_to_addresses(Emails, _) ->
+    lager:debug("using ~p for To", [Emails]),
+    Emails.
+
+%%%===================================================================
+%%% Build data functions
+%%%===================================================================
+
+-spec get_faxbox_doc(kz_json:object()) -> kz_json:object().
+get_faxbox_doc(DataJObj) ->
+    case teletype_util:open_doc(<<"faxbox">>, kz_json:get_value(<<"faxbox_id">>, DataJObj), DataJObj) of
+        {'ok', J} -> J;
+        {'error', _} -> kz_json:new()
+    end.
+
+-spec error_data(kz_json:object(), boolean()) -> kz_json:object().
+error_data(DataJObj, 'true') ->
+    kz_json:from_list(
+      [{<<"call_info">>, kz_json:get_value(<<"fax_error">>, DataJObj)}
+      ,{<<"fax_info">>, kz_json:get_value([<<"fax_info">>, <<"fax_result_text">>], DataJObj)}
+      ]);
+error_data(_, 'false') ->
+    kz_json:from_list(
+      [{<<"call_info">>, <<"CALL_INFO">>}
+      ,{<<"fax_info">>, <<"FAX_INFO">>}
+      ]).
+
+-spec get_owner_doc(kz_json:object(), kz_json:object()) -> kz_json:object().
+get_owner_doc(DataJObj, FaxBoxJObj) ->
+    OwnerId = kzd_fax_box:owner_id(FaxBoxJObj, kz_json:get_value(<<"owner_id">>, DataJObj)),
+    case teletype_util:open_doc(<<"user">>, OwnerId, DataJObj) of
+        {'ok', J} -> J;
+        {'error', _} -> kz_json:new()
+    end.
+
+-spec maybe_get_fax_doc(kz_json:object(), boolean()) -> kz_json:object().
+maybe_get_fax_doc(DataJObj, 'true') ->
+    case teletype_util:open_doc(<<"fax">>, 'undefined', DataJObj) of
+        {'ok', JObj} -> JObj;
+        {'error', _E} -> kz_json:new()
+    end;
+maybe_get_fax_doc(DataJObj, 'false') ->
+    FaxId = kz_json:get_ne_value(<<"fax_id">>, DataJObj),
+    case get_fax_doc(fax_db(DataJObj), FaxId) of
+        {'ok', JObj} -> JObj;
+        {'error', _} -> kz_json:new()
+    end.
+
+-spec get_fax_doc(api_binary(), api_binary()) -> {'ok', kz_json:object()} | {'error', any()}.
+get_fax_doc(_, 'undefined') ->
+    lager:debug("undefined fax_id"),
+    {'error', 'not_found'};
+get_fax_doc('undefined', _) ->
+    lager:debug("undefined db for fax"),
+    {'error', 'not_found'};
+get_fax_doc(Db, Id) ->
+    case kz_datamgr:open_cache_doc(Db, {kzd_fax:type(), Id}) of
+        {'ok', _}=OK -> OK;
+        {'error', 'not_found'} when Db =/= ?KZ_FAXES_DB ->
+            get_fax_doc(?KZ_FAXES_DB, Id);
+        {'error', _Reason}=Error ->
+            lager:debug("failed to open fax ~s document: ~p", [Id, _Reason]),
+            Error
+    end.
 
 -spec find_timezone(api_ne_binary() | kz_json:object(), kz_json:object()) -> ne_binary().
 find_timezone('undefined', FaxBoxJObj) ->
@@ -46,105 +172,41 @@ find_timezone(DataJObj, FaxBoxJObj) ->
             ],
     find_timezone(kz_json:get_first_defined(Paths, DataJObj), FaxBoxJObj).
 
--spec maybe_add_document_data(kz_proplist(), attachments()) -> kz_proplist().
-maybe_add_document_data(Macros, []) -> Macros;
-maybe_add_document_data(Macros, [{ContentType, Filename, Bin}]) ->
-    Values =
-        props:filter_undefined(
-          [{<<"media">>, Filename}
-          ,{<<"document_type">>, kz_mime:to_extension(ContentType)}
-          ,{<<"document_size">>, erlang:size(Bin)}
-          ]),
-    Fax = props:set_values(Values, props:get_value(<<"fax">>, Macros, [])),
-    props:set_value(<<"fax">>, Fax, Macros).
+%%%===================================================================
+%%% Attachment Utilites
+%%%===================================================================
 
-
--spec convert(ne_binary(), ne_binary(), binary()) -> {ok, binary()} |
-                                                     {error, atom() | string()}.
-convert(FromFormat, FromFormat, Bin) ->
-    {'ok', Bin};
-convert(FromFormat0, ToFormat0, Bin) ->
-    lager:debug("converting from ~s to ~s", [FromFormat0, ToFormat0]),
-    FromFormat = valid_format(FromFormat0),
-    ToFormat = valid_format(ToFormat0),
-    Filename = kz_binary:rand_hex(8),
-    FromFile = <<"/tmp/", Filename/binary, ".", FromFormat/binary>>,
-    ToFile = <<"/tmp/", Filename/binary, ".", ToFormat/binary>>,
-    'ok' = file:write_file(FromFile, Bin),
-    ConvertCmd = kapps_config:get_binary(?FAX_CONFIG_CAT, <<"tiff_to_pdf_conversion_command">>, ?TIFF_TO_PDF_CMD),
-    Cmd = io_lib:format(ConvertCmd, [ToFile, FromFile]),
-    lager:debug("running conversion command: ~s", [Cmd]),
-    Response = case os:cmd(Cmd) of
-                   "success" ->
-                       case file:read_file(ToFile) of
-                           {'ok', PDF} ->
-                               lager:debug("convert file ~s to ~s succeeded", [FromFile, ToFile]),
-                               {'ok', PDF};
-                           {'error', _R}=E ->
-                               lager:debug("unable to read converted file ~s : ~p", [ToFile, _R]),
-                               E
-                       end;
-                   Else ->
-                       lager:debug("could not convert file ~s : ~p", [FromFile, Else]),
-                       {'error', Else}
-               end,
-    _ = kz_util:delete_file(FromFile),
-    _ = kz_util:delete_file(ToFile),
-    Response.
-
-valid_format(<<"tiff">>) -> <<"tif">>;
-valid_format(Format) -> Format.
-
--spec get_fax_doc(kz_json:object()) -> kz_json:object().
--spec get_fax_doc(kz_json:object(), boolean()) -> kz_json:object().
-get_fax_doc(DataJObj) ->
-    get_fax_doc(DataJObj, teletype_util:is_preview(DataJObj)).
-
-get_fax_doc(DataJObj, 'true') ->
-    case teletype_util:open_doc(<<"fax">>, 'undefined', DataJObj) of
-        {'ok', JObj} -> JObj;
-        {'error', _E} -> kz_json:new()
-    end;
-get_fax_doc(DataJObj, 'false') ->
-    FaxId     = kz_json:get_value(<<"fax_id">>, DataJObj),
-    AccountDb = kapi_notifications:account_db(DataJObj),
-
-    case kz_datamgr:open_cache_doc(AccountDb, {kzd_fax:type(), FaxId}) of
-        {'ok', JObj} ->
-            JObj;
-        {'error', _E} ->
-            lager:debug("failed to find fax ~s: ~p", [FaxId, _E]),
-            teletype_util:send_update(DataJObj, <<"failed">>, <<"Fax-ID was invalid">>),
-            throw({'error', 'no_fax_id'})
+-spec fax_db(kz_json:object()) -> api_binary().
+fax_db(DataJObj) ->
+    case kapi_notifications:account_db(DataJObj) of
+        'undefined' -> ?KZ_FAXES_DB;
+        Db -> Db
     end.
 
--spec maybe_get_fax_doc(kz_json:object()) -> kz_json:object().
-maybe_get_fax_doc(DataJObj) ->
-    try get_fax_doc(DataJObj)
-    catch _:_ ->
-            kz_json:new()
-    end.
-
--spec get_attachments(kz_json:object(), kz_proplist()) -> attachments().
--spec maybe_get_attachments(kz_json:object(), kz_proplist(), boolean()) -> attachments().
-get_attachments(DataJObj, Macros) ->
-    maybe_get_attachments(DataJObj, Macros, teletype_util:is_preview(DataJObj)).
-
-maybe_get_attachments(_DataJObj, _Macros, 'true') ->
+-spec maybe_fetch_attachments(kz_json:object(), kz_proplist(), boolean()) -> attachments().
+maybe_fetch_attachments(_, _, 'true') ->
     lager:debug("this is a preview, no attachments"),
     [];
-maybe_get_attachments(DataJObj, Macros, 'false') ->
-    FaxMacros = props:get_value(<<"fax">>, Macros),
-    FaxId = props:get_first_defined([<<"id">>, <<"fax_jobid">>, <<"fax_id">>], FaxMacros),
-    Db = fax_db(DataJObj),
-    lager:debug("accessing fax at ~s / ~s", [Db, FaxId]),
-    case get_attachment_binary(Db, FaxId) of
-        {'error', 'no_attachment'} -> [];
-        {'ok', ContentType, Bin} ->
-            maybe_convert_attachment(Macros, ContentType, Bin)
+maybe_fetch_attachments('undefined', _, 'false') ->
+    lager:debug("no fax document, no attachments"),
+    [];
+maybe_fetch_attachments(FaxJObj, Macros, 'false') ->
+    FaxId = props:get_first_defined([<<"id">>, <<"fax_jobid">>, <<"fax_id">>], FaxJObj),
+    Db = kz_doc:account_db(FaxJObj),
+    [AttachmentName] = kz_doc:attachment_names(FaxJObj),
+
+    lager:debug("accessing fax attachment ~s at ~s / ~s", [AttachmentName, Db, FaxId]),
+
+    case kz_datamgr:fetch_attachment(Db, {kzd_fax:type(), FaxId}, AttachmentName) of
+        {'ok', Bin} ->
+            ContentType = kz_doc:attachment_content_type(FaxJObj, AttachmentName),
+            maybe_convert_attachment(Macros, ContentType, Bin);
+        {'error', _E} ->
+            lager:debug("failed to fetch attachment ~s: ~p", [AttachmentName, _E]),
+            []
     end.
 
--spec maybe_convert_attachment(kz_proplist(), ne_binary(), binary()) -> attachments().
+-spec maybe_convert_attachment(kz_proplist(), api_binary(), binary()) -> attachments().
 maybe_convert_attachment(Macros, ContentType, Bin) ->
     ToFormat = kapps_config:get_ne_binary(?FAX_CONFIG_CAT, <<"attachment_format">>, <<"pdf">>),
     FromFormat = from_format_from_content_type(ContentType),
@@ -159,12 +221,10 @@ maybe_convert_attachment(Macros, ContentType, Bin) ->
             []
     end.
 
-
 -spec from_format_from_content_type(ne_binary()) -> ne_binary().
-from_format_from_content_type(<<"application/pdf">>) ->
-    <<"pdf">>;
-from_format_from_content_type(<<"image/tiff">>) ->
-    <<"tif">>;
+from_format_from_content_type(<<"application/pdf">>) -> <<"pdf">>;
+from_format_from_content_type(<<"image/tiff">>) -> <<"tif">>;
+from_format_from_content_type('undefined') -> <<"tif">>;
 from_format_from_content_type(ContentType) ->
     [_Type, SubType] = binary:split(ContentType, <<"/">>),
     SubType.
@@ -190,117 +250,47 @@ get_file_name(Macros, Ext) ->
     FName = list_to_binary([CallerID, "_", kz_time:pretty_print_datetime(LocalDateTime), ".", Ext]),
     re:replace(kz_term:to_lower_binary(FName), <<"\\s+">>, <<"_">>, [{'return', 'binary'}, 'global']).
 
--spec get_attachment_binary(ne_binary(), api_binary()) ->
-                                   {'ok', ne_binary(), binary()} |
-                                   {'error', 'no_attachment'}.
-get_attachment_binary(Db, Id) ->
-    case kz_datamgr:open_cache_doc(Db, {<<"fax">>, Id}) of
-        {'error', 'not_found'} when Db =/= ?KZ_FAXES_DB ->
-            get_attachment_binary(?KZ_FAXES_DB, Id);
-        {'error', 'not_found'} ->
-            lager:debug("no attachment binary to send"),
-            {'error', 'no_attachment'};
-        {'ok', FaxJObj} ->
-            case kz_doc:attachment(FaxJObj) of
-                'undefined' ->
-                    {'error', 'no_attachment'};
-                _AttachmentJObj ->
-                    get_attachment_binary(Db, Id, FaxJObj)
-            end
-    end.
+-spec convert(ne_binary(), ne_binary(), binary()) -> {ok, binary()} | {error, atom() | string()}.
+convert(FromFormat, FromFormat, Bin) ->
+    {'ok', Bin};
+convert(FromFormat0, ToFormat0, Bin) ->
+    lager:debug("converting from ~s to ~s", [FromFormat0, ToFormat0]),
 
--spec get_attachment_binary(ne_binary(), ne_binary(), kz_json:object()) ->
-                                   {'ok', ne_binary(), binary()} |
-                                   {'error', 'no_attachment'}.
-get_attachment_binary(Db, Id, FaxJObj) ->
-    [AttachmentName] = kz_doc:attachment_names(FaxJObj),
+    FromFormat = valid_format(FromFormat0),
+    ToFormat = valid_format(ToFormat0),
 
-    case kz_datamgr:fetch_attachment(Db, {<<"fax">>, Id}, AttachmentName) of
-        {'ok', Bin} ->
-            get_attachment(kz_doc:attachment_content_type(FaxJObj, AttachmentName), Bin);
-        {'error', _E} ->
-            lager:debug("failed to fetch attachment ~s: ~p", [AttachmentName, _E]),
-            {'error', 'no_attachment'}
-    end.
+    Filename = kz_binary:rand_hex(8),
+    FromFile = <<"/tmp/", Filename/binary, ".", FromFormat/binary>>,
+    ToFile = <<"/tmp/", Filename/binary, ".", ToFormat/binary>>,
 
--spec get_attachment(api_binary(), binary()) -> {'ok', ne_binary(), binary()}.
-get_attachment('undefined', Bin) ->
-    get_attachment_binary(<<"image/tiff">>, Bin);
-get_attachment(ContentType, Bin) ->
-    {'ok', ContentType, Bin}.
+    'ok' = file:write_file(FromFile, Bin),
 
--spec fax_db(kz_json:object()) -> ne_binary().
-fax_db(DataJObj) ->
-    case kapi_notifications:account_db(DataJObj) of
-        'undefined' -> ?KZ_FAXES_DB;
-        Db -> Db
-    end.
+    ConvertCmd = kapps_config:get_binary(?FAX_CONFIG_CAT, <<"tiff_to_pdf_conversion_command">>, ?TIFF_TO_PDF_CMD),
+    Cmd = io_lib:format(ConvertCmd, [ToFile, FromFile]),
 
--spec to_email_addresses(kz_json:object(), ne_binary()) -> api_binaries().
-to_email_addresses(DataJObj, ModConfigCat) ->
-    to_email_addresses(DataJObj
-                      ,ModConfigCat
-                      ,kz_json:get_first_defined([[<<"to">>, <<"email_addresses">>]
-                                                 ,[<<"fax">>, <<"email">>, <<"send_to">>]
-                                                 ,[<<"fax">>, <<"notifications">>, <<"email">>, <<"send_to">>]
-                                                 ,[<<"fax_notifications">>, <<"email">>, <<"send_to">>]
-                                                 ,[<<"notifications">>, <<"email">>, <<"send_to">>]
-                                                 ,[<<"owner">>, <<"email">>]
-                                                 ,[<<"owner">>, <<"username">>]
-                                                 ]
-                                                ,DataJObj
-                                                )
-                      ).
+    Response = run_convert_command(Cmd, FromFile, ToFile),
+    _ = kz_util:delete_file(FromFile),
+    _ = kz_util:delete_file(ToFile),
+    Response.
 
--spec to_email_addresses(kz_json:object(), ne_binary(), ne_binary() | api_binaries()) -> api_binaries().
-to_email_addresses(_DataJObj, _ModConfigCat, <<_/binary>> = Email) ->
-    [Email];
-to_email_addresses(_DataJObj, _ModConfigCat, [_|_] = Emails) ->
-    Emails;
-to_email_addresses(DataJObj, ModConfigCat, _) ->
-    case teletype_util:find_account_rep_email(DataJObj) of
-        'undefined' ->
-            lager:debug("failed to find account rep email, using defaults"),
-            default_to_addresses(ModConfigCat);
-        Emails ->
-            lager:debug("using ~p for To", [Emails]),
-            Emails
-    end.
+-spec run_convert_command(string(), ne_binary(), ne_binary()) -> {ok, binary()} | {error, atom() | string()}.
+run_convert_command(Cmd, FromFile, ToFile) ->
+    lager:debug("running conversion command: ~s", [Cmd]),
+    case os:cmd(Cmd) of
+       "success" ->
+           case file:read_file(ToFile) of
+               {'ok', PDF} ->
+                   lager:debug("convert file ~s to ~s succeeded", [FromFile, ToFile]),
+                   {'ok', PDF};
+               {'error', _R}=E ->
+                   lager:debug("unable to read converted file ~s : ~p", [ToFile, _R]),
+                   E
+           end;
+       Else ->
+           lager:debug("could not convert file ~s : ~p", [FromFile, Else]),
+           {'error', Else}
+   end.
 
--spec default_to_addresses(ne_binary()) -> api_binaries().
-default_to_addresses(ModConfigCat) ->
-    case kapps_config:get_ne_binary_or_ne_binaries(ModConfigCat, <<"default_to">>) of
-        'undefined' -> 'undefined';
-        <<_/binary>> = Email -> [Email];
-        [_|_]=Emails -> Emails
-    end.
-
--spec get_faxbox_doc(kz_json:object()) -> kz_json:object().
-get_faxbox_doc(DataJObj) ->
-    case teletype_util:open_doc(<<"faxbox">>, kz_json:get_value(<<"faxbox_id">>, DataJObj), DataJObj) of
-        {'ok', J} -> J;
-        {'error', _} -> kz_json:new()
-    end.
-
--spec get_owner_doc(kz_json:object(), kz_json:object()) -> kz_json:object().
-get_owner_doc(DataJObj, FaxBoxJObj) ->
-    OwnerId = kzd_fax_box:owner_id(FaxBoxJObj, kz_json:get_value(<<"owner_id">>, DataJObj)),
-    case teletype_util:open_doc(<<"user">>, OwnerId, DataJObj) of
-        {'ok', J} -> J;
-        {'error', _} -> kz_json:new()
-    end.
-
--spec error_data(kz_json:object()) -> kz_json:object().
-error_data(DataJObj) ->
-    case teletype_util:is_preview(DataJObj) of
-        'false' ->
-            kz_json:from_list(
-              [{<<"call_info">>, kz_json:get_value(<<"fax_error">>, DataJObj)}
-              ,{<<"fax_info">>, kz_json:get_value([<<"fax_info">>, <<"fax_result_text">>], DataJObj)}
-              ]);
-        'true'->
-            kz_json:from_list(
-              [{<<"call_info">>, <<"CALL_INFO">>}
-              ,{<<"fax_info">>, <<"FAX_INFO">>}
-              ])
-    end.
+-spec valid_format(ne_binary()) -> ne_binary().
+valid_format(<<"tiff">>) -> <<"tif">>;
+valid_format(Format) -> Format.

--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -37,7 +37,7 @@ add_attachments(DataJObj, Macros, ShouldTerminate) ->
     IsPreview = teletype_util:is_preview(DataJObj),
     FaxDoc = props:get_value(<<"fax">>, Macros),
     case kz_json:is_json_object(FaxDoc)
-        andalso kz_json:is_empty(FaxDoc)
+        andalso not kz_json:is_empty(FaxDoc)
         andalso maybe_fetch_attachments(FaxDoc, Macros, IsPreview)
     of
         'false' -> maybe_terminate(Macros, ShouldTerminate, IsPreview);

--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -45,7 +45,7 @@ add_attachments(DataJObj, Macros, ShouldTerminate) ->
 -spec maybe_terminate(kz_json:object(), kz_proplist(), boolean()) -> {kz_proplist(), attachments()}.
 maybe_terminate(DataJObj, _, 'true') ->
     lager:debug("No attachments were found for this fax"),
-    teletype_util:send_update(DataJObj, <<"failed">>, <<"No attachments were found for this fax">>),
+    teletype_util:send_update(DataJObj, <<"failed">>, <<"no_fax_attachment">>),
     throw({'error', 'no_attachment'});
 maybe_terminate(_, Macros, 'false') ->
     lager:debug("No attachments were found for this fax"),

--- a/applications/teletype/src/teletype_templates.erl
+++ b/applications/teletype/src/teletype_templates.erl
@@ -93,7 +93,9 @@ build_renderer(TemplateId, ContentType, Template) ->
     ModuleName = renderer_name(TemplateId, ContentType),
     case kz_template:compile(Template, ModuleName,[{'auto_escape', 'false'}]) of
         {'ok', _} -> 'ok';
-        {'error', _} -> throw({'error', 'failed_template', ModuleName})
+        {'error', _E} ->
+            lager:debug("failed to render '~s': ~p", [TemplateId, _E]),
+            throw({'error', 'failed_template', ModuleName})
     end.
 
 -type template_attachment() :: {ne_binary(), binary()}.
@@ -296,7 +298,8 @@ render_master(?NE_BINARY=TemplateId, ?NE_BINARY=ContentType, Macros) ->
         {'ok', IOList} ->
             iolist_to_binary(IOList);
         {'error', _R} ->
-            throw({'error', 'template_error'})
+            lager:debug("failed to render '~s': ~p", [TemplateId, _R]),
+            throw({'error', 'template_error', <<"failed to render template ", TemplateId/binary>>})
     end.
 
 -spec render_accounts(ne_binary(), ne_binary(), macros()) -> kz_proplist().

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -454,7 +454,7 @@ render(TemplateId, Template, Macros) ->
         {'ok', IOData} -> iolist_to_binary(IOData);
         {'error', _E} ->
             lager:debug("failed to render '~s': ~p '~s'", [TemplateId, _E, Template]),
-            throw({'error', 'template_error'})
+            throw({'error', 'template_error', <<"failed to render template ", TemplateId/binary>>})
     end.
 
 -spec sort_templates(rendered_templates()) -> rendered_templates().

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -522,7 +522,7 @@ send_update(RespQ, MsgId, Status, Msg) ->
 
 -spec find_account_rep_email(api_object() | ne_binary()) -> api_binaries().
 find_account_rep_email('undefined') -> 'undefined';
-find_account_rep_email(<<_/binary>> = AccountId) ->
+find_account_rep_email(?NE_BINARY=AccountId) ->
     case kz_services:is_reseller(AccountId) of
         'true' ->
             lager:debug("finding admin email for reseller account ~s", [AccountId]),
@@ -532,9 +532,7 @@ find_account_rep_email(<<_/binary>> = AccountId) ->
             find_account_admin_email(find_reseller_id(AccountId))
     end;
 find_account_rep_email(AccountJObj) ->
-    find_account_rep_email(
-      find_account_id(AccountJObj)
-     ).
+    find_account_rep_email(find_account_id(AccountJObj)).
 
 -spec find_account_admin_email(api_binary()) -> api_binaries().
 -spec find_account_admin_email(api_binary(), api_binary()) -> api_binaries().

--- a/applications/teletype/src/templates/teletype_account_zone_change.erl
+++ b/applications/teletype/src/templates/teletype_account_zone_change.erl
@@ -10,7 +10,7 @@
 
 -export([
          init/0
-        ,handle_account_zone_change/1
+        ,handle_req/1
         ]).
 
 -include("teletype.hrl").
@@ -49,14 +49,18 @@ init() ->
                                           ,{'bcc', ?TEMPLATE_BCC}
                                           ,{'reply_to', ?TEMPLATE_REPLY_TO}
                                           ]),
-    teletype_bindings:bind(<<"account_zone_change">>, ?MODULE, 'handle_account_zone_change').
+    teletype_bindings:bind(<<"account_zone_change">>, ?MODULE, 'handle_req').
 
--spec handle_account_zone_change(kz_json:object()) -> 'ok'.
-handle_account_zone_change(JObj) ->
-    'true' = kapi_notifications:account_zone_change_v(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:account_zone_change_v(JObj)).
 
-    kz_util:put_callid(JObj),
-
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
     DataJObj  = kz_json:normalize(JObj),
     AccountId = kz_json:get_value(<<"account_id">>, DataJObj),
 

--- a/applications/teletype/src/templates/teletype_cnam_request.erl
+++ b/applications/teletype/src/templates/teletype_cnam_request.erl
@@ -9,7 +9,7 @@
 -module(teletype_cnam_request).
 
 -export([init/0
-        ,handle_cnam_request/1
+        ,handle_req/1
         ]).
 
 -include("teletype.hrl").
@@ -53,13 +53,20 @@ init() ->
                                           ,{'bcc', ?TEMPLATE_BCC}
                                           ,{'reply_to', ?TEMPLATE_REPLY_TO}
                                           ]),
-    teletype_bindings:bind(<<"cnam_request">>, ?MODULE, 'handle_cnam_request').
+    teletype_bindings:bind(<<"cnam_request">>, ?MODULE, 'handle_req').
 
 
--spec handle_cnam_request(kz_json:object()) -> 'ok'.
-handle_cnam_request(JObj) ->
-    'true' = kapi_notifications:cnam_request_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:cnam_request_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
+
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
     AccountId = kz_json:get_value(<<"account_id">>, DataJObj),

--- a/applications/teletype/src/templates/teletype_customer_update.erl
+++ b/applications/teletype/src/templates/teletype_customer_update.erl
@@ -57,10 +57,16 @@ init() ->
                                           ]),
     teletype_bindings:bind(<<"customer_update">>, ?MODULE, 'handle_req').
 
--spec handle_req(kz_json:object()) -> kz_proplist()|'ok'.
+-spec handle_req(kz_json:object()) -> kz_proplist() | 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:customer_update_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:customer_update_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> kz_proplist() | 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
@@ -70,7 +76,7 @@ handle_req(JObj) ->
         'true' -> process_req(DataJObj, teletype_util:is_preview(DataJObj))
     end.
 
--spec process_req(kz_json:object(), boolean()) -> kz_proplist()|'ok'.
+-spec process_req(kz_json:object(), boolean()) -> kz_proplist() | 'ok'.
 process_req(DataJObj, 'true') ->
     send_update_to_user(kz_json:new(), DataJObj);
 process_req(DataJObj, 'false') ->
@@ -79,7 +85,7 @@ process_req(DataJObj, 'false') ->
         'undefined' -> process_accounts(DataJObj)
     end.
 
--spec process_accounts(kz_json:object()) -> kz_proplist()|'ok'.
+-spec process_accounts(kz_json:object()) -> kz_proplist() | 'ok'.
 process_accounts(DataJObj) ->
     SenderId = kz_json:get_value(<<"account_id">>, DataJObj),
     ViewOpts = [{'startkey', [SenderId]}
@@ -94,7 +100,7 @@ process_accounts(DataJObj) ->
             teletype_util:send_update(DataJObj, <<"failed">>, kz_term:to_binary(Msg))
     end.
 
--spec process_account(ne_binary(), kz_json:object()) -> kz_proplist()|'ok'.
+-spec process_account(ne_binary(), kz_json:object()) -> kz_proplist() | 'ok'.
 process_account(AccountId, DataJObj) ->
     case kz_json:get_value(<<"user_type">>, DataJObj) of
         <<UserId:32/binary>> ->

--- a/applications/teletype/src/templates/teletype_denied_emergency_bridge.erl
+++ b/applications/teletype/src/templates/teletype_denied_emergency_bridge.erl
@@ -56,8 +56,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:denied_emergency_bridge_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:denied_emergency_bridge_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_deregister.erl
+++ b/applications/teletype/src/templates/teletype_deregister.erl
@@ -16,7 +16,7 @@
         ,category/0
         ,friendly_name/0
         ]).
--export([handle_deregister/1]).
+-export([handle_req/1]).
 
 -include("teletype.hrl").
 
@@ -62,12 +62,18 @@ friendly_name() ->
 init() ->
     kz_util:put_callid(?MODULE),
     teletype_templates:init(?MODULE),
-    teletype_bindings:bind(id(), ?MODULE, 'handle_deregister').
+    teletype_bindings:bind(id(), ?MODULE, 'handle_req').
 
--spec handle_deregister(kz_json:object()) -> 'ok'.
-handle_deregister(JObj) ->
-    'true' = kapi_notifications:deregister_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:deregister_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [id()]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [id()]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
@@ -75,11 +81,11 @@ handle_deregister(JObj) ->
 
     case teletype_util:is_notice_enabled(AccountId, JObj, id()) of
         'false' -> teletype_util:notification_disabled(DataJObj, id());
-        'true' -> handle_req(DataJObj)
+        'true' -> process_req(DataJObj)
     end.
 
--spec handle_req(kz_json:object()) -> 'ok'.
-handle_req(DataJObj) ->
+-spec process_req(kz_json:object()) -> 'ok'.
+process_req(DataJObj) ->
     Macros = macros(DataJObj),
 
     %% Load templates

--- a/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
@@ -127,8 +127,7 @@ is_true_fax_error(AccountId, JObj) ->
 -spec handle_fax_inbound(kz_json:object(), ne_binary()) -> send_email_return().
 handle_fax_inbound(DataJObj, TemplateId) ->
     TemplateData = build_template_data(DataJObj),
-    EmailAttachements = teletype_fax_util:get_attachments(DataJObj, TemplateData),
-    Macros = teletype_fax_util:maybe_add_document_data(TemplateData, EmailAttachements),
+    {Macros, EmailAttachements} = teletype_fax_util:add_attachments(DataJObj, TemplateData, 'false'),
 
     %% Populate templates
     RenderedTemplates = teletype_templates:render(TemplateId, Macros, DataJObj),

--- a/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
@@ -73,8 +73,6 @@ handle_req(JObj, 'false') ->
 handle_req(JObj, 'true') ->
     lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
-    lager:debug("processing fax inbound error to email"),
-
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
     AccountId = kz_json:get_value(<<"account_id">>, DataJObj),

--- a/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
@@ -70,8 +70,7 @@ handle_fax_inbound(JObj) ->
 -spec process_req(kz_json:object()) -> 'ok'.
 process_req(DataJObj) ->
     TemplateData = build_template_data(DataJObj),
-    EmailAttachements = teletype_fax_util:get_attachments(DataJObj, TemplateData),
-    Macros = teletype_fax_util:maybe_add_document_data(TemplateData, EmailAttachements),
+    {Macros, EmailAttachements} = teletype_fax_util:add_attachments(DataJObj, TemplateData, 'true'),
 
     %% Load templates
     RenderedTemplates = teletype_templates:render(?TEMPLATE_ID, Macros, DataJObj),
@@ -91,10 +90,7 @@ process_req(DataJObj) ->
                 kz_json:set_value(<<"to">>, teletype_fax_util:to_email_addresses(DataJObj, ?MOD_CONFIG_CAT), DataJObj)
         end,
 
-    Emails = teletype_util:find_addresses(EmailsJObj
-                                         ,TemplateMetaJObj
-                                         ,?MOD_CONFIG_CAT
-                                         ),
+    Emails = teletype_util:find_addresses(EmailsJObj, TemplateMetaJObj, ?MOD_CONFIG_CAT),
 
     case teletype_util:send_email(Emails, Subject, RenderedTemplates, EmailAttachements) of
         'ok' -> teletype_util:send_update(DataJObj, <<"completed">>);

--- a/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
@@ -62,8 +62,6 @@ handle_req(JObj, 'false') ->
 handle_req(JObj, 'true') ->
     lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
-    lager:debug("processing fax inbound to email"),
-
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
     AccountId = kz_json:get_value(<<"account_id">>, DataJObj),

--- a/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
@@ -9,7 +9,7 @@
 -module(teletype_fax_outbound_error_to_email).
 
 -export([init/0
-        ,handle_fax_outbound_error/1
+        ,handle_req/1
         ]).
 
 -include("teletype.hrl").
@@ -51,12 +51,18 @@ init() ->
                                           ,{'bcc', ?TEMPLATE_BCC}
                                           ,{'reply_to', ?TEMPLATE_REPLY_TO}
                                           ]),
-    teletype_bindings:bind(<<"outbound_fax_error">>, ?MODULE, 'handle_fax_outbound_error').
+    teletype_bindings:bind(<<"outbound_fax_error">>, ?MODULE, 'handle_req').
 
--spec handle_fax_outbound_error(kz_json:object()) -> 'ok'.
-handle_fax_outbound_error(JObj) ->
-    'true' = kapi_notifications:fax_outbound_error_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:fax_outbound_error_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     lager:debug("processing fax outbound error to email"),
 

--- a/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
@@ -72,8 +72,7 @@ handle_fax_outbound_error(JObj) ->
 -spec process_req(kz_json:object()) -> 'ok'.
 process_req(DataJObj) ->
     TemplateData = build_template_data(DataJObj),
-    EmailAttachements = teletype_fax_util:get_attachments(DataJObj, TemplateData),
-    Macros = teletype_fax_util:maybe_add_document_data(TemplateData, EmailAttachements),
+    {Macros, EmailAttachements} = teletype_fax_util:add_attachments(DataJObj, TemplateData, 'false'),
 
     %% Load templates
     RenderedTemplates = teletype_templates:render(?TEMPLATE_ID, Macros, DataJObj),

--- a/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
@@ -64,8 +64,6 @@ handle_req(JObj, 'false') ->
 handle_req(JObj, 'true') ->
     lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
-    lager:debug("processing fax outbound error to email"),
-
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
     AccountId = kz_json:get_value(<<"account_id">>, DataJObj),

--- a/applications/teletype/src/templates/teletype_fax_outbound_smtp_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_smtp_error_to_email.erl
@@ -8,7 +8,7 @@
 -module(teletype_fax_outbound_smtp_error_to_email).
 
 -export([init/0
-        ,handle_fax_outbound_smtp_error/1
+        ,handle_req/1
         ]).
 
 -include("teletype.hrl").
@@ -40,14 +40,18 @@ init() ->
                                           ,{'bcc', ?TEMPLATE_BCC}
                                           ,{'reply_to', ?TEMPLATE_REPLY_TO}
                                           ]),
-    teletype_bindings:bind(<<"outbound_smtp_fax_error">>, ?MODULE, 'handle_fax_outbound_smtp_error').
+    teletype_bindings:bind(<<"outbound_smtp_fax_error">>, ?MODULE, 'handle_req').
 
--spec handle_fax_outbound_smtp_error(kz_json:object()) -> 'ok'.
-handle_fax_outbound_smtp_error(JObj) ->
-    'true' = kapi_notifications:fax_outbound_smtp_error_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:fax_outbound_smtp_error_v(JObj)).
 
-    lager:debug("processing fax outbound error to email"),
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
@@ -70,8 +70,7 @@ handle_fax_outbound(JObj) ->
 -spec process_req(kz_json:object()) -> 'ok'.
 process_req(DataJObj) ->
     TemplateData = build_template_data(DataJObj),
-    EmailAttachements = teletype_fax_util:get_attachments(DataJObj, TemplateData),
-    Macros = teletype_fax_util:maybe_add_document_data(TemplateData, EmailAttachements),
+    {Macros, EmailAttachements} = teletype_fax_util:add_attachments(DataJObj, TemplateData, 'true'),
 
     %% Load templates
     RenderedTemplates = teletype_templates:render(?TEMPLATE_ID, Macros, DataJObj),

--- a/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
@@ -9,7 +9,7 @@
 -module(teletype_fax_outbound_to_email).
 
 -export([init/0
-        ,handle_fax_outbound/1
+        ,handle_req/1
         ]).
 
 -include("teletype.hrl").
@@ -49,14 +49,18 @@ init() ->
                                           ,{'bcc', ?TEMPLATE_BCC}
                                           ,{'reply_to', ?TEMPLATE_REPLY_TO}
                                           ]),
-    teletype_bindings:bind(<<"outbound_fax">>, ?MODULE, 'handle_fax_outbound').
+    teletype_bindings:bind(<<"outbound_fax">>, ?MODULE, 'handle_req').
 
--spec handle_fax_outbound(kz_json:object()) -> 'ok'.
-handle_fax_outbound(JObj) ->
-    'true' = kapi_notifications:fax_outbound_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:fax_outbound_v(JObj)).
 
-    lager:debug("processing fax outbound to email"),
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_first_occurrence.erl
+++ b/applications/teletype/src/templates/teletype_first_occurrence.erl
@@ -9,7 +9,7 @@
 -module(teletype_first_occurrence).
 
 -export([init/0
-        ,first_occurrence/1
+        ,handle_req/1
         ]).
 
 -include("teletype.hrl").
@@ -49,12 +49,18 @@ init() ->
                                           ,{'bcc', ?TEMPLATE_BCC}
                                           ,{'reply_to', ?TEMPLATE_REPLY_TO}
                                           ]),
-    teletype_bindings:bind(<<"first_occurrence">>, ?MODULE, 'first_occurrence').
+    teletype_bindings:bind(<<"first_occurrence">>, ?MODULE, 'handle_req').
 
--spec first_occurrence(kz_json:object()) -> 'ok'.
-first_occurrence(JObj) ->
-    'true' = kapi_notifications:first_occurrence_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:first_occurrence_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
@@ -62,7 +68,7 @@ first_occurrence(JObj) ->
 
     case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
-        'true' -> handle_req(DataJObj)
+        'true' -> process_req(DataJObj)
     end.
 
 -spec build_macro_data(kz_json:object()) -> kz_proplist().
@@ -74,8 +80,8 @@ build_macro_data(DataJObj) ->
     ,{<<"event">>, kz_json:get_binary_value(<<"occurrence">>, DataJObj)}
     ].
 
--spec handle_req(kz_json:object()) -> 'ok'.
-handle_req(DataJObj) ->
+-spec process_req(kz_json:object()) -> 'ok'.
+process_req(DataJObj) ->
     Macros = build_macro_data(DataJObj),
 
     %% Load templates

--- a/applications/teletype/src/templates/teletype_new_account.erl
+++ b/applications/teletype/src/templates/teletype_new_account.erl
@@ -16,7 +16,7 @@
         ,category/0
         ,friendly_name/0
         ]).
--export([handle_new_account/1]).
+-export([handle_req/1]).
 
 -include("teletype.hrl").
 
@@ -50,12 +50,18 @@ friendly_name() ->
 init() ->
     kz_util:put_callid(?MODULE),
     teletype_templates:init(?MODULE),
-    teletype_bindings:bind(id(), ?MODULE, 'handle_new_account').
+    teletype_bindings:bind(id(), ?MODULE, 'handle_req').
 
--spec handle_new_account(kz_json:object()) -> 'ok'.
-handle_new_account(JObj) ->
-    'true' = kapi_notifications:new_account_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:new_account_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [id()]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [id()]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_new_user.erl
+++ b/applications/teletype/src/templates/teletype_new_user.erl
@@ -52,8 +52,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:new_user_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:new_user_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [id()]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [id()]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_port_cancel.erl
+++ b/applications/teletype/src/templates/teletype_port_cancel.erl
@@ -51,8 +51,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:port_cancel_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:port_cancel_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_port_comment.erl
+++ b/applications/teletype/src/templates/teletype_port_comment.erl
@@ -52,8 +52,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:port_comment_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:port_comment_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_port_pending.erl
+++ b/applications/teletype/src/templates/teletype_port_pending.erl
@@ -51,8 +51,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:port_pending_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:port_pending_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_port_rejected.erl
+++ b/applications/teletype/src/templates/teletype_port_rejected.erl
@@ -51,8 +51,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:port_rejected_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:port_rejected_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_port_request.erl
+++ b/applications/teletype/src/templates/teletype_port_request.erl
@@ -51,8 +51,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:port_request_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:port_request_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_port_request_admin.erl
+++ b/applications/teletype/src/templates/teletype_port_request_admin.erl
@@ -51,8 +51,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:port_request_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:port_request_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_port_scheduled.erl
+++ b/applications/teletype/src/templates/teletype_port_scheduled.erl
@@ -51,8 +51,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:port_scheduled_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:port_scheduled_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_port_unconfirmed.erl
+++ b/applications/teletype/src/templates/teletype_port_unconfirmed.erl
@@ -51,8 +51,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:port_unconfirmed_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:port_unconfirmed_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_ported.erl
+++ b/applications/teletype/src/templates/teletype_ported.erl
@@ -51,8 +51,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:ported_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:ported_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_service_added.erl
+++ b/applications/teletype/src/templates/teletype_service_added.erl
@@ -57,8 +57,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:service_added_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:service_added_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [id()]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [id()]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_template_skel.erl
+++ b/applications/teletype/src/templates/teletype_template_skel.erl
@@ -130,9 +130,10 @@ get_user(DataJObj) ->
     case kz_datamgr:open_cache_doc(AccountDb, UserId) of
         {'ok', UserJObj} -> UserJObj;
         {'error', _E} ->
-            lager:debug("failed to find user ~s in ~s: ~p", [UserId, AccountId, _E]),
+            Msg = io_lib:format("failed to find user ~s in ~s: ~p", [UserId, AccountId, _E]),
+            lager:debug(Msg),
             case teletype_util:is_preview(DataJObj) of
-                'false' -> throw({'error', 'not_found'});
+                'false' -> throw({'error', 'missing_data', Msg});
                 'true' -> kz_json:new()
             end
     end.

--- a/applications/teletype/src/templates/teletype_template_skel.erl
+++ b/applications/teletype/src/templates/teletype_template_skel.erl
@@ -51,8 +51,14 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> 'ok'.
 handle_req(JObj) ->
-    'true' = kapi_notifications:skel_v(JObj),
-    kz_util:put_callid(JObj),
+    handle_req(JObj, kapi_notifications:skel_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),

--- a/applications/teletype/src/templates/teletype_topup.erl
+++ b/applications/teletype/src/templates/teletype_topup.erl
@@ -161,7 +161,7 @@ get_topup_amount(DataJObj) ->
         'undefined' when IsPreview -> 20.0;
         'undefined' ->
             lager:warning("failed to get topup amount from data: ~p", [DataJObj]),
-            throw({'error', 'no_topup_amount'});
+            throw({'error', 'missing_data', <<"no topup amount">>});
         Amount -> Amount
     end.
 

--- a/applications/teletype/src/templates/teletype_topup.erl
+++ b/applications/teletype/src/templates/teletype_topup.erl
@@ -9,7 +9,7 @@
 -module(teletype_topup).
 
 -export([init/0
-        ,handle_topup/1
+        ,handle_req/1
         ]).
 
 -ifdef(TEST).
@@ -54,12 +54,18 @@ init() ->
                                           ,{'bcc', ?TEMPLATE_BCC}
                                           ,{'reply_to', ?TEMPLATE_REPLY_TO}
                                           ]),
-    teletype_bindings:bind(<<"topup">>, ?MODULE, 'handle_topup').
+    teletype_bindings:bind(<<"topup">>, ?MODULE, 'handle_req').
 
--spec handle_topup(kz_json:object()) -> 'ok'.
-handle_topup(JObj) ->
-    'true' = kapi_notifications:topup_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:topup_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
@@ -70,7 +76,7 @@ handle_topup(JObj) ->
 
     case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
-        'true' -> handle_req(kz_json:merge_jobjs(DataJObj, ReqData))
+        'true' -> process_req(kz_json:merge_jobjs(DataJObj, ReqData))
     end.
 
 -spec macros(kz_json:object()) -> kz_proplist().
@@ -86,8 +92,8 @@ macros(DataJObj) ->
     ,{<<"success">>, props:get_value(<<"success">>, TransactionProps)} %% backward compatibility
     ].
 
--spec handle_req(kz_json:object()) -> 'ok'.
-handle_req(DataJObj) ->
+-spec process_req(kz_json:object()) -> 'ok'.
+process_req(DataJObj) ->
     Macros = macros(DataJObj),
     RenderedTemplates = teletype_templates:render(?TEMPLATE_ID, Macros, DataJObj),
 

--- a/applications/teletype/src/templates/teletype_transaction.erl
+++ b/applications/teletype/src/templates/teletype_transaction.erl
@@ -183,7 +183,7 @@ get_transaction_amount(DataJObj) ->
         'undefined' when IsPreview -> 20.0;
         'undefined' ->
             lager:warning("failed to get topup amount from data: ~p", [DataJObj]),
-            throw({'error', 'no_topup_amount'});
+            throw({'error', 'missing_data',  <<"no transaction amount">>});
         Amount -> Amount
     end.
 

--- a/applications/teletype/src/templates/teletype_transaction.erl
+++ b/applications/teletype/src/templates/teletype_transaction.erl
@@ -9,7 +9,7 @@
 -module(teletype_transaction).
 
 -export([init/0
-        ,handle_transaction/1
+        ,handle_req/1
         ]).
 
 -include("teletype.hrl").
@@ -64,7 +64,7 @@ init() ->
                    ],
     teletype_templates:init(?SUCCESS_TEMPLATE_ID, SucessParams),
     teletype_templates:init(?FAILED_TEMPLATE_ID, FailedParams),
-    teletype_bindings:bind(<<"transaction">>, ?MODULE, 'handle_transaction').
+    teletype_bindings:bind(<<"transaction">>, ?MODULE, 'handle_req').
 
 -spec transaction_template_id(kz_json:object()) -> ne_binary().
 transaction_template_id(DataJObj) ->
@@ -73,8 +73,17 @@ transaction_template_id(DataJObj) ->
         'false' -> ?FAILED_TEMPLATE_ID
     end.
 
--spec handle_transaction(kz_json:object()) -> 'ok'.
-handle_transaction(JObj) ->
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:transaction_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?SUCCESS_TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?SUCCESS_TEMPLATE_ID]),
+
     'true' = kapi_notifications:transaction_v(JObj),
     kz_util:put_callid(JObj),
 
@@ -88,11 +97,11 @@ handle_transaction(JObj) ->
     TemplateId = transaction_template_id(DataJObj),
     case teletype_util:is_notice_enabled(AccountId, JObj, TemplateId) of
         'false' -> teletype_util:notification_disabled(DataJObj, TemplateId);
-        'true' -> handle_req(kz_json:merge_jobjs(DataJObj, ReqData))
+        'true' -> process_req(kz_json:merge_jobjs(DataJObj, ReqData))
     end.
 
--spec handle_req(kz_json:object()) -> 'ok'.
-handle_req(DataJObj) ->
+-spec process_req(kz_json:object()) -> 'ok'.
+process_req(DataJObj) ->
     TemplateId = transaction_template_id(DataJObj),
     Macros = [{<<"system">>, teletype_util:system_params()}
              ,{<<"account">>, teletype_util:account_params(DataJObj)}

--- a/applications/teletype/src/templates/teletype_voicemail_full.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_full.erl
@@ -9,7 +9,7 @@
 -module(teletype_voicemail_full).
 
 -export([init/0
-        ,handle_full_voicemail/1
+        ,handle_req/1
         ]).
 
 -include("teletype.hrl").
@@ -53,12 +53,18 @@ init() ->
                                           ,{'bcc', ?TEMPLATE_BCC}
                                           ,{'reply_to', ?TEMPLATE_REPLY_TO}
                                           ]),
-    teletype_bindings:bind(<<"voicemail_full">>, ?MODULE, 'handle_full_voicemail').
+    teletype_bindings:bind(<<"voicemail_full">>, ?MODULE, 'handle_req').
 
--spec handle_full_voicemail(kz_json:object()) -> 'ok'.
-handle_full_voicemail(JObj) ->
-    'true' = kapi_notifications:voicemail_full_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:voicemail_full_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
@@ -66,11 +72,11 @@ handle_full_voicemail(JObj) ->
 
     case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
-        'true' -> handle_req(DataJObj, AccountId)
+        'true' -> process_req(DataJObj, AccountId)
     end.
 
--spec handle_req(kz_json:object(), ne_binary()) -> 'ok'.
-handle_req(DataJObj, AccountId) ->
+-spec process_req(kz_json:object(), ne_binary()) -> 'ok'.
+process_req(DataJObj, AccountId) ->
     VMBox = get_vm_box(AccountId, DataJObj),
     User = get_vm_box_owner(VMBox, DataJObj),
 

--- a/applications/teletype/src/templates/teletype_webhook_disabled.erl
+++ b/applications/teletype/src/templates/teletype_webhook_disabled.erl
@@ -9,7 +9,7 @@
 -module(teletype_webhook_disabled).
 
 -export([init/0
-        ,handle_webhook_disabled/1
+        ,handle_req/1
         ]).
 
 -include("teletype.hrl").
@@ -52,12 +52,18 @@ init() ->
                                           ,{'bcc', ?TEMPLATE_BCC}
                                           ,{'reply_to', ?TEMPLATE_REPLY_TO}
                                           ]),
-    teletype_bindings:bind(<<"webhook_disabled">>, ?MODULE, 'handle_webhook_disabled').
+    teletype_bindings:bind(<<"webhook_disabled">>, ?MODULE, 'handle_req').
 
--spec handle_webhook_disabled(kz_json:object()) -> 'ok'.
-handle_webhook_disabled(JObj) ->
-    'true' = kapi_notifications:webhook_disabled_v(JObj),
-    kz_util:put_callid(JObj),
+-spec handle_req(kz_json:object()) -> 'ok'.
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:webhook_disabled_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> 'ok'.
+handle_req(JObj, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:send_update(JObj, <<"failed">>, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
 
     %% Gather data for template
     DataJObj = kz_json:normalize(JObj),
@@ -65,11 +71,11 @@ handle_webhook_disabled(JObj) ->
 
     case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
-        'true' -> handle_req(DataJObj, AccountId)
+        'true' -> process_req(DataJObj, AccountId)
     end.
 
--spec handle_req(kz_json:object(), ne_binary()) -> 'ok'.
-handle_req(DataJObj, AccountId) ->
+-spec process_req(kz_json:object(), ne_binary()) -> 'ok'.
+process_req(DataJObj, AccountId) ->
     HookId = kz_json:get_value(<<"hook_id">>, DataJObj),
 
     lager:debug("looking for hook ~s in account ~s", [HookId, AccountId]),

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -20,7 +20,6 @@
         ,fax_outbound/1, fax_outbound_v/1
         ,fax_outbound_error/1, fax_outbound_error_v/1
         ,fax_outbound_smtp_error/1, fax_outbound_smtp_error_v/1
-        ,register/1, register_v/1
         ,deregister/1, deregister_v/1
         ,first_occurrence/1, first_occurrence_v/1
         ,password_recovery/1, password_recovery_v/1
@@ -61,7 +60,6 @@
         ,publish_fax_inbound_error/1, publish_fax_inbound_error/2
         ,publish_fax_outbound_error/1, publish_fax_outbound_error/2
         ,publish_fax_outbound_smtp_error/1, publish_fax_outbound_smtp_error/2
-        ,publish_register/1, publish_register/2
         ,publish_deregister/1, publish_deregister/2
         ,publish_first_occurrence/1, publish_first_occurrence/2
         ,publish_password_recovery/1, publish_password_recovery/2
@@ -111,13 +109,10 @@
 -define(NOTIFY_FAX_OUTBOUND_SMTP_ERROR, <<"notifications.fax.outbound_smtp_error">>).
 -define(NOTIFY_DEREGISTER, <<"notifications.sip.deregister">>).
 -define(NOTIFY_FIRST_OCCURRENCE, <<"notifications.sip.first_occurrence">>).
-%%-define(NOTIFY_REGISTER_OVERWRITE, <<"notifications.sip.register_overwrite">>).
--define(NOTIFY_REGISTER, <<"notifications.sip.register">>).
 -define(NOTIFY_PASSWORD_RECOVERY, <<"notifications.user.password_recovery">>).
 -define(NOTIFY_NEW_ACCOUNT, <<"notifications.account.new">>).
 -define(NOTIFY_ACCOUNT_ZONE_CHANGE, <<"notifications.account.zone_change">>).
 -define(NOTIFY_NEW_USER, <<"notifications.user.new">>).
-%% -define(NOTIFY_DELETE_ACCOUNT, <<"notifications.account.delete">>).
 -define(NOTIFY_PORT_UNCONFIRMED, <<"notifications.number.port_unconfirmed">>).
 -define(NOTIFY_PORT_REQUEST, <<"notifications.number.port">>).
 -define(NOTIFY_PORT_PENDING, <<"notifications.number.port_pending">>).
@@ -268,23 +263,6 @@
                            ,{<<"Event-Name">>, <<"deregister">>}
                            ]).
 -define(DEREGISTER_TYPES, []).
-
-%% Notify Register
--define(REGISTER_HEADERS, [<<"Username">>, <<"Realm">>, <<"Account-ID">>]).
--define(OPTIONAL_REGISTER_HEADERS, [<<"Owner-ID">>, <<"User-Agent">>, <<"Call-ID">>
-                                   ,<<"From-User">>, <<"From-Host">>
-                                   ,<<"To-User">>, <<"To-Host">>
-                                   ,<<"Network-IP">>, <<"Network-Port">>
-                                   ,<<"Event-Timestamp">>, <<"Contact">>
-                                   ,<<"Expires">>, <<"Account-DB">>
-                                   ,<<"Authorizing-ID">>, <<"Authorizing-Type">>
-                                   ,<<"Suppress-Unregister-Notify">>
-                                        | ?DEFAULT_OPTIONAL_HEADERS
-                                   ]).
--define(REGISTER_VALUES, [{<<"Event-Category">>, <<"notification">>}
-                         ,{<<"Event-Name">>, <<"register">>}
-                         ]).
--define(REGISTER_TYPES, []).
 
 %% Notify First Occurrence
 -define(FIRST_OCCURRENCE_HEADERS, [<<"Account-ID">>, <<"Occurrence">>]).
@@ -808,24 +786,6 @@ fax_outbound_smtp_error_v(Prop) when is_list(Prop) ->
 fax_outbound_smtp_error_v(JObj) -> fax_outbound_smtp_error_v(kz_json:to_proplist(JObj)).
 
 %%--------------------------------------------------------------------
-%% @doc Register (unregister is a key word) - see wiki
-%% Takes proplist, creates JSON string or error
-%% @end
-%%--------------------------------------------------------------------
--spec register(api_terms()) -> api_formatter_return().
-register(Prop) when is_list(Prop) ->
-    case register_v(Prop) of
-        'true' -> kz_api:build_message(Prop, ?REGISTER_HEADERS, ?OPTIONAL_REGISTER_HEADERS);
-        'false' -> {'error', "Proplist failed validation for register"}
-    end;
-register(JObj) -> register(kz_json:to_proplist(JObj)).
-
--spec register_v(api_terms()) -> boolean().
-register_v(Prop) when is_list(Prop) ->
-    kz_api:validate(Prop, ?REGISTER_HEADERS, ?REGISTER_VALUES, ?REGISTER_TYPES);
-register_v(JObj) -> register_v(kz_json:to_proplist(JObj)).
-
-%%--------------------------------------------------------------------
 %% @doc Deregister (unregister is a key word) - see wiki
 %% Takes proplist, creates JSON string or error
 %% @end
@@ -1317,7 +1277,6 @@ skel_v(JObj) -> skel_v(kz_json:to_proplist(JObj)).
                        'outbound_fax_error' |
                        'outbound_smtp_fax_error' |
                        'fax_error' |
-                       'register' |
                        'deregister' |
                        'password_recovery' |
                        'first_occurrence' |
@@ -1385,9 +1344,6 @@ bind_to_q(Q, ['outbound_smtp_fax_error'|T]) ->
 bind_to_q(Q, ['fax_error'|T]) ->
     'ok' = amqp_util:bind_q_to_notifications(Q, ?NOTIFY_FAX_INBOUND_ERROR),
     'ok' = amqp_util:bind_q_to_notifications(Q, ?NOTIFY_FAX_OUTBOUND_ERROR),
-    bind_to_q(Q, T);
-bind_to_q(Q, ['register'|T]) ->
-    'ok' = amqp_util:bind_q_to_notifications(Q, ?NOTIFY_REGISTER),
     bind_to_q(Q, T);
 bind_to_q(Q, ['deregister'|T]) ->
     'ok' = amqp_util:bind_q_to_notifications(Q, ?NOTIFY_DEREGISTER),
@@ -1505,9 +1461,6 @@ unbind_q_from(Q, ['outbound_smtp_fax_error'|T]) ->
 unbind_q_from(Q, ['fax_error'|T]) ->
     'ok' = amqp_util:unbind_q_from_notifications(Q,?NOTIFY_FAX_OUTBOUND_ERROR),
     'ok' = amqp_util:unbind_q_from_notifications(Q,?NOTIFY_FAX_INBOUND_ERROR),
-    unbind_q_from(Q, T);
-unbind_q_from(Q, ['register'|T]) ->
-    'ok' = amqp_util:unbind_q_from_notifications(Q, ?NOTIFY_REGISTER),
     unbind_q_from(Q, T);
 unbind_q_from(Q, ['deregister'|T]) ->
     'ok' = amqp_util:unbind_q_from_notifications(Q, ?NOTIFY_DEREGISTER),
@@ -1654,13 +1607,6 @@ publish_fax_outbound_smtp_error(JObj) -> publish_fax_outbound_smtp_error(JObj, ?
 publish_fax_outbound_smtp_error(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?FAX_OUTBOUND_SMTP_ERROR_VALUES, fun fax_outbound_smtp_error/1),
     amqp_util:notifications_publish(?NOTIFY_FAX_OUTBOUND_SMTP_ERROR, Payload, ContentType).
-
--spec publish_register(api_terms()) -> 'ok'.
--spec publish_register(api_terms(), ne_binary()) -> 'ok'.
-publish_register(JObj) -> publish_register(JObj, ?DEFAULT_CONTENT_TYPE).
-publish_register(API, ContentType) ->
-    {'ok', Payload} = kz_api:prepare_api_payload(API, ?REGISTER_VALUES, fun register/1),
-    amqp_util:notifications_publish(?NOTIFY_REGISTER, Payload, ContentType).
 
 -spec publish_deregister(api_terms()) -> 'ok'.
 -spec publish_deregister(api_terms(), ne_binary()) -> 'ok'.

--- a/core/kazoo_apps/src/kapps_notify_publisher.erl
+++ b/core/kazoo_apps/src/kapps_notify_publisher.erl
@@ -163,7 +163,7 @@ maybe_ignore_failure(<<"missing_from">>) -> 'true';
 maybe_ignore_failure(<<"invalid_to_addresses">>) -> 'true';
 maybe_ignore_failure(<<"no_to_addresses">>) -> 'true';
 maybe_ignore_failure(<<"email_encoding_failed">>) -> 'true';
-maybe_ignore_failure(<<"validation_failed">>) -> 'true'.
+maybe_ignore_failure(<<"validation_failed">>) -> 'true';
 maybe_ignore_failure(_) -> 'false'.
 
 %% @private

--- a/core/kazoo_apps/src/kapps_notify_publisher.erl
+++ b/core/kazoo_apps/src/kapps_notify_publisher.erl
@@ -163,6 +163,7 @@ maybe_ignore_failure(<<"missing_from">>) -> 'true';
 maybe_ignore_failure(<<"invalid_to_addresses">>) -> 'true';
 maybe_ignore_failure(<<"no_to_addresses">>) -> 'true';
 maybe_ignore_failure(<<"email_encoding_failed">>) -> 'true';
+maybe_ignore_failure(<<"validation_failed">>) -> 'true'.
 maybe_ignore_failure(_) -> 'false'.
 
 %% @private

--- a/core/kazoo_apps/src/kapps_notify_publisher.erl
+++ b/core/kazoo_apps/src/kapps_notify_publisher.erl
@@ -8,6 +8,7 @@
 
 -export([call_collect/2
         ,cast/2
+        ,is_completed/1
         ]).
 
 -include_lib("kazoo_apps.hrl").
@@ -152,7 +153,12 @@ is_completed([JObj|_]) ->
         andalso kz_json:get_ne_binary_value(<<"Status">>, JObj)
     of
         <<"completed">> -> 'true';
-        <<"failed">> -> maybe_ignore_failure(kz_json:get_ne_binary_value(<<"Failure-Message">>, JObj));
+        <<"failed">> ->
+            FailureMsg = kz_json:get_ne_binary_value(<<"Failure-Message">>, JObj),
+            ShouldIgnore = maybe_ignore_failure(FailureMsg),
+            ShouldIgnore
+                andalso lager:debug("teletype failed with reason ~s, ignoring", [FailureMsg]),
+            ShouldIgnore;
         %% FIXME: Is pending enough to consider publish was successful? at least teletype recieved the notification!
         %% <<"pending">> -> 'true';
         _ -> 'false'
@@ -164,6 +170,14 @@ maybe_ignore_failure(<<"invalid_to_addresses">>) -> 'true';
 maybe_ignore_failure(<<"no_to_addresses">>) -> 'true';
 maybe_ignore_failure(<<"email_encoding_failed">>) -> 'true';
 maybe_ignore_failure(<<"validation_failed">>) -> 'true';
+maybe_ignore_failure(<<"missing_data:", _/binary>>) -> 'true';
+maybe_ignore_failure(<<"failed_template:", _/binary>>) -> 'true'; %% rendering problems
+maybe_ignore_failure(<<"template_error:", _/binary>>) -> 'true'; %% rendering problems
+
+%% explicitly not ignoring these below:
+maybe_ignore_failure(<<"unknown_template_error">>) -> 'false'; %% maybe something went wrong with template, trying later?
+maybe_ignore_failure(<<"no_attachment">>) -> 'false'; %% probably fax or voicemail is not stored in storage yet, retry later
+maybe_ignore_failure(<<"badmatch">>) -> 'false'; %% not ignoring it yet (voicemail_new)
 maybe_ignore_failure(_) -> 'false'.
 
 %% @private


### PR DESCRIPTION
* Fix an issue when sending a fax error template with no fax doc or attachment resulted in crash
* Increase timeout for notify resender to 10s to allow templates like voicemail to fetch attachments
* ~~Remove obsolete `register` template~~
* Return and log failure when data is invalid instead of crash so the publisher won't wait to timeout
* See if any templates binding was successful, if not return failure so the publisher won't wait to timeout
