### PR TITLE
Prod 154 master

### DIFF
--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -86,8 +86,10 @@ build_offnet_request(Data, Call) ->
       ,{?KEY_B_LEG_EVENTS, [<<"DTMF">>]}
       ,{?KEY_CALL_ID, cf_exe:callid(Call)}
       ,{?KEY_CCVS, get_channel_vars(Call)}
+      ,{?KEY_REQUESTOR_CCVS, kapps_call:custom_channel_vars(Call)}
       ,{?KEY_CONTROL_QUEUE, cf_exe:control_queue(Call)}
       ,{?KEY_CSHS, get_sip_headers(Data, Call)}
+      ,{?KEY_REQUESTOR_CSHS, kapps_call:custom_sip_headers(Call)}
       ,{?KEY_E_CALLER_ID_NAME, ECIDName}
       ,{?KEY_E_CALLER_ID_NUMBER, ECIDNum}
       ,{?KEY_FLAGS, get_flags(Data, Call)}

--- a/applications/crossbar/doc/ref/resources.md
+++ b/applications/crossbar/doc/ref/resources.md
@@ -33,6 +33,10 @@ Key | Description | Type | Default | Required
 `gateways.[].format_from_uri` | When set to true requests to this resource gateway will have a re-formated SIP From Header | `boolean()` |   | `false`
 `gateways.[].from_uri_realm` | When formating SIP From on outbound requests this can be used to override the realm | `string()` |   | `false`
 `gateways.[].invite_format` | The format of the DID needed by the underlying hardware/gateway | `string('route' | 'username' | 'e164' | 'npan' | '1npan')` | `route` | `false`
+`gateways.[].invite_parameters.dynamic` | A list of properties that, if found on the inbound call, should be added as an INVITE parameter | `array()` |   | `false`
+`gateways.[].invite_parameters.static.[]` |   | `string()` |   | `false`
+`gateways.[].invite_parameters.static` | A list of static values that should be added as INVITE parameters | `array(string())` |   | `false`
+`gateways.[].invite_parameters` |   | `object()` |   | `false`
 `gateways.[].media.fax_option` | Is T.38 Supported? | `boolean()` |   | `false`
 `gateways.[].media.rtcp_mux` | RTCP protocol messages mixed with RTP data | `boolean()` |   | `false`
 `gateways.[].media` | The media parameters for the resource gateway | `object()` |   | `false`

--- a/applications/crossbar/doc/resources.md
+++ b/applications/crossbar/doc/resources.md
@@ -49,6 +49,10 @@ Key | Description | Type | Default | Required
 `gateways.[].format_from_uri` | When set to true requests to this resource gateway will have a re-formated SIP From Header | `boolean()` |   | `false`
 `gateways.[].from_uri_realm` | When formating SIP From on outbound requests this can be used to override the realm | `string()` |   | `false`
 `gateways.[].invite_format` | The format of the DID needed by the underlying hardware/gateway | `string('route' | 'username' | 'e164' | 'npan' | '1npan')` | `route` | `false`
+`gateways.[].invite_parameters.dynamic` | A list of properties that, if found on the inbound call, should be added as an INVITE parameter | `array()` |   | `false`
+`gateways.[].invite_parameters.static.[]` |   | `string()` |   | `false`
+`gateways.[].invite_parameters.static` | A list of static values that should be added as INVITE parameters | `array(string())` |   | `false`
+`gateways.[].invite_parameters` |   | `object()` |   | `false`
 `gateways.[].media.fax_option` | Is T.38 Supported? | `boolean()` |   | `false`
 `gateways.[].media.rtcp_mux` | RTCP protocol messages mixed with RTP data | `boolean()` |   | `false`
 `gateways.[].media` | The media parameters for the resource gateway | `object()` |   | `false`
@@ -114,6 +118,38 @@ Key | Description | Type | Default | Required
 `suffix` | Appends value against the result of a successful regex match | `string()` |   | `false`
 `value` | Replaces the current value with the static value defined | `string()` |   | `false`
 
