### PR TITLE
Service sync via amqp

### DIFF
--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -440,7 +440,7 @@ move_account(AccountId, JObj, ToAccount, ToTree) ->
             NewResellerId = kz_services:find_reseller_id(ToAccount),
             {'ok', _} = replicate_account_definition(JObj1),
             {'ok', _} = move_descendants(AccountId, ToTree, NewResellerId),
-            {'ok', _} = kz_service_sync:mark_dirty(AccountId),
+            {'ok', _} = kz_services:mark_dirty(AccountId),
             move_service(AccountId, ToTree, NewResellerId, 'true')
     end.
 

--- a/applications/crossbar/src/modules/cb_braintree.erl
+++ b/applications/crossbar/src/modules/cb_braintree.erl
@@ -577,5 +577,5 @@ add_credit_to_account(BraintreeData, Units, LedgerId, AccountId, OrderId) ->
 -spec sync(cb_context:context()) -> 'ok'.
 sync(Context) ->
     AccountId = cb_context:account_id(Context),
-    _P = kz_util:spawn(fun kz_service_sync:sync/1, [AccountId]),
-    'ok'.
+    _P = kz_util:spawn(fun kz_services:sync/1, [AccountId]),
+    lager:debug("syncing ~s in ~p", [AccountId, _P]).

--- a/applications/crossbar/src/modules/cb_service_plans.erl
+++ b/applications/crossbar/src/modules/cb_service_plans.erl
@@ -195,7 +195,7 @@ post(Context) ->
                        ]).
 
 post(Context, ?SYNCHRONIZATION) ->
-    kz_service_sync:sync(cb_context:account_id(Context)),
+    _ = kz_services:sync(cb_context:account_id(Context)),
     cb_context:set_resp_status(Context, 'success');
 post(Context, ?RECONCILIATION) ->
     try kz_services:reconcile(cb_context:account_id(Context)) of

