### PR TITLE
Make ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ FMT = $(ROOT)/make/erlang-formatter-master/fmt.sh
 
 # You can override this when calling make, e.g. make JOBS=1
 # to prevent parallel builds, or make JOBS="8".
-JOBS ?=
+JOBS ?= 1
 
 KAZOODIRS = core/Makefile applications/Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,9 @@ RELX = $(ROOT)/deps/relx
 ELVIS = $(ROOT)/deps/elvis
 FMT = $(ROOT)/make/erlang-formatter-master/fmt.sh
 
-# You can override this when calling make, e.g. make MAKEFLAGS=""
-# to prevent parallel builds, or make MAKEFLAGS="-j8".
-# Note that this only applies to the core and applications
-# targets.
-MAKEFLAGS ?= -j
+# You can override this when calling make, e.g. make JOBS=1
+# to prevent parallel builds, or make JOBS="8".
+JOBS ?=
 
 KAZOODIRS = core/Makefile applications/Makefile
 
@@ -19,7 +17,7 @@ compile: ACTION = all
 compile: deps kazoo
 
 $(KAZOODIRS):
-	$(MAKE) -C $(@D) $(ACTION)
+	@$(MAKE) -j$(JOBS) -C $(@D) $(ACTION)
 
 clean: ACTION = clean
 clean: $(KAZOODIRS)
@@ -64,17 +62,17 @@ clean-deps:
 	wget 'https://raw.githubusercontent.com/ninenines/erlang.mk/2017.07.06/erlang.mk' -O $(ROOT)/erlang.mk
 
 deps: deps/Makefile
-	$(MAKE) -C deps/ all
+	@$(MAKE) -C deps/ all
 deps/Makefile: .erlang.mk
 	mkdir -p deps
-	$(MAKE) -f erlang.mk deps
+	@$(MAKE) -f erlang.mk deps
 	cp $(ROOT)/make/Makefile.deps deps/Makefile
 
 core:
-	$(MAKE) $(MAKEFLAGS) -C core/ all
+	@$(MAKE) -j$(JOBS) -C core/ all
 
 apps: core
-	$(MAKE) $(MAKEFLAGS) -C applications/ all
+	@$(MAKE) -j$(JOBS) -C applications/ all
 
 kazoo: apps
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ compile: ACTION = all
 compile: deps kazoo
 
 $(KAZOODIRS):
-	@$(MAKE) -j$(JOBS) -C $(@D) $(ACTION)
+	@$(MAKE) -C $(@D) $(ACTION)
 
 clean: ACTION = clean
 clean: $(KAZOODIRS)

--- a/applications/Makefile
+++ b/applications/Makefile
@@ -1,6 +1,6 @@
 ROOT = ..
 
-MAKEDIRS = */Makefile
+MAKEDIRS = $(sort $(wildcard */Makefile))
 
 .PHONY: all compile compile-test clean clean-test eunit test $(MAKEDIRS)
 
@@ -25,4 +25,4 @@ test: ACTION = test
 test: $(MAKEDIRS)
 
 $(MAKEDIRS):
-	$(MAKE) -C $(@D) $(ACTION)
+	@$(MAKE) -C $(@D) $(ACTION)

--- a/circle.yml
+++ b/circle.yml
@@ -59,4 +59,5 @@ test:
   post:
     - mkdir $CIRCLE_ARTIFACTS/logs
     - mv ./_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
-    - cp ./rel/relx.config $CIRCLE_ARTIFACTS/logs/
+    - cp ./rel/relx.config $CIRCLE_ARTIFACTS/
+    - cp ./_rel/kazoo/releases/4.0.0/kazoo.rel $CIRCLE_ARTIFACTS/

--- a/circle.yml
+++ b/circle.yml
@@ -59,3 +59,4 @@ test:
   post:
     - mkdir $CIRCLE_ARTIFACTS/logs
     - mv ./_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - cp ./rel/relx.config $CIRCLE_ARTIFACTS/logs/

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ test:
     - ./scripts/code_checks.bash $($CHANGED)
     - make fmt
     - if [[ "$CIRCLE_BRANCH" = 'master' ]]; then make bump-copyright; fi
