### PR TITLE
make easy to add attachment to fixturedb

### DIFF
--- a/core/kazoo_fixturedb/doc/README.md
+++ b/core/kazoo_fixturedb/doc/README.md
@@ -1,18 +1,18 @@
 # Kazoo FixtureDB
 
-What can you say about a data application? That it loves to be distributed and fault tolerant? That it listens to data streams and not understand a bit? yeah, that.
+What can you say about a data application? That it loves to be distributed and fault tolerant? That it listens to data streams and not understand a bit?
 
 ## Overview
 
-General speaking, FixtureDB removes dependency of Kazoo Data Manager for AMQP and Kazoo Cache and removes the burden of isolating source codes with `-ifdef(TEST)` when it comes to reading from database, which in parts result in a tiny little bit more coverage (if any).
+General speaking, FixtureDB removes dependency of Kazoo Data Manager to CouchDB and RabbitMQ for running EUnit tests and removes the burden of isolating source codes with `-ifdef(TEST)` when it comes to reading from database, which in part result in a tiny little bit more coverage (if any) by running through all Kazoo Data Manager code.
 
-FixtureDB acts as central repository for all fixtures which we simply use during tests.
+FixtureDB acts as a central repository for all fixtures which we simply use during tests.
 
-When writing your EUnit test you can use [_fixture_ test representation](http://erlang.org/doc/apps/eunit/chapter.html#Fixtures) to setup a dummy connection to FixtureDB, and cleanup the connection later.
+When writing your EUnit test you can use [_fixture_ test representation](http://erlang.org/doc/apps/eunit/chapter.html#Fixtures) to setup a your test environment by starting a dummy connection to FixtureDB, and cleanup the connection later.
 
-Below is an example with `setup` and `cleanup` method, in `setup()` we're starting `kazoo_config` applications to read the default [`config-test.ini`](../../../rel/config-test.init and then starts the Kazoo Data connection manager. After these steps most of the calls to `kz_datamgr` functions will use FixtureDB (few operations, like view maintenance cleanup, are not implemented, also save document/put attachments simply return what you submitted without actually writing anything).
+Below is an example with `setup` and `cleanup` method. In `setup()` function we're starting `kazoo_config` applications to read the default [`config-test.ini`](../../../rel/config-test.init) and then starts the Kazoo data link supervisor. After these steps most of the calls to `kz_datamgr` functions will use FixtureDB (few operations, like view maintenance cleanup, are not implemented).
 
-* Sample test using setup/cleanup method
+##### Example EUnit Test Using Setup/Cleanup Method
 
 ```erlang
 -spec render_test_() -> any().
@@ -37,34 +37,14 @@ setup() ->
     LinkPid.
 
 cleanup(LinkPid) ->
-    _DataLink = erlang:exit(LinkPid, normal),
-    Ref = monitor(process, LinkPid),
-    receive
-        {'DOWN', Ref, process, LinkPid, _Reason} ->
-            _KConfig = application:stop(kazoo_config),
-            ?LOG_DEBUG(":: Stopped Kazoo FixtureDB, data_link: ~p kazoo_config: ~p", [_DataLink, _KConfig])
-    after 1000 ->
-            _KConfig = application:stop(kazoo_config),
-            ?LOG_DEBUG(":: Stopped Kazoo FixtureDB, data_link: timeout kazoo_config: ~p", [_KConfig])
-    end.
+    _ = erlang:exit(LinkPid, normal),
+    _ = application:stop(kazoo_config),
+    ?LOG_DEBUG(":: Stopped Kazoo FixtureDB").
 ```
 
-## Using FixtureDB
+### Database File Structure
 
-FixtureDB acts as database driver for `kazoo_data`, so basically it needs `kazoo_config` reads the database configuration. You need to start `kazoo_config`, then to make `kazoo_data` know about FixtureDB, `kazoo_data_link_sup:start_link()` should be called to bring up Kazoo data connection ETS table. After that `kzs_plan` can find the connection and plan for database operation on FixtureDB.
-
-OS environment `KAZOO_CONFIG` is necessary for `kazoo_config` to read the database configuration and by default is set to [`$(ROOT)/rel/config-test.ini`](../../../rel/config-test.ini) in [`kz.mk`](../../../make/kz.mk) file for `test`, `eunit` and `proper` target.
-
-In the test which need accessing to database you have to bring up `kazoo_config` and `kazoo_data_link_sup`:
-
-```erlang
-{'ok', _} = application:ensure_all_started('kazoo_config').
-{'ok', _Pid} = kazoo_data_link_sup:start_link().
-```
-
-> **NOTE:** Don't forget to stop the `kazoo_config` and `kazoo_data_link_sup` after you test!
-
-All of the fixtures are in [core/kazoo_fixturedb/priv/dbs](../priv/dbs). In `dbs` directory each sub-directory is represented a database. For example `dbs/accounts` is represented `accounts` database. Inside these database directories, there are sub-directories to store the JSON document for this database (in `docs` dir) and CouchDB view result (in `views` dir):
+All of the fixtures are reside in [core/kazoo_fixturedb/priv/dbs](../priv/dbs). In `dbs` directory, each sub-directory is represented a database. For example `dbs/accounts` is represented `accounts` database. Inside these database directories, there are sub-directories to store the JSON document for this database (in `docs` directory) and CouchDB view result (in `views` directory):
 
 ```shell
 $ tree core/kazoo_fixturedb/priv/dbs/
@@ -88,9 +68,42 @@ core/kazoo_fixturedb/priv/dbs/
 ...
 ```
 
+#### Attachments are Reside in `docs` Directory
+
+Document attachments are stores in `docs` directory. Their file names are encoded by the document ID and attachment name, (see [Document Attachments](#document-attachments) section). Attachments are usually audio files, PDFs or pictures. FixtureDB has some default files in `priv/media_files`. You can simply use them by creating a symbolic link to them.
+
+#### View Results Directory
+
+View results are exactly the same result sets which `kz_datamgr:get_results/2,3` returns. It is your responsibility to write the correct view result structure and in the order. Complex queries has their own unique filename which is explained in [View Results](#view-results) section.
+
+## Using FixtureDB
+
+FixtureDB acts as database driver for `kazoo_data`, so you need to start `kazoo_config` first to read the database configuration, then start `kazoo_data` connection link by running `kazoo_data_link_sup:start_link()` to bring up Kazoo data connection ETS table. `kazoo_data_link_sup` is lite version of `kazoo_data_sup` which is not depend on `kazoo_amqp` and tracing capability to be available, it's just make a new connection to database (which in this case is FixtureDB).
+
+OS environment `KAZOO_CONFIG` is necessary for `kazoo_config` to read the correct FixtureDB database configuration and by default is set to [`$(ROOT)/rel/config-test.ini`](../../../rel/config-test.ini) in [`kz.mk`](../../../make/kz.mk) file for `test`, `eunit`, `proper` and `fixture_db` targets.
+
+In the tests which need accessing to database you have to bring up `kazoo_config` and `kazoo_data_link_sup`:
+
+```erlang
+{'ok', _} = application:ensure_all_started('kazoo_config').
+{'ok', _Pid} = kazoo_data_link_sup:start_link().
+```
+
+> **NOTE:** Don't forget to stop the `kazoo_config` and `kazoo_data_link_sup` after your test is finished (see [EUnit test example](#example-unit-test-using-setupcleanup-method) above), otherwise your test would failed because the `kazoo_config` and `kazoo_data_link_sup` are not shut down normally!
+
+### Database
+
+Each database has a directory of their own inside `core/kazoo_fixturedb/priv/dbs/`.
+
+> **NOTE:** Database name in URL encoded, e.g. `account/xxxx` becomes `account%2Fac%2Fco%2Funtxxxx`.
+
+In each database there are two directories: `docs` for storing regular document inside database and `views` for storing view results.
+
+To make it easy to map each attachment or complex view to their corresponding files in `docs` and `views` directories there are two CSV index files at the root of the database directory.
+
 ### Fixture JSON Documents
 
-Documents are the exact copy of a real CouchDB documents. Document's filename is the `_id` of the document with `.json` extension.
+Documents are the exact copy of a real CouchDB documents. Document's filename is the `_id` of the document with `.json` extension in the end.
 
 > **NOTE:** The `_id` in the filename is URL encoded, e.g. `_design/services` becomes `_design%2Fservices.json`.
 
@@ -98,7 +111,7 @@ You can use `kz_fixturedb_util:get_doc_path/2,3` to get document's file path.
 
 Saving a document is not really saving the JObj in a file, instead it just returned an updated JObj with bumped `_rev` and updated `pvt_document_hash`. If database (the database folder) does not exists it returns error `{'error', 'not_found'}`. If you try to save a document which exists in the `docs` without correct `_rev` then the result is `{'error', 'conflict'}` as expected.
 
-Delete document(s) is result in a bulk save in CouchBeam, so to mimic this behavior it returns a bulk save result:
+Delete document(s) is result in a bulk save in CouchBeam, so it returns a bulk save result:
 
 ```erlang
 (fixturedb@hes.2600hz.com)12> kz_datamgr:del_docs(<<"accounts">>, [<<"file_not_exists">>, <<"account0000000000000000000000002">>]).
@@ -113,11 +126,13 @@ Delete document(s) is result in a bulk save in CouchBeam, so to mimic this behav
        {<<"accepted">>,true}]}]}
 ```
 
-If you changed an already exists JSON file manually with a text editor and need to update `pvt_document_hash` you can use `kz_fixturedb_util:update_pvt_doc_hash(Path)`. This is necessary for example in Teletype notification templates in `system_config` database since during initializing a template teletype checks if document hash is changed or not so it does not updates template which is customized directly in database.
+#### Utility Functions
+
+If you change an existing JSON file manually and need to update `pvt_document_hash` you can use `kz_fixturedb_util:update_pvt_doc_hash(Path)`. This is necessary for example in Teletype notification templates in `system_config` database since during initializing a template, teletype checks if document hash is changed or not so it does not update template which is customized directly in database.
 
 To update all JSON files document hash in FixtureDB use `kz_fixturedb_util:update_pvt_doc_hash/0`.
 
-### Attachments
+### Document Attachments
 
 Each document's attachment is saved in database `docs` directory in a separate file. Attachment's filename is the MD5 hash of `{DOC_ID}` and `{ATTACHMENT_NAME}` ending in `.att`. Use `kz_fixturedb_util:get_att_path/3,4` to get the file path:
 
@@ -136,24 +151,27 @@ doc_id, attachment_name, attachment_file_name
 201710-vm_message0000000000000000000001, vm-new_message.wav, 5cef38cd0260632cf119c6fcf0c44f58.att
 ```
 
-When you're adding an attachment use `kz_fixturedb_util:get_att_path/3,4` to get the file path and save it there then use `kz_fixturedb_util:add_att_path_to_index/3,4` to add the attachment file name to the `attachment-index.csv` file.
-
-Putting an attachment is just returning the updated document JObj back. Deleting an attachment is returning tuple `{'ok', JObj}` whic JObj just have `id` and `rev`. Both put and delete will return error tuple if the JSON document file does not exists in database.
+Putting an attachment is just returning the updated document JObj back. Deleting an attachment is returning tuple `{'ok', JObj}` which the JObj just have the `id` and `rev`. Both put and delete will return error tuple if the JSON document file does not exists in database.
 
 For large attachments like voicemail or a fax, use the files from `core/kazoo_fixturedb/priv/media_files` (or if it does not exists add one). And then soft link it in the destination database. For example in Unix shell if you're already at `code/kazoo_fixturedb` directory:
 
 ```shell
-kazoo_fixturedb $ ln -sf ../../../media_files/vm-new_message.mp3 priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000003-201710/docs/5cef38cd0260632cf119c6fcf0c44f58.att
-kazoo_fixturedb $
 kazoo_fixturedb $ ls -l priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000003-201710/docs/
 lrwxrwxrwx 1 hehe hehe   39 Oct 28 17:45 5cef38cd0260632cf119c6fcf0c44f58.att -> ../../../media_files/vm-new_message.mp3
 ```
 
-### View Result
+#### Utility Functions
 
-FixtureDB uses a new advanced high performance technique called Human® to compute the CouchDB view's result.
+* `kz_fixturedb_util:get_att_path(DbName, DocId, AName)`: you can use this to get the attachment file path and inspect the hashed filename
+* `kz_fixturedb_util:add_att_to_index(DbName, DocId, AName)`: will create `doc_id+attachment_name` hash and add it to the `attachment-index.csv` file and make a symbolic link to a file in `core/kazoo_fixturedb/priv/media_files` if the `attachment_name` matches want of the file in that directory.
 
-All view result are `views` database's directory. Since views are tricky when it comes to `reduce`, `group_level`, `startkey` and etc..., when FixtureDB sees these view options, it hashes the view options and will add it to the file name. For example:
+**Advanced Usage:** To use a customized data plan you can use arity 4 of above function (as first argument).
+
+### View Results
+
+FixtureDB uses a new cutting edge advanced high performance technique called Human® to compute the CouchDB view's result. Same like [attachments](#document-attachments), there is an index file for views at `view-index.csv` in each database root directory to help you keep track of filename and query.
+
+All view result are in the `views` database's directory. Since views are tricky when it comes to `reduce`, `group_level`, `startkey` and etc..., every time FixtureDB sees these view options, it hashes the view options and will add it to the file name. For example:
 
 ```erlang
 (fixturedb@hes.2600hz.com)17> kz_fixturedb_util:get_view_path(<<"account%2Fac%2Fco%2Funt0000000000000000000000001">>, <<"users/crossbar_listing">>, []).
@@ -161,7 +179,7 @@ All view result are `views` database's directory. Since views are tricky when it
 "/opt/kazoo/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/views/users+crossbar_listing.json"
 ```
 
-As you can see above when there is no complex view options (in this example an empty options `[]`) the filename is simply reflect the view name. Here is an example with a complex view options:
+As you can see above when there is no complex view options (in this example an empty options `[]`) the filename is simply reflecting the view name. Here is an example with a complex view options:
 
 ```erlang
 (fixturedb@hes.2600hz.com)18> kz_fixturedb_util:get_view_path(<<"account%2Fac%2Fco%2Funt0000000000000000000000001">>, <<"users/crossbar_listing">>, [{key,<<"user">>},include_docs]).
@@ -169,16 +187,21 @@ As you can see above when there is no complex view options (in this example an e
 "/opt/kazoo/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/views/users+crossbar_listing-ba9ee0020a95e519332f16eacf0a3324.json"
 ```
 
-As you can see to get file path for your view query use `kz_fixturedb_util:get_view_path/3,4`. There is an index file for view's file (`view-index.csv`) in each database directory to help you keep track of filename and query. After adding a view result to `views` directory use `kz_fixturedb_util:add_view_path_to_index/3,4` to update the index file.
-
-The list of view options which are result in creating a hashed file name are defined in [`kz_fixturedb.hrl`](../src/kz_fixturedb.hrl) and currently are:
+The list of view options which will result in creating a hashed file name are defined in [`kz_fixturedb.hrl`](../src/kz_fixturedb.hrl). Current options are:
 
 ```erlang
 -define(DANGEROUS_VIEW_OPTS, [startkey, endkey, key
                              ,keys, group, group_level
-                             ,reduce, list
+                             ,reduce, list, skip
                              ]).
 ```
+
+#### Utility Functions
+
+* `kz_fixturedb_util:get_view_path(DbName, Design, Options)`: get file path for your view query. After adding a view result to `views` directory use
+* `kz_fixturedb_util:add_view_to_index(DbName, Design, Options)`: adds the view with options to the index file
+
+**Advanced Usage:** To use a customized data plan you can use arity 4 of above function (as first argument).
 
 #### Note about `include_docs`
 
@@ -187,6 +210,8 @@ If `include_docs` is set, you don't need to include docs in your view result, `k
 #### Note about `limit` and `descending`
 
 As a rule write your view result in the `ascending` order. Again `kz_fixturedb_view` is reversing the the result if `descending` is set.
+
+This only works if your query does not have `reduce`, `group` or `group_level` view options.
 
 This includes `limit` too, if your test case is not have a complex view options (it doesn't have any of `?DANGEROUS_VIEW_OPTS`) you have to include all view results in the file `kz_fixturedb_view` keep taking care of splitting the result set.
 
@@ -200,10 +225,12 @@ It's simple:
 
 ```erlang
 SystemPlan = kzs_plan:plan().
-PlanForThisDb = kzs_plan:plan().
+PlanForThisDb = kzs_plan:plan(SomeDb).
 ```
 
-### Have Database in Other Application Directory
+### Have Database in Other Application Directory (Experimental)
+
+> **Note:** currently there is no way to have update the `kz_dataconncetion` to use this feature.
 
 FixtureDB has an experimental way to read database from other path than the default `core/kazoo_fixturedb/priv/dbs` path. It could be useful if you want to test an applications which maybe requires a lot of document and you want to put them in the default path.
 

--- a/core/kazoo_fixturedb/src/kz_fixturedb_server.erl
+++ b/core/kazoo_fixturedb/src/kz_fixturedb_server.erl
@@ -23,6 +23,9 @@
         ,maybe_use_app_connection/2
         ]).
 
+%% Lazy Tools
+-export([get_dummy_plan/0]).
+
 -include("kz_fixturedb.hrl").
 
 %%%===================================================================
@@ -94,6 +97,14 @@ maybe_use_app_connection(#{options := Options}=Server, DbName) ->
             ?LOG_DEBUG("requested db ~s is not test_db ~s, using kazoo_fixturedb database path...", [DbName, _OtherDb]),
             Server
     end.
+
+%% @doc
+%% For using kazoo_fixturedb directly without starting up kazoo_data, returns a dummy plan
+%% @end
+-spec get_dummy_plan() -> map().
+get_dummy_plan() ->
+    {ok, Server} = new_connection(#{}),
+    #{server => {kazoo_fixturedb, Server}}.
 
 %%%===================================================================
 %%% Internal functions

--- a/core/kazoo_fixturedb/src/kz_fixturedb_view.erl
+++ b/core/kazoo_fixturedb/src/kz_fixturedb_view.erl
@@ -66,7 +66,9 @@ all_docs(Server, DbName, Options) ->
 
 -spec prepare_view_result(server_map(), kz_term:ne_binary(), kz_json:objects(), kz_data:options()) -> kz_json:objects().
 prepare_view_result(Server, DbName, Result, Options) ->
-    case props:get_value(include_docs, Options, false) of
+    case props:get_value(include_docs, Options, false)
+        andalso kz_term:is_false(props:get_first_defined([reduce, group, group_level], Options, false))
+    of
         false -> sort_and_limit(Result, Options);
         true ->
             [kz_json:set_value(<<"doc">>, Opened, V)


### PR DESCRIPTION
Allow to call fixturedb functions utility without starting without need
to start kazoo_data and config.

Also enhance add attachment to fixturedb by creating sym linking att
file to the media_files/* if you're using files from media_files

(I need to update the document, maybe tomorrow :)