### PR TITLE
Update records

### DIFF
--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -101,10 +101,10 @@
                ,sync_ref :: api_reference()
                ,pause_ref :: api_reference()
 
-               ,member_call :: kapps_call:call()
+               ,member_call :: kapps_call:call() | 'undefined'
                ,member_call_id :: api_binary()
                ,member_call_queue_id :: api_binary()
-               ,member_call_start :: kz_now() | undefined
+               ,member_call_start :: kz_now() | 'undefined'
                ,caller_exit_key = <<"#">> :: ne_binary()
                ,queue_notifications :: api_object()
 
@@ -398,7 +398,7 @@ init([AccountId, AgentId, Supervisor, Props, IsThief]) ->
     {'ok'
     ,'wait'
     ,#state{account_id = AccountId
-           ,account_db = kz_util:format_account_id(AccountId, 'encoded')
+           ,account_db = kz_util:format_account_db(AccountId)
            ,agent_id = AgentId
            ,statem_call_id = StateMCallId
            ,max_connect_failures = max_failures(AccountId)

--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -70,7 +70,7 @@
 
 -define(SERVER, ?MODULE).
 
--record(state, {call :: kapps_call:call()
+-record(state, {call :: kapps_call:call() | 'undefined'
                ,acdc_queue_id :: api_ne_binary() % the ACDc Queue ID
                ,msg_queue_id :: api_ne_binary() % the AMQP Queue ID of the ACDc Queue process
                ,agent_id :: api_ne_binary()
@@ -78,8 +78,8 @@
                ,acct_id :: api_ne_binary()
                ,fsm_pid :: api_pid()
                ,agent_queues = [] :: ne_binaries()
-               ,last_connect :: kz_now() | undefined % last connection
-               ,last_attempt :: kz_now() | undefined % last attempt to connect
+               ,last_connect :: kz_now() | 'undefined' % last connection
+               ,last_attempt :: kz_now() | 'undefined' % last attempt to connect
                ,my_id :: ne_binary()
                ,my_q :: api_binary() % AMQP queue name
                ,timer_ref :: api_reference()

--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -83,7 +83,7 @@
                ,my_id :: ne_binary()
                ,my_q :: api_binary() % AMQP queue name
                ,timer_ref :: api_reference()
-               ,sync_resp :: kz_json:object() % furthest along resp
+               ,sync_resp :: api_object() % furthest along resp
                ,supervisor :: pid()
                ,record_calls = 'false' :: boolean()
                ,recording_url :: api_binary() %% where to send recordings after the call
@@ -207,9 +207,9 @@ stop(Srv) -> gen_listener:cast(Srv, {'stop_agent', self()}).
 member_connect_resp(Srv, ReqJObj) ->
     gen_listener:cast(Srv, {'member_connect_resp', ReqJObj}).
 
--spec member_connect_retry(pid(), kz_json:object()) -> 'ok'.
-member_connect_retry(Srv, WinJObj) ->
-    gen_listener:cast(Srv, {'member_connect_retry', WinJObj}).
+-spec member_connect_retry(pid(), ne_binary() | kz_json:object()) -> 'ok'.
+member_connect_retry(Srv, WinOrCallId) ->
+    gen_listener:cast(Srv, {'member_connect_retry', WinOrCallId}).
 
 -spec agent_timeout(pid()) -> 'ok'.
 agent_timeout(Srv) -> gen_listener:cast(Srv, 'agent_timeout').

--- a/applications/acdc/src/acdc_agent_maintenance.erl
+++ b/applications/acdc/src/acdc_agent_maintenance.erl
@@ -68,6 +68,6 @@ agent_restart(AcctId, AgentId) ->
             lager:info("Terminating existing agent process ~p", [S]),
             exit(S, 'kill'),
             lager:info("Restarting agent ~s in ~s", [AgentId, AcctId]),
-            acdc_agents_sup:new(AcctId, AgentId),
+            _ = acdc_agents_sup:new(AcctId, AgentId),
             'ok'
     end.

--- a/applications/acdc/src/acdc_maintenance.erl
+++ b/applications/acdc/src/acdc_maintenance.erl
@@ -295,7 +295,7 @@ flush_call_stat(CallId) ->
             acdc_stats:call_abandoned(kz_json:get_value(<<"Account-ID">>, Call)
                                      ,kz_json:get_value(<<"Queue-ID">>, Call)
                                      ,CallId
-                                     ,<<"INTERNAL_ERROR">>
+                                     ,'INTERNAL_ERROR'
                                      ),
             io:format("setting call to 'abandoned'~n", [])
     end.

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -69,7 +69,7 @@
                ,connection_timer_ref :: api_reference() % how long can a caller wait in the queue
                ,agent_ring_timer_ref :: api_reference() % how long to ring an agent before moving to the next
 
-               ,member_call :: kapps_call:call()
+               ,member_call :: kapps_call:call() | 'undefined'
                ,member_call_start :: api_non_neg_integer()
                ,member_call_winner :: api_object() %% who won the call
 

--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -68,7 +68,7 @@
                ,member_call_queue :: api_ne_binary()
 
                                      %% While processing a call
-               ,call :: kapps_call:call()
+               ,call :: kapps_call:call() | 'undefined'
                ,agent_id :: api_ne_binary()
                ,delivery :: gen_listener:basic_deliver() | 'undefined'
                }).

--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -70,7 +70,7 @@
                                      %% While processing a call
                ,call :: kapps_call:call()
                ,agent_id :: api_ne_binary()
-               ,delivery :: gen_listener:basic_deliver()
+               ,delivery :: gen_listener:basic_deliver() | 'undefined'
                }).
 -type state() :: #state{}.
 

--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -428,7 +428,7 @@ handle_cast({'member_call_cancel', K, JObj}, #state{ignored_member_calls=Dict}=S
     CallId = kz_json:get_value(<<"Call-ID">>, JObj),
     Reason = kz_json:get_value(<<"Reason">>, JObj),
 
-    acdc_stats:call_abandoned(AccountId, QueueId, CallId, Reason),
+    'ok' = acdc_stats:call_abandoned(AccountId, QueueId, CallId, Reason),
     {'noreply', State#state{ignored_member_calls=dict:store(K, 'true', Dict)}};
 handle_cast({'monitor_call', Call}, State) ->
     CallId = kapps_call:call_id(Call),
@@ -560,12 +560,12 @@ handle_cast({'add_queue_member', JObj}, #state{account_id=AccountId
                                             ,Position
                                             ,kapps_call:from_json(kz_json:get_value(<<"Call">>, JObj))),
 
-    acdc_stats:call_waiting(AccountId, QueueId
-                           ,kapps_call:call_id(Call)
-                           ,kapps_call:caller_id_name(Call)
-                           ,kapps_call:caller_id_number(Call)
-                           ,kz_json:get_integer_value(<<"Member-Priority">>, JObj)
-                           ),
+    'ok' = acdc_stats:call_waiting(AccountId, QueueId
+                                  ,kapps_call:call_id(Call)
+                                  ,kapps_call:caller_id_name(Call)
+                                  ,kapps_call:caller_id_number(Call)
+                                  ,kz_json:get_integer_value(<<"Member-Priority">>, JObj)
+                                  ),
 
     publish_queue_member_add(AccountId, QueueId, Call),
 
@@ -978,7 +978,7 @@ cancel_position_announcements(Call, Pids) ->
         Pid ->
             lager:debug("cancelling announcements for ~s", [CallId]),
             Pids1 = maps:remove(CallId, Pids),
-            acdc_announcements_sup:stop_announcements(Pid),
+            _ = acdc_announcements_sup:stop_announcements(Pid),
 
             %% Attempt to skip remaining announcement media, but don't flush hangups
             NoopId = kz_datamgr:get_uuid(),

--- a/applications/acdc/src/acdc_stats.erl
+++ b/applications/acdc/src/acdc_stats.erl
@@ -69,7 +69,7 @@
                   ,api_binary()
                   ,api_binary()
                   ,api_binary()
-                  ) -> 'ok' | {'error', any()}.
+                  ) -> 'ok'.
 call_waiting(AccountId, QueueId, CallId, CallerIdName, CallerIdNumber, CallerPriority) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AccountId}
