### PR TITLE
PISTON-470: ACDc position/wait time announcements

### DIFF
--- a/applications/acdc/src/acdc.hrl
+++ b/applications/acdc/src/acdc.hrl
@@ -36,6 +36,8 @@
 
 -type deliveries() :: [gen_listener:basic_deliver()].
 
+-type announcements_pids() :: #{ne_binary() => pid()}.
+
 -type fsm_state_name() :: 'wait' | 'sync' | 'ready' | 'ringing' |
                           'ringing_callback' | 'awaiting_callback' |
                           'answered' | 'wrapup' | 'paused' | 'outbound'.

--- a/applications/acdc/src/acdc_announcements.erl
+++ b/applications/acdc/src/acdc_announcements.erl
@@ -1,0 +1,286 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Voxter Communications
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%   Daniel Finke
+%%%-------------------------------------------------------------------
+-module(acdc_announcements).
+
+%% API
+-export([start_link/3]).
+-export([init/3]).
+
+-include("acdc.hrl").
+
+-define(DEFAULT_ANNOUNCEMENTS_MEDIA, [{<<"you_are_at_position">>, <<"queue-you_are_at_position">>}
+                                     ,{<<"in_the_queue">>, <<"queue-in_the_queue">>}
+                                     ,{<<"increase_in_call_volume">>, <<"queue-increase_in_call_volume">>}
+                                     ,{<<"the_estimated_wait_time_is">>, <<"queue-the_estimated_wait_time_is">>}
+                                     ]).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the announcements process
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec start_link(pid(), kapps_call:call(), kz_proplist()) -> startlink_ret().
+start_link(Manager, Call, Props) ->
+    {'ok', kz_util:spawn_link(fun ?MODULE:init/3, [Manager, Call, Props])}.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Initializes the announcements process
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec init(pid(), kapps_call:call(), kz_proplist()) -> 'no_return'.
+init(Manager, Call, Props) ->
+    Config = get_config(Props),
+    State = init_state(Manager, Call, Config),
+    loop(State).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Load config from props into map
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec get_config(kz_proplist()) -> map().
+get_config(Props) ->
+    #{position_announcements_enabled => props:get_is_true(<<"position_announcements_enabled">>, Props, 'false')
+     ,wait_time_announcements_enabled => props:get_is_true(<<"wait_time_announcements_enabled">>, Props, 'false')
+     ,announcements_interval => props:get_integer_value(<<"interval">>, Props, 30)
+     ,announcements_media => announcements_media(Props)
+     }.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Get media file configuration from props
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec announcements_media(kz_proplist()) -> kz_proplist().
+announcements_media(Props) ->
+    case props:get_value(<<"media">>, Props) of
+        'undefined' ->
+            ?DEFAULT_ANNOUNCEMENTS_MEDIA;
+        AnnouncementsMedia ->
+            AnnouncementsMedia
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Initialize state for the announcements process
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec init_state(pid(), kapps_call:call(), map()) -> map().
+init_state(Manager, Call, Config) ->
+    #{manager => Manager
+     ,call => Call
+     ,config => Config
+     ,last_average_wait_time => 'undefined'
+     }.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Loop entry point
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec loop(map()) -> 'no_return'.
+loop(State) ->
+    maybe_announce_position(State).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Conditionally add position announcements prompts to playlist
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec maybe_announce_position(map()) -> 'no_return'.
+maybe_announce_position(#{config := #{position_announcements_enabled := 'false'}}=State) ->
+    maybe_announce_wait_time([], State);
+maybe_announce_position(#{manager := Manager
+                         ,call := Call
+                         ,config := Config
+                         }=State) ->
+    Language = kapps_call:language(Call),
+    Position = gen_listener:call(Manager, {'queue_position', kapps_call:call_id(Call)}),
+
+    Prompts = [{'prompt', announcements_media_file(<<"you_are_at_position">>, Config), Language, <<"A">>}
+              ,{'say', kz_term:to_binary(Position), <<"number">>}
+              ,{'prompt', announcements_media_file(<<"in_the_queue">>, Config), Language, <<"A">>}],
+    maybe_announce_wait_time(Prompts, State).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Conditionally add wait time announcements prompts to playlist
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec maybe_announce_wait_time(kapps_call_command:audio_macro_prompts(), map()) -> 'no_return'.
+maybe_announce_wait_time(PromptAcc, #{config := #{wait_time_announcements_enabled := 'false'}}=State) ->
+    play_announcements(PromptAcc, State);
+maybe_announce_wait_time(PromptAcc, #{call := Call
+                                     ,config := Config
+                                     ,last_average_wait_time := LastAverageWaitTime
+                                     }=State) ->
+    Language = kapps_call:language(Call),
+    AverageWaitTime = get_average_wait_time(Call),
+
+    PromptAcc1 = case LastAverageWaitTime =/= 'undefined'
+                     andalso AverageWaitTime > LastAverageWaitTime
+                 of
+                     'true' ->
+                         PromptAcc ++ [{'prompt', announcements_media_file(<<"increase_in_call_volume">>, Config), Language, <<"A">>}];
+                     'false' ->
+                         PromptAcc
+                 end,
+    PromptAcc2 = PromptAcc1 ++
+        [{'prompt', announcements_media_file(<<"the_estimated_wait_time_is">>, Config), Language, <<"A">>}
+        ,time_prompt(AverageWaitTime, Language)
+        ],
+    play_announcements(PromptAcc2, State#{last_average_wait_time := AverageWaitTime}).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Play the prompts on the playlist, sleep till the next execution,
+%% repeat
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec play_announcements(kapps_call_command:audio_macro_prompts(), map()) -> 'no_return'.
+play_announcements(Prompts, #{call := Call
+                             ,config := Config
+                             }=State) ->
+    kapps_call_command:audio_macro(Prompts, Call),
+
+    AnnouncementsInterval = announcements_interval(Config),
+    timer:sleep(AnnouncementsInterval * ?MILLISECONDS_IN_SECOND),
+    loop(State).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Get the average wait time from stats via AMQP
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec get_average_wait_time(kapps_call:call()) -> api_pos_integer().
+get_average_wait_time(Call) ->
+    AccountId = kapps_call:account_id(Call),
+    QueueId = kapps_call:custom_channel_var(<<"Queue-ID">>, Call),
+    Req = props:filter_undefined(
+            [{<<"Account-ID">>, kapps_call:account_id(Call)}
+            ,{<<"Queue-ID">>, QueueId}
+             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+            ]),
+    case kapps_util:amqp_pool_request(Req
+                                     ,fun kapi_acdc_stats:publish_current_calls_req/1
+                                     ,fun kapi_acdc_stats:current_calls_resp_v/1
+                                     )
+    of
+        {'error', E} ->
+            lager:error("failed to receive current calls from AMQP: ~p", [E]),
+            'undefined';
+        {'ok', Resp} ->
+            calculate_average_wait_time(Resp)
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Compute the average wait time based on the current_calls_resp
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec calculate_average_wait_time(kz_json:object()) -> pos_integer().
+calculate_average_wait_time(JObj) ->
+    WaitTimeCalls = kz_json:get_list_value(<<"Waiting">>, JObj, []) ++
+        kz_json:get_list_value(<<"Handled">>, JObj, []) ++
+        kz_json:get_list_value(<<"Processed">>, JObj, []),
+    Abandoned = length(kz_json:get_list_value(<<"Abandoned">>, JObj, [])),
+    Total = length(kz_json:get_list_value(<<"Abandoned">>, JObj, [])) +
+        length(kz_json:get_list_value(<<"Handled">>, JObj, [])) +
+        length(kz_json:get_list_value(<<"Processed">>, JObj, [])),
+
+    TotalWait = lists:foldl(fun(Stat, Acc) ->
+                                    Acc + kz_json:get_integer_value(<<"wait_time">>, Stat, 0)
+                            end, 0, WaitTimeCalls),
+    calculate_average_wait_time(Abandoned, Total, TotalWait).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Calculate average wait time, considering div by 0
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec calculate_average_wait_time(pos_integer(), pos_integer(), pos_integer()) -> pos_integer().
+calculate_average_wait_time(Total, Total, TotalWait) ->
+    TotalWait;
+calculate_average_wait_time(Abandoned, Total, TotalWait) ->
+    TotalWait div (Total - Abandoned).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Structure for time prompt entries
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec time_prompt(pos_integer(), binary()) -> {'prompt', ne_binary(), binary(), ne_binary()}.
+time_prompt(Time, Language) ->
+    {'prompt', time_prompt2(Time), Language, <<"A">>}.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Returns the appropriate prompt name for the given average wait time
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec time_prompt2(pos_integer()) -> ne_binary().
+time_prompt2(Time) when Time < ?SECONDS_IN_MINUTE ->
+    <<"queue-less_than_1_minute">>;
+time_prompt2(Time) when Time =< 5 * ?SECONDS_IN_MINUTE ->
+    <<"queue-about_5_minutes">>;
+time_prompt2(Time) when Time =< 10 * ?SECONDS_IN_MINUTE ->
+    <<"queue-about_10_minutes">>;
+time_prompt2(Time) when Time =< 15 * ?SECONDS_IN_MINUTE ->
+    <<"queue-about_15_minutes">>;
+time_prompt2(Time) when Time =< 30 * ?SECONDS_IN_MINUTE ->
+    <<"queue-about_30_minutes">>;
+time_prompt2(Time) when Time =< 45 * ?SECONDS_IN_MINUTE ->
+    <<"queue-about_45_minutes">>;
+time_prompt2(Time) when Time =< 60 * ?SECONDS_IN_MINUTE ->
+    <<"queue-about_1_hour">>;
+time_prompt2(_) ->
+    <<"queue-at_least_1_hour">>.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Return the time interval between announcements
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec announcements_interval(map()) -> non_neg_integer().
+announcements_interval(#{announcements_interval := Interval}) ->
+    Interval.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Return the media file of a given name from the config
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec announcements_media_file(ne_binary(), map()) -> api_ne_binary().
+announcements_media_file(Name, #{announcements_media := Media}) ->
+    props:get_binary_value(Name, Media).

--- a/applications/acdc/src/acdc_announcements_sup.erl
+++ b/applications/acdc/src/acdc_announcements_sup.erl
@@ -49,12 +49,8 @@ start_link() ->
 maybe_start_announcements(Manager, Call, Props) ->
     Enabled = props:get_is_true(<<"position_announcements_enabled">>, Props, 'false')
         orelse props:get_is_true(<<"wait_time_announcements_enabled">>, Props, 'false'),
-    case Enabled of
-        'true' ->
-            supervisor:start_child(?SERVER, [Manager, Call, Props]);
-        'false' ->
-            'false'
-    end.
+    Enabled
+        andalso supervisor:start_child(?SERVER, [Manager, Call, Props]).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/applications/acdc/src/acdc_announcements_sup.erl
+++ b/applications/acdc/src/acdc_announcements_sup.erl
@@ -1,0 +1,94 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Voxter Communications
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%   Daniel Finke
+%%%-------------------------------------------------------------------
+-module(acdc_announcements_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+-export([maybe_start_announcements/3
+        ,stop_announcements/1
+        ]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+-include("acdc.hrl").
+
+-define(SERVER, ?MODULE).
+-define(CHILDREN, [?WORKER('acdc_announcements')]).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the supervisor
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec start_link() -> sup_startchild_ret().
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Start an announcements child if either position or wait time
+%% announcements are enabled
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec maybe_start_announcements(pid(), kapps_call:call(), kz_proplist()) -> supervisor:startchild_ret() | 'false'.
+maybe_start_announcements(Manager, Call, Props) ->
+    Enabled = props:get_is_true(<<"position_announcements_enabled">>, Props, 'false')
+        orelse props:get_is_true(<<"wait_time_announcements_enabled">>, Props, 'false'),
+    case Enabled of
+        'true' ->
+            supervisor:start_child(?SERVER, [Manager, Call, Props]);
+        'false' ->
+            'false'
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Stop an announcements child process
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec stop_announcements(pid()) -> 'ok' | {'error', atom()}.
+stop_announcements(Pid) ->
+    supervisor:terminate_child(?SERVER, Pid).
+
+%%%===================================================================
+%%% Supervisor callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever a supervisor is started using supervisor:start_link/[2,3],
+%% this function is called by the new process to find out about
+%% restart strategy, maximum restart intensity, and child
+%% specifications.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec init(list()) -> sup_init_ret().
+init([]) ->
+
+    SupFlags = #{strategy => simple_one_for_one,
+                 intensity => 1,
+                 period => 5},
+
+    {ok, {SupFlags, ?CHILDREN}}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -353,9 +353,9 @@ handle_call({'should_ignore_member_call', {AccountId, QueueId, CallId}=K}, _, #s
 handle_call({'up_next', CallId}, _, #state{strategy_state=SS
                                           ,current_member_calls=CurrentCalls
                                           }=State) ->
-    Available = ss_size(SS, 'free'),
-    Reply = up_next_fold(lists:reverse(CurrentCalls), CallId, Available),
-    {'reply', Reply, State};
+    FreeAgents = ss_size(SS, 'free'),
+    Position = call_position(CallId, lists:reverse(CurrentCalls)),
+    {'reply', FreeAgents >= Position, State};
 
 handle_call('config', _, #state{account_id=AccountId
                                ,queue_id=QueueId
@@ -395,6 +395,10 @@ handle_call('current_agents', _, #state{strategy='mi'
                                        ,strategy_state=#strategy_state{agents=L}
                                        }=State) ->
     {'reply', L, State};
+
+handle_call({'queue_position', CallId}, _, #state{current_member_calls=CurrentCalls}=State) ->
+    Position = call_position(CallId, lists:reverse(CurrentCalls)),
+    {'reply', Position, State};
 
 handle_call(_Request, _From, State) ->
     {'reply', 'ok', State}.
@@ -548,6 +552,8 @@ handle_cast({'gen_listener',{'is_consuming',_IsConsuming}}, State) ->
 handle_cast({'add_queue_member', JObj}, #state{account_id=AccountId
                                               ,queue_id=QueueId
                                               ,current_member_calls=CurrentCalls
+                                              ,announcements_config=AnnouncementsConfig
+                                              ,announcements_pids=AnnouncementsPids
                                               }=State) ->
     Position = length(CurrentCalls)+1,
     Call = kapps_call:set_custom_channel_var(<<"Queue-Position">>
@@ -571,7 +577,16 @@ handle_cast({'add_queue_member', JObj}, #state{account_id=AccountId
 
     acdc_util:presence_update(AccountId, QueueId, ?PRESENCE_RED_FLASH),
 
+    %% Schedule position/wait time announcements
+    AnnouncementsPids1 = case acdc_announcements_sup:maybe_start_announcements(self(), Call, AnnouncementsConfig) of
+                             'false' -> AnnouncementsPids;
+                             {'ok', Pid} ->
+                                 CallId = kapps_call:call_id(Call),
+                                 AnnouncementsPids#{CallId => Pid}
+                         end,
+
     {'noreply', State#state{current_member_calls=[Call | CurrentCalls]
+                           ,announcements_pids=AnnouncementsPids1
                            }};
 
 handle_cast({'handle_queue_member_add', JObj}, #state{current_member_calls=CurrentCalls}=State) ->
@@ -581,10 +596,9 @@ handle_cast({'handle_queue_member_add', JObj}, #state{current_member_calls=Curre
 
     {'noreply', State#state{current_member_calls = [Call | lists:keydelete(CallId, 2, CurrentCalls)]}};
 
-handle_cast({'handle_queue_member_remove', CallId}, #state{current_member_calls=CurrentCalls}=State) ->
-    lager:debug("removing call id ~s", [CallId]),
-
-    {'noreply', State#state{current_member_calls=lists:keydelete(CallId, 2, CurrentCalls)}};
+handle_cast({'handle_queue_member_remove', CallId}, State) ->
+    State1 = maybe_remove_queue_member(CallId, State),
+    {'noreply', State1};
 
 handle_cast(_Msg, State) ->
     lager:debug("unhandled cast: ~p", [_Msg]),
@@ -901,6 +915,19 @@ update_strategy_state(Srv, 'mi', #strategy_state{agents=AgentL}) ->
 update_strategy_state(Srv, L) ->
     [gen_listener:cast(Srv, {'sync_with_agent', A}) || A <- L].
 
+-spec call_position(ne_binary(), [kapps_call:call()]) -> api_integer().
+-spec call_position(ne_binary(), [kapps_call:call()], pos_integer()) -> pos_integer().
+call_position(CallId, Calls) ->
+    call_position(CallId, Calls, 1).
+
+call_position(_, [], _) ->
+    'undefined';
+call_position(CallId, [Call|Calls], Position) ->
+    case kapps_call:call_id(Call) of
+        CallId -> Position;
+        _ -> call_position(CallId, Calls, Position + 1)
+    end.
+
 -spec ss_size(strategy_state(), 'free' | 'logged_in') -> integer().
 ss_size(#strategy_state{agents=Agents}, 'logged_in') ->
     case queue:is_queue(Agents) of
@@ -919,22 +946,6 @@ ss_size(#strategy_state{agents=Agents
 ss_size(#strategy_state{agents=Agents}=SS, 'free') ->
     ss_size(SS#strategy_state{agents=queue:to_list(Agents)}, 'free').
 
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Returns true if CallId is within the first Max elements of Calls
-%%
-%% @end
-%%--------------------------------------------------------------------
--spec up_next_fold([kapps_call:call()], ne_binary(), integer()) -> boolean().
-up_next_fold(Calls, _, Max) when Max >= length(Calls) -> 'true';
-up_next_fold(_, _, 0) -> 'false';
-up_next_fold([Call|Calls], CallId, Max) ->
-    case kapps_call:call_id(Call) of
-        CallId -> 'true';
-        _ -> up_next_fold(Calls, CallId, Max-1)
-    end.
-
 maybe_start_queue_workers(QueueSup, AgentCount) ->
     WSup = acdc_queue_sup:workers_sup(QueueSup),
     case acdc_queue_workers_sup:worker_count(WSup) of
@@ -947,4 +958,47 @@ update_properties(QueueJObj, State) ->
     State#state{
       enter_when_empty=kz_json:is_true(<<"enter_when_empty">>, QueueJObj, 'true')
                ,moh=kz_json:get_ne_value(<<"moh">>, QueueJObj)
+               ,announcements_config=announcements_config(QueueJObj)
      }.
+
+-spec announcements_config(kz_json:object()) -> kz_proplist().
+announcements_config(Config) ->
+    kz_json:recursive_to_proplist(
+      kz_json:get_json_value(<<"announcements">>, Config, kz_json:new())).
+
+-spec cancel_position_announcements(kapps_call:call() | 'false', map()) ->
+                                           map().
+cancel_position_announcements('false', Pids) -> Pids;
+cancel_position_announcements(Call, Pids) ->
+    CallId = kapps_call:call_id(Call),
+    case maps:is_key(CallId, Pids) of
+        'true' ->
+            lager:debug("cancelling announcements for ~s", [CallId]),
+            {Pid, Pids1} = maps:take(CallId, Pids),
+            acdc_announcements_sup:stop_announcements(Pid),
+
+            %% Attempt to skip remaining announcement media, but don't flush hangups
+            NoopId = kz_datamgr:get_uuid(),
+            Command = [{<<"Application-Name">>, <<"noop">>}
+                      ,{<<"Msg-ID">>, NoopId}
+                      ,{<<"Insert-At">>, <<"now">>}
+                      ,{<<"Filter-Applications">>, [<<"play">>, <<"say">>, <<"play">>]}
+                      ],
+            kapps_call_command:send_command(Command, Call),
+            Pids1;
+        'false' ->
+            lager:debug("did not have the announcements for call ~s", [CallId]),
+            Pids
+    end.
+
+-spec maybe_remove_queue_member(api_binary(), mgr_state()) -> mgr_state().
+maybe_remove_queue_member(CallId, #state{current_member_calls=CurrentCalls
+                                        ,announcements_pids=AnnouncementsPids
+                                        }=State) ->
+    lager:debug("removing call id ~s", [CallId]),
+
+    AnnouncementsPids1 = cancel_position_announcements(lists:keyfind(CallId, 2, CurrentCalls), AnnouncementsPids),
+
+    State#state{current_member_calls=lists:keydelete(CallId, 2, CurrentCalls)
+               ,announcements_pids=AnnouncementsPids1
+               }.

--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -597,7 +597,7 @@ handle_cast({'handle_queue_member_add', JObj}, #state{current_member_calls=Curre
     {'noreply', State#state{current_member_calls = [Call | lists:keydelete(CallId, 2, CurrentCalls)]}};
 
 handle_cast({'handle_queue_member_remove', CallId}, State) ->
-    State1 = maybe_remove_queue_member(CallId, State),
+    State1 = remove_queue_member(CallId, State),
     {'noreply', State1};
 
 handle_cast(_Msg, State) ->
@@ -991,10 +991,10 @@ cancel_position_announcements(Call, Pids) ->
             Pids
     end.
 
--spec maybe_remove_queue_member(api_binary(), mgr_state()) -> mgr_state().
-maybe_remove_queue_member(CallId, #state{current_member_calls=CurrentCalls
-                                        ,announcements_pids=AnnouncementsPids
-                                        }=State) ->
+-spec remove_queue_member(api_binary(), mgr_state()) -> mgr_state().
+remove_queue_member(CallId, #state{current_member_calls=CurrentCalls
+                                  ,announcements_pids=AnnouncementsPids
+                                  }=State) ->
     lager:debug("removing call id ~s", [CallId]),
 
     AnnouncementsPids1 = cancel_position_announcements(lists:keyfind(CallId, 2, CurrentCalls), AnnouncementsPids),

--- a/applications/acdc/src/acdc_queue_manager.hrl
+++ b/applications/acdc/src/acdc_queue_manager.hrl
@@ -22,6 +22,8 @@
                ,enter_when_empty = 'true' :: boolean() % allow caller into queue if no agents are logged in
                ,moh :: api_ne_binary()
                ,current_member_calls = [] :: list() % ordered list of current members waiting
+               ,announcements_config = [] :: kz_proplist()
+               ,announcements_pids = #{} :: announcements_pids()
                }).
 -type mgr_state() :: #state{}.
 

--- a/applications/acdc/src/acdc_sup.erl
+++ b/applications/acdc/src/acdc_sup.erl
@@ -25,6 +25,7 @@
                   ,?SUPER('acdc_agents_sup')
                   ,?SUPER('acdc_queues_sup')
                   ,?SUPER('acdc_stats_sup')
+                  ,?SUPER('acdc_announcements_sup')
                   ,?WORKER('acdc_agent_manager')
                   ,?WORKER('acdc_init')
                   ,?WORKER('acdc_listener')

--- a/applications/crossbar/doc/queues.md
+++ b/applications/crossbar/doc/queues.md
@@ -15,7 +15,6 @@ Key | Description | Type | Default | Required
 `agent_ring_timeout` | In seconds, how long to ring an agent before progressing to the next agent available | `integer()` | `15` | `false`
 `agent_wrapup_time` | Pre-defined wait period applied after an agent handles a customer call | `integer()` | `0` | `false`
 `announce` | Media ID (or appropriate media URI) of media to play when caller is about to be connected. | `string()` |   | `false`
-`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object` |   | `false`
 `announcements.interval` | Time between announcements | `integer` | `30` | `false`
 `announcements.media` | Custom prompts to be played for the announcements | `object` |   | `false`
 `announcements.media.in_the_queue` | Played after the numeric position | `string` |   | `true`
@@ -24,6 +23,7 @@ Key | Description | Type | Default | Required
 `announcements.media.you_are_at_position` | Played before the numeric position | `string` |   | `true`
 `announcements.position_announcements_enabled` | Whether announcements of the caller's position in the queue should be played | `boolean` |   | `false`
 `announcements.wait_time_announcements_enabled` | Whether announcements of the estimated wait time in the queue should be played | `boolean` |   | `false`
+`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object` |   | `false`
 `caller_exit_key` | Key caller can press while on hold to exit the queue and continue in the callflow | `string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '*' | '0' | '#')` | `#` | `false`
 `cdr_url` | An optional HTTP URL to POST the CDR | `string()` |   | `false`
 `connection_timeout` | In seconds, how long to try to connect the caller before progressing past the queue callflow action | `integer()` | `3600` | `false`

--- a/applications/crossbar/doc/queues.md
+++ b/applications/crossbar/doc/queues.md
@@ -15,15 +15,15 @@ Key | Description | Type | Default | Required
 `agent_ring_timeout` | In seconds, how long to ring an agent before progressing to the next agent available | `integer()` | `15` | `false`
 `agent_wrapup_time` | Pre-defined wait period applied after an agent handles a customer call | `integer()` | `0` | `false`
 `announce` | Media ID (or appropriate media URI) of media to play when caller is about to be connected. | `string()` |   | `false`
-`announcements.interval` | Time between announcements | `integer` | `30` | `false`
-`announcements.media` | Custom prompts to be played for the announcements | `object` |   | `false`
-`announcements.media.in_the_queue` | Played after the numeric position | `string` |   | `true`
-`announcements.media.increase_in_call_volume` | Played if the estimated wait time has increased since the previous wait time announcement | `string` |   | `true`
-`announcements.media.the_estimated_wait_time_is` | Played before the estimated wait time media | `string` |   | `true`
-`announcements.media.you_are_at_position` | Played before the numeric position | `string` |   | `true`
-`announcements.position_announcements_enabled` | Whether announcements of the caller's position in the queue should be played | `boolean` |   | `false`
-`announcements.wait_time_announcements_enabled` | Whether announcements of the estimated wait time in the queue should be played | `boolean` |   | `false`
-`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object` |   | `false`
+`announcements.interval` | Time between announcements | `integer()` | `30` | `false`
+`announcements.media.in_the_queue` | Played after the numeric position | `string()` |   | `true`
+`announcements.media.increase_in_call_volume` | Played if the estimated wait time has increased since the previous wait time announcement | `string()` |   | `true`
+`announcements.media.the_estimated_wait_time_is` | Played before the estimated wait time media | `string()` |   | `true`
+`announcements.media.you_are_at_position` | Played before the numeric position | `string()` |   | `true`
+`announcements.media` | Custom prompts to be played for the announcements | `object()` |   | `false`
+`announcements.position_announcements_enabled` | Whether announcements of the caller's position in the queue should be played | `boolean()` |   | `false`
+`announcements.wait_time_announcements_enabled` | Whether announcements of the estimated wait time in the queue should be played | `boolean()` |   | `false`
+`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object()` |   | `false`
 `caller_exit_key` | Key caller can press while on hold to exit the queue and continue in the callflow | `string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '*' | '0' | '#')` | `#` | `false`
 `cdr_url` | An optional HTTP URL to POST the CDR | `string()` |   | `false`
 `connection_timeout` | In seconds, how long to try to connect the caller before progressing past the queue callflow action | `integer()` | `3600` | `false`

--- a/applications/crossbar/doc/queues.md
+++ b/applications/crossbar/doc/queues.md
@@ -15,6 +15,15 @@ Key | Description | Type | Default | Required
 `agent_ring_timeout` | In seconds, how long to ring an agent before progressing to the next agent available | `integer()` | `15` | `false`
 `agent_wrapup_time` | Pre-defined wait period applied after an agent handles a customer call | `integer()` | `0` | `false`
 `announce` | Media ID (or appropriate media URI) of media to play when caller is about to be connected. | `string()` |   | `false`
+`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object` |   | `false`
+`announcements.interval` | Time between announcements | `integer` | `30` | `false`
+`announcements.media` | Custom prompts to be played for the announcements | `object` |   | `false`
+`announcements.media.in_the_queue` | Played after the numeric position | `string` |   | `true`
+`announcements.media.increase_in_call_volume` | Played if the estimated wait time has increased since the previous wait time announcement | `string` |   | `true`
+`announcements.media.the_estimated_wait_time_is` | Played before the estimated wait time media | `string` |   | `true`
+`announcements.media.you_are_at_position` | Played before the numeric position | `string` |   | `true`
+`announcements.position_announcements_enabled` | Whether announcements of the caller's position in the queue should be played | `boolean` |   | `false`
+`announcements.wait_time_announcements_enabled` | Whether announcements of the estimated wait time in the queue should be played | `boolean` |   | `false`
 `caller_exit_key` | Key caller can press while on hold to exit the queue and continue in the callflow | `string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '*' | '0' | '#')` | `#` | `false`
 `cdr_url` | An optional HTTP URL to POST the CDR | `string()` |   | `false`
 `connection_timeout` | In seconds, how long to try to connect the caller before progressing past the queue callflow action | `integer()` | `3600` | `false`

--- a/applications/crossbar/doc/ref/queues.md
+++ b/applications/crossbar/doc/ref/queues.md
@@ -13,6 +13,15 @@ Key | Description | Type | Default | Required
 `agent_ring_timeout` | In seconds, how long to ring an agent before progressing to the next agent available | `integer()` | `15` | `false`
 `agent_wrapup_time` | Pre-defined wait period applied after an agent handles a customer call | `integer()` | `0` | `false`
 `announce` | Media ID (or appropriate media URI) of media to play when caller is about to be connected. | `string()` |   | `false`
+`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object` |   | `false`
+`announcements.interval` | Time between announcements | `integer` | `30` | `false`
+`announcements.media` | Custom prompts to be played for the announcements | `object` |   | `false`
+`announcements.media.in_the_queue` | Played after the numeric position | `string` |   | `true`
+`announcements.media.increase_in_call_volume` | Played if the estimated wait time has increased since the previous wait time announcement | `string` |   | `true`
+`announcements.media.the_estimated_wait_time_is` | Played before the estimated wait time media | `string` |   | `true`
+`announcements.media.you_are_at_position` | Played before the numeric position | `string` |   | `true`
+`announcements.position_announcements_enabled` | Whether announcements of the caller's position in the queue should be played | `boolean` |   | `false`
+`announcements.wait_time_announcements_enabled` | Whether announcements of the estimated wait time in the queue should be played | `boolean` |   | `false`
 `caller_exit_key` | Key caller can press while on hold to exit the queue and continue in the callflow | `string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '*' | '0' | '#')` | `#` | `false`
 `cdr_url` | An optional HTTP URL to POST the CDR | `string()` |   | `false`
 `connection_timeout` | In seconds, how long to try to connect the caller before progressing past the queue callflow action | `integer()` | `3600` | `false`

--- a/applications/crossbar/doc/ref/queues.md
+++ b/applications/crossbar/doc/ref/queues.md
@@ -13,7 +13,6 @@ Key | Description | Type | Default | Required
 `agent_ring_timeout` | In seconds, how long to ring an agent before progressing to the next agent available | `integer()` | `15` | `false`
 `agent_wrapup_time` | Pre-defined wait period applied after an agent handles a customer call | `integer()` | `0` | `false`
 `announce` | Media ID (or appropriate media URI) of media to play when caller is about to be connected. | `string()` |   | `false`
-`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object` |   | `false`
 `announcements.interval` | Time between announcements | `integer` | `30` | `false`
 `announcements.media` | Custom prompts to be played for the announcements | `object` |   | `false`
 `announcements.media.in_the_queue` | Played after the numeric position | `string` |   | `true`
@@ -22,6 +21,7 @@ Key | Description | Type | Default | Required
 `announcements.media.you_are_at_position` | Played before the numeric position | `string` |   | `true`
 `announcements.position_announcements_enabled` | Whether announcements of the caller's position in the queue should be played | `boolean` |   | `false`
 `announcements.wait_time_announcements_enabled` | Whether announcements of the estimated wait time in the queue should be played | `boolean` |   | `false`
+`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object` |   | `false`
 `caller_exit_key` | Key caller can press while on hold to exit the queue and continue in the callflow | `string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '*' | '0' | '#')` | `#` | `false`
 `cdr_url` | An optional HTTP URL to POST the CDR | `string()` |   | `false`
 `connection_timeout` | In seconds, how long to try to connect the caller before progressing past the queue callflow action | `integer()` | `3600` | `false`

--- a/applications/crossbar/doc/ref/queues.md
+++ b/applications/crossbar/doc/ref/queues.md
@@ -13,15 +13,15 @@ Key | Description | Type | Default | Required
 `agent_ring_timeout` | In seconds, how long to ring an agent before progressing to the next agent available | `integer()` | `15` | `false`
 `agent_wrapup_time` | Pre-defined wait period applied after an agent handles a customer call | `integer()` | `0` | `false`
 `announce` | Media ID (or appropriate media URI) of media to play when caller is about to be connected. | `string()` |   | `false`
-`announcements.interval` | Time between announcements | `integer` | `30` | `false`
-`announcements.media` | Custom prompts to be played for the announcements | `object` |   | `false`
-`announcements.media.in_the_queue` | Played after the numeric position | `string` |   | `true`
-`announcements.media.increase_in_call_volume` | Played if the estimated wait time has increased since the previous wait time announcement | `string` |   | `true`
-`announcements.media.the_estimated_wait_time_is` | Played before the estimated wait time media | `string` |   | `true`
-`announcements.media.you_are_at_position` | Played before the numeric position | `string` |   | `true`
-`announcements.position_announcements_enabled` | Whether announcements of the caller's position in the queue should be played | `boolean` |   | `false`
-`announcements.wait_time_announcements_enabled` | Whether announcements of the estimated wait time in the queue should be played | `boolean` |   | `false`
-`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object` |   | `false`
+`announcements.interval` | Time between announcements | `integer()` | `30` | `false`
+`announcements.media.in_the_queue` | Played after the numeric position | `string()` |   | `true`
+`announcements.media.increase_in_call_volume` | Played if the estimated wait time has increased since the previous wait time announcement | `string()` |   | `true`
+`announcements.media.the_estimated_wait_time_is` | Played before the estimated wait time media | `string()` |   | `true`
+`announcements.media.you_are_at_position` | Played before the numeric position | `string()` |   | `true`
+`announcements.media` | Custom prompts to be played for the announcements | `object()` |   | `false`
+`announcements.position_announcements_enabled` | Whether announcements of the caller's position in the queue should be played | `boolean()` |   | `false`
+`announcements.wait_time_announcements_enabled` | Whether announcements of the estimated wait time in the queue should be played | `boolean()` |   | `false`
+`announcements` | Configuration for periodic announcements to callers waiting in the queue | `object()` |   | `false`
 `caller_exit_key` | Key caller can press while on hold to exit the queue and continue in the callflow | `string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '*' | '0' | '#')` | `#` | `false`
 `cdr_url` | An optional HTTP URL to POST the CDR | `string()` |   | `false`
 `connection_timeout` | In seconds, how long to try to connect the caller before progressing past the queue callflow action | `integer()` | `3600` | `false`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -23027,6 +23027,54 @@
                     "description": "Media ID (or appropriate media URI) of media to play when caller is about to be connected.",
                     "type": "string"
                 },
+                "announcements": {
+                    "description": "Configuration for periodic announcements to callers waiting in the queue",
+                    "properties": {
+                        "interval": {
+                            "default": 30,
+                            "description": "Time between announcements",
+                            "minimum": 15,
+                            "type": "integer"
+                        },
+                        "media": {
+                            "description": "Custom prompts to be played for the announcements",
+                            "properties": {
+                                "in_the_queue": {
+                                    "description": "Played after the numeric position",
+                                    "type": "string"
+                                },
+                                "increase_in_call_volume": {
+                                    "description": "Played if the estimated wait time has increased since the previous wait time announcement",
+                                    "type": "string"
+                                },
+                                "the_estimated_wait_time_is": {
+                                    "description": "Played before the estimated wait time media",
+                                    "type": "string"
+                                },
+                                "you_are_at_position": {
+                                    "description": "Played before the numeric position",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "in_the_queue",
+                                "increase_in_call_volume",
+                                "the_estimated_wait_time_is",
+                                "you_are_at_position"
+                            ],
+                            "type": "object"
+                        },
+                        "position_announcements_enabled": {
+                            "description": "Whether announcements of the caller's position in the queue should be played",
+                            "type": "boolean"
+                        },
+                        "wait_time_announcements_enabled": {
+                            "description": "Whether announcements of the estimated wait time in the queue should be played",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
                 "caller_exit_key": {
                     "default": "#",
                     "description": "Key caller can press while on hold to exit the queue and continue in the callflow",

--- a/applications/crossbar/priv/couchdb/schemas/queues.json
+++ b/applications/crossbar/priv/couchdb/schemas/queues.json
@@ -19,6 +19,54 @@
             "description": "Media ID (or appropriate media URI) of media to play when caller is about to be connected.",
             "type": "string"
         },
+        "announcements": {
+            "description": "Configuration for periodic announcements to callers waiting in the queue",
+            "properties": {
+                "interval": {
+                    "default": 30,
+                    "description": "Time between announcements",
+                    "minimum": 15,
+                    "type": "integer"
+                },
+                "media": {
+                    "description": "Custom prompts to be played for the announcements",
+                    "properties": {
+                        "in_the_queue": {
+                            "description": "Played after the numeric position",
+                            "type": "string"
+                        },
+                        "increase_in_call_volume": {
+                            "description": "Played if the estimated wait time has increased since the previous wait time announcement",
+                            "type": "string"
+                        },
+                        "the_estimated_wait_time_is": {
+                            "description": "Played before the estimated wait time media",
+                            "type": "string"
+                        },
+                        "you_are_at_position": {
+                            "description": "Played before the numeric position",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "in_the_queue",
+                        "increase_in_call_volume",
+                        "the_estimated_wait_time_is",
+                        "you_are_at_position"
+                    ],
+                    "type": "object"
+                },
+                "position_announcements_enabled": {
+                    "description": "Whether announcements of the caller's position in the queue should be played",
+                    "type": "boolean"
+                },
+                "wait_time_announcements_enabled": {
+                    "description": "Whether announcements of the estimated wait time in the queue should be played",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "caller_exit_key": {
             "default": "#",
             "description": "Key caller can press while on hold to exit the queue and continue in the callflow",

--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -439,6 +439,8 @@ audio_macro([{'play', MediaName}|T], Call, Queue) ->
     audio_macro(T, Call, [play_command(MediaName, ?ANY_DIGIT, Call) | Queue]);
 audio_macro([{'play', MediaName, Terminators}|T], Call, Queue) ->
     audio_macro(T, Call, [play_command(MediaName, Terminators, Call) | Queue]);
+audio_macro([{'play', MediaName, Terminators, Leg}|T], Call, Queue) ->
+    audio_macro(T, Call, [play_command(MediaName, Terminators, Leg, Call) | Queue]);
 audio_macro([{'prompt', PromptName}|T], Call, Queue) ->
     audio_macro(T, Call, [play_command(kapps_call:get_prompt(Call, PromptName)
                                       ,?ANY_DIGIT
@@ -449,6 +451,14 @@ audio_macro([{'prompt', PromptName}|T], Call, Queue) ->
 audio_macro([{'prompt', PromptName, Lang}|T], Call, Queue) ->
     audio_macro(T, Call, [play_command(kapps_call:get_prompt(Call, PromptName, Lang)
                                       ,?ANY_DIGIT
+                                      ,Call
+                                      )
+                          | Queue
+                         ]);
+audio_macro([{'prompt', PromptName, Lang, Leg}|T], Call, Queue) ->
+    audio_macro(T, Call, [play_command(kapps_call:get_prompt(Call, PromptName, Lang)
+                                      ,?ANY_DIGIT
+                                      ,Leg
                                       ,Call
                                       )
                           | Queue


### PR DESCRIPTION
Add support for periodic position and estimated wait time announcements while waiting for call to be answered in ACDc queue.
Either can be enabled independently, time interval and media files are customizable.

Relevant media files at: https://github.com/2600hz/kazoo-sounds/pull/6