### PR TITLE
[master] fix pass recovery template when previewing

### DIFF
--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -302,6 +302,8 @@
 -define(OPTIONAL_PASSWORD_RECOVERY_HEADERS, [<<"Account-DB">>
                                             ,<<"First-Name">>
                                             ,<<"Last-Name">>
+                                            ,<<"Timezone">>
+                                            ,<<"User-ID">>
                                                  | ?DEFAULT_OPTIONAL_HEADERS
                                             ]).
 -define(PASSWORD_RECOVERY_VALUES, [{<<"Event-Category">>, <<"notification">>}

--- a/core/kazoo_documents/src/kzd_user.erl
+++ b/core/kazoo_documents/src/kzd_user.erl
@@ -66,7 +66,7 @@ open_cache_doc(AccountDb, UserId) ->
 email(User) ->
     email(User, 'undefined').
 email(User, Default) ->
-    kz_json:get_value(?KEY_EMAIL, User, Default).
+    kz_json:get_ne_binary_value(?KEY_EMAIL, User, Default).
 
 -spec voicemail_notification_enabled(doc()) -> boolean().
 -spec voicemail_notification_enabled(doc(), Default) -> boolean() | Default.


### PR DESCRIPTION
if `Email` is not present in payload and it's previewing use `to` email
addresses