### PR TITLE
Reconcile IPs

### DIFF
--- a/applications/callflow/src/module/cf_group.erl
+++ b/applications/callflow/src/module/cf_group.erl
@@ -85,11 +85,10 @@ build_endpoints(JObj, Call) ->
     lists:flatten(
       [Endpoint
        || {_, {'ok', Endpoint}} <-
-              lists:foldl(
-                fun(F, E) -> F(E, Members, Call) end
+              lists:foldl(fun(F, E) -> F(E, Members, Call) end
                          ,[]
                          ,Routines
-               )
+                         )
       ]
      ).
 

--- a/applications/crossbar/doc/ips.md
+++ b/applications/crossbar/doc/ips.md
@@ -1,6 +1,6 @@
-### Ips
+### IPs
 
-#### About Ips
+#### About IPs
 
 The IPs API allows users to manage the IP addresses assigned to their accounts. In the future they will be able to fully manage dedicated IPs.
 

--- a/applications/crossbar/doc/ips.md
+++ b/applications/crossbar/doc/ips.md
@@ -6,23 +6,6 @@ The IPs API allows users to manage the IP addresses assigned to their accounts. 
 
 The common use case is adding proxy IPs that must be used when routing calls to upstream resources. If the upstream requires traffic to come from a specific set of IPs, adding those IPs here will cause outbound calls to carriers to be routed through the IP(s) supplied.
 
-#### Adding IPs to the system
-
-IPs need to be configured by the system admin using the `sup kazoo_ips_maintenance add {IP} {ZONE} {HOST}` command:
-
-```shell
-sup kazoo_ips_maintenance add "1.2.3.4" "us-east" "proxy1.us-east.myswitch.com"
-added IP 1.2.3.4 to available dedicated ips
-```
-
-Key | Description | Type | Default | Required
---- | ----------- | ---- | ------- | --------
-`{IP}` | The IP address of the proxy | `string` |   | `true`
-`{ZONE}` | The Kazoo zone this proxy is assigned  | `string` |   | `true`
-`{HOST}` | The Hostname associated with the IP | `string` | | `true`
-
-Once you've added IPs to the system, you can assign those to different customer accounts to proxy their calls through using the below Crossbar APIs.
-
 #### Schema
 
 IP addresses assigned to the account
@@ -245,4 +228,37 @@ curl -v -X GET \
     "revision": "{REVISION}",
     "status": "success"
 }
+```
+
+
+### Adding IPs to the system
+
+#### Via SUP
+
+IPs can be configured by the system admin using the `sup kazoo_ips_maintenance add {IP} {ZONE} {HOST}` command:
+
+```shell
+sup kazoo_ips_maintenance add "1.2.3.4" "us-east" "proxy1.us-east.myswitch.com"
+added IP 1.2.3.4 to available dedicated ips
+```
+
+Key | Description | Type | Default | Required
+--- | ----------- | ---- | ------- | --------
+`{IP}` | The IP address of the proxy | `string` |   | `true`
+`{ZONE}` | The Kazoo zone this proxy is assigned  | `string` |   | `true`
+`{HOST}` | The Hostname associated with the IP | `string` | | `true`
+
+Once you've added IPs to the system, you can assign those to different customer accounts to proxy their calls through using the below Crossbar APIs.
+
+#### Via API
+
+This requires a superduper admin auth token:
+
+> PUT /v2/ips
+
+```shell
+curl -v -X PUT \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -d '{"data":{"ip":"1.2.3.4", "zone":"us-east", "host":"proxy1.us-east.myswitch.com"}}'
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/ips
 ```

--- a/applications/crossbar/doc/ref/ips.md
+++ b/applications/crossbar/doc/ref/ips.md
@@ -25,6 +25,16 @@ curl -v -X GET \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/ips
 ```
 
