### PR TITLE
Fix bad catch in sup.erl

### DIFF
--- a/core/sup/src/sup.erl
+++ b/core/sup/src/sup.erl
@@ -99,13 +99,13 @@ print_result(Result, true) ->
     String = io_lib:print(Result, 1, ?MAX_CHARS, -1),
     try stdout("Result: ~s", [String])
     catch
-        erro:badarg -> stdout("Result: ~p", [String])
+        error:badarg -> stdout("Result: ~p", [String])
     end;
 print_result(Result, false) ->
     String = io_lib:print(Result, 1, ?MAX_CHARS, -1),
     try stdout("~s", [String])
     catch
-        erro:badarg -> stdout("~p", [String])
+        error:badarg -> stdout("~p", [String])
     end.
 
 -spec get_target(kz_proplist(), boolean()) -> atom().


### PR DESCRIPTION
In `sup:print_result/2`, the code

```erlang
try stdout("~s", [String])
catch
    erro:badarg -> stdout("Result: ~p", [String])
end
```

is not catching `badarg` errors because `erro:` is not a valid exception class. This causes an exception to be propagated when it should not be.

This was fixed by changing the offending line to

```erlang
    error:badarg -> stdout("Result: ~p", [String])
```