### PR TITLE
Refresh commands over AMQP

### DIFF
--- a/applications/acdc/src/acdc_maint_listener.erl
+++ b/applications/acdc/src/acdc_maint_listener.erl
@@ -24,6 +24,7 @@
 -include("acdc.hrl").
 
 -define(SERVER, ?MODULE).
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -record(state, {}).
 -type state() :: #state{}.
@@ -55,6 +56,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/acdc/src/acdc_maint_listener.erl
+++ b/applications/acdc/src/acdc_maint_listener.erl
@@ -1,0 +1,174 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(acdc_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("acdc.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_ACDC_DB)]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    Created = kz_datamgr:db_create(?KZ_ACDC_DB),
+    send_resp(MaintJObj, Created).
+
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Created) ->
+    Resp = [{<<"Code">>, code(Created)}
+           ,{<<"Message">>, message(Created)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+code('true') -> 200;
+code('false') -> 500.
+
+message('true') -> <<"Success">>;
+message('false') -> <<"Failure">>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/applications/acdc/src/acdc_sup.erl
+++ b/applications/acdc/src/acdc_sup.erl
@@ -29,6 +29,7 @@
                   ,?WORKER('acdc_agent_manager')
                   ,?WORKER('acdc_init')
                   ,?WORKER('acdc_listener')
+                  ,?WORKER('acdc_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/applications/cccp/src/cccp_maint_listener.erl
+++ b/applications/cccp/src/cccp_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("cccp.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -52,6 +53,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/cccp/src/cccp_maint_listener.erl
+++ b/applications/cccp/src/cccp_maint_listener.erl
@@ -1,0 +1,171 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(cccp_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("cccp.hrl").
+
+-define(SERVER, ?MODULE).
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_CCCPS_DB)]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    Created = kz_datamgr:db_create(?KZ_CCCPS_DB),
+    send_resp(MaintJObj, Created).
+
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Created) ->
+    Resp = [{<<"Code">>, code(Created)}
+           ,{<<"Message">>, message(Created)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+code('true') -> 200;
+code('false') -> 500.
+
+message('true') -> <<"Success">>;
+message('false') -> <<"Failure">>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', 'ok'}.
+init([]) ->
+    {'ok', 'ok'}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), 'ok') -> handle_call_ret_state('ok').
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), 'ok') -> handle_cast_ret_state('ok').
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), 'ok') -> handle_info_ret_state('ok').
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), 'ok') -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), 'ok', any()) -> {'ok', 'ok'}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/applications/cccp/src/cccp_sup.erl
+++ b/applications/cccp/src/cccp_sup.erl
@@ -21,6 +21,7 @@
 -define(CHILDREN, [?SUPER('cccp_platform_sup')
                   ,?SUPER('cccp_callback_sup')
                   ,?WORKER('cccp_listener')
+                  ,?WORKER('cccp_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/applications/cdr/src/cdr_maint_listener.erl
+++ b/applications/cdr/src/cdr_maint_listener.erl
@@ -65,8 +65,8 @@ start_link() ->
 handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
     handle_refresh(MaintJObj
-                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
+                  ,kapi_maintenance:req_action(MaintJObj)
+                  ,kapi_maintenance:req_database(MaintJObj)
                   ).
 
 handle_refresh(MaintJObj, <<"refresh_database">>, ?KZ_ANONYMOUS_CDR_DB) ->

--- a/applications/cdr/src/cdr_maint_listener.erl
+++ b/applications/cdr/src/cdr_maint_listener.erl
@@ -31,9 +31,7 @@
 
 %% By convention, we put the options here in macros, but not required.
 %% define what databases or classifications we're interested in
--define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_ANONYMOUS_CDR_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_ANONYMOUS_CDR_DB)
-                      ]).
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_views_db(?KZ_ANONYMOUS_CDR_DB)]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
 -define(RESPONDERS, [{{?MODULE, 'handle_req'}
                      ,[{<<"maintenance">>, <<"req">>}]
@@ -71,9 +69,6 @@ handle_req(MaintJObj, _Props) ->
                   ,kapi_maintenance:req_database(MaintJObj)
                   ).
 
-handle_refresh(MaintJObj, <<"refresh_database">>, ?KZ_ANONYMOUS_CDR_DB) ->
-    Created = kz_datamgr:db_create(?KZ_ANONYMOUS_CDR_DB),
-    send_resp(MaintJObj, Created);
 handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_ANONYMOUS_CDR_DB) ->
     Revised = kz_datamgr:revise_doc_from_file(?KZ_ANONYMOUS_CDR_DB, 'cdr', <<"cdr.json">>),
     send_resp(MaintJObj, Revised).

--- a/applications/cdr/src/cdr_maint_listener.erl
+++ b/applications/cdr/src/cdr_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("cdr.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -57,6 +58,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/cdr/src/cdr_maint_listener.erl
+++ b/applications/cdr/src/cdr_maint_listener.erl
@@ -1,0 +1,193 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(cdr_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("cdr.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_ANONYMOUS_CDR_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_ANONYMOUS_CDR_DB)
+                      ]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    handle_refresh(MaintJObj
+                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
+                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
+                  ).
+
+handle_refresh(MaintJObj, <<"refresh_database">>, ?KZ_ANONYMOUS_CDR_DB) ->
+    Created = kz_datamgr:db_create(?KZ_ANONYMOUS_CDR_DB),
+    send_resp(MaintJObj, Created);
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_ANONYMOUS_CDR_DB) ->
+    Revised = kz_datamgr:revise_doc_from_file(?KZ_ANONYMOUS_CDR_DB, 'cdr', <<"cdr.json">>),
+    send_resp(MaintJObj, Revised).
+
+-type results() :: boolean() |
+                   {'ok', kz_json:object()} |
+                   kz_datamgr:data_error().
+
+-spec send_resp(kapi_mainteannce:req(), results()) -> 'ok'.
+send_resp(MaintJObj, Results) ->
+    Resp = [{<<"Code">>, code(Results)}
+           ,{<<"Message">>, message(Results)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+code('true') -> 200;
+code({'ok', _}) -> 200;
+code('false') -> 500;
+code({'error', _}) -> 500.
+
+message('true') -> <<"Success">>;
+message({'ok', _}) -> <<"Success">>;
+message('false') -> <<"Failure">>;
+message({'error', _}) -> <<"Failure">>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/applications/cdr/src/cdr_maint_listener.erl
+++ b/applications/cdr/src/cdr_maint_listener.erl
@@ -73,8 +73,7 @@ handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_ANONYMOUS_CDR_DB) ->
     Revised = kz_datamgr:revise_doc_from_file(?KZ_ANONYMOUS_CDR_DB, 'cdr', <<"cdr.json">>),
     send_resp(MaintJObj, Revised).
 
--type results() :: boolean() |
-                   {'ok', kz_json:object()} |
+-type results() :: {'ok', kz_json:object()} |
                    kz_datamgr:data_error().
 
 -spec send_resp(kapi_mainteannce:req(), results()) -> 'ok'.
@@ -86,14 +85,10 @@ send_resp(MaintJObj, Results) ->
            ],
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
-code('true') -> 200;
 code({'ok', _}) -> 200;
-code('false') -> 500;
 code({'error', _}) -> 500.
 
-message('true') -> <<"Success">>;
 message({'ok', _}) -> <<"Success">>;
-message('false') -> <<"Failure">>;
 message({'error', _}) -> <<"Failure">>.
 
 %%%===================================================================

--- a/applications/cdr/src/cdr_sup.erl
+++ b/applications/cdr/src/cdr_sup.erl
@@ -21,7 +21,9 @@
 
 -define(SERVER, ?MODULE).
 
--define(CHILDREN, [?WORKER('cdr_listener')]).
+-define(CHILDREN, [?WORKER('cdr_listener')
+                  ,?WORKER('cdr_maint_listener')
+                  ]).
 
 %% ===================================================================
 %% API functions

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -13357,6 +13357,67 @@
             },
             "type": "object"
         },
+        "kapi.maintenance.req": {
+            "description": "AMQP API for maintenance.req",
+            "properties": {
+                "Action": {
+                    "enum": [
+                        "refresh_database",
+                        "refresh_views"
+                    ],
+                    "type": "string"
+                },
+                "Classification": {
+                    "type": "string"
+                },
+                "Database": {
+                    "type": "string"
+                },
+                "Event-Category": {
+                    "enum": [
+                        "maintenance"
+                    ],
+                    "type": "string"
+                },
+                "Event-Name": {
+                    "enum": [
+                        "req"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Action"
+            ],
+            "type": "object"
+        },
+        "kapi.maintenance.resp": {
+            "description": "AMQP API for maintenance.resp",
+            "properties": {
+                "Code": {
+                    "type": "integer"
+                },
+                "Event-Category": {
+                    "enum": [
+                        "maintenance"
+                    ],
+                    "type": "string"
+                },
+                "Event-Name": {
+                    "enum": [
+                        "resp"
+                    ],
+                    "type": "string"
+                },
+                "Message": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Code"
+            ],
+            "type": "object"
+        },
         "kapi.media.error": {
             "description": "AMQP API for media.error",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/kapi.maintenance.req.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.maintenance.req.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.maintenance.req",
+    "description": "AMQP API for maintenance.req",
+    "properties": {
+        "Action": {
+            "enum": [
+                "refresh_database",
+                "refresh_views"
+            ],
+            "type": "string"
+        },
+        "Classification": {
+            "type": "string"
+        },
+        "Database": {
+            "type": "string"
+        },
+        "Event-Category": {
+            "enum": [
+                "maintenance"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "req"
+            ],
+            "type": "string"
+        }
+    },
+    "required": [
+        "Action"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/kapi.maintenance.resp.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.maintenance.resp.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.maintenance.resp",
+    "description": "AMQP API for maintenance.resp",
+    "properties": {
+        "Code": {
+            "type": "integer"
+        },
+        "Event-Category": {
+            "enum": [
+                "maintenance"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "resp"
+            ],
+            "type": "string"
+        },
+        "Message": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Code"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/src/crossbar_bindings.erl
+++ b/applications/crossbar/src/crossbar_bindings.erl
@@ -194,6 +194,7 @@ is_cb_module(Mod) ->
 -spec start_link() -> 'ignore'.
 start_link() ->
     _ = init(),
+    garbage_collect(self()),
     'ignore'.
 
 -spec init() -> 'ok'.

--- a/applications/crossbar/src/crossbar_maint_listener.erl
+++ b/applications/crossbar/src/crossbar_maint_listener.erl
@@ -148,16 +148,14 @@ send_resp(MaintJObj, Revised) ->
 code({'ok', _}) -> 200;
 code('true') -> 200;
 code('ok') -> 200;
-code({'error', _}) -> 500;
-code('false') -> 500.
+code({'error', _}) -> 500.
 
 -spec message(results()) -> ne_binary().
 message({'ok', _}) -> <<"Revised crossbar docs/views">>;
 message('ok') -> <<"Revised crossbar docs/views">>;
 message({'error', E}) ->
     <<"Failed to revise docs/views: ", (kz_term:to_binary(E))/binary>>;
-message('true') -> <<"Created database">>;
-message('false') -> <<"Failed to create database">>.
+message('true') -> <<"Created database">>.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/applications/crossbar/src/crossbar_maint_listener.erl
+++ b/applications/crossbar/src/crossbar_maint_listener.erl
@@ -30,9 +30,18 @@
 
 %% By convention, we put the options here in macros, but not required.
 -define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_SCHEMA_DB)
+
                       ,kapi_maintenance:restrict_to_views_db(?KZ_CONFIG_DB)
                       ,kapi_maintenance:restrict_to_views_db(?KZ_SCHEMA_DB)
                       ,kapi_maintenance:restrict_to_views_db(?KZ_MEDIA_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_SIP_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_PORT_REQUESTS_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_ACDC_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_CCCPS_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_TOKEN_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_ALERTS_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_PENDING_NOTIFY_DB)
+
                       ,kapi_maintenance:restrict_to_views_classification('ratedeck')
                       ]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
@@ -90,6 +99,30 @@ handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_MEDIA_DB, _Class) ->
     send_resp(MaintJObj, Revised);
 handle_refresh(MaintJObj, <<"refresh_views">>, Database, 'ratedeck') ->
     Revised = kz_datamgr:revise_doc_from_file(Database, 'crossbar', <<"views/rates.json">>),
+    send_resp(MaintJObj, Revised);
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_SIP_DB, _Class) ->
+    View = kapps_util:get_view_json('crossbar', <<"views/resources.json">>),
+    case kapps_util:update_views(?KZ_SIP_DB, [View], 'true') of
+        'true' -> send_resp(MaintJObj, {'ok', MaintJObj});
+        'false' -> send_resp(MaintJObj, {'error', 'not_found'})
+    end;
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_PORT_REQUESTS_DB, _Class) ->
+    Revised = kz_datamgr:revise_doc_from_file(?KZ_PORT_REQUESTS_DB, 'crossbar', <<"views/port_requests.json">>),
+    send_resp(MaintJObj, Revised);
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_ACDC_DB, _Class) ->
+    Revised = kz_datamgr:revise_doc_from_file(?KZ_ACDC_DB, 'crossbar', <<"views/acdc.json">>),
+    send_resp(MaintJObj, Revised);
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_CCCPS_DB, _Class) ->
+    Revised = kz_datamgr:revise_doc_from_file(?KZ_CCCPS_DB, 'crossbar', <<"views/cccps.json">>),
+    send_resp(MaintJObj, Revised);
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_TOKEN_DB, _Class) ->
+    Revised = kz_datamgr:revise_doc_from_file(?KZ_TOKEN_DB, 'crossbar', "views/token_auth.json"),
+    send_resp(MaintJObj, Revised);
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_ALERTS_DB, _Class) ->
+    Revised = kz_datamgr:revise_doc_from_file(?KZ_ALERTS_DB, 'crossbar', "views/alerts.json"),
+    send_resp(MaintJObj, Revised);
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_PENDING_NOTIFY_DB, _Class) ->
+    Revised = kz_datamgr:revise_doc_from_file(?KZ_PENDING_NOTIFY_DB, 'crossbar', "views/pending_notify.json"),
     send_resp(MaintJObj, Revised).
 
 -spec send_resp(kapi_mainteannce:req(), {'ok', kz_json:object()} | kz_datamgr:data_error() | boolean()) -> 'ok'.

--- a/applications/crossbar/src/crossbar_maint_listener.erl
+++ b/applications/crossbar/src/crossbar_maint_listener.erl
@@ -35,7 +35,7 @@
                      ,[{<<"maintenance">>, <<"req">>}]
                      }
                     ]).
--define(QUEUE_NAME, <<"crossbar_maint_listener">>).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
 -define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
 -define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
 

--- a/applications/crossbar/src/crossbar_maint_listener.erl
+++ b/applications/crossbar/src/crossbar_maint_listener.erl
@@ -35,7 +35,7 @@
                      ,[{<<"maintenance">>, <<"req">>}]
                      }
                     ]).
--define(QUEUE_NAME, <<"teletype_maint_listener">>).
+-define(QUEUE_NAME, <<"crossbar_maint_listener">>).
 -define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
 -define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
 
@@ -66,21 +66,19 @@ handle_req(MaintJObj, _Props) ->
 
 -spec send_resp(kapi_mainteannce:req(), {'ok', kz_json:object()} | kz_datamgr:data_error()) -> 'ok'.
 send_resp(MaintJObj, Revised) ->
