### PR TITLE
Check spelling of forward in config

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -82,7 +82,7 @@
 
 -define(DEFAULT_FORWARD_TYPE
        ,kapps_config:get_ne_binary(?CF_CONFIG_CAT
-                                  ,[?KEY_VOICEMAIL, <<"vm_message_foraward_type">>]
+                                  ,[?KEY_VOICEMAIL, <<"vm_message_forward_type">>]
                                   ,<<"only_forward">>
                                   )).
 

--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -91,7 +91,7 @@
     "callflow.route_win_timeout": "callflow route win timeout",
     "callflow.save_after_notify": "Move the voicemail to save folder after the notification has been sent (This setting will override delete_after_notify)",
     "callflow.singular_call_hook_url": "callflow singular call hook url",
-    "callflow.vm_message_foraward_type": "Enable or disable the ability to prepend a message when forwarding a voicemail message",
+    "callflow.vm_message_forward_type": "Enable or disable the ability to prepend a message when forwarding a voicemail message",
     "camper.stop_after": "camper stop after",
     "camper.timeout": "camper timeout",
     "camper.tries": "camper tries",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -24717,9 +24717,13 @@
                             "description": "callflow save after notify",
                             "type": "boolean"
                         },
-                        "vm_message_foraward_type": {
+                        "vm_message_forward_type": {
                             "default": "only_forward",
                             "description": "Enable or disable the ability to prepend a message when forwarding a voicemail message",
+                            "enum": [
+                                "only_forward",
+                                "prepend_forward"
+                            ],
                             "type": "string"
                         }
                     },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
@@ -150,9 +150,13 @@
                     "description": "callflow save after notify",
                     "type": "boolean"
                 },
-                "vm_message_foraward_type": {
+                "vm_message_forward_type": {
                     "default": "only_forward",
                     "description": "Enable or disable the ability to prepend a message when forwarding a voicemail message",
+                    "enum": [
+                        "only_forward",
+                        "prepend_forward"
+                    ],
                     "type": "string"
                 }
             },

--- a/core/kazoo_config/src/kapps_config.erl
+++ b/core/kazoo_config/src/kapps_config.erl
@@ -52,7 +52,7 @@
 -export([migrate/0]).
 
 -type config_category() :: ne_binary() | nonempty_string() | atom().
--type config_key() :: ne_binary() | nonempty_string() | atom() | [config_key(),...].
+-type config_key() :: ne_binary() | nonempty_string() | atom() | ne_binaries().
 
 -type update_option() :: {'node_specific', boolean()} |
                          {'pvt_fields', api_object()}.
@@ -974,6 +974,10 @@ get_category(Category, 'false') ->
         ,{{<<"media">>, <<"tts_cache">>}
          ,{<<"speech">>, <<"tts_cache">>}
          }
+
+        ,{{<<"callflow">>, [<<"voicemail">>, <<"vm_message_foraward_type">>]}
+         ,{<<"callflow">>, [<<"voicemail">>, <<"vm_message_forward_type">>]}
+         }
         ]).
 
 -spec migrate() -> 'ok'.
@@ -1093,5 +1097,7 @@ remove_config_setting([{Id, Node, Setting} | Keys], JObj, Removed) ->
 
 -spec config_setting_key(ne_binary(), config_key()) -> ne_binaries().
 %% NOTE: to support nested keys, update this merge function
+config_setting_key(Node, [_|_]=Setting) ->
+    [Node | Setting];
 config_setting_key(Node, Setting) ->
     [Node, Setting].


### PR DESCRIPTION
* fix spelling

* update system config

* update swagger

* remove old config from swagger

* set the enum properties up

* revert description

* migrate setting