+
+
+#### INVITE Parameters
+
+The INVITE parameters object defines both static and dynamic parameters that should be added to the request URI.
+
+Static parameters are added 'as-is' and can be any format.  However, they should follow the SIP standard for the header field format and should not include a semi-colon.
+
+Dynamic parameters obtain the value from properties of the initiating call (requestor) if present, and are ignored if not. Dynamic parameters can be defined either as a string or an object.  When defined as a string the property is extracted from the requestor and if found the resulting value used without modification as an INVITE parameter.  When defined as an object both a tag as well as a key propery must be defined.  The key property is used to extract the value from the requestor and the tag is appended as the INVITE parameter name.  By default the INVITE parameter name and value are seperated by an equals sign but this can be overridden by providing a seperator property.
+
+For example, if a resource gateway contains the following object:
+
+```
+           "invite_parameters": {
+               "dynamic": [
+                   "custom_channel_vars.pass-through",
+                   {
+                       "tag": "id",
+                       "key": "custom_channel_vars.account_id"
+                   }
+               ],
+               "static": [
+                   "npid"
+               ]
+           }
+```
+
+and assuming the requesting call has pass-through (with value "pass-through=0288") as well as account_id (with value "XXXX") custom channel variables it will result in an INVITE request URI such as:
+
+```
+INVITE sip:+14158867900@10.26.0.88;npid;id=XXXX;pass-through=0288 SIP/2.0
+```
 
 
 #### Fetch

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -9510,6 +9510,12 @@
                 "Ringback": {
                     "type": "string"
                 },