-    RespQueue = kz_api:server_id(MaintJObj),
-
     Resp = [{<<"Code">>, code(Revised)}
            ,{<<"Message">>, message(Revised)}
            ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
-            | kz_api:default_headers(RespQueue, ?APP_NAME, ?APP_VERSION)
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
-    kapi_maintenance:publish_resp(RespQueue, Resp).
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
 -spec code({'ok', kz_json:object()} | kz_datamgr:data_error()) -> 200 | 500.
 code({'ok', _}) -> 200;
 code({'error', _}) -> 500.
 
 -spec message({'ok', kz_json:object()} | kz_datamgr:data_error()) -> ne_binary().
-message({'ok', _}) -> <<"Revised teletype views in ", (?KZ_CONFIG_DB)/binary>>;
+message({'ok', _}) -> <<"Revised crossbar views in ", (?KZ_CONFIG_DB)/binary>>;
 message({'error', E}) ->
     <<"Failed to review teletype views in "
       ,(?KZ_CONFIG_DB)/binary, ": ", (kz_term:to_binary(E))/binary

--- a/applications/crossbar/src/crossbar_maint_listener.erl
+++ b/applications/crossbar/src/crossbar_maint_listener.erl
@@ -30,9 +30,7 @@
 -type state() :: #state{}.
 
 %% By convention, we put the options here in macros, but not required.
--define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_SCHEMA_DB)
-
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_CONFIG_DB)
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_views_db(?KZ_CONFIG_DB)
                       ,kapi_maintenance:restrict_to_views_db(?KZ_SCHEMA_DB)
                       ,kapi_maintenance:restrict_to_views_db(?KZ_MEDIA_DB)
                       ,kapi_maintenance:restrict_to_views_db(?KZ_SIP_DB)
@@ -87,9 +85,6 @@ handle_req(MaintJObj, _Props) ->
                   ).
 
 -spec handle_refresh(kapi_maintenance:req(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
-handle_refresh(MaintJObj, <<"refresh_database">>, Db, _Class) ->
-    Created = kz_datamgr:db_create(Db),
-    send_resp(MaintJObj, Created);
 handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_CONFIG_DB, _Class) ->
     Revised = kz_datamgr:revise_doc_from_file(?KZ_CONFIG_DB, 'crossbar', <<"views/system_configs.json">>),
     send_resp(MaintJObj, Revised);

--- a/applications/crossbar/src/crossbar_maint_listener.erl
+++ b/applications/crossbar/src/crossbar_maint_listener.erl
@@ -79,9 +79,9 @@ handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
 
     handle_refresh(MaintJObj
-                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Classification">>, MaintJObj)
+                  ,kapi_maintenance:req_action(MaintJObj)
+                  ,kapi_maintenance:req_database(MaintJObj)
+                  ,kapi_maintenance:req_classification(MaintJObj)
                   ).
 
 -spec handle_refresh(kapi_maintenance:req(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.

--- a/applications/crossbar/src/crossbar_maint_listener.erl
+++ b/applications/crossbar/src/crossbar_maint_listener.erl
@@ -125,7 +125,11 @@ handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_PENDING_NOTIFY_DB, _Class) ->
     Revised = kz_datamgr:revise_doc_from_file(?KZ_PENDING_NOTIFY_DB, 'crossbar', "views/pending_notify.json"),
     send_resp(MaintJObj, Revised).
 
--spec send_resp(kapi_mainteannce:req(), {'ok', kz_json:object()} | kz_datamgr:data_error() | boolean()) -> 'ok'.
+-type results() :: {'ok', kz_json:object()} |
+                   kz_datamgr:data_error() |
+                   boolean() | 'ok'.
+
+-spec send_resp(kapi_mainteannce:req(), results()) -> 'ok'.
 send_resp(MaintJObj, Revised) ->
     Resp = [{<<"Code">>, code(Revised)}
            ,{<<"Message">>, message(Revised)}
@@ -134,14 +138,16 @@ send_resp(MaintJObj, Revised) ->
            ],
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
--spec code({'ok', kz_json:object()} | kz_datamgr:data_error() | boolean()) -> 200 | 500.
+-spec code(results()) -> 200 | 500.
 code({'ok', _}) -> 200;
 code('true') -> 200;
+code('ok') -> 200;
 code({'error', _}) -> 500;
 code('false') -> 500.
 
--spec message({'ok', kz_json:object()} | kz_datamgr:data_error()) -> ne_binary().
+-spec message(results()) -> ne_binary().
 message({'ok', _}) -> <<"Revised crossbar docs/views">>;
+message('ok') -> <<"Revised crossbar docs/views">>;
 message({'error', E}) ->
     <<"Failed to revise docs/views: ", (kz_term:to_binary(E))/binary>>;
 message('true') -> <<"Created database">>;

--- a/applications/crossbar/src/crossbar_maint_listener.erl
+++ b/applications/crossbar/src/crossbar_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("crossbar.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -70,6 +71,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/crossbar/src/crossbar_maint_listener.erl
+++ b/applications/crossbar/src/crossbar_maint_listener.erl
@@ -99,7 +99,7 @@ handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_SCHEMA_DB, _Class) ->
 handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_MEDIA_DB, _Class) ->
     Revised = kz_datamgr:revise_doc_from_file(?KZ_MEDIA_DB, 'crossbar', "account/media.json"),
     send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, Database, 'ratedeck') ->
+handle_refresh(MaintJObj, <<"refresh_views">>, Database, <<"ratedeck">>) ->
     Revised = kz_datamgr:revise_doc_from_file(Database, 'crossbar', <<"views/rates.json">>),
     send_resp(MaintJObj, Revised);
 handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_SIP_DB, _Class) ->

