### PR TITLE
Fix broken voip-innovations module by forcing TLS v1.2

### DIFF
--- a/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
@@ -6,7 +6,7 @@
 %%%
 %%% @end
 %%% @contributors
-%%%   Pierre Fenoll
+%%%   Pierre Fenoll, Joe Black
 %%%-------------------------------------------------------------------
 -module(knm_voip_innovations).
 -behaviour(knm_gen_carrier).
@@ -371,7 +371,7 @@ soap_request(Action, Body) ->
               ,{"User-Agent", ?KNM_USER_AGENT}
               ,{"Content-Type", "text/xml;charset=UTF-8"}
               ],
-    HTTPOptions = [{'ssl', [{'verify', 'verify_none'}]}
+    HTTPOptions = [{'ssl', [{'verify', 'verify_none'}, {versions, ['tlsv1.2']}]}
                   ,{'timeout', 180 * ?MILLISECONDS_IN_SECOND}
                   ,{'connect_timeout', 180 * ?MILLISECONDS_IN_SECOND}
                   ,{'body_format', 'string'}


### PR DESCRIPTION
The Voip-Innovations carrier module is broken because of TLS issues.

For us, compiling with erlang 19.2, this prevents the voip-innovations module from functioning at all.

Forcing TLS v1.2 in HTTPOptions fixes this issue.