@@ -81,9 +81,9 @@ call_waiting(AccountId, QueueId, CallId, CallerIdName, CallerIdNumber, CallerPri
              ,{<<"Caller-Priority">>, CallerPriority}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_call_waiting/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_call_waiting/1).
 
--spec call_abandoned(ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
+-spec call_abandoned(ne_binary(), ne_binary(), ne_binary(), atom()) -> 'ok'.
 call_abandoned(AccountId, QueueId, CallId, Reason) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AccountId}
@@ -93,9 +93,9 @@ call_abandoned(AccountId, QueueId, CallId, Reason) ->
              ,{<<"Abandon-Timestamp">>, kz_time:now_s()}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_call_abandoned/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_call_abandoned/1).
 
--spec call_handled(ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
+-spec call_handled(ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 call_handled(AccountId, QueueId, CallId, AgentId) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AccountId}
@@ -105,9 +105,9 @@ call_handled(AccountId, QueueId, CallId, AgentId) ->
              ,{<<"Handled-Timestamp">>, kz_time:now_s()}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_call_handled/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_call_handled/1).
 
--spec call_missed(ne_binary(), ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
+-spec call_missed(ne_binary(), ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 call_missed(AccountId, QueueId, AgentId, CallId, ErrReason) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AccountId}
@@ -118,9 +118,9 @@ call_missed(AccountId, QueueId, AgentId, CallId, ErrReason) ->
              ,{<<"Miss-Timestamp">>, kz_time:now_s()}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_call_missed/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_call_missed/1).
 
--spec call_processed(ne_binary(), ne_binary(), ne_binary(), ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
+-spec call_processed(ne_binary(), ne_binary(), ne_binary(), ne_binary(), atom()) -> 'ok'.
 call_processed(AccountId, QueueId, AgentId, CallId, Initiator) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AccountId}
@@ -131,9 +131,9 @@ call_processed(AccountId, QueueId, AgentId, CallId, Initiator) ->
              ,{<<"Hung-Up-By">>, Initiator}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_call_processed/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_call_processed/1).
 
--spec agent_ready(ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
+-spec agent_ready(ne_binary(), ne_binary()) -> 'ok'.
 agent_ready(AcctId, AgentId) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AcctId}
@@ -142,9 +142,9 @@ agent_ready(AcctId, AgentId) ->
              ,{<<"Status">>, <<"ready">>}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_status_ready/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_ready/1).
 
--spec agent_logged_in(ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
+-spec agent_logged_in(ne_binary(), ne_binary()) -> 'ok'.
 agent_logged_in(AcctId, AgentId) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AcctId}
@@ -153,9 +153,9 @@ agent_logged_in(AcctId, AgentId) ->
              ,{<<"Status">>, <<"logged_in">>}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_status_logged_in/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_logged_in/1).
 
--spec agent_logged_out(ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
+-spec agent_logged_out(ne_binary(), ne_binary()) -> 'ok'.
 agent_logged_out(AcctId, AgentId) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AcctId}
@@ -164,10 +164,10 @@ agent_logged_out(AcctId, AgentId) ->
              ,{<<"Status">>, <<"logged_out">>}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_status_logged_out/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_logged_out/1).
 
