### PR TITLE
encode start_keys in request and response

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -25314,6 +25314,7 @@
                 "pagination_page_size": {
                     "default": 50,
                     "description": "crossbar pagination page size",
+                    "minimum": 1,
                     "type": "integer"
                 },
                 "port": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
@@ -71,6 +71,7 @@
         "pagination_page_size": {
             "default": 50,
             "description": "crossbar pagination page size",
+            "minimum": 1,
             "type": "integer"
         },
         "port": {

--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -159,8 +159,6 @@ maybe_decode_start_key(Context) ->
     case cb_context:req_value(Context, <<"start_key">>) of
         'undefined' -> Context;
         Value ->
-            Decoded = try erlang:binary_to_term(kz_binary:from_hex(Value)) catch _:_ -> Value end,
-
             QS = cb_context:query_string(Context),
             ReqData = cb_context:req_data(Context),
             ReqJson = cb_context:req_json(Context),
@@ -169,7 +167,7 @@ maybe_decode_start_key(Context) ->
                              'true' -> kz_json:delete_key(<<"start_key">>, ReqData);
                              'false' -> ReqData
                          end,
-            NewQS = kz_json:set_value(<<"start_key">>, Decoded, QS),
+            NewQS = kz_json:set_value(<<"start_key">>, api_util:decode_start_key(Value), QS),
 
             Setters = [{fun cb_context:set_req_data/2, NewReqData}
                       ,{fun cb_context:set_query_string/2, NewQS}

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -1356,11 +1356,11 @@ do_create_resp_envelope(Context) ->
 -spec encode_start_keys(kz_json:object()) -> kz_json:object().
 encode_start_keys(Resp) ->
     lists:foldl(fun(Key, JObj) ->
-                       case kz_json:get_value(Key, JObj) of
-                           'undefined' -> JObj;
-                           Value ->
-                               kz_json:set_value(Key, encode_start_key(Value), JObj)
-                       end
+                        case kz_json:get_value(Key, JObj) of
+                            'undefined' -> JObj;
+                            Value ->
+                                kz_json:set_value(Key, encode_start_key(Value), JObj)
+                        end
                 end
                ,Resp
                ,[<<"start_key">>, <<"next_start_key">>]

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -37,6 +37,8 @@
         ,content_type_matches/2
         ,ensure_content_type/1
         ,create_event_name/2
+
+        ,encode_start_key/1, decode_start_key/1
         ]).
 
 -include("crossbar.hrl").
@@ -1357,13 +1359,22 @@ encode_start_keys(Resp) ->
                        case kz_json:get_value(Key, JObj) of
                            'undefined' -> JObj;
                            Value ->
-                               Encoded = kz_binary:hexencode(erlang:term_to_binary(Value)),
-                               kz_json:set_value(Key, Encoded, JObj)
+                               kz_json:set_value(Key, encode_start_key(Value), JObj)
                        end
                 end
                ,Resp
                ,[<<"start_key">>, <<"next_start_key">>]
                ).
+
+-spec encode_start_key(kz_json:path()) -> ne_binary().
+encode_start_key(StartKey) ->
+    kz_binary:hexencode(erlang:term_to_binary(StartKey)).
+
+-spec decode_start_key(ne_binary()) -> kz_json:path().
+decode_start_key(Encoded) ->
+    try erlang:binary_to_term(kz_binary:from_hex(Encoded))
+    catch _:_ -> Encoded
+    end.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -1368,11 +1368,11 @@ encode_start_keys(Resp) ->
 
 -spec encode_start_key(kz_json:path()) -> ne_binary().
 encode_start_key(StartKey) ->
-    kz_binary:hexencode(erlang:term_to_binary(StartKey)).
+    kz_base64url:encode(erlang:term_to_binary(StartKey)).
 
 -spec decode_start_key(ne_binary()) -> kz_json:path().
 decode_start_key(Encoded) ->
-    try erlang:binary_to_term(kz_binary:from_hex(Encoded))
+    try erlang:binary_to_term(kz_base64url:decode(Encoded))
     catch _:_ -> Encoded
     end.
 

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -1349,10 +1349,21 @@ do_create_resp_envelope(Context) ->
                    ]
            end,
 
