### PR TITLE
remove abs on rollup update

### DIFF
--- a/core/kazoo_transactions/src/wht_util.erl
+++ b/core/kazoo_transactions/src/wht_util.erl
@@ -570,7 +570,7 @@ update_rollup(Account, Balance, JObj) ->
         _Else ->
             EncodedMODb = kz_util:format_account_modb(kazoo_modb:get_modb(Account), 'encoded'),
             {'ok', _} = kz_datamgr:del_doc(EncodedMODb, JObj),
-            rollup(Account, abs(Balance))
+            rollup(Account, Balance)
     end.
 
 -spec update_existing_rollup(ne_binary(), integer(), kz_transaction:transaction()) -> 'ok'.


### PR DESCRIPTION
Looks like there is no need in abs/1 over here, otherwise there will be always credit type of transaction..