### PR TITLE
Schemas config dir

### DIFF
--- a/core/kazoo_ast/src/kapps_config_usage.erl
+++ b/core/kazoo_ast/src/kapps_config_usage.erl
@@ -15,13 +15,19 @@
 -define(FIELD_PROPERTIES, <<"properties">>).
 -define(FIELD_TYPE, <<"type">>).
 -define(SYSTEM_CONFIG_DESCRIPTIONS, kz_ast_util:api_path(<<"descriptions.system_config.json">>)).
--define(UNKNOWN_DEFAULT, undefined).
+-define(UNKNOWN_DEFAULT, 'undefined').
+
+-type acc() :: #{'schema_dir' := 'default' | file:filename_all()
+                ,'app_schemas' := kz_json:object()
+                ,'project_schemas' := kz_json:object()
+                }.
 
 -spec to_schema_docs() -> 'ok'.
 to_schema_docs() ->
     kz_json:foreach(fun update_schema/1, process_project()).
 
--spec update_schema({kz_json:key(), kz_json:json_term()}) -> 'ok'.
+-spec update_schema({file:filename_all(), kz_json:json_term()}) -> 'ok'.
+-spec update_schema(kz_json:key(), kz_json:json_object(), file:filename_all()) -> 'ok'.
 update_schema({PrivDir, Schemas}) ->
     kz_json:foreach(fun({Name, AutoGenSchema}) ->
                             update_schema(Name, AutoGenSchema, PrivDir)
@@ -34,7 +40,7 @@ update_schema(Name, AutoGenSchema, PrivDir) ->
         andalso update_schema(Name, AccountSchema, PrivDir, <<"account_config">>),
     update_schema(Name, AccountSchema, PrivDir, <<"system_config">>).
 
--spec update_schema(ne_binary(), kz_json:key(), kz_json:object()) -> ok.
+-spec update_schema(ne_binary(), kz_json:object(), file:filename_all(), ne_binary()) -> 'ok'.
 update_schema(Name, AutoGenSchema, PrivDir, ConfigType) ->
     Path = kz_ast_util:schema_path(<<ConfigType/binary, ".", Name/binary, ".json">>, PrivDir),
 
@@ -109,10 +115,6 @@ print_dot(_Module, Acc) ->
     io:format("."),
     Acc.
 
--type acc() :: #{schema_dir := 'default' | file:filename_all()
-                ,app_schemas := kz_json:object()
-                ,project_schemas := kz_json:object()
-                }.
 -spec new_acc() -> acc().
 new_acc() ->
     #{schema_dir => 'default'

--- a/core/kazoo_ast/src/kapps_config_usage.erl
+++ b/core/kazoo_ast/src/kapps_config_usage.erl
@@ -22,18 +22,26 @@ to_schema_docs() ->
     kz_json:foreach(fun update_schema/1, process_project()).
 
 -spec update_schema({kz_json:key(), kz_json:json_term()}) -> 'ok'.
-update_schema({Name, AutoGenSchema}) ->
+update_schema({PrivDir, Schemas}) ->
+    kz_json:foreach(fun({Name, AutoGenSchema}) ->
+                            update_schema(Name, AutoGenSchema, PrivDir)
+                    end
+                   ,Schemas
+                   ).
+update_schema(Name, AutoGenSchema, PrivDir) ->
     AccountSchema = account_properties(AutoGenSchema),
     _ = kz_json:new() =/= AccountSchema
-        andalso update_schema(<<"account_config">>, Name, AccountSchema),
-    update_schema(<<"system_config">>, Name, AutoGenSchema).
+        andalso update_schema(Name, AccountSchema, PrivDir, <<"account_config">>),
+    update_schema(Name, AccountSchema, PrivDir, <<"system_config">>).
 
 -spec update_schema(ne_binary(), kz_json:key(), kz_json:object()) -> ok.
-update_schema(ConfigType, Name, AutoGenSchema) ->
-    Path = kz_ast_util:schema_path(<<ConfigType/binary, ".", Name/binary, ".json">>),
+update_schema(Name, AutoGenSchema, PrivDir, ConfigType) ->
+    Path = kz_ast_util:schema_path(<<ConfigType/binary, ".", Name/binary, ".json">>, PrivDir),
+
     GeneratedJObj = static_fields(ConfigType, Name, remove_source(AutoGenSchema)),
     MergedJObj = kz_json:merge(fun kz_json:merge_left/2, existing_schema(Path), GeneratedJObj),
     UpdatedSchema = kz_json:delete_key(<<"id">>, MergedJObj),
+    'ok' = filelib:ensure_dir(Path),
     'ok' = file:write_file(Path, kz_json:encode(UpdatedSchema)).
 
 -spec existing_schema(file:filename_all()) -> kz_json:object().
