### PR TITLE
vmargs-lager: no need to mention lager in vm.args

### DIFF
--- a/core/kazoo_apps/src/kazoo_apps.app.src
+++ b/core/kazoo_apps/src/kazoo_apps.app.src
@@ -1,12 +1,17 @@
 {application, kazoo_apps,
- [
-  {description, "Applications on top of Kazoo"}
+ [{description, "Applications on top of Kazoo"}
  ,{id, "9fd3b140-8727-11e0-9d78-0800200c9a66"}
  ,{vsn, "4.0.0"}
  ,{modules, []}
  ,{registered, [kazoo_apps_sup, kz_hooks_cache, kz_hooks_listener, kz_hooks_listener_sup, kz_nodes, kz_hooks_shared_listener, kapps_sup]}
  ,{applications, [ kernel
                  , stdlib
+
+                 , syslog
+                 , lager
+                 , lager_syslog
+                 , gproc
+                 , eflame
 
                  , kazoo
                  , kazoo_bindings
@@ -21,12 +26,6 @@
                  , kazoo_caches
                  , kazoo_web
                  , kazoo_globals
-
-                 , syslog
-                 , lager
-                 , lager_syslog
-                 , gproc
-                 , eflame
                  ]}
  ,{mod, {kazoo_apps_app, []}}
  ]}.

--- a/rel/args
+++ b/rel/args
@@ -26,5 +26,4 @@
 # When crashing, write dump with highest priority
 -env ERL_CRASH_DUMP_NICE 1
 
--s lager
 -s kazoo_apps_app


### PR DESCRIPTION
Thought it was weird.
https://github.com/2600hz/kazoo/commit/40b5f524fea944bfd536077dd74ad64ef863cd37 does not say why it was introduced. Maybe things are different now, @lazedo ?