-    kz_json:set_values(
-      props:filter_undefined(Resp)
-                      ,cb_context:resp_envelope(Context)
-     ).
+    encode_start_keys(kz_json:set_values(props:filter_undefined(Resp), cb_context:resp_envelope(Context))).
+
+-spec encode_start_keys(kz_json:object()) -> kz_json:object().
+encode_start_keys(Resp) ->
+    lists:foldl(fun(Key, JObj) ->
+                       case kz_json:get_value(Key, JObj) of
+                           'undefined' -> JObj;
+                           Value ->
+                               Encoded = kz_binary:hexencode(erlang:term_to_binary(Value)),
+                               kz_json:set_value(Key, Encoded, JObj)
+                       end
+                end
+               ,Resp
+               ,[<<"start_key">>, <<"next_start_key">>]
+               ).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -23,7 +23,6 @@
         ,current_doc_vsn/0
         ,update_pvt_parameters/2
         ,start_key/1, start_key/2
-        ,pagination_page_size/0, pagination_page_size/1
         ,has_qs_filter/1
         ,filtered_doc_by_qs/2, filtered_doc_by_qs/3
         ]).
@@ -56,9 +55,6 @@
                   ,fun add_pvt_auth/2
                   ]).
 
--define(PAGINATION_PAGE_SIZE
-       ,kapps_config:get_integer(?CONFIG_CAT, <<"pagination_page_size">>, 50)).
-
 -type direction() :: 'ascending' | 'descending'.
 
 -type startkey() :: kz_json:api_json_term().
@@ -88,22 +84,6 @@
                           ,direction = 'ascending' :: direction()
                           }).
 -type load_view_params() :: #load_view_params{}.
-
--spec pagination_page_size() -> pos_integer().
--spec pagination_page_size(cb_context:context()) -> api_pos_integer().
--spec pagination_page_size(cb_context:context(), ne_binary()) -> api_pos_integer().
-pagination_page_size() ->
-    ?PAGINATION_PAGE_SIZE.
-
-pagination_page_size(Context) ->
-    pagination_page_size(Context, cb_context:api_version(Context)).
-
-pagination_page_size(_Context, ?VERSION_1) -> 'undefined';
-pagination_page_size(Context, _Version) ->
-    case cb_context:req_value(Context, <<"page_size">>) of
-        'undefined' -> pagination_page_size();
-        V -> try kz_term:to_integer(V) catch _:_ -> 'undefined' end
-    end.
 
 %%--------------------------------------------------------------------
 %% @public
@@ -355,7 +335,7 @@ patch_the_doc(RequestData, ExistingDoc) ->
 load_view(View, Options, Context) ->
     load_view(View, Options, Context
              ,start_key(Options, Context)
-             ,pagination_page_size(Context)
+             ,cb_context:pagination_page_size(Context)
              ,'undefined'
              ).
 
