### PR TITLE
[4.1] don't send fax to reseller, fix user email lookup

### DIFF
--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -799,9 +799,10 @@ notify_fields(JObj, Resp) ->
 
     ToNumber = kz_term:to_binary(kz_json:get_value(<<"to_number">>, JObj)),
     ToName = kz_term:to_binary(kz_json:get_value(<<"to_name">>, JObj, ToNumber)),
-    Notify = [E || E <- kz_json:get_value([<<"notifications">>,<<"email">>,<<"send_to">>], JObj, [])
-                       ,not kz_term:is_empty(E)
-             ],
+    Emails = kz_json:find_first_defined([[<<"notifications">>, <<"email">>, <<"send_to">>]
+                                        ,[<<"notifications">>, <<"outbound">>, <<"email">>, <<"send_to">>]
+                                        ], JObj, []),
+    Notify = [E || E <- Emails, not kz_term:is_empty(E)],
 
     props:filter_empty(
       [{<<"Caller-ID-Name">>, kz_json:get_value(<<"from_name">>, JObj)}

--- a/applications/notify/src/notify_fax_inbound_to_email.erl
+++ b/applications/notify/src/notify_fax_inbound_to_email.erl
@@ -68,6 +68,7 @@ handle_req(JObj, _Props) ->
     {'ok', HTMLBody} = notify_util:render_template(CustomHtmlTemplate, ?DEFAULT_HTML_TMPL, Props),
     {'ok', Subject} = notify_util:render_template(CustomSubjectTemplate, ?DEFAULT_SUBJ_TMPL, Props),
 
+    notify_util:send_update(RespQ, MsgId, <<"pending">>),
     notify_util:maybe_send_update(build_and_send_email(TxtBody, HTMLBody, Subject, Emails, props:filter_empty(Props))
                                  ,RespQ
                                  ,MsgId

--- a/applications/teletype/src/teletype_bindings.erl
+++ b/applications/teletype/src/teletype_bindings.erl
@@ -46,8 +46,8 @@ notification(JObj) ->
             FailureMsg = build_failure_message(Res),
             lager:debug("notification ~s did not result in successes: ~s", [RoutingKey, FailureMsg]),
             teletype_util:send_update(JObj, <<"failed">>, FailureMsg);
-        _Successes ->
-            lager:debug("notification ~s result in some successes", [RoutingKey])
+        Successes ->
+            lager:debug("notification ~s result in ~s success(es)", [RoutingKey, length(Successes)])
     end.
 
 -spec start_modules() -> 'ok'.
@@ -67,9 +67,6 @@ filter_out_failed('ok') -> 'true';
 filter_out_failed(_) -> 'false'.
 
 -spec build_failure_message(any()) -> ne_binary().
-build_failure_message([{'EXIT', {'error', 'no_attachment'}}|_]) ->
-    <<"no_attachment">>;
-
 build_failure_message([{'EXIT', {'error', 'missing_data',  Missing}}|_]) ->
     <<"missing_data: ", (kz_term:to_binary(Missing))/binary>>;
 
@@ -87,10 +84,15 @@ build_failure_message([{'EXIT', {'undef', _ST}}|_]) ->
     <<"template_error: crashed with undef">>;
 
 build_failure_message([{'EXIT', {'error', {'badmatch',  _}}}|_]) ->
-    %% Some templates (like voicemail_new) is matching agianst successful open_doc
+    %% Some templates (like voicemail_new) is matching against successful open_doc
     %% maybe because the document or attachment is not stored yet.
     %% Let the publisher save the payload to load later
     <<"badmatch">>;
+
+build_failure_message([{'EXIT', {'error', Reason}}|_]) ->
+    try kz_term:to_binary(Reason)
+    catch _:_ -> <<"unknown error throw-ed">>
+    end;
 
 build_failure_message([{'EXIT', {_Exp, _ST}}|_]) ->
     <<"template_error: crashed with exception">>;

--- a/applications/teletype/src/teletype_bindings.erl
+++ b/applications/teletype/src/teletype_bindings.erl
@@ -47,7 +47,7 @@ notification(JObj) ->
             lager:debug("notification ~s did not result in successes: ~s", [RoutingKey, FailureMsg]),
             teletype_util:send_update(JObj, <<"failed">>, FailureMsg);
         Successes ->
-            lager:debug("notification ~s result in ~s success(es)", [RoutingKey, length(Successes)])
+            lager:debug("notification ~s result in ~b success(es)", [RoutingKey, length(Successes)])
     end.
 
 -spec start_modules() -> 'ok'.

--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -72,7 +72,7 @@ add_document_data(FaxDoc, Macros, [{ContentType, Filename, Bin}]) ->
 
 -spec to_email_addresses(kz_json:object(), ne_binary()) -> api_binaries().
 to_email_addresses(DataJObj, ModConfigCat) ->
-    BoxEmailPath = case ModConfigCat of
+    BoxEmailPath = case binary:split(ModConfigCat, <<".">>) of
                        [_, <<"fax_inbound", _/binary>>] ->
                            [<<"notifications">>, <<"inbound">>, <<"email">>, <<"send_to">>]; %% inbound from faxbox doc
                        _ ->

--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -189,7 +189,7 @@ find_timezone(DataJObj, FaxBoxJObj) ->
 
 -spec fax_db(kz_json:object(), api_ne_binary()) -> ne_binary().
 fax_db(DataJObj, FaxId) ->
-    case kapi_notifications:account_db(DataJObj) of
+    case kapi_notifications:account_db(DataJObj, 'true') of
         'undefined' ->
             maybe_get_fax_db_from_id(kz_json:get_ne_binary_value(<<"account_id">>, DataJObj), FaxId);
         Db -> maybe_get_fax_db_from_id(Db, FaxId)

--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -39,7 +39,7 @@ add_attachments(DataJObj, Macros, ShouldTerminate) ->
     FaxDoc = kz_json:get_value(<<"fax_doc">>, DataJObj),
     case kz_json:is_json_object(FaxDoc)
         andalso not kz_json:is_empty(FaxDoc)
-        andalso maybe_fetch_attachments(FaxDoc, Macros, IsPreview)
+        andalso maybe_fetch_attachments(DataJObj, FaxDoc, Macros, IsPreview)
     of
         'false' -> maybe_terminate(Macros, ShouldTerminate, IsPreview);
         [] -> maybe_terminate(Macros, ShouldTerminate, IsPreview);
@@ -184,7 +184,7 @@ find_timezone(DataJObj, FaxBoxJObj) ->
     find_timezone(kz_json:get_first_defined(Paths, DataJObj), FaxBoxJObj).
 
 %%%===================================================================
-%%% Attachment Utilites
+%%% Attachment Utilities
 %%%===================================================================
 
 -spec fax_db(kz_json:object(), api_ne_binary()) -> ne_binary().
@@ -201,37 +201,38 @@ maybe_get_fax_db_from_id(?MATCH_MODB_SUFFIX_ENCODED(_, _, _)=Db, _) -> Db;
 maybe_get_fax_db_from_id(Db, ?MATCH_MODB_PREFIX(Year, Month, _)) -> kazoo_modb:get_modb(kz_util:format_account_id(Db), Year, Month);
 maybe_get_fax_db_from_id(Db, _) -> Db.
 
--spec maybe_fetch_attachments(kz_json:object(), kz_proplist(), boolean()) -> attachments().
-maybe_fetch_attachments(_, _, 'true') ->
+-spec maybe_fetch_attachments(kz_json:object(), kz_json:object(), kz_proplist(), boolean()) -> attachments().
+maybe_fetch_attachments(_, _, _, 'true') ->
     [];
-maybe_fetch_attachments(FaxJObj, Macros, 'false') ->
+maybe_fetch_attachments(DataJObj, FaxJObj, Macros, 'false') ->
     FaxId = kz_doc:id(FaxJObj),
     Db = kz_doc:account_db(FaxJObj),
     [AttachmentName] = kz_doc:attachment_names(FaxJObj),
 
     lager:debug("accessing fax attachment ~s at ~s / ~s", [AttachmentName, Db, FaxId]),
+    teletype_util:send_update(DataJObj, <<"pending">>),
 
     case kz_datamgr:fetch_attachment(Db, {kzd_fax:type(), FaxId}, AttachmentName) of
         {'ok', Bin} ->
             ContentType = kz_doc:attachment_content_type(FaxJObj, AttachmentName),
-            maybe_convert_attachment(Macros, ContentType, Bin);
+            maybe_convert_attachment(DataJObj, Macros, ContentType, Bin);
         {'error', _E} ->
             lager:debug("failed to fetch attachment ~s: ~p", [AttachmentName, _E]),
             []
     end.
 
--spec maybe_convert_attachment(kz_proplist(), api_binary(), binary()) -> attachments().
-maybe_convert_attachment(Macros, ContentType, Bin) ->
+-spec maybe_convert_attachment(kz_json:object(), kz_proplist(), api_binary(), binary()) -> attachments().
+maybe_convert_attachment(DataJObj, Macros, ContentType, Bin) ->
     ToFormat = kapps_config:get_ne_binary(?FAX_CONFIG_CAT, <<"attachment_format">>, <<"pdf">>),
     FromFormat = from_format_from_content_type(ContentType),
 
-    case convert(FromFormat, ToFormat, Bin) of
+    case convert(DataJObj, FromFormat, ToFormat, Bin) of
         {'ok', Converted} ->
             Filename = get_file_name(Macros, ToFormat),
             lager:debug("adding attachment as ~s", [Filename]),
             [{content_type_from_extension(Filename), Filename, Converted}];
         {'error', Reason} ->
-            lager:debug("error converting atachment with reason : ~p", [Reason]),
+            lager:debug("error converting attachment with reason : ~p", [Reason]),
             []
     end.
 
@@ -264,11 +265,12 @@ get_file_name(Macros, Ext) ->
     FName = list_to_binary([CallerID, "_", kz_time:pretty_print_datetime(LocalDateTime), ".", Ext]),
     re:replace(kz_term:to_lower_binary(FName), <<"\\s+">>, <<"_">>, [{'return', 'binary'}, 'global']).
 
--spec convert(ne_binary(), ne_binary(), binary()) -> {ok, binary()} | {error, atom() | string()}.
-convert(FromFormat, FromFormat, Bin) ->
+-spec convert(kz_json:object(), ne_binary(), ne_binary(), binary()) -> {ok, binary()} | {error, atom() | string()}.
+convert(_, FromFormat, FromFormat, Bin) ->
     {'ok', Bin};
-convert(FromFormat0, ToFormat0, Bin) ->
+convert(DataJObj, FromFormat0, ToFormat0, Bin) ->
     lager:debug("converting from ~s to ~s", [FromFormat0, ToFormat0]),
+    teletype_util:send_update(DataJObj, <<"pending">>),
 
     FromFormat = valid_format(FromFormat0),
     ToFormat = valid_format(ToFormat0),

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -465,12 +465,13 @@ sort_templates({K1, _}, {K2, _}) ->
         props:get_value(K2, ?TEMPLATE_RENDERING_ORDER, 1).
 
 -spec find_account_db(ne_binary(), kz_json:object()) -> api_binary().
-find_account_db(<<"account">>, JObj) -> kapi_notifications:account_db(JObj);
-find_account_db(<<"user">>, JObj) -> kapi_notifications:account_db(JObj);
-find_account_db(<<"fax">>, JObj) -> kapi_notifications:account_db(JObj);
+find_account_db(<<"account">>, JObj) -> kapi_notifications:account_db(JObj, 'false');
+find_account_db(<<"user">>, JObj) -> kapi_notifications:account_db(JObj, 'false');
+find_account_db(<<"faxbox">>, JObj) -> kapi_notifications:account_db(JObj, 'false');
+find_account_db(<<"fax">>, JObj) -> kapi_notifications:account_db(JObj, 'true');
 find_account_db(<<"port_request">>, _JObj) -> ?KZ_PORT_REQUESTS_DB;
 find_account_db(<<"webhook">>, _JObj) -> ?KZ_WEBHOOKS_DB;
-find_account_db(_, JObj) -> kapi_notifications:account_db(JObj).
+find_account_db(_, JObj) -> kapi_notifications:account_db(JObj, 'false').
 
 -spec send_update(kz_json:object(), ne_binary()) -> 'ok'.
 -spec send_update(kz_json:object(), ne_binary(), api_binary()) -> 'ok'.

--- a/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_error_to_email.erl
@@ -87,15 +87,18 @@ handle_req(JObj, 'true') ->
             lager:debug("notification ~s handling not configured for account ~s, only handling ~s"
                        ,[?TEMPLATE_ID, AccountId, ?TEMPLATE_ID_FILTERED]
                        ),
+            teletype_util:send_update(DataJObj, <<"pending">>),
             Res = handle_fax_inbound(teletype_fax_util:add_data(DataJObj), ?TEMPLATE_ID_FILTERED),
             send_update(DataJObj, Res);
         {'true', 'false'} ->
             lager:debug("notification ~s handling not configured for account ~s, only handling ~s"
                        ,[?TEMPLATE_ID_FILTERED, AccountId, ?TEMPLATE_ID]
                        ),
+            teletype_util:send_update(DataJObj, <<"pending">>),
             Res = handle_fax_inbound(teletype_fax_util:add_data(DataJObj), ?TEMPLATE_ID),
             send_update(DataJObj, Res);
         {'true', 'true'} ->
+            teletype_util:send_update(DataJObj, <<"pending">>),
             Res0 = handle_fax_inbound(teletype_fax_util:add_data(DataJObj), ?TEMPLATE_ID),
             Res1 = handle_fax_inbound(teletype_fax_util:add_data(DataJObj), ?TEMPLATE_ID_FILTERED),
             send_update(DataJObj, Res0, Res1)

--- a/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_inbound_to_email.erl
@@ -68,7 +68,9 @@ handle_req(JObj, 'true') ->
 
     case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
-        'true' -> process_req(teletype_fax_util:add_data(DataJObj))
+        'true' ->
+            teletype_util:send_update(DataJObj, <<"pending">>),
+            process_req(teletype_fax_util:add_data(DataJObj))
     end.
 
 -spec process_req(kz_json:object()) -> 'ok'.

--- a/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
@@ -70,7 +70,9 @@ handle_req(JObj, 'true') ->
 
     case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
-        'true' -> process_req(teletype_fax_util:add_data(DataJObj))
+        'true' ->
+            teletype_util:send_update(DataJObj, <<"pending">>),
+            process_req(teletype_fax_util:add_data(DataJObj))
     end.
 
 -spec process_req(kz_json:object()) -> 'ok'.

--- a/applications/teletype/src/templates/teletype_fax_outbound_smtp_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_smtp_error_to_email.erl
@@ -59,7 +59,9 @@ handle_req(JObj, 'true') ->
 
     case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
-        'true' -> process_req(DataJObj)
+        'true' ->
+            teletype_util:send_update(DataJObj, <<"pending">>),
+            process_req(DataJObj)
     end.
 
 -spec process_req(kz_json:object()) -> 'ok'.

--- a/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
@@ -68,7 +68,9 @@ handle_req(JObj, 'true') ->
 
     case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
-        'true' -> process_req(teletype_fax_util:add_data(DataJObj))
+        'true' ->
+            teletype_util:send_update(DataJObj, <<"pending">>),
+            process_req(teletype_fax_util:add_data(DataJObj))
     end.
 
 -spec process_req(kz_json:object()) -> 'ok'.

--- a/applications/teletype/src/templates/teletype_voicemail_full.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_full.erl
@@ -99,7 +99,7 @@ maybe_add_user_email(BoxEmails, UserEmail) -> [UserEmail | BoxEmails].
 -spec get_vm_box(ne_binary(), kz_json:object()) -> kz_json:object().
 get_vm_box(AccountId, JObj) ->
     VMBoxId = kz_json:get_value(<<"voicemail_box">>, JObj),
-    case teletype_util:open_doc(<<"voicemail">>, VMBoxId, JObj) of
+    case teletype_util:open_doc(<<"vmbox">>, VMBoxId, JObj) of
         {'ok', VMBox} -> VMBox;
         {'error', _E} ->
             lager:debug("failed to load vm box ~s from ~s", [VMBoxId, AccountId]),

--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -199,15 +199,17 @@ email_attachments(DataJObj, Macros, 'false') ->
                      throw({'error', 'no_attachment'})
              end,
 
-    maybe_fetch_attachments(Db, VMId, get_file_name(VMJObj, Macros), kz_doc:attachments(VMJObj)).
+    maybe_fetch_attachments(DataJObj, Db, VMId, get_file_name(VMJObj, Macros), kz_doc:attachments(VMJObj)).
 
--spec maybe_fetch_attachments(ne_binary(), ne_binary(), ne_binary(), api_object()) -> attachments().
-maybe_fetch_attachments(_, _, _, 'undefined') ->
+-spec maybe_fetch_attachments(kz_json:object(), ne_binary(), ne_binary(), ne_binary(), api_object()) -> attachments().
+maybe_fetch_attachments(_, _, _, _, 'undefined') ->
     throw({'error', 'no_attachment'});
-maybe_fetch_attachments(Db, VMId, FileName, Attachments) ->
+maybe_fetch_attachments(DataJObj, Db, VMId, FileName, Attachments) ->
     case kz_json:is_empty(Attachments) of
         'true' -> throw({'error', 'no_attachment'});
-        'false' -> fetch_attachments(Db, VMId, FileName, Attachments)
+        'false' ->
+            teletype_util:send_update(DataJObj, <<"pending">>),
+            fetch_attachments(Db, VMId, FileName, Attachments)
     end.
 
 -spec fetch_attachments(ne_binary(), ne_binary(), ne_binary(), kz_json:object()) -> attachments().

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -335,8 +335,8 @@
 -define(ACCOUNT_ZONE_CHANGE_TYPES, []).
 
 %% Notify New User
--define(NEW_USER_HEADERS, [<<"Account-ID">>, <<"User-ID">>, <<"Password">>]).
--define(OPTIONAL_NEW_USER_HEADERS, ?DEFAULT_OPTIONAL_HEADERS).
+-define(NEW_USER_HEADERS, [<<"Account-ID">>, <<"User-ID">>]).
+-define(OPTIONAL_NEW_USER_HEADERS, [<<"Password">> | ?DEFAULT_OPTIONAL_HEADERS]).
 -define(NEW_USER_VALUES, [{<<"Event-Category">>, <<"notification">>}
                          ,{<<"Event-Name">>, <<"new_user">>}
                          ]).

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -50,7 +50,7 @@
         ,missed_call/1, missed_call_v/1
         ,skel/1, skel_v/1
         ,headers/1
-        ,account_id/1, account_db/1
+        ,account_id/1, account_db/2
         ]).
 
 -export([publish_voicemail_new/1, publish_voicemail_new/2
@@ -598,8 +598,8 @@ account_id(JObj) ->
             ],
     kz_json:get_first_defined(Paths, JObj).
 
--spec account_db(kz_json:object()) -> api_ne_binary().
-account_db(JObj) ->
+-spec account_db(kz_json:object(), boolean()) -> api_ne_binary().
+account_db(JObj, MaybeAssumeMODB) ->
     Paths = [<<"account_db">>, <<"pvt_account_db">>, <<"Account-DB">>],
     case kz_json:get_first_defined(Paths, JObj) of
         'undefined' ->
@@ -607,9 +607,9 @@ account_db(JObj) ->
                 'undefined' -> 'undefined';
                 AccountId -> kz_util:format_account_db(AccountId)
             end;
-        ?MATCH_MODB_SUFFIX_RAW(_, _, _)=Db -> kz_util:format_account_modb(Db, 'encoded');
-        ?MATCH_MODB_SUFFIX_UNENCODED(_, _, _)=Db -> kz_util:format_account_modb(Db, 'encoded');
-        ?MATCH_MODB_SUFFIX_ENCODED(_, _, _)=Db -> Db;
+        ?MATCH_MODB_SUFFIX_RAW(_, _, _)=Db when MaybeAssumeMODB -> kz_util:format_account_modb(Db, 'encoded');
+        ?MATCH_MODB_SUFFIX_UNENCODED(_, _, _)=Db when MaybeAssumeMODB -> kz_util:format_account_modb(Db, 'encoded');
+        ?MATCH_MODB_SUFFIX_ENCODED(_, _, _)=Db when MaybeAssumeMODB -> Db;
         ?NE_BINARY=Db -> kz_util:format_account_db(Db);
         _ -> 'undefined'
     end.

--- a/core/kazoo_apps/src/kapps_notify_publisher.erl
+++ b/core/kazoo_apps/src/kapps_notify_publisher.erl
@@ -157,31 +157,31 @@ is_completed([JObj|_]) ->
         <<"completed">> -> 'true';
         <<"failed">> ->
             FailureMsg = kz_json:get_ne_binary_value(<<"Failure-Message">>, JObj),
-            ShouldIgnore = maybe_ignore_failure(FailureMsg),
-            ShouldIgnore
-                andalso lager:debug("teletype failed with reason ~s, ignoring", [FailureMsg]),
+            ShouldIgnore = should_ignore_failure(FailureMsg),
+            lager:debug("teletype failed with reason ~s, ignoring: ", [FailureMsg, ShouldIgnore]),
             ShouldIgnore;
         %% FIXME: Is pending enough to consider publish was successful? at least teletype recieved the notification!
         %% <<"pending">> -> 'true';
         _ -> 'false'
     end.
 
--spec maybe_ignore_failure(api_ne_binary()) -> boolean().
-maybe_ignore_failure(<<"missing_from">>) -> 'true';
-maybe_ignore_failure(<<"invalid_to_addresses">>) -> 'true';
-maybe_ignore_failure(<<"no_to_addresses">>) -> 'true';
-maybe_ignore_failure(<<"email_encoding_failed">>) -> 'true';
-maybe_ignore_failure(<<"validation_failed">>) -> 'true';
-maybe_ignore_failure(<<"missing_data:", _/binary>>) -> 'true';
-maybe_ignore_failure(<<"failed_template:", _/binary>>) -> 'true'; %% rendering problems
-maybe_ignore_failure(<<"template_error:", _/binary>>) -> 'true'; %% rendering problems
-maybe_ignore_failure(<<"no teletype template modules responded">>) -> 'true'; %% rendering problems
+-spec should_ignore_failure(api_ne_binary()) -> boolean().
+should_ignore_failure(<<"missing_from">>) -> 'true';
+should_ignore_failure(<<"invalid_to_addresses">>) -> 'true';
+should_ignore_failure(<<"no_to_addresses">>) -> 'true';
+should_ignore_failure(<<"email_encoding_failed">>) -> 'true';
+should_ignore_failure(<<"validation_failed">>) -> 'true';
+should_ignore_failure(<<"missing_data:", _/binary>>) -> 'true';
+should_ignore_failure(<<"failed_template:", _/binary>>) -> 'true'; %% rendering problems
+should_ignore_failure(<<"template_error:", _/binary>>) -> 'true'; %% rendering problems
+should_ignore_failure(<<"no teletype template modules responded">>) -> 'true'; %% rendering problems
+should_ignore_failure(<<"unknown error throw-ed">>) -> 'true';
 
 %% explicitly not ignoring these below:
-maybe_ignore_failure(<<"unknown_template_error">>) -> 'false'; %% maybe something went wrong with template, trying later?
-maybe_ignore_failure(<<"no_attachment">>) -> 'false'; %% probably fax or voicemail is not stored in storage yet, retry later
-maybe_ignore_failure(<<"badmatch">>) -> 'false'; %% not ignoring it yet (voicemail_new)
-maybe_ignore_failure(_) -> 'false'.
+should_ignore_failure(<<"unknown_template_error">>) -> 'false'; %% maybe something went wrong with template, trying later?
+should_ignore_failure(<<"no_attachment">>) -> 'false'; %% probably fax or voicemail is not stored in storage yet, retry later
+should_ignore_failure(<<"badmatch">>) -> 'false'; %% not ignoring it yet (voicemail_new)
+should_ignore_failure(_) -> 'false'.
 
 %% @private
 %% @doc try to find account id in different part of payload(copied from teletype_util)

--- a/core/kazoo_apps/src/kapps_notify_publisher.erl
+++ b/core/kazoo_apps/src/kapps_notify_publisher.erl
@@ -26,6 +26,8 @@
        ).
 
 -define(DEFAULT_TYPE_EXCEPTION, [<<"system_alert">>
+                                ,<<"voicemail_save">>
+                                ,<<"register">>
                                 ]).
 -define(GLOBAL_FORCE_NOTIFY_TYPE_EXCEPTION,
         kapps_config:get_ne_binaries(?NOTIFY_CAT, <<"notify_presist_temprorary_force_exceptions">>, [])

--- a/core/kazoo_apps/src/kapps_notify_publisher.erl
+++ b/core/kazoo_apps/src/kapps_notify_publisher.erl
@@ -174,7 +174,7 @@ should_ignore_failure(<<"validation_failed">>) -> 'true';
 should_ignore_failure(<<"missing_data:", _/binary>>) -> 'true';
 should_ignore_failure(<<"failed_template:", _/binary>>) -> 'true'; %% rendering problems
 should_ignore_failure(<<"template_error:", _/binary>>) -> 'true'; %% rendering problems
-should_ignore_failure(<<"no teletype template modules responded">>) -> 'true'; %% rendering problems
+should_ignore_failure(<<"no teletype template modules responded">>) -> 'true'; %% no module is binded?
 should_ignore_failure(<<"unknown error throw-ed">>) -> 'true';
 
 %% explicitly not ignoring these below:

--- a/core/kazoo_apps/src/kapps_notify_publisher.erl
+++ b/core/kazoo_apps/src/kapps_notify_publisher.erl
@@ -36,8 +36,8 @@
 
 %%--------------------------------------------------------------------
 %% @doc Publish notification and collect notify update messages from
-%%      teletype, useful if you want to make sure teletype proccessed
-%%      the notifaction compeletly (e.g. new voicemail)
+%%      teletype, useful if you want to make sure teletype processed
+%%      the notification completely (e.g. new voicemail)
 %%--------------------------------------------------------------------
 -spec call_collect(api_terms(), kz_amqp_worker:publish_fun()) -> kz_amqp_worker:request_return().
 call_collect(Req, PublishFun) ->
@@ -76,7 +76,7 @@ handle_resp(NotifyType, Req, {'returned', _, Resp}) -> check_for_failure(NotifyT
 handle_resp(NotifyType, Req, {'timeout', _}=Resp) -> check_for_failure(NotifyType, Req, Resp).
 
 %% @private
-%% @doc check for notify update messages from teeltype/notify apps
+%% @doc check for notify update messages from teletype/notify apps
 -spec check_for_failure(api_ne_binary(), api_terms(), {'ok' | 'returned' | 'timeout', kz_json:objects()}) -> 'ok'.
 check_for_failure(NotifyType, Req, {_ErrorType, Responses}=Resp) ->
     case is_completed(Responses) of
@@ -97,7 +97,7 @@ maybe_handle_error(NotifyType, Req, Error) ->
 %% @doc save pay load to db to retry later
 -spec handle_error(ne_binary(), api_terms(), any()) -> 'ok'.
 handle_error(NotifyType, Req, Error) ->
-    lager:warning("attempt for publishing notifcation ~s was unsuccessful: ~p", [NotifyType, Error]),
+    lager:warning("attempt for publishing notification ~s was unsuccessful: ~p", [NotifyType, Error]),
     Props = props:filter_undefined(
               [{<<"description">>, <<"failed to publish notification">>}
               ,{<<"failure_reason">>, error_to_failure_reason(Error)}
@@ -120,7 +120,7 @@ save_pending_notification(_NotifyType, _JObj, Loop) when Loop < 0 ->
 save_pending_notification(NotifyType, JObj, Loop) ->
     case kz_datamgr:save_doc(?KZ_PENDING_NOTIFY_DB, JObj) of
         {'ok', _} ->
-            lager:warning("payload for failed notification ~s publish attempt was saved", [NotifyType]);
+            lager:warning("payload for failed notification ~s publish attempt was saved to ~s", [NotifyType, kz_doc:id(JObj)]);
         {'error', 'not_found'} ->
             kapps_maintenance:refresh(?KZ_PENDING_NOTIFY_DB),
             save_pending_notification(NotifyType, JObj, Loop - 1);


### PR DESCRIPTION
* Don't send fax notifications to reseller if could not find owner email address
* fix issue with finding account_db (found during debugging fax notification)

master: #4211 