+                "SIP-Invite-Parameters": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "SIP-Transport": {
                     "enum": [
                         "udp",
@@ -9579,6 +9585,12 @@
                         "contact"
                     ],
                     "type": "string"
+                },
+                "SIP-Invite-Parameters": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "SIP-Transport": {
                     "enum": [
@@ -9710,6 +9722,9 @@
                     "type": "string"
                 },
                 "SIP-Interface": {
+                    "type": "string"
+                },
+                "SIP-Invite-Parameters": {
                     "type": "string"
                 },
                 "SIP-Transport": {
@@ -17018,6 +17033,12 @@
                 "Presence-ID": {
                     "type": "string"
                 },
+                "Requestor-Custom-Channel-Vars": {
+                    "type": "object"
+                },
+                "Requestor-Custom-SIP-Headers": {
+                    "type": "object"
+                },
                 "Resource-Type": {
                     "enum": [
                         "audio",
@@ -18475,6 +18496,9 @@
                 "Ringback": {
                     "type": "string"
                 },
+                "SIP-Invite-Parameters": {
+                    "type": "string"
+                },
                 "SIP-Transport": {
                     "type": "string"
                 },
@@ -18703,6 +18727,9 @@
                 "Ringback": {
                     "type": "string"
                 },
+                "SIP-Invite-Parameters": {
+                    "type": "string"
+                },
                 "SIP-Transport": {
                     "type": "string"
                 },
@@ -18874,6 +18901,9 @@
                     "type": "string"
                 },
                 "SIP-Interface": {
+                    "type": "string"
+                },
+                "SIP-Invite-Parameters": {
                     "type": "string"
                 },
                 "SIP-Transport": {
@@ -20168,6 +20198,9 @@
                 "SIP-Headers": {
                     "type": "object"
                 },
+                "SIP-Invite-Parameters": {
+                    "type": "string"
+                },
                 "SIP-Transport": {
                     "enum": [
                         "udp",
@@ -20346,6 +20379,9 @@
                     "type": "string"
                 },
                 "SIP-Interface": {
+                    "type": "string"
+                },
+                "SIP-Invite-Parameters": {
                     "type": "string"
                 },
                 "SIP-Transport": {
@@ -23588,6 +23624,23 @@
                                     "1npan"
                                 ],
                                 "type": "string"
+                            },
+                            "invite_parameters": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "dynamic": {
+                                        "description": "A list of properties that, if found on the inbound call, should be added as an INVITE parameter",
+                                        "type": "array"
+                                    },
+                                    "static": {
+                                        "description": "A list of static values that should be added as INVITE parameters",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object"
                             },
                             "media": {
                                 "description": "The media parameters for the resource gateway",

--- a/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.bridge.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.bridge.json
@@ -170,6 +170,12 @@
         "Ringback": {
             "type": "string"
         },
+        "SIP-Invite-Parameters": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
         "SIP-Transport": {
             "enum": [
                 "udp",

--- a/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.bridge_endpoint.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.bridge_endpoint.json
@@ -45,6 +45,12 @@
             ],
             "type": "string"
         },
+        "SIP-Invite-Parameters": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
         "SIP-Transport": {
             "enum": [
                 "udp",

--- a/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.bridge_endpoint_headers.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.bridge_endpoint_headers.json
@@ -120,6 +120,9 @@
         "SIP-Interface": {
             "type": "string"
         },
+        "SIP-Invite-Parameters": {
+            "type": "string"
+        },
         "SIP-Transport": {
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.offnet_resource.req.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.offnet_resource.req.json
@@ -180,6 +180,12 @@
         "Presence-ID": {
             "type": "string"
         },
+        "Requestor-Custom-Channel-Vars": {
+            "type": "object"
+        },
+        "Requestor-Custom-SIP-Headers": {
+            "type": "object"
+        },
         "Resource-Type": {
             "enum": [
                 "audio",

--- a/applications/crossbar/priv/couchdb/schemas/kapi.resource.eavesdrop_req.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.resource.eavesdrop_req.json
@@ -152,6 +152,9 @@
         "Ringback": {
             "type": "string"
         },
+        "SIP-Invite-Parameters": {
+            "type": "string"
+        },
         "SIP-Transport": {
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.resource.originate_req.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.resource.originate_req.json
@@ -172,6 +172,9 @@
         "Ringback": {
             "type": "string"
         },
+        "SIP-Invite-Parameters": {
+            "type": "string"
+        },
         "SIP-Transport": {
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.resource.originate_req_endpoint_headers.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.resource.originate_req_endpoint_headers.json
@@ -120,6 +120,9 @@
         "SIP-Interface": {
             "type": "string"
         },
+        "SIP-Invite-Parameters": {
+            "type": "string"
+        },
         "SIP-Transport": {
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.sms.message.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.sms.message.json
@@ -156,6 +156,9 @@
         "SIP-Headers": {
             "type": "object"
         },
+        "SIP-Invite-Parameters": {
+            "type": "string"
+        },
         "SIP-Transport": {
             "enum": [
                 "udp",

--- a/applications/crossbar/priv/couchdb/schemas/kapi.sms.message_endpoint_headers.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.sms.message_endpoint_headers.json
@@ -120,6 +120,9 @@
         "SIP-Interface": {
             "type": "string"
         },
+        "SIP-Invite-Parameters": {
+            "type": "string"
+        },
         "SIP-Transport": {
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/resources.json
+++ b/applications/crossbar/priv/couchdb/schemas/resources.json
@@ -150,6 +150,75 @@
                         ],
                         "type": "string"
                     },
+                    "invite_parameters": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "dynamic": {
+                                "description": "A list of properties that, if found on the inbound call, should be added as an INVITE parameter",
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "pattern": "custom_channel_vars\\..*",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "pattern": "custom_sip_headers\\..*",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "enum": [
+                                                "zone"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "key": {
+                                                    "oneOf": [
+                                                        {
+                                                            "pattern": "custom_channel_vars\\..*",
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "pattern": "custom_sip_headers\\..*",
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "enum": [
+                                                                "zone"
+                                                            ],
+                                                            "type": "string"
+                                                        }
+                                                    ]
+                                                },
+                                                "seperator": {
+                                                    "type": "string"
+                                                },
+                                                "tag": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "tag"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            "static": {
+                                "description": "A list of static values that should be added as INVITE parameters",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
+                    },
                     "media": {
                         "description": "The media parameters for the resource gateway",
                         "properties": {

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -546,6 +546,9 @@ get_channel_vars({<<"Confirm-File">>, V}, Vars) ->
                     ,"'"
                     ]) | Vars];
 
+get_channel_vars({<<"SIP-Invite-Parameters">>, V}, Vars) ->
+    [list_to_binary(["sip_invite_params='", kz_util:iolist_join(<<";">>, V), "'"]) | Vars];
+
 get_channel_vars({AMQPHeader, V}, Vars) when not is_list(V) ->
     case lists:keyfind(AMQPHeader, 1, ?SPECIAL_CHANNEL_VARS) of
         'false' -> Vars;

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -110,6 +110,7 @@
                  ,is_emergency = 'false' :: boolean()
                  ,force_port = 'false' :: boolean()
                  ,privacy_mode = 'undefined' :: api_binary()
+                 ,invite_parameters = 'undefined' :: api_object()
                  }).
 
 -record(resrc, {id :: api_binary()
@@ -455,7 +456,7 @@ resources_to_endpoints(Resources, Number, OffnetJObj) ->
             %% No endpoints found based on resources with classifiers, look up by
             %% resources that doesn't have classifier
             lager:debug("no resources satisfy classifier look up, matching against resource rules..."),
-            RuleResources = maps:get('no_classification', ResourceMap),
+            RuleResources = maps:get('no_classification', ResourceMap, []),
             build_endpoints_from_resources(RuleResources, Number, OffnetJObj);
         ClassifiedResources ->
             lager:debug("found resources to satisy classifier ~s (number ~s), building against classification rules..."
@@ -666,7 +667,6 @@ gateway_to_endpoint(DestinationNumber
                             }=Gateway
                    ,OffnetJObj
                    ) ->
-
     IsEmergency = gateway_emergency_resource(Gateway),
     {CIDName, CIDNumber} = gateway_cid(OffnetJObj, IsEmergency, PrivacyMode),
 
@@ -696,8 +696,64 @@ gateway_to_endpoint(DestinationNumber
         ,{<<"Custom-Channel-Vars">>, kz_json:from_list(CCVs)}
         ,{<<"Outbound-Caller-ID-Number">>, CIDNumber}
         ,{<<"Outbound-Caller-ID-Name">>, CIDName}
+        ,{<<"SIP-Invite-Parameters">>, sip_invite_parameters(Gateway, OffnetJObj)}
          | maybe_get_t38(Gateway, OffnetJObj)
         ])).
+
+
+-spec sip_invite_parameters(gateway(), kz_json:object()) -> ne_binaries().
+sip_invite_parameters(Gateway, OffnetJObj) ->
+    static_sip_invite_parameters(Gateway)
+        ++ dynamic_sip_invite_parameters(Gateway, OffnetJObj).
+
+-spec static_sip_invite_parameters(gateway()) -> ne_binaries().
+static_sip_invite_parameters(#gateway{invite_parameters='undefined'}) -> [];
+static_sip_invite_parameters(#gateway{invite_parameters=Parameters}) ->
+    kz_json:get_list_value(<<"static">>, Parameters, []).
+
+-spec dynamic_sip_invite_parameters(gateway(), kz_json:object()) -> ne_binaries().
+dynamic_sip_invite_parameters(#gateway{invite_parameters='undefined'}, _) -> [];
+dynamic_sip_invite_parameters(#gateway{invite_parameters=Parameters}, OffnetJObj) ->
+    CCVs = kz_json:normalize(kapi_offnet_resource:requestor_custom_channel_vars(OffnetJObj, kz_json:new())),
+    CSHs = kz_json:normalize(kapi_offnet_resource:requestor_custom_sip_headers(OffnetJObj, kz_json:new())),
+    Keys = kz_json:get_list_value(<<"dynamic">>, Parameters, []),
+    dynamic_sip_invite_parameters(Keys, CCVs, CSHs).
+
+-spec dynamic_sip_invite_parameters(api_binaries(), kz_json:object(), kz_json:object()) -> ne_binaries().
+dynamic_sip_invite_parameters(Keys, CCVs, CSHs) ->
+    dynamic_sip_invite_parameters(Keys, CCVs, CSHs, []).
+
+-spec dynamic_sip_invite_parameters(api_binaries(), kz_json:object(), kz_json:object(), ne_binaries()) -> ne_binaries().
+dynamic_sip_invite_parameters([], _, _, Parameters) -> Parameters;
+dynamic_sip_invite_parameters([Key|Keys], CCVs, CSHs, Parameters) when is_binary(Key) ->
+    case dynamic_sip_invite_value(Key, CCVs, CSHs) of
+        'undefined' -> dynamic_sip_invite_parameters(Keys, CCVs, CSHs, Parameters);
+        Parameter ->
+            lager:debug("adding dynamic invite parameter ~s", [Parameter]),
+            dynamic_sip_invite_parameters(Keys, CCVs, CSHs, [Parameter|Parameters])
+    end;
+dynamic_sip_invite_parameters([JObj|Keys], CCVs, CSHs, Parameters) ->
+    'true' = kz_json:is_json_object(JObj),
+    Key = kz_json:get_ne_value(<<"key">>, JObj),
+    Tag = kz_json:get_ne_value(<<"tag">>, JObj),
+    Seperator = kz_json:get_value(<<"seperator">>, JObj, <<"=">>),
+    case dynamic_sip_invite_value(Key, CCVs, CSHs) of
+        'undefined' -> dynamic_sip_invite_parameters(Keys, CCVs, CSHs, Parameters);
+        Value ->
+            Parameter = erlang:iolist_to_binary([Tag, Seperator, Value]),
+            lager:debug("adding dynamic invite parameter ~s", [Parameter]),
+            dynamic_sip_invite_parameters(Keys, CCVs, CSHs, [Parameter|Parameters])
+    end.
+
+-spec dynamic_sip_invite_value(ne_binary(), kz_json:object(), kz_json:object()) -> api_binary().
+dynamic_sip_invite_value(<<"zone">>, _, _) ->
+    kz_term:to_binary(kz_nodes:local_zone());
+dynamic_sip_invite_value(<<"custom_sip_headers.", Key/binary>>, _, CSHs) ->
+    kz_json:get_ne_binary_value(Key, CSHs);
+dynamic_sip_invite_value(<<"custom_channel_vars.", Key/binary>>, CCVs, _) ->
+    kz_json:get_ne_binary_value(Key, CCVs);
+dynamic_sip_invite_value(_, _, _) -> 'undefined'.
+
 
 -spec gateway_cid(kapi_offnet_resource:req(), api_binary(), api_binary()) -> {ne_binary(), ne_binary()}.
 gateway_cid(OffnetJObj, IsEmergency, PrivacyMode) ->
@@ -1142,6 +1198,7 @@ gateway_from_jobj(JObj, #resrc{is_emergency=IsEmergency
             ,progress_timeout = kz_json:get_integer_value(<<"progress_timeout">>, JObj, ?DEFAULT_PROGRESS_TIMEOUT)
             ,endpoint_options = endpoint_options(JObj, EndpointType)
             ,privacy_mode=kz_json:get_value(<<"privacy_mode">>, JObj, PrivacyMode)
+            ,invite_parameters=kz_json:get_ne_value(<<"invite_parameters">>, JObj)
             }.
 
 -spec gateway_is_emergency(kz_json:object(), boolean()) -> boolean().

--- a/applications/trunkstore/src/ts_from_onnet.erl
+++ b/applications/trunkstore/src/ts_from_onnet.erl
@@ -74,7 +74,7 @@ onnet_data(CallID, AccountId, FromUser, ToDID, Options, State) ->
     AccountOptions = kz_json:get_value(<<"account">>, Options, kz_json:new()),
     ServerOptions = kz_json:get_value([<<"server">>, <<"options">>], Options, kz_json:new()),
     RouteReq = ts_callflow:get_request_data(State),
-    CustomSIPHeaders = kz_json:get_value(<<"Custom-SIP-Headers">>, RouteReq),
+    CustomSIPHeaders = ts_callflow:get_custom_sip_headers(State),
     MediaHandling = ts_util:get_media_handling([kz_json:get_value(<<"media_handling">>, DIDOptions)
                                                ,kz_json:get_value(<<"media_handling">>, ServerOptions)
                                                ,kz_json:get_value(<<"media_handling">>, AccountOptions)
@@ -145,6 +145,8 @@ onnet_data(CallID, AccountId, FromUser, ToDID, Options, State) ->
                          ,{<<"Custom-SIP-Headers">>, SIPHeaders}
                          ,{<<"Hunt-Account-ID">>, kz_json:get_value(<<"hunt_account_id">>, ServerOptions)}
                          ,{<<"Custom-Channel-Vars">>, kz_json:from_list([{<<"Account-ID">>, AccountId}])}
+                         ,{<<"Requestor-Custom-Channel-Vars">>, ts_callflow:get_custom_channel_vars(State)}
+                         ,{<<"Requestor-Custom-SIP-Headers">>, CustomSIPHeaders}
                           | kz_api:default_headers(ts_callflow:get_worker_queue(State)
                                                   ,?APP_NAME, ?APP_VERSION
                                                   )

--- a/core/kazoo_amqp/include/kapi_offnet_resource.hrl
+++ b/core/kazoo_amqp/include/kapi_offnet_resource.hrl
@@ -9,8 +9,10 @@
 -define(KEY_B_LEG_EVENTS, <<"B-Leg-Events">>).
 -define(KEY_CALL_ID, <<"Call-ID">>).
 -define(KEY_CCVS, <<"Custom-Channel-Vars">>).
+-define(KEY_REQUESTOR_CCVS, <<"Requestor-Custom-Channel-Vars">>).
 -define(KEY_CONTROL_QUEUE, <<"Control-Queue">>).
 -define(KEY_CSHS, <<"Custom-SIP-Headers">>).
+-define(KEY_REQUESTOR_CSHS, <<"Requestor-Custom-SIP-Headers">>).
 -define(KEY_ENABLE_T38 ,<<"Enable-T38-Fax">>).
 -define(KEY_ENABLE_T38_GATEWAY, <<"Enable-T38-Gateway">>).
 -define(KEY_ENABLE_T38_PASSTHROUGH, <<"Enable-T38-Passthrough">>).

--- a/core/kazoo_amqp/src/api/kapi_dialplan.hrl
+++ b/core/kazoo_amqp/src/api/kapi_dialplan.hrl
@@ -72,6 +72,7 @@
         ,<<"Outbound-Caller-ID-Number">>
         ,<<"Ringback">>
         ,<<"SIP-Transport">>
+        ,<<"SIP-Invite-Parameters">>
         ,<<"Secure-RTP">>
         ,<<"Timeout">>
         ,<<"Simplify-Loopback">>
@@ -92,6 +93,7 @@
                           ,{<<"Continue-On-Fail">>, fun kz_term:is_boolean/1}
                           ,{<<"Secure-RTP">>, fun kz_term:is_boolean/1}
                           ,{<<"B-Leg-Events">>, fun b_leg_events_v/1}
+                          ,{<<"SIP-Invite-Parameters">>, fun is_list/1}
                           ]).
 
 %% Bridge Endpoints
@@ -134,6 +136,7 @@
         ,<<"Route">>
         ,<<"SIP-Interface">>
         ,<<"SIP-Transport">>
+        ,<<"SIP-Invite-Parameters">>
         ,<<"To-DID">>
         ,<<"To-IP">>
         ,<<"To-Realm">>
@@ -154,6 +157,7 @@
                                    ,{<<"Endpoint-Options">>, fun kz_json:is_json_object/1}
                                    ,{<<"Ignore-Early-Media">>, fun kz_term:is_boolean/1}
                                    ,{<<"Bypass-Media">>, fun kz_term:is_boolean/1}
+                                   ,{<<"SIP-Invite-Parameters">>, fun is_list/1}
                                    ]).
 
 %% Page Request

--- a/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
+++ b/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
@@ -25,8 +25,11 @@
         ,call_id/1, call_id/2
         ,control_queue/1, control_queue/2
         ,custom_channel_vars/1, custom_channel_vars/2
+        ,requestor_custom_channel_vars/1, requestor_custom_channel_vars/2
         ,custom_sip_headers/1, custom_sip_headers/2
         ,custom_sip_header/2
+        ,requestor_custom_sip_headers/1, requestor_custom_sip_headers/2
+        ,requestor_custom_sip_header/2
         ,emergency_caller_id_name/1, emergency_caller_id_name/2
         ,emergency_caller_id_number/1, emergency_caller_id_number/2
         ,fax_identity_name/1, fax_identity_name/2
@@ -96,7 +99,9 @@
         ,?KEY_CALL_ID
         ,?KEY_CONTROL_QUEUE
         ,?KEY_CCVS
+        ,?KEY_REQUESTOR_CCVS
         ,?KEY_CSHS
+        ,?KEY_REQUESTOR_CSHS
         ,?KEY_E_CALLER_ID_NAME
         ,?KEY_E_CALLER_ID_NUMBER
         ,?KEY_ENABLE_T38
@@ -151,7 +156,9 @@
         ,{?KEY_CALL_ID, fun erlang:is_binary/1}
         ,{?KEY_CONTROL_QUEUE, fun erlang:is_binary/1}
         ,{?KEY_CCVS, fun kz_json:is_json_object/1}
+        ,{?KEY_REQUESTOR_CCVS, fun kz_json:is_json_object/1}
         ,{?KEY_CSHS, fun kz_json:is_json_object/1}
+        ,{?KEY_REQUESTOR_CSHS, fun kz_json:is_json_object/1}
         ,{?KEY_ENABLE_T38_GATEWAY, fun erlang:is_binary/1}
         ,{?KEY_FLAGS, fun erlang:is_list/1}
         ,{?KEY_FORCE_FAX, fun kz_term:is_boolean/1}
@@ -359,6 +366,13 @@ custom_channel_vars(Req) ->
 custom_channel_vars(?REQ_TYPE(JObj), Default) ->
     kz_json:get_json_value(?KEY_CCVS, JObj, Default).
 
+-spec requestor_custom_channel_vars(req()) -> api_object().
+-spec requestor_custom_channel_vars(req(), Default) -> kz_json:object() | Default.
+requestor_custom_channel_vars(Req) ->
+    requestor_custom_channel_vars(Req, 'undefined').
+requestor_custom_channel_vars(?REQ_TYPE(JObj), Default) ->
+    kz_json:get_json_value(?KEY_REQUESTOR_CCVS, JObj, Default).
+
 -spec custom_sip_headers(req()) -> api_object().
 -spec custom_sip_headers(req(), Default) -> kz_json:object() | Default.
 custom_sip_headers(Req) ->
@@ -369,6 +383,18 @@ custom_sip_headers(?REQ_TYPE(JObj), Default) ->
 -spec custom_sip_header(req(), kz_json:key()) -> kz_json:json_term() | 'undefined'.
 custom_sip_header(Req, Header) ->
     SipHeaders = custom_sip_headers(Req, kz_json:new()),
+    kz_json:get_value(Header, SipHeaders).
+
+-spec requestor_custom_sip_headers(req()) -> api_object().
+-spec requestor_custom_sip_headers(req(), Default) -> kz_json:object() | Default.
+requestor_custom_sip_headers(Req) ->
+    requestor_custom_sip_headers(Req, 'undefined').
+requestor_custom_sip_headers(?REQ_TYPE(JObj), Default) ->
+    kz_json:get_json_value(?KEY_REQUESTOR_CSHS, JObj, Default).
+
+-spec requestor_custom_sip_header(req(), kz_json:key()) -> kz_json:json_term() | 'undefined'.
+requestor_custom_sip_header(Req, Header) ->
+    SipHeaders = requestor_custom_sip_headers(Req, kz_json:new()),
     kz_json:get_value(Header, SipHeaders).
 
 -spec timeout(req()) -> api_integer().


### PR DESCRIPTION
This allows you to add the following to a resource gateway:

```
           "invite_parameters": {
               "dynamic": [
                   "custom_channel_vars.pass-through",
                   {
                       "tag": "id",
                       "key": "custom_channel_vars.account_id"
                   }
               ],
               "static": [
                   "npid"
               ]
           }
```

Assuming the inbound call has pass-through (with value "pass-through=0288") and account_id (with value "XXXX") CCVs it will result in an INVITE request such as:

```
INVITE sip:+14158867900@10.26.0.88;npid;id=XXXX;pass-through=0288 SIP/2.0
```