### PR TITLE
Config as app vars

### DIFF
--- a/core/kazoo/src/kz_doc.erl
+++ b/core/kazoo/src/kz_doc.erl
@@ -437,7 +437,7 @@ id(JObj, Default) ->
 set_id(JObj, Id) ->
     kz_json:set_value(?KEY_ID, Id, JObj).
 
--spec type(kz_json:object()) -> api_binary().
+-spec type(kz_json:object()) -> api_ne_binary().
 -spec type(kz_json:object(), Default) -> ne_binary() | Default.
 type(JObj) ->
     type(JObj, 'undefined').

--- a/core/kazoo_data/src/kazoo_data.app.src
+++ b/core/kazoo_data/src/kazoo_data.app.src
@@ -15,4 +15,8 @@
                  , kazoo_attachments
                  ]}
  ,{mod, {kazoo_data_app, []}}
+ ,{env, [{'default_archive_folder', <<"/tmp">>}
+        ,{'max_bulk_insert', 2000}
+        ,{'max_bulk_read', 2000}
+        ]}
  ]}.

--- a/core/kazoo_data/src/kazoo_data_config.erl
+++ b/core/kazoo_data/src/kazoo_data_config.erl
@@ -18,7 +18,7 @@ get_pos_integer(Key) ->
 get_pos_integer(Key, Default) ->
     case get(Key) of
         'undefined' -> Default;
-        Value -> as_integer(Value, Default, fun(V) -> V > 0 end)
+        {'ok', Value} -> as_integer(Value, Default, fun(V) -> V > 0 end)
     end.
 
 -spec get_ne_binary(ne_binary()) -> api_ne_binary().

--- a/core/kazoo_data/src/kazoo_data_config.erl
+++ b/core/kazoo_data/src/kazoo_data_config.erl
@@ -1,0 +1,101 @@
+-module(kazoo_data_config).
+
+-export([get_ne_binary/1, get_ne_binary/2
+        ,get_ne_binaries/1, get_ne_binaries/2
+        ,get_pos_integer/1, get_pos_integer/2
+        ,get_json/1, get_json/2
+        ,get_is_true/1, get_is_true/2
+        ]).
+
+-include("kz_data.hrl").
+
+-compile({no_auto_import,[get/1]}).
+
+-spec get_pos_integer(ne_binary()) -> api_pos_integer().
+-spec get_pos_integer(ne_binary(), Default) -> pos_integer() | Default.
+get_pos_integer(Key) ->
+    get_pos_integer(Key, 'undefined').
+get_pos_integer(Key, Default) ->
+    case get(Key) of
+        'undefined' -> Default;
+        Value -> as_integer(Value, Default, fun(V) -> V > 0 end)
+    end.
+
+-spec get_ne_binary(ne_binary()) -> api_ne_binary().
+-spec get_ne_binary(ne_binary(), Default) -> ne_binary() | Default.
+get_ne_binary(Key) ->
+    get_ne_binary(Key, 'undefined').
+get_ne_binary(Key, Default) ->
+    case get(Key) of
+        'undefined' -> Default;
+        {'ok', Value} ->
+            nonempty(kz_term:to_binary(Value), Default)
+    end.
+
+-spec get_ne_binaries(ne_binary()) -> api_ne_binaries().
+-spec get_ne_binaries(ne_binary(), Default) -> ne_binaries() | Default.
+get_ne_binaries(Key) ->
+    get_ne_binaries(Key, 'undefined').
+get_ne_binaries(Key, Default) ->
+    case get(Key) of
+        'undefined' -> Default;
+        {'ok', Value} ->
+            nonempty(Value, Default)
+    end.
+
+-spec get_json(ne_binary()) -> api_object().
+-spec get_json(ne_binary(), Default) -> kz_json:object() | Default.
+get_json(Key) ->
+    get_json(Key, 'undefined').
+get_json(Key, Default) ->
+    case get(Key) of
+        'undefined' -> Default;
+        {'ok', Value} ->
+            as_json(Value, Default)
+    end.
+
+-spec get_is_true(ne_binary()) -> boolean().
+-spec get_is_true(ne_binary(), Default) -> boolean() | Default.
+get_is_true(Key) ->
+    get_is_true(Key, 'false').
+get_is_true(Key, Default) ->
+    case get(Key) of
+        'undefined' -> Default;
+        {'ok', Value} ->
+            as_boolean(Value, Default)
+    end.
+
+-spec get(ne_binary()) -> 'undefined' |
+                          {'ok', any()}.
+get(<<_/binary>>=Key) ->
+    application:get_env(?APP, kz_term:to_atom(Key, 'true')).
+
+-spec nonempty(any(), Default) -> any() | Default.
+nonempty(Value, Default) ->
+    case kz_term:is_empty(Value) of
+        'true' -> Default;
+        'false' -> Value
+    end.
+
+-spec as_integer(any(), Default, fun((integer()) -> boolean())) -> integer() | Default.
+as_integer(Value, Default, VFun) ->
+    VInt = kz_term:to_integer(Value),
+    case VFun(VInt) of
+        'true' -> VInt;
+        'false' -> Default
+    end.
+
+-spec as_json(any(), Default) -> kz_json:object() | Default.
+as_json(Value, Default) ->
+    case kz_json:is_json_object(Value) of
+        'true' -> Value;
+        'false' -> Default
+    end.
+
+-spec as_boolean(any(), Default) -> boolean() | Default.
+as_boolean(Value, Default) ->
+    try kz_term:to_boolean(Value) of
+        Boolean -> Boolean
+    catch
+        _:_ -> Default
+    end.

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -379,9 +379,12 @@ db_view_cleanup(DbName) ->
             'false'
     end.
 
