### PR TITLE
PISTON-494: wrap as JSON the values in cf_webhook's props to publish

### DIFF
--- a/applications/callflow/src/module/cf_webhook.erl
+++ b/applications/callflow/src/module/cf_webhook.erl
@@ -37,7 +37,7 @@ handle_webhook(Data, Call) ->
             ],
     kapps_notify_publisher:cast(Props, fun kapi_notifications:publish_webhook/1).
 
--spec format_call_data(kapps_call:call()) -> kz_proplist().
+-spec format_call_data(kapps_call:call()) -> kz_json:object().
 format_call_data(Call) ->
     JObj = kapps_call:to_json(Call),
     RemoveKeys = [<<"Key-Value-Store">>
@@ -45,17 +45,18 @@ format_call_data(Call) ->
                  ,<<"Controller-Queue">>
                  ,<<"Custom-Channel-Vars">>
                  ],
-    kz_json:recursive_to_proplist(kz_json:normalize_jobj(JObj, RemoveKeys, [])).
+    kz_json:normalize_jobj(JObj, RemoveKeys, []).
 
--spec set_hook(kz_json:object(), kz_proplist()) -> kz_proplist().
-set_hook(Data, CallProps) ->
+-spec set_hook(kz_json:object(), kz_json:object()) -> kz_json:object().
+set_hook(Data, CallJObj) ->
     Now = calendar:datetime_to_gregorian_seconds(calendar:local_time()),
-    props:filter_undefined(
-      [{<<"_id">>, kz_term:to_binary(Now)}
-      ,{<<"uri">>, kz_json:get_ne_binary_value(<<"uri">>, Data)}
-      ,{<<"hook">>, <<"callflow">>}
-      ,{<<"http_verb">>, kz_json:get_ne_binary_value(<<"http_verb">>, Data)}
-      ,{<<"retries">>, kz_json:get_integer_value(<<"retries">>, Data)}
-      ,{<<"pvt_account_id">>, props:get_ne_binary_value(<<"account_id">>, CallProps)}
-      ,{<<"custom_data">>, kz_json:get_json_value(<<"custom_data">>, Data)}
-      ]).
+    kz_json:from_list(
+      props:filter_undefined(
+        [{<<"_id">>, kz_term:to_binary(Now)}
+        ,{<<"uri">>, kz_json:get_ne_binary_value(<<"uri">>, Data)}
+        ,{<<"hook">>, <<"callflow">>}
+        ,{<<"http_verb">>, kz_json:get_ne_binary_value(<<"http_verb">>, Data)}
+        ,{<<"retries">>, kz_json:get_integer_value(<<"retries">>, Data)}
+        ,{<<"pvt_account_id">>, kz_json:get_ne_binary_value(<<"account_id">>, CallJObj)}
+        ,{<<"custom_data">>, kz_json:get_json_value(<<"custom_data">>, Data)}
+        ])).


### PR DESCRIPTION
Right now the JSON payload to kapi_notifications:publish_webhook/1 is recursively converted to proplist, but kz_api does not recursively convert back before the publish, leading to "invalid_ejson". The "Hook" and "Data" props are at fault.
PR just leaves the types as kz_json:object() so the conversion is not required.