--- a/applications/fax/src/fax_maint_listener.erl
+++ b/applications/fax/src/fax_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("fax.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -60,6 +61,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/fax/src/fax_maint_listener.erl
+++ b/applications/fax/src/fax_maint_listener.erl
@@ -74,7 +74,7 @@ handle_refresh(MaintJObj, <<"refresh_views">>) ->
     _ = kz_datamgr:revise_doc_from_file(?KZ_FAXES_DB, 'fax', ?FAXBOX_VIEW_FILE),
     send_resp(MaintJObj, 'true').
 
--spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+-spec send_resp(kapi_mainteannce:req(), 'true') -> 'ok'.
 send_resp(MaintJObj, Results) ->
     Resp = [{<<"Code">>, code(Results)}
            ,{<<"Message">>, message(Results)}
@@ -83,11 +83,9 @@ send_resp(MaintJObj, Results) ->
            ],
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
-code('true') -> 200;
-code('false') -> 500.
+code('true') -> 200.
 
-message('true') -> <<"Success">>;
-message('false') -> <<"Failure">>.
+message('true') -> <<"Success">>.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/applications/fax/src/fax_maint_listener.erl
+++ b/applications/fax/src/fax_maint_listener.erl
@@ -1,0 +1,186 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(fax_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("fax.hrl").
+
+-define(SERVER, ?MODULE).
+
+-define(FAXES_VIEW_FILE, <<"views/faxes.json">>).
+-define(FAXBOX_VIEW_FILE, <<"views/faxbox.json">>).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_FAXES_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_FAXES_DB)
+                      ]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    handle_refresh(MaintJObj, kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)).
+
+handle_refresh(MaintJObj, <<"refresh_database">>) ->
+    Created = kz_datamgr:db_create(?KZ_FAXES_DB),
+    send_resp(MaintJObj, Created);
+handle_refresh(MaintJObj, <<"refresh_views">>) ->
+    _ = kz_datamgr:revise_doc_from_file(?KZ_FAXES_DB, 'fax', ?FAXES_VIEW_FILE),
+    _ = kz_datamgr:revise_doc_from_file(?KZ_FAXES_DB, 'fax', ?FAXBOX_VIEW_FILE),
+    send_resp(MaintJObj, 'true').
+
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Results) ->
+    Resp = [{<<"Code">>, code(Results)}
+           ,{<<"Message">>, message(Results)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+code('true') -> 200;
+code('false') -> 500.
+
+message('true') -> <<"Success">>;
+message('false') -> <<"Failure">>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/applications/fax/src/fax_maint_listener.erl
+++ b/applications/fax/src/fax_maint_listener.erl
@@ -67,7 +67,7 @@ start_link() ->
 -spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
 handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
-    handle_refresh(MaintJObj, kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)).
+    handle_refresh(MaintJObj, kapi_maintenance:req_action(MaintJObj)).
 
 handle_refresh(MaintJObj, <<"refresh_database">>) ->
     Created = kz_datamgr:db_create(?KZ_FAXES_DB),

--- a/applications/fax/src/fax_maint_listener.erl
+++ b/applications/fax/src/fax_maint_listener.erl
@@ -34,9 +34,7 @@
 
 %% By convention, we put the options here in macros, but not required.
 %% define what databases or classifications we're interested in
--define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_FAXES_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_FAXES_DB)
-                      ]).
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_views_db(?KZ_FAXES_DB)]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
 -define(RESPONDERS, [{{?MODULE, 'handle_req'}
                      ,[{<<"maintenance">>, <<"req">>}]
@@ -71,9 +69,6 @@ handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
     handle_refresh(MaintJObj, kapi_maintenance:req_action(MaintJObj)).
 
-handle_refresh(MaintJObj, <<"refresh_database">>) ->
-    Created = kz_datamgr:db_create(?KZ_FAXES_DB),
-    send_resp(MaintJObj, Created);
 handle_refresh(MaintJObj, <<"refresh_views">>) ->
     _ = kz_datamgr:revise_doc_from_file(?KZ_FAXES_DB, 'fax', ?FAXES_VIEW_FILE),
     _ = kz_datamgr:revise_doc_from_file(?KZ_FAXES_DB, 'fax', ?FAXBOX_VIEW_FILE),

--- a/applications/fax/src/fax_monitor.erl
+++ b/applications/fax/src/fax_monitor.erl
@@ -118,6 +118,7 @@ handle_info('timeout', State) ->
         {'ok', []} -> {'noreply', State, ?POLLING_INTERVAL};
         {'ok', AccountIds} ->
             _ = distribute_accounts(AccountIds),
+            _ = garbage_collect(),
             {'noreply', State, ?POLLING_INTERVAL};
         {'error', _Reason} ->
             lager:debug("failed to fetch fax account jobs: ~p", [_Reason]),

--- a/applications/fax/src/fax_sup.erl
+++ b/applications/fax/src/fax_sup.erl
@@ -40,6 +40,7 @@
                   ,?WORKER('fax_shared_listener')
                   ,?WORKER('fax_monitor')
                   ,?WORKER_ARGS('gen_smtp_server', ?SMTP_ARGS)
+                  ,?WORKER('fax_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/applications/hotornot/src/hotornot_maint_listener.erl
+++ b/applications/hotornot/src/hotornot_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("hotornot.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -57,6 +58,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/hotornot/src/hotornot_maint_listener.erl
+++ b/applications/hotornot/src/hotornot_maint_listener.erl
@@ -75,7 +75,7 @@ handle_refresh(MaintJObj, <<"refresh_views">>, RateDb) ->
     kz_datamgr:load_fixtures_from_folder(RateDb, 'hotornot'),
     send_resp(MaintJObj, Revised).
 
--type results() :: boolean() | 'ok'.
+-type results() :: 'ok'.
 
 -spec send_resp(kapi_mainteannce:req(), results()) -> 'ok'.
 send_resp(MaintJObj, Result) ->
@@ -86,13 +86,9 @@ send_resp(MaintJObj, Result) ->
            ],
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
-code('true') -> 200;
-code('ok') -> 200;
-code('false') -> 500.
+code('ok') -> 200.
 
-message('true') -> <<"Created databse">>;
-message('ok') -> <<"Refreshed database">>;
-message('false') -> <<"Failed to create database">>.
+message('ok') -> <<"Refreshed database">>.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/applications/hotornot/src/hotornot_maint_listener.erl
+++ b/applications/hotornot/src/hotornot_maint_listener.erl
@@ -31,9 +31,7 @@
 
 %% By convention, we put the options here in macros, but not required.
 %% define what databases or classifications we're interested in
--define(RESTRICTIONS, [kapi_maintenance:restrict_to_classification('ratedeck')
-                      ,kapi_maintenance:restrict_to_views_classification('ratedeck')
-                      ]).
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_views_classification('ratedeck')]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
 -define(RESPONDERS, [{{?MODULE, 'handle_req'}
                      ,[{<<"maintenance">>, <<"req">>}]
@@ -72,9 +70,6 @@ handle_req(MaintJObj, _Props) ->
                   ,kapi_maintenance:req_database(MaintJObj)
                   ).
 
-handle_refresh(MaintJObj, <<"refresh_database">>, RateDb) ->
-    Created = kz_datamgr:db_create(RateDb),
-    send_resp(MaintJObj, Created);
 handle_refresh(MaintJObj, <<"refresh_views">>, RateDb) ->
     Revised = kz_datamgr:revise_docs_from_folder(RateDb, 'hotornot', "views"),
     kz_datamgr:load_fixtures_from_folder(RateDb, 'hotornot'),

--- a/applications/hotornot/src/hotornot_maint_listener.erl
+++ b/applications/hotornot/src/hotornot_maint_listener.erl
@@ -66,8 +66,8 @@ handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
 
     handle_refresh(MaintJObj
-                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
+                  ,kapi_maintenance:req_action(MaintJObj)
+                  ,kapi_maintenance:req_database(MaintJObj)
                   ).
 
 handle_refresh(MaintJObj, <<"refresh_database">>, RateDb) ->

--- a/applications/hotornot/src/hotornot_maint_listener.erl
+++ b/applications/hotornot/src/hotornot_maint_listener.erl
@@ -78,7 +78,9 @@ handle_refresh(MaintJObj, <<"refresh_views">>, RateDb) ->
     kz_datamgr:load_fixtures_from_folder(RateDb, 'hotornot'),
     send_resp(MaintJObj, Revised).
 
--spec send_resp(kapi_mainteannce:req(), boolean() | tuple()) -> 'ok'.
+-type results() :: boolean() | 'ok'.
+
+-spec send_resp(kapi_mainteannce:req(), results()) -> 'ok'.
 send_resp(MaintJObj, Result) ->
     Resp = [{<<"Code">>, code(Result)}
            ,{<<"Message">>, message(Result)}
@@ -88,14 +90,12 @@ send_resp(MaintJObj, Result) ->
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
 code('true') -> 200;
-code({'ok', _}) -> 200;
-code('false') -> 500;
-code({'error', _}) -> 500.
+code('ok') -> 200;
+code('false') -> 500.
 
 message('true') -> <<"Created databse">>;
-message({'ok', _}) -> <<"Refreshed database">>;
-message('false') -> <<"Failed to create database">>;
-message({'error', _}) -> <<"Failed to refresh database">>.
+message('ok') -> <<"Refreshed database">>;
+message('false') -> <<"Failed to create database">>.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/applications/hotornot/src/hotornot_sup.erl
+++ b/applications/hotornot/src/hotornot_sup.erl
@@ -22,6 +22,7 @@
 
 -define(CHILDREN, [?CACHE(?CACHE_NAME)
                   ,?WORKER('hotornot_listener')
+                  ,?WORKER('hotornot_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/applications/registrar/src/reg.hrl
+++ b/applications/registrar/src/reg.hrl
@@ -33,7 +33,6 @@
                    }).
 -type auth_user() :: #auth_user{}.
 
-
 -define(GSM_CACHED_METHOD, <<"gsm_cached">>).
 -define(GSM_A3A8_METHOD, <<"gsm_a3a8">>).
 -define(GSM_ROAMING_METHOD, <<"gsm_roaming">>).

--- a/applications/registrar/src/registrar_maint_listener.erl
+++ b/applications/registrar/src/registrar_maint_listener.erl
@@ -78,10 +78,12 @@ handle_req(MaintJObj, _Props) ->
 
 handle_refresh(MaintJObj, <<"refresh_database">>, ?KZ_SIP_DB) ->
     Created = kz_datamgr:db_create(?KZ_SIP_DB),
+    lager:debug("created ~s: ~p", [?KZ_SIP_DB, Created]),
     send_resp(MaintJObj, Created);
 handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_SIP_DB) ->
     View = kapps_util:get_view_json('registrar', <<"credentials.json">>),
     Update = kapps_util:update_views(?KZ_SIP_DB, [View], 'true'),
+    lager:debug("refreshed views in ~s", [?KZ_SIP_DB]),
     send_resp(MaintJObj, Update).
 
 -type results() :: boolean().

--- a/applications/registrar/src/registrar_maint_listener.erl
+++ b/applications/registrar/src/registrar_maint_listener.erl
@@ -1,0 +1,189 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(registrar_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("reg.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_SIP_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_SIP_DB)
+                      ]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+
+    handle_refresh(MaintJObj
+                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
+                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
+                  ).
+
+handle_refresh(MaintJObj, <<"refresh_database">>, ?KZ_SIP_DB) ->
+    Created = kz_datamgr:db_create(?KZ_SIP_DB),
+    send_resp(MaintJObj, Created);
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_SIP_DB) ->
+    View = kapps_util:get_view_json('registrar', <<"credentials.json">>),
+    Update = kapps_util:update_views(?KZ_SIP_DB, [View], 'true'),
+    send_resp(MaintJObj, Update).
+
+-type results() :: boolean().
+
+-spec send_resp(kapi_mainteannce:req(), results()) -> 'ok'.
+send_resp(MaintJObj, Results) ->
+    Resp = [{<<"Code">>, code(Results)}
+           ,{<<"Message">>, message(Results)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+code('true') -> 200;
+code('false') -> 500.
+
+message('true') -> <<"Success">>;
+message('false') -> <<"Failure">>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/applications/registrar/src/registrar_maint_listener.erl
+++ b/applications/registrar/src/registrar_maint_listener.erl
@@ -35,9 +35,7 @@
 
 %% By convention, we put the options here in macros, but not required.
 %% define what databases or classifications we're interested in
--define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_SIP_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_SIP_DB)
-                      ]).
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_views_db(?KZ_SIP_DB)]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
 -define(RESPONDERS, [{{?MODULE, 'handle_req'}
                      ,[{<<"maintenance">>, <<"req">>}]

--- a/applications/registrar/src/registrar_maint_listener.erl
+++ b/applications/registrar/src/registrar_maint_listener.erl
@@ -21,7 +21,12 @@
         ,code_change/3
         ]).
 
--include("reg.hrl").
+-include_lib("kazoo_stdlib/include/kz_types.hrl").
+-include_lib("kazoo_stdlib/include/kz_databases.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
+
+-define(APP_NAME, <<"registrar">>).
+-define(APP_VERSION, <<"4.0.0">>).
 
 -define(SERVER, ?MODULE).
 
@@ -57,6 +62,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/registrar/src/registrar_maint_listener.erl
+++ b/applications/registrar/src/registrar_maint_listener.erl
@@ -66,8 +66,8 @@ handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
 
     handle_refresh(MaintJObj
-                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
+                  ,kapi_maintenance:req_action(MaintJObj)
+                  ,kapi_maintenance:req_database(MaintJObj)
                   ).
 
 handle_refresh(MaintJObj, <<"refresh_database">>, ?KZ_SIP_DB) ->

--- a/applications/registrar/src/registrar_sup.erl
+++ b/applications/registrar/src/registrar_sup.erl
@@ -19,6 +19,7 @@
 -define(CHILDREN, [?CACHE(?CACHE_NAME)
                   ,?WORKER('registrar_init')
                   ,?SUPER('registrar_shared_listener_sup')
+                  ,?WORKER('registrar_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/applications/stepswitch/src/stepswitch_app.erl
+++ b/applications/stepswitch/src/stepswitch_app.erl
@@ -20,7 +20,6 @@
 -spec start(application:start_type(), any()) -> startapp_ret().
 start(_StartType, _StartArgs) ->
     _ = declare_exchanges(),
-    _ = kapps_maintenance:bind({'refresh', ?KZ_OFFNET_DB}, 'stepswitch_maintenance', 'refresh'),
     stepswitch_sup:start_link().
 
 %%--------------------------------------------------------------------
@@ -29,7 +28,6 @@ start(_StartType, _StartArgs) ->
 %%--------------------------------------------------------------------
 -spec stop(any()) -> any().
 stop(_State) ->
-    _ = kapps_maintenance:unbind({'refresh', ?KZ_OFFNET_DB}, 'stepswitch_maintenance', 'refresh'),
     'ok'.
 
 -spec declare_exchanges() -> 'ok'.

--- a/applications/stepswitch/src/stepswitch_maint_listener.erl
+++ b/applications/stepswitch/src/stepswitch_maint_listener.erl
@@ -64,7 +64,7 @@ start_link() ->
 -spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
 handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
-    handle_refresh(MaintJObj, kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)).
+    handle_refresh(MaintJObj, kapi_maintenance:req_action(MaintJObj)).
 
 handle_refresh(MaintJObj, <<"refresh_database">>) ->
     Created = kz_datamgr:db_create(?KZ_OFFNET_DB),

--- a/applications/stepswitch/src/stepswitch_maint_listener.erl
+++ b/applications/stepswitch/src/stepswitch_maint_listener.erl
@@ -31,9 +31,7 @@
 
 %% By convention, we put the options here in macros, but not required.
 %% define what databases or classifications we're interested in
--define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_OFFNET_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_OFFNET_DB)
-                      ]).
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_views_db(?KZ_OFFNET_DB)]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
 -define(RESPONDERS, [{{?MODULE, 'handle_req'}
                      ,[{<<"maintenance">>, <<"req">>}]
@@ -68,9 +66,6 @@ handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
     handle_refresh(MaintJObj, kapi_maintenance:req_action(MaintJObj)).
 
-handle_refresh(MaintJObj, <<"refresh_database">>) ->
-    Created = kz_datamgr:db_create(?KZ_OFFNET_DB),
-    send_resp(MaintJObj, Created);
 handle_refresh(MaintJObj, <<"refresh_views">>) ->
     Views = kapps_util:get_views_json('stepswitch', "views"),
     kapps_util:update_views(?RESOURCES_DB, Views, 'true'),

--- a/applications/stepswitch/src/stepswitch_maint_listener.erl
+++ b/applications/stepswitch/src/stepswitch_maint_listener.erl
@@ -71,7 +71,7 @@ handle_refresh(MaintJObj, <<"refresh_views">>) ->
     kapps_util:update_views(?RESOURCES_DB, Views, 'true'),
     send_resp(MaintJObj, 'true').
 
--spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+-spec send_resp(kapi_mainteannce:req(), 'true') -> 'ok'.
 send_resp(MaintJObj, Results) ->
     Resp = [{<<"Code">>, code(Results)}
            ,{<<"Message">>, message(Results)}
@@ -80,11 +80,9 @@ send_resp(MaintJObj, Results) ->
            ],
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
-code('true') -> 200;
-code('false') -> 500.
+code('true') -> 200.
 
-message('true') -> <<"Success">>;
-message('false') -> <<"Failure">>.
+message('true') -> <<"Success">>.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/applications/stepswitch/src/stepswitch_maint_listener.erl
+++ b/applications/stepswitch/src/stepswitch_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("stepswitch.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -57,6 +58,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/stepswitch/src/stepswitch_maint_listener.erl
+++ b/applications/stepswitch/src/stepswitch_maint_listener.erl
@@ -5,7 +5,7 @@
 %%% @end
 %%% @contributors
 %%%-------------------------------------------------------------------
--module(crossbar_maint_listener).
+-module(stepswitch_maint_listener).
 -behaviour(gen_listener).
 
 -export([start_link/0
@@ -21,7 +21,7 @@
         ,code_change/3
         ]).
 
--include("crossbar.hrl").
+-include("stepswitch.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -29,22 +29,9 @@
 -type state() :: #state{}.
 
 %% By convention, we put the options here in macros, but not required.
--define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_SCHEMA_DB)
-
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_CONFIG_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_SCHEMA_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_MEDIA_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_SIP_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_PORT_REQUESTS_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_ACDC_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_CCCPS_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_TOKEN_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_ALERTS_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_PENDING_NOTIFY_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_WEBHOOKS_DB)
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_OFFNET_DB)
                       ,kapi_maintenance:restrict_to_views_db(?KZ_OFFNET_DB)
-
-                      ,kapi_maintenance:restrict_to_views_classification('ratedeck')
                       ]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
 -define(RESPONDERS, [{{?MODULE, 'handle_req'}
@@ -77,90 +64,30 @@ start_link() ->
 -spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
 handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
+    handle_refresh(MaintJObj, kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)).
 
-    handle_refresh(MaintJObj
-                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Classification">>, MaintJObj)
-                  ).
-
--spec handle_refresh(kapi_maintenance:req(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
-handle_refresh(MaintJObj, <<"refresh_database">>, Db, _Class) ->
-    Created = kz_datamgr:db_create(Db),
+handle_refresh(MaintJObj, <<"refresh_database">>) ->
+    Created = kz_datamgr:db_create(?KZ_OFFNET_DB),
     send_resp(MaintJObj, Created);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_CONFIG_DB, _Class) ->
-    Revised = kz_datamgr:revise_doc_from_file(?KZ_CONFIG_DB, 'crossbar', <<"views/system_configs.json">>),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_SCHEMA_DB, _Class) ->
-    kz_datamgr:suppress_change_notice(),
-    Revised = kz_datamgr:revise_docs_from_folder(?KZ_SCHEMA_DB, 'crossbar', "schemas"),
-    kz_datamgr:enable_change_notice(),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_MEDIA_DB, _Class) ->
-    Revised = kz_datamgr:revise_doc_from_file(?KZ_MEDIA_DB, 'crossbar', "account/media.json"),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, Database, 'ratedeck') ->
-    Revised = kz_datamgr:revise_doc_from_file(Database, 'crossbar', <<"views/rates.json">>),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_SIP_DB, _Class) ->
-    View = kapps_util:get_view_json('crossbar', <<"views/resources.json">>),
-    case kapps_util:update_views(?KZ_SIP_DB, [View], 'true') of
-        'true' -> send_resp(MaintJObj, {'ok', MaintJObj});
-        'false' -> send_resp(MaintJObj, {'error', 'not_found'})
-    end;
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_PORT_REQUESTS_DB, _Class) ->
-    Revised = kz_datamgr:revise_doc_from_file(?KZ_PORT_REQUESTS_DB, 'crossbar', <<"views/port_requests.json">>),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_ACDC_DB, _Class) ->
-    Revised = kz_datamgr:revise_doc_from_file(?KZ_ACDC_DB, 'crossbar', <<"views/acdc.json">>),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_CCCPS_DB, _Class) ->
-    Revised = kz_datamgr:revise_doc_from_file(?KZ_CCCPS_DB, 'crossbar', <<"views/cccps.json">>),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_TOKEN_DB, _Class) ->
-    Revised = kz_datamgr:revise_doc_from_file(?KZ_TOKEN_DB, 'crossbar', "views/token_auth.json"),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_ALERTS_DB, _Class) ->
-    Revised = kz_datamgr:revise_doc_from_file(?KZ_ALERTS_DB, 'crossbar', "views/alerts.json"),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_PENDING_NOTIFY_DB, _Class) ->
-    Revised = kz_datamgr:revise_doc_from_file(?KZ_PENDING_NOTIFY_DB, 'crossbar', "views/pending_notify.json"),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_WEBHOOKS_DB, _Class) ->
-    Revised = kz_datamgr:revise_doc_from_file(?KZ_WEBHOOKS_DB, 'crossbar', <<"views/webhooks.json">>),
-    send_resp(MaintJObj, Revised);
-handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_OFFNET_DB, _Class) ->
-    View = kapps_util:get_view_json('crossbar', <<"views/resources.json">>),
-    kapps_util:update_views(?KZ_OFFNET_DB, [View], 'true'),
+handle_refresh(MaintJObj, <<"refresh_views">>) ->
+    Views = kapps_util:get_views_json('stepswitch', "views"),
+    kapps_util:update_views(?RESOURCES_DB, Views, 'true'),
     send_resp(MaintJObj, 'true').
 