--spec agent_connecting(ne_binary(), ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
--spec agent_connecting(ne_binary(), ne_binary(), ne_binary(), api_ne_binary(), api_ne_binary()) -> 'ok' | {'error', any()}.
+-spec agent_connecting(ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
+-spec agent_connecting(ne_binary(), ne_binary(), ne_binary(), api_ne_binary(), api_ne_binary()) -> 'ok'.
 agent_connecting(AcctId, AgentId, CallId) ->
     agent_connecting(AcctId, AgentId, CallId, 'undefined', 'undefined').
 agent_connecting(AcctId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
@@ -181,10 +181,10 @@ agent_connecting(AcctId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
              ,{<<"Caller-ID-Number">>, CallerIDNumber}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_status_connecting/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_connecting/1).
 
--spec agent_connected(ne_binary(), ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
--spec agent_connected(ne_binary(), ne_binary(), ne_binary(), api_ne_binary(), api_ne_binary()) -> 'ok' | {'error', any()}.
+-spec agent_connected(ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
+-spec agent_connected(ne_binary(), ne_binary(), ne_binary(), api_ne_binary(), api_ne_binary()) -> 'ok'.
 agent_connected(AcctId, AgentId, CallId) ->
     agent_connected(AcctId, AgentId, CallId, 'undefined', 'undefined').
 agent_connected(AcctId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
@@ -198,9 +198,9 @@ agent_connected(AcctId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
              ,{<<"Caller-ID-Number">>, CallerIDNumber}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_status_connected/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_connected/1).
 
--spec agent_wrapup(ne_binary(), ne_binary(), pos_integer()) -> 'ok' | {'error', any()}.
+-spec agent_wrapup(ne_binary(), ne_binary(), pos_integer()) -> 'ok'.
 agent_wrapup(AcctId, AgentId, WaitTime) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AcctId}
@@ -210,9 +210,9 @@ agent_wrapup(AcctId, AgentId, WaitTime) ->
              ,{<<"Wait-Time">>, WaitTime}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_status_wrapup/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_wrapup/1).
 
--spec agent_paused(ne_binary(), ne_binary(), api_pos_integer()) -> 'ok' | {'error', any()}.
+-spec agent_paused(ne_binary(), ne_binary(), api_pos_integer()) -> 'ok'.
 agent_paused(AcctId, AgentId, 'undefined') ->
     lager:debug("undefined pause time for ~s(~s)", [AgentId, AcctId]);
 agent_paused(AcctId, AgentId, PauseTime) ->
@@ -224,9 +224,9 @@ agent_paused(AcctId, AgentId, PauseTime) ->
              ,{<<"Pause-Time">>, PauseTime}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_status_paused/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_paused/1).
 
--spec agent_outbound(ne_binary(), ne_binary(), ne_binary()) -> 'ok' | {'error', any()}.
+-spec agent_outbound(ne_binary(), ne_binary(), ne_binary()) -> 'ok'.
 agent_outbound(AcctId, AgentId, CallId) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AcctId}
@@ -236,7 +236,7 @@ agent_outbound(AcctId, AgentId, CallId) ->
              ,{<<"Call-ID">>, CallId}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    kapps_util:amqp_pool_send(Prop, fun kapi_acdc_stats:publish_status_outbound/1).
+    'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_outbound/1).
 
 -spec agent_statuses() -> ne_binaries().
 agent_statuses() ->

--- a/applications/blackhole/src/modules/bh_fax.erl
+++ b/applications/blackhole/src/modules/bh_fax.erl
@@ -55,7 +55,8 @@ bindings(_Context, #{account_id := AccountId
         ,listeners => Listeners
         }.
 
--spec fax_status_bind_options(ne_binary(), ne_binary()) -> kz_proplist().
+-spec fax_status_bind_options(ne_binary(), ne_binary()) ->
+                                     kz_proplist().
 fax_status_bind_options(AccountId, FaxId) ->
     [{'restrict_to', ['status']}
     ,{'account_id', AccountId}
@@ -63,7 +64,8 @@ fax_status_bind_options(AccountId, FaxId) ->
     ,'federate'
     ].
 
--spec fax_object_bind_options(ne_binary(), ne_binary()) -> gen_listener:bindings().
+-spec fax_object_bind_options(ne_binary(), ne_binary()) ->
+                                     kz_proplist().
 fax_object_bind_options(MODB, Action) ->
     [{'keys', [[{'action', Action}
                ,{'db', MODB}

--- a/applications/blackhole/src/modules/bh_skel.erl
+++ b/applications/blackhole/src/modules/bh_skel.erl
@@ -41,7 +41,7 @@ bindings(_Context, #{account_id := AccountId
         ,listeners => Listeners
         }.
 
--spec skel_bind_options(ne_binary(), ne_binary()) -> gen_listener:bindings().
+-spec skel_bind_options(ne_binary(), ne_binary()) -> kz_proplist().
 skel_bind_options(AccountId, MyId) ->
     [{'restrict_to', ['skel.updates']}
     ,{'account_id', AccountId}

--- a/applications/call_inspector/src/parsers/ci_parser_freeswitch.erl
+++ b/applications/call_inspector/src/parsers/ci_parser_freeswitch.erl
@@ -42,8 +42,8 @@
 %% @doc Starts the server
 %%--------------------------------------------------------------------
 -spec start_link([ci_parsers_util:parser_args()]) -> startlink_ret().
-start_link(Args) ->
-    ServerName = ci_parsers_util:make_name(Args),
+start_link([Arg]=Args) ->
+    ServerName = ci_parsers_util:make_name(Arg),
     gen_server:start_link({'local', ServerName}, ?MODULE, Args, []).
 
 %%%===================================================================

--- a/applications/call_inspector/src/parsers/ci_parser_hep.erl
+++ b/applications/call_inspector/src/parsers/ci_parser_hep.erl
@@ -39,8 +39,8 @@
 %% @doc Starts the server
 %%--------------------------------------------------------------------
 -spec start_link([ci_parsers_util:parser_args()]) -> startlink_ret().
-start_link(Args) ->
-    ServerName = ci_parsers_util:make_name(Args),
+start_link([Arg]=Args) ->
+    ServerName = ci_parsers_util:make_name(Arg),
     gen_server:start_link({'local', ServerName}, ?MODULE, Args, []).
 
 %%%===================================================================

--- a/applications/callflow/src/module/cf_camping_feature.erl
+++ b/applications/callflow/src/module/cf_camping_feature.erl
@@ -36,7 +36,7 @@
                ,id :: api_ne_binary()
                ,type :: api_ne_binary()
                ,number :: ne_binary()
-               ,channels :: kz_json:objects()
+               ,channels = [] :: kz_json:objects()
                ,config :: kz_json:object()
                }).
 -type state() :: #state{}.
@@ -162,12 +162,13 @@ get_sip_usernames_for_target(TargetId, TargetType, Call) ->
                       []
               end,
     AccountDb = kapps_call:account_db(Call),
-    props:filter_undefined(
-      [get_device_sip_username(AccountDb, DeviceId)
-       || DeviceId <- Targets
-      ]).
+    [SIPUsername
+     || DeviceId <- Targets,
+        SIPUsername <- [get_device_sip_username(AccountDb, DeviceId)],
+        'undefined' =/= SIPUsername
+    ].
 
--spec get_device_sip_username(ne_binary(), ne_binary()) -> api_binary().
+-spec get_device_sip_username(ne_binary(), ne_binary()) -> api_ne_binary().
 get_device_sip_username(AccountDb, DeviceId) ->
     {'ok', JObj} = kz_datamgr:open_cache_doc(AccountDb, DeviceId),
     kz_device:sip_username(JObj).

--- a/applications/callflow/src/module/cf_dynamic_cid.erl
+++ b/applications/callflow/src/module/cf_dynamic_cid.erl
@@ -58,7 +58,7 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
--spec handle(kz_json:object(), kapps_call:call(), api_binary(), api_binary()) -> 'ok'.
+-spec handle(kz_json:object(), kapps_call:call(), api_ne_binary(), api_ne_binary()) -> 'ok'.
 handle(Data, Call) ->
     CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
     Action = kz_json:get_ne_binary_value(<<"action">>, Data),
@@ -86,7 +86,7 @@ handle(Data, Call, _Manual, CaptureGroup) ->
 %% Handle manual mode of dynamic cid
 %% @end
 %%--------------------------------------------------------------------
--spec handle_manual(kz_json:object(), kapps_call:call(), api_binary()) -> 'ok'.
+-spec handle_manual(kz_json:object(), kapps_call:call(), api_ne_binary()) -> 'ok'.
 handle_manual(Data, Call, CaptureGroup) ->
     CID = collect_cid_number(Data, Call),
     update_call(Call, CID, CaptureGroup),
@@ -99,7 +99,7 @@ handle_manual(Data, Call, CaptureGroup) ->
 %% Handle static mode of dynamic cid
 %% @end
 %%--------------------------------------------------------------------
--spec handle_static(kz_json:object(), kapps_call:call(), api_binary()) -> 'ok'.
+-spec handle_static(kz_json:object(), kapps_call:call(), api_ne_binary()) -> 'ok'.
 handle_static(Data, Call, CaptureGroup) ->
     {CIDName, CIDNumber} = get_static_cid_entry(Data, Call),
     update_call(Call, CIDNumber, CIDName, CaptureGroup),
@@ -110,7 +110,8 @@ handle_static(Data, Call, CaptureGroup) ->
 %% @doc Read CID info from a list of CID defined in database
 %% @end
 %%--------------------------------------------------------------------
--type list_cid_entry() :: {ne_binary(), ne_binary(), ne_binary()} | {'error', kz_datamgr:data_error()}.
+-type list_cid_entry() :: {ne_binary(), ne_binary(), ne_binary()} |
+                          {'error', kz_datamgr:data_error()}.
 
 -spec handle_list(kz_json:object(), kapps_call:call()) -> 'ok'.
 handle_list(Data, Call) ->
@@ -141,7 +142,7 @@ proceed_with_call(NewCallerIdName, NewCallerIdNumber, Dest, Data, Call) ->
 %% request, to and callee_number
 %% @end
 %%--------------------------------------------------------------------
--spec update_call(kapps_call:call(), ne_binary(), api_ne_binary()) -> kapps_call:call().
+-spec update_call(kapps_call:call(), ne_binary(), api_ne_binary()) -> 'ok'.
 update_call(Call, CIDNumber, CaptureGroup) ->
     Updates = [{fun kapps_call:kvs_store/3, 'dynamic_cid', CIDNumber}
               ,{fun kapps_call:set_caller_id_number/2, CIDNumber}
@@ -157,7 +158,7 @@ update_call(Call, CIDNumber, CaptureGroup) ->
 %% @doc Same as update_call/3, but also sets caller id name
 %% @end
 %%--------------------------------------------------------------------
--spec update_call(kapps_call:call(), ne_binary(), ne_binary(), api_ne_binary()) -> kapps_call:call().
+-spec update_call(kapps_call:call(), ne_binary(), ne_binary(), api_ne_binary()) -> 'ok'.
 update_call(Call, CIDNumber, CIDName, CaptureGroup) ->
     Updates = [{fun kapps_call:kvs_store/3, 'dynamic_cid', {CIDNumber, CIDName}}
               ,{fun kapps_call:set_caller_id_number/2, CIDNumber}
@@ -178,7 +179,7 @@ update_call(Call, CIDNumber, CIDName, CaptureGroup) ->
 %% @doc If CaptureGroup exists correct request, to and callee_id_number
 %% @end
 %%--------------------------------------------------------------------
--spec maybe_strip_features_code(kapps_call:call(), api_ne_binary()) -> kapps_call:call().
+-spec maybe_strip_features_code(kapps_call:call(), api_ne_binary()) -> 'ok'.
 maybe_strip_features_code(Call, 'undefined') ->
     cf_exe:set_call(Call);
 maybe_strip_features_code(Call, CaptureGroup) ->

--- a/applications/callflow/src/module/cf_prepend_cid.erl
+++ b/applications/callflow/src/module/cf_prepend_cid.erl
@@ -20,7 +20,7 @@
 handle(Data, Call) ->
     handle(Data, Call, kz_json:get_ne_binary_value(<<"action">>, Data, <<"prepend">>)).
 
--spec handle(ne_binary(), kz_json:object(), kapps_call:call()) -> 'ok'.
+-spec handle(kz_json:object(), kapps_call:call(), ne_binary()) -> 'ok'.
 handle(_Data, Call, <<"reset">>) ->
     lager:info("reset prepend cid"),
     set_values('undefined', 'undefined', Call);
@@ -44,7 +44,7 @@ handle(Data, Call, <<"prepend">>) ->
     lager:info("update prepend cid to <~s> ~s", [Name, Number]),
     set_values(Name, Number, Call).
 
--spec set_values(api_binary(), api_binary(), kapps_call:call()) -> 'ok'.
+-spec set_values(api_ne_binary(), api_ne_binary(), kapps_call:call()) -> 'ok'.
 set_values(Name, Number, Call) ->
     Updates = [fun(C) -> kapps_call:kvs_store('prepend_cid_number', Number, C) end
               ,fun(C) -> kapps_call:kvs_store('prepend_cid_name', Name, C) end

--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -38,8 +38,7 @@ handle(Data, Call, <<"start">>) ->
 handle(_Data, Call, <<"stop">>) ->
     cf_exe:update_call(kapps_call:stop_recording(Call)).
 
--spec get_action(api_object()) -> ne_binary().
-get_action('undefined') -> <<"start">>;
+-spec get_action(kz_json:object()) -> ne_binary().
 get_action(Data) ->
     case kz_json:get_ne_binary_value(<<"action">>, Data) of
         <<"stop">> -> <<"stop">>;

--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -1626,12 +1626,12 @@ delete_mod_dbs(AccountId, Year, Month) ->
 delete_remove_from_accounts(Context) ->
     case kz_datamgr:open_doc(?KZ_ACCOUNTS_DB, cb_context:account_id(Context)) of
         {'ok', JObj} ->
-            crossbar_doc:delete(
-              cb_context:setters(Context
-                                ,[{fun cb_context:set_account_db/2, ?KZ_ACCOUNTS_DB}
-                                 ,{fun cb_context:set_doc/2, JObj}
-                                 ])
-             );
+            UpdatedContext = cb_context:setters(Context
+                                               ,[{fun cb_context:set_account_db/2, ?KZ_ACCOUNTS_DB}
+                                                ,{fun cb_context:set_doc/2, JObj}
+                                                ]),
+            crossbar_doc:delete(UpdatedContext);
+
         {'error', 'not_found'} ->
             crossbar_util:response(kz_json:new(), Context);
         {'error', _R} ->

--- a/applications/crossbar/src/modules/cb_auth.erl
+++ b/applications/crossbar/src/modules/cb_auth.erl
@@ -308,8 +308,11 @@ validate_path(Context, ?PROVIDERS_PATH, Id, ?HTTP_POST) ->
 validate_path(Context, ?PROVIDERS_PATH, Id, ?HTTP_DELETE) ->
     Options = [{'key', Id}],
     case kz_datamgr:get_result_keys(cb_context:account_db(Context), ?PROVIDERS_APP_VIEW, Options) of
-        [] -> Context;
-        _ -> cb_context:add_system_error(<<"apps exist for provider">>, Context)
+        {'ok', []} -> Context;
+        {'ok', _} -> cb_context:add_system_error(<<"apps exist for provider">>, Context);
+        {'error', _E} ->
+            lager:info("failed to get result keys: ~p", [_E]),
+            cb_context:add_system_error(<<"datastore error">>, Context)
     end;
 
 %% validating /auth/links/{link_id}

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -320,7 +320,7 @@ load_interaction_cdr_summary(Context, _Nouns) ->
 -spec load_cdr_summary(cb_context:context()) -> cb_context:context().
 load_cdr_summary(Context) ->
     lager:debug("loading cdr summary for account ~s", [cb_context:account_id(Context)]),
-    case create_view_options(undefined, fun create_summary_view_options/4, Context) of
+    case create_view_options('undefined', fun create_summary_view_options/4, Context) of
         {'ok', ViewOptions} ->
             AccountId = cb_context:account_id(Context),
             DBs = chunked_dbs(AccountId, ViewOptions, fun view_option/2),
@@ -414,7 +414,7 @@ create_view_options(OwnerId, Context, CreatedFrom, CreatedTo) ->
        ])
     }.
 
--spec create_interaction_view_options(api_binary(), cb_context:context(), pos_integer(), pos_integer()) ->
+-spec create_interaction_view_options(api_ne_binary(), cb_context:context(), pos_integer(), pos_integer()) ->
                                              {'ok', crossbar_doc:view_options()}.
 create_interaction_view_options('undefined', Context, CreatedFrom, CreatedTo) ->
     StartKey = maybe_get_start_key_from_req(Context, [CreatedTo]),
@@ -449,9 +449,9 @@ create_interaction_view_options(OwnerId, Context, CreatedFrom, CreatedTo) ->
 maybe_add_stale_to_options(true) -> [{stale, ok}];
 maybe_add_stale_to_options(_) ->[].
 
--spec create_summary_view_options(api_binary(), cb_context:context(), pos_integer(), pos_integer()) ->
+-spec create_summary_view_options(api_ne_binary(), cb_context:context(), pos_integer(), pos_integer()) ->
                                          {'ok', crossbar_doc:view_options()}.
-create_summary_view_options(Context, _, CreatedFrom, CreatedTo) ->
+create_summary_view_options(_, Context, CreatedFrom, CreatedTo) ->
     StartKey = maybe_get_start_key_from_req(Context, CreatedTo),
     {'ok', [{'startkey', StartKey}
            ,{'endkey', CreatedFrom}
@@ -471,8 +471,6 @@ pagination_page_size(Context) ->
     case cb_context:should_paginate(Context)
         andalso cb_context:pagination_page_size(Context)
     of
-        'false' -> 'undefined';
-        'undefined' -> 'undefined';
         PageSize when is_integer(PageSize) -> PageSize + 1;
         _ -> 'undefined'
     end.

--- a/applications/crossbar/src/modules/provisioner_v5.erl
+++ b/applications/crossbar/src/modules/provisioner_v5.erl
@@ -351,23 +351,23 @@ settings_keys(Assoc, KeyKind, JObj) ->
 
 -spec get_label(binary(), binary()) -> binary().
 get_label(AccountId, DocId) ->
-    AccountDb = kz_util:format_account_id(AccountId, 'encoded'),
-    Doc = kz_datamgr:open_cache_doc(AccountDb, DocId),
+    AccountDb = kz_util:format_account_db(AccountId),
+    {'ok', Doc} = kz_datamgr:open_cache_doc(AccountDb, DocId),
 
     get_label(Doc).
 
 -spec get_label(kz_json:object()) -> binary().
 get_label(Doc) ->
-    case {kz_json:get_value(<<"first_name">>, Doc), kz_json:get_value(<<"last_name">>, Doc)} of
+    case {kz_json:get_ne_binary_value(<<"first_name">>, Doc)
+         ,kz_json:get_ne_binary_value(<<"last_name">>, Doc)
+         }
+    of
         {'undefined', 'undefined'} ->
             kz_json:get_value(<<"name">>, Doc);
-
         {First, 'undefined'} ->
             First;
-
         {'undefined', Last} ->
             Last;
-
         {First, Last} ->
             <<First/binary, " ", Last/binary>>
     end.

--- a/applications/ecallmgr/src/ecallmgr_fs_conferences.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_conferences.erl
@@ -654,9 +654,7 @@ xml_attr_to_conference(Conference, 'exit_sound', Value) ->
 xml_attr_to_conference(Conference, 'enter_sound', Value) ->
     Conference#conference{enter_sound=kz_term:is_true(Value)};
 xml_attr_to_conference(Conference, 'run_time', Value) ->
-    Conference#conference{start_time=kz_time:decr_timeout(kz_time:now_s()
-                                                         ,kz_term:to_integer(Value)
-                                                         )};
+    Conference#conference{start_time=kz_time:now_s() - kz_term:to_integer(Value)};
 xml_attr_to_conference(Conference, _Name, _Value) ->
     lager:debug("unhandled conference k/v ~s: ~p", [_Name, _Value]),
     Conference.

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -156,9 +156,6 @@ handle_DATA(From, [To|_]=ToList, Data, #state{to='undefined'}=State) ->
     handle_DATA(From, ToList, Data, State#state{to=To});
 handle_DATA(From, To, Data, #state{doc='undefined'}=State) ->
     case check_faxbox(State) of
-        {'ok', #state{doc='undefined'}=NewState} ->
-            lager:error("check_faxbox returned no error but also no doc : ~p", [NewState]),
-            {'error', "552 unable to process", NewState};
         {'ok', NewState} -> handle_DATA(From, To, Data, NewState);
         Error -> Error
     end;

--- a/applications/hotornot/src/hon_util.erl
+++ b/applications/hotornot/src/hon_util.erl
@@ -277,7 +277,7 @@ options_match(RateOptions, RouteOptions) ->
              ,RouteOptions
              ).
 
--spec maybe_add_resource_flag(kapi_rate:req(), ne_binary()) -> kz_proplist().
+-spec maybe_add_resource_flag(kapi_rate:req(), ne_binary()) -> ne_binaries().
 maybe_add_resource_flag(RateReq, AccountId) ->
     case hotornot_config:should_account_filter_by_resource(AccountId) of
         'true' ->

--- a/applications/jonny5/src/jonny5_maintenance.erl
+++ b/applications/jonny5/src/jonny5_maintenance.erl
@@ -239,7 +239,7 @@ pretty_print_field(Name, Value) when is_number(Value) ->
 pretty_print_field(Name, Value) ->
     io:format("~-25s: ~s~n", [Name, Value]).
 
--spec current_balance(ne_binary()) -> ne_binary().
+-spec current_balance(ne_binary()) -> iolist().
 current_balance(AccountId) ->
     case wht_util:current_balance(AccountId) of
         {'ok', Balance} -> kz_term:to_list(wht_util:units_to_dollars(Balance));

--- a/applications/konami/src/konami_code_statem.erl
+++ b/applications/konami/src/konami_code_statem.erl
@@ -512,7 +512,7 @@ add_bleg_dtmf(#state{b_collected_dtmf=Collected
                ,b_collected_dtmf = maybe_fast_rearm(DTMF, BindingDigit, Collected)
                }.
 
--spec maybe_add_call_event_bindings(api_binary() | kapps_call:call()) -> 'ok'.
+-spec maybe_add_call_event_bindings(api_ne_binary() | kapps_call:call()) -> 'ok'.
 -spec maybe_add_call_event_bindings(kapps_call:call(), listen_on()) -> 'ok'.
 maybe_add_call_event_bindings('undefined') -> 'ok';
 maybe_add_call_event_bindings(<<_/binary>> = Leg) -> konami_event_listener:add_call_binding(Leg);

--- a/applications/konami/src/module/konami_transfer.erl
+++ b/applications/konami/src/module/konami_transfer.erl
@@ -91,18 +91,20 @@
 
 -define(TRANSFEREE_CALL_EVENTS, ?TRANSFEROR_CALL_EVENTS).
 
--define(TARGET_CALL_EVENTS, [<<"CHANNEL_CREATE">>
-                            ,<<"CHANNEL_BRIDGE">>
+-define(TARGET_CALL_EVENTS, [<<"CHANNEL_BRIDGE">>
+                            ,<<"CHANNEL_CREATE">>
                             ,<<"CHANNEL_DESTROY">>
-                            ,<<"DTMF">>, <<"CHANNEL_REPLACED">>
+                            ,<<"CHANNEL_REPLACED">>
+                            ,<<"DTMF">>
+                            ,<<"LEG_CREATED">>
+                            ,<<"LEG_DESTROYED">>
                             ,<<"dialplan">>
-                            ,<<"LEG_CREATED">>, <<"LEG_DESTROYED">>
                             ]).
 
 -spec handle(kz_json:object(), kapps_call:call()) -> no_return().
 handle(Data, Call) ->
     kapps_call:put_callid(Call),
-    Transferor = kz_json:get_value(<<"dtmf_leg">>, Data),
+    Transferor = kz_json:get_ne_binary_value(<<"dtmf_leg">>, Data),
     Transferee =
         case kapps_call:call_id(Call) of
             Transferor -> kapps_call:other_leg_call_id(Call);

--- a/applications/notify/src/notify_transaction.erl
+++ b/applications/notify/src/notify_transaction.erl
@@ -159,11 +159,12 @@ transaction_data(Event) ->
      ).
 
 %% amount is expected to be in dollars
--spec get_transaction_amount(kz_proplist()) -> api_binary().
+-spec get_transaction_amount('undefined' | kz_proplist()) -> api_float().
+get_transaction_amount('undefined') -> 'undefined';
 get_transaction_amount(Props) ->
-    case kz_term:to_float(props:get_value(<<"amount">>, Props)) of
+    case props:get_value(<<"amount">>, Props) of
         'undefined' -> 'undefined';
-        Amount -> Amount
+        Amount -> kz_term:to_float(Amount)
     end.
 
 -spec purchase_order(kz_proplist()) -> binary().

--- a/applications/tasks/src/knm_number_crawler.erl
+++ b/applications/tasks/src/knm_number_crawler.erl
@@ -27,22 +27,24 @@
 
 -define(SERVER, ?MODULE).
 
--define(NUMBERS_TO_CRAWL,
-        kapps_config:get_pos_integer(?SYSCONFIG_COUCH, <<"default_chunk_size">>, 1000)).
+-define(NUMBERS_TO_CRAWL
+       ,kapps_config:get_pos_integer(?SYSCONFIG_COUCH, <<"default_chunk_size">>, 1000)
+       ).
 
--define(DISCOVERY_EXPIRY,
-        kapps_config:get_non_neg_integer(?CONFIG_CAT, <<"discovery_expiry_d">>, 1)).
+-define(DISCOVERY_EXPIRY
+       ,kapps_config:get_non_neg_integer(?CONFIG_CAT, <<"discovery_expiry_d">>, 1)
+       ).
 
--define(AGING_EXPIRY,
-        kapps_config:get_non_neg_integer(?CONFIG_CAT, <<"aging_expiry_d">>, 90)).
+-define(AGING_EXPIRY
+       ,kapps_config:get_non_neg_integer(?CONFIG_CAT, <<"aging_expiry_d">>, 90)
+       ).
 
--define(TIME_BETWEEN_CRAWLS,
-        kapps_config:get_non_neg_integer(?CONFIG_CAT, <<"crawler_timer_ms">>, ?MILLISECONDS_IN_DAY)).
+-define(TIME_BETWEEN_CRAWLS
+       ,kapps_config:get_non_neg_integer(?CONFIG_CAT, <<"crawler_timer_ms">>, ?MILLISECONDS_IN_DAY)
+       ).
 
--record(state, {cleanup_ref :: reference()
-               }).
+-record(state, {cleanup_ref :: reference()}).
 -type state() :: #state{}.
-
 
 %%%===================================================================
 %%% API

--- a/applications/tasks/src/kz_notify_resend.erl
+++ b/applications/tasks/src/kz_notify_resend.erl
@@ -336,7 +336,6 @@ db_bulk_result(JObj) ->
     end.
 
 -spec handle_result(kz_amqp_worker:request_return()) -> boolean().
-handle_result('ok') -> 'true';
 handle_result({'ok', Resp}) -> is_completed(Resp);
 handle_result({'error', [Error|_]=List}) ->
     case kz_json:is_json_object(Error) of
@@ -440,7 +439,7 @@ collecting([JObj|_]) ->
         _ -> 'false'
     end.
 
--spec is_completed(kz_json:objects()) -> boolean().
+-spec is_completed(kz_json:object() | kz_json:objects()) -> boolean().
 is_completed([]) -> 'false';
 is_completed([JObj|_]) ->
     case kapi_notifications:notify_update_v(JObj)
@@ -450,4 +449,5 @@ is_completed([JObj|_]) ->
         %% FIXME: Is pending enough to consider publish was successful? at least teletype received the notification!
         %% <<"pending">> -> 'true';
         _ -> 'false'
-    end.
+    end;
+is_completed(JObj) -> is_completed([JObj]).

--- a/applications/webhooks/src/webhooks_shared_listener.erl
+++ b/applications/webhooks/src/webhooks_shared_listener.erl
@@ -188,10 +188,9 @@ remove_account_bindings() ->
 
 add_responder() ->
     gen_listener:add_responder(?SERVER
-                              ,{'webhooks_init', 'maybe_init_account'}
+                              ,fun webhooks_init:maybe_init_account/2
                               ,[{<<"configuration">>, ?DB_CREATED}]
                               ).
-
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/core/amqp_cron/src/amqp_cron.erl
+++ b/core/amqp_cron/src/amqp_cron.erl
@@ -339,9 +339,10 @@ send_tasks(Tasks, Election) ->
     case amqp_leader_proc:alive(Election) -- [node()] of
         [] -> 'ok';
         Alive ->
-            Election = amqp_leader_proc:broadcast({'from_leader', {'tasks', Tasks}},
-                                                  Alive,
-                                                  Election),
+            Election = amqp_leader_proc:broadcast({'from_leader', {'tasks', Tasks}}
+                                                 ,Alive
+                                                 ,Election
+                                                 ),
             'ok'
     end.
 

--- a/core/amqp_leader/src/amqp_leader_proc.erl
+++ b/core/amqp_leader/src/amqp_leader_proc.erl
@@ -138,7 +138,9 @@ workers(_) -> [].
 -spec candidates(sign()) -> atoms().
 candidates(_) -> [node()].
 
--spec broadcast(atom(), atoms(), sign()) -> sign().
+-type msg() :: {'from_leader', any()}.
+
+-spec broadcast(msg(), atoms(), sign()) -> sign().
 broadcast(Msg, _Nodes, #sign{name = Name} = Sign) ->
     send({Name, 'broadcast'}, Msg),
     Sign.

--- a/core/gcm/src/gcm.erl
+++ b/core/gcm/src/gcm.erl
@@ -8,6 +8,7 @@
 
 -export([push/3, push/4, sync_push/3, sync_push/4]).
 
+-include_lib("kazoo_stdlib/include/kz_types.hrl").
 -include_lib("kazoo_stdlib/include/kz_log.hrl").
 
 -define(SERVER, ?MODULE).
@@ -34,11 +35,11 @@ start(Name, Key) ->
 stop(Name) ->
     gen_server:call(Name, stop).
 
--spec push(atom(), list(), any()) -> ok.
+-spec push(server_ref(), list(), any()) -> ok.
 push(Name, RegIds, Message) ->
     push(Name, RegIds, Message, ?RETRY).
 
--spec push(atom(), list(), any(), non_neg_integer()) -> ok.
+-spec push(server_ref(), list(), any(), non_neg_integer()) -> ok.
 push(Name, RegIds, Message, Retry) ->
     gen_server:cast(Name, {send, RegIds, Message, Retry}).
 

--- a/core/kazoo_amqp/include/kz_api.hrl
+++ b/core/kazoo_amqp/include/kz_api.hrl
@@ -3,7 +3,7 @@
 -include_lib("kazoo/include/kz_api_literals.hrl").
 
 -type api_formatter_return() :: {'ok', iolist()} | {'error', string()}.
--type api_headers() :: ne_binaries() | [ne_binaries()].
+-type api_headers() :: ne_binaries() | [ne_binary() | ne_binaries()].
 
 -type api_types() :: [{ne_binary(), fun()}].
 -type valid_value() :: ne_binary() | integer().

--- a/core/kazoo_amqp/src/api/kz_api.erl
+++ b/core/kazoo_amqp/src/api/kz_api.erl
@@ -484,19 +484,19 @@ add_optional_headers(Prop, Fields, Headers) ->
                 end, {Headers, Prop}, Fields).
 
 %% Checks Prop against a list of required headers, returns true | false
--spec has_all(kz_proplist() | kz_proplists(), api_headers()) -> boolean().
+-spec has_all(kz_proplist(), api_headers()) -> boolean().
 has_all(Prop, Headers) ->
     lists:all(fun(Header) -> has_all_header(Header, Prop) end, Headers).
 
--spec has_all_header(kz_proplist() | kz_proplists(), api_headers()) -> boolean().
-has_all_header(Header, Prop) when is_list(Header) ->
-    case has_any(Prop, Header) of
+-spec has_all_header(api_headers(), kz_proplist()) -> boolean().
+has_all_header(Headers, Prop) when is_list(Headers) ->
+    case has_any(Prop, Headers) of
         'true' -> 'true';
         'false' ->
-            lager:debug("failed to find one of keys '~p' on API message", [Header]),
+            lager:debug("failed to find one of keys '~p' on API message", [Headers]),
             'false'
     end;
-has_all_header(Header, Prop) ->
+has_all_header(Header, Prop) when is_binary(Header) ->
     case props:is_defined(Header, Prop) of
         'true' -> 'true';
         'false' ->

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -278,7 +278,7 @@ enter_loop(Module, Options, ModuleState, ServerName, Timeout) ->
     gen_server:enter_loop(?MODULE, [], MyState, ServerName, Timeout).
 
 -spec add_responder(server_ref(), responder_callback(), responder_callback_mapping() | responder_callback_mappings()) -> 'ok'.
-add_responder(Srv, Responder, Key) when not is_list(Key) ->
+add_responder(Srv, Responder, {_,_}=Key) ->
     add_responder(Srv, Responder, [Key]);
 add_responder(Srv, Responder, [{_,_}|_] = Keys) ->
     gen_server:cast(Srv, {'add_responder', Responder, Keys}).

--- a/core/kazoo_amqp/src/listener_types.hrl
+++ b/core/kazoo_amqp/src/listener_types.hrl
@@ -28,12 +28,16 @@
                          {'auto_ack', boolean()}
                         ].
 
--type responder_callback_fun2() :: fun((kz_json:object(), kz_proplist()) -> no_return()).
--type responder_callback_fun3() :: fun((kz_json:object(), kz_proplist(), basic_deliver()) -> no_return()).
--type responder_callback_fun4() :: fun((kz_json:object(), kz_proplist(), basic_deliver(), amqp_basic()) -> no_return()).
--type responder_callback_fun() :: responder_callback_fun2() | responder_callback_fun3() | responder_callback_fun4().
+-type responder_callback_fun2() :: fun((kz_json:object(), kz_proplist()) -> any()).
+-type responder_callback_fun3() :: fun((kz_json:object(), kz_proplist(), basic_deliver()) -> any()).
+-type responder_callback_fun4() :: fun((kz_json:object(), kz_proplist(), basic_deliver(), amqp_basic()) -> any()).
+-type responder_callback_fun() :: responder_callback_fun2() |
+                                  responder_callback_fun3() |
+                                  responder_callback_fun4().
 
--type responder_callback() :: module() | {module(), function()} | responder_callback_fun().
+-type responder_callback() :: module() |
+                              {module(), atom()} |
+                              responder_callback_fun().
 -type responder_callback_mapping() :: {ne_binary(), ne_binary()}.
 -type responder_callback_mappings() :: [responder_callback_mapping()].
 
@@ -42,7 +46,7 @@
 -type responder_mfa() :: mfa() | {responder_callback_fun(), arity()}.
 
 %% { {Event-Category, Event-Name}, CallbackModule | {CallbackModule, Function} | CallbackFun}
--type responder() :: {responder_callback_mapping(), responder_mfa() }.
+-type responder() :: {responder_callback_mapping(), responder_mfa()}.
 -type responders() :: [responder()].
 
 -define(KZ_LISTENER_TYPES_HRL, 'true').

--- a/core/kazoo_amqp/src/listener_utils.erl
+++ b/core/kazoo_amqp/src/listener_utils.erl
@@ -22,30 +22,39 @@
              ,responders/0
              ]).
 
--spec add_responder(responders(), responder_callback(), kz_json:json_proplist()) -> responders().
+-spec add_responder(responders(), responder_callback(), responder_callback_mapping()) -> responders().
 add_responder(Responders, Responder, Keys) when is_atom(Responder) ->
     add_responder(Responders, {Responder, ?DEFAULT_CALLBACK}, Keys);
 add_responder(Responders, Responder, Keys) ->
     _ = maybe_init_responder(Responder, is_responder_known(Responders, Responder)),
     case responder(Responder) of
         'undefined' -> Responders;
-        ResponderMFA -> lists:foldr(fun maybe_add_mapping/2, Responders, [{Evt, ResponderMFA} || Evt <- Keys])
+        ResponderMFA -> update_responders(Responders, ResponderMFA, Keys)
     end.
 
--spec rm_responder(responders(), responder_callback(), kz_json:json_proplist()) -> responders().
+-spec update_responders(responders(), responder_mfa(), responder_callback_mappings()) ->
+                               responders().
+update_responders(Responders, ResponderMFA, Keys) ->
+    lists:foldr(fun maybe_add_mapping/2
+               ,Responders
+               ,[{Evt, ResponderMFA} || Evt <- Keys]
+               ).
+
+-spec rm_responder(responders(), responder_callback(), responder_callback_mapping()) ->
+                          responders().
 %% remove all events for responder
 rm_responder(Responders, Responder, Keys) when is_atom(Responder) ->
     rm_responder(Responders, {Responder, ?DEFAULT_CALLBACK}, Keys);
 rm_responder(Responders, Responder, []) ->
-    [ N || {_, Module}=N <- Responders, Module =/= Responder];
+    [N || {_, Module}=N <- Responders, Module =/= Responder];
 %% remove events in Keys for module Responder
 rm_responder(Responders, Responder, Keys) ->
     %% if Evt is in the list of Keys and Module =:= Responder, remove it from the list of Responders
-    [ N || {Evt, Module}=N <- Responders,
-           (not (Module =:= Responder
-                 andalso lists:member(Evt, Keys)
-                )
-           )
+    [N || {Evt, Module}=N <- Responders,
+          (not (Module =:= Responder
+                andalso lists:member(Evt, Keys)
+               )
+          )
     ].
 
 %%--------------------------------------------------------------------
@@ -60,6 +69,7 @@ is_responder_known(Responders, {Responder,_}=Callback) ->
 is_responder_known(_Responders, Callback)
   when is_function(Callback) -> 'false'.
 
+-spec maybe_load_responder(module()) -> 'ok'.
 maybe_load_responder(Responder) ->
     case erlang:module_loaded(Responder) of
         'true' -> 'ok';
@@ -78,30 +88,34 @@ maybe_add_mapping(Mapping, Acc) ->
         'false' -> [Mapping | Acc]
     end.
 
--spec filter_responder_fun([tuple()], atom()) -> [tuple()].
+-type export() :: {atom(), arity()}.
+-type exports() :: [export()].
+
+-spec filter_responder_fun(exports(), atom()) -> exports().
 filter_responder_fun(Exports, Fun) ->
-    lists:filter(fun({ExportedFun, _}) -> ExportedFun =:= Fun end, Exports).
+    lists:keysort(2, lists:filter(fun({ExportedFun, _}) -> ExportedFun =:= Fun end, Exports)).
 
 -spec responder_mfa(module(), atom()) -> mfa() | 'undefined'.
 responder_mfa(Module, Fun) ->
-    Exports = Module:module_info(exports),
+    Exports = Module:module_info('exports'),
     case filter_responder_fun(Exports, Fun) of
         [] -> 'undefined';
         [{_, I} | _] -> {Module, Fun, I}
     end.
 
--spec responder({module(), atom()} | responder_callback_fun()) -> responder() | 'undefined'.
-responder({Module, Fun}) ->
+-spec responder(responder_callback()) -> responder_mfa() | 'undefined'.
+responder({Module, Fun}) when is_atom(Module), is_atom(Fun) ->
     responder_mfa(Module, Fun);
 responder(CallbackFun)
   when is_function(CallbackFun, 2);
        is_function(CallbackFun, 3);
        is_function(CallbackFun, 4) ->
-    {'arity', Arity} = erlang:fun_info(CallbackFun,arity),
+    {'arity', Arity} = erlang:fun_info(CallbackFun, 'arity'),
     {CallbackFun, Arity};
 responder(_) -> 'undefined'.
 
 -spec maybe_init_responder(responder_callback(), boolean()) -> 'ok'.
+maybe_init_responder(_, 'false') -> 'ok';
 maybe_init_responder({Responder, _Fun}, 'true') when is_atom(Responder) ->
     try Responder:init() of
         _Init ->
@@ -111,5 +125,4 @@ maybe_init_responder({Responder, _Fun}, 'true') when is_atom(Responder) ->
             ST = erlang:get_stacktrace(),
             lager:debug("responder ~s crashed: ~s: ~p", [Responder, _E, _R]),
             kz_util:log_stacktrace(ST)
-    end;
-maybe_init_responder(_, 'false') -> 'ok'.
+    end.

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -477,11 +477,11 @@ db_compact(DbName) ->
 %% Delete a database (takes an 'encoded' DbName)
 %% @end
 %%--------------------------------------------------------------------
--spec db_delete(text()) -> 'ok' | data_error().
+-spec db_delete(text()) -> boolean().
+-spec db_delete(text(), db_delete_options()) -> boolean().
 db_delete(DbName) ->
     db_delete(DbName, []).
 
--spec db_delete(text(), db_delete_options()) -> 'ok' | data_error().
 db_delete(DbName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_delete(kzs_plan:plan(DbName), DbName, Options);
 db_delete(DbName, Options) ->

--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -47,8 +47,8 @@
 -include_lib("kazoo_stdlib/include/kazoo_json.hrl").
 -include("knm.hrl").
 
--record(knm_number, {knm_phone_number :: knm_phone_number:knm_phone_number()
-                    ,services :: kz_services:services()
+-record(knm_number, {knm_phone_number :: knm_phone_number:knm_phone_number() | 'undefined'
+                    ,services :: kz_services:services() | 'undefined'
                     ,transactions = [] :: kz_transaction:transactions()
                     ,charges = [] :: [{ne_binary(), non_neg_integer()}]
                     }).

--- a/core/kazoo_token_buckets/src/kz_buckets.erl
+++ b/core/kazoo_token_buckets/src/kz_buckets.erl
@@ -52,7 +52,7 @@
        ,kapps_config:get_integer(?APP_NAME, [App, <<"tokens_fill_rate">>], ?FILL_RATE)
        ).
 
--record(state, {table_id :: ets:tid()
+-record(state, {table_id :: ets:tid() | 'undefined'
                ,inactivity_timer_ref :: reference()
                }).
 -type state() :: #state{}.
@@ -302,6 +302,14 @@ init([]) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec handle_call(any(), pid_ref(), state()) -> handle_call_ret_state(state()).
+handle_call({'start', _App, _Name, _MaxTokens, _FillRate, _FillTime}
+           ,_From
+           ,#state{table_id='undefined'}=State
+           ) ->
+    lager:debug("not starting token bucket for ~p ~p, table not ready"
+               ,[_App, _Name]
+               ),
+    {'reply', 'error', State};
 handle_call({'start', App, Name, MaxTokens, FillRate, FillTime}, _From, #state{table_id=Tbl}=State) ->
     lager:debug("maybe starting token bucket for ~s, ~s (~b at ~b/~s)"
                ,[App, Name, MaxTokens, FillRate, FillTime]

--- a/core/kazoo_translator/src/kzt_receiver.erl
+++ b/core/kazoo_translator/src/kzt_receiver.erl
@@ -26,7 +26,7 @@
                   ,hangup_dtmf :: api_binary()
                   ,collect_dtmf = 'false' :: boolean()
                   ,record_call :: boolean()
-                  ,call_timeout :: kz_timeout()
+                  ,call_timeout :: kz_timeout() | 'undefined'
                   ,call_time_limit :: kz_timeout()
                   ,start :: kz_now()
                   ,call_b_leg :: api_binary()
@@ -524,9 +524,8 @@ handle_dtmf_event(#dial_req{call=Call
             lager:info("collecting dtmf ~s", [DTMF]),
             LoopFun(
               update_offnet_timers(
-                DialReq#dial_req{
-                  call=kzt_util:add_digit_collected(DTMF, Call)
-                 }));
+                DialReq#dial_req{call=kzt_util:add_digit_collected(DTMF, Call)}
+               ));
         _DTMF ->
             lager:info("caller pressed dtmf tone but we're not collecting it"),
             wait_for_offnet_events(update_offnet_timers(DialReq))
@@ -681,10 +680,9 @@ recording_name(ALeg, BLeg) ->
     iolist_to_binary([DateTime, "_", ALeg, "_to_", BLeg, ".mp3"]).
 
 -spec handle_offnet_timeout(dial_req()) -> {'ok', kapps_call:call()}.
-handle_offnet_timeout(#dial_req{
-                         call=Call
+handle_offnet_timeout(#dial_req{call=Call
                                ,call_timeout='undefined'
-                        }) ->
+                               }) ->
     lager:info("call timeout exceeded"),
     kapps_call_command:hangup(Call),
     {'ok', kzt_util:update_call_status(?STATUS_COMPLETED, Call)};
@@ -693,10 +691,9 @@ handle_offnet_timeout(#dial_req{call=Call}) ->
     {'ok', kzt_util:update_call_status(?STATUS_NOANSWER, Call)}.
 
 -spec handle_conference_timeout(dial_req()) -> {'ok', kapps_call:call()}.
-handle_conference_timeout(#dial_req{
-                             call=Call
+handle_conference_timeout(#dial_req{call=Call
                                    ,call_timeout='undefined'
-                            }) ->
+                                   }) ->
     lager:debug("time limit for conference exceeded"),
     kapps_call_command:park(Call),
     {'ok', kzt_util:update_call_status(?STATUS_COMPLETED, Call)};


### PR DESCRIPTION
With Erlang 19+, records no longer have an implicit `undefined` type for fields. Those warnings clog up Dialyzer output so this attempts to address those issues (and other low hanging spec/type issues).