--- a/core/kazoo_services/src/bookkeepers/kz_bookkeeper_braintree.erl
+++ b/core/kazoo_services/src/bookkeepers/kz_bookkeeper_braintree.erl
@@ -23,7 +23,7 @@
 -define(TR_DESCRIPTION, <<"braintree transaction">>).
 
 -record(kz_service_update, {bt_subscription :: braintree_subscription:subscription()
-                           ,plan_id :: ne_binary()
+                           ,plan_id :: api_ne_binary()
                            }).
 
 -record(kz_service_updates, {bt_subscriptions = [] :: [update()]
@@ -620,10 +620,9 @@ fetch_or_create_subscription(PlanId, #kz_service_updates{bt_subscriptions=[]
 fetch_or_create_subscription(PlanId, #kz_service_updates{bt_subscriptions=Subscriptions
                                                         ,bt_customer=Customer
                                                         }) ->
-    case lists:keyfind(PlanId, #kz_service_update.plan_id, Subscriptions) of
-        'false' ->
-            fetch_or_create_subscription(PlanId, Customer);
-        #kz_service_update{bt_subscription=Subscription} -> Subscription
+    case find_subscription_by_plan_id(PlanId, Subscriptions) of
+        'undefined' -> fetch_or_create_subscription(PlanId, Customer);
+        Subscription -> Subscription
     end;
 fetch_or_create_subscription(PlanId, #bt_customer{}=Customer) ->
     try braintree_customer:get_subscription(PlanId, Customer) of
@@ -636,6 +635,20 @@ fetch_or_create_subscription(PlanId, #bt_customer{}=Customer) ->
         'throw':{'not_found', _} ->
             lager:debug("creating new subscription for plan id ~s", [PlanId]),
             braintree_customer:new_subscription(PlanId, Customer)
+    end.
+
+-spec find_subscription_by_plan_id(ne_binary(), [update()]) ->
+                                          'undefined' |
+                                          braintree_subscription:subscription().
+find_subscription_by_plan_id(PlanId, Subscriptions) ->
+    case [Subscription || #kz_service_update{bt_subscription=Subscription
+                                            ,plan_id=UpdatePlanId
+                                            } <- Subscriptions,
+                          UpdatePlanId =:= PlanId
+         ]
+    of
+        [] -> 'undefined';
+        [Subscription] -> Subscription
     end.
 
 %% @private

--- a/core/kazoo_services/src/bookkeepers/kz_bookkeeper_local.erl
+++ b/core/kazoo_services/src/bookkeepers/kz_bookkeeper_local.erl
@@ -31,7 +31,7 @@ is_good_standing(_AccountId, _Status) -> 'true'.
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec sync(kz_service_item:items(), ne_binary()) -> bookkeeper_sync_result().
+-spec sync(kz_service_items:items(), ne_binary()) -> bookkeeper_sync_result().
 sync(_Items, _AccountId) -> 'ok'.
 
 %%--------------------------------------------------------------------

--- a/core/kazoo_services/src/kazoo_services_maintenance.erl
+++ b/core/kazoo_services/src/kazoo_services_maintenance.erl
@@ -156,7 +156,7 @@ reconcile(Account) ->
 sync(Account) when not is_binary(Account) ->
     sync(kz_term:to_binary(Account));
 sync(Account) ->
-    kz_service_sync:sync(Account),
+    _ = kz_services:sync(Account),
     'ok'.
 
 -spec sync_descendants(text()) -> 'ok'.

--- a/core/kazoo_services/src/kz_gen_bookkeeper.erl
+++ b/core/kazoo_services/src/kz_gen_bookkeeper.erl
@@ -13,7 +13,7 @@
 -callback is_good_standing(ne_binary(), ne_binary()) ->
     boolean().
 
--callback sync(kz_service_item:items(), ne_binary()) ->
+-callback sync(kz_service_items:items(), ne_binary()) ->
     bookkeeper_sync_result().
 
 -callback transactions(ne_binary(), gregorian_seconds(), gregorian_seconds()) ->

--- a/core/kazoo_services/src/kz_service_items.erl
+++ b/core/kazoo_services/src/kz_service_items.erl
@@ -14,7 +14,7 @@
 -export([find/3]).
 -export([update/2]).
 
--type items() :: dict:dict().
+-opaque items() :: dict:dict().
 -export_type([items/0]).
 
 -include("services.hrl").
@@ -38,13 +38,12 @@ empty() ->
 -spec get_updated_items(items(), items()) -> items().
 -spec get_updated_items(any(), kz_service_item:item(), items(), items()) -> items().
 get_updated_items(UpdatedItems, ExistingItems) ->
-    dict:fold(
-      fun(Key, UpdatedItem, DifferingItems) ->
-              get_updated_items(Key, UpdatedItem, ExistingItems, DifferingItems)
-      end
+    dict:fold(fun(Key, UpdatedItem, DifferingItems) ->
+                      get_updated_items(Key, UpdatedItem, ExistingItems, DifferingItems)
+              end
              ,dict:new()
              ,UpdatedItems
-     ).
+             ).
 
 get_updated_items(Key, UpdatedItem, ExistingItems, DifferingItems) ->
     case get_item(Key, ExistingItems) of

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -1636,7 +1636,7 @@ maybe_clean_old_billing_id(#kz_services{}=Services) ->
 -spec clean(ne_binary()) -> kz_std_return().
 clean(Account) ->
     AccountId = kz_util:format_account_id(Account),
-    case kz_services:fetch_services_doc(AccountId, 'true') of
+    case ?MODULE:fetch_services_doc(AccountId, 'true') of
         {'error', _}=E -> E;
         {'ok', ServicesJObj} ->
             immediate_sync(AccountId, kz_doc:set_soft_deleted(ServicesJObj, 'true'))
@@ -1660,7 +1660,7 @@ immediate_sync(AccountId, ServicesJObj) ->
 sync(Account) ->
     AccountId = kz_util:format_account_id(Account),
     kz_util:put_callid(<<AccountId/binary, "-sync">>),
-    case kz_services:fetch_services_doc(AccountId, 'true') of
+    case ?MODULE:fetch_services_doc(AccountId, 'true') of
         {'error', _}=E -> E;
         {'ok', ServicesJObj} ->
             sync(AccountId, ServicesJObj)
@@ -1720,7 +1720,7 @@ sync_services(AccountId, ServicesJObj, ServiceItems) ->
 
 -spec sync_services_bookkeeper(ne_binary(), kz_json:object(), kz_service_items:items()) -> 'ok' | 'delinquent' | 'retry'.
 sync_services_bookkeeper(AccountId, ServicesJObj, ServiceItems) ->
-    Bookkeeper = kz_services:select_bookkeeper(AccountId),
+    Bookkeeper = ?MODULE:select_bookkeeper(AccountId),
     lager:debug("attempting to sync with bookkeeper ~s", [Bookkeeper]),
     Result = Bookkeeper:sync(ServiceItems, AccountId),
     maybe_sync_transactions(AccountId, ServicesJObj, Bookkeeper),
@@ -1729,7 +1729,7 @@ sync_services_bookkeeper(AccountId, ServicesJObj, ServiceItems) ->
 -spec maybe_sync_transactions(ne_binary(), kzd_services:doc()) -> 'ok'.
 -spec maybe_sync_transactions(ne_binary(), kzd_services:doc(), atom()) -> 'ok'.
 maybe_sync_transactions(AccountId, ServicesJObj) ->
-    Bookkeeper = kz_services:select_bookkeeper(AccountId),
+    Bookkeeper = ?MODULE:select_bookkeeper(AccountId),
     maybe_sync_transactions(AccountId, ServicesJObj, Bookkeeper).
 
 maybe_sync_transactions(AccountId, ServicesJObj, Bookkeeper) ->
@@ -1834,7 +1834,7 @@ get_billing_id(AccountId, ServicesJObj) ->
 
 -spec mark_dirty(ne_binary() | kzd_services:doc()) -> kz_std_return().
 mark_dirty(?MATCH_ACCOUNT_RAW(AccountId)) ->
-    case kz_services:fetch_services_doc(AccountId, true) of
+    case ?MODULE:fetch_services_doc(AccountId, 'true') of
         {'error', _}=E -> E;
         {'ok', ServicesJObj} -> mark_dirty(ServicesJObj)
     end;

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -36,7 +36,7 @@
 -export([select_bookkeeper/1]).
 -export([check_bookkeeper/2]).
 -export([set_billing_id/2]).
--export([get_billing_id/1]).
+-export([get_billing_id/1, get_billing_id/2]).
 -export([find_reseller_id/1]).
 
 -export([account_id/1
@@ -58,6 +58,11 @@
 -export([get_reseller_id/1]).
 
 -export([dry_run/1]).
+
+-export([clean/1
+        ,sync/1, sync/2
+        ,mark_dirty/1
+        ]).
 
 -export([is_services/1]).
 
@@ -1621,8 +1626,228 @@ maybe_clean_old_billing_id(#kz_services{current_billing_id = BillingId
     case kzd_services:is_reseller(JObj) of
         'true' -> Services;
         'false' ->
-            _ = kz_service_sync:clean(BillingId),
+            _ = clean(BillingId),
             Services
     end;
 maybe_clean_old_billing_id(#kz_services{}=Services) ->
     Services.
+
+
+-spec clean(ne_binary()) -> kz_std_return().
+clean(Account) ->
+    AccountId = kz_util:format_account_id(Account),
+    case kz_services:fetch_services_doc(AccountId, 'true') of
+        {'error', _}=E -> E;
+        {'ok', ServicesJObj} ->
+            immediate_sync(AccountId, kz_doc:set_soft_deleted(ServicesJObj, 'true'))
+    end.
+
+-spec immediate_sync(ne_binary(), kzd_services:doc()) -> kz_std_return().
+immediate_sync(AccountId, ServicesJObj) ->
+    case kz_service_plans:create_items(ServicesJObj) of
+        {'error', 'no_plans'}=E -> E;
+        {'ok', ServiceItems} ->
+            %% TODO: support other bookkeepers...
+            try kz_bookkeeper_braintree:sync(ServiceItems, AccountId) of
+                _ -> {'ok', ServicesJObj}
+            catch
+                'throw':{_, R} -> {'error', R};
+                _E:R -> {'error', R}
+            end
+    end.
+
+-spec sync(ne_binary()) -> kz_std_return().
+sync(Account) ->
+    AccountId = kz_util:format_account_id(Account),
+    kz_util:put_callid(<<AccountId/binary, "-sync">>),
+    case kz_services:fetch_services_doc(AccountId, 'true') of
+        {'error', _}=E -> E;
+        {'ok', ServicesJObj} ->
+            sync(AccountId, ServicesJObj)
+    end.
+
+-spec sync(ne_binary(), kz_json:object()) -> kz_std_return().
+sync(AccountId, ServicesJObj) ->
+    case get_billing_id(AccountId, ServicesJObj) of
+        AccountId -> maybe_sync_services(AccountId, ServicesJObj);
+        BillingId ->
+            io:format("Account ~s is configured to use the credit card of ~s, following billing tree~n"
+                     ,[AccountId, BillingId]),
+            lager:debug("account ~s is configured to use the credit card of ~s, following billing tree"
+                       ,[AccountId, BillingId]),
+            sync(BillingId)
+    end.
+
+-spec maybe_sync_services(ne_binary(), kzd_services:doc()) -> kz_std_return().
+maybe_sync_services(AccountId, ServicesJObj) ->
+    case kz_service_plans:create_items(ServicesJObj) of
+        {'error', 'no_plans'} ->
+            lager:debug("no services plans found"),
+            _ = maybe_sync_transactions(AccountId, ServicesJObj),
+            _ = mark_clean_and_status(kzd_services:status_good(), ServicesJObj),
+            maybe_sync_reseller(AccountId, ServicesJObj);
+        {'ok', ServiceItems} ->
+            sync_services(AccountId, ServicesJObj, ServiceItems)
+    end.
+
+-spec sync_services(ne_binary(), kzd_services:doc(), kz_service_items:items()) -> kz_std_return().
+sync_services(AccountId, ServicesJObj, ServiceItems) ->
+    try sync_services_bookkeeper(AccountId, ServicesJObj, ServiceItems) of
+        'ok' ->
+            _ = mark_clean_and_status(kzd_services:status_good(), ServicesJObj),
+            io:format("synchronization with bookkeeper complete (good-standing)~n"),
+            lager:debug("synchronization with bookkeeper complete (good-standing)"),
+            maybe_sync_reseller(AccountId, ServicesJObj);
+        'delinquent' ->
+            _ = mark_clean_and_status(kzd_services:status_delinquent(), ServicesJObj),
+            io:format("synchronization with bookkeeper complete (delinquent)~n"),
+            lager:debug("synchronization with bookkeeper complete (delinquent)"),
+            maybe_sync_reseller(AccountId, ServicesJObj);
+        'retry' ->
+            io:format("synchronization with bookkeeper complete (retry)~n"),
+            lager:debug("synchronization with bookkeeper complete (retry)"),
+            {'error', 'retry'}
+    catch
+        'throw':{Reason, _}=_R ->
+            lager:info("bookkeeper error: ~p", [_R]),
+            _ = mark_clean_and_status(kz_term:to_binary(Reason), ServicesJObj),
+            maybe_sync_reseller(AccountId, ServicesJObj);
+        _E:R ->
+            lager:info("unable to sync services(~p): ~p", [_E, R]),
+            kz_util:log_stacktrace(),
+            {'error', R}
+    end.
+
+-spec sync_services_bookkeeper(ne_binary(), kz_json:object(), kz_service_items:items()) -> 'ok' | 'delinquent' | 'retry'.
+sync_services_bookkeeper(AccountId, ServicesJObj, ServiceItems) ->
+    Bookkeeper = kz_services:select_bookkeeper(AccountId),
+    lager:debug("attempting to sync with bookkeeper ~s", [Bookkeeper]),
+    Result = Bookkeeper:sync(ServiceItems, AccountId),
+    maybe_sync_transactions(AccountId, ServicesJObj, Bookkeeper),
+    Result.
+
+-spec maybe_sync_transactions(ne_binary(), kzd_services:doc()) -> 'ok'.
+-spec maybe_sync_transactions(ne_binary(), kzd_services:doc(), atom()) -> 'ok'.
+maybe_sync_transactions(AccountId, ServicesJObj) ->
+    Bookkeeper = kz_services:select_bookkeeper(AccountId),
+    maybe_sync_transactions(AccountId, ServicesJObj, Bookkeeper).
+
+maybe_sync_transactions(AccountId, ServicesJObj, Bookkeeper) ->
+    case kzd_services:transactions(ServicesJObj) of
+        [] -> 'ok';
+        Trs ->
+            Transactions = maybe_delete_topup_transaction(AccountId, Trs),
+            sync_transactions(AccountId, ServicesJObj, Bookkeeper, Transactions)
+    end.
+
+-spec maybe_delete_topup_transaction(ne_binary(), kz_json:objects()) -> kz_json:objects().
+maybe_delete_topup_transaction(AccountId, Transactions) ->
+    NonTopup = lists:filter(
+                 fun(J) ->
+                         kz_json:get_integer_value(<<"pvt_code">>, J) =/= ?CODE_TOPUP
+                 end, Transactions
+                ),
+    case NonTopup of
+        Transactions -> Transactions;
+        _Other ->
+            case kz_topup:should_topup(AccountId) of
+                'true' -> Transactions;
+                'false' -> NonTopup
+            end
+    end.
+
+-spec sync_transactions(ne_binary(), kzd_services:doc(), atom(), kz_json:objects()) ->
+                               'ok'.
+sync_transactions(AccountId, ServicesJObj, Bookkeeper, Transactions) ->
+    BillingId = kzd_services:billing_id(ServicesJObj),
+    FailedTransactions = Bookkeeper:charge_transactions(BillingId, Transactions),
+    case kz_datamgr:save_doc(?KZ_SERVICES_DB
+                            ,kzd_services:set_transactions(ServicesJObj, FailedTransactions)
+                            )
+    of
+        {'error', _E} ->
+            lager:warning("failed to clean pending transactions ~p", [_E]);
+        {'ok', _} ->
+            handle_topup_transactions(AccountId, Transactions, FailedTransactions)
+    end.
+
+-spec handle_topup_transactions(ne_binary(), kz_json:objects(), kz_json:objects() | integer()) -> 'ok'.
+handle_topup_transactions(Account, JObjs, Failed) when is_list(Failed) ->
+    case did_topup_failed(Failed) of
+        'true' -> 'ok';
+        'false' -> handle_topup_transactions(Account, JObjs, 3)
+    end;
+handle_topup_transactions(_, [], _) -> 'ok';
+handle_topup_transactions(Account, [JObj|JObjs]=List, Retry) when Retry > 0 ->
+    case kz_json:get_integer_value(<<"pvt_code">>, JObj) of
+        ?CODE_TOPUP ->
+            Amount = kz_json:get_value(<<"pvt_amount">>, JObj),
+            Transaction = kz_transaction:credit(Account, Amount),
+            Transaction1 = kz_transaction:set_reason(wht_util:topup(), Transaction),
+            case kz_transaction:save(Transaction1) of
+                {'ok', _} -> 'ok';
+                {'error', 'conflict'} ->
+                    lager:warning("did not write top up transaction for account ~s already exist for today", [Account]);
+                {'error', _E} ->
+                    lager:error("failed to write top up transaction ~p , for account ~s (amount: ~p), retrying ~p..."
+                               ,[_E, Account, Amount, Retry]
+                               ),
+                    handle_topup_transactions(Account, List, Retry-1)
+            end;
+        _ -> handle_topup_transactions(Account, JObjs, 3)
+    end;
+handle_topup_transactions(Account, _, _) ->
+    lager:error("failed to write top up transaction for account ~s too many retries", [Account]).
+
+-spec did_topup_failed(kz_json:objects()) -> boolean().
+did_topup_failed(JObjs) ->
+    lists:foldl(
+      fun(JObj, Acc) ->
+              case kz_json:get_integer_value(<<"pvt_code">>, JObj) of
+                  ?CODE_TOPUP -> 'true';
+                  _ -> Acc
+              end
+      end
+               ,'false'
+               ,JObjs
+     ).
+
+-spec maybe_sync_reseller(ne_binary(), kzd_services:doc()) -> kz_std_return().
+maybe_sync_reseller(AccountId, ServicesJObj) ->
+    case kzd_services:reseller_id(ServicesJObj, AccountId) of
+        AccountId -> {'ok', ServicesJObj};
+        ResellerId ->
+            lager:debug("marking reseller ~s as dirty", [ResellerId]),
+            mark_dirty(ResellerId)
+    end.
+
+-spec get_billing_id(ne_binary(), kzd_services:doc()) -> ne_binary().
+get_billing_id(AccountId, ServicesJObj) ->
+    case kzd_services:is_reseller(ServicesJObj) of
+        'true' -> AccountId;
+        'false' ->
+            case ?SUPPORT_BILLING_ID of
+                'true' -> kzd_services:billing_id(ServicesJObj, AccountId);
+                'false' -> AccountId
+            end
+    end.
+
+-spec mark_dirty(ne_binary() | kzd_services:doc()) -> kz_std_return().
+mark_dirty(?MATCH_ACCOUNT_RAW(AccountId)) ->
+    case kz_services:fetch_services_doc(AccountId, true) of
+        {'error', _}=E -> E;
+        {'ok', ServicesJObj} -> mark_dirty(ServicesJObj)
+    end;
+mark_dirty(ServicesJObj) ->
+    Values = [{?SERVICES_PVT_IS_DIRTY, 'true'}
+             ,{?SERVICES_PVT_MODIFIED, kz_time:now_s()}
+             ],
+    kz_datamgr:save_doc(?KZ_SERVICES_DB, kz_json:set_values(Values, ServicesJObj)).
+
+-spec mark_clean_and_status(ne_binary(), kzd_services:doc()) -> kz_std_return().
+mark_clean_and_status(Status, ServicesJObj) ->
+    lager:debug("marking services clean with status ~s", [Status]),
+    Values = [{?SERVICES_PVT_IS_DIRTY, 'false'}
+             ,{?SERVICES_PVT_STATUS, Status}
+             ],
+    kz_datamgr:save_doc(?KZ_SERVICES_DB, kz_json:set_values(Values, ServicesJObj)).


### PR DESCRIPTION
kz_service_sync is the gen_listener that both receives AMQP maintenance payloads to initiate a service clean as well as a timer-manager to periodically sync dirty service plans. However, other apps had been calling into it to do explicit sync/clean/mark_dirty actions. When kz_service_sync moved to tasks, this created an inter-app dependency.

This PR moves the core functionality back to kz_services so other apps can call directly to the functionality without a dependency on the tasks app. The PR also adds a maintenance AMQP for cleaning services. This also removes a circular dep between kz_service_sync (tasks) and kz_services (kazoo_services).