+#### Create
+
+> PUT /v2/accounts/{ACCOUNT_ID}/ips
+
+```shell
+curl -v -X PUT \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/ips
+```
+
 #### Change
 
 > POST /v2/accounts/{ACCOUNT_ID}/ips

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -34830,6 +34830,29 @@
                         "description": "request succeeded"
                     }
                 }
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "ips",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ips"
+                        }
+                    },
+                    {
+                        "$ref": "#/parameters/auth_token_header"
+                    },
+                    {
+                        "$ref": "#/parameters/ACCOUNT_ID"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "request succeeded"
+                    }
+                }
             }
         },
         "/accounts/{ACCOUNT_ID}/ips/assigned": {

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -735,11 +735,14 @@ response(#cb_context{resp_error_code=Code
                                    context().
 validate_request_data(SchemaId, Context) ->
     validate_request_data(SchemaId, Context, 'undefined').
+
 validate_request_data(SchemaId, Context, OnSuccess) ->
     validate_request_data(SchemaId, Context, OnSuccess, 'undefined').
+
 validate_request_data(SchemaId, Context, OnSuccess, OnFailure) ->
     SchemaRequired = fetch(Context, 'ensure_valid_schema', ?SHOULD_ENSURE_SCHEMA_IS_VALID),
     validate_request_data(SchemaId, Context, OnSuccess, OnFailure, SchemaRequired).
+
 validate_request_data('undefined', Context, OnSuccess, _OnFailure, 'false') ->
     lager:error("schema id or schema JSON not defined, continuing anyway"),
     validate_passed(Context, OnSuccess);

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -764,10 +764,14 @@ validate_request_data(?NE_BINARY=SchemaId, Context, OnSuccess, OnFailure, Schema
 validate_request_data(SchemaJObj, Context, OnSuccess, OnFailure, _SchemaRequired) ->
     Strict = fetch(Context, 'schema_strict_validation', ?SHOULD_FAIL_ON_INVALID_DATA),
     try kz_json_schema:validate(SchemaJObj, kz_doc:public_fields(req_data(Context))) of
-        {'ok', JObj} -> validate_passed(set_req_data(Context, JObj), OnSuccess);
+        {'ok', JObj} ->
+            lager:debug("validation passed"),
+            validate_passed(set_req_data(Context, JObj), OnSuccess);
         {'error', Errors} when Strict ->
+            lager:debug("validation errors when strictly validating"),
             validate_failed(SchemaJObj, Context, Errors, OnFailure);
         {'error', Errors} ->
+            lager:debug("validation errors but not stricly validating, trying to fix request"),
             maybe_fix_js_types(SchemaJObj, Context, OnSuccess, OnFailure, Errors)
     catch
         'error':'function_clause' ->

--- a/applications/crossbar/src/modules/cb_ips.erl
+++ b/applications/crossbar/src/modules/cb_ips.erl
@@ -47,12 +47,13 @@ init() ->
 
 -spec authorize(cb_context:context()) -> boolean().
 authorize(Context) ->
+    cb_context:put_reqid(Context),
     authorize(Context, cb_context:req_nouns(Context)).
 
 authorize(Context, [{<<"ips">>, []}]) ->
     cb_context:is_superduper_admin(Context);
 authorize(_Context, _Nouns) ->
-    'false'.
+    'true'.
 
 %%--------------------------------------------------------------------
 %% @public
@@ -102,9 +103,11 @@ resource_exists(_) -> 'true'.
 -spec validate(cb_context:context()) -> cb_context:context().
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
+    cb_context:put_reqid(Context),
     validate_ips(Context, cb_context:req_verb(Context)).
 
 validate(Context, PathToken) ->
+    cb_context:put_reqid(Context),
     validate_ips(Context, PathToken, cb_context:req_verb(Context)).
 
 -spec validate_ips(cb_context:context(), ne_binary()) -> cb_context:context().
@@ -170,6 +173,7 @@ put(Context) ->
     Zone = kz_json:get_ne_binary_value(<<"zone">>, ReqData),
     Host = kz_json:get_ne_binary_value(<<"host">>, ReqData),
 
+    lager:debug("creating ip ~p", [ReqData]),
     case kz_ip:create(IP, Zone, Host) of
         {'ok', IPJObj} ->
             lager:debug("created ip ~s: ~p", [IP, IPJObj]),

--- a/applications/crossbar/src/modules/cb_ips.erl
+++ b/applications/crossbar/src/modules/cb_ips.erl
@@ -432,6 +432,7 @@ release_ip(Context, Id) ->
             crossbar_doc:handle_datamgr_errors(Reason, Id, Context)
     end.
 
+-spec delete_ip(cb_context:context(), ne_binary()) -> cb_context:context().
 delete_ip(Context, IP) ->
     case kz_ip:delete(IP) of
         {'ok', Deleted} -> crossbar_doc:handle_json_success(Context, Deleted);

--- a/applications/crossbar/src/modules/cb_ips.erl
+++ b/applications/crossbar/src/modules/cb_ips.erl
@@ -199,7 +199,7 @@ put(Context) ->
 -spec load_available(cb_context:context()) -> cb_context:context().
 load_available(Context) ->
     QS = cb_context:query_string(Context),
-    Zone = kz_json:get_value(<<"zone">>, QS),
+    Zone = kz_json:get_ne_binary_value(<<"zone">>, QS),
     case kz_ips:available(Zone) of
         {'ok', JObjs} ->
             cb_context:set_resp_data(cb_context:set_resp_status(Context, 'success')

--- a/applications/crossbar/src/modules/cb_ips.erl
+++ b/applications/crossbar/src/modules/cb_ips.erl
@@ -435,7 +435,7 @@ release_ip(Context, Id) ->
 -spec delete_ip(cb_context:context(), ne_binary()) -> cb_context:context().
 delete_ip(Context, IP) ->
     case kz_ip:delete(IP) of
-        {'ok', Deleted} -> crossbar_doc:handle_json_success(Context, Deleted);
+        {'ok', Deleted} -> crossbar_doc:handle_json_success(Deleted, Context);
         {'error', Error} -> crossbar_doc:handle_datamgr_errors(Error, IP, Context)
     end.
 

--- a/applications/crossbar/src/modules/cb_simple_authz.erl
+++ b/applications/crossbar/src/modules/cb_simple_authz.erl
@@ -21,12 +21,13 @@
 
 -define(SERVER, ?MODULE).
 -define(VIEW_SUMMARY, <<"accounts/listing_by_id">>).
--define(SYS_ADMIN_MODS, [<<"global_resources">>
-                        ,<<"templates">>
-                        ,<<"rates">>
-                        ,<<"acls">>
+-define(SYS_ADMIN_MODS, [<<"acls">>
                         ,<<"global_provisioner_templates">>
+                        ,<<"global_resources">>
+                        ,<<"ips">>
+                        ,<<"rates">>
                         ,<<"sup">>
+                        ,<<"templates">>
                         ]).
 
 %% Endpoints performing their own auth
@@ -43,6 +44,7 @@ init() ->
 
 -spec authorize(cb_context:context()) -> boolean().
 authorize(Context) ->
+    cb_context:put_reqid(Context),
     authorize(Context, cb_context:req_verb(Context), cb_context:req_nouns(Context)).
 
 authorize(Context, Verb, [{?KZ_ACCOUNTS_DB, []}]) ->

--- a/core/kazoo/Makefile
+++ b/core/kazoo/Makefile
@@ -14,6 +14,13 @@ CLEAN_MOAR = clean-generated
 
 all: compile
 
+eunit: kz-test
+
+test: kz-test
+
+kz-test:
+	$(MAKE) compile-test -C $(ROOT)/core/kazoo_stdlib
+
 include $(ROOT)/make/kz.mk
 
 clean-generated:

--- a/core/kazoo/test/kz_doc_tests.erl
+++ b/core/kazoo/test/kz_doc_tests.erl
@@ -9,12 +9,12 @@
 -module(kz_doc_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--define(APP, kazoo).
+-define(APP, 'kazoo').
 
 latest_attachment_id_test_() ->
-    {ok,JObj1} = kz_json:fixture(?APP, <<"fixtures/doc_no_attachment.json">>),
-    {ok,JObj2} = kz_json:fixture(?APP, <<"fixtures/doc_one_attachment.json">>),
-    {ok,JObj3} = kz_json:fixture(?APP, <<"fixtures/doc_multiple_attachments.json">>),
+    {'ok', JObj1} = kz_json:fixture(?APP, <<"fixtures/doc_no_attachment.json">>),
+    {'ok', JObj2} = kz_json:fixture(?APP, <<"fixtures/doc_one_attachment.json">>),
+    {'ok', JObj3} = kz_json:fixture(?APP, <<"fixtures/doc_multiple_attachments.json">>),
     [?_assertEqual('undefined', kz_doc:latest_attachment_id(JObj1))
     ,?_assertEqual(<<"csv.csv">>, kz_doc:latest_attachment_id(JObj2))
     ,?_assertEqual(<<"newest">>, kz_doc:latest_attachment_id(JObj3))
@@ -24,12 +24,12 @@ read_only_test_() ->
     {'ok', JObj} = kz_json:fixture(?APP, <<"fixtures/doc_no_attachment.json">>),
     Leaked = kz_doc:leak_private_fields(JObj),
 
-    ?debugFmt("jobj: ~p~nleaked: ~p~n", [JObj, Leaked]),
     {Tests, _} = kz_json:foldl(fun read_only_fold/3, {[], Leaked}, JObj),
     Tests.
 
 read_only_fold(Key, Value, {Tests, Leaked}) ->
-    {[?_assertEqual(Value, kz_json:get_value([<<"_read_only">>, kz_doc:remove_pvt(Key)], Leaked))
+    {[{"has leaked key " ++ kz_term:to_list(kz_doc:remove_pvt(Key)), ?_assertEqual(Value, kz_json:get_value([<<"_read_only">>, kz_doc:remove_pvt(Key)], Leaked))}
+     ,{"doesn't have private key " ++ kz_term:to_list(Key), ?_assert(not kz_json:is_defined(Key, Leaked))}
       | Tests
      ]
     ,Leaked

--- a/core/kazoo/test/kz_doc_tests.erl
+++ b/core/kazoo/test/kz_doc_tests.erl
@@ -19,3 +19,18 @@ latest_attachment_id_test_() ->
     ,?_assertEqual(<<"csv.csv">>, kz_doc:latest_attachment_id(JObj2))
     ,?_assertEqual(<<"newest">>, kz_doc:latest_attachment_id(JObj3))
     ].
+
+read_only_test_() ->
+    {'ok', JObj} = kz_json:fixture(?APP, <<"fixtures/doc_no_attachment.json">>),
+    Leaked = kz_doc:leak_private_fields(JObj),
+
+    ?debugFmt("jobj: ~p~nleaked: ~p~n", [JObj, Leaked]),
+    {Tests, _} = kz_json:foldl(fun read_only_fold/3, {[], Leaked}, JObj),
+    Tests.
+
+read_only_fold(Key, Value, {Tests, Leaked}) ->
+    {[?_assertEqual(Value, kz_json:get_value([<<"_read_only">>, kz_doc:remove_pvt(Key)], Leaked))
+      | Tests
+     ]
+    ,Leaked
+    }.

--- a/core/kazoo_ips/src/kazoo_ips_maintenance.erl
+++ b/core/kazoo_ips/src/kazoo_ips_maintenance.erl
@@ -72,21 +72,21 @@ assign() ->
 
 -spec assign(ne_binary(), ne_binary()) -> 'no_return'.
 assign(IP, Account) ->
-    AccountDb = kz_util:format_account_id(Account, 'encoded'),
-    AccountId = kz_util:format_account_id(Account, 'raw'),
-    _ = case kz_datamgr:open_doc(AccountDb, AccountId) of
-            {'ok', _} ->
-                case kz_ip:assign(Account, IP) of
-                    {'ok', _} ->
-                        io:format("assigned IP ~s to ~s~n"
-                                 ,[IP, Account]);
-                    {'error', _R} ->
-                        io:format("unable to assign IP: ~p~n", [_R])
-                end;
-            {'error', _R} ->
-                io:format("unable to find account: ~p~n", [_R])
-        end,
+    case kz_account:fetch(Account) of
+        {'ok', _} -> do_assignment(Account, IP);
+        {'error', _R} ->
+            io:format("unable to find account: ~p~n", [_R])
+    end,
     'no_return'.
+
+-spec do_assignment(ne_binary(), ne_binary()) -> 'ok'.
+do_assignment(Account, IP) ->
+    case kz_ip:assign(Account, IP) of
+        {'ok', _} ->
+            io:format("assigned IP ~s to ~s~n", [IP, Account]);
+        {'error', _R} ->
+            io:format("unable to assign IP: ~p~n", [_R])
+    end.
 
 %%--------------------------------------------------------------------
 %% @public

--- a/core/kazoo_ips/src/kz_ip.erl
+++ b/core/kazoo_ips/src/kz_ip.erl
@@ -129,9 +129,7 @@ assign(Account, IPDoc) ->
                     ,{<<"pvt_modified">>, kz_time:current_tstamp()}
                     ,{<<"pvt_status">>, ?ASSIGNED}
                     ],
-            save(kz_json:set_values(Props, IPJObj)
-                ,kz_json:get_ne_binary_value(<<"pvt_assigned_to">>, IPJObj)
-                )
+            save(kz_json:set_values(Props, IPJObj))
     end.
 
 %%--------------------------------------------------------------------
@@ -155,9 +153,7 @@ release(IP) ->
             ,{<<"pvt_modified">>, kz_time:current_tstamp()}
             ],
     JObj = to_json(IP),
-    save(kz_json:delete_keys(RemoveKeys, kz_json:set_values(Props, JObj))
-        ,kz_json:get_ne_binary_value(<<"pvt_assigned_to">>, JObj)
-        ).
+    save(kz_json:delete_keys(RemoveKeys, kz_json:set_values(Props, JObj))).
 
 %%--------------------------------------------------------------------
 %% @public
@@ -262,27 +258,13 @@ is_available(IP) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec save(kz_json:object(), api_binary()) ->
+-spec save(kz_json:object()) ->
                   {'ok', ip()} |
                   {'error', any()}.
-save(JObj, PrevAccountId) ->
+save(JObj) ->
     case kz_datamgr:save_doc(?KZ_DEDICATED_IP_DB, JObj) of
-        {'ok', J} ->
-            AccountId = kz_json:get_value(<<"pvt_assigned_to">>, J),
-            _ = reconcile_services(PrevAccountId, AccountId),
-            {'ok', from_json(J)};
+        {'ok', J} -> {'ok', from_json(J)};
         {'error', _R}=E ->
             lager:debug("failed to save dedicated ip ~s: ~p", [kz_doc:id(JObj), _R]),
             E
     end.
-
--spec reconcile_services(api_binary(), api_binary()) -> 'false' | kz_services:services().
-reconcile_services('undefined', AccountId) ->
-    kz_services:reconcile(AccountId, <<"ips">>);
-reconcile_services(AccountId, 'undefined') ->
-    kz_services:reconcile(AccountId, <<"ips">>);
-reconcile_services(AccountId, AccountId) ->
-    kz_services:reconcile(AccountId, <<"ips">>);
-reconcile_services(PrevAccountId, AccountId) ->
-    _ = kz_services:reconcile(PrevAccountId, <<"ips">>),
-    kz_services:reconcile(AccountId, <<"ips">>).

--- a/core/kazoo_ips/src/kz_ip.erl
+++ b/core/kazoo_ips/src/kz_ip.erl
@@ -74,11 +74,13 @@ create(IP, Zone, Host) ->
             kz_ip_utils:refresh_database(fun() -> create(IP, Zone, Host) end);
         {'ok', SavedJObj} ->
             lager:debug("created dedicated ip ~s in zone ~s on host ~s"
-                       ,[IP, Zone, Host]),
+                       ,[IP, Zone, Host]
+                       ),
             {'ok', from_json(SavedJObj)};
         {'error', _R}=E ->
             lager:debug("unable to create dedicated ip ~s: ~p"
-                       ,[IP, _R]),
+                       ,[IP, _R]
+                       ),
             E
     end.
 

--- a/core/kazoo_proper/doc/README.md
+++ b/core/kazoo_proper/doc/README.md
@@ -8,6 +8,8 @@ I like to set console level to critical (chatty otherwise): `kazoo_maintenance:c
 
 After each quickcheck, I like to clean soft-deleted account docs from the `accounts` database: `kt_cleanup:cleanup_soft_deletes(<<"accounts">>).`
 
+Also, clearing the data traces is good to do: `kz_data_tracing:clear_all_traces().`
+
 ### [Phone Numbers](src/pqc_cb_phone_numbers.erl)
 
 Tests the [`phone_numbers`](../../applications/crossbar/doc/phone_numbers.md) API
@@ -20,3 +22,7 @@ Cleanup deleted account docs: `kt_cleanup:cleanup_soft_deletes(<<"accounts">>).`
 ### [Ratedecks](src/pqc_cb_rates.erl)
 
 Tests the ratedeck upload task and rating a DID against account-vs-system ratedecks.
+
+### [IPs](src/pqc_cb_ips.erl)
+
+Tests the dedicated IPs endpoint.

--- a/core/kazoo_proper/src/pqc_cb_accounts.erl
+++ b/core/kazoo_proper/src/pqc_cb_accounts.erl
@@ -94,7 +94,7 @@ check_accounts_db(Name) ->
             kz_datamgr:del_docs(?KZ_ACCOUNTS_DB, JObjs)
     end.
 
--spec account_url(ne_binary() | map()) -> string().
+-spec account_url(account_id() | map()) -> string().
 account_url(#{}=API) ->
     account_url(pqc_cb_api:auth_account_id(API));
 account_url(AccountId) ->

--- a/core/kazoo_proper/src/pqc_cb_accounts.erl
+++ b/core/kazoo_proper/src/pqc_cb_accounts.erl
@@ -13,7 +13,12 @@
 
 -export([account_url/1]).
 
+-export_type([account_id/0]).
+
 -include("kazoo_proper.hrl").
+
+-type account_id() :: {'call', 'pqc_kazoo_model', 'account_id_by_name', [pqc_cb_api:state() | proper_types:type()]} |
+                      ne_binary().
 
 -spec command(pqc_kazoo_model:model(), ne_binary() | proper_types:type()) ->
                      {'call', ?MODULE, 'create_account', [pqc_cb_api:state() | proper_types:term()]}.
@@ -21,7 +26,7 @@ command(Model, Name) ->
     {'call', ?MODULE, 'create_account', [pqc_kazoo_model:api(Model), Name]}.
 
 -spec symbolic_account_id(pqc_kazoo_model:model(), ne_binary() | proper_types:type()) ->
-                                 {'call', 'pqc_kazoo_model', 'account_id_by_name', [pqc_cb_api:state() | proper_types:type()]}.
+                                 account_id().
 symbolic_account_id(Model, Name) ->
     {'call', 'pqc_kazoo_model', 'account_id_by_name', [Model, Name]}.
 

--- a/core/kazoo_proper/src/pqc_cb_api.erl
+++ b/core/kazoo_proper/src/pqc_cb_api.erl
@@ -154,9 +154,9 @@ make_request(ExpectedCodes, HTTP, URL, RequestHeaders, RequestBody) ->
     ?DEBUG("body: ~s", [RequestBody]),
     handle_response(ExpectedCodes, HTTP(URL, RequestHeaders, iolist_to_binary(RequestBody))).
 
--spec create_envelope(kz_json:object()) ->
+-spec create_envelope(kz_json:json_term()) ->
                              kz_json:object().
--spec create_envelope(kz_json:object(), kz_json:object()) ->
+-spec create_envelope(kz_json:json_term(), kz_json:object()) ->
                              kz_json:object().
 create_envelope(Data) ->
     create_envelope(Data, kz_json:new()).
@@ -184,7 +184,11 @@ handle_response(_ExtectedCode, {'error','socket_closed_remotely'}=E) ->
     throw(E);
 handle_response(_ExpectedCode, {'ok', _ActualCode, _RespHeaders, RespBody}) ->
     ?ERROR("failed to get ~w: ~p: ~s", [_ExpectedCode, _ActualCode, RespBody]),
-    {'error', RespBody}.
+    {'error', RespBody};
+handle_response(_ExpectedCode, {'error', _}=E) ->
+    ?ERROR("broked req: ~p", [E]),
+    E.
+
 
 -spec start_trace(ne_binary()) -> {'ok', kz_data_tracing:trace_ref()}.
 start_trace(RequestId) ->

--- a/core/kazoo_proper/src/pqc_cb_api.erl
+++ b/core/kazoo_proper/src/pqc_cb_api.erl
@@ -129,7 +129,9 @@ default_request_headers() ->
 
 default_request_headers(RequestId) ->
     NowMS = kz_time:now_ms(),
-    [{<<"x-request-id">>, kz_term:to_list(RequestId) ++ "-" ++ integer_to_list(NowMS)}
+    APIRequestID = kz_term:to_list(RequestId) ++ "-" ++ integer_to_list(NowMS),
+    ?DEBUG("request id ~s", [APIRequestID]),
+    [{<<"x-request-id">>, APIRequestID}
      | default_request_headers()
     ].
 

--- a/core/kazoo_proper/src/pqc_cb_ips.erl
+++ b/core/kazoo_proper/src/pqc_cb_ips.erl
@@ -1,0 +1,106 @@
+-module(pqc_cb_ips).
+-behaviour(proper_statem).
+
+-export([command/1
+        ,initial_state/0
+        ,next_state/3
+        ,postcondition/3
+        ,precondition/2
+
+        ,correct/0
+        ,correct_parallel/0
+        ]).
+
+-export([cleanup/0, cleanup/1]).
+
+-include_lib("proper/include/proper.hrl").
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<"account_for_ips">>]).
+
+-spec cleanup() -> any().
+-spec cleanup(pqc_cb_api:state()) -> any().
+cleanup() ->
+    ?INFO("CLEANUP ALL THE THINGS"),
+    kz_data_tracing:clear_all_traces(),
+    pqc_cb_service_plans:cleanup(),
+    cleanup(pqc_cb_api:authenticate()).
+
+cleanup(API) ->
+    ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+
+    pqc_cb_api:cleanup(API).
+
+-spec command(any()) -> proper_types:type().
+command(Model) ->
+    _API = pqc_kazoo_model:api(Model),
+
+    AccountName = account_name(),
+    _AccountId = pqc_cb_accounts:symbolic_account_id(Model, AccountName),
+
+    oneof([pqc_cb_accounts:command(Model, AccountName)]).
+
+account_name() ->
+    oneof(?ACCOUNT_NAMES).
+
+-spec initial_state() -> pqc_kazoo_model:model().
+initial_state() ->
+    API = pqc_cb_api:authenticate(),
+    ?INFO("state initialized to ~p", [API]),
+    pqc_kazoo_model:new(API).
+
+-spec next_state(pqc_kazoo_model:model(), any(), any()) -> pqc_kazoo_model:model().
+next_state(Model, APIResp, {'call', _, 'create_account', _Args}=Call) ->
+    pqc_cb_accounts:next_state(Model, APIResp, Call).
+
+-spec precondition(pqc_kazoo_model:model(), any()) -> boolean().
+precondition(_Model, _Call) -> 'true'.
+
+-spec postcondition(pqc_kazoo_model:model(), any(), any()) -> boolean().
+postcondition(Model, {'call', _, 'create_account', _Args}=Call, APIResult) ->
+    pqc_cb_accounts:postcondition(Model, Call, APIResult).
+
+-spec correct() -> any().
+correct() ->
+    ?FORALL(Cmds
+           ,commands(?MODULE)
+           ,?TRAPEXIT(
+               begin
+                   timer:sleep(1000),
+                   try run_commands(?MODULE, Cmds) of
+                       {History, Model, Result} ->
+                           cleanup(pqc_kazoo_model:api(Model)),
+                           ?WHENFAIL(io:format("Final Model:~n~p~n~nFailing Cmds:~n~p~n"
+                                              ,[pqc_kazoo_model:pp(Model), zip(Cmds, History)]
+                                              )
+                                    ,aggregate(command_names(Cmds), Result =:= 'ok')
+                                    )
+                   catch
+                       _E:_R ->
+                           ST = erlang:get_stacktrace(),
+                           io:format("exception running commands: ~s:~p~n", [_E, _R]),
+                           [io:format("~p~n", [S]) || S <- ST],
+                           cleanup(),
+                           'false'
+                   end
+
+               end
+              )
+           ).
+
+-spec correct_parallel() -> any().
+correct_parallel() ->
+    ?FORALL(Cmds
+           ,parallel_commands(?MODULE)
+           ,?TRAPEXIT(
+               begin
+                   {Sequential, Parallel, Result} = run_parallel_commands(?MODULE, Cmds),
+                   cleanup(),
+
+                   ?WHENFAIL(io:format("S: ~p~nP: ~p~n", [Sequential, Parallel])
+                            ,aggregate(command_names(Cmds), Result =:= 'ok')
+                            )
+               end
+              )
+           ).

--- a/core/kazoo_proper/src/pqc_cb_ips.erl
+++ b/core/kazoo_proper/src/pqc_cb_ips.erl
@@ -333,7 +333,7 @@ seq() ->
             [?INFO("st: ~p", [S]) || S <- ST]
     after
         pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
-        delete_ip(API, IP),
+        _ = delete_ip(API, IP),
         pqc_cb_api:cleanup(API)
     end,
     ?INFO("seq finished running: ~p", [API]),

--- a/core/kazoo_proper/src/pqc_cb_ips.erl
+++ b/core/kazoo_proper/src/pqc_cb_ips.erl
@@ -352,8 +352,7 @@ command(Model, 'true') ->
     AccountName = account_name(),
     AccountId = pqc_cb_accounts:symbolic_account_id(Model, AccountName),
 
-    oneof([pqc_cb_accounts:command(Model, AccountName)
-          ,{'call', ?MODULE, 'list_ips', [API]}
+    oneof([{'call', ?MODULE, 'list_ips', [API]}
           ,{'call', ?MODULE, 'assign_ips', [API, AccountId, ips()]}
           ,{'call', ?MODULE, 'remove_ip', [API, AccountId, ip()]}
           ,{'call', ?MODULE, 'fetch_ip', [API, AccountId, ip()]}

--- a/core/kazoo_proper/src/pqc_cb_ips.erl
+++ b/core/kazoo_proper/src/pqc_cb_ips.erl
@@ -299,7 +299,25 @@ seq() ->
 
         AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
         AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
-        ?INFO("created account ~s", [AccountId])
+        ?INFO("created account ~s", [AccountId]),
+
+        {'ok', []} = list_ips(API, AccountId),
+
+        {'ok', Assigned} = assign_ip(API, AccountId, IP),
+        ?INFO("assigned ~s: ~p", [IP, Assigned]),
+
+        {'ok', Fetched} = fetch_ip(API, AccountId, IP),
+        ?INFO("fetched ~s: ~p", [IP, Fetched]),
+
+        {'ok', Hosts} = fetch_hosts(API, AccountId),
+        ?INFO("hosts: ~p", [Hosts]),
+
+        {'ok', Zones} = fetch_zones(API, AccountId),
+        ?INFO("zones: ~p", [Zones]),
+
+        {'ok', AssignedIPs} = fetch_assigned(API, AccountId),
+        ?INFO("assigned ips: ~p", [AssignedIPs])
+
     catch
         _E:_R ->
             ST = erlang:get_stacktrace(),
@@ -310,7 +328,8 @@ seq() ->
         delete_ip(API, IP),
         pqc_cb_api:cleanup(API)
     end,
-    ?INFO("seq finished running").
+    ?INFO("seq finished running: ~p", [API]),
+    io:format("seq finished running: ~p", [API]).
 
 -spec command(any()) -> proper_types:type().
 command(Model) ->

--- a/core/kazoo_proper/src/pqc_cb_ips.erl
+++ b/core/kazoo_proper/src/pqc_cb_ips.erl
@@ -103,7 +103,7 @@ assign_ips(API, AccountId, Dedicateds) ->
                        {'ok', kz_json:object()} |
                        {'error', 'not_found'}.
 remove_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([200, 404]
                                 ,fun kz_http:delete/2
                                 ,ip_url(AccountId, IP)
                                 ,pqc_cb_api:request_headers(API)
@@ -230,7 +230,7 @@ create_ip(API, ?DEDICATED(IP, Host, Zone)) ->
                        {'ok', kz_json:object()} |
                        {'error', 'not_found'}.
 delete_ip(API, ?DEDICATED(IP, _Host, _Zone)) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([200, 404]
                                 ,fun kz_http:delete/2
                                 ,ip_url(IP)
                                 ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_kazoo_model.erl
+++ b/core/kazoo_proper/src/pqc_kazoo_model.erl
@@ -8,7 +8,7 @@
         ,account_id_by_name/2
         ,number_data/2
         ,ratedeck/1, ratedeck/2
-        ,dedicated_ip/2
+        ,dedicated_ips/1, dedicated_ip/2
         ,dedicated_zones/1
         ,dedicated_hosts/1
         ,account_ips/2
@@ -116,6 +116,15 @@ ratedeck(Model) ->
 
 ratedeck(#kazoo_model{'ratedecks'=Ratedecks}, Name) ->
     maps:get(Name, Ratedecks, #{}).
+
+-spec dedicated_ips(model()) -> [{ne_binary(), dedicated_ip()}].
+dedicated_ips(#kazoo_model{'dedicated_ips'=IPs}) ->
+    maps:fold(fun(IP, IPInfo, Acc) ->
+                      [{IP, IPInfo} | Acc]
+              end
+             ,[]
+             ,IPs
+             ).
 
 -spec dedicated_ip(model(), ne_binary()) -> dedicated_ip() | 'undefined'.
 dedicated_ip(#kazoo_model{'dedicated_ips'=IPs}, IP) ->

--- a/core/kazoo_proper/src/pqc_kazoo_model.erl
+++ b/core/kazoo_proper/src/pqc_kazoo_model.erl
@@ -9,6 +9,8 @@
         ,number_data/2
         ,ratedeck/1, ratedeck/2
         ,dedicated_ip/2
+        ,dedicated_zones/1
+        ,dedicated_hosts/1
         ,account_ips/2
 
          %% Predicates
@@ -118,6 +120,20 @@ ratedeck(#kazoo_model{'ratedecks'=Ratedecks}, Name) ->
 -spec dedicated_ip(model(), ne_binary()) -> dedicated_ip() | 'undefined'.
 dedicated_ip(#kazoo_model{'dedicated_ips'=IPs}, IP) ->
     maps:get(IP, IPs, 'undefined').
+
+-spec dedicated_zones(model()) -> ne_binaries().
+dedicated_zones(#kazoo_model{'dedicated_ips'=IPs}) ->
+    maps:fold(fun(_IP, #{'zone' := Zone}, Zones) -> [Zone | Zones] end
+             ,[]
+             ,IPs
+             ).
+
+-spec dedicated_hosts(model()) -> ne_binaries().
+dedicated_hosts(#kazoo_model{'dedicated_ips'=IPs}) ->
+    maps:fold(fun(_IP, #{'host' := Host}, Hosts) -> [Host | Hosts] end
+             ,[]
+             ,IPs
+             ).
 
 -spec account_ips(model(), ne_binary()) -> [{ne_binary(), dedicated_ip()}].
 account_ips(#kazoo_model{'dedicated_ips'=IPs}, AccountId) ->

--- a/core/kazoo_proper/src/pqc_util.erl
+++ b/core/kazoo_proper/src/pqc_util.erl
@@ -95,14 +95,15 @@ run_call(Var, {'call', M, F, Args}, {Step, PQC, State, Vars}) ->
     Args1 = resolve_args(Args, pqc_kazoo_model:api(State), Vars),
     ?INFO("(~p) ~p:~p(~p) -> ", [Step, M, F, Args1]),
     Resp = erlang:apply(M, F, Args1),
-    ?INFO("~p: ~p~n~n", [Var, Resp]),
+    ?INFO("applied ~p:~p, assoc var ~p with resp ~p~n~n", [M, F, Var, Resp]),
     case PQC:postcondition(State, {'call', M, F, Args1}, Resp) of
         'true' ->
+            ?INFO("~n", []),
             {Step+1, PQC, PQC:next_state(State, Resp, {'call', M, F, Args1}), Vars#{Var => Resp}};
         'false' ->
-            ?INFO("postcondition failed:~n", []),
-            _ = [?INFO("~p~n", [Model]) || Model <- pqc_kazoo_model:pp(State)],
-            ?INFO("call ~p:~p(~p)~n", [M, F, Args1]),
+            ?INFO("postcondition failed:~n  model:~n", []),
+            _ = [?INFO("    ~p~n", [Model]) || Model <- pqc_kazoo_model:pp(State)],
+            ?INFO("  call ~p:~p(~p)~n", [M, F, Args1]),
             throw({'failed_postcondition', State, {M, F, Args1}, Resp})
     end.
 

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -45,7 +45,7 @@
 -export([filter/2, filter/3
         ,filtermap/2
         ,map/2
-        ,foldl/3,foldr/3
+        ,foldl/3, foldr/3
         ,find/2, find/3
         ,find_first_defined/2, find_first_defined/3
         ,find_value/3, find_value/4


### PR DESCRIPTION
To avoid a circular dependency between kazoo_ips and kazoo_services (and to be more inline with what most charge-able crossbar endpoints do), move reconciliation to the endpoint code and out of the core kz_ip module.

Also added a PropEr quickcheck suite of the IPs API