### PR TITLE
HELP-32352 fix endpoint inbound sip headers

### DIFF
--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1432,13 +1432,17 @@ maybe_add_diversion(JObj, Endpoint, _Inception, Call) ->
 
 -spec maybe_add_sip_headers(kz_json:object(), kz_json:object(), kapps_call:call()) -> kz_json:object().
 maybe_add_sip_headers(JObj, Endpoint, Call) ->
+    lists:foldl(fun merge_custom_sip_headers/2, JObj, get_sip_headers(Endpoint, Call)).
+
+-spec get_sip_headers(kz_json:object(), kapps_call:call()) -> kz_json:objects().
+get_sip_headers(Endpoint, Call) ->
     case ?MODULE:get(Call) of
-        {'error', _} -> JObj;
+        {'error', _} ->
+            [kz_device:custom_sip_headers_inbound(Endpoint)];
         {'ok', AuthorizingEndpoint} ->
-            MergeHeaders = [kz_device:custom_sip_headers_inbound(Endpoint)
-                           ,kz_device:custom_sip_headers_outbound(AuthorizingEndpoint)
-                           ],
-            lists:foldl(fun merge_custom_sip_headers/2, JObj, MergeHeaders)
+            [kz_device:custom_sip_headers_inbound(Endpoint)
+            ,kz_device:custom_sip_headers_outbound(AuthorizingEndpoint)
+            ]
     end.
 
 -spec merge_custom_sip_headers(kz_json:object(), kz_json:object()) -> kz_json:object().


### PR DESCRIPTION
inbound sip headers are not set when there's no authorizing endpoint