--spec db_view_update(ne_binary(), views_listing()) -> boolean().
--spec db_view_update(ne_binary(), views_listing(), boolean()) -> boolean().
-
+-spec db_view_update(ne_binary(), views_listing()) ->
+                            boolean() |
+                            {'error', 'invalid_db_name'}.
+-spec db_view_update(ne_binary(), views_listing(), boolean()) ->
+                            boolean() |
+                            {'error', 'invalid_db_name'}.
 db_view_update(DbName, Views) ->
     db_view_update(DbName, Views, 'false').
 
@@ -499,7 +502,7 @@ db_delete(DbName, Options) ->
 -spec db_archive(ne_binary()) -> 'ok' | data_error().
 -spec db_archive(ne_binary(), ne_binary()) -> 'ok' | data_error().
 db_archive(DbName) ->
-    Folder = kapps_config:get_ne_binary(?CONFIG_CAT, <<"default_archive_folder">>, <<"/tmp">>),
+    Folder = kazoo_data_config:get_ne_binary(<<"default_archive_folder">>, <<"/tmp">>),
     db_archive(DbName, filename:join([<<Folder/binary, "/", DbName/binary, ".json">>])).
 
 db_archive(DbName, Filename) when ?VALID_DBNAME(DbName) ->
@@ -1223,7 +1226,7 @@ maybe_create_view(DbName, Plan, DesignDoc, Options) ->
     case props:get_value('view_json', Options) of
         'undefined' -> {'error', 'not_found'};
         ViewJson ->
-            db_view_update(DbName, ViewJson),
+            'true' = db_view_update(DbName, ViewJson),
             kzs_view:get_results(Plan, DbName, DesignDoc, Options)
     end.
 
@@ -1425,7 +1428,7 @@ move_doc(FromDB, FromId, ToDB, ToId, Options) ->
 %%------------------------------------------------------------------------------
 -spec max_bulk_insert() -> pos_integer().
 max_bulk_insert() ->
-    kapps_config:get_pos_integer(?CONFIG_CAT, <<"max_bulk_insert">>, 2000).
+    kazoo_data_config:get_pos_integer(<<"max_bulk_insert">>, 2000).
 
 %%------------------------------------------------------------------------------
 %% @public
@@ -1435,11 +1438,11 @@ max_bulk_insert() ->
 %%------------------------------------------------------------------------------
 -spec max_bulk_read() -> pos_integer().
 max_bulk_read() ->
-    kapps_config:get_pos_integer(?CONFIG_CAT, <<"max_bulk_read">>, 2000).
+    kazoo_data_config:get_pos_integer(<<"max_bulk_read">>, 2000).
 
 -spec max_bulk_read(view_options()) -> pos_integer().
 max_bulk_read(ViewOptions) ->