@@ -80,9 +88,9 @@ process_project() ->
     io:format("processing kapps_config/kapps_account_config/ecallmgr_config usage: "),
     Options = [{'expression', fun expression_to_schema/2}
               ,{'module', fun print_dot/2}
-              ,{'accumulator', kz_json:new()}
+              ,{'accumulator', new_acc()}
               ],
-    Usage = kazoo_ast:walk_project(Options),
+    #{'project_schemas' := Usage} = kazoo_ast:walk_project(Options),
     io:format(" done~n"),
     Usage.
 
@@ -90,13 +98,44 @@ process_project() ->
 process_app(App) ->
     Options = [{'expression', fun expression_to_schema/2}
               ,{'module', fun print_dot/2}
-              ,{'accumulator', kz_json:new()}
+              ,{'accumulator', new_acc()}
+              ,{'application', fun add_app_config/2}
+              ,{'after_application', fun add_schemas_to_bucket/2}
               ],
-    kazoo_ast:walk_app(App, Options).
+    #{'project_schemas' := Usage} = kazoo_ast:walk_app(App, Options),
+    Usage.
 
 print_dot(_Module, Acc) ->
     io:format("."),
     Acc.
+
+-type acc() :: #{schema_dir := 'default' | file:filename_all()
+                ,app_schemas := kz_json:object()
+                ,project_schemas := kz_json:object()
+                }.
+-spec new_acc() -> acc().
+new_acc() ->
+    #{schema_dir => 'default'
+     ,app_schemas => kz_json:new() %% SchemaName => SchemaProperties
+     ,project_schemas => kz_json:from_list([{'default', kz_json:new()}]) %% Path => Schemas
+     }.
+
+-spec add_app_config(atom(), acc()) -> acc().
+add_app_config(App, Acc) ->
+    case application:get_env(App, 'schema_dir') of
+        'undefined' -> Acc#{schema_dir => 'default'};
+        {'ok', PrivDir} -> Acc#{schema_dir => PrivDir}
+    end.
+
+add_schemas_to_bucket(_App, #{schema_dir := PrivDir
+                             ,app_schemas := AppSchemas
+                             ,project_schemas := ProjectSchemas
+                             }=Acc) ->
+    ProjectSchema = kz_json:get_json_value(PrivDir, ProjectSchemas),
+    UpdatedSchema = kz_json:merge(ProjectSchema, AppSchemas),
+    Acc#{app_schemas => kz_json:new()
+        ,project_schemas => kz_json:set_value(PrivDir, UpdatedSchema, ProjectSchemas)
+        }.
 
 -spec expression_to_schema(any(), kz_json:object()) -> kz_json:object().
 expression_to_schema(?MOD_FUN_ARGS('kapps_config', 'set', _), Schemas) ->
@@ -178,11 +217,11 @@ config_to_schema(Source, F, [Cat, K, Default], Schemas) ->
 
 config_key_to_schema(_Source, _F, 'undefined', _Key, _Default, Schemas) ->
     Schemas;
-config_key_to_schema(Source, F, Document, Key, Default, Schemas) ->
+config_key_to_schema(Source, F, Document, Key, Default, #{app_schemas := Schemas}=Acc) ->
     Properties = guess_properties(Document, Source, Key, guess_type(F, Default), Default),
     Path = [Document, ?FIELD_PROPERTIES | Key],
 
-    kz_json:set_value(Path, Properties, Schemas).
+    Acc#{app_schemas => kz_json:set_value(Path, Properties, Schemas)}.
 
 category_to_document(?VAR(_)) -> 'undefined';
 category_to_document(Cat) ->

--- a/core/kazoo_ast/src/kapps_config_usage.erl
+++ b/core/kazoo_ast/src/kapps_config_usage.erl
@@ -52,7 +52,6 @@ update_schema(Name, AutoGenSchema, PrivDir, ConfigType) ->
     MergedJObj = kz_json:merge(fun kz_json:merge_left/2, existing_schema(Path), GeneratedJObj),
     UpdatedSchema = kz_json:delete_key(<<"id">>, MergedJObj),
     'ok' = filelib:ensure_dir(Path),
-    io:format("writing ~s to ~s~n", [Name, Path]),
     'ok' = file:write_file(Path, kz_json:encode(UpdatedSchema)).
 
 -spec existing_schema(file:filename_all()) -> kz_json:object().
@@ -102,7 +101,7 @@ process_project() ->
               ,{'accumulator', new_acc()}
               ],
     #{'project_schemas' := Usage} = kazoo_ast:walk_project(Options),
-    io:format(" done~n~p~n", [Usage]),
+    io:format(" done~n"),
     Usage.
 
 -spec process_app(atom()) -> kz_json:object().
@@ -131,9 +130,6 @@ new_acc() ->
 add_app_config(App, Acc) ->
     case application:get_env(App, 'schemas_to_priv') of
         {'ok', 'true'} ->