--type results() :: {'ok', kz_json:object()} |
-                   kz_datamgr:data_error() |
-                   boolean() | 'ok'.
-
--spec send_resp(kapi_mainteannce:req(), results()) -> 'ok'.
-send_resp(MaintJObj, Revised) ->
-    Resp = [{<<"Code">>, code(Revised)}
-           ,{<<"Message">>, message(Revised)}
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Results) ->
+    Resp = [{<<"Code">>, code(Results)}
+           ,{<<"Message">>, message(Results)}
            ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
--spec code(results()) -> 200 | 500.
-code({'ok', _}) -> 200;
 code('true') -> 200;
-code('ok') -> 200;
-code({'error', _}) -> 500;
 code('false') -> 500.
 
--spec message(results()) -> ne_binary().
-message({'ok', _}) -> <<"Revised crossbar docs/views">>;
-message('ok') -> <<"Revised crossbar docs/views">>;
-message({'error', E}) ->
-    <<"Failed to revise docs/views: ", (kz_term:to_binary(E))/binary>>;
-message('true') -> <<"Created database">>;
-message('false') -> <<"Failed to create database">>.
+message('true') -> <<"Success">>;
+message('false') -> <<"Failure">>.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/applications/stepswitch/src/stepswitch_maintenance.erl
+++ b/applications/stepswitch/src/stepswitch_maintenance.erl
@@ -129,11 +129,9 @@ cnam_flush() ->
 -spec refresh() -> 'ok'.
 refresh() ->
     lager:debug("ensuring database ~s exists", [?RESOURCES_DB]),
-    kz_datamgr:db_create(?RESOURCES_DB), % RESOURCES_DB = KZ_OFFNET_DB
-    Views = [kapps_util:get_view_json('crossbar', <<"views/resources.json">>)
-             | kapps_util:get_views_json('stepswitch', "views")
-            ],
-    kapps_util:update_views(?RESOURCES_DB, Views, 'true'),
+    kapi_maintenance:refresh_database(?RESOURCES_DB),
+    kapi_maintenance:refresh_views(?RESOURCES_DB),
+
     case catch kz_datamgr:all_docs(?RESOURCES_DB, ['include_docs']) of
         {'error', _} -> 'ok';
         {'EXIT', _E} ->

--- a/applications/stepswitch/src/stepswitch_outbound.erl
+++ b/applications/stepswitch/src/stepswitch_outbound.erl
@@ -14,6 +14,7 @@
 
 -include("stepswitch.hrl").
 -include_lib("kazoo_amqp/include/kapi_offnet_resource.hrl").
+-include_lib("kazoo/include/kz_api_literals.hrl").
 
 %%--------------------------------------------------------------------
 %% @public

--- a/applications/stepswitch/src/stepswitch_sup.erl
+++ b/applications/stepswitch/src/stepswitch_sup.erl
@@ -28,6 +28,7 @@
                   ,?SUPER('stepswitch_cnam_pool_sup')
                   ,?SUPER('stepswitch_request_sup')
                   ,?WORKER('stepswitch_listener')
+                  ,?WORKER('stepswitch_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/applications/tasks/src/knm_port_request_crawler.erl
+++ b/applications/tasks/src/knm_port_request_crawler.erl
@@ -122,7 +122,7 @@ handle_cast(_Msg, State) ->
 -spec handle_info(any(), state()) -> handle_info_ret_state(state()).
 handle_info({'timeout', Ref, _Msg}, #state{cleanup_ref=Ref}=State) ->
     _ = kz_util:spawn(fun crawl_port_requests/0),
-    {'noreply', State#state{cleanup_ref=cleanup_timer()}};
+    {'noreply', State#state{cleanup_ref=cleanup_timer()}, 'hibernate'};
 handle_info(_Msg, State) ->
     lager:debug("unhandled msg: ~p", [_Msg]),
     {'noreply', State}.

--- a/applications/tasks/src/knm_port_request_crawler.erl
+++ b/applications/tasks/src/knm_port_request_crawler.erl
@@ -26,8 +26,9 @@
 -include("tasks.hrl").
 -include_lib("kazoo_number_manager/include/knm_phone_number.hrl").
 
--define(CLEANUP_ROUNDTRIP_TIME,
-        kapps_config:get_integer(?CONFIG_CAT, <<"crawler_delay_time_ms">>, ?MILLISECONDS_IN_MINUTE)).
+-define(CLEANUP_ROUNDTRIP_TIME
+       ,kapps_config:get_integer(?CONFIG_CAT, <<"crawler_delay_time_ms">>, ?MILLISECONDS_IN_MINUTE)
+       ).
 
 -record(state, {cleanup_ref :: reference()
                }).
@@ -158,7 +159,8 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 
--spec crawl_port_requests() -> ok.
+-spec crawl_port_requests() -> 'ok'.
 crawl_port_requests() ->
+    Start = kz_time:now(),
     knm_port_request:send_submitted_requests(),
-    lager:info("port_request crawler completed a full crawl").
+    lager:info("port_request crawler completed a full crawl in ~pms", [kz_time:elapsed_ms(Start)]).

--- a/applications/tasks/src/tasks_maint_listener.erl
+++ b/applications/tasks/src/tasks_maint_listener.erl
@@ -64,7 +64,7 @@ start_link() ->
 -spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
 handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
-    handle_refresh(MaintJObj, kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)).
+    handle_refresh(MaintJObj, kapi_maintenance:req_action(MaintJObj)).
 
 handle_refresh(MaintJObj, <<"refresh_database">>) ->
     Created = kz_datamgr:db_create(?KZ_TASKS_DB),

--- a/applications/tasks/src/tasks_maint_listener.erl
+++ b/applications/tasks/src/tasks_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("tasks.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -57,6 +58,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/tasks/src/tasks_maint_listener.erl
+++ b/applications/tasks/src/tasks_maint_listener.erl
@@ -31,9 +31,7 @@
 
 %% By convention, we put the options here in macros, but not required.
 %% define what databases or classifications we're interested in
--define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_TASKS_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_TASKS_DB)
-                      ]).
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_views_db(?KZ_TASKS_DB)]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
 -define(RESPONDERS, [{{?MODULE, 'handle_req'}
                      ,[{<<"maintenance">>, <<"req">>}]
@@ -68,9 +66,6 @@ handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
     handle_refresh(MaintJObj, kapi_maintenance:req_action(MaintJObj)).
 
-handle_refresh(MaintJObj, <<"refresh_database">>) ->
-    Created = kz_datamgr:db_create(?KZ_TASKS_DB),
-    send_resp(MaintJObj, Created);
 handle_refresh(MaintJObj, <<"refresh_views">>) ->
     _ = kz_datamgr:revise_views_from_folder(?KZ_TASKS_DB, 'tasks'),
     send_resp(MaintJObj, 'true').

--- a/applications/tasks/src/tasks_maint_listener.erl
+++ b/applications/tasks/src/tasks_maint_listener.erl
@@ -70,7 +70,7 @@ handle_refresh(MaintJObj, <<"refresh_views">>) ->
     _ = kz_datamgr:revise_views_from_folder(?KZ_TASKS_DB, 'tasks'),
     send_resp(MaintJObj, 'true').
 
--spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+-spec send_resp(kapi_mainteannce:req(), 'true') -> 'ok'.
 send_resp(MaintJObj, Results) ->
     Resp = [{<<"Code">>, code(Results)}
            ,{<<"Message">>, message(Results)}
@@ -79,11 +79,9 @@ send_resp(MaintJObj, Results) ->
            ],
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
-code('true') -> 200;
-code('false') -> 500.
+code('true') -> 200.
 
-message('true') -> <<"Success">>;
-message('false') -> <<"Failure">>.
+message('true') -> <<"Success">>.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/applications/tasks/src/tasks_maint_listener.erl
+++ b/applications/tasks/src/tasks_maint_listener.erl
@@ -1,0 +1,182 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(tasks_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("tasks.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_TASKS_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_TASKS_DB)
+                      ]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    handle_refresh(MaintJObj, kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)).
+
+handle_refresh(MaintJObj, <<"refresh_database">>) ->
+    Created = kz_datamgr:db_create(?KZ_TASKS_DB),
+    send_resp(MaintJObj, Created);
+handle_refresh(MaintJObj, <<"refresh_views">>) ->
+    _ = kz_datamgr:revise_views_from_folder(?KZ_TASKS_DB, 'tasks'),
+    send_resp(MaintJObj, 'true').
+
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Results) ->
+    Resp = [{<<"Code">>, code(Results)}
+           ,{<<"Message">>, message(Results)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+code('true') -> 200;
+code('false') -> 500.
+
+message('true') -> <<"Success">>;
+message('false') -> <<"Failure">>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/applications/tasks/src/tasks_sup.erl
+++ b/applications/tasks/src/tasks_sup.erl
@@ -28,6 +28,7 @@
                   ,?WORKER('kz_account_crawler')
                    %% Standalone tasks
                   ,?WORKER('kz_notify_resend')
+                  ,?WORKER('tasks_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/applications/teletype/src/teletype_bindings.erl
+++ b/applications/teletype/src/teletype_bindings.erl
@@ -21,6 +21,7 @@
 -spec start_link() -> startlink_ret().
 start_link() ->
     start_modules(),
+    garbage_collect(self()),
     'ignore'.
 
 -spec bind(ne_binary(), module(), atom()) -> 'ok'.
@@ -60,7 +61,6 @@ start_modules([Module | Remaining]) ->
     start_modules(Remaining);
 start_modules([]) ->
     lager:info("started all teletype modules").
-
 
 -spec filter_out_failed(any()) -> boolean().
 filter_out_failed('ok') -> 'true';

--- a/applications/teletype/src/teletype_maint_listener.erl
+++ b/applications/teletype/src/teletype_maint_listener.erl
@@ -35,7 +35,7 @@
                      ,[{<<"maintenance">>, <<"req">>}]
                      }
                     ]).
--define(QUEUE_NAME, <<"teletype_maint_listener">>).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
 -define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
 -define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
 

--- a/applications/teletype/src/teletype_maint_listener.erl
+++ b/applications/teletype/src/teletype_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("teletype.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -54,6 +55,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/webhooks/src/webhooks_app.erl
+++ b/applications/webhooks/src/webhooks_app.erl
@@ -21,7 +21,6 @@
 -spec start(application:start_type(), any()) -> startapp_ret().
 start(_Type, _Args) ->
     _ = declare_exchanges(),
-    _ = kapps_maintenance:bind({'refresh', ?KZ_WEBHOOKS_DB}, 'webhooks_maintenance', 'reset_webhooks_list'),
     webhooks_sup:start_link().
 
 %%--------------------------------------------------------------------
@@ -30,7 +29,6 @@ start(_Type, _Args) ->
 %%--------------------------------------------------------------------
 -spec stop(any()) -> any().
 stop(_State) ->
-    _ = kapps_maintenance:unbind({'refresh', ?KZ_WEBHOOKS_DB}, 'webhooks_maintenance', 'reset_webhooks_list'),
     'ok'.
 
 -spec declare_exchanges() -> 'ok'.

--- a/applications/webhooks/src/webhooks_maint_listener.erl
+++ b/applications/webhooks/src/webhooks_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("webhooks.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -57,6 +58,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/applications/webhooks/src/webhooks_maint_listener.erl
+++ b/applications/webhooks/src/webhooks_maint_listener.erl
@@ -70,7 +70,7 @@ handle_refresh(MaintJObj, <<"refresh_views">>) ->
     _ = webhooks_maintenance:reset_webhooks_list(),
     send_resp(MaintJObj, 'true').
 
--spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+-spec send_resp(kapi_mainteannce:req(), 'true') -> 'ok'.
 send_resp(MaintJObj, Results) ->
     Resp = [{<<"Code">>, code(Results)}
            ,{<<"Message">>, message(Results)}
@@ -79,11 +79,9 @@ send_resp(MaintJObj, Results) ->
            ],
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
-code('true') -> 200;
-code('false') -> 500.
+code('true') -> 200.
 
-message('true') -> <<"Success">>;
-message('false') -> <<"Failure">>.
+message('true') -> <<"Success">>.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/applications/webhooks/src/webhooks_maint_listener.erl
+++ b/applications/webhooks/src/webhooks_maint_listener.erl
@@ -31,9 +31,7 @@
 
 %% By convention, we put the options here in macros, but not required.
 %% define what databases or classifications we're interested in
--define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_WEBHOOKS_DB)
-                      ,kapi_maintenance:restrict_to_views_db(?KZ_WEBHOOKS_DB)
-                      ]).
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_views_db(?KZ_WEBHOOKS_DB)]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
 -define(RESPONDERS, [{{?MODULE, 'handle_req'}
                      ,[{<<"maintenance">>, <<"req">>}]
@@ -68,9 +66,6 @@ handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
     handle_refresh(MaintJObj, kapi_maintenance:req_action(MaintJObj)).
 
-handle_refresh(MaintJObj, <<"refresh_database">>) ->
-    Created = kz_datamgr:db_create(?KZ_WEBHOOKS_DB),
-    send_resp(MaintJObj, Created);
 handle_refresh(MaintJObj, <<"refresh_views">>) ->
     _ = webhooks_maintenance:reset_webhooks_list(),
     send_resp(MaintJObj, 'true').

--- a/applications/webhooks/src/webhooks_maint_listener.erl
+++ b/applications/webhooks/src/webhooks_maint_listener.erl
@@ -64,7 +64,7 @@ start_link() ->
 -spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
 handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
-    handle_refresh(MaintJObj, kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)).
+    handle_refresh(MaintJObj, kapi_maintenance:req_action(MaintJObj)).
 
 handle_refresh(MaintJObj, <<"refresh_database">>) ->
     Created = kz_datamgr:db_create(?KZ_WEBHOOKS_DB),

--- a/applications/webhooks/src/webhooks_maintenance.erl
+++ b/applications/webhooks/src/webhooks_maintenance.erl
@@ -118,8 +118,9 @@ enable_descendant_hooks(AccountId) ->
 
 -spec reset_webhooks_list() -> 'ok'.
 reset_webhooks_list() ->
-    kz_datamgr:db_create(?KZ_WEBHOOKS_DB),
-    kz_datamgr:revise_doc_from_file(?KZ_WEBHOOKS_DB, 'crossbar', <<"views/webhooks.json">>),
+    _ = kapi_maintenance:refresh_database(?KZ_WEBHOOKS_DB),
+    _ = kapi_maintenance:refresh_views(?KZ_WEBHOOKS_DB),
+
     case kapps_util:get_master_account_db() of
         {'ok', MasterAccountDb} ->
             Ids = get_webhooks(MasterAccountDb),

--- a/applications/webhooks/src/webhooks_sup.erl
+++ b/applications/webhooks/src/webhooks_sup.erl
@@ -34,6 +34,7 @@
                   ,?WORKER('webhooks_listener')
                   ,?WORKER('webhooks_shared_listener')
                   ,?WORKER('webhooks_init')
+                  ,?WORKER('webhooks_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/core/kazoo/src/kz_doc.erl
+++ b/core/kazoo/src/kz_doc.erl
@@ -320,7 +320,7 @@ attachment(JObj, AName, Default) ->
 
 -spec attachment_length(kz_json:object(), ne_binary()) -> api_integer().
 attachment_length(JObj, AName) ->
-    attachment_property(JObj, AName, <<"length">>).
+    attachment_property(JObj, AName, <<"length">>, fun kz_json:get_integer_value/1).
 
 -spec attachment_content_type(kz_json:object()) -> api_binary().
 -spec attachment_content_type(kz_json:object(), ne_binary()) -> api_binary().
@@ -339,9 +339,14 @@ attachment_content_type(JObj, AName, DefaultContentType) ->
         ContentType -> ContentType
     end.
 
--spec attachment_property(kz_json:object(), ne_binary(), kz_json:path()) -> kz_json:api_json_term().
+-spec attachment_property(kz_json:object(), ne_binary(), kz_json:path()) ->
+                                 kz_json:api_json_term().
+-spec attachment_property(kz_json:object(), ne_binary(), kz_json:path(), fun((kz_json:path(), kz_json:object()) -> kz_json:api_json_term())) ->
+                                 kz_json:api_json_term().
 attachment_property(JObj, AName, Key) ->
-    kz_json:get_value(Key, attachment(JObj, AName, kz_json:new())).
+    attachment_property(JObj, AName, Key, fun kz_json:get_value/2).
+attachment_property(JObj, AName, Key, Get) ->
+    Get(Key, attachment(JObj, AName, kz_json:new())).
 
 -spec delete_attachments(kz_json:object()) -> kz_json:object().
 delete_attachments(JObj) ->

--- a/core/kazoo/src/kz_doc.erl
+++ b/core/kazoo/src/kz_doc.erl
@@ -26,9 +26,9 @@
         ,attachment_revision/1
         ,compare_attachments/2
 
-        ,attachment_length/2
+        ,attachment_length/2, attachment_length/3
         ,attachment_content_type/1, attachment_content_type/2, attachment_content_type/3
-        ,attachment_property/3
+        ,attachment_property/3, attachment_property/4
         ,delete_attachments/1, delete_attachment/2
         ,maybe_remove_attachments/1, maybe_remove_attachments/2
 
@@ -319,8 +319,11 @@ attachment(JObj, AName, Default) ->
     kz_json:get_value(AName, attachments(JObj, kz_json:new()), Default).
 
 -spec attachment_length(kz_json:object(), ne_binary()) -> api_integer().
+-spec attachment_length(kz_json:object(), ne_binary(), Default) -> non_neg_integer() | Default.
 attachment_length(JObj, AName) ->
-    attachment_property(JObj, AName, <<"length">>, fun kz_json:get_integer_value/1).
+    attachment_length(JObj, AName, 'undefined').
+attachment_length(JObj, AName, Default) ->
+    attachment_property(JObj, AName, <<"length">>, Default, fun kz_json:get_integer_value/3).
 
 -spec attachment_content_type(kz_json:object()) -> api_binary().
 -spec attachment_content_type(kz_json:object(), ne_binary()) -> api_binary().
@@ -329,24 +332,25 @@ attachment_content_type(JObj) ->
     case kz_json:get_values(attachments(JObj, kz_json:new())) of
         {[], []} -> 'undefined';
         {[_Attachment|_], [AName|_]} ->
-            attachment_property(JObj, AName, <<"content_type">>)
+            attachment_content_type(JObj, AName)
     end.
 attachment_content_type(JObj, AName) ->
-    attachment_property(JObj, AName, <<"content_type">>).
-attachment_content_type(JObj, AName, DefaultContentType) ->
-    case attachment_content_type(JObj, AName) of
-        'undefined' -> DefaultContentType;
-        ContentType -> ContentType
-    end.
+    attachment_content_type(JObj, AName, 'undefined').
+attachment_content_type(JObj, AName, Default) ->
+    attachment_property(JObj, AName, <<"content_type">>, Default, fun kz_json:get_ne_binary_value/3).
 
 -spec attachment_property(kz_json:object(), ne_binary(), kz_json:path()) ->
                                  kz_json:api_json_term().
--spec attachment_property(kz_json:object(), ne_binary(), kz_json:path(), fun((kz_json:path(), kz_json:object()) -> kz_json:api_json_term())) ->
-                                 kz_json:api_json_term().
+-spec attachment_property(kz_json:object(), ne_binary(), kz_json:path(), Default) ->
+                                 Default | kz_json:json_term().
+-spec attachment_property(kz_json:object(), ne_binary(), kz_json:path(), Default, fun((kz_json:path(), kz_json:object(), Default) -> Default | kz_json:json_term())) ->
+                                 Default | kz_json:json_term().
 attachment_property(JObj, AName, Key) ->
-    attachment_property(JObj, AName, Key, fun kz_json:get_value/2).
-attachment_property(JObj, AName, Key, Get) ->
-    Get(Key, attachment(JObj, AName, kz_json:new())).
+    attachment_property(JObj, AName, Key, 'undefined').
+attachment_property(JObj, AName, Key, Default) ->
+    attachment_property(JObj, AName, Key, Default, fun kz_json:get_value/3).
+attachment_property(JObj, AName, Key, Default, Get) when is_function(Get, 3) ->
+    Get(Key, attachment(JObj, AName, kz_json:new()), Default).
 
 -spec delete_attachments(kz_json:object()) -> kz_json:object().
 delete_attachments(JObj) ->

--- a/core/kazoo/src/kz_doc.erl
+++ b/core/kazoo/src/kz_doc.erl
@@ -325,9 +325,9 @@ attachment_length(JObj, AName) ->
 attachment_length(JObj, AName, Default) ->
     attachment_property(JObj, AName, <<"length">>, Default, fun kz_json:get_integer_value/3).
 
--spec attachment_content_type(kz_json:object()) -> api_binary().
--spec attachment_content_type(kz_json:object(), ne_binary()) -> api_binary().
--spec attachment_content_type(kz_json:object(), ne_binary(), ne_binary()) -> ne_binary().
+-spec attachment_content_type(kz_json:object()) -> api_ne_binary().
+-spec attachment_content_type(kz_json:object(), ne_binary()) -> api_ne_binary().
+-spec attachment_content_type(kz_json:object(), ne_binary(), Default) -> Default | ne_binary().
 attachment_content_type(JObj) ->
     case kz_json:get_values(attachments(JObj, kz_json:new())) of
         {[], []} -> 'undefined';

--- a/core/kazoo_amqp/include/kapi_offnet_resource.hrl
+++ b/core/kazoo_amqp/include/kapi_offnet_resource.hrl
@@ -1,7 +1,5 @@
 -ifndef(KAPI_OFFNET_RESOURCE_HRL).
 
--include_lib("kazoo_amqp/src/amqp_util.hrl").
-
 -define(KEY_ACCOUNT_ID, <<"Account-ID">>).
 -define(KEY_ACCOUNT_REALM, <<"Account-Realm">>).
 -define(KEY_APPLICATION_DATA, <<"Application-Data">>).

--- a/core/kazoo_amqp/src/amqp_util.erl
+++ b/core/kazoo_amqp/src/amqp_util.erl
@@ -578,8 +578,7 @@ new_exchange(Exchange, Type, Options) ->
 declare_exchange(Exchange, Type) ->
     declare_exchange(Exchange, Type, []).
 declare_exchange(Exchange, Type, Options) ->
-    #'exchange.declare'{
-       exchange = Exchange
+    #'exchange.declare'{exchange = Exchange
                        ,type = Type
                        ,passive = ?P_GET('passive', Options, 'false')
                        ,durable = ?P_GET('durable', Options, 'false')
@@ -587,7 +586,7 @@ declare_exchange(Exchange, Type, Options) ->
                        ,internal = ?P_GET('internal', Options, 'false')
                        ,nowait = ?P_GET('nowait', Options, 'false')
                        ,arguments = ?P_GET('arguments', Options, [])
-      }.
+                       }.
 
 %%------------------------------------------------------------------------------
 %% @public
@@ -1161,14 +1160,13 @@ flow_control_reply(Active) ->
 -spec access_request(kz_proplist()) -> #'access.request'{}.
 access_request() -> access_request([]).
 access_request(Options) ->
-    #'access.request'{
-       realm = ?P_GET('realm', Options, <<"/data">>)
+    #'access.request'{realm = ?P_GET('realm', Options, <<"/data">>)
                      ,exclusive = ?P_GET('exclusive', Options, 'false')
                      ,passive = ?P_GET('passive', Options, 'true')
                      ,active = ?P_GET('active', Options, 'true')
                      ,write = ?P_GET('write', Options, 'true')
                      ,read = ?P_GET('read', Options, 'true')
-      }.
+                     }.
 
 %%------------------------------------------------------------------------------
 %% @public

