### PR TITLE
Document new `bill.carrier` property in port request schema

### DIFF
--- a/applications/crossbar/doc/port_requests.md
+++ b/applications/crossbar/doc/port_requests.md
@@ -69,7 +69,7 @@ Schema for a port request
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
-`bill.carrier` | Name of the losing carrier | `string()` |   | `false`
+`bill.carrier` | The name of the losing carrier | `string()` |   | `false`
 `bill.extended_address` | The suite/floor/apt of the billing address the losing carrier has on record | `string()` |   | `false`
 `bill.locality` | The locality (city) of the billing address the losing carrier has on record | `string()` |   | `false`
 `bill.name` | The losing carrier billing/account name | `string()` |   | `false`

--- a/applications/crossbar/doc/port_requests.md
+++ b/applications/crossbar/doc/port_requests.md
@@ -69,6 +69,7 @@ Schema for a port request
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
+`bill.carrier` | Name of the losing carrier | `string()` |   | `false`
 `bill.extended_address` | The suite/floor/apt of the billing address the losing carrier has on record | `string()` |   | `false`
 `bill.locality` | The locality (city) of the billing address the losing carrier has on record | `string()` |   | `false`
 `bill.name` | The losing carrier billing/account name | `string()` |   | `false`

--- a/applications/crossbar/doc/ref/port_requests.md
+++ b/applications/crossbar/doc/ref/port_requests.md
@@ -10,6 +10,7 @@ Schema for a port request
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
+`bill.carrier` | The name of the losing carrier | `string()` |   | `false`
 `bill.extended_address` | The suite/floor/apt of the billing address the losing carrier has on record | `string()` |   | `false`
 `bill.locality` | The locality (city) of the billing address the losing carrier has on record | `string()` |   | `false`
 `bill.name` | The losing carrier billing/account name | `string()` |   | `false`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -23518,6 +23518,10 @@
                 "bill": {
                     "description": "Billing information of the losing carrier",
                     "properties": {
+                        "carrier": {
+                            "description": "The name of the losing carrier",
+                            "type": "string"
+                        },
                         "extended_address": {
                             "description": "The suite/floor/apt of the billing address the losing carrier has on record",
                             "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/port_requests.json
+++ b/applications/crossbar/priv/couchdb/schemas/port_requests.json
@@ -6,6 +6,10 @@
         "bill": {
             "description": "Billing information of the losing carrier",
             "properties": {
+                "carrier": {
+                    "description": "The name of the losing carrier",
+                    "type": "string"
+                },
                 "extended_address": {
                     "description": "The suite/floor/apt of the billing address the losing carrier has on record",
                     "type": "string"


### PR DESCRIPTION
A new `bill.carrier` field was added to save the losing carrier's name.

I assume the schema should be updated accordingly.