### PR TITLE
Fix Content-Length header for all crossbar endpoints

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -816,8 +816,7 @@ to_binary(Req, Context, 'undefined') ->
             Setters = [{fun cb_context:set_resp_data/2, Content}
                       ,{fun cb_context:set_resp_error_code/2, ErrorCode}
                       ,{fun cb_context:add_resp_headers/2
-                       ,[{<<"Content-Length">>, kz_term:to_binary(Length)}
-                        ,{<<"Content-Range">>, kz_term:to_binary(io_lib:fwrite("bytes ~B-~B/~B", [Start, End, FileLength]))}
+                       ,[{<<"Content-Range">>, kz_term:to_binary(io_lib:fwrite("bytes ~B-~B/~B", [Start, End, FileLength]))}
                         ,{<<"Accept-Ranges">>, <<"bytes">>}
                         ]
                        }
@@ -916,7 +915,6 @@ to_pdf(Req, Context, <<>>) ->
     to_pdf(Req, Context, kz_pdf:error_empty());
 to_pdf(Req, Context, RespData) ->
     RespHeaders = [{<<"Content-Type">>, <<"application/pdf">>}
-                  ,{<<"Content-Length">>, erlang:size(RespData)}
                   ,{<<"Content-Disposition">>, <<"attachment; filename=\"file.pdf\"">>}
                    | cb_context:resp_headers(Context)
                   ],

--- a/applications/crossbar/src/modules/cb_apps_store.erl
+++ b/applications/crossbar/src/modules/cb_apps_store.erl
@@ -647,7 +647,6 @@ add_attachment(Context, Id, Attachment, AttachBin) ->
     RespHeaders =
         [{<<"Content-Disposition">>, <<"attachment; filename=", Id/binary>>}
         ,{<<"Content-Type">>, kz_json:get_value(<<"content_type">>, Attachment)}
-        ,{<<"Content-Length">>, kz_json:get_value(<<"length">>, Attachment)}
         ],
     cb_context:setters(Context
                       ,[{fun cb_context:set_resp_data/2, AttachBin}

--- a/applications/crossbar/src/modules/cb_auth.erl
+++ b/applications/crossbar/src/modules/cb_auth.erl
@@ -554,7 +554,6 @@ set_public_key_response(Context, PublicKeyPem, <<"application/x-pem-file">>=CT) 
               ,{fun cb_context:add_resp_headers/2
                ,[{<<"Content-Type">>, CT}
                 ,{<<"Content-Disposition">>, <<"attachment; filename=public_key.pem">>}
-                ,{<<"Content-Length">>, erlang:size(PublicKeyPem)}
                 ]
                }
               ],

--- a/applications/crossbar/src/modules/cb_faxboxes.erl
+++ b/applications/crossbar/src/modules/cb_faxboxes.erl
@@ -436,7 +436,6 @@ register_cloud_printer(Context, FaxboxId) ->
     ContentLength = length(Body),
     Headers = [?GPC_PROXY_HEADER
               ,{"Content-Type",ContentType}
-              ,{'Content-Length', ContentLength}
               ],
     Url = kz_term:to_list(?GPC_URL_REGISTER),
     case kz_http:post(Url, Headers, Body) of

--- a/applications/crossbar/src/modules/cb_faxboxes.erl
+++ b/applications/crossbar/src/modules/cb_faxboxes.erl
@@ -433,7 +433,6 @@ register_cloud_printer(Context, FaxboxId) ->
     Boundary = <<"------", (kz_binary:rand_hex(16))/binary>>,
     Body = register_body(ResellerId, FaxboxId, Boundary),
     ContentType = kz_term:to_list(<<"multipart/form-data; boundary=", Boundary/binary>>),
-    ContentLength = length(Body),
     Headers = [?GPC_PROXY_HEADER
               ,{"Content-Type",ContentType}
               ],

--- a/applications/crossbar/src/modules/cb_faxes.erl
+++ b/applications/crossbar/src/modules/cb_faxes.erl
@@ -653,7 +653,6 @@ set_fax_binary(Context, AttachmentId) ->
                        ,{fun cb_context:add_resp_headers/2
                         ,[{<<"Content-Disposition">>, <<Disposition/binary, "; filename=", AttachmentId/binary>>}
                          ,{<<"Content-Type">>, kz_doc:attachment_content_type(cb_context:doc(Context), AttachmentId)}
-                         ,{<<"Content-Length">>, kz_doc:attachment_length(cb_context:doc(Context), AttachmentId)}
                          ]
                         }
                        ]

--- a/applications/crossbar/src/modules/cb_freeswitch.erl
+++ b/applications/crossbar/src/modules/cb_freeswitch.erl
@@ -163,7 +163,6 @@ load_last_data(Context, File) ->
                                         kz_term:to_lower_binary(
                                           filename:extension(BaseName)))
                  }
-                ,{<<"Content-Length">>, byte_size(AttachBin)}
                 ]}
               ]).
 

