### PR TITLE
PISTON-492: find a valid to_user for presence event so ecallmgr_fs_presence doesn't crash

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_presence.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_presence.erl
@@ -234,6 +234,7 @@ to_user(Props) ->
 
 to_user(<<"initiator">>, Props) ->
     props:get_first_defined([<<"Caller-Destination-Number">>
+                            ,<<"Other-Leg-Destination-Number">>
                             ,<<"variable_sip_to_user">>
                             ], Props);
 to_user(<<"recipient">>, Props) ->


### PR DESCRIPTION
https://forums.2600hz.com/forums/topic/9453-blf-when-using-fast-pickup

[log-snippet.txt](https://github.com/2600hz/kazoo/files/1540326/log-snippet.txt)

[culprit code](https://github.com/2600hz/kazoo/blob/master/applications/ecallmgr/src/ecallmgr_fs_presence.erl#L236)

Attached is a snippet that shows the presence props when picking up a KFP. Propose having a backup of "Other-Leg-Destination-Number" to prevent the crash. It matches the "Caller-Destination-Number" of the presence props for the other channel's dialog (parked channel).