-    - . ~/.kerl/$OTP_VERSION/activate && make
+    - . ~/.kerl/$OTP_VERSION/activate && JOBS="" make
     - . ~/.kerl/$OTP_VERSION/activate && make code_checks
     - . ~/.kerl/$OTP_VERSION/activate && make app_applications
     - ./scripts/validate-js.sh $($CHANGED)

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,6 +1,6 @@
 ROOT = ..
 
-MAKEDIRS = */Makefile
+MAKEDIRS = $(sort $(wildcard */Makefile))
 
 .PHONY: all compile compile-test clean clean-test eunit test first $(MAKEDIRS)
 
@@ -25,9 +25,9 @@ test: ACTION = test
 test: $(MAKEDIRS)
 
 first:
-	$(MAKE) -C kazoo_stdlib/ $(ACTION)
-	$(MAKE) -C kazoo_amqp/ $(ACTION)
-	$(MAKE) -C kazoo_data/ $(ACTION)
+	@$(MAKE) -C kazoo_stdlib/ $(ACTION)
+	@$(MAKE) -C kazoo_amqp/ $(ACTION)
+	@$(MAKE) -C kazoo_data/ $(ACTION)
 
 $(MAKEDIRS): first
-	$(MAKE) -C $(@D) $(ACTION)
+	@$(MAKE) -C $(@D) $(ACTION)

--- a/make/kz.mk
+++ b/make/kz.mk
@@ -60,11 +60,11 @@ compile: $(COMPILE_MOAR) ebin/$(PROJECT).app json
 
 ebin/$(PROJECT).app: $(SOURCES)
 	@mkdir -p ebin/
-	ERL_LIBS=$(ELIBS) erlc -v $(ERLC_OPTS) $(PA) -o ebin/ $?
+	@ERL_LIBS=$(ELIBS) erlc -v $(ERLC_OPTS) $(PA) -o ebin/ $?
 	@sed "s/{modules,\s*\[\]}/{modules, \[`echo ebin/*.beam | sed 's%\.beam ebin/%, %g;s%ebin/%%;s/\.beam//'`\]}/" src/$(PROJECT).app.src > $@
 
 app_src:
-	ERL_LIBS=$(ROOT)/deps:$(ROOT)/core:$(ROOT)/applications $(ROOT)/scripts/apps_of_app.escript -a $(shell find $(ROOT) -name $(PROJECT).app.src)
+	@ERL_LIBS=$(ROOT)/deps:$(ROOT)/core:$(ROOT)/applications $(ROOT)/scripts/apps_of_app.escript -a $(shell find $(ROOT) -name $(PROJECT).app.src)
 
 
 json: JSON = $(shell find . -name '*.json')
@@ -78,7 +78,7 @@ test/$(PROJECT).app: ERLC_OPTS += -DTEST
 test/$(PROJECT).app: $(TEST_SOURCES)
 	@mkdir -p test/
 	@mkdir -p ebin/
-	ERL_LIBS=$(ELIBS) erlc -v +nowarn_missing_spec $(ERLC_OPTS) $(TEST_PA) -o ebin/ $?
+	@ERL_LIBS=$(ELIBS) erlc -v +nowarn_missing_spec $(ERLC_OPTS) $(TEST_PA) -o ebin/ $?
 	@sed "s/{modules,\s*\[\]}/{modules, \[`echo ebin/*.beam | sed 's%\.beam ebin/%, %g;s%ebin/%%;s/\.beam//'`\]}/" src/$(PROJECT).app.src > $@
 	@sed "s/{modules,\s*\[\]}/{modules, \[`echo ebin/*.beam | sed 's%\.beam ebin/%, %g;s%ebin/%%;s/\.beam//'`\]}/" src/$(PROJECT).app.src > ebin/$(PROJECT).app
 


### PR DESCRIPTION
Orders the core/application folders for compiling. 

Changes to use `JOBS` in top level Makefile instead of setting/overriding `MAKEFLAGS` as the `-j` was problematic. 

Quieter compiling too.