### PR TITLE
Enable override of the 'make -j' flag (#4420)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ RELX = $(ROOT)/deps/relx
 ELVIS = $(ROOT)/deps/elvis
 FMT = $(ROOT)/make/erlang-formatter-master/fmt.sh
 
+# You can override this when calling make, e.g. make MAKEFLAGS=""
+# to prevent parallel builds, or make MAKEFLAGS="-j8".
+# Note that this only applies to the core and applications
+# targets.
+MAKEFLAGS ?= -j
+
 KAZOODIRS = core/Makefile applications/Makefile
 
 .PHONY: $(KAZOODIRS) deps core apps xref xref_release dialyze dialyze-it dialyze-apps dialyze-core dialyze-kazoo clean clean-test clean-release build-release build-ci-release tar-release release read-release-cookie elvis install ci diff fmt bump-copyright apis validate-swagger sdks coverage-report fs-headers docs validate-schemas circle circle-pre circle-fmt circle-codechecks circle-build circle-docs circle-schemas circle-dialyze circle-release circle-unstaged fixture_shell
@@ -65,10 +71,10 @@ deps/Makefile: .erlang.mk
 	cp $(ROOT)/make/Makefile.deps deps/Makefile
 
 core:
-	$(MAKE) -j -C core/ all
+	$(MAKE) $(MAKEFLAGS) -C core/ all
 
 apps: core
-	$(MAKE) -j -C applications/ all
+	$(MAKE) $(MAKEFLAGS) -C applications/ all
 
 kazoo: apps
 


### PR DESCRIPTION
`make -j` allows `make` to spawn as many parallel jobs as it needs when
building a large number of modules. The problem with this is that it
can, and does, overwhelm systems with restricted memory, CPU power, or
`ulimit` settings, and it can (and does) cause builds on such systems to
fail, which consumes an enormous amount of time when doing multiple test
runs during development or maintenance.

This commit adds the `make` variable `MAKEFLAGS`, which defaults to `-j`.
This variable can be overridden on a case-to-case basis, to limit or
eliminate parallel jobs.

The change made is backwards-compatible with existing build invocations.

`make all MAKEFLAGS=""     # Eliminate parallel jobs`
`make all MAKEFLAGS="-j8"  # Limit parallel jobs to a max of 8`