### PR TITLE
[4.1] Resurrect kt compactor

### DIFF
--- a/applications/tasks/priv/list_task_modules.py
+++ b/applications/tasks/priv/list_task_modules.py
@@ -5,6 +5,7 @@ import sys, os, glob
 
 header_path = "src/task_modules.hrl"
 task_modules_path = "src/modules/*.erl"
+ignore_files = ['kt_compactor_worker', 'kt_skel']
 
 def fname(path):
     (name, ext) = (os.path.splitext(os.path.basename(path)))
@@ -14,7 +15,7 @@ with open(header_path, 'w') as header_file:
     name = fname(header_path)
     header_name = name.upper()
 
-    keys = glob.glob(task_modules_path)
+    keys = [fname(key) for key in glob.glob(task_modules_path) if fname(key) not in ignore_files]
     keys.sort()
     first, rest = keys[0], keys[1:]
 
@@ -22,11 +23,10 @@ with open(header_path, 'w') as header_file:
 
     header_file.write("-define("+header_name+"_HRL, 'true').\n\n")
 
-    header_file.write("-define(TASKS, ['"+fname(first)+"'\n")
+    header_file.write("-define(TASKS, ['"+first+"'\n")
 
     for k in rest:
-        if "kt_skel" not in k:
-            header_file.write("               ,'"+fname(k)+"'\n")
+        header_file.write("               ,'"+k+"'\n")
 
     header_file.write("               ]).\n\n")
     header_file.write("-endif.\n")

--- a/applications/tasks/src/modules/kt_compactor_worker.erl
+++ b/applications/tasks/src/modules/kt_compactor_worker.erl
@@ -154,8 +154,8 @@ compact_design_docs(Conn, Shard, DDs) ->
             compact_design_docs(Conn, Shard, Remaining)
     catch
         'error':'badarg' ->
-            lager:debug("  compacting last chunk of views: ~p", [DDs]),
-            _ = [kz_couch_view:design_compact(Conn, Shard, DD) || DD <- DDs],
+            IsStarted = [{DD, kz_couch_view:design_compact(Conn, Shard, DD)} || DD <- DDs],
+            lager:debug("  is shard ~s compacting last chunk of views started: ~p", [Shard, IsStarted]),
             wait_for_design_compaction(Conn, Shard, DDs)
     end.
 

--- a/applications/tasks/src/modules/kt_compactor_worker.erl
+++ b/applications/tasks/src/modules/kt_compactor_worker.erl
@@ -41,8 +41,8 @@
                    ,shards :: ne_binaries()
                    ,design_docs = [] :: ne_binaries()
                    ,heuristic :: heuristic()
-                   }
-       ).
+                   }).
+
 -type compactor() :: #compactor{}.
 -export_type([compactor/0]).
 