@@ -364,12 +344,12 @@ load_view(View, Options, Context, FilterFun)
        is_function(FilterFun, 3) ->
     load_view(View, Options, Context
              ,start_key(Options, Context)
-             ,pagination_page_size(Context)
+             ,cb_context:pagination_page_size(Context)
              ,FilterFun
              );
 load_view(View, Options, Context, StartKey) ->
     load_view(View, Options, Context, StartKey
-             ,pagination_page_size(Context)
+             ,cb_context:pagination_page_size(Context)
              ).
 
 load_view(View, Options, Context, StartKey, PageSize) ->

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -412,7 +412,7 @@ load_view(#load_view_params{view = View
         props:filter_undefined(
           [{'startkey', StartKey}
           ,{'limit', Limit}
-           | props:delete_keys(['startkey', 'limit', 'databases'], Options)
+           | props:delete_keys(['startkey', 'startkey_fun', 'limit', 'databases'], Options)
           ]),
 
     IncludeOptions =

--- a/applications/crossbar/src/crossbar_modb_view.erl
+++ b/applications/crossbar/src/crossbar_modb_view.erl
@@ -6,7 +6,7 @@
 %%% @contributors
 %%%   Roman Galeev
 %%%-------------------------------------------------------------------
--module(crossbar_view).
+-module(crossbar_modb_view).
 
 -export([load/3]).
 

--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -1016,14 +1016,12 @@ start_key(Context) ->
 
 -spec fix_envelope(cb_context:context()) -> cb_context:context().
 fix_envelope(Context) ->
-    cb_context:set_resp_envelope(
-      cb_context:set_resp_data(Context, lists:reverse(cb_context:resp_data(Context)))
-                                ,lists:foldl(
-                                   fun fix_envelope_fold/2
-                                            ,cb_context:resp_envelope(Context)
-                                            ,[<<"start_key">>, <<"next_start_key">>]
-                                  )
-     ).
+    RespData = lists:reverse(cb_context:resp_data(Context)),
+    RespEnv = lists:foldl(fun fix_envelope_fold/2
+                         ,cb_context:resp_envelope(Context)
+                         ,[<<"start_key">>, <<"next_start_key">>]
+                         ),
+    cb_context:set_resp_envelope(cb_context:set_resp_data(Context, RespData), RespEnv).
 
 -spec fix_envelope_fold(binary(), kz_json:object()) -> kz_json:object().
 fix_envelope_fold(Key, JObj) ->

--- a/applications/crossbar/src/modules/cb_acdc_call_stats.erl
+++ b/applications/crossbar/src/modules/cb_acdc_call_stats.erl
@@ -235,7 +235,7 @@ create_view_options('undefined', Context, CreatedFrom, CreatedTo) ->
 
 -spec pagination_page_size(cb_context:context()) -> pos_integer().
 pagination_page_size(Context) ->
-    case crossbar_doc:pagination_page_size(Context) of
+    case cb_context:pagination_page_size(Context) of
         'undefined' -> 'undefined';
         PageSize -> PageSize + 1
     end.

--- a/applications/crossbar/src/modules/cb_acdc_call_stats.erl
+++ b/applications/crossbar/src/modules/cb_acdc_call_stats.erl
@@ -90,6 +90,8 @@ to_json(Req0, Context) ->
                            ),
     {Req2, cb_context:store(Context1, 'is_chunked', 'true')}.
 
+%%FIXME: fix page_size, start_key and next_start_key properly
+%%       probably page size is wrong here!
 -spec pagination(payload()) -> payload().
 pagination({Req, Context}=Payload) ->
     PageSize = cb_context:fetch(Context, 'page_size', 0),
@@ -233,6 +235,7 @@ create_view_options('undefined', Context, CreatedFrom, CreatedTo) ->
            ,'descending'
            ]}.
 
+%%FIXME: check if pagination is on or off
 -spec pagination_page_size(cb_context:context()) -> pos_integer().
 pagination_page_size(Context) ->
     case cb_context:pagination_page_size(Context) of
@@ -282,6 +285,8 @@ send_chunked_stats({Req, Context}) ->
     Dbs = cb_context:fetch(Context, 'chunked_dbs'),
     send_chunked_stats(Dbs, {Req, Context}).
 
+%%FIXME: loop over databases until either page size is exhausted or database
+%%       This code is fetching from all databases the same amount as page_size!
 -spec send_chunked_stats(ne_binaries(), payload()) -> payload().
 send_chunked_stats([], Payload) -> Payload;
 send_chunked_stats([Db | Dbs], {Req, Context}) ->

--- a/applications/crossbar/src/modules/cb_allotments.erl
+++ b/applications/crossbar/src/modules/cb_allotments.erl
@@ -174,13 +174,13 @@ create_viewoptions(Context, Classification, JObj, {'cycle', DateTime}) ->
     From = cycle_start(Cycle, DateTime),
     To = cycle_end(Cycle, DateTime),
     case cb_modules_util:range_modb_view_options(Context, [Classification], [], From, To) of