-    AskedFor = props:get_integer_value(max_bulk_read, ViewOptions, max_bulk_read()),
+    AskedFor = props:get_integer_value('max_bulk_read', ViewOptions, max_bulk_read()),
     UpperBound = min(AskedFor, max_bulk_read()),
     max(UpperBound, 1).
 

--- a/core/kazoo_data/src/kzs_cache.erl
+++ b/core/kazoo_data/src/kzs_cache.erl
@@ -26,7 +26,8 @@
                                   ,<<"fax">>, <<"mailbox_message">>
                                   ]).
 -define(NO_CACHING_TYPES
-       ,kapps_config:get(?CONFIG_CAT, <<"no_caching_doc_types">>, ?DEFAULT_NO_CACHING_TYPES)).
+       ,kazoo_data_config:get_ne_binaries(<<"no_caching_doc_types">>, ?DEFAULT_NO_CACHING_TYPES)
+       ).
 
 -define(DEFAULT_CACHE_PERIOD, 15 * ?SECONDS_IN_MINUTE).
 -define(DEFAULT_CACHING_POLICY, kz_json:from_list(
@@ -202,7 +203,7 @@ expires_policy_value(DbName, CacheValue) ->
 expires_policy_value(<<"system_config">>, _, _) -> 'infinity';
 expires_policy_value(<<"system_data">>, _, _) -> 'infinity';
 expires_policy_value(DbName, Classification, Type) ->
-    CachePolicy = kapps_config:get_json(?CONFIG_CAT, <<"cache_policy">>, ?DEFAULT_CACHING_POLICY),
+    CachePolicy = kazoo_data_config:get_json(<<"cache_policy">>, ?DEFAULT_CACHING_POLICY),
     case kz_json:get_first_defined([[DbName, Type]
                                    ,[DbName, <<"any">>]
                                    ,[Classification, Type]

--- a/core/kazoo_data/src/kzs_perf.erl
+++ b/core/kazoo_data/src/kzs_perf.erl
@@ -39,7 +39,7 @@ load_profile_config_from_disk() ->
 
 -spec load_profile_config() -> kz_json:object().
 load_profile_config() ->
-    case kapps_config:get_json(?CONFIG_CAT, <<"performance">>) of
+    case kazoo_data_config:get_json(<<"performance">>) of
         'undefined' -> load_profile_config_from_disk();
         JObj -> JObj
     end.

--- a/core/kazoo_data/src/kzs_plan.erl
+++ b/core/kazoo_data/src/kzs_plan.erl
@@ -301,7 +301,7 @@ fetch_dataplan(Id) ->
         {'ok', JObj} -> JObj;
         {'error', _} when Id =:= ?SYSTEM_DATAPLAN ->
             JObj = default_dataplan(),
-            kz_datamgr:add_to_doc_cache(?KZ_DATA_DB, Id, JObj),
+            'ok' = kz_datamgr:add_to_doc_cache(?KZ_DATA_DB, Id, JObj),
             JObj;
         {'error', _} -> kz_json:new()
     end.

--- a/core/kazoo_data/src/kzs_publish.erl
+++ b/core/kazoo_data/src/kzs_publish.erl
@@ -61,7 +61,7 @@ should_publish_doc(Doc) ->
 -spec should_publish_db_changes(ne_binary()) -> boolean().
 should_publish_db_changes(DbName) ->
     Key = <<"publish_", (kz_term:to_binary(kzs_util:db_classification(DbName)))/binary, "_changes">>,
-    kapps_config:get_is_true(?CONFIG_CAT, Key, 'true').
+    kazoo_data_config:get_is_true(Key, 'true').
 
 -spec publish_doc(ne_binary(), kz_json:object(), kz_json:object()) -> 'ok'.
 publish_doc(DbName, Doc, JObj) ->
@@ -90,7 +90,7 @@ do_publish_db(DbName, Action) ->
                                  )
         ],
     Fun = fun(P) -> kapi_conf:publish_db_update(Action, DbName, P) end,
-    kapps_util:amqp_pool_send(Props, Fun).
+    kz_amqp_worker:cast(Props, Fun).
 
 -spec publish_fields(kz_json:object()) -> kz_proplist().
 -spec publish_fields(kz_json:object(), kz_json:object()) -> kz_json:object().


### PR DESCRIPTION
Remove circular dependency between kazoo_data and kazoo_config (specifically kapps_config usage in kazoo_data).