### PR TITLE
KAZOO-5758: tts can be uninterrupted

### DIFF
--- a/applications/crossbar/doc/channels.md
+++ b/applications/crossbar/doc/channels.md
@@ -118,7 +118,7 @@ Metaflow feature is a `metaflow` object which validates with its json schema.
 curl -v -X PUT \
     -H "Content-Type: application/json" \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -d '{"data": {"action": "metaflow", "data": { "module": "hangup" }}}' \
+    -d '{"action":"metaflow", "data": {"data": { "module": "hangup" }}}' \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/channels/{UUID}
 ```
 

--- a/applications/crossbar/src/modules/cb_channels.erl
+++ b/applications/crossbar/src/modules/cb_channels.erl
@@ -239,7 +239,10 @@ validate_action(Context, CallId) ->
     Ctx = read(Context, CallId),
     case cb_context:has_errors(Ctx) of
         'true' -> Ctx;
-        'false' -> validate_action(Ctx, CallId, cb_context:req_value(Context, <<"action">>))
+        'false' ->
+            Envelope = cb_context:req_json(Context),
+            Data = cb_context:req_data(Context),
+            validate_action(Ctx, CallId, kz_json:find(<<"action">>, [Envelope, Data]))
     end.
 
 validate_action(Context, _UUID, <<"metaflow">>) ->

--- a/applications/ecallmgr/src/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_command.erl
@@ -1454,8 +1454,9 @@ play_vars(Node, UUID, JObj) ->
 %%--------------------------------------------------------------------
 -spec get_terminators(api_binary() | ne_binaries() | kz_json:object()) ->
                              {ne_binary(), ne_binary()} | 'undefined'.
-get_terminators('undefined') -> 'undefined';
+get_terminators('undefined') -> {<<"playback_terminators">>, <<"none">>};
 get_terminators(Ts) when is_binary(Ts) -> get_terminators([Ts]);
+get_terminators([]) -> {<<"playback_terminators">>, <<"none">>};
 get_terminators([_|_]=Ts) ->
     case Ts =:= get('$prior_terminators') of
         'true' -> 'undefined';

--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -1492,7 +1492,9 @@ tts_command(SayMe, Voice, Language, Terminators, Engine, Call) ->
       ,{<<"Call-ID">>, kapps_call:call_id(Call)}
       ]).
 
+-spec tts_terminators(api_ne_binaries()) -> api_ne_binaries().
 tts_terminators('undefined') -> ?ANY_DIGIT;
+tts_terminators([]) -> 'undefined';
 tts_terminators(Terminators) -> Terminators.
 
 tts_voice('undefined') -> kazoo_tts:default_voice();


### PR DESCRIPTION
also fixes searching for the envelope first when doing metaflows