### PR TITLE
Update schema for longer time limit

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/callflows.record_caller.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.record_caller.json
@@ -23,7 +23,7 @@
         "time_limit": {
             "default": 3600,
             "description": "Time limit, in seconds, for the recording",
-            "maximum": 3600,
+            "maximum": 10800,
             "minimum": 5,
             "type": "integer"
         },


### PR DESCRIPTION
Allow schema to accept up to 3 hours or recording time.