--- a/core/kazoo_amqp/src/amqp_util.hrl
+++ b/core/kazoo_amqp/src/amqp_util.hrl
@@ -6,5 +6,8 @@
 -include_lib("kazoo_stdlib/include/kz_log.hrl").
 -include_lib("kazoo/include/kz_api_literals.hrl").
 
+-define(APP_NAME, <<"kazoo_amqp">>).
+-define(APP_VERSION, <<"4.0.0">>).
+
 -define(AMQP_UTIL_HRL, 'true').
 -endif.

--- a/core/kazoo_amqp/src/api/kapi_maintenance.erl
+++ b/core/kazoo_amqp/src/api/kapi_maintenance.erl
@@ -252,7 +252,7 @@ refresh_database(Database, Worker, Classification) ->
           ,{?KEY_DATABASE, Database}
            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
           ],
-    kz_amqp_worker:cast(Req, fun kapi_maintenance:publish_req/1, Worker),
+    kz_amqp_worker:cast(Req, fun ?MODULE:publish_req/1, Worker),
     wait_for_response(10 * ?MILLISECONDS_IN_SECOND, 1).
 
 -spec refresh_views(ne_binary()) ->
@@ -284,7 +284,7 @@ refresh_views(Database, Worker, Classification) ->
            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
           ],
     kz_amqp_worker:cast(Req
-                       ,fun kapi_maintenance:publish_req/1
+                       ,fun ?MODULE:publish_req/1
                        ,Worker
                        ),
     wait_for_response(30 * ?MILLISECONDS_IN_SECOND, 1).
@@ -307,7 +307,7 @@ wait_for_response(Timeout, Responses, Resps) ->
     receive
         {'amqp_msg', JObj} ->
             Left = kz_time:decr_timeout(Timeout, Start),
-            case kapi_maintenance:resp_v(JObj) of
+            case ?MODULE:resp_v(JObj) of
                 'true' -> wait_for_response(Left, Responses-1, [JObj|Resps]);
                 'false' -> wait_for_response(Left, Responses, Resps)
             end

--- a/core/kazoo_amqp/src/api/kapi_maintenance.erl
+++ b/core/kazoo_amqp/src/api/kapi_maintenance.erl
@@ -312,7 +312,7 @@ wait_for_response(Timeout, Responses, Resps) ->
                 'false' -> wait_for_response(Left, Responses, Resps)
             end
     after
-        Timeout -> wait_for_response(0, Resps)
+        Timeout -> wait_for_response(0, Responses, Resps)
     end.
 
 -spec req_action(req()) -> api_ne_binary().

--- a/core/kazoo_amqp/src/api/kapi_maintenance.erl
+++ b/core/kazoo_amqp/src/api/kapi_maintenance.erl
@@ -21,6 +21,11 @@
         ,restrict_to_views_classification/1
         ]).
 
+-export([req_action/1
+        ,req_database/1
+        ,req_classification/1
+        ]).
+
 -export_type([req/0, resp/0]).
 
 -type req() :: api_terms().
@@ -302,3 +307,15 @@ wait_for_response(Timeout, Resps) ->
     after
         Timeout -> wait_for_response(0, Resps)
     end.
+
+-spec req_action(req()) -> api_ne_binary().
+req_action(Req) ->
+    kz_json:get_ne_binary_value(<<"Action">>, Req).
+
+-spec req_database(req()) -> api_ne_binary().
+req_database(Req) ->
+    kz_json:get_ne_binary_value(<<"Database">>, Req).
+
+-spec req_classification(req()) -> api_ne_binary().
+req_classification(Req) ->
+    kz_json:get_ne_binary_value(<<"Classification">>, Req).

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -1,4 +1,4 @@
-%%%-------------------------------------------------------------------
+%%-------------------------------------------------------------------
 %%% @copyright (C) 2011-2017, 2600Hz
 %%% @doc
 %%%
@@ -1262,9 +1262,9 @@ maybe_channel_flow('true') ->
     amqp_util:flow_control();
 maybe_channel_flow(_) -> 'ok'.
 
--spec maybe_declare_exchanges(kz_proplist()) ->
+-spec maybe_declare_exchanges(declare_exchanges()) ->
                                      command_ret().
--spec maybe_declare_exchanges(kz_amqp_assignment(), kz_proplist()) ->
+-spec maybe_declare_exchanges(kz_amqp_assignment(), declare_exchanges()) ->
                                      command_ret().
 maybe_declare_exchanges([]) -> 'ok';
 maybe_declare_exchanges(Exchanges) ->
@@ -1276,7 +1276,7 @@ maybe_declare_exchanges(Channel, [{Ex, Type, Opts} | Exchanges]) ->
 maybe_declare_exchanges(Channel, [{Ex, Type} | Exchanges]) ->
     declare_exchange(Channel, amqp_util:declare_exchange(Ex, Type), Exchanges).
 
--spec declare_exchange(kz_amqp_assignment(), kz_amqp_exchange(), kz_proplist()) -> command_ret().
+-spec declare_exchange(kz_amqp_assignment(), kz_amqp_exchange(), declare_exchanges()) -> command_ret().
 declare_exchange(Channel, Exchange, Exchanges) ->
     case kz_amqp_channel:command(Channel, Exchange) of
         {'ok', _} -> maybe_declare_exchanges(Channel, Exchanges);

