### PR TITLE
event is metaflow.bind

### DIFF
--- a/applications/konami/src/konami_listener.erl
+++ b/applications/konami/src/konami_listener.erl
@@ -31,7 +31,7 @@
 -type state() :: #state{}.
 
 %% By convention, we put the options here in macros, but not required.
--define(BINDINGS, [{'metaflow', [{'restrict_to', ['bindings']}]}
+-define(BINDINGS, [{'metaflow', [{'restrict_to', ['bind']}]}
                   ,{'route', []}
                   ]).
 -define(RESPONDERS, [{{?MODULE, 'handle_metaflow'}


### PR DESCRIPTION
defined in kapi_metaflow:
define(METAFLOW_BIND_ROUTING_KEY(AccountId, CallId), <<"metaflow.bind.", (amqp_util:encode(AccountId))/binary, ".", (amqp_util:encode(CallId))/binary>>).