### PR TITLE
[4.1] fix pass recovery template when previewing

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -15178,7 +15178,13 @@
                 "Text": {
                     "type": "string"
                 },
+                "Timezone": {
+                    "type": "string"
+                },
                 "To": {
+                    "type": "string"
+                },
+                "User-ID": {
                     "type": "string"
                 }
             },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.password_recovery.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.password_recovery.json
@@ -60,7 +60,13 @@
         "Text": {
             "type": "string"
         },
+        "Timezone": {
+            "type": "string"
+        },
         "To": {
+            "type": "string"
+        },
+        "User-ID": {
             "type": "string"
         }
     },

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -302,6 +302,8 @@
 -define(OPTIONAL_PASSWORD_RECOVERY_HEADERS, [<<"Account-DB">>
                                             ,<<"First-Name">>
                                             ,<<"Last-Name">>
+                                            ,<<"Timezone">>
+                                            ,<<"User-ID">>
                                                  | ?DEFAULT_OPTIONAL_HEADERS
                                             ]).
 -define(PASSWORD_RECOVERY_VALUES, [{<<"Event-Category">>, <<"notification">>}

--- a/core/kazoo_documents/src/kzd_user.erl
+++ b/core/kazoo_documents/src/kzd_user.erl
@@ -51,7 +51,7 @@
 email(User) ->
     email(User, 'undefined').
 email(User, Default) ->
-    kz_json:get_value(?KEY_EMAIL, User, Default).
+    kz_json:get_ne_binary_value(?KEY_EMAIL, User, Default).
 
 -spec voicemail_notification_enabled(doc()) -> boolean().
 -spec voicemail_notification_enabled(doc(), Default) -> boolean() | Default.


### PR DESCRIPTION
if `Email` is not present in payload and it's previewing use `to` email
addresses

master: #4192 