### PR TITLE
Updating to current API requirements

### DIFF
--- a/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_voip_innovations.erl
@@ -348,7 +348,7 @@ body("assignDID", Numbers=[_|_]) ->
     ["<tns:didParams>",
      [ ["<tns:DIDParam>"
         "<tns:tn>", Number, "</tns:tn>"
-        "<tns:epg>", ?VI_ENDPOINT_GROUP, "</tns:epg>"
+        "<tns:endpointId>", ?VI_ENDPOINT_GROUP, "</tns:endpointId>"
         "</tns:DIDParam>"]
        || Number <- Numbers
      ],


### PR DESCRIPTION
Per https://backoffice.voipinnovations.com/Wiki/View.aspx?article=ListingofAllAPIMethods, epg is no longer valid and has been changed to endpointId for the assignDID API method.