### PR TITLE
[Fix #kazoo-5748] Fix send worker update check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ fixture_shell:
 		erl -name fixturedb -s reloader "$$@"
 
 DIALYZER ?= dialyzer
-DIZLYZER += --statistics --no_native
+DIALYZER += --statistics --no_native
 PLT ?= .kazoo.plt
 
 OTP_APPS ?= erts kernel stdlib crypto public_key ssl asn1 inets xmerl

--- a/applications/tasks/src/modules/kt_numbers.erl
+++ b/applications/tasks/src/modules/kt_numbers.erl
@@ -47,13 +47,15 @@
 -define(MOD_CAT, <<(?CONFIG_CAT)/binary, ".numbers">>).
 -define(IMPORT_DEFAULTS_TO_CARRIER
         %% Defaults to knm_carriers:default_carrier()'s default value
-       ,kapps_config:get_binary(?MOD_CAT, <<"import_defaults_to_carrier">>, ?CARRIER_LOCAL)).
+       ,kapps_config:get_binary(?MOD_CAT, <<"import_defaults_to_carrier">>, ?CARRIER_LOCAL)
+       ).
 
 -define(DB_DUMP_BULK_SIZE
-       ,kapps_config:get_integer(?MOD_CAT, <<"db_page_size">>, 1000)).
+       ,kapps_config:get_integer(?MOD_CAT, <<"db_page_size">>, 1000)
+       ).
 
