### PR TITLE
[4.1] KAZOO-5718: send notification on direct port comment

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -15343,7 +15343,7 @@
                 "Cc": {
                     "type": "string"
                 },
-                "Comments": {
+                "Comment": {
                     "type": "string"
                 },
                 "Event-Category": {

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -15343,6 +15343,9 @@
                 "Cc": {
                     "type": "string"
                 },
+                "Comments": {
+                    "type": "string"
+                },
                 "Event-Category": {
                     "enum": [
                         "notification"

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_comment.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_comment.json
@@ -21,7 +21,7 @@
         "Cc": {
             "type": "string"
         },
-        "Comments": {
+        "Comment": {
             "type": "string"
         },
         "Event-Category": {

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_comment.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_comment.json
@@ -21,6 +21,9 @@
         "Cc": {
             "type": "string"
         },
+        "Comments": {
+            "type": "string"
+        },
         "Event-Category": {
             "enum": [
                 "notification"

--- a/applications/crossbar/src/modules/cb_global_provisioner_templates.erl
+++ b/applications/crossbar/src/modules/cb_global_provisioner_templates.erl
@@ -62,7 +62,6 @@ init() ->
     _ = crossbar_bindings:bind(<<"*.execute.put.global_provisioner_templates">>, ?MODULE, 'put'),
     _ = crossbar_bindings:bind(<<"*.execute.post.global_provisioner_templates">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"*.execute.delete.global_provisioner_templates">>, ?MODULE, 'delete'),
-    _ = crossbar_bindings:bind(<<"*.finish_request.put.devices">>, ?MODULE, 'device_updated'),
     ok.
 
 init_db() ->

--- a/applications/crossbar/src/modules/cb_local_provisioner_templates.erl
+++ b/applications/crossbar/src/modules/cb_local_provisioner_templates.erl
@@ -59,7 +59,6 @@ init() ->
     _ = crossbar_bindings:bind(<<"*.execute.put.local_provisioner_templates">>, ?MODULE, 'put'),
     _ = crossbar_bindings:bind(<<"*.execute.post.local_provisioner_templates">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"*.execute.delete.local_provisioner_templates">>, ?MODULE, 'delete'),
-    _ = crossbar_bindings:bind(<<"*.finish_request.put.devices">>, ?MODULE, 'device_updated'),
     ok.
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -25,6 +25,7 @@
         ,authority/1
 
         ,acceptable_content_types/0
+
         ]).
 
 -include("crossbar.hrl").
@@ -1149,7 +1150,7 @@ maybe_send_port_comment_notification(Context, Id) ->
     case has_new_comment(DbDocComments, ReqDataComments) of
         'false' -> lager:debug("no new comments in ~s, ignoring", [Id]);
         'true' ->
-            try send_port_comment_notification(Context, Id) of
+            try send_port_comment_notification(Context, Id, ReqDataComments) of
                 _ -> lager:debug("port comment notification sent")
             catch
                 _E:_R ->
@@ -1229,11 +1230,12 @@ revert_patch(Context) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec send_port_comment_notification(cb_context:context(), ne_binary()) -> 'ok'.
-send_port_comment_notification(Context, Id) ->
+-spec send_port_comment_notification(cb_context:context(), ne_binary(), kz_json:objects()) -> 'ok'.
+send_port_comment_notification(Context, Id, NewComments) ->
     Req = [{<<"Account-ID">>, cb_context:account_id(Context)}
           ,{<<"Authorized-By">>, cb_context:auth_account_id(Context)}
           ,{<<"Port-Request-ID">>, Id}
+          ,{<<"Comments">>, NewComments}
           ,{<<"Version">>, cb_context:api_version(Context)}
            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
           ],

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -1150,7 +1150,7 @@ maybe_send_port_comment_notification(Context, Id) ->
     case has_new_comment(DbDocComments, ReqDataComments) of
         'false' -> lager:debug("no new comments in ~s, ignoring", [Id]);
         'true' ->
-            try send_port_comment_notification(Context, Id, ReqDataComments) of
+            try send_port_comment_notification(Context, Id, lists:last(ReqDataComments)) of
                 _ -> lager:debug("port comment notification sent")
             catch
                 _E:_R ->
@@ -1230,15 +1230,22 @@ revert_patch(Context) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec send_port_comment_notification(cb_context:context(), ne_binary(), kz_json:objects()) -> 'ok'.
-send_port_comment_notification(Context, Id, NewComments) ->
+-spec send_port_comment_notification(cb_context:context(), ne_binary(), kz_json:object()) -> 'ok'.
+send_port_comment_notification(Context, Id, NewComment) ->
+    Props = [{<<"user_id">>, cb_context:auth_user_id(Context)}
+            ,{<<"account_id">>, cb_context:auth_account_id(Context)}
+            ],
+    Comment = kz_json:set_values(Props, NewComment),
     Req = [{<<"Account-ID">>, cb_context:account_id(Context)}
           ,{<<"Authorized-By">>, cb_context:auth_account_id(Context)}
           ,{<<"Port-Request-ID">>, Id}
-          ,{<<"Comments">>, NewComments}
+          ,{<<"Comment">>, Comment}
           ,{<<"Version">>, cb_context:api_version(Context)}
            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
           ],
+    lager:debug("sending port request notification for new comment by user ~s in account ~s"
+               ,[cb_context:auth_user_id(Context), cb_context:auth_account_id(Context)]
+               ),
     kapps_notify_publisher:cast(Req, fun kapi_notifications:publish_port_comment/1).
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -66,7 +66,6 @@ init() ->
     _ = crossbar_bindings:bind(<<"*.execute.post.vmboxes">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"*.execute.patch.vmboxes">>, ?MODULE, 'patch'),
     _ = crossbar_bindings:bind(<<"*.execute.delete.vmboxes">>, ?MODULE, 'delete'),
-    _ = crossbar_bindings:bind(<<"*.finish_request.post.vmboxes">>, ?MODULE, 'finish_request'),
     ok.
 
 %%--------------------------------------------------------------------

--- a/applications/teletype/priv/templates/port_comment.html
+++ b/applications/teletype/priv/templates/port_comment.html
@@ -45,7 +45,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" bgcolor="#eaeaea" width="80%" style="background-color:#eaeaea;border-radius:5px;">
                             <tr>
                                 <td style="padding:.9em;font-size:.9em;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-radius:5px;">
-                                    <p style="margin:0;padding:0;font-size:.7em;font-family:'Open Sans',sans-serif;color:#555555;"><b>{% firstof user.first_name user.last_name %}</b> commented at {{port_request.comment.timestamp.local|date:"l, F j, Y \\a\\t H:i"}}:</p>
+                                    <p style="margin:0;padding:0;font-size:.7em;font-family:'Open Sans',sans-serif;color:#555555;"><b>{{user.first_name}} {{user.last_name}}</b> commented on {{port_request.comment.date.local|date:"l, F j, Y \\a\\t H:i"}}:</p>
                                     <p style="margin:0;padding:0">{{port_request.comment.content}}</p>
                                 </td>
                             </tr>

--- a/applications/teletype/priv/templates/port_comment.text
+++ b/applications/teletype/priv/templates/port_comment.text
@@ -2,7 +2,7 @@
 
 Comment on your port request "{{port_request.name}}" of account '{{account.name}}'.
 
-{% firstof user.first_name user.last_name %} commented at {{port_request.comment.timestamp.local|date:"l, F j, Y \\a\\t H:i"}}:
+{{user.first_name}} {{user.last_name}} commented on {{port_request.comment.date.local|date:"l, F j, Y \\a\\t H:i"}}:
 {{port_request.comment.content}}
 
 

--- a/applications/teletype/src/teletype.hrl
+++ b/applications/teletype/src/teletype.hrl
@@ -120,9 +120,9 @@
 
 -define(PORT_REQUEST_MACROS
        ,[?MACRO_VALUE(<<"port_request.comment.content">>, <<"comment.content">>, <<"Comment Text">>, <<"Comment Text">>)
-        ,?MACRO_VALUE(<<"port_request.comment.timestamp.local">>, <<"comment.timestamp_local">>, <<"Comment UTC Timestamp">>, <<"Comment Local Timestamp">>)
-        ,?MACRO_VALUE(<<"port_request.comment.timestamp.utc">>, <<"comment.timestamp_utc">>, <<"Comment UTC Timestamp">>, <<"Comment UTC Timestamp">>)
-        ,?MACRO_VALUE(<<"port_request.comment.timestamp.timezone">>, <<"comment.timestamp_timezone">>, <<"Comment Local Timestamp">>, <<"Comment Timestamp Local Timezone">>)
+        ,?MACRO_VALUE(<<"port_request.comment.date.local">>, <<"comment.date_local">>, <<"Comment Local Timestamp">>, <<"Comment Local Timestamp">>)
+        ,?MACRO_VALUE(<<"port_request.comment.date.utc">>, <<"comment.date_utc">>, <<"Comment UTC Timestamp">>, <<"Comment UTC Timestamp">>)
+        ,?MACRO_VALUE(<<"port_request.comment.date.timezone">>, <<"comment.date_timezone">>, <<"Comment Local Timestamp">>, <<"Comment Timestamp Local Timezone">>)
         ,?MACRO_VALUE(<<"port_request.customser_contact">>, <<"customser_contact">>, <<"Customser Email">>, <<"Customser Email">>)
         ,?MACRO_VALUE(<<"port_request.bill_name">>, <<"bill_name">>, <<"Bill Name">>, <<"Name on the bill">>)
         ,?MACRO_VALUE(<<"port_request.bill_address">>, <<"bill_address">>, <<"Bill Address">>, <<"Address on the bill">>)
@@ -137,7 +137,9 @@
         ,?MACRO_VALUE(<<"port_request.port_scheduled_date.utc">>, <<"port_scheduled_date_utc">>, <<"UTC Scheduled Date">>, <<"UTC Scheduled Date">>)
         ,?MACRO_VALUE(<<"port_request.port_scheduled_date.timezone">>, <<"port_scheduled_date_timezone">>, <<"Scheduled Date Timezone">>, <<"Scheduled Date Local Timezone">>)
         ,?MACRO_VALUE(<<"port_request.service_provider">>, <<"service_provider">>, <<"Service Provider">>, <<"Service Provider">>)
-        ,?MACRO_VALUE(<<"port_request.requested_port_date">>, <<"requested_port_date">>, <<"Requested Port Date">>, <<"Requested Port Date">>)
+        ,?MACRO_VALUE(<<"port_request.requested_port_date.local">>, <<"requested_port_date_local">>, <<"Local Requested Port Date">>, <<"Local Requested Port Date">>)
+        ,?MACRO_VALUE(<<"port_request.requested_port_date.utc">>, <<"requested_port_date_utc">>, <<"UTC Requested Port Date">>, <<"UTC Requested Port Date">>)
+        ,?MACRO_VALUE(<<"port_request.requested_port_date.timezone">>, <<"requested_port_date_timezone">>, <<"Requested Port Date Timezone">>, <<"Requested Port Date Local Timezone">>)
         ]).
 
 -define(TRANSACTION_MACROS

--- a/applications/teletype/src/teletype_port_utils.erl
+++ b/applications/teletype/src/teletype_port_utils.erl
@@ -11,7 +11,7 @@
 -export([is_comment_private/1]).
 -export([get_attachments/1]).
 -export([fix_email/1, fix_email/2]).
--export([fix_port_request_data/1]).
+-export([fix_port_request_data/2]).
 
 -include("teletype.hrl").
 
@@ -97,22 +97,22 @@ get_port_req_email(ReqData) ->
         _ -> []
     end.
 
--spec fix_port_request_data(kz_json:object()) -> kz_json:object().
-fix_port_request_data(JObj) ->
-    Routines = [fun fix_numbers/1
-               ,fun fix_billing/1
-               ,fun fix_comments/1
-               ,fun fix_dates/1
-               ,fun fix_notifications/1
-               ,fun fix_carrier/1
-               ,fun fix_transfer_date/1
-               ,fun fix_scheduled_date/1
-               ,fun fix_ui_metadata/1
+-spec fix_port_request_data(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_port_request_data(JObj, DataJObj) ->
+    Routines = [fun fix_numbers/2
+               ,fun fix_billing/2
+               ,fun fix_comments/2
+               ,fun fix_dates/2
+               ,fun fix_notifications/2
+               ,fun fix_carrier/2
+               ,fun fix_transfer_date/2
+               ,fun fix_scheduled_date/2
+               ,fun fix_ui_metadata/2
                ],
-    lists:foldl(fun(F, J) -> F(J) end, JObj, Routines).
+    lists:foldl(fun(F, J) -> F(J, DataJObj) end, JObj, Routines).
 
--spec fix_numbers(kz_json:object()) -> kz_json:object().
-fix_numbers(JObj) ->
+-spec fix_numbers(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_numbers(JObj, _DataJObj) ->
     NumbersJObj = kz_json:get_value(<<"numbers">>, JObj, kz_json:new()),
     Numbers = kz_json:foldl(fun fix_number_fold/3, [], NumbersJObj),
     kz_json:set_value(<<"numbers">>, Numbers, JObj).
@@ -121,8 +121,8 @@ fix_numbers(JObj) ->
 fix_number_fold(Number, _Value, Acc) ->
     [Number|Acc].
 
--spec fix_billing(kz_json:object()) -> kz_json:object().
-fix_billing(JObj) ->
+-spec fix_billing(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_billing(JObj, _DataJObj) ->
     kz_json:foldl(fun fix_billing_fold/3
                  ,kz_json:delete_key(<<"bill">>, JObj)
                  ,kz_json:get_json_value(<<"bill">>, JObj, kz_json:new())
@@ -133,15 +133,15 @@ fix_billing(JObj) ->
 fix_billing_fold(Key, Value, Acc) ->
     kz_json:set_value(<<"bill_", Key/binary>>, Value, Acc).
 
--spec fix_comments(kz_json:object()) -> kz_json:object().
-fix_comments(JObj) ->
-    case kz_json:get_list_value(<<"comments">>, JObj, []) of
+-spec fix_comments(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_comments(JObj, DataJObj) ->
+    case kz_json:get_list_value(<<"comments">>, DataJObj, []) of
         [] -> kz_json:delete_key(<<"comments">>, JObj);
         Comments ->
             LastComment = lists:last(Comments),
 
             Timestamp = kz_json:get_integer_value(<<"timestamp">>, LastComment),
-            Date = kz_json:from_list(teletype_util:fix_timestamp(Timestamp, JObj)),
+            Date = kz_json:from_list(teletype_util:fix_timestamp(Timestamp, DataJObj)),
             Comment = kz_json:set_values([{<<"date">>, Date}
                                          ,{<<"timestamp">>, kz_json:get_value(<<"local">>, Date)} %% backward compatibility
                                          ], LastComment),
@@ -152,8 +152,8 @@ fix_comments(JObj) ->
                              )
     end.
 
--spec fix_dates(kz_json:object()) -> kz_json:object().
-fix_dates(JObj) ->
+-spec fix_dates(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_dates(JObj, _DataJObj) ->
     lists:foldl(fun fix_date_fold/2, JObj, [<<"transfer_date">>, <<"scheduled_date">>]).
 
 -spec fix_date_fold(kz_json:path(), kz_json:object()) -> kz_json:object().
@@ -165,32 +165,32 @@ fix_date_fold(Key, JObj) ->
             kz_json:set_value(Key, Date, JObj)
     end.
 
--spec fix_notifications(kz_json:path()) -> kz_json:object().
-fix_notifications(JObj) ->
+-spec fix_notifications(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_notifications(JObj, _DataJObj) ->
     kz_json:set_value(<<"customer_contact">>
                      ,kz_json:get_value([<<"notifications">>, <<"email">>, <<"send_to">>], JObj)
                      ,JObj %% not deleting the key for backward compatibility
                      ).
 
--spec fix_carrier(kz_json:path()) -> kz_json:object().
-fix_carrier(JObj) ->
+-spec fix_carrier(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_carrier(JObj, _DataJObj) ->
     kz_json:set_value(<<"service_provider">>
                      ,kz_json:get_value(<<"carrier">>, JObj)
                      ,JObj %% not deleting the key for backward compatibility
                      ).
 
--spec fix_transfer_date(kz_json:path()) -> kz_json:object().
-fix_transfer_date(JObj) ->
+-spec fix_transfer_date(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_transfer_date(JObj, _DataJObj) ->
     kz_json:set_values([{<<"requested_port_date">>, kz_json:get_value(<<"transfer_date">>, JObj)}
                        ,{<<"transfer_date">>, kz_json:get_value([<<"transfer_date">>, <<"local">>], JObj)} %% backward compatibility
                        ], JObj).
 
--spec fix_scheduled_date(kz_json:path()) -> kz_json:object().
-fix_scheduled_date(JObj) ->
+-spec fix_scheduled_date(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_scheduled_date(JObj, _DataJObj) ->
     kz_json:set_values([{<<"port_scheduled_date">>, kz_json:get_value(<<"scheduled_date">>, JObj)}
                        ,{<<"scheduled_date">>, kz_json:get_value([<<"scheduled_date">>, <<"local">>], JObj)}
                        ], JObj).
 
--spec fix_ui_metadata(kz_json:path()) -> kz_json:object().
-fix_ui_metadata(JObj) ->
+-spec fix_ui_metadata(kz_json:object(), kz_json:object()) -> kz_json:object().
+fix_ui_metadata(JObj, _DataJObj) ->
     kz_json:delete_key(<<"ui_metadata">>, JObj).

--- a/applications/teletype/src/templates/teletype_port_cancel.erl
+++ b/applications/teletype/src/templates/teletype_port_cancel.erl
@@ -75,7 +75,7 @@ process_req(DataJObj) ->
     {'ok', PortReqJObj} = teletype_util:open_doc(<<"port_request">>, PortReqId, DataJObj),
 
     ReqData = kz_json:set_value(<<"port_request">>
-                               ,teletype_port_utils:fix_port_request_data(PortReqJObj)
+                               ,teletype_port_utils:fix_port_request_data(PortReqJObj, DataJObj)
                                ,DataJObj
                                ),
 

--- a/applications/teletype/src/templates/teletype_port_comment.erl
+++ b/applications/teletype/src/templates/teletype_port_comment.erl
@@ -76,7 +76,7 @@ process_req(DataJObj) ->
     {'ok', PortReqJObj} = teletype_util:open_doc(<<"port_request">>, PortReqId, DataJObj),
 
     ReqData = kz_json:set_value(<<"port_request">>
-                               ,teletype_port_utils:fix_port_request_data(PortReqJObj)
+                               ,teletype_port_utils:fix_port_request_data(PortReqJObj, DataJObj)
                                ,DataJObj
                                ),
 

--- a/applications/teletype/src/templates/teletype_port_comment.erl
+++ b/applications/teletype/src/templates/teletype_port_comment.erl
@@ -25,7 +25,7 @@
          )
        ).
 
--define(TEMPLATE_SUBJECT, <<"New comment for port request'{{port_request.name}}'">>).
+-define(TEMPLATE_SUBJECT, <<"New comment for port request '{{port_request.name}}'">>).
 -define(TEMPLATE_CATEGORY, <<"port_request">>).
 -define(TEMPLATE_NAME, <<"Port Comment">>).
 

--- a/applications/teletype/src/templates/teletype_port_comment.erl
+++ b/applications/teletype/src/templates/teletype_port_comment.erl
@@ -82,11 +82,8 @@ process_req(DataJObj) ->
 
     case teletype_util:is_preview(DataJObj) of
         'false' ->
-            Comments = kz_json:get_value(<<"comments">>, PortReqJObj),
             handle_port_request(
-              teletype_port_utils:fix_email(ReqData
-                                           ,teletype_port_utils:is_comment_private(Comments)
-                                           )
+              teletype_port_utils:fix_email(ReqData, teletype_port_utils:is_comment_private(DataJObj))
              );
         'true' -> handle_port_request(kz_json:merge_jobjs(DataJObj, ReqData))
     end.
@@ -113,8 +110,7 @@ handle_port_request(DataJObj) ->
 
     Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?MOD_CONFIG_CAT),
 
-    EmailAttachements = teletype_port_utils:get_attachments(DataJObj),
-    case teletype_util:send_email(Emails, Subject, RenderedTemplates, EmailAttachements) of
+    case teletype_util:send_email(Emails, Subject, RenderedTemplates) of
         'ok' ->
             teletype_util:send_update(DataJObj, <<"completed">>);
         {'error', Reason} ->
@@ -130,7 +126,7 @@ user_data(DataJObj, 'true') ->
     AccountId = kz_json:get_value(<<"account_id">>, DataJObj),
     teletype_util:user_params(teletype_util:find_account_admin(AccountId));
 user_data(DataJObj, 'false') ->
-    AccountId = kz_json:get_value(<<"account_id">>, DataJObj),
-    UserId = props:get_value(<<"user_id">>, kz_json:get_value([<<"port_request">>, <<"comment">>], DataJObj)),
+    AccountId = kz_json:get_value([<<"port_request">>, <<"comment">>, <<"account_id">>], DataJObj),
+    UserId = kz_json:get_value([<<"port_request">>, <<"comment">>, <<"user_id">>], DataJObj),
     {'ok', UserJObj} = kzd_user:fetch(AccountId, UserId),
     teletype_util:user_params(UserJObj).

--- a/applications/teletype/src/templates/teletype_port_pending.erl
+++ b/applications/teletype/src/templates/teletype_port_pending.erl
@@ -75,7 +75,7 @@ process_req(DataJObj) ->
     {'ok', PortReqJObj} = teletype_util:open_doc(<<"port_request">>, PortReqId, DataJObj),
 
     ReqData = kz_json:set_value(<<"port_request">>
-                               ,teletype_port_utils:fix_port_request_data(PortReqJObj)
+                               ,teletype_port_utils:fix_port_request_data(PortReqJObj, DataJObj)
                                ,DataJObj
                                ),
 

--- a/applications/teletype/src/templates/teletype_port_rejected.erl
+++ b/applications/teletype/src/templates/teletype_port_rejected.erl
@@ -75,7 +75,7 @@ process_req(DataJObj) ->
     {'ok', PortReqJObj} = teletype_util:open_doc(<<"port_request">>, PortReqId, DataJObj),
 
     ReqData = kz_json:set_value(<<"port_request">>
-                               ,teletype_port_utils:fix_port_request_data(PortReqJObj)
+                               ,teletype_port_utils:fix_port_request_data(PortReqJObj, DataJObj)
                                ,DataJObj
                                ),
 

--- a/applications/teletype/src/templates/teletype_port_request.erl
+++ b/applications/teletype/src/templates/teletype_port_request.erl
@@ -75,7 +75,7 @@ process_req(DataJObj) ->
     {'ok', PortReqJObj} = teletype_util:open_doc(<<"port_request">>, PortReqId, DataJObj),
 
     ReqData = kz_json:set_value(<<"port_request">>
-                               ,teletype_port_utils:fix_port_request_data(PortReqJObj)
+                               ,teletype_port_utils:fix_port_request_data(PortReqJObj, DataJObj)
                                ,DataJObj
                                ),
 

--- a/applications/teletype/src/templates/teletype_port_request_admin.erl
+++ b/applications/teletype/src/templates/teletype_port_request_admin.erl
@@ -75,7 +75,7 @@ process_req(DataJObj) ->
     {'ok', PortReqJObj} = teletype_util:open_doc(<<"port_request">>, PortReqId, DataJObj),
 
     ReqData = kz_json:set_value(<<"port_request">>
-                               ,teletype_port_utils:fix_port_request_data(PortReqJObj)
+                               ,teletype_port_utils:fix_port_request_data(PortReqJObj, DataJObj)
                                ,DataJObj
                                ),
 

--- a/applications/teletype/src/templates/teletype_port_scheduled.erl
+++ b/applications/teletype/src/templates/teletype_port_scheduled.erl
@@ -75,7 +75,7 @@ process_req(DataJObj) ->
     {'ok', PortReqJObj} = teletype_util:open_doc(<<"port_request">>, PortReqId, DataJObj),
 
     ReqData = kz_json:set_value(<<"port_request">>
-                               ,teletype_port_utils:fix_port_request_data(PortReqJObj)
+                               ,teletype_port_utils:fix_port_request_data(PortReqJObj, DataJObj)
                                ,DataJObj
                                ),
 

--- a/applications/teletype/src/templates/teletype_port_unconfirmed.erl
+++ b/applications/teletype/src/templates/teletype_port_unconfirmed.erl
@@ -75,7 +75,7 @@ process_req(DataJObj) ->
     {'ok', PortReqJObj} = teletype_util:open_doc(<<"port_request">>, PortReqId, DataJObj),
 
     ReqData = kz_json:set_value(<<"port_request">>
-                               ,teletype_port_utils:fix_port_request_data(PortReqJObj)
+                               ,teletype_port_utils:fix_port_request_data(PortReqJObj, DataJObj)
                                ,DataJObj
                                ),
 

--- a/applications/teletype/src/templates/teletype_ported.erl
+++ b/applications/teletype/src/templates/teletype_ported.erl
@@ -75,7 +75,7 @@ process_req(DataJObj) ->
     {'ok', PortReqJObj} = teletype_util:open_doc(<<"port_request">>, PortReqId, DataJObj),
 
     ReqData = kz_json:set_value(<<"port_request">>
-                               ,teletype_port_utils:fix_port_request_data(PortReqJObj)
+                               ,teletype_port_utils:fix_port_request_data(PortReqJObj, DataJObj)
                                ,DataJObj
                                ),
 

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -426,7 +426,7 @@
 -define(PORTED_TYPES, []).
 
 %% Notify Ported Request
--define(PORT_COMMENT_HEADERS, [<<"Account-ID">>, <<"Comments">>]).
+-define(PORT_COMMENT_HEADERS, [<<"Account-ID">>, <<"Comment">>]).
 -define(OPTIONAL_PORT_COMMENT_HEADERS, [<<"Number-State">>, <<"Local-Number">>, <<"Authorized-By">>, <<"Request">>
                                        ,<<"Port-Request-ID">>, <<"Number">>, <<"Port">>
                                             | ?DEFAULT_OPTIONAL_HEADERS

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -426,7 +426,7 @@
 -define(PORTED_TYPES, []).
 
 %% Notify Ported Request
--define(PORT_COMMENT_HEADERS, [<<"Account-ID">>]).
+-define(PORT_COMMENT_HEADERS, [<<"Account-ID">>, <<"Comments">>]).
 -define(OPTIONAL_PORT_COMMENT_HEADERS, [<<"Number-State">>, <<"Local-Number">>, <<"Authorized-By">>, <<"Request">>
                                        ,<<"Port-Request-ID">>, <<"Number">>, <<"Port">>
                                             | ?DEFAULT_OPTIONAL_HEADERS


### PR DESCRIPTION
Also fixes port dates macros (just referencing KAZOO-5668 here since old dates macro was used for template metadata. Actual problem with the ticket was either the template was not using `date` filter or was using wrong macro)