### PR TITLE
remove defaults from voicemail key schema

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -31902,7 +31902,6 @@
             "properties": {
                 "configure": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "5",
                     "description": "DTMF key which will enter the config menu when pressed at the main menu"
                 },
                 "continue": {
@@ -31911,87 +31910,70 @@
                 },
                 "delete": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "7",
                     "description": "DTMF key which will delete the voicemail message when pressed at the post playback menu"
                 },
                 "exit": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "#",
                     "description": "DTMF key which will exit the main menu when pressed"
                 },
                 "hear_new": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "1",
                     "description": "DTMF key which will play new voicemail messages when pressed at the main menu"
                 },
                 "hear_saved": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "2",
                     "description": "DTMF key which will play saved voicemail messages when pressed at the main menu"
                 },
                 "keep": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "1",
                     "description": "DTMF key which will keep the voicemail message when pressed at the post playback menu"
                 },
                 "listen": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "2",
                     "description": "DTMF key which will listen to the recording when pressed at the recording review menu"
                 },
                 "login": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "*",
                     "description": "DTMF key which will log into the voicemail box when pressed at the compose voicemail menu"
                 },
                 "next": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "6",
                     "description": "DTMF key which will go to the next voicemail message when pressed at the post playback menu"
                 },
                 "operator": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "0",
                     "description": "DTMF key which will call the operator when pressed"
                 },
                 "prev": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "4",
                     "description": "DTMF key which will go to the previous voicemail message when pressed at the post playback menu"
                 },
                 "rec_name": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "2",
                     "description": "DTMF key which will enter the record the voicemail box name when pressed at the config menu"
                 },
                 "rec_unavailable": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "1",
                     "description": "DTMF key which will enter the record the unavailable greeting when pressed at the config menu"
                 },
                 "record": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "3",
                     "description": "DTMF key which will record when pressed at the recording review menu"
                 },
                 "replay": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "2",
                     "description": "DTMF key which will replay the voicemail message when pressed at the post playback menu"
                 },
                 "return_main": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "0",
                     "description": "DTMF key which will return to the main menu when pressed at the config menu"
                 },
                 "save": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "1",
                     "description": "DTMF key which will save when pressed at the recording review menu"
                 },
                 "set_pin": {
                     "$ref": "#/definitions/voicemail_keys.dtmf_key",
-                    "default": "3",
                     "description": "DTMF key which will allow the user to set their pin when pressed at the config menu"
                 }
             }

--- a/applications/crossbar/priv/couchdb/schemas/voicemail_keys.json
+++ b/applications/crossbar/priv/couchdb/schemas/voicemail_keys.json
@@ -5,7 +5,6 @@
     "properties": {
         "configure": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "5",
             "description": "DTMF key which will enter the config menu when pressed at the main menu"
         },
         "continue": {
@@ -14,87 +13,70 @@
         },
         "delete": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "7",
             "description": "DTMF key which will delete the voicemail message when pressed at the post playback menu"
         },
         "exit": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "#",
             "description": "DTMF key which will exit the main menu when pressed"
         },
         "hear_new": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "1",
             "description": "DTMF key which will play new voicemail messages when pressed at the main menu"
         },
         "hear_saved": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "2",
             "description": "DTMF key which will play saved voicemail messages when pressed at the main menu"
         },
         "keep": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "1",
             "description": "DTMF key which will keep the voicemail message when pressed at the post playback menu"
         },
         "listen": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "2",
             "description": "DTMF key which will listen to the recording when pressed at the recording review menu"
         },
         "login": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "*",
             "description": "DTMF key which will log into the voicemail box when pressed at the compose voicemail menu"
         },
         "next": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "6",
             "description": "DTMF key which will go to the next voicemail message when pressed at the post playback menu"
         },
         "operator": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "0",
             "description": "DTMF key which will call the operator when pressed"
         },
         "prev": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "4",
             "description": "DTMF key which will go to the previous voicemail message when pressed at the post playback menu"
         },
         "rec_name": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "2",
             "description": "DTMF key which will enter the record the voicemail box name when pressed at the config menu"
         },
         "rec_unavailable": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "1",
             "description": "DTMF key which will enter the record the unavailable greeting when pressed at the config menu"
         },
         "record": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "3",
             "description": "DTMF key which will record when pressed at the recording review menu"
         },
         "replay": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "2",
             "description": "DTMF key which will replay the voicemail message when pressed at the post playback menu"
         },
         "return_main": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "0",
             "description": "DTMF key which will return to the main menu when pressed at the config menu"
         },
         "save": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "1",
             "description": "DTMF key which will save when pressed at the recording review menu"
         },
         "set_pin": {
             "$ref": "voicemail_keys.dtmf_key",
-            "default": "3",
             "description": "DTMF key which will allow the user to set their pin when pressed at the config menu"
         }
     }


### PR DESCRIPTION
on further discussion, it was deemed good to not have defaults because
accounts overriding individual keys would get the defaults from the
schema added on validation. if the global values were to be changed,
these accounts would no longer use the global values of keys they
didn't override.

Without defaults, the account config doc will reflect only the keys
overridden by the account and all other keys will be pulled from the
reseller/global configs.