### PR TITLE
do not use 'readlink -f' to support macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOT = $(shell readlink -f .)
+ROOT = $(shell cd "$(dirname '.')" && pwd -P)
 RELX = $(ROOT)/deps/relx
 ELVIS = $(ROOT)/deps/elvis
 FMT = $(ROOT)/make/erlang-formatter-master/fmt.sh

--- a/doc/mkdocs/Makefile
+++ b/doc/mkdocs/Makefile
@@ -1,6 +1,6 @@
 .PHONY: docs-build docs-serve clean
 
-DOCS_ROOT ?= $(shell readlink -f .)
+DOCS_ROOT ?= $(shell cd "$(dirname '.')" && pwd -P)
 
 YML ?= $(filter-out local,$(wildcard *.yml))
 LOCAL = $(YML:.yml=.local)

--- a/scripts/setup_docs.bash
+++ b/scripts/setup_docs.bash
@@ -4,7 +4,7 @@
 pushd $(dirname $0) > /dev/null
 
 cd $(pwd -P)/..
-DOCS_ROOT=`readlink -f ./doc/mkdocs`
+DOCS_ROOT=`cd "$(dirname './doc/mkdocs')" && pwd -P`
 
 if [ -z `command -v cpio` ] ; then
 	echo "cpio command is not available, please install it" && exit 1

--- a/scripts/setup_docs.bash
+++ b/scripts/setup_docs.bash
@@ -4,10 +4,10 @@
 pushd $(dirname $0) > /dev/null
 
 cd $(pwd -P)/..
-DOCS_ROOT=`cd "$(dirname './doc/mkdocs')" && pwd -P`
+DOCS_ROOT=`cd ./doc/mkdocs && pwd -P`
 
 if [ -z `command -v cpio` ] ; then
-	echo "cpio command is not available, please install it" && exit 1
+    echo "cpio command is not available, please install it" && popd > /dev/null && exit 1
 fi
 
 find {scripts,doc,core,applications} -type f -path "doc/mkdocs*" -prune -o -regex ".+\.\(md\|png\|jpg\|svg|json\)$" -print | cpio -p -dum --quiet $DOCS_ROOT/docs


### PR DESCRIPTION
Please do not use `readlink -f`, macOS is lame and doesn't support GNU commands.