-        {'ok', ViewOptions} -> {Cycle, ViewOptions};
+        {'ok', ViewOptions} -> {Cycle, ViewOptions}; %%TODO: reverse databases order and start, end keys
         ContextErr -> ContextErr
     end;
 
 create_viewoptions(Context, Classification, _JObj, {'manual', From, To}) ->
     case cb_modules_util:range_modb_view_options(Context, [Classification], [], From, To) of
-        {'ok', ViewOptions} -> {<<"manual">>, ViewOptions};
+        {'ok', ViewOptions} -> {<<"manual">>, ViewOptions}; %%TODO: reverse databases order and start, end keys
         ContextErr -> ContextErr
     end.
 

--- a/applications/crossbar/src/modules/cb_call_inspector.erl
+++ b/applications/crossbar/src/modules/cb_call_inspector.erl
@@ -50,6 +50,7 @@ to_json({Req1, Context}, []) ->
     'ok' = cowboy_req:chunk("{\"status\":\"success\", \"data\":[", Req2),
     {Req3, Context1} = send_chunked_cdrs({Req2, Context}),
     'ok' = cowboy_req:chunk("]", Req3),
+    %%FIXME: fix page_size, start_key and next_start_key properly
     _ = cb_cdrs:pagination({Req3, Context1}),
     'ok' = cowboy_req:chunk([",\"request_id\":\"", cb_context:req_id(Context), "\""
                             ,",\"auth_token\":\"", cb_context:auth_token(Context), "\""
@@ -177,6 +178,8 @@ send_chunked_cdrs({Req, Context}) ->
     IsReseller = kz_services:is_reseller(AuthAccountId),
     send_chunked_cdrs(Dbs, {Req, cb_context:store(Context, 'is_reseller', IsReseller)}).
 
+%%FIXME: loop over databases until either page size is exhausted or database
+%%       This code is fetching from all databases the same amount as page_size!
 -spec send_chunked_cdrs(ne_binaries(), cb_cdrs:payload()) -> cb_cdrs:payload().
 send_chunked_cdrs([], Payload) -> Payload;
 send_chunked_cdrs([Db | Dbs], {Req, Context}) ->

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -462,7 +462,7 @@ create_summary_view_options(_, _, CreatedFrom, CreatedTo) ->
 -spec pagination_page_size(cb_context:context()) -> api_pos_integer().
 pagination_page_size(Context) ->
     case cb_context:should_paginate(Context)
-        andalso crossbar_doc:pagination_page_size(Context)
+        andalso cb_context:pagination_page_size(Context)
     of
         'false' -> 'undefined';
         'undefined' -> 'undefined';

--- a/applications/crossbar/src/modules/cb_faxes.erl
+++ b/applications/crossbar/src/modules/cb_faxes.erl
@@ -580,7 +580,8 @@ fax_modb_summary(Context, Folder) ->
     JObj = get_filter_doc(Context),
     {View, PreFilter, PostFilter} = get_incoming_view_and_filter(JObj, Folder),
     case cb_modules_util:range_modb_view_options(Context, PreFilter, PostFilter) of
-        {'ok', ViewOptions} ->
+        {'ok', ViewOptions0} ->
+            ViewOptions = cb_modules_util:make_modb_view_descending(ViewOptions0),
             crossbar_doc:load_view(View
                                   ,['include_docs' | ViewOptions]
                                   ,cb_context:set_resp_status(Context, 'success')
@@ -608,7 +609,8 @@ get_incoming_view_and_filter(JObj, Folder) ->
 -spec load_smtp_log(cb_context:context()) -> cb_context:context().
 load_smtp_log(Context) ->
     case cb_modules_util:range_modb_view_options(Context) of
-        {'ok', ViewOptions} ->
+        {'ok', ViewOptions0} ->
+            ViewOptions = cb_modules_util:make_modb_view_descending(ViewOptions0),
             crossbar_doc:load_view(?CB_LIST_SMTP_LOG
                                   ,['include_docs' | ViewOptions]
                                   ,Context

--- a/applications/crossbar/src/modules/cb_ledgers.erl
+++ b/applications/crossbar/src/modules/cb_ledgers.erl
@@ -338,7 +338,7 @@ read_ledger(Context, Ledger) ->
 
 -spec pagination_page_size(cb_context:context()) -> api_pos_integer().
 pagination_page_size(Context) ->
-    case crossbar_doc:pagination_page_size(Context) of
+    case cb_context:pagination_page_size(Context) of
         'undefined' -> 'undefined';
         PageSize -> PageSize + 1
     end.

--- a/applications/crossbar/src/modules/cb_ledgers.erl
+++ b/applications/crossbar/src/modules/cb_ledgers.erl
@@ -407,7 +407,7 @@ normalize_view_result(Context, _DocType, JObj) ->
 -spec maybe_set_doc_modb_prefix(ne_binary(), api_integer()) -> ne_binary().
 maybe_set_doc_modb_prefix(?MATCH_MODB_PREFIX(_,_,_)=Id, _) -> Id;
 maybe_set_doc_modb_prefix(Id, Created) ->
-    {Year, Month, _} = calendar:gregorian_seconds_to_datetime(Created),
+    {Year, Month, _} = kz_term:to_date(Created),
     kazoo_modb_util:modb_id(Year, Month, Id).
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -23,6 +23,7 @@
         ,range_view_options/1, range_view_options/2, range_view_options/3, range_view_options/5
 
         ,range_modb_view_options/1, range_modb_view_options/2, range_modb_view_options/3, range_modb_view_options/5
+        ,make_modb_view_descending/1
 
         ,take_sync_field/1
 
@@ -141,6 +142,17 @@ range_modb_view_options1(Context, PrefixKeys, SuffixKeys, CreatedFrom, CreatedTo
      ,{'databases', kazoo_modb:get_range(cb_context:account_id(Context), CreatedFrom, CreatedTo)}
      ]
     }.
+
+-spec make_modb_view_descending(crossbar_doc:view_options()) -> crossbar_doc:view_options().
+make_modb_view_descending(Options) ->
+    MODbs = lists:reverse(props:get_value('databases', Options, [])),
+    StartKey = props:get_value('startkey', Options),
+    EndKey = props:get_value('endkey', Options),
+    Funs = [fun(Props) -> props:set_value('databases', MODbs, Props) end
+           ,fun(Props) -> props:set_value('startkey', EndKey, Props) end
+           ,fun(Props) -> props:set_value('endkey', StartKey, Props) end
+           ],
+    sets:to_list(sets:from_list(lists:foldl(fun(Fun, Acc) -> Fun(Acc) end, ['descending'|Options], Funs))).
 
 -spec range_to(cb_context:context(), pos_integer(), ne_binary()) -> pos_integer().
 range_to(Context, TStamp, Key) ->

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -148,9 +148,12 @@ range_to(Context, TStamp, Key) ->
         'undefined' ->
             lager:debug("building ~s_to from req value", [Key]),
             kz_term:to_integer(cb_context:req_value(Context, <<Key/binary, "_to">>, TStamp));
-        StartKey ->
-            lager:debug("found startkey ~p as ~s_to", [StartKey, Key]),
-            kz_term:to_integer(StartKey)
+        StartKey when is_integer(StartKey) ->
+            lager:debug("found start_key ~p as ~s_to", [StartKey, Key]),
+            kz_term:to_integer(StartKey);
+        _CompoundStartKey ->
+            lager:debug("start_key is compound key, building ~s_to from req value", [Key]),
+            kz_term:to_integer(cb_context:req_value(Context, <<Key/binary, "_to">>, TStamp))
     end.
 
 -spec range_from(cb_context:context(), pos_integer(), pos_integer(), ne_binary()) -> pos_integer().

--- a/applications/crossbar/src/modules/cb_multi_factor.erl
+++ b/applications/crossbar/src/modules/cb_multi_factor.erl
@@ -138,12 +138,10 @@ validate(Context) ->
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?ATTEMPTS) ->
-    crossbar_view:load(Context
-                      ,?CB_LIST_ATTEMPT_LOG
-                      ,[{mapper, fun normalize_attempt_view_result/1}
-                       ,{key_map, <<"multi_factor">>}
-                       ]
-                      );
+    Options = [{mapper, fun normalize_attempt_view_result/1}
+              ,{key_map, <<"multi_factor">>}
+              ],
+    crossbar_modb_view:load(Context, ?CB_LIST_ATTEMPT_LOG, Options);
 validate(Context, ConfigId) ->
     case cb_context:req_nouns(Context) of
         [{<<"multi_factor">>, _}] ->

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -245,7 +245,7 @@ validate(Context) ->
     validate_notifications(maybe_update_db(Context), ReqVerb).
 
 validate(Context, ?SMTP_LOG) ->
-    crossbar_view:load(Context, ?CB_LIST_SMTP_LOG, [{mapper, fun normalize_view_result/1}]);
+    crossbar_modb_view:load(Context, ?CB_LIST_SMTP_LOG, [{mapper, fun normalize_view_result/1}]);
 validate(Context, Id) ->
     ReqVerb = cb_context:req_verb(Context),
     DbId = kz_notification:db_id(Id),

--- a/applications/crossbar/src/modules/cb_recordings.erl
+++ b/applications/crossbar/src/modules/cb_recordings.erl
@@ -130,7 +130,8 @@ validate(Context, RecordingId) ->
 recording_summary(Context) ->
     {View, PreFilter, PostFilter} = get_view_and_filter(Context),
     case cb_modules_util:range_modb_view_options(Context, PreFilter, PostFilter) of
-        {'ok', ViewOptions} ->
+        {'ok', ViewOptions0} ->
+            ViewOptions = cb_modules_util:make_modb_view_descending(ViewOptions0),
             recording_summary(Context, View, ViewOptions);
         Ctx -> Ctx
     end.

--- a/applications/crossbar/src/modules/cb_resources.erl
+++ b/applications/crossbar/src/modules/cb_resources.erl
@@ -458,7 +458,7 @@ jobs_summary(Context) ->
             crossbar_doc:load_view(?JOBS_LIST
                                   ,[{'startkey', CreatedFrom}
                                    ,{'endkey', CreatedTo}
-                                   ,{'limit', crossbar_doc:pagination_page_size(Context)}
+                                   ,{'limit', cb_context:pagination_page_size(Context)}
                                    ,{'databases', databases(Context, CreatedFrom, CreatedTo)}
                                    ]
                                   ,cb_context:set_account_db(Context, cb_context:account_modb(Context))

--- a/applications/crossbar/src/modules/cb_search.erl
+++ b/applications/crossbar/src/modules/cb_search.erl
@@ -292,7 +292,7 @@ search(Context, Type, Query, Val) ->
     ViewOptions =
         [{'startkey', get_start_key(Context, Type, Value)}
         ,{'endkey', get_end_key(Context, Type, Value)}
-        ,{'limit', crossbar_doc:pagination_page_size(Context)}
+        ,{'limit', cb_context:pagination_page_size(Context)}
         ],
     fix_envelope(
       crossbar_doc:load_view(ViewName

--- a/applications/crossbar/src/modules/cb_security.erl
+++ b/applications/crossbar/src/modules/cb_security.erl
@@ -146,7 +146,7 @@ validate(Context) ->
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?ATTEMPTS) ->
-    crossbar_view:load(Context, ?CB_LIST_ATTEMPT_LOG, [{mapper, fun normalize_attempt_view_result/1}]).
+    crossbar_modb_view:load(Context, ?CB_LIST_ATTEMPT_LOG, [{mapper, fun normalize_attempt_view_result/1}]).
 
 -spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ?ATTEMPTS, AttemptId) ->

--- a/applications/crossbar/src/modules/cb_sms.erl
+++ b/applications/crossbar/src/modules/cb_sms.erl
@@ -273,7 +273,8 @@ create_sms_doc_id() ->
 summary(Context) ->
     {View, PreFilter, PostFilter} = get_view_and_filter(Context),
     case cb_modules_util:range_modb_view_options(Context, PreFilter, PostFilter) of
-        {'ok', ViewOptions} ->
+        {'ok', ViewOptions0} ->
+            ViewOptions = cb_modules_util:make_modb_view_descending(ViewOptions0),
             crossbar_doc:load_view(View, ViewOptions, Context, fun normalize_view_results/2);
         Ctx -> Ctx
     end.

--- a/core/kazoo_stdlib/src/kz_date.erl
+++ b/core/kazoo_stdlib/src/kz_date.erl
@@ -33,7 +33,7 @@
         ]).
 
 %%--------------------------------------------------------------------
-%% @doc Convert a gregorian seconds integer to kz_date taking into consideration timezone
+%% @doc Convert a Gregorian seconds integer to kz_date taking into consideration timezone
 %% @end
 %%--------------------------------------------------------------------
 -spec from_gregorian_seconds(gregorian_seconds(), ne_binary()) -> kz_date().
@@ -45,7 +45,7 @@ from_gregorian_seconds(Seconds, <<_/binary>>=TZ) when is_integer(Seconds) ->
 
 %%--------------------------------------------------------------------
 %% @doc
-%% Caclulates the date of a given ISO 8601 week
+%% Calculates the date of a given ISO 8601 week
 %% @end
 %%--------------------------------------------------------------------
 -spec from_iso_week(kz_iso_week()) -> kz_date().
@@ -63,8 +63,8 @@ from_iso_week({Year, Week}) ->
 %%--------------------------------------------------------------------
 %% @doc
 %% Normalizes dates, for example corrects for months that are given
-%% with more days then they have (ie: {2011, 1, 36} -> {2011, 2, 5}).
-%% I have been refering to this as 'spanning a month/year border'
+%% with more days then they have (i.e.: {2011, 1, 36} -> {2011, 2, 5}).
+%% I have been referring to this as 'spanning a month/year border'
 %% @end
 %%--------------------------------------------------------------------
 -spec normalize(kz_date()) -> kz_date().
@@ -103,7 +103,7 @@ relative_difference(Date1, Date2) ->
 
 %%--------------------------------------------------------------------
 %% @doc
-%% Calculates the date of the next occurance of a weekday from the given
+%% Calculates the date of the next occurrence of a weekday from the given
 %% start date.
 %%
 %% NOTICE!
@@ -120,7 +120,7 @@ find_next_weekday({Y, M, D}, Weekday) ->
         %% If the DOW has not occurred this week yet
         DOW when RefDOW > DOW ->
             normalize({Y, M, D + (RefDOW - DOW)});
-        %% If the DOW occurance has already happend, calculate
+        %% If the DOW occurrence has already happened, calculate
         %%   for the next week using the current DOW as a reference
         DOW ->
             normalize({Y, M, D + ( 7 - DOW ) + RefDOW})

--- a/core/kazoo_stdlib/src/kz_time.erl
+++ b/core/kazoo_stdlib/src/kz_time.erl
@@ -1,7 +1,7 @@
 %%%-------------------------------------------------------------------
 %%% @copyright (C) 2010-2017, 2600Hz INC
 %%% @doc
-%%% Various utilities - a veritable cornicopia
+%%% Various utilities - a veritable cornucopia
 %%% @end
 %%% @contributors
 %%%-------------------------------------------------------------------


### PR DESCRIPTION
We usually normalizing `start_key` and `next_start_key` to be a timestamp, and for every db request we construct the `startkey` and `endkey` based on that, but in some situation like CDRs this is not helping. View's key in cdrs is a list and to have accurate view result we need at least two element in view's key list.

This PR is base64 encoding (url safe) erlang term binary representation of `start_key` and `next_start_key`, so for the next request we can decode it to erlang term again use that as the `startkey` as is.  

For example if `next_start_key` is `[63660927599, <<"abc123">>]` will encoded to `"g2wAAAACbgUAb6p80g5tAAAABmFiYzEyM2o"` and the client can set it as `start_key` value, and in crossbar we can decode it as erlang term again to use as `startkey` for CouchDB query.

Also this PR is returning `descending` result of MODBs for some api like recordings. (by adding a helper function `cb_modules_util:make_modb_view_descending/1`)

Also fixed KAZOO-5678 - Ledgers pagination doesn't return all results if range across 2 months