### PR TITLE
Rate direction fixes

### DIFF
--- a/core/kazoo_documents/src/kzd_rate.erl
+++ b/core/kazoo_documents/src/kzd_rate.erl
@@ -233,7 +233,12 @@ constrain_weight(X) -> X.
 direction(Rate) ->
     direction(Rate, ?BOTH_DIRECTIONS).
 direction(Rate, Default) ->
-    kz_json:get_list_value(<<"direction">>, Rate, Default).
+    case kz_json:get_value(<<"direction">>, Rate) of
+        <<"inbound">>=V -> [V];
+        <<"outbound">>=V -> [V];
+        'undefined' -> Default;
+        Directions when is_list(Directions) -> Directions
+    end.
 
 -spec set_direction(doc(), ne_binary() | ne_binaries()) -> doc().
 set_direction(Rate, Directions) when is_list(Directions) ->

--- a/core/kazoo_documents/src/kzd_rate.erl
+++ b/core/kazoo_documents/src/kzd_rate.erl
@@ -36,6 +36,8 @@
 
 -include("kz_documents.hrl").
 
+-define(KEY_DIRECTION, <<"direction">>).
+
 -type doc() :: kz_json:object().
 -type docs() :: [doc()].
 -type weight_range() :: 1..100.
@@ -46,7 +48,20 @@
 -spec from_map(map()) -> doc().
 from_map(Map) ->
     Rate = kz_doc:public_fields(kz_json:from_map(Map)),
-    ensure_id(set_type(Rate)).
+    Fs = [fun set_type/1
+         ,fun ensure_id/1
+         ,fun maybe_fix_direction/1
+         ],
+    lists:foldl(fun(F, R) -> F(R) end, Rate, Fs).
+
+-spec maybe_fix_direction(doc()) -> doc().
+maybe_fix_direction(Rate) ->
+    case kz_json:get_value(?KEY_DIRECTION, Rate) of
+        'undefined' -> Rate;
+        L when is_list(L) -> Rate;
+        <<"inbound">> -> set_direction(Rate, [<<"inbound">>]);
+        <<"outbound">> -> set_direction(Rate, [<<"outbound">>])
+    end.
 
 -spec ensure_id(doc()) -> doc().
 -spec ensure_id(doc(), api_ne_binary()) -> doc().


### PR DESCRIPTION
When specifying a direction on a rate doc, it would default to both directions (since binary() is not list()). Add conversion code in from_map/1 to ensure direction is a list of one when specified in the CSV.