--- a/core/kazoo_amqp/src/kz_amqp_worker.erl
+++ b/core/kazoo_amqp/src/kz_amqp_worker.erl
@@ -989,7 +989,7 @@ reset(#state{req_timeout_ref = ReqRef
             'true' -> erlang:demonitor(ClientRef, ['flush']);
             'false' -> 'ok'
         end,
-    lager:debug("reset worker state"),
+
     State#state{client_pid = 'undefined'
                ,client_ref = 'undefined'
                ,client_from = 'undefined'

--- a/core/kazoo_amqp/src/listener_types.hrl
+++ b/core/kazoo_amqp/src/listener_types.hrl
@@ -5,7 +5,11 @@
 -include_lib("kazoo_stdlib/include/kz_log.hrl").
 
 -type binding_module() :: atom() | ne_binary().
--type binding() :: {binding_module(), kz_proplist()}. %% {kapi_module, options}
+
+-type binding_property() :: {'restrict_to', list()}.
+-type binding_properties() :: [binding_property()].
+
+-type binding() :: {binding_module(), binding_properties()}. %% {kapi_module, options}
 -type bindings() :: [binding()].
 
 %% ExchangeName, ExchangeType[, ExchangeOptions]

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -71,8 +71,6 @@ unbind(Event, M, F) -> kazoo_bindings:unbind(binding(Event), M, F).
 
 -define(DEVICES_CB_LIST, <<"devices/crossbar_listing">>).
 -define(RESELLER_VIEW_FILE, <<"views/reseller.json">>).
--define(FAXES_VIEW_FILE, <<"views/faxes.json">>).
--define(FAXBOX_VIEW_FILE, <<"views/faxbox.json">>).
 
 -define(ACCOUNTS_AGG_NOTIFY_VIEW_FILE, <<"views/notify.json">>).
 
@@ -290,11 +288,6 @@ old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(?KZ_FAXES_DB) ->
-    kz_datamgr:db_create(?KZ_FAXES_DB),
-    _ = kz_datamgr:revise_doc_from_file(?KZ_FAXES_DB, 'fax', ?FAXES_VIEW_FILE),
-    _ = kz_datamgr:revise_doc_from_file(?KZ_FAXES_DB, 'fax', ?FAXBOX_VIEW_FILE),
-    'ok';
 old_refresh(?KZ_PORT_REQUESTS_DB) ->
     kz_datamgr:db_create(?KZ_PORT_REQUESTS_DB),
     _ = kz_util:spawn(fun knm_port_request:migrate/0),

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -22,7 +22,6 @@
 -export([find_invalid_acccount_dbs/0]).
 -export([refresh/0, refresh/1
         ,refresh_account_db/1
-        ,refresh_ratedeck_db/1
         ]).
 -export([blocking_refresh/0
         ,blocking_refresh/1
@@ -342,8 +341,6 @@ old_refresh(?KZ_SIP_DB) ->
             ,kapps_util:get_view_json('crossbar', <<"views/resources.json">>)
             ],
     kapps_util:update_views(?KZ_SIP_DB, Views, 'true');
-old_refresh(?KZ_RATES_DB) ->
-    refresh_ratedeck_db(?KZ_RATES_DB);
 old_refresh(?KZ_ANONYMOUS_CDR_DB) ->
     kz_datamgr:db_create(?KZ_ANONYMOUS_CDR_DB),
     _ = kz_datamgr:revise_doc_from_file(?KZ_ANONYMOUS_CDR_DB, 'cdr', <<"cdr.json">>),
@@ -401,17 +398,8 @@ old_refresh(Database) when is_binary(Database) ->
         'system' ->
             kz_datamgr:db_create(Database),
             'ok';
-        'ratedeck' -> refresh_ratedeck_db(Database);
         _Else -> 'ok'
     end.
-
--spec refresh_ratedeck_db(ne_binary()) -> 'ok'.
-refresh_ratedeck_db(RateDb) ->
-    kz_datamgr:db_create(RateDb),
-    kz_datamgr:revise_docs_from_folder(RateDb, 'hotornot', "views"),
-    _ = kz_datamgr:revise_doc_from_file(RateDb, 'crossbar', <<"views/rates.json">>),
-    kz_datamgr:load_fixtures_from_folder(RateDb, 'hotornot'),
-    'ok'.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -334,10 +334,6 @@ old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(?KZ_ANONYMOUS_CDR_DB) ->
-    kz_datamgr:db_create(?KZ_ANONYMOUS_CDR_DB),
-    _ = kz_datamgr:revise_doc_from_file(?KZ_ANONYMOUS_CDR_DB, 'cdr', <<"cdr.json">>),
-    'ok';
 old_refresh(?KZ_DEDICATED_IP_DB) ->
     kz_datamgr:db_create(?KZ_DEDICATED_IP_DB),
     kz_ip_utils:refresh_database();

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -338,7 +338,6 @@ old_refresh(?KZ_SIP_DB) ->
     kz_datamgr:db_create(?KZ_SIP_DB),
     Views = [kapps_util:get_view_json('kazoo_apps', ?MAINTENANCE_VIEW_FILE)
             ,kapps_util:get_view_json('registrar', <<"credentials.json">>)
-            ,kapps_util:get_view_json('crossbar', <<"views/resources.json">>)
             ],
     kapps_util:update_views(?KZ_SIP_DB, Views, 'true');
 old_refresh(?KZ_ANONYMOUS_CDR_DB) ->
@@ -363,24 +362,19 @@ old_refresh(?KZ_FAXES_DB) ->
     'ok';
 old_refresh(?KZ_PORT_REQUESTS_DB) ->
     kz_datamgr:db_create(?KZ_PORT_REQUESTS_DB),
-    _ = kz_datamgr:revise_doc_from_file(?KZ_PORT_REQUESTS_DB, 'crossbar', <<"views/port_requests.json">>),
     _ = kz_util:spawn(fun knm_port_request:migrate/0),
     'ok';
 old_refresh(?KZ_ACDC_DB) ->
     kz_datamgr:db_create(?KZ_ACDC_DB),
-    _ = kz_datamgr:revise_doc_from_file(?KZ_ACDC_DB, 'crossbar', <<"views/acdc.json">>),
     'ok';
 old_refresh(?KZ_CCCPS_DB) ->
     kz_datamgr:db_create(?KZ_CCCPS_DB),
-    _ = kz_datamgr:revise_doc_from_file(?KZ_CCCPS_DB, 'crossbar', <<"views/cccps.json">>),
     'ok';
 old_refresh(?KZ_TOKEN_DB) ->
     _ = kz_datamgr:db_create(?KZ_TOKEN_DB),
-    kz_datamgr:revise_doc_from_file(?KZ_TOKEN_DB, 'crossbar', "views/token_auth.json"),
     'ok';
 old_refresh(?KZ_ALERTS_DB) ->
     _ = kz_datamgr:db_create(?KZ_ALERTS_DB),
-    kz_datamgr:revise_doc_from_file(?KZ_ALERTS_DB, 'crossbar', "views/alerts.json"),
     'ok';
 old_refresh(?KZ_TASKS_DB) ->
     _ = kz_datamgr:db_create(?KZ_TASKS_DB),
@@ -388,7 +382,6 @@ old_refresh(?KZ_TASKS_DB) ->
     'ok';
 old_refresh(?KZ_PENDING_NOTIFY_DB) ->
     _ = kz_datamgr:db_create(?KZ_PENDING_NOTIFY_DB),
-    kz_datamgr:revise_doc_from_file(?KZ_PENDING_NOTIFY_DB, 'crossbar', "views/pending_notify.json"),
     'ok';
 old_refresh(Database) when is_binary(Database) ->
     case kz_datamgr:db_classification(Database) of

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -331,9 +331,6 @@ refresh_views(Database, Worker, Classification) ->
     wait_for_response(30 * ?MILLISECONDS_IN_SECOND).
 
 -spec old_refresh(ne_binary() | nonempty_string()) -> 'ok' | 'remove'.
-old_refresh(?KZ_OAUTH_DB) ->
-    kz_datamgr:db_create(?KZ_OAUTH_DB),
-    kazoo_oauth_maintenance:register_common_providers();
 old_refresh(?KZ_AUTH_DB) ->
     kz_datamgr:db_create(?KZ_AUTH_DB),
     kazoo_auth_maintenance:register_common_providers(),

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -290,8 +290,6 @@ old_refresh(?KZ_OFFNET_DB=Part) ->
 old_refresh(Database) when is_binary(Database) ->
     case kz_datamgr:db_classification(Database) of
         'account' -> refresh_account_db(Database);
-        'modb' -> kazoo_modb:refresh_views(Database);
-        'numbers' -> kazoo_number_manager_maintenance:refresh_numbers_db(Database);
         'system' ->
             kz_datamgr:db_create(Database),
             'ok';

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -287,12 +287,6 @@ old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(?KZ_TOKEN_DB) ->
-    _ = kz_datamgr:db_create(?KZ_TOKEN_DB),
-    'ok';
-old_refresh(?KZ_ALERTS_DB) ->
-    _ = kz_datamgr:db_create(?KZ_ALERTS_DB),
-    'ok';
 old_refresh(?KZ_TASKS_DB) ->
     _ = kz_datamgr:db_create(?KZ_TASKS_DB),
     _ = kz_datamgr:revise_views_from_folder(?KZ_TASKS_DB, 'tasks'),

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -296,15 +296,6 @@ do_refresh(Database, Worker) ->
     RefreshedViews = kapi_maintenance:refresh_views(Database, Worker, Classification),
     {RefreshedDb, RefreshedViews}.
 
--spec old_refresh(ne_binary() | nonempty_string()) -> 'ok' | 'remove'.
-old_refresh(?KZ_OFFNET_DB=Part) ->
-    kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(Database) when is_binary(Database) ->
-    case kz_datamgr:db_classification(Database) of
-        'account' -> refresh_account_db(Database);
-        _Else -> 'ok'
-    end.
-
 %%--------------------------------------------------------------------
 %% @public
 %% @doc

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -287,8 +287,9 @@ refresh(Database) ->
 -spec do_refresh(ne_binary(), pid()) -> refresh_result().
 do_refresh(Database, Worker) ->
     Classification = kz_datamgr:db_classification(Database),
-    _ = kapi_maintenance:refresh_database(Database, Worker, Classification),
-    _ = kapi_maintenance:refresh_views(Database, Worker, Classification).
+    {kapi_maintenance:refresh_database(Database, Worker, Classification)
+    ,kapi_maintenance:refresh_views(Database, Worker, Classification)
+    }.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -287,9 +287,6 @@ old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(?KZ_PENDING_NOTIFY_DB) ->
-    _ = kz_datamgr:db_create(?KZ_PENDING_NOTIFY_DB),
-    'ok';
 old_refresh(Database) when is_binary(Database) ->
     case kz_datamgr:db_classification(Database) of
         'account' -> refresh_account_db(Database);

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -53,7 +53,6 @@
 -export([flush_account_views/0]).
 -export([flush_getby_cache/0]).
 
--include_lib("kazoo_number_manager/include/knm_phone_number.hrl").
 -include_lib("kazoo_caches/include/kazoo_caches.hrl").
 -include("kazoo_apps.hrl").
 
@@ -288,10 +287,6 @@ old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(?KZ_PORT_REQUESTS_DB) ->
-    kz_datamgr:db_create(?KZ_PORT_REQUESTS_DB),
-    _ = kz_util:spawn(fun knm_port_request:migrate/0),
-    'ok';
 old_refresh(?KZ_ACDC_DB) ->
     kz_datamgr:db_create(?KZ_ACDC_DB),
     'ok';

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -335,9 +335,6 @@ old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(?KZ_SERVICES_DB) ->
-    kz_datamgr:db_create(?KZ_SERVICES_DB),
-    kazoo_services_maintenance:refresh();
 old_refresh(?KZ_SIP_DB) ->
     kz_datamgr:db_create(?KZ_SIP_DB),
     Views = [kapps_util:get_view_json('kazoo_apps', ?MAINTENANCE_VIEW_FILE)

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -331,8 +331,6 @@ refresh_views(Database, Worker, Classification) ->
     wait_for_response(30 * ?MILLISECONDS_IN_SECOND).
 
 -spec old_refresh(ne_binary() | nonempty_string()) -> 'ok' | 'remove'.
-old_refresh(?KZ_DATA_DB) ->
-    kz_datamgr:revise_docs_from_folder(?KZ_DATA_DB, 'kazoo_data', <<"views">>);
 old_refresh(?KZ_OAUTH_DB) ->
     kz_datamgr:db_create(?KZ_OAUTH_DB),
     kazoo_oauth_maintenance:register_common_providers();

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -331,10 +331,6 @@ refresh_views(Database, Worker, Classification) ->
     wait_for_response(30 * ?MILLISECONDS_IN_SECOND).
 
 -spec old_refresh(ne_binary() | nonempty_string()) -> 'ok' | 'remove'.
-old_refresh(?KZ_AUTH_DB) ->
-    kz_datamgr:db_create(?KZ_AUTH_DB),
-    kazoo_auth_maintenance:register_common_providers(),
-    kazoo_auth_maintenance:refresh();
 old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -281,20 +281,14 @@ get_database_sort(Db1, Db2) ->
 refresh(Database) ->
     {'ok', Worker} = kz_amqp_worker:checkout_worker(),
     kz_amqp_worker:relay_to(Worker, self()),
-    RefreshResult = do_refresh(Database, Worker),
-    kz_amqp_worker:checkin_worker(Worker),
-    print_refresh_result(RefreshResult).
-
--spec print_refresh_result(refresh_result()) -> 'ok'.
-print_refresh_result({Db, Views}) ->
-    io:format('user', "db: ~p~nviews: ~p~n", [Db, Views]).
+    _ = do_refresh(Database, Worker),
+    kz_amqp_worker:checkin_worker(Worker).
 
 -spec do_refresh(ne_binary(), pid()) -> refresh_result().
 do_refresh(Database, Worker) ->
     Classification = kz_datamgr:db_classification(Database),
-    RefreshedDb = kapi_maintenance:refresh_database(Database, Worker, Classification),
-    RefreshedViews = kapi_maintenance:refresh_views(Database, Worker, Classification),
-    {RefreshedDb, RefreshedViews}.
+    _ = kapi_maintenance:refresh_database(Database, Worker, Classification),
+    _ = kapi_maintenance:refresh_views(Database, Worker, Classification).
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -287,10 +287,6 @@ old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(?KZ_TASKS_DB) ->
-    _ = kz_datamgr:db_create(?KZ_TASKS_DB),
-    _ = kz_datamgr:revise_views_from_folder(?KZ_TASKS_DB, 'tasks'),
-    'ok';
 old_refresh(?KZ_PENDING_NOTIFY_DB) ->
     _ = kz_datamgr:db_create(?KZ_PENDING_NOTIFY_DB),
     'ok';

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -287,12 +287,6 @@ old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(?KZ_ACDC_DB) ->
-    kz_datamgr:db_create(?KZ_ACDC_DB),
-    'ok';
-old_refresh(?KZ_CCCPS_DB) ->
-    kz_datamgr:db_create(?KZ_CCCPS_DB),
-    'ok';
 old_refresh(?KZ_TOKEN_DB) ->
     _ = kz_datamgr:db_create(?KZ_TOKEN_DB),
     'ok';

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -342,10 +342,6 @@ old_refresh(?KZ_SIP_DB) ->
             ,kapps_util:get_view_json('crossbar', <<"views/resources.json">>)
             ],
     kapps_util:update_views(?KZ_SIP_DB, Views, 'true');
-old_refresh(?KZ_MEDIA_DB) ->
-    kz_datamgr:db_create(?KZ_MEDIA_DB),
-    kazoo_media_maintenance:refresh(),
-    'ok';
 old_refresh(?KZ_RATES_DB) ->
     refresh_ratedeck_db(?KZ_RATES_DB);
 old_refresh(?KZ_ANONYMOUS_CDR_DB) ->

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -70,13 +70,11 @@ bind(Event, M, F) -> kazoo_bindings:bind(binding(Event), M, F).
 unbind(Event, M, F) -> kazoo_bindings:unbind(binding(Event), M, F).
 
 -define(DEVICES_CB_LIST, <<"devices/crossbar_listing">>).
--define(MAINTENANCE_VIEW_FILE, <<"views/maintenance.json">>).
 -define(RESELLER_VIEW_FILE, <<"views/reseller.json">>).
 -define(FAXES_VIEW_FILE, <<"views/faxes.json">>).
 -define(FAXBOX_VIEW_FILE, <<"views/faxbox.json">>).
--define(ACCOUNTS_AGG_VIEW_FILE, <<"views/accounts.json">>).
+
 -define(ACCOUNTS_AGG_NOTIFY_VIEW_FILE, <<"views/notify.json">>).
--define(SEARCH_VIEW_FILE, <<"views/search.json">>).
 
 -define(VMBOX_VIEW, <<"vmboxes/crossbar_listing">>).
 -define(PMEDIA_VIEW, <<"media/listing_private_media">>).
@@ -336,12 +334,6 @@ old_refresh(?KZ_WEBHOOKS_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
 old_refresh(?KZ_OFFNET_DB=Part) ->
     kazoo_bindings:map(binding({'refresh', Part}), []);
-old_refresh(?KZ_SIP_DB) ->
-    kz_datamgr:db_create(?KZ_SIP_DB),
-    Views = [kapps_util:get_view_json('kazoo_apps', ?MAINTENANCE_VIEW_FILE)
-            ,kapps_util:get_view_json('registrar', <<"credentials.json">>)
-            ],
-    kapps_util:update_views(?KZ_SIP_DB, Views, 'true');
 old_refresh(?KZ_ANONYMOUS_CDR_DB) ->
     kz_datamgr:db_create(?KZ_ANONYMOUS_CDR_DB),
     _ = kz_datamgr:revise_doc_from_file(?KZ_ANONYMOUS_CDR_DB, 'cdr', <<"cdr.json">>),
@@ -349,14 +341,6 @@ old_refresh(?KZ_ANONYMOUS_CDR_DB) ->
 old_refresh(?KZ_DEDICATED_IP_DB) ->
     kz_datamgr:db_create(?KZ_DEDICATED_IP_DB),
     kz_ip_utils:refresh_database();
-old_refresh(?KZ_ACCOUNTS_DB) ->
-    kz_datamgr:db_create(?KZ_ACCOUNTS_DB),
-    Views = [kapps_util:get_view_json('kazoo_apps', ?MAINTENANCE_VIEW_FILE)
-            ,kapps_util:get_view_json('kazoo_apps', ?ACCOUNTS_AGG_VIEW_FILE)
-            ,kapps_util:get_view_json('kazoo_apps', ?SEARCH_VIEW_FILE)
-            ],
-    kapps_util:update_views(?KZ_ACCOUNTS_DB, Views, 'true'),
-    'ok';
 old_refresh(?KZ_FAXES_DB) ->
     kz_datamgr:db_create(?KZ_FAXES_DB),
     _ = kz_datamgr:revise_doc_from_file(?KZ_FAXES_DB, 'fax', ?FAXES_VIEW_FILE),

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -345,12 +345,6 @@ old_refresh(?KZ_SIP_DB) ->
             ,kapps_util:get_view_json('crossbar', <<"views/resources.json">>)
             ],
     kapps_util:update_views(?KZ_SIP_DB, Views, 'true');
-old_refresh(?KZ_SCHEMA_DB) ->
-    kz_datamgr:db_create(?KZ_SCHEMA_DB),
-    kz_datamgr:suppress_change_notice(),
-    kz_datamgr:revise_docs_from_folder(?KZ_SCHEMA_DB, 'crossbar', "schemas"),
-    kz_datamgr:enable_change_notice(),
-    'ok';
 old_refresh(?KZ_MEDIA_DB) ->
     kz_datamgr:db_create(?KZ_MEDIA_DB),
     kazoo_media_maintenance:refresh(),

--- a/core/kazoo_apps/src/kapps_notify_publisher.erl
+++ b/core/kazoo_apps/src/kapps_notify_publisher.erl
@@ -107,10 +107,10 @@ handle_error(NotifyType, Req, Error) ->
               ]),
     JObj = kz_doc:update_pvt_parameters(kz_json:from_list_recursive(Props)
                                        ,'undefined'
-                                       , [{'type', <<"failed_notify">>}
-                                         ,{'account_id', find_account_id(Req)}
-                                         ,{'account_db', ?KZ_PENDING_NOTIFY_DB}
-                                         ]
+                                       ,[{'type', <<"failed_notify">>}
+                                        ,{'account_id', find_account_id(Req)}
+                                        ,{'account_db', ?KZ_PENDING_NOTIFY_DB}
+                                        ]
                                        ),
     save_pending_notification(NotifyType, JObj, 2).
 

--- a/core/kazoo_apps/src/kazoo_apps.hrl
+++ b/core/kazoo_apps/src/kazoo_apps.hrl
@@ -30,5 +30,9 @@
                        ,'webhooks'
                        ]).
 
+-define(MAINTENANCE_VIEW_FILE, <<"views/maintenance.json">>).
+-define(ACCOUNTS_AGG_VIEW_FILE, <<"views/accounts.json">>).
+-define(SEARCH_VIEW_FILE, <<"views/search.json">>).
+
 -define(KAZOO_APPS_HRL, 'true').
 -endif.

--- a/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
+++ b/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
@@ -76,9 +76,9 @@ start_link() ->
 handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
     handle_refresh(MaintJObj
-                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Classification">>, MaintJObj)
+                  ,kapi_maintenance:req_action(MaintJObj)
+                  ,kapi_maintenance:req_database(MaintJObj)
+                  ,kapi_maintenance:req_classification(MaintJObj)
                   ).
 
 handle_refresh(MaintJObj, <<"refresh_views">>, Database, <<"modb">>) ->

--- a/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
+++ b/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("kazoo_apps.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -68,6 +69,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
+++ b/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
@@ -34,6 +34,7 @@
                       ,kapi_maintenance:restrict_to_db(?KZ_DEDICATED_IP_DB)
                       ,kapi_maintenance:restrict_to_db(?KZ_TOKEN_DB)
                       ,kapi_maintenance:restrict_to_db(?KZ_ALERTS_DB)
+                      ,kapi_maintenance:restrict_to_db(?KZ_PENDING_NOTIFY_DB)
 
                       ,kapi_maintenance:restrict_to_views_db(?KZ_SIP_DB)
                       ,kapi_maintenance:restrict_to_views_db(?KZ_ACCOUNTS_DB)

--- a/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
+++ b/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
@@ -32,6 +32,8 @@
 %% define what databases or classifications we're interested in
 -define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_ACCOUNTS_DB)
                       ,kapi_maintenance:restrict_to_db(?KZ_DEDICATED_IP_DB)