@@ -127,15 +127,14 @@ continue_compacting_shard(#compactor{shards=[Shard]}=Compactor) ->
     wait_for_compaction(compactor_admin(Compactor), Shard),
 
     %% cleans up old view indexes
-    lager:debug("  db view cleanup starting"),
-    kz_couch_db:db_view_cleanup(compactor_conn(Compactor), Shard),
+    IsCleanup = kz_couch_db:db_view_cleanup(compactor_admin(Compactor), Shard),
+    lager:debug("  is shard view cleaning up started ~s: ~s", [Shard, IsCleanup]),
 
     wait_for_compaction(compactor_admin(Compactor), Shard),
 
     %% compacts views
-    lager:debug("  design doc compaction starting"),
-    Database = shard_to_database(Shard),
-    compact_design_docs(compactor_conn(Compactor), Database, compactor_design_docs(Compactor)),
+    lager:debug("  design doc compaction starting for shard ~s", [Shard]),
+    compact_design_docs(compactor_admin(Compactor), Shard, compactor_design_docs(Compactor)),
 
     case get_db_disk_and_data(compactor_admin(Compactor), Shard) of
         'undefined' -> lager:debug("  finished compacting shard");
@@ -144,20 +143,13 @@ continue_compacting_shard(#compactor{shards=[Shard]}=Compactor) ->
             lager:debug("  finished compacting shard: ~p disk/~p data", [AfterDisk, AfterData])
     end.
 
--spec shard_to_database(ne_binary()) -> ne_binary().
-shard_to_database(<<"shards"
-                    ,_RangeAndSeparators:23/binary
-                    ,DbAndSuffix/binary
-                  >>) ->
-    binary:part(DbAndSuffix, 0, byte_size(DbAndSuffix)-11).
-
 -spec compact_design_docs(kz_data:connection(), ne_binary(), ne_binaries()) -> 'ok'.
 compact_design_docs(_Conn, _Shard, []) -> 'ok';
 compact_design_docs(Conn, Shard, DDs) ->
     try lists:split(?MAX_COMPACTING_VIEWS, DDs) of
         {Compact, Remaining} ->
-            lager:debug("  compacting chunk of views: ~p", [Compact]),
-            _ = [kz_couch_view:design_compact(Conn, Shard, DD) || DD <- Compact],
+            IsStarted = [{DD, kz_couch_view:design_compact(Conn, Shard, DD)} || DD <- Compact],
+            lager:debug("  is shard ~s compacting chunk of views started: ~p", [Shard, IsStarted]),
             wait_for_design_compaction(Conn, Shard, Compact),
             compact_design_docs(Conn, Shard, Remaining)
     catch
@@ -246,16 +238,16 @@ should_compact(Compactor, ?HEUR_RATIO) ->
 -spec get_db_disk_and_data(kz_data:connection(), ne_binary(), 0..3) ->
                                   {pos_integer(), pos_integer()} |
                                   'undefined' | 'not_found'.
-get_db_disk_and_data(Conn, Unencoded) ->
-    get_db_disk_and_data(Conn, Unencoded, 0).
+get_db_disk_and_data(Conn, DbName) ->
+    get_db_disk_and_data(Conn, DbName, 0).
 
-get_db_disk_and_data(_Conn, _Unencoded, 3=_N) ->
-    lager:warning("getting db info for ~s failed ~b times", [_Unencoded, _N]),
+get_db_disk_and_data(_Conn, _DbName, 3=_N) ->
+    lager:warning("getting db info for ~s failed ~b times", [_DbName, _N]),
     'undefined';
-get_db_disk_and_data(Conn, Unencoded, N) ->
+get_db_disk_and_data(Conn, DbName, N) ->
     N > 0
         andalso lager:debug("getting db info re-attempt ~p", [N]),
-    case kz_couch_db:db_info(Conn, encode_db(Unencoded)) of
+    case kz_couch_db:db_info(Conn, DbName) of
         {'ok', Info} ->
             {kz_json:get_integer_value(<<"disk_size">>, Info)
             ,kz_json:get_integer_value([<<"other">>, <<"data_size">>], Info)
@@ -263,15 +255,15 @@ get_db_disk_and_data(Conn, Unencoded, N) ->
         {'error', {'conn_failed',{'error','timeout'}}} ->
             lager:debug("timed out asking for info, waiting and trying again"),
             'ok' = timer:sleep(?MILLISECONDS_IN_SECOND),
-            get_db_disk_and_data(Conn, Unencoded, N+1);
+            get_db_disk_and_data(Conn, DbName, N+1);
         {'error', 'not_found'} ->
-            lager:debug("db '~s' not found, skipping", [Unencoded]),
+            lager:debug("db '~s' not found, skipping", [DbName]),
             'not_found';
         {'error', 'db_not_found'} ->
-            lager:debug("shard '~s' not found, skipping", [Unencoded]),
+            lager:debug("shard '~s' not found, skipping", [DbName]),
             'not_found';
         {'error', _E} ->
-            lager:debug("failed to lookup info: ~p", [_E]),
+            lager:debug("failed to lookup ~s info: ~p", [DbName, _E]),
             'undefined'
     end.
 
@@ -319,7 +311,7 @@ compactor_heuristic(#compactor{heuristic=Heuristic}) -> Heuristic.
                  compactor().
 new(Node, Heuristic, APIConn, AdminConn, Database) ->
     #compactor{node=Node
-              ,database=Database
+              ,database=kz_http_util:urlencode(Database)
               ,conn=APIConn
               ,admin=AdminConn
               ,heuristic=Heuristic
@@ -340,13 +332,9 @@ node_shards(Node, Unencoded, DbInfo) ->
      || Range <- Ranges
     ].
 
--spec encode_db(ne_binary()) -> ne_binary().
-encode_db(Database) ->
-    kz_http_util:urlencode(Database).
-
 -spec db_design_docs(kz_data:connection(), ne_binary()) -> ne_binaries().
 db_design_docs(Conn, D) ->
-    case kz_couch_view:all_design_docs(Conn, encode_db(D)) of
+    case kz_couch_view:all_design_docs(Conn, kz_http_util:urlencode(D)) of
         {'ok', Designs} ->
             [encode_design_doc(kz_doc:id(Design)) || Design <- Designs];
         {'error', _} -> []

--- a/core/kazoo_config/src/kapps_config.erl
+++ b/core/kazoo_config/src/kapps_config.erl
@@ -196,10 +196,14 @@ get_integer(Category, Key) ->
         'undefined' -> 'undefined';
         Else -> kz_term:to_integer(Else)
     end.
+
 get_integer(Category, Key, Default) ->
     get_integer(Category, Key, Default, kz_term:to_binary(node())).
 get_integer(Category, Key, Default, Node) ->
-    kz_term:to_integer(get(Category, Key, Default, Node)).
+    case get(Category, Key, Default, Node) of
+        'undefined' -> 'undefined';
+        Else -> kz_term:to_integer(Else)
+    end.
 
 %%-----------------------------------------------------------------------------
 %% @public

--- a/core/kazoo_couch/src/kazoo_couch.erl
+++ b/core/kazoo_couch/src/kazoo_couch.erl
@@ -92,7 +92,7 @@ get_admin_nodes() ->
     get_admin_nodes(Conn).
 
 get_admin_nodes(#server{}=Server) ->
-    get_admin_dbs(server_version(Server));
+    get_admin_nodes(server_version(Server));
 get_admin_nodes('bigcouch') -> <<"nodes">>;
 get_admin_nodes(_Driver) -> <<"_nodes">>.
 
@@ -117,7 +117,7 @@ db_create(Server, DbName, Options) ->
 db_delete(Server, DbName) ->
     kz_couch_db:db_delete(Server, DbName).
 
--spec db_view_cleanup(kz_data:connection(), ne_binary()) -> any().
+-spec db_view_cleanup(kz_data:connection(), ne_binary()) -> boolean().
 db_view_cleanup(Server, DbName) ->
     kz_couch_db:db_view_cleanup(Server, DbName).
 

--- a/core/kazoo_couch/src/kz_couch_util.erl
+++ b/core/kazoo_couch/src/kz_couch_util.erl
@@ -220,6 +220,7 @@ is_admin_db(<<"_users">>, 'couchdb_1_6') -> 'true';
 is_admin_db(<<"_nodes">>, 'couchdb_1_6') -> 'true';
 is_admin_db(<<"dbs">>, 'bigcouch') -> 'true';
 is_admin_db(<<"users">>, 'bigcouch') -> 'true';
+is_admin_db(<<"nodes">>, 'bigcouch') -> 'true';
 is_admin_db(_Db, _Driver) -> 'false'.
 
 -spec maybe_use_admin_conn(kz_data:connection()) -> kz_data:connection().

--- a/core/kazoo_couch/src/kz_couch_view.erl
+++ b/core/kazoo_couch/src/kz_couch_view.erl
@@ -27,7 +27,7 @@
 design_compact(#server{}=Conn, DbName, Design) ->
     case couchbeam:compact(kz_couch_util:get_db(Conn, DbName), Design) of
         {'error', _E} ->
-            lager:debug("failed to compact design doc: ~p", [kz_couch_util:format_error(_E)]),
+            lager:debug("failed to compact design doc ~s/~s: ~p", [DbName, Design, kz_couch_util:format_error(_E)]),
             'false';
         'ok' -> 'true'
     end.

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -373,7 +373,9 @@ db_view_cleanup(DbName) when ?VALID_DBNAME(DbName) ->
 db_view_cleanup(DbName) ->
     case maybe_convert_dbname(DbName) of
         {'ok', Db} -> db_view_cleanup(Db);
-        {'error', _}=E -> E
+        {'error', _Reason} ->
+            lager:debug("failed to convert db name ~s: ~p", [DbName, _Reason]),
+            'false'
     end.
 
 -spec db_view_update(ne_binary(), views_listing()) -> boolean().

--- a/core/kazoo_data/src/kzs_util.erl
+++ b/core/kazoo_data/src/kzs_util.erl
@@ -28,6 +28,7 @@ db_classification(<<"_dbs">>) -> 'external';
 db_classification(<<"users">>) -> 'external';
 db_classification(<<"dbs">>) -> 'external';
 db_classification(<<"_nodes">>) -> 'external';
+db_classification(<<"nodes">>) -> 'external';
 db_classification(<<"_replicator">>) -> 'external';
 db_classification(<<"_global_changes">>) -> 'external';
 db_classification(<<"ts">>) -> 'deprecated';

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -56,12 +56,14 @@ dep_jiffy = git https://github.com/fenollp/jiffy patch-1  ## See https://github.
 dep_nklib = git https://github.com/NetComposer/nklib
 dep_plists = hex 1.0.0
 
-dep_couchbeam = git https://github.com/2600hz/couchbeam 1.4.1a
+dep_couchbeam = git https://github.com/2600hz/couchbeam 1.4.1b
 ###dep_couchbeam = git https://github.com/benoitc/couchbeam 1.4.1
 ### waiting for pull requests
 ### https://github.com/benoitc/couchbeam/pull/158
 ### https://github.com/benoitc/couchbeam/pull/164
 ### https://github.com/benoitc/couchbeam/pull/165
+### https://github.com/benoitc/couchbeam/pull/166
+### https://github.com/benoitc/couchbeam/pull/174
 
 dep_jesse = git https://github.com/2600hz/jesse 1.5-rc6
 ##dep_jesse = git https://github.com/for-GET/jesse 1.5.0-rc2


### PR DESCRIPTION
Fix various problem in `kt_compactor`.

**Note:** `couchbeam` needs to patch to have `Content-type` header when doing `view_cleanup` otherwise BigCouch is returning an error

master: #4109 