### PR TITLE
HELP-31826: forward-port from 4.0

### DIFF
--- a/applications/registrar/src/registrar_maintenance.erl
+++ b/applications/registrar/src/registrar_maintenance.erl
@@ -18,7 +18,7 @@ device_by_ip(IP) when not is_binary(IP) ->
     device_by_ip(kz_term:to_binary(IP));
 device_by_ip(IP) ->
     io:format("Looking up IP: ~s~n", [IP]),
-    case reg_authn_req:lookup_account_by_ip(IP) of
+    case reg_route_req:lookup_account_by_ip(IP) of
         {'ok', AccountProps} ->
             pretty_print_device_by_ip(AccountProps);
         {'error', _E} ->

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -9,9 +9,6 @@
 %%%-------------------------------------------------------------------
 -module(kapps_maintenance).
 
--include_lib("kazoo_number_manager/include/knm_phone_number.hrl").
--include("kazoo_apps.hrl").
-
 -export([rebuild_token_auth/0
         ,rebuild_token_auth/1
         ]).
@@ -55,6 +52,11 @@
 -export([bind/3, unbind/3]).
 
 -export([flush_account_views/0]).
+-export([flush_getby_cache/0]).
+
+-include_lib("kazoo_number_manager/include/knm_phone_number.hrl").
+-include_lib("kazoo_caches/include/kazoo_caches.hrl").
+-include("kazoo_apps.hrl").
 
 binding('migrate') -> <<"maintenance.migrate">>;
 binding('refresh') -> <<"maintenance.refresh">>;
@@ -1355,3 +1357,8 @@ cleanup_system_configs() ->
 validate_system_configs() ->
     Results = [ {Config, validate_system_config(Config)} || Config <- kapps_config_doc:list_configs() ],
     [ Result || Result = {_, Status} <- Results, Status =/= [] ].
+
+-spec flush_getby_cache() -> 'ok'.
+flush_getby_cache() ->
+    kz_cache:flush_local(?KAPPS_GETBY_CACHE),
+    'ok'.


### PR DESCRIPTION
[4.0] HELP-31826 (#4085)

* HELP-31826: better logging of CCVs for debugging

* add flush for getby cache

* move lookup by ip to route_req handler

* HELP-31826: normalize checking if things are enabled

* HELP-31826: functions to help figure out what's being checked

* HELP-31826: ensure account id is present

* HELP-31826: finer return type, formatting

* spel much gud