+                      ,kapi_maintenance:restrict_to_db(?KZ_TOKEN_DB)
+                      ,kapi_maintenance:restrict_to_db(?KZ_ALERTS_DB)
 
                       ,kapi_maintenance:restrict_to_views_db(?KZ_SIP_DB)
                       ,kapi_maintenance:restrict_to_views_db(?KZ_ACCOUNTS_DB)

--- a/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
+++ b/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
@@ -1,0 +1,194 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kazoo_apps_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("kazoo_apps.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_ACCOUNTS_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_SIP_DB)
+                      ,kapi_maintenance:restrict_to_views_db(?KZ_ACCOUNTS_DB)
+                      ]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    handle_refresh(MaintJObj
+                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
+                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
+                  ).
+
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_SIP_DB) ->
+    Views = [kapps_util:get_view_json('kazoo_apps', ?MAINTENANCE_VIEW_FILE)],
+    Updated = kapps_util:update_views(?KZ_SIP_DB, Views, 'true'),
+    send_resp(MaintJObj, Updated);
+handle_refresh(MaintJObj, <<"refresh_database">>, ?KZ_ACCOUNTS_DB) ->
+    Created = kz_datamgr:db_create(?KZ_ACCOUNTS_DB),
+    send_resp(MaintJObj, Created);
+handle_refresh(MaintJObj, <<"refresh_views">>, ?KZ_ACCOUNTS_DB) ->
+    Views = [kapps_util:get_view_json('kazoo_apps', ?MAINTENANCE_VIEW_FILE)
+            ,kapps_util:get_view_json('kazoo_apps', ?ACCOUNTS_AGG_VIEW_FILE)
+            ,kapps_util:get_view_json('kazoo_apps', ?SEARCH_VIEW_FILE)
+            ],
+    Updated = kapps_util:update_views(?KZ_ACCOUNTS_DB, Views, 'true'),
+    send_resp(MaintJObj, Updated).
+
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Created) ->
+    Resp = [{<<"Code">>, code(Created)}
+           ,{<<"Message">>, message(Created)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+code('true') -> 200;
+code('false') -> 500.
+
+message('true') -> <<"Success">>;
+message('false') -> <<"Failed">>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
+++ b/core/kazoo_apps/src/kazoo_apps_maint_listener.erl
@@ -97,7 +97,10 @@ refresh_database(MaintJObj, Database) ->
     Created = kz_datamgr:db_create(Database),
     send_resp(MaintJObj, Created).
 
--spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+-type results() :: boolean() |
+                   'ok'.
+
+-spec send_resp(kapi_mainteannce:req(), results()) -> 'ok'.
 send_resp(MaintJObj, Created) ->
     Resp = [{<<"Code">>, code(Created)}
            ,{<<"Message">>, message(Created)}
@@ -107,9 +110,11 @@ send_resp(MaintJObj, Created) ->
     kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
 code('true') -> 200;
+code('ok') -> 200;
 code('false') -> 500.
 
 message('true') -> <<"Success">>;
+message('ok') -> <<"Success">>;
 message('false') -> <<"Failed">>.
 
 %%%===================================================================

--- a/core/kazoo_apps/src/kazoo_apps_sup.erl
+++ b/core/kazoo_apps/src/kazoo_apps_sup.erl
@@ -21,6 +21,7 @@
 -define(CHILDREN, [?SUPER('kz_hooks_listener_sup')
                   ,?WORKER('kazoo_apps_init')
                   ,?WORKER('kapps_controller')
+                  ,?WORKER('kazoo_apps_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/core/kazoo_auth/src/kazoo_auth_maint_listener.erl
+++ b/core/kazoo_auth/src/kazoo_auth_maint_listener.erl
@@ -1,0 +1,181 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kazoo_auth_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("kazoo_auth.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_AUTH_DB)]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+
+    Created = kz_datamgr:db_create(?KZ_AUTH_DB),
+    _ = kz_util:spawn(fun kazoo_auth_maintenance:register_common_providers/0),
+    _ = kz_util:spawn(fun kazoo_auth_maintenance:refresh/0),
+
+    send_resp(MaintJObj, Created).
+
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Created) ->
+    Resp = [{<<"Code">>, code(Created)}
+           ,{<<"Message">>, message(Created)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+
+-spec code(boolean()) -> 200 | 500.
+code('true') -> 200;
+code('false') -> 500.
+
+-spec message(boolean()) -> ne_binary().
+message('true') -> <<"Created ", (?KZ_AUTH_DB)/binary>>;
+message('false') -> <<"Did not create ", (?KZ_AUTH_DB)/binary>>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/core/kazoo_auth/src/kazoo_auth_maint_listener.erl
+++ b/core/kazoo_auth/src/kazoo_auth_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("kazoo_auth.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -55,6 +56,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/core/kazoo_auth/src/kazoo_auth_maintenance.erl
+++ b/core/kazoo_auth/src/kazoo_auth_maintenance.erl
@@ -43,7 +43,6 @@ register_auth_app_key(AppId, PemFile) ->
 refresh() ->
     kz_datamgr:revise_views_from_folder(?KZ_AUTH_DB, 'kazoo_auth').
 
-
 -spec register_common_providers() -> 'ok'.
 register_common_providers() ->
     kz_datamgr:revise_docs_from_folder(?KZ_AUTH_DB, 'kazoo_auth', "providers").

--- a/core/kazoo_auth/src/kazoo_auth_sup.erl
+++ b/core/kazoo_auth/src/kazoo_auth_sup.erl
@@ -29,6 +29,7 @@
                   ,?CACHE_ARGS(?PROFILE_CACHE, ?CACHE_PROPS)
                   ,?WORKER('kz_auth_rsa')
                   ,?WORKER('kz_auth_init')
+                  ,?WORKER('kazoo_auth_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/core/kazoo_data/src/kazoo_data.erl
+++ b/core/kazoo_data/src/kazoo_data.erl
@@ -6,7 +6,7 @@
              ,data_error/0
              ,data_errors/0
              ,get_results_return/0
-             ,db_classifications/0
+             ,db_classification/0
              ,view_options/0
              ,docid/0, docids/0
              ]).

--- a/core/kazoo_data/src/kazoo_data_sup.erl
+++ b/core/kazoo_data/src/kazoo_data_sup.erl
@@ -33,6 +33,7 @@
                   ,?WORKER('kz_dataconnections')
                   ,?WORKER('kazoo_data_bootstrap')
                   ,?WORKER('kz_data_tracing')
+                  ,?WORKER('kz_data_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/core/kazoo_data/src/kz_data.hrl
+++ b/core/kazoo_data/src/kz_data.hrl
@@ -106,6 +106,7 @@
                              'modb' |
                              'numbers' |
                              'provisioner' |
+                             'ratedeck' |
                              'resource_selectors' |
                              'system' |
                              'undefined'.

--- a/core/kazoo_data/src/kz_data_maint_listener.erl
+++ b/core/kazoo_data/src/kz_data_maint_listener.erl
@@ -1,0 +1,170 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kz_data_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("kz_data.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_DATA_DB)]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    _ = kz_util:spawn(fun() ->
+                              kz_datamgr:revise_docs_from_folder(?KZ_DATA_DB, 'kazoo_data', <<"views">>)
+                      end),
+    send_resp(MaintJObj).
+
+-spec send_resp(kapi_mainteannce:req()) -> 'ok'.
+send_resp(MaintJObj) ->
+    Resp = [{<<"Code">>, 200}
+           ,{<<"Message">>, <<"Refreshing views in ", ?KZ_DATA_DB/binary>>}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/core/kazoo_data/src/kz_data_maint_listener.erl
+++ b/core/kazoo_data/src/kz_data_maint_listener.erl
@@ -69,7 +69,7 @@ handle_req(MaintJObj, _Props) ->
 
 -spec send_resp(kapi_mainteannce:req()) -> 'ok'.
 send_resp(MaintJObj) ->
-    Resp = [{<<"Code">>, 200}
+    Resp = [{<<"Code">>, 202}
            ,{<<"Message">>, <<"Refreshing views in ", ?KZ_DATA_DB/binary>>}
            ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)

--- a/core/kazoo_data/src/kz_data_maint_listener.erl
+++ b/core/kazoo_data/src/kz_data_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("kz_data.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -55,6 +56,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -652,7 +652,7 @@ handle_info({'heartbeat', Ref}
         _E:_N ->
             lager:error("error creating node ~p : ~p", [_E, _N]),
             kz_util:log_stacktrace(),
-            {'noreply', State#state{heartbeat_ref=Reference}}
+            {'noreply', State#state{heartbeat_ref=Reference}, 'hibernate'}
     end;
 
 handle_info({'DOWN', Ref, 'process', Pid, _}

--- a/core/kazoo_ips/src/kz_ip_utils.erl
+++ b/core/kazoo_ips/src/kz_ip_utils.erl
@@ -9,28 +9,17 @@
 
 -include("kazoo_ips.hrl").
 
--export([refresh_database/0
-        ,refresh_database/1
-        ]).
+-export([refresh_database/0, refresh_database/1]).
 
-%%--------------------------------------------------------------------
-%% @public
-%% @doc
-%%
-%% @end
-%%--------------------------------------------------------------------
 -spec refresh_database() -> 'ok'.
 refresh_database() ->
-    _ = kz_datamgr:db_create(?KZ_DEDICATED_IP_DB),
-    _ = kz_datamgr:revise_docs_from_folder(?KZ_DEDICATED_IP_DB
-                                          ,'kazoo_ips'
-                                          ,"views"
-                                          ),
+    _ = kapi_maintenance:refresh_database(?KZ_DEDICATED_IP_DB),
+    _ = kapi_maintenance:refresh_views(?KZ_DEDICATED_IP_DB),
     'ok'.
 
 -spec refresh_database(function()) -> any().
 refresh_database(Callback) ->
-    _ = refresh_database(),
+    refresh_database(),
     case refresh_database_retries() < 2 of
         'false' -> {'error', 'not_found'};
         'true' -> Callback()

--- a/core/kazoo_maintenance/src/kapps_config_maint_listener.erl
+++ b/core/kazoo_maintenance/src/kapps_config_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("kazoo_maintenance.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -54,6 +55,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/core/kazoo_maintenance/src/kapps_config_maint_listener.erl
+++ b/core/kazoo_maintenance/src/kapps_config_maint_listener.erl
@@ -67,6 +67,8 @@ handle_req(MaintJObj, _Props) ->
 handle_refresh(MaintJObj, ?KZ_CONFIG_DB) ->
     Created = kz_datamgr:db_create(?KZ_CONFIG_DB),
     _ = kz_util:spawn(fun cleanup_invalid_notify_docs/0, []),
+    _ = kz_util:spawn(fun delete_system_media_references/0, []),
+    _ = kz_util:spwan(fun accounts_config_deprecate_timezone_for_default_timezone/0, []),
     send_resp(MaintJObj, Created).
 
 -spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
@@ -203,3 +205,95 @@ maybe_remove_invalid_notify_doc(<<"notification">>, _, JObj) ->
     _ = kz_datamgr:del_doc(?KZ_CONFIG_DB, JObj),
     'ok';
 maybe_remove_invalid_notify_doc(_Type, _Id, _Doc) -> 'ok'.
+
+
+-spec delete_system_media_references() -> 'ok'.
+delete_system_media_references() ->
+    DocId = kz_call_response:config_doc_id(),
+    case kz_datamgr:open_doc(?KZ_CONFIG_DB, DocId) of
+        {'ok', CallResponsesDoc} ->
+            delete_system_media_references(DocId, CallResponsesDoc);
+        {'error', 'not_found'} -> 'ok'
+    end.
+
+-spec delete_system_media_references(ne_binary(), kz_json:object()) -> 'ok'.
+delete_system_media_references(DocId, CallResponsesDoc) ->
+    TheKey = <<"default">>,
+    Default = kz_json:get_value(TheKey, CallResponsesDoc),
+
+    case kz_json:map(fun remove_system_media_refs/2, Default) of
+        Default -> 'ok';
+        NewDefault ->
+            io:format("updating ~s with stripped system_media references~n", [DocId]),
+            NewCallResponsesDoc = kz_json:set_value(TheKey, NewDefault, CallResponsesDoc),
+            _Resp = kz_datamgr:save_doc(?KZ_CONFIG_DB, NewCallResponsesDoc),
+            'ok'
+    end.
+
+-spec remove_system_media_refs(kz_json:path(), kz_json:objects()) ->
+                                      {kz_json:path(), kz_json:json_term()}.
+remove_system_media_refs(HangupCause, Config) ->
+    case kz_json:is_json_object(Config) of
+        'false' -> {HangupCause, Config};
+        'true' ->
+            {HangupCause
+            ,kz_json:foldl(fun remove_system_media_ref/3, kz_json:new(), Config)
+            }
+    end.
+
+-spec remove_system_media_ref(kz_json:path(), kz_json:json_term(), kz_json:object()) ->
+                                     kz_json:object().
+remove_system_media_ref(Key, <<"/system_media/", Value/binary>>, Acc) -> kz_json:set_value(Key, Value, Acc);
+remove_system_media_ref(Key, Value, Acc) -> kz_json:set_value(Key, Value, Acc).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Remove system_config/accounts timezone key and use only
+%% default_timezone
+%% @end
+%%--------------------------------------------------------------------
+-spec accounts_config_deprecate_timezone_for_default_timezone() -> 'ok'.
+-spec accounts_config_deprecate_timezone_for_default_timezone(kz_json:object()) -> 'ok'.
+accounts_config_deprecate_timezone_for_default_timezone() ->
+    case kz_datamgr:open_cache_doc(?KZ_CONFIG_DB, <<"accounts">>) of
+        {'ok', AccountsConfig} ->
+            accounts_config_deprecate_timezone_for_default_timezone(AccountsConfig);
+        {'error', E} ->
+            lager:warning("unable to fetch system_config/accounts: ~p", [E])
+    end.
+
+accounts_config_deprecate_timezone_for_default_timezone(AccountsConfig) ->
+    PublicFields = kz_doc:public_fields(AccountsConfig),
+    case kz_json:get_keys(PublicFields) of
+        [] -> 'ok';
+        Keys ->
+            MigratedConfig = deprecate_timezone_for_default_timezone(Keys, AccountsConfig),
+            kz_datamgr:save_doc(?KZ_CONFIG_DB, MigratedConfig),
+            'ok'
+    end.
+
+-spec deprecate_timezone_for_default_timezone(kz_json:keys(), kz_json:object()) ->
+                                                     kz_json:object().
+deprecate_timezone_for_default_timezone(Nodes, AccountsConfig) ->
+    lists:foldl(fun deprecate_timezone_for_node/2, AccountsConfig, Nodes).
+
+-spec deprecate_timezone_for_node(kz_json:key(), kz_json:object()) ->
+                                         kz_json:object().
+-spec deprecate_timezone_for_node(kz_json:key(), kz_json:object(), api_ne_binary(), api_ne_binary()) ->
+                                         kz_json:object().
+deprecate_timezone_for_node(Node, AccountsConfig) ->
+    Timezone = kz_json:get_value([Node, <<"timezone">>], AccountsConfig),
+    DefaultTimezone = kz_json:get_value([Node, <<"default_timezone">>], AccountsConfig),
+    deprecate_timezone_for_node(Node, AccountsConfig, Timezone, DefaultTimezone).
+
+deprecate_timezone_for_node(_Node, AccountsConfig, 'undefined', _Default) ->
+    AccountsConfig;
+deprecate_timezone_for_node(Node, AccountsConfig, Timezone, 'undefined') ->
+    io:format("setting default timezone to ~s for node ~s~n", [Timezone, Node]),
+    kz_json:set_value([Node, <<"default_timezone">>]
+                     ,Timezone
+                     ,kz_json:delete_key([Node, <<"timezone">>], AccountsConfig)
+                     );
+deprecate_timezone_for_node(Node, AccountsConfig, _Timezone, _Default) ->
+    kz_json:delete_key([Node, <<"timezone">>], AccountsConfig).

--- a/core/kazoo_maintenance/src/kapps_config_maint_listener.erl
+++ b/core/kazoo_maintenance/src/kapps_config_maint_listener.erl
@@ -68,7 +68,7 @@ handle_refresh(MaintJObj, ?KZ_CONFIG_DB) ->
     Created = kz_datamgr:db_create(?KZ_CONFIG_DB),
     _ = kz_util:spawn(fun cleanup_invalid_notify_docs/0, []),
     _ = kz_util:spawn(fun delete_system_media_references/0, []),
-    _ = kz_util:spwan(fun accounts_config_deprecate_timezone_for_default_timezone/0, []),
+    _ = kz_util:spawn(fun accounts_config_deprecate_timezone_for_default_timezone/0, []),
     send_resp(MaintJObj, Created).
 
 -spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.

--- a/core/kazoo_maintenance/src/kazoo_maintenance.app.src
+++ b/core/kazoo_maintenance/src/kazoo_maintenance.app.src
@@ -7,9 +7,9 @@
                   , stdlib
 
                   , kazoo
+                  , kazoo_amqp
 
                   , lager
-                  , zucchini
                   ]}
  , {mod, {kazoo_maintenance_app, []}}
  ]}.

--- a/core/kazoo_maintenance/src/kazoo_maintenance.app.src
+++ b/core/kazoo_maintenance/src/kazoo_maintenance.app.src
@@ -8,6 +8,7 @@
 
                   , kazoo
                   , kazoo_amqp
+                  , kazoo_data
 
                   , lager
                   ]}

--- a/core/kazoo_maintenance/src/kazoo_maintenance_app.erl
+++ b/core/kazoo_maintenance/src/kazoo_maintenance_app.erl
@@ -23,6 +23,7 @@
 %%--------------------------------------------------------------------
 -spec start(application:start_type(), any()) -> startapp_ret().
 start(_StartType, _StartArgs) ->
+    kapi_maintenance:declare_exchanges(),
     kazoo_maintenance_sup:start_link().
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_maintenance/src/kazoo_maintenance_sup.erl
+++ b/core/kazoo_maintenance/src/kazoo_maintenance_sup.erl
@@ -17,7 +17,7 @@
 
 -define(SERVER, ?MODULE).
 
--define(CHILDREN, [?WORKER('kz_config_maint_listener')]).
+-define(CHILDREN, [?WORKER('kapps_config_maint_listener')]).
 
 %% ===================================================================
 %% API functions

--- a/core/kazoo_maintenance/src/kazoo_maintenance_sup.erl
+++ b/core/kazoo_maintenance/src/kazoo_maintenance_sup.erl
@@ -17,7 +17,9 @@
 
 -define(SERVER, ?MODULE).
 
--define(CHILDREN, [?WORKER('kapps_config_maint_listener')]).
+-define(CHILDREN, [?WORKER('kapps_config_maint_listener')
+                  ,?WORKER('kazoo_oauth_maint_listener')
+                  ]).
 
 %% ===================================================================
 %% API functions

--- a/core/kazoo_maintenance/src/kazoo_oauth_maint_listener.erl
+++ b/core/kazoo_maintenance/src/kazoo_oauth_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("kazoo_maintenance.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -55,6 +56,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/core/kazoo_maintenance/src/kazoo_oauth_maint_listener.erl
+++ b/core/kazoo_maintenance/src/kazoo_oauth_maint_listener.erl
@@ -1,0 +1,177 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kazoo_oauth_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("kazoo_maintenance.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_OAUTH_DB)]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    Created = kz_datamgr:db_create(?KZ_OAUTH_DB),
+    _ = kz_util:spawn(fun kazoo_oauth_maintenance:register_common_providers/0),
+    send_resp(MaintJObj, Created).
+
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Created) ->
+    Resp = [{<<"Code">>, code(Created)}
+           ,{<<"Message">>, message(Created)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+-spec code(boolean()) -> 200 | 500.
+code('true') -> 200;
+code('false') -> 500.
+
+-spec message(boolean()) -> ne_binary().
+message('true') -> <<"Created ", (?KZ_OAUTH_DB)/binary>>;
+message('false') -> <<"Did not create ", (?KZ_OAUTH_DB)/binary>>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/core/kazoo_maintenance/src/kz_config_maint_listener.erl
+++ b/core/kazoo_maintenance/src/kz_config_maint_listener.erl
@@ -70,6 +70,7 @@ send_resp(MaintJObj, Created) ->
 
     Resp = [{<<"Code">>, code(Created)}
            ,{<<"Message">>, message(Created)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
             | kz_api:default_headers(RespQueue, ?APP_NAME, ?APP_VERSION)
            ],
     kapi_maintenance:publish_resp(RespQueue, Resp).

--- a/core/kazoo_maintenance/src/kz_config_maint_listener.erl
+++ b/core/kazoo_maintenance/src/kz_config_maint_listener.erl
@@ -66,14 +66,12 @@ handle_req(MaintJObj, _Props) ->
 
 -spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
 send_resp(MaintJObj, Created) ->
-    RespQueue = kz_api:server_id(MaintJObj),
-
     Resp = [{<<"Code">>, code(Created)}
            ,{<<"Message">>, message(Created)}
            ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
-            | kz_api:default_headers(RespQueue, ?APP_NAME, ?APP_VERSION)
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
-    kapi_maintenance:publish_resp(RespQueue, Resp).
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
 
 -spec code(boolean()) -> 200 | 500.
 code('true') -> 200;

--- a/core/kazoo_maintenance/src/skel_maint_listener.erl
+++ b/core/kazoo_maintenance/src/skel_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("kazoo_maintenance.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -55,6 +56,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/core/kazoo_maintenance/src/skel_maint_listener.erl
+++ b/core/kazoo_maintenance/src/skel_maint_listener.erl
@@ -1,0 +1,167 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(skel_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("kazoo_maintenance.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, []).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    send_resp(MaintJObj).
+
+-spec send_resp(kapi_mainteannce:req()) -> 'ok'.
+send_resp(MaintJObj) ->
+    Resp = [{<<"Code">>, 200}
+           ,{<<"Message">>, <<"I heard you!">>}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/core/kazoo_media/src/kazoo_media_maint_listener.erl
+++ b/core/kazoo_media/src/kazoo_media_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("kazoo_media.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -55,6 +56,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/core/kazoo_media/src/kazoo_media_maintenance.erl
+++ b/core/kazoo_media/src/kazoo_media_maintenance.erl
@@ -242,7 +242,15 @@ maybe_retry_upload(ID, AttachmentName, Contents, Options, Retries) ->
 
 -spec refresh() -> 'ok'.
 refresh() ->
-    kz_datamgr:revise_doc_from_file(?KZ_MEDIA_DB, 'crossbar', "account/media.json"),
+    Req = [{<<"Database">>, ?KZ_MEDIA_DB}
+          ,{<<"Classification">>, kz_datamgr:db_classification(?KZ_MEDIA_DB)}
+          ,{<<"Action">>, <<"refresh_views">>}
+           | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+          ],
+    {'ok', _} = kz_amqp_worker:call(Req
+                                   ,fun kapi_maintenance:publish_req/1
+                                   ,fun kapi_maintenance:resp_v/1
+                                   ),
     'ok'.
 
 -spec maybe_migrate_system_config(ne_binary()) -> 'ok'.

--- a/core/kazoo_media/src/kazoo_media_sup.erl
+++ b/core/kazoo_media/src/kazoo_media_sup.erl
@@ -28,6 +28,7 @@
                                 ])
                   ,?WORKER('kz_media_map')
                   ,?WORKER('kz_media_proxy')
+                  ,?WORKER('kazoo_media_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/core/kazoo_number_manager/src/kazoo_number_manager_sup.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_sup.erl
@@ -30,6 +30,7 @@
 %% Helper macro for declaring children of supervisor
 -define(CHILDREN, [?CACHE_ARGS(?CACHE_NAME, ?CACHE_PROPS)
                   ,?WORKER('knm_search')
+                  ,?WORKER('knm_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/core/kazoo_number_manager/src/knm_maint_listener.erl
+++ b/core/kazoo_number_manager/src/knm_maint_listener.erl
@@ -65,9 +65,9 @@ start_link() ->
 handle_req(MaintJObj, _Props) ->
     'true' = kapi_maintenance:req_v(MaintJObj),
     handle_refresh(MaintJObj
-                  ,kz_json:get_ne_binary_value(<<"Action">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Database">>, MaintJObj)
-                  ,kz_json:get_ne_binary_value(<<"Classification">>, MaintJObj)
+                  ,kapi_maintenance:req_action(MaintJObj)
+                  ,kapi_maintenance:req_database(MaintJObj)
+                  ,kapi_maintenance:req_classification(MaintJObj)
                   ).
 
 handle_refresh(MaintJObj, <<"refresh_database">>, ?KZ_PORT_REQUESTS_DB, _Class) ->

--- a/core/kazoo_number_manager/src/knm_maint_listener.erl
+++ b/core/kazoo_number_manager/src/knm_maint_listener.erl
@@ -31,7 +31,7 @@
 %% By convention, we put the options here in macros, but not required.
 %% define what databases or classifications we're interested in
 -define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_PORT_REQUESTS_DB)
-                      ,kapi_maintenance:restrict_to_views_type('numbers')
+                      ,kapi_maintenance:restrict_to_views_classification('numbers')
                       ]).
 -define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
 -define(RESPONDERS, [{{?MODULE, 'handle_req'}

--- a/core/kazoo_number_manager/src/knm_maint_listener.erl
+++ b/core/kazoo_number_manager/src/knm_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("knm.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -57,6 +58,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/core/kazoo_number_manager/src/knm_maint_listener.erl
+++ b/core/kazoo_number_manager/src/knm_maint_listener.erl
@@ -1,0 +1,175 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(knm_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("knm.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_PORT_REQUESTS_DB)]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    Created = kz_datamgr:db_create(?KZ_PORT_REQUESTS_DB),
+    _ = kz_util:spawn(fun knm_port_request:migrate/0),
+    send_resp(MaintJObj, Created).
+
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Created) ->
+    Resp = [{<<"Code">>, code(Created)}
+           ,{<<"Message">>, message(Created)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+code('true') -> 200;
+code('false') -> 500.
+
+message('true') -> <<"Success">>;
+message('false') -> <<"Failure">>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/core/kazoo_services/src/kazoo_services_maint_listener.erl
+++ b/core/kazoo_services/src/kazoo_services_maint_listener.erl
@@ -22,6 +22,7 @@
         ]).
 
 -include("services.hrl").
+-include_lib("kazoo_amqp/include/kz_amqp.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -55,6 +56,7 @@ start_link() ->
                             ,{'queue_name', ?QUEUE_NAME}       % optional to include
                             ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
                             ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ,{'declare_exchanges', [{?EXCHANGE_SYSCONF, ?TYPE_SYSCONF}]}
                             ]
                            ,[]
                            ).

--- a/core/kazoo_services/src/kazoo_services_maint_listener.erl
+++ b/core/kazoo_services/src/kazoo_services_maint_listener.erl
@@ -1,0 +1,177 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, 2600Hz
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%-------------------------------------------------------------------
+-module(kazoo_services_maint_listener).
+-behaviour(gen_listener).
+
+-export([start_link/0
+        ,handle_req/2
+        ]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,handle_event/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("services.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+%% By convention, we put the options here in macros, but not required.
+%% define what databases or classifications we're interested in
+-define(RESTRICTIONS, [kapi_maintenance:restrict_to_db(?KZ_SERVICES_DB)]).
+-define(BINDINGS, [{'maintenance', [{'restrict_to', ?RESTRICTIONS}]}]).
+-define(RESPONDERS, [{{?MODULE, 'handle_req'}
+                     ,[{<<"maintenance">>, <<"req">>}]
+                     }
+                    ]).
+-define(QUEUE_NAME, <<?MODULE_STRING>>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc Starts the server
+%%--------------------------------------------------------------------
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_listener:start_link(?SERVER
+                           ,[{'bindings', ?BINDINGS}
+                            ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}       % optional to include
+                            ,{'queue_options', ?QUEUE_OPTIONS} % optional to include
+                            ,{'consume_options', ?CONSUME_OPTIONS} % optional to include
+                            ]
+                           ,[]
+                           ).
+
+-spec handle_req(kapi_maintenance:req(), kz_proplist()) -> 'ok'.
+handle_req(MaintJObj, _Props) ->
+    'true' = kapi_maintenance:req_v(MaintJObj),
+    Created = kz_datamgr:db_create(?KZ_SERVICES_DB),
+    _ = kz_util:spawn(fun kazoo_services_maintenance:refresh/0),
+    send_resp(MaintJObj, Created).
+
+-spec send_resp(kapi_mainteannce:req(), boolean()) -> 'ok'.
+send_resp(MaintJObj, Created) ->
+    Resp = [{<<"Code">>, code(Created)}
+           ,{<<"Message">>, message(Created)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(MaintJObj)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+    kapi_maintenance:publish_resp(kz_api:server_id(MaintJObj), Resp).
+
+-spec code(boolean()) -> 200 | 500.
+code('true') -> 200;
+code('false') -> 500.
+
+-spec message(boolean()) -> ne_binary().
+message('true') -> <<"Created ", (?KZ_SERVICES_DB)/binary>>;
+message('false') -> <<"Did not create ", (?KZ_SERVICES_DB)/binary>>.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Initializes the server
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%%--------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling call messages
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling cast messages
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> handle_cast_ret_state(state()).
+handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
+    {'noreply', State};
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
+    {'noreply', State};
+handle_cast(_Msg, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Handling all non call/cast messages
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%%--------------------------------------------------------------------
+-spec handle_info(any(), state()) -> handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    {'noreply', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Allows listener to pass options to handlers
+%% @spec handle_event(JObj, State) -> {reply, Options}
+%%--------------------------------------------------------------------
+-spec handle_event(kz_json:object(), kz_proplist()) -> gen_listener:handle_event_return().
+handle_event(_JObj, _State) ->
+    {'reply', []}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%% @spec terminate(Reason, State) -> void()
+%%--------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("listener terminating: ~p", [_Reason]).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Convert process state when code is changed
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%%--------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/core/kazoo_services/src/kazoo_services_sup.erl
+++ b/core/kazoo_services/src/kazoo_services_sup.erl
@@ -26,6 +26,7 @@
 -define(CHILDREN, [?CACHE_ARGS(?CACHE_NAME, ?CACHE_PROPS)
                   ,?WORKER('kz_services_modb')
                   ,?WORKER('kz_service_sync')
+                  ,?WORKER('kazoo_services_maint_listener')
                   ]).
 
 %% ===================================================================

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -1127,7 +1127,7 @@ replace_in_list(N, V1, [V | Vs], Acc) ->
                                     object() |
                                     {'error', atom()}.
 
--spec load_fixture_from_file(atom(), nonempty_string() | ne_binary(), ne_binary()) ->
+-spec load_fixture_from_file(atom(), nonempty_string() | ne_binary(), iodata()) ->
                                     object() |
                                     {'error', atom()}.
 


### PR DESCRIPTION
Start to build maintenance commands out as AMQP requests. Since apps contains view/fixture/other data, and those apps might not be running where the SUP command is issued, moving to AMQP makes sense to distribute the work to where the data is.

First pass is distributing the refresh work out.