-            io:format("storing app ~s detected schemas in ~p~n"
-                     ,[App, kz_term:to_binary(code:priv_dir(App))]
-                     ),
             Acc#{schema_dir => kz_term:to_binary(code:priv_dir(App))};
         _ -> Acc#{schema_dir => 'default'}
     end.

--- a/core/kazoo_ast/src/kazoo_ast.erl
+++ b/core/kazoo_ast/src/kazoo_ast.erl
@@ -21,6 +21,7 @@
                         fun((function(), arity(), accumulator()) -> fun_return()).
 -type clause_fun() :: fun(([erl_parse:abstract_expr()], [erl_parse:abstract_expr()], accumulator()) -> accumulator()).
 -type module_fun() :: fun((atom(), accumulator()) -> fun_return()).
+-type app_fun() :: fun((atom(), accumulator()) -> fun_return()).
 -type record_fun() :: fun((any(), accumulator()) -> fun_return()).
 
 -type option() :: {'expression', expression_fun()} |
@@ -28,6 +29,8 @@
                   {'clause', clause_fun()} |
                   {'module', module_fun()} |
                   {'after_module', module_fun()} |
+                  {'application', app_fun()} |
+                  {'after_application', app_fun()} |
                   {'record', record_fun()} |
                   {'accumulator', accumulator()}.
 -type options() :: [option()].
@@ -71,7 +74,13 @@ option_to_config({K, V}, Config) ->
     maps:put(K, V, Config).
 
 -spec process_app(atom(), config()) -> config().
-process_app(App, Config) ->
+-spec process_app_modules(atom(), config()) -> config().
+process_app(App, Config0) ->
+    Config2 = process_app_modules(App, callback_application(App, Config0)),
+    callback_after_application(App, Config2).
+
+process_app_modules(_App, {'skip', Config}) -> Config;
+process_app_modules(App, Config) ->
     try process_modules(kz_ast_util:app_modules(App), Config)
     catch 'throw':{'stop', Acc} -> Acc
     end.
@@ -313,6 +322,34 @@ callback_after_module(Module
             Config0#{'accumulator' => Acc}
     end;
 callback_after_module(_Module, Config) -> Config.
+
+callback_application(App, #{'application' := Fun
+                           ,'accumulator' := Acc0
+                           }=Config0
+                    ) ->
+    case Fun(App, Acc0) of
+        {'skip', Acc} ->
+            {'skip', Config0#{'accumulator' => Acc}};
+        {'stop', Acc} ->
+            throw({'stop', Acc});
+        Acc ->
+            Config0#{'accumulator' => Acc}
+    end;
+callback_application(_App, Config) -> Config.
+
+callback_after_application(App, #{'after_application' := Fun
+                                 ,'accumulator' := Acc0
+                                 }=Config0
+                          ) ->
+    case Fun(App, Acc0) of
+        {'skip', Acc} ->
+            {'skip', Config0#{'accumulator' => Acc}};
+        {'stop', Acc} ->
+            throw({'stop', Acc});
+        Acc ->
+            Config0#{'accumulator' => Acc}
+    end;
+callback_after_application(_App, Config) -> Config.
 
 callback_clause(Args, Guards, #{'accumulator' := Acc
                                 ,'clause' := ClauseFun

--- a/core/kazoo_ast/src/kazoo_ast.erl
+++ b/core/kazoo_ast/src/kazoo_ast.erl
@@ -10,7 +10,7 @@
 
 %% define the callback function for the various options
 
--type accumulator() :: kz_json:object() | tuple().
+-type accumulator() :: any().
 
 -type fun_return() :: accumulator() |
                       {'skip', accumulator()} |

--- a/core/kazoo_ast/src/kz_ast_util.erl
+++ b/core/kazoo_ast/src/kz_ast_util.erl
@@ -8,7 +8,7 @@
         ,binary_match_to_binary/1
         ,smash_snake/1
 
-        ,schema_path/1
+        ,schema_path/1, schema_path/2
         ,api_path/1
         ,ensure_file_exists/1
         ,create_schema/1
@@ -125,8 +125,11 @@ format_name_part(Part) ->
     kz_binary:ucfirst(Part).
 
 -spec schema_path(binary()) -> file:filename_all().
+-spec schema_path(binary(), file:filename_all()) -> file:filename_all().
 schema_path(Base) ->
-    case filename:join([code:priv_dir('crossbar')
+    schema_path(Base, code:priv_dir('crossbar')).
+schema_path(Base, PrivDir) ->
+    case filename:join([PrivDir
                        ,<<"couchdb">>
                        ,<<"schemas">>
                        ,Base


### PR DESCRIPTION
Not all apps want their detected schemas in the default location. This allows apps to override the default with an app-specific location.