### PR TITLE
Removed special calendar arithmetics for years starting on Monday

### DIFF
--- a/core/kazoo_stdlib/src/kz_date.erl
+++ b/core/kazoo_stdlib/src/kz_date.erl
@@ -52,12 +52,7 @@ from_gregorian_seconds(Seconds, <<_/binary>>=TZ) when is_integer(Seconds) ->
 from_iso_week({Year, Week}) ->
     Jan1 = calendar:date_to_gregorian_days(Year, 1, 1),
     Offset = 4 - calendar:day_of_the_week(Year, 1, 4),
-    Days =
-        case Offset =:= 0 of
-            'true' -> Jan1 + ( Week * 7 );
-            'false' ->
-                Jan1 + Offset + ( ( Week - 1 ) * 7 )
-        end,
+    Days = Jan1 + Offset + ( ( Week - 1 ) * 7 ),
     calendar:gregorian_days_to_date(Days).
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
If I understand correctly, iso_week_to_gregorian_date({Y,W}) should
return the starting day (Monday) of the ISO week; but when the year Y
starts on Monday, it computes the starting day of the _next_ week.

The change could be terribly broken if its purpose is not what I
guessed.

Sometimes you can get unexpected results, e.g.: iso_week_to_gregorian_date({2015,1}) = {2014,12,29}.
But probably is better than iso_week_to_gregorian_date({2018,1}) = {2018,1,8}