--- a/applications/crossbar/src/modules/cb_media.erl
+++ b/applications/crossbar/src/modules/cb_media.erl
@@ -356,9 +356,6 @@ get(Context, _MediaId, ?BIN_DATA) ->
                                ,[{<<"Content-Type">>
                                  ,kz_json:get_value(<<"content-type">>, cb_context:doc(Context), <<"application/octet-stream">>)
                                  }
-                                ,{<<"Content-Length">>
-                                 ,binary:referenced_byte_size(cb_context:resp_data(Context))
-                                 }
                                 ]).
 
 -spec put(cb_context:context()) -> cb_context:context().
@@ -918,7 +915,6 @@ load_media_binary(Context, MediaId) ->
                                                   )
                                                ,[{<<"Content-Disposition">>, <<"attachment; filename=", Attachment/binary>>}
                                                 ,{<<"Content-Type">>, kz_doc:attachment_content_type(cb_context:doc(Context1), Attachment)}
-                                                ,{<<"Content-Length">>, kz_doc:attachment_length(cb_context:doc(Context1), Attachment)}
                                                 ])
             end;
         _Status -> Context1

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -1046,7 +1046,6 @@ read_template(Context, Id, Accept) ->
               read_account_attachment(Context, AttachmentsDb, Id, AttachmentName)
                                        ,[{<<"Content-Disposition">>, attachment_filename(Id, Accept)}
                                         ,{<<"Content-Type">>, kz_doc:attachment_content_type(Doc, AttachmentName)}
-                                        ,{<<"Content-Length">>, kz_doc:attachment_length(Doc, AttachmentName)}
                                         ])
     end.
 

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -1040,7 +1040,6 @@ load_attachment(AttachmentId, Context) ->
     Headers =
         [{<<"Content-Disposition">>, <<"attachment; filename=", AttachmentId/binary>>}
         ,{<<"Content-Type">>, kz_doc:attachment_content_type(cb_context:doc(Context), AttachmentId)}
-        ,{<<"Content-Length">>, kz_doc:attachment_length(cb_context:doc(Context), AttachmentId)}
         ],
     cb_context:add_resp_headers(Context1, Headers).
 

--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -973,7 +973,6 @@ load_attachment_from_message(Doc, Context, Timezone) ->
                       ,{fun cb_context:add_resp_headers/2
                        ,[{<<"Content-Type">>, kz_doc:attachment_content_type(Doc, AttachmentId)}
                         ,{<<"Content-Disposition">>, <<"attachment; filename=", Filename/binary>>}
-                        ,{<<"Content-Length">>, kz_doc:attachment_length(Doc, AttachmentId)}
                         ]
                        }
                       ],
@@ -1064,7 +1063,6 @@ create_zip_file(WorkDir, Files, Context) ->
               ,{fun cb_context:add_resp_headers/2
                ,[{<<"Content-Type">>, <<"application/zip">>}
                 ,{<<"Content-Disposition">>, <<"attachment; filename=", (kz_term:to_binary(ZipName))/binary>>}
-                ,{<<"Content-Length">>, filelib:file_size(ZipPath)}
                 ]
                }
               ],

--- a/applications/crossbar/src/modules/cb_whitelabel.erl
+++ b/applications/crossbar/src/modules/cb_whitelabel.erl
@@ -750,7 +750,6 @@ update_response_with_attachment(Context, AttachmentId, JObj) ->
         crossbar_doc:load_attachment(cb_context:doc(Context), AttachmentId, ?TYPE_CHECK_OPTION(<<"whitelabel">>), Context)
                                  ,[{<<"Content-Disposition">>, <<"attachment; filename=", AttachmentId/binary>>}
                                   ,{<<"Content-Type">>, kz_json:get_value([AttachmentId, <<"content_type">>], JObj)}
-                                  ,{<<"Content-Length">>, kz_json:get_value([AttachmentId, <<"length">>], JObj)}
                                   ]
        ), 'undefined'
      ).

--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -330,7 +330,6 @@ load_attachment(AttachmentId, Context) ->
     Headers =
         [{<<"Content-Disposition">>, <<"attachment; filename=", AttachmentId/binary>>}
         ,{<<"Content-Type">>, kz_doc:attachment_content_type(cb_context:doc(Context), AttachmentId)}
-        ,{<<"Content-Length">>, kz_doc:attachment_length(cb_context:doc(Context), AttachmentId)}
         ],
     cb_context:add_resp_headers(
       crossbar_doc:load_attachment(cb_context:doc(Context)


### PR DESCRIPTION
The Content-Length header that is manually set in many Crossbar endpoints is incorrect when compression is used (most of the time).
This leaves many clients waiting for more data that never arrives, and causes many issues.
When we do not set the Content-Length header, Cowboy correctly computes the length, and sets the header for us.

If possible it would be fantastic to get this fix in 4.1 also. I'm happy to submit another pull request when this is approved.