--define(ON_SETTING_PUBLIC_FIELDS,
-        "To add a public field 'MyPub' to a number, create a column named 'opaque.MyPub'.\n"
+-define(ON_SETTING_PUBLIC_FIELDS
+       ,"To add a public field 'MyPub' to a number, create a column named 'opaque.MyPub'.\n"
         "Note: to nest a public field 'my_nested_field' under 'my_field', name the column thusly: 'opaque.my_field.my_nested_field'.\n"
         "Note: some fields may be disabled by configuration in which case it is forbidden to set them.\n"
        ).
@@ -119,11 +121,11 @@ cleanup(<<"import">>, AccountIds) ->
         end,
     lists:foreach(F, sets:to_list(AccountIds)),
     kz_datamgr:enable_change_notice();
-cleanup(?NE_BINARY, _) -> ok.
+cleanup(?NE_BINARY, _) -> 'ok'.
 
 -spec result_output_header() -> kz_tasks:output_header().
 result_output_header() ->
-    {replace, list_output_header() ++ [?OUTPUT_CSV_HEADER_ERROR]}.
+    {'replace', list_output_header() ++ [?OUTPUT_CSV_HEADER_ERROR]}.
 
 -spec list_output_header() -> kz_tasks:output_header().
 list_output_header() ->
@@ -363,39 +365,39 @@ force_outbound(Cell) -> is_cell_boolean(Cell).
 
 %% @private
 -spec is_cell_boolean(ne_binary()) -> boolean().
-is_cell_boolean(<<"true">>) -> true;
-is_cell_boolean(<<"false">>) -> true;
-is_cell_boolean(_) -> false.
+is_cell_boolean(<<"true">>) -> 'true';
+is_cell_boolean(<<"false">>) -> 'true';
+is_cell_boolean(_) -> 'false'.
 
 %% @private
 -spec is_cell_true(api_ne_binary()) -> boolean().
-is_cell_true(undefined) -> undefined;
-is_cell_true(<<"true">>) -> true;
-is_cell_true(_) -> false.
+is_cell_true('undefined') -> 'undefined';
+is_cell_true(<<"true">>) -> 'true';
+is_cell_true(_) -> 'false'.
 
 %%% Appliers
 
 -spec list(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-list(#{account_id := ForAccount}, init) ->
+list(#{account_id := ForAccount}, 'init') ->
     ToList = [{ForAccount, NumberDb} || NumberDb <- knm_util:get_all_number_dbs()],
-    {ok, ToList};
-list(_, []) -> stop;
+    {'ok', ToList};
+list(_, []) -> 'stop';
 list(#{auth_account_id := AuthBy}, Todo) ->
     list_assigned_to(AuthBy, Todo).
 
 -spec list_numbers(ne_binary(), ne_binaries()) -> [kz_csv:row()].
 list_numbers(AuthBy, E164s) ->
-    Options = [{auth_by, AuthBy}
-              ,{batch_run, true}
+    Options = [{'auth_by', AuthBy}
+              ,{'batch_run', 'true'}
               ],
     #{ok := Ns, ko := KOs} = knm_numbers:get(E164s, Options),
     maps:fold(fun list_bad_rows/3, [], KOs)
         ++ [list_number(N) || N <- Ns].
 
-list_bad_rows(E164, not_reconcilable, Rows) ->
+list_bad_rows(E164, 'not_reconcilable', Rows) ->
     %% Numbers that shouldn't be in the system (e.g. '+141510010+14')
     %% Their fields are not queriable but we return the id to show it exists.
-    Row = [E164 | lists:duplicate(length(list_output_header()) - 1, undefined)],
+    Row = [E164 | lists:duplicate(length(list_output_header()) - 1, 'undefined')],
     [Row|Rows];
 list_bad_rows(_E164, _R, Rows) ->
     lager:error("wild number ~s appeared: ~p", [_E164, _R]),
@@ -442,42 +444,42 @@ list_number(N) ->
 -spec account_name(api_ne_binary()) -> api_ne_binary().
 account_name(MaybeAccountId) ->
     case kz_account:fetch_name(MaybeAccountId) of
-        undefined -> undefined;
+        'undefined' -> 'undefined';
         Name -> quote(Name)
     end.
 
 -spec quote(api_ne_binary()) -> api_ne_binary().
-quote(undefined) -> undefined;
+quote('undefined') -> 'undefined';
 quote(Bin) -> <<$\", Bin/binary, $\">>.
 
 -spec list_all(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-list_all(#{account_id := Account}, init) ->
+list_all(#{account_id := Account}, 'init') ->
     ForAccounts = [Account | kapps_util:account_descendants(Account)],
     ToList = [{ForAccount, NumberDb}
               || ForAccount <- ForAccounts,
                  NumberDb <- knm_util:get_all_number_dbs()
              ],
-    {ok, ToList};
+    {'ok', ToList};
 list_all(_, []) -> stop;
 list_all(_, Todo) ->
     list_assigned_to(?KNM_DEFAULT_AUTH_BY, Todo).
 
 -spec find(kz_tasks:extra_args(), kz_tasks:iterator(), kz_tasks:args()) -> kz_tasks:return().
 find(#{auth_account_id := AuthBy}, _IterValue, Args=#{<<"e164">> := Num}) ->
-    handle_result(Args, knm_number:get(Num, [{auth_by,AuthBy}])).
+    handle_result(Args, knm_number:get(Num, [{'auth_by', AuthBy}])).
 
 -spec dump(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump(ExtraArgs, init) ->
+dump(ExtraArgs, 'init') ->
     init_dump(ExtraArgs);
-dump(_, []) -> stop;
+dump(_, []) -> 'stop';
 dump(_, Todo) ->
     dump_next(fun db_and_view_for_dump/1, Todo).
 
 init_dump(ExtraArgs) ->
-    {ok, MasterAccountId} = kapps_util:get_master_account_id(),
-    case maps:get(auth_account_id, ExtraArgs) of
-        MasterAccountId -> {ok, knm_util:get_all_number_dbs()};
-        _ -> stop
+    {'ok', MasterAccountId} = kapps_util:get_master_account_id(),
+    case maps:get('auth_account_id', ExtraArgs) of
+        MasterAccountId -> {'ok', knm_util:get_all_number_dbs()};
+        _ -> 'stop'
     end.
 
 dump_by_state(State, Todo) ->
@@ -485,53 +487,53 @@ dump_by_state(State, Todo) ->
     dump_next(ViewFun, Todo).
 
 -spec dump_aging(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump_aging(ExtraArgs, init) -> init_dump(ExtraArgs);
-dump_aging(_, []) -> stop;
+dump_aging(ExtraArgs, 'init') -> init_dump(ExtraArgs);
+dump_aging(_, []) -> 'stop';
 dump_aging(_, Todo) -> dump_by_state(?NUMBER_STATE_AGING, Todo).
 
 -spec dump_available(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump_available(ExtraArgs, init) -> init_dump(ExtraArgs);
-dump_available(_, []) -> stop;
+dump_available(ExtraArgs, 'init') -> init_dump(ExtraArgs);
+dump_available(_, []) -> 'stop';
 dump_available(_, Todo) -> dump_by_state(?NUMBER_STATE_AVAILABLE, Todo).
 
 -spec dump_deleted(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump_deleted(ExtraArgs, init) -> init_dump(ExtraArgs);
-dump_deleted(_, []) -> stop;
+dump_deleted(ExtraArgs, 'init') -> init_dump(ExtraArgs);
+dump_deleted(_, []) -> 'stop';
 dump_deleted(_, Todo) -> dump_by_state(?NUMBER_STATE_DELETED, Todo).
 
 -spec dump_discovery(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump_discovery(ExtraArgs, init) -> init_dump(ExtraArgs);
-dump_discovery(_, []) -> stop;
+dump_discovery(ExtraArgs, 'init') -> init_dump(ExtraArgs);
+dump_discovery(_, []) -> 'stop';
 dump_discovery(_, Todo) -> dump_by_state(?NUMBER_STATE_DISCOVERY, Todo).
 
 -spec dump_in_service(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump_in_service(ExtraArgs, init) -> init_dump(ExtraArgs);
-dump_in_service(_, []) -> stop;
+dump_in_service(ExtraArgs, 'init') -> init_dump(ExtraArgs);
+dump_in_service(_, []) -> 'stop';
 dump_in_service(_, Todo) -> dump_by_state(?NUMBER_STATE_IN_SERVICE, Todo).
 
 -spec dump_port_in(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump_port_in(ExtraArgs, init) -> init_dump(ExtraArgs);
-dump_port_in(_, []) -> stop;
+dump_port_in(ExtraArgs, 'init') -> init_dump(ExtraArgs);
+dump_port_in(_, []) -> 'stop';
 dump_port_in(_, Todo) -> dump_by_state(?NUMBER_STATE_PORT_IN, Todo).
 
 -spec dump_port_out(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump_port_out(ExtraArgs, init) -> init_dump(ExtraArgs);
-dump_port_out(_, []) -> stop;
+dump_port_out(ExtraArgs, 'init') -> init_dump(ExtraArgs);
+dump_port_out(_, []) -> 'stop';
 dump_port_out(_, Todo) -> dump_by_state(?NUMBER_STATE_PORT_OUT, Todo).
 
 -spec dump_released(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump_released(ExtraArgs, init) -> init_dump(ExtraArgs);
-dump_released(_, []) -> stop;
+dump_released(ExtraArgs, 'init') -> init_dump(ExtraArgs);
+dump_released(_, []) -> 'stop';
 dump_released(_, Todo) -> dump_by_state(?NUMBER_STATE_RELEASED, Todo).
 
 -spec dump_reserved(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-dump_reserved(ExtraArgs, init) -> init_dump(ExtraArgs);
-dump_reserved(_, []) -> stop;
+dump_reserved(ExtraArgs, 'init') -> init_dump(ExtraArgs);
+dump_reserved(_, []) -> 'stop';
 dump_reserved(_, Todo) -> dump_by_state(?NUMBER_STATE_RESERVED, Todo).
 
 -spec import(kz_tasks:extra_args(), kz_tasks:iterator(), kz_tasks:args()) ->
                     {kz_tasks:return(), sets:set()}.
-import(ExtraArgs, init, Args) ->
+import(ExtraArgs, 'init', Args) ->
     kz_datamgr:suppress_change_notice(),
     IterValue = sets:new(),
     import(ExtraArgs, IterValue, Args);
@@ -551,12 +553,12 @@ import(#{account_id := Account
              }
       ) ->
     AccountId = select_account_id(AccountId0, Account),
-    Options = [{auth_by, AuthAccountId}
-              ,{batch_run, true}
-              ,{assign_to, AccountId}
-              ,{module_name, import_module_name(AuthAccountId, Carrier)}
-              ,{ported_in, PortedIn =:= <<"true">>}
-              ,{public_fields, public_fields(Args)}
+    Options = [{'auth_by', AuthAccountId}
+              ,{'batch_run', 'true'}
+              ,{'assign_to', AccountId}
+              ,{'module_name', import_module_name(AuthAccountId, Carrier)}
+              ,{'ported_in', PortedIn =:= <<"true">>}
+              ,{'public_fields', public_fields(Args)}
                | import_state(AuthAccountId, State)
               ],
     Row = handle_result(Args, knm_number:create(E164, Options)),
@@ -581,7 +583,7 @@ pub_fields(Args=#{<<"cnam.inbound">> := CNAMInbound
                  ,<<"failover.e164">> := FailoverE164
                  ,<<"failover.sip">> := FailoverSIP
                  }) ->
-    RenameCarrier = maps:get(?FEATURE_RENAME_CARRIER, Args, undefined),
+    RenameCarrier = maps:get(?FEATURE_RENAME_CARRIER, Args, 'undefined'),
     [props:filter_undefined([{?FEATURE_RENAME_CARRIER, RenameCarrier}])
     ,cnam(props:filter_undefined(
             [{?CNAM_DISPLAY_NAME, CNAMOutbound}
@@ -629,26 +631,26 @@ import_module_name(AuthBy, Carrier) ->
     case kz_util:is_system_admin(AuthBy)
         andalso Carrier
     of
-        false -> ?IMPORT_DEFAULTS_TO_CARRIER;
-        undefined -> ?IMPORT_DEFAULTS_TO_CARRIER;
+        'false' -> ?IMPORT_DEFAULTS_TO_CARRIER;
+        'undefined' -> ?IMPORT_DEFAULTS_TO_CARRIER;
         _ -> Carrier
     end.
 
 %% @private
 import_state(AuthBy, State) ->
     case kz_util:is_system_admin(AuthBy)
-        andalso undefined =/= State
+        andalso 'undefined' =/= State
     of
-        false -> [];
-        true -> [{state, State}]
+        'false' -> [];
+        'true' -> [{'state', State}]
     end.
 
 %% @private
 additional_fields_to_json(Args) ->
     F = fun (Field, JObj) ->
-                Path = binary:split(Field, <<$.>>, [global]),
-                case maps:get(<<"opaque.",Field/binary>>, Args) of
-                    undefined -> JObj;
+                Path = binary:split(Field, <<$.>>, ['global']),
+                case maps:get(<<"opaque.", Field/binary>>, Args, 'undefined') of
+                    'undefined' -> JObj;
                     Value ->
                         lager:debug("setting public field ~p to ~p", [Path, Value]),
                         kz_json:set_value(Path, Value, JObj)
@@ -670,15 +672,14 @@ additional_fields(Args) ->
 select_account_id(?MATCH_ACCOUNT_RAW(_)=AccountId, _) -> AccountId;
 select_account_id(_, AccountId) -> AccountId.
 
-
 -spec assign_to(kz_tasks:extra_args(), kz_tasks:iterator(), kz_tasks:args()) -> kz_tasks:return().
 assign_to(#{auth_account_id := AuthBy, account_id := Account}
          ,_IterValue
          ,Args=#{<<"e164">> := Num, <<"account_id">> := AccountId0}
          ) ->
     AccountId = select_account_id(AccountId0, Account),
-    Options = [{auth_by, AuthBy}
-              ,{batch_run, true}
+    Options = [{'auth_by', AuthBy}
+              ,{'batch_run', 'true'}
               ],
     handle_result(Args, knm_number:move(Num, AccountId, Options)).
 
@@ -687,8 +688,8 @@ update_merge(#{auth_account_id := AuthBy}
             ,_IterValue
             ,Args=#{<<"e164">> := Num}
             ) ->
-    Options = [{auth_by, AuthBy}
-              ,{batch_run, true}
+    Options = [{'auth_by', AuthBy}
+              ,{'batch_run', 'true'}
               ],
     Updates = [{fun knm_phone_number:update_doc/2, public_fields(Args)}],
     handle_result(Args, knm_number:update(Num, Updates, Options)).
@@ -698,8 +699,8 @@ update_overwrite(#{auth_account_id := AuthBy}
                 ,_IterValue
                 ,Args=#{<<"e164">> := Num}
                 ) ->
-    Options = [{auth_by, AuthBy}
-              ,{batch_run, true}
+    Options = [{'auth_by', AuthBy}
+              ,{'batch_run', 'true'}
               ],
     Updates = [{fun knm_phone_number:reset_doc/2, public_fields(Args)}],
     handle_result(Args, knm_number:update(Num, Updates, Options)).
@@ -709,8 +710,8 @@ release(#{auth_account_id := AuthBy}
        ,_IterValue
        ,Args=#{<<"e164">> := Num}
        ) ->
-    Options = [{auth_by, AuthBy}
-              ,{batch_run, true}
+    Options = [{'auth_by', AuthBy}
+              ,{'batch_run', 'true'}
               ],
     handle_result(Args, knm_number:release(Num, Options)).
 
@@ -719,9 +720,9 @@ reserve(#{auth_account_id := AuthBy, account_id := Account}
        ,_IterValue
        ,Args=#{<<"e164">> := Num, <<"account_id">> := AccountId0}
        ) ->
-    Options = [{auth_by, AuthBy}
-              ,{batch_run, true}
-              ,{assign_to, select_account_id(AccountId0, Account)}
+    Options = [{'auth_by', AuthBy}
+              ,{'batch_run', 'true'}
+              ,{'assign_to', select_account_id(AccountId0, Account)}
               ],
     handle_result(Args, knm_number:reserve(Num, Options)).
 
@@ -730,8 +731,8 @@ delete(#{auth_account_id := AuthBy}
       ,_IterValue
       ,Args=#{<<"e164">> := Num}
       ) ->
-    Options = [{auth_by, AuthBy}
-              ,{batch_run, true}
+    Options = [{'auth_by', AuthBy}
+              ,{'batch_run', 'true'}
               ],
     handle_result(Args, knm_number:delete(Num, Options)).
 
@@ -763,14 +764,14 @@ format_result(_, N) ->
 
 -type accountid_or_startkey_and_numberdbs() :: [{ne_binary() | ne_binaries(), ne_binary()}].
 -spec list_assigned_to(ne_binary(), accountid_or_startkey_and_numberdbs()) ->
-                              {ok | [kz_csv:row()], accountid_or_startkey_and_numberdbs()}.
+                              {ok | error  | [kz_csv:row()], accountid_or_startkey_and_numberdbs()}.
 list_assigned_to(AuthBy, [{Next,NumberDb}|Rest]) ->
     ViewOptions = [{limit,?DB_DUMP_BULK_SIZE} | view_for_list_assigned(Next)],
     case kz_datamgr:get_result_keys(NumberDb, <<"numbers/assigned_to">>, ViewOptions) of
         {ok, []} -> {ok, Rest};
         {error, _R} ->
             lager:error("could not get ~p's numbers in ~s: ~p", [ViewOptions, NumberDb, _R]),
-            {ok, Rest};
+            {error, Rest};
         {ok, Keys} ->
             Rows = list_numbers(AuthBy, [lists:last(Key) || Key <- Keys]),
             {Rows, [{lists:last(Keys),NumberDb}|Rest]}
@@ -789,7 +790,7 @@ view_for_list_assigned(StartKey=[AccountId,_]) ->
 
 -type startkey_or_numberdb() :: ne_binary() | ne_binaries().
 -spec dump_next(fun((startkey_or_numberdb()) -> {ne_binary(), kz_datamgr:view_options()}), startkey_or_numberdb()) ->
-                       {ok | [kz_csv:row()], [startkey_or_numberdb()]}.
+                       {ok | error | [kz_csv:row()], [startkey_or_numberdb()]}.
 dump_next(ViewFun, [Next|Rest]) ->
     {NumberDb, MoreViewOptions} = ViewFun(Next),
     ViewOptions = [{limit, ?DB_DUMP_BULK_SIZE} | MoreViewOptions],
@@ -797,7 +798,7 @@ dump_next(ViewFun, [Next|Rest]) ->
         {ok, []} -> {ok, Rest};
         {error, _R} ->
             lager:error("could not get ~p from ~s: ~p", [ViewOptions, NumberDb, _R]),
-            {ok, Rest};
+            {error, Rest};
         {ok, Keys} ->
             Rows = list_numbers(?KNM_DEFAULT_AUTH_BY, [lists:last(Key) || Key <- Keys]),
             {Rows, [lists:last(Keys)|Rest]}

--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -83,8 +83,8 @@
 
 -type t_pn() :: t(knm_phone_number:knm_phone_number()).
 
--opaque collection() :: t().
--opaque pn_collection() :: t_pn().
+-type collection() :: t().
+-type pn_collection() :: t_pn().
 -export_type([collection/0, pn_collection/0]).
 
 -type options() :: knm_number_options:options().
@@ -255,7 +255,7 @@ do_get_pn(Nums, Options, Error) ->
     do(fun knm_phone_number:fetch/1, new(Options, Yes, No, Error)).
 
 %% @public (used by knm_number_crawler)
--spec from_jobjs(kz_json:objects()) -> t_pn().
+-spec from_jobjs(kz_json:objects()) -> t().
 from_jobjs(JObjs) ->
     Options = knm_number_options:default(),
     PNs = [knm_phone_number:from_json_with_options(Doc, Options)
@@ -297,7 +297,6 @@ from_jobjs(JObjs) ->
 create(Nums, Options) ->
     T0 = pipe(do_get_pn(Nums
                        ,?OPTIONS_FOR_LOAD(Nums, props:delete(state, Options))
-                       ,knm_errors:to_json(not_reconcilable)
                        )
              ,[fun fail_if_assign_to_is_not_an_account_id/1
               ]),
@@ -680,7 +679,7 @@ take_not_founds(T=#{ko := KOs}) ->
     Nums = [Num || {Num,not_found} <- NumsNotFound],
     {T#{ko := maps:from_list(NewKOs)}, Nums}.
 
--spec maybe_create(nums(), t_pn()) -> t_pn().
+-spec maybe_create(nums(), t()) -> t().
 maybe_create(NotFounds, T) ->
     Ta = do(fun knm_number:ensure_can_create/1, new(options(T), NotFounds)),
     Tb = pipe(T, [fun knm_number:ensure_can_load_to_create/1

--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -530,7 +530,7 @@ delete(T=#{todo := PNs, options := Options}) ->
                                 ])
     end.
 
--spec log_permanent_deletion(knm_numbers:pn_collection()) -> knm_numbers:pn_collection().
+-spec log_permanent_deletion(knm_numbers:collection()) -> knm_numbers:collection().
 log_permanent_deletion(T=#{todo := PNs}) ->
     F = fun (_PN) -> ?LOG_DEBUG("deleting permanently ~s", [number(_PN)]) end,
     lists:foreach(F, PNs),

--- a/core/kazoo_number_manager/test/knm_numbers_test.erl
+++ b/core/kazoo_number_manager/test/knm_numbers_test.erl
@@ -25,24 +25,24 @@ get_test_() ->
     [?_assertEqual(#{}, maps:get(ko, Ret))
     ,?_assertMatch([_], maps:get(ok, Ret))
     ,?_assertEqual(?TEST_AVAILABLE_NUM, knm_phone_number:number(pn_x(1, Ret)))
-    ,?_assertMatch(#{ko := #{?NOT_NUM := not_reconcilable}}
+    ,?_assertMatch(#{ko := #{?NOT_NUM := 'not_reconcilable'}}
                   ,knm_numbers:get([?NOT_NUM], [])
                   )
     ,?_assertMatch(#{ko := #{?TEST_CREATE_NUM := not_found}}
                   ,knm_numbers:get([?TEST_CREATE_NUM], [])
                   )
-    ,?_assertMatch(#{ko := #{?NOT_NUM := not_reconcilable}
+    ,?_assertMatch(#{ko := #{?NOT_NUM := 'not_reconcilable'}
                     ,ok := [_]
                     }
                   ,knm_numbers:get([?TEST_AVAILABLE_NUM, ?NOT_NUM])
                   )
-    ,?_assertMatch(#{ko := #{?NOT_NUM := not_reconcilable}
+    ,?_assertMatch(#{ko := #{?NOT_NUM := 'not_reconcilable'}
                     ,ok := [_]
                     }
                   ,knm_numbers:get([?TEST_AVAILABLE_NUM, ?NOT_NUM
                                    ,?TEST_AVAILABLE_NUM, ?NOT_NUM])
                   )
-    ,?_assertMatch(#{ko := #{?NOT_NUM := not_reconcilable
+    ,?_assertMatch(#{ko := #{?NOT_NUM := 'not_reconcilable'
                             ,?TEST_CREATE_NUM := not_found
                             }
                     ,ok := [_]
@@ -87,14 +87,6 @@ create_test_() ->
     ].
 
 
-not_reconcilable() ->
-    kz_json:from_list(
-      [{<<"code">>, 500}
-      ,{<<"error">>, <<"unspecified_fault">>}
-      ,{<<"message">>, <<"not_reconcilable">>}
-      ]).
-
-
 create_new_test_() ->
     Num = ?TEST_TELNYX_NUM,
     Options = [{'auth_by', ?MASTER_ACCOUNT_ID}
@@ -102,7 +94,7 @@ create_new_test_() ->
               ,{<<"auth_by_account">>, kz_json:new()}
               ],
     Ret = knm_numbers:create([Num, ?NOT_NUM, ?TEST_CREATE_NUM], Options),
-    [?_assertEqual(#{?NOT_NUM => not_reconcilable()}, maps:get(ko, Ret))
+    [?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret))
     ,?_assertMatch([_, _], maps:get(ok, Ret))
     ,?_assertEqual(true, knm_number:is_number(n_x(1, Ret)))
     ,?_assertEqual(true, knm_number:is_number(n_x(2, Ret)))
@@ -119,7 +111,7 @@ create_new_test_() ->
 
 move_test_() ->
     Ret = knm_numbers:move([?NOT_NUM, ?TEST_AVAILABLE_NUM], ?CHILD_ACCOUNT_ID),
-    [?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret))
+    [?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret))
     ,?_assertMatch([_], maps:get(ok, Ret))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret)))
     ,?_assertEqual(?TEST_AVAILABLE_NUM, knm_phone_number:number(pn_x(1, Ret)))
@@ -141,7 +133,7 @@ update_test_() ->
     ,{"verify ported_in is set to default"
      ,?_assertNotEqual(NotDefault, knm_phone_number:ported_in(pn_x(1, Ret0)))
      }
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret))
+    ,?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret))
     ,?_assertMatch([_], maps:get(ok, Ret))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret)))
     ,{"verify number was indeed updated"
@@ -185,7 +177,7 @@ attempt_setting_e911_on_disallowed_number_test_() ->
 
 delete_test_() ->
     Ret = knm_numbers:delete([?NOT_NUM, ?TEST_AVAILABLE_NUM], knm_number_options:default()),
-    [?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret))
+    [?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret))
     ,?_assertMatch([_], maps:get(ok, Ret))
     ,{"verify number was indeed deleted"
      ,?_assertEqual(?NUMBER_STATE_DELETED, knm_phone_number:state(pn_x(1, Ret)))
@@ -199,12 +191,12 @@ reconcile_test_() ->
     Ret1 = knm_numbers:reconcile([?NOT_NUM, ?TEST_AVAILABLE_NUM], knm_number_options:default()),
     Ret2 = knm_numbers:reconcile([?NOT_NUM, ?TEST_AVAILABLE_NUM]
                                 ,[{assign_to, ?RESELLER_ACCOUNT_ID} | knm_number_options:default()]),
-    [?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret0))
+    [?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret0))
     ,?_assertEqual([], maps:get(ok, Ret0))
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable, ?TEST_AVAILABLE_NUM => error_assign_to_undefined()}
+    ,?_assertEqual(#{?NOT_NUM => 'not_reconcilable', ?TEST_AVAILABLE_NUM => error_assign_to_undefined()}
                   ,maps:get(ko, Ret1))
     ,?_assertEqual([], maps:get(ok, Ret1))
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret2))
+    ,?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret2))
     ,?_assertMatch([_], maps:get(ok, Ret2))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret2)))
     ,{"verify number is now in service"
@@ -233,15 +225,15 @@ reserve_test_() ->
     Ret2 = knm_numbers:reserve([?NOT_NUM, ?TEST_IN_SERVICE_NUM]
                               ,[{assign_to,?RESELLER_ACCOUNT_ID} | knm_number_options:default()]),
     Ret3 = knm_numbers:reserve([?NOT_NUM, ?TEST_IN_SERVICE_NUM], AssignToChild),
-    [?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret1))
+    [?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret1))
     ,?_assertMatch([_], maps:get(ok, Ret1))
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret2))
+    ,?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret2))
     ,?_assertMatch([_], maps:get(ok, Ret2))
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable
+    ,?_assertEqual(#{?NOT_NUM => 'not_reconcilable'
                     ,?TEST_IN_SERVICE_NUM => error_assign_to_undefined()
                     }, maps:get(ko, Ret2b))
     ,?_assertEqual([], maps:get(ok, Ret2b))
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret3))
+    ,?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret3))
     ,?_assertMatch([_], maps:get(ok, Ret3))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret1)))
     ,{"verify number was indeed reserved"
@@ -268,14 +260,14 @@ assign_to_app_test_() ->
     MyApp = <<"my_app">>,
     Ret1 = knm_numbers:get([?NOT_NUM, ?TEST_AVAILABLE_NUM]),
     Ret2 = knm_numbers:assign_to_app([?NOT_NUM, ?TEST_AVAILABLE_NUM], MyApp),
-    [?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret1))
+    [?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret1))
     ,?_assertMatch([_], maps:get(ok, Ret1))
     ,{"Verify number is not already assigned to MyApp"
      ,?_assertNotEqual(MyApp, knm_phone_number:used_by(pn_x(1, Ret1)))
      }
     ,?_assertEqual(false, knm_phone_number:is_dirty(pn_x(1, Ret1)))
     ,?_assertEqual(true,  knm_phone_number:is_dirty(pn_x(1, Ret2)))
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret2))
+    ,?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret2))
     ,?_assertMatch([_], maps:get(ok, Ret2))
     ,{"Verify number is now used by MyApp"
      ,?_assertEqual(MyApp, knm_phone_number:used_by(pn_x(1, Ret2)))
@@ -287,20 +279,20 @@ release_test_() ->
     Ret1 = knm_numbers:release([?NOT_NUM, ?TEST_IN_SERVICE_WITH_HISTORY_NUM]),
     Ret2 = knm_numbers:release([?NOT_NUM, ?TEST_IN_SERVICE_MDN], knm_number_options:mdn_options()),
     Ret3 = knm_numbers:release([?NOT_NUM, ?TEST_IN_SERVICE_BAD_CARRIER_NUM]),
-    [?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret1))
+    [?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret1))
     ,?_assertMatch([_], maps:get(ok, Ret1))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret1)))
     ,{"Verify number went from in_service to reserved"
      ,?_assertEqual(?NUMBER_STATE_RESERVED, knm_phone_number:state(pn_x(1, Ret1)))
      }
     ,?_assertEqual(?MASTER_ACCOUNT_ID, knm_phone_number:assigned_to(pn_x(1, Ret1)))
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret2))
+    ,?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret2))
     ,?_assertMatch([_], maps:get(ok, Ret2))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret2)))
     ,{"Verify number went from in_service to deleted"
      ,?_assertEqual(?NUMBER_STATE_DELETED, knm_phone_number:state(pn_x(1, Ret2)))
      }
-    ,?_assertEqual(#{?NOT_NUM => not_reconcilable}, maps:get(ko, Ret3))
+    ,?_assertEqual(#{?NOT_NUM => 'not_reconcilable'}, maps:get(ko, Ret3))
     ,?_assertMatch([_], maps:get(ok, Ret3))
     ,?_assert(knm_phone_number:is_dirty(pn_x(1, Ret3)))
     ,{"Verify number went from in_service to available"


### PR DESCRIPTION
Also:
-  Mark job as partial when listing or dumping numbers and some of those numbers cannot be obtained
- Fix typo within kazoo/Makefile