### PR TITLE
remove evil specs

### DIFF
--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -323,10 +323,8 @@ status(ServerRef) -> gen_statem:call(ServerRef, 'status').
 %% function does not return until Module:init/1 has returned.
 %% @end
 %%--------------------------------------------------------------------
--spec start_link(pid(), kz_json:object()) -> kz_types:startlink_ret().
--spec start_link(pid(), kapps_call:call(), kz_term:ne_binary()) -> kz_types:startlink_ret().
--spec start_link(kz_term:ne_binary(), kz_term:ne_binary(), pid(), kz_term:proplist()) -> kz_types:startlink_ret().
 
+-spec start_link(pid(), kz_json:object()) -> kz_types:startlink_ret().
 start_link(Supervisor, AgentJObj) when is_pid(Supervisor) ->
     pvt_start_link(kz_doc:account_id(AgentJObj)
                   ,kz_doc:id(AgentJObj)
@@ -334,6 +332,8 @@ start_link(Supervisor, AgentJObj) when is_pid(Supervisor) ->
                   ,[]
                   ,'false'
                   ).
+
+-spec start_link(pid(), kapps_call:call(), kz_term:ne_binary()) -> kz_types:startlink_ret().
 start_link(Supervisor, ThiefCall, _QueueId) ->
     pvt_start_link(kapps_call:account_id(ThiefCall)
                   ,kapps_call:owner_id(ThiefCall)
@@ -341,6 +341,8 @@ start_link(Supervisor, ThiefCall, _QueueId) ->
                   ,[]
                   ,'true'
                   ).
+
+-spec start_link(kz_term:ne_binary(), kz_term:ne_binary(), pid(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(AccountId, AgentId, Supervisor, Props) ->
     pvt_start_link(AccountId, AgentId, Supervisor, Props, 'false').
 
@@ -360,13 +362,15 @@ pvt_start_link(AccountId, AgentId, Supervisor, Props, IsThief) ->
     gen_statem:start_link(?SERVER, [AccountId, AgentId, Supervisor, Props, IsThief], []).
 
 -spec new_endpoint(pid(), kz_json:object()) -> 'ok'.
--spec edited_endpoint(pid(), kz_json:object()) -> 'ok'.
--spec deleted_endpoint(pid(), kz_json:object()) -> 'ok'.
 new_endpoint(ServerRef, EP) ->
     lager:debug("sending EP to ~p: ~p", [ServerRef, EP]).
+
+-spec edited_endpoint(pid(), kz_json:object()) -> 'ok'.
 edited_endpoint(ServerRef, EP) ->
     lager:debug("sending EP to ~p: ~p", [ServerRef, EP]),
     gen_statem:cast(ServerRef, {'edited_endpoint', kz_doc:id(EP), EP}).
+
+-spec deleted_endpoint(pid(), kz_json:object()) -> 'ok'.
 deleted_endpoint(ServerRef, EP) ->
     lager:debug("sending EP to ~p: ~p", [ServerRef, EP]).
 
@@ -1502,9 +1506,10 @@ start_wrapup_timer(Timeout) when Timeout =< 0 -> start_wrapup_timer(1); % send i
 start_wrapup_timer(Timeout) -> erlang:start_timer(Timeout*1000, self(), ?WRAPUP_FINISHED).
 
 -spec start_sync_timer() -> reference().
--spec start_sync_timer(pid()) -> reference().
 start_sync_timer() ->
     erlang:start_timer(?SYNC_RESPONSE_TIMEOUT, self(), ?SYNC_RESPONSE_MESSAGE).
+
+-spec start_sync_timer(pid()) -> reference().
 start_sync_timer(P) ->
     erlang:start_timer(?SYNC_RESPONSE_TIMEOUT, P, ?SYNC_RESPONSE_MESSAGE).
 
@@ -1626,12 +1631,12 @@ hangup_call(#state{agent_listener=AgentListener
     wrapup_timer(State).
 
 -spec maybe_stop_timer(kz_term:api_reference()) -> 'ok'.
--spec maybe_stop_timer(kz_term:api_reference(), boolean()) -> 'ok'.
 maybe_stop_timer('undefined') -> 'ok';
 maybe_stop_timer(ConnRef) when is_reference(ConnRef) ->
     _ = erlang:cancel_timer(ConnRef),
     'ok'.
 
+-spec maybe_stop_timer(kz_term:api_reference(), boolean()) -> 'ok'.
 maybe_stop_timer(TimerRef, 'true') -> maybe_stop_timer(TimerRef);
 maybe_stop_timer(_, 'false') -> 'ok'.
 
@@ -1687,12 +1692,12 @@ find_username(EP) ->
 find_sip_username(EP, 'undefined') -> kz_json:get_value(<<"To-User">>, EP);
 find_sip_username(_EP, Username) -> Username.
 
--spec find_endpoint_id(kz_json:object()) -> kz_term:api_binary().
--spec find_endpoint_id(kz_json:object(), kz_term:api_binary()) -> kz_term:api_binary().
 
+-spec find_endpoint_id(kz_json:object()) -> kz_term:api_binary().
 find_endpoint_id(EP) ->
     find_endpoint_id(EP, kz_doc:id(EP)).
 
+-spec find_endpoint_id(kz_json:object(), kz_term:api_binary()) -> kz_term:api_binary().
 find_endpoint_id(EP, 'undefined') -> kz_json:get_value(<<"Endpoint-ID">>, EP);
 find_endpoint_id(_EP, EPId) -> EPId.
 

--- a/applications/acdc/src/acdc_agent_handler.erl
+++ b/applications/acdc/src/acdc_agent_handler.erl
@@ -263,10 +263,10 @@ handle_originate_resp(JObj, Props) ->
     end.
 
 -spec handle_member_message(kz_json:object(), kz_term:proplist()) -> 'ok'.
--spec handle_member_message(kz_json:object(), kz_term:proplist(), kz_term:ne_binary()) -> 'ok'.
 handle_member_message(JObj, Props) ->
     handle_member_message(JObj, Props, kz_json:get_value(<<"Event-Name">>, JObj)).
 
+-spec handle_member_message(kz_json:object(), kz_term:proplist(), kz_term:ne_binary()) -> 'ok'.
 handle_member_message(JObj, Props, <<"connect_req">>) ->
     'true' = kapi_acdc_queue:member_connect_req_v(JObj),
     acdc_agent_fsm:member_connect_req(props:get_value('fsm_pid', Props), JObj);
@@ -277,10 +277,10 @@ handle_member_message(_, _, EvtName) ->
     lager:debug("not handling member event ~s", [EvtName]).
 
 -spec handle_agent_message(kz_json:object(), kz_term:proplist()) -> 'ok'.
--spec handle_agent_message(kz_json:object(), kz_term:proplist(), kz_term:ne_binary()) -> 'ok'.
 handle_agent_message(JObj, Props) ->
     handle_agent_message(JObj, Props, kz_json:get_value(<<"Event-Name">>, JObj)).
 
+-spec handle_agent_message(kz_json:object(), kz_term:proplist(), kz_term:ne_binary()) -> 'ok'.
 handle_agent_message(JObj, Props, <<"connect_timeout">>) ->
     'true' = kapi_acdc_queue:agent_timeout_v(JObj),
     acdc_agent_fsm:agent_timeout(props:get_value('fsm_pid', Props), JObj);

--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -170,15 +170,15 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(pid(), kz_json:object()) -> kz_types:startlink_ret().
--spec start_link(pid(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binaries()) -> kz_types:startlink_ret().
--spec start_link(pid(), kapps_call:call(), kz_term:ne_binary()) -> kz_types:startlink_ret().
 start_link(Supervisor, AgentJObj) ->
     AgentId = kz_doc:id(AgentJObj),
     AcctId = account_id(AgentJObj),
     Queues = kz_json:get_value(<<"queues">>, AgentJObj, []),
     start_link(Supervisor, AgentJObj, AcctId, AgentId, Queues).
 
+-spec start_link(pid(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binaries()) -> kz_types:startlink_ret().
 start_link(Supervisor, AgentJObj, AcctId, AgentId, Queues) ->
     lager:debug("start bindings for ~s(~s) in ready", [AcctId, AgentId]),
     gen_listener:start_link(?SERVER
@@ -188,6 +188,7 @@ start_link(Supervisor, AgentJObj, AcctId, AgentId, Queues) ->
                            ,[Supervisor, AgentJObj, Queues]
                            ).
 
+-spec start_link(pid(), kapps_call:call(), kz_term:ne_binary()) -> kz_types:startlink_ret().
 start_link(Supervisor, ThiefCall, QueueId) ->
     AgentId = kapps_call:owner_id(ThiefCall),
     AcctId = kapps_call:account_id(ThiefCall),
@@ -215,9 +216,10 @@ member_connect_retry(Srv, WinOrCallId) ->
 agent_timeout(Srv) -> gen_listener:cast(Srv, 'agent_timeout').
 
 -spec member_connect_accepted(pid()) -> 'ok'.
--spec member_connect_accepted(pid(), kz_term:ne_binary()) -> 'ok'.
 member_connect_accepted(Srv) ->
     gen_listener:cast(Srv, {'member_connect_accepted'}).
+
+-spec member_connect_accepted(pid(), kz_term:ne_binary()) -> 'ok'.
 member_connect_accepted(Srv, ACallId) ->
     gen_listener:cast(Srv, {'member_connect_accepted', ACallId}).
 
@@ -271,8 +273,9 @@ send_agent_busy(Srv) ->
 send_sync_req(Srv) -> gen_listener:cast(Srv, {'send_sync_req'}).
 
 -spec send_sync_resp(pid(), kz_term:text(), kz_json:object()) -> 'ok'.
--spec send_sync_resp(pid(), kz_term:text(), kz_json:object(), kz_term:proplist()) -> 'ok'.
 send_sync_resp(Srv, Status, ReqJObj) -> send_sync_resp(Srv, Status, ReqJObj, []).
+
+-spec send_sync_resp(pid(), kz_term:text(), kz_json:object(), kz_term:proplist()) -> 'ok'.
 send_sync_resp(Srv, Status, ReqJObj, Options) ->
     gen_listener:cast(Srv, {'send_sync_resp', Status, ReqJObj, Options}).
 
@@ -300,9 +303,10 @@ rm_acdc_queue(Srv, Q) ->
     gen_listener:cast(Srv, {'rm_acdc_queue', Q}).
 
 -spec call_status_req(pid()) -> 'ok'.
--spec call_status_req(pid(), kz_term:ne_binary()) -> 'ok'.
 call_status_req(Srv) ->
     gen_listener:cast(Srv, 'call_status_req').
+
+-spec call_status_req(pid(), kz_term:ne_binary()) -> 'ok'.
 call_status_req(Srv, CallId) ->
     gen_listener:cast(Srv, {'call_status_req', CallId}).
 
@@ -992,7 +996,6 @@ send_member_connect_resp(JObj, MyQ, AgentId, MyId, LastConn) ->
     kapi_acdc_queue:publish_member_connect_resp(Queue, Resp).
 
 -spec send_member_connect_retry(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec send_member_connect_retry(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 send_member_connect_retry(JObj, MyId, AgentId) ->
     send_member_connect_retry(kz_json:get_value(<<"Server-ID">>, JObj)
                              ,call_id(JObj)
@@ -1000,6 +1003,7 @@ send_member_connect_retry(JObj, MyId, AgentId) ->
                              ,AgentId
                              ).
 
+-spec send_member_connect_retry(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 send_member_connect_retry('undefined', _, _, _) ->
     lager:debug("no queue to send the retry to, seems bad");
 send_member_connect_retry(Queue, CallId, MyId, AgentId) ->

--- a/applications/acdc/src/acdc_agent_stats.erl
+++ b/applications/acdc/src/acdc_agent_stats.erl
@@ -34,10 +34,12 @@
 -include("acdc_stats.hrl").
 
 -spec status_table_id() -> atom().
--spec status_key_pos() -> pos_integer().
--spec status_table_opts() -> kz_term:proplist().
 status_table_id() -> 'acdc_stats_status'.
+
+-spec status_key_pos() -> pos_integer().
 status_key_pos() -> #status_stat.id.
+
+-spec status_table_opts() -> kz_term:proplist().
 status_table_opts() ->
     ['protected', 'named_table'
     ,{'keypos', status_key_pos()}
@@ -98,10 +100,11 @@ agent_pending_logged_out(AccountId, AgentId) ->
 
 -spec agent_connecting(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                               'ok'.
--spec agent_connecting(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
-                              'ok'.
 agent_connecting(AccountId, AgentId, CallId) ->
     agent_connecting(AccountId, AgentId, CallId, 'undefined', 'undefined').
+
+-spec agent_connecting(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
+                              'ok'.
 agent_connecting(AccountId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AccountId}
@@ -119,10 +122,11 @@ agent_connecting(AccountId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
 
 -spec agent_connected(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                              'ok'.
--spec agent_connected(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
-                             'ok'.
 agent_connected(AccountId, AgentId, CallId) ->
     agent_connected(AccountId, AgentId, CallId, 'undefined', 'undefined').
+
+-spec agent_connected(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
+                             'ok'.
 agent_connected(AccountId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AccountId}

--- a/applications/acdc/src/acdc_agent_sup.erl
+++ b/applications/acdc/src/acdc_agent_sup.erl
@@ -37,13 +37,16 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the supervisor
 %%--------------------------------------------------------------------
+
 -spec start_link(kz_json:object()) -> kz_types:startlink_ret().
--spec start_link(kapps_call:call(), kz_term:ne_binary()) -> kz_types:startlink_ret().
--spec start_link(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), kz_term:ne_binaries()) -> kz_types:startlink_ret().
 start_link(AgentJObj) ->
     supervisor:start_link(?SERVER, [AgentJObj]).
+
+-spec start_link(kapps_call:call(), kz_term:ne_binary()) -> kz_types:startlink_ret().
 start_link(ThiefCall, QueueId) ->
     supervisor:start_link(?SERVER, [ThiefCall, QueueId]).
+
+-spec start_link(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), kz_term:ne_binaries()) -> kz_types:startlink_ret().
 start_link(AcctId, AgentId, AgentJObj, Queues) ->
     supervisor:start_link(?SERVER, [AcctId, AgentId, AgentJObj, Queues]).
 

--- a/applications/acdc/src/acdc_agent_util.erl
+++ b/applications/acdc/src/acdc_agent_util.erl
@@ -25,9 +25,10 @@
 -include("acdc.hrl").
 
 -spec update_status(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec update_status(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 update_status(AccountId, AgentId, Status) ->
     update_status(AccountId, AgentId, Status, []).
+
+-spec update_status(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 update_status(?NE_BINARY = AccountId, AgentId, Status, Options) ->
     API = [{<<"Account-ID">>, AccountId}
           ,{<<"Agent-ID">>, AgentId}
@@ -112,16 +113,14 @@ prev_month_recent_db_status(AccountId, AgentId) ->
     end.
 
 -type statuses_return() :: {'ok', kz_json:object()}.
+
 -spec most_recent_statuses(kz_term:ne_binary()) ->
                                   statuses_return().
--spec most_recent_statuses(kz_term:ne_binary(), kz_term:api_binary() | kz_term:proplist()) ->
-                                  statuses_return().
--spec most_recent_statuses(kz_term:ne_binary(), kz_term:api_binary(), kz_term:proplist()) ->
-                                  statuses_return().
-
 most_recent_statuses(AccountId) ->
     most_recent_statuses(AccountId, 'undefined', []).
 
+-spec most_recent_statuses(kz_term:ne_binary(), kz_term:api_binary() | kz_term:proplist()) ->
+                                  statuses_return().
 most_recent_statuses(AccountId, 'undefined') ->
     most_recent_statuses(AccountId, 'undefined', []);
 most_recent_statuses(AccountId, ?NE_BINARY = AgentId) ->
@@ -129,6 +128,8 @@ most_recent_statuses(AccountId, ?NE_BINARY = AgentId) ->
 most_recent_statuses(AccountId, Options) when is_list(Options) ->
     most_recent_statuses(AccountId, props:get_value(<<"Agent-ID">>, Options), Options).
 
+-spec most_recent_statuses(kz_term:ne_binary(), kz_term:api_binary(), kz_term:proplist()) ->
+                                  statuses_return().
 most_recent_statuses(AccountId, AgentId, Options) ->
     ETS = kz_util:spawn_monitor(fun async_most_recent_ets_statuses/4, [AccountId, AgentId, Options, self()]),
     DB = maybe_start_db_lookup('async_most_recent_db_statuses'
@@ -170,12 +171,13 @@ reduce_agent_statuses(_, Data, {T, _}=Acc) ->
     end.
 
 -type receive_info() :: [{pid(), reference()} | 'undefined'].
+
 -spec receive_statuses(receive_info()) ->
-                              kz_json:object().
--spec receive_statuses(receive_info(), kz_json:object()) ->
                               kz_json:object().
 receive_statuses(Reqs) -> receive_statuses(Reqs, kz_json:new()).
 
+-spec receive_statuses(receive_info(), kz_json:object()) ->
+                              kz_json:object().
 receive_statuses([], AccJObj) -> AccJObj;
 receive_statuses(['undefined' | Reqs], AccJObj) ->
     receive_statuses(Reqs, AccJObj);
@@ -229,20 +231,20 @@ async_most_recent_db_statuses(AccountId, AgentId, Options, Pid) ->
 -spec most_recent_ets_statuses(kz_term:ne_binary()) ->
                                       statuses_return() |
                                       {'error', any()}.
--spec most_recent_ets_statuses(kz_term:ne_binary(), kz_term:api_binary()) ->
-                                      statuses_return() |
-                                      {'error', any()}.
--spec most_recent_ets_statuses(kz_term:ne_binary(), kz_term:api_binary(), kz_term:proplist()) ->
-                                      statuses_return() |
-                                      {'error', any()}.
 most_recent_ets_statuses(AccountId) ->
     most_recent_ets_statuses(AccountId, 'undefined', []).
 
+-spec most_recent_ets_statuses(kz_term:ne_binary(), kz_term:api_binary()) ->
+                                      statuses_return() |
+                                      {'error', any()}.
 most_recent_ets_statuses(AccountId, ?NE_BINARY = AgentId) ->
     most_recent_ets_statuses(AccountId, AgentId, []);
 most_recent_ets_statuses(AccountId, Options) when is_list(Options) ->
     most_recent_ets_statuses(AccountId, 'undefined', Options).
 
+-spec most_recent_ets_statuses(kz_term:ne_binary(), kz_term:api_binary(), kz_term:proplist()) ->
+                                      statuses_return() |
+                                      {'error', any()}.
 most_recent_ets_statuses(AccountId, AgentId, Options) ->
     API = props:filter_undefined(
             [{<<"Account-ID">>, AccountId}
@@ -262,19 +264,20 @@ most_recent_ets_statuses(AccountId, AgentId, Options) ->
 -spec most_recent_db_statuses(kz_term:ne_binary()) ->
                                      statuses_return() |
                                      {'error', any()}.
+most_recent_db_statuses(AccountId) ->
+    most_recent_db_statuses(AccountId, 'undefined', []).
+
 -spec most_recent_db_statuses(kz_term:ne_binary(), kz_term:api_binary()) ->
                                      statuses_return() |
                                      {'error', any()}.
--spec most_recent_db_statuses(kz_term:ne_binary(), kz_term:api_binary(), kz_term:proplist()) ->
-                                     statuses_return() |
-                                     {'error', any()}.
-most_recent_db_statuses(AccountId) ->
-    most_recent_db_statuses(AccountId, 'undefined', []).
 most_recent_db_statuses(AccountId, ?NE_BINARY = AgentId) ->
     most_recent_db_statuses(AccountId, AgentId, []);
 most_recent_db_statuses(AccountId, Options) when is_list(Options) ->
     most_recent_db_statuses(AccountId, 'undefined', Options).
 
+-spec most_recent_db_statuses(kz_term:ne_binary(), kz_term:api_binary(), kz_term:proplist()) ->
+                                     statuses_return() |
+                                     {'error', any()}.
 most_recent_db_statuses(AccountId, 'undefined', ReqOptions) ->
     case props:get_value(<<"Agent-ID">>, ReqOptions) of
         'undefined' -> most_recent_db_statuses_by_timestamp(AccountId, ReqOptions);

--- a/applications/acdc/src/acdc_agents_sup.erl
+++ b/applications/acdc/src/acdc_agents_sup.erl
@@ -52,13 +52,13 @@ status() ->
     'ok'.
 
 -spec new(kz_json:object()) -> kz_types:sup_startchild_ret().
--spec new(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_types:sup_startchild_ret().
 new(JObj) ->
     case find_agent_supervisor(kz_doc:account_id(JObj), kz_doc:id(JObj)) of
         'undefined' -> supervisor:start_child(?SERVER, [JObj]);
         P when is_pid(P) -> lager:debug("agent already started here: ~p", [P])
     end.
 
+-spec new(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_types:sup_startchild_ret().
 new(AcctId, AgentId) ->
     case find_agent_supervisor(AcctId, AgentId) of
         'undefined' ->
@@ -106,9 +106,9 @@ agents_running() ->
     [{W, catch acdc_agent_listener:config(acdc_agent_sup:listener(W))} || W <- workers()].
 
 -spec find_agent_supervisor(kz_term:api_binary(), kz_term:api_binary()) -> kz_term:api_pid().
--spec find_agent_supervisor(kz_term:api_binary(), kz_term:api_binary(), kz_term:pids()) -> kz_term:api_pid().
 find_agent_supervisor(AcctId, AgentId) -> find_agent_supervisor(AcctId, AgentId, workers()).
 
+-spec find_agent_supervisor(kz_term:api_binary(), kz_term:api_binary(), kz_term:pids()) -> kz_term:api_pid().
 find_agent_supervisor(_AcctId, _AgentId, []) ->
     lager:debug("ran out of supers"),
     'undefined';

--- a/applications/acdc/src/acdc_handlers.erl
+++ b/applications/acdc/src/acdc_handlers.erl
@@ -80,12 +80,13 @@ update_agent(Call) ->
     end.
 
 -spec update_acdc_actor(kapps_call:call()) -> any().
--spec update_acdc_actor(kapps_call:call(), kz_term:api_binary(), kz_term:api_binary()) -> any().
 update_acdc_actor(Call) ->
     update_acdc_actor(Call
                      ,kapps_call:custom_channel_var(<<"ACDc-ID">>, Call)
                      ,kapps_call:custom_channel_var(<<"ACDc-Type">>, Call)
                      ).
+
+-spec update_acdc_actor(kapps_call:call(), kz_term:api_binary(), kz_term:api_binary()) -> any().
 update_acdc_actor(_Call, 'undefined', _) -> 'ok';
 update_acdc_actor(_Call, _, 'undefined') -> 'ok';
 update_acdc_actor(Call, QueueId, <<"queue">>) ->

--- a/applications/acdc/src/acdc_queue_handler.erl
+++ b/applications/acdc/src/acdc_queue_handler.erl
@@ -21,12 +21,12 @@
 -include_lib("kazoo_amqp/include/kapi_conf.hrl").
 
 -spec handle_call_event(kz_json:object(), kz_term:proplist()) -> 'ok'.
--spec handle_call_event(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), kz_term:proplist()) -> 'ok'.
 handle_call_event(JObj, Props) ->
     'true' = kapi_call:event_v(JObj),
     {Cat, Name} = kz_util:get_event_type(JObj),
     handle_call_event(Cat, Name, JObj, Props).
 
+-spec handle_call_event(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), kz_term:proplist()) -> 'ok'.
 handle_call_event(Category, <<"CHANNEL_DESTROY">> = Name, JObj, Props) ->
     case acdc_queue_fsm:cdr_url(props:get_value('fsm_pid', Props)) of
         'undefined' -> 'ok';

--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -153,19 +153,22 @@ exit_member_call_empty(Srv) ->
     gen_listener:cast(Srv, {'exit_member_call_empty'}).
 
 -spec finish_member_call(pid()) -> 'ok'.
--spec finish_member_call(pid(), kz_json:object()) -> 'ok'.
 finish_member_call(Srv) ->
     gen_listener:cast(Srv, {'finish_member_call'}).
+
+-spec finish_member_call(pid(), kz_json:object()) -> 'ok'.
 finish_member_call(Srv, AcceptJObj) ->
     gen_listener:cast(Srv, {'finish_member_call', AcceptJObj}).
 
 -spec cancel_member_call(pid()) -> 'ok'.
--spec cancel_member_call(pid(), kz_json:object()) -> 'ok'.
--spec cancel_member_call(pid(), kz_json:object(), gen_listener:basic_deliver()) -> 'ok'.
 cancel_member_call(Srv) ->
     gen_listener:cast(Srv, {'cancel_member_call'}).
+
+-spec cancel_member_call(pid(), kz_json:object()) -> 'ok'.
 cancel_member_call(Srv, RejectJObj) ->
     gen_listener:cast(Srv, {'cancel_member_call', RejectJObj}).
+
+-spec cancel_member_call(pid(), kz_json:object(), gen_listener:basic_deliver()) -> 'ok'.
 cancel_member_call(Srv, MemberCallJObj, Delivery) ->
     gen_listener:cast(Srv, {'cancel_member_call', MemberCallJObj, Delivery}).
 
@@ -678,7 +681,6 @@ clear_call_state(#state{account_id=AccountId
                }.
 
 -spec publish(kz_term:api_terms(), kz_amqp_worker:publish_fun()) -> 'ok'.
--spec publish(kz_term:ne_binary(), kz_term:api_terms(), fun((kz_term:ne_binary(), kz_term:api_terms()) -> 'ok')) -> 'ok'.
 publish(Req, F) ->
     try F(Req)
     catch _E:_R ->
@@ -687,6 +689,8 @@ publish(Req, F) ->
             kz_util:log_stacktrace(ST),
             'ok'
     end.
+
+-spec publish(kz_term:ne_binary(), kz_term:api_terms(), fun((kz_term:ne_binary(), kz_term:api_terms()) -> 'ok')) -> 'ok'.
 publish(Q, Req, F) ->
     try F(Q, Req)
     catch _E:_R ->

--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -240,13 +240,14 @@ handle_config_change(Srv, JObj) ->
     gen_listener:cast(Srv, {'update_queue_config', JObj}).
 
 -spec should_ignore_member_call(kz_types:server_ref(), kapps_call:call(), kz_json:object()) -> boolean().
--spec should_ignore_member_call(kz_types:server_ref(), kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
 should_ignore_member_call(Srv, Call, CallJObj) ->
     should_ignore_member_call(Srv
                              ,Call
                              ,kz_json:get_value(<<"Account-ID">>, CallJObj)
                              ,kz_json:get_value(<<"Queue-ID">>, CallJObj)
                              ).
+
+-spec should_ignore_member_call(kz_types:server_ref(), kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
 should_ignore_member_call(Srv, Call, AccountId, QueueId) ->
     K = make_ignore_key(AccountId, QueueId, kapps_call:call_id(Call)),
     gen_listener:call(Srv, {'should_ignore_member_call', K}).
@@ -916,10 +917,10 @@ update_strategy_state(Srv, L) ->
     [gen_listener:cast(Srv, {'sync_with_agent', A}) || A <- L].
 
 -spec call_position(kz_term:ne_binary(), [kapps_call:call()]) -> kz_term:api_integer().
--spec call_position(kz_term:ne_binary(), [kapps_call:call()], pos_integer()) -> pos_integer().
 call_position(CallId, Calls) ->
     call_position(CallId, Calls, 1).
 
+-spec call_position(kz_term:ne_binary(), [kapps_call:call()], pos_integer()) -> pos_integer().
 call_position(_, [], _) ->
     'undefined';
 call_position(CallId, [Call|Calls], Position) ->

--- a/applications/acdc/src/acdc_queues_sup.erl
+++ b/applications/acdc/src/acdc_queues_sup.erl
@@ -64,10 +64,10 @@ is_queue_in_acct(Super, AcctId) ->
     end.
 
 -spec find_queue_supervisor(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_pid().
--spec find_queue_supervisor(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:pids()) -> kz_term:api_pid().
 find_queue_supervisor(AcctId, QueueId) ->
     find_queue_supervisor(AcctId, QueueId, workers()).
 
+-spec find_queue_supervisor(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:pids()) -> kz_term:api_pid().
 find_queue_supervisor(_AcctId, _QueueId, []) -> 'undefined';
 find_queue_supervisor(AcctId, QueueId, [Super|Rest]) ->
     case catch acdc_queue_manager:config(acdc_queue_sup:manager(Super)) of

--- a/applications/acdc/src/acdc_stats.erl
+++ b/applications/acdc/src/acdc_stats.erl
@@ -167,9 +167,10 @@ agent_logged_out(AcctId, AgentId) ->
     'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_logged_out/1).
 
 -spec agent_connecting(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec agent_connecting(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> 'ok'.
 agent_connecting(AcctId, AgentId, CallId) ->
     agent_connecting(AcctId, AgentId, CallId, 'undefined', 'undefined').
+
+-spec agent_connecting(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> 'ok'.
 agent_connecting(AcctId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AcctId}
@@ -184,9 +185,10 @@ agent_connecting(AcctId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
     'ok' = kz_amqp_worker:cast(Prop, fun kapi_acdc_stats:publish_status_connecting/1).
 
 -spec agent_connected(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec agent_connected(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> 'ok'.
 agent_connected(AcctId, AgentId, CallId) ->
     agent_connected(AcctId, AgentId, CallId, 'undefined', 'undefined').
+
+-spec agent_connected(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> 'ok'.
 agent_connected(AcctId, AgentId, CallId, CallerIDName, CallerIDNumber) ->
     Prop = props:filter_undefined(
              [{<<"Account-ID">>, AcctId}
@@ -243,11 +245,14 @@ agent_statuses() ->
     ?STATUS_STATUSES.
 
 %% ETS config
+
 -spec call_table_id() -> atom().
--spec call_key_pos() -> pos_integer().
--spec call_table_opts() -> kz_term:proplist().
 call_table_id() -> 'acdc_stats_call'.
+
+-spec call_key_pos() -> pos_integer().
 call_key_pos() -> #call_stat.id.
+
+-spec call_table_opts() -> kz_term:proplist().
 call_table_opts() ->
     ['protected', 'named_table'
     ,{'keypos', call_key_pos()}
@@ -762,8 +767,9 @@ talk_time(H, P) when is_integer(H), is_integer(P) -> P - H;
 talk_time(_, _) -> 'undefined'.
 
 -spec misses_to_docs(agent_misses()) -> kz_json:objects().
--spec miss_to_doc(agent_miss()) -> kz_json:object().
 misses_to_docs(Misses) -> [miss_to_doc(Miss) || Miss <- Misses].
+
+-spec miss_to_doc(agent_miss()) -> kz_json:object().
 miss_to_doc(#agent_miss{agent_id=AgentId
                        ,miss_reason=Reason
                        ,miss_timestamp=T
@@ -792,11 +798,12 @@ maybe_created_db(DbName, 'true') ->
     kz_datamgr:revise_views_from_folder(DbName, 'acdc').
 
 -spec call_stat_id(kz_json:object()) -> kz_term:ne_binary().
--spec call_stat_id(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 call_stat_id(JObj) ->
     call_stat_id(kz_json:get_value(<<"Call-ID">>, JObj)
                 ,kz_json:get_value(<<"Queue-ID">>, JObj)
                 ).
+
+-spec call_stat_id(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 call_stat_id(CallId, QueueId) -> <<CallId/binary, "::", QueueId/binary>>.
 
 -spec handle_waiting_stat(kz_json:object(), kz_term:proplist()) -> 'ok'.

--- a/applications/acdc/src/acdc_stats_util.erl
+++ b/applications/acdc/src/acdc_stats_util.erl
@@ -33,9 +33,10 @@ pause_time(<<"paused">>, JObj) ->
 pause_time(_, _JObj) -> 'undefined'.
 
 -spec caller_id_name(any(), kz_json:object()) -> kz_term:api_ne_binary().
--spec caller_id_number(any(), kz_json:object()) -> kz_term:api_integer().
 caller_id_name(_, JObj) ->
     kz_json:get_value(<<"Caller-ID-Name">>, JObj).
+
+-spec caller_id_number(any(), kz_json:object()) -> kz_term:api_integer().
 caller_id_number(_, JObj) ->
     kz_json:get_value(<<"Caller-ID-Number">>, JObj).
 

--- a/applications/acdc/src/acdc_util.erl
+++ b/applications/acdc/src/acdc_util.erl
@@ -49,9 +49,10 @@ agent_presence_update(AcctId, AgentId) ->
     end.
 
 -spec presence_update(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec presence_update(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 presence_update(AcctId, PresenceId, State) ->
     presence_update(AcctId, PresenceId, State, kz_term:to_hex_binary(crypto:hash('md5', PresenceId))).
+
+-spec presence_update(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 presence_update(AcctId, PresenceId, State, CallId) ->
     {'ok', AcctDoc} = kz_account:fetch(AcctId),
     To = <<PresenceId/binary, "@", (kz_json:get_value(<<"realm">>, AcctDoc))/binary>>,
@@ -128,8 +129,10 @@ unbind_from_call_events({CallId, _}, Pid) -> unbind_from_call_events(CallId, Pid
 unbind_from_call_events(Call, Pid) -> unbind_from_call_events(kapps_call:call_id(Call), Pid).
 
 -spec proc_id() -> kz_term:ne_binary().
--spec proc_id(pid()) -> kz_term:ne_binary().
--spec proc_id(pid(), atom() | kz_term:ne_binary()) -> kz_term:ne_binary().
 proc_id() -> proc_id(self()).
+
+-spec proc_id(pid()) -> kz_term:ne_binary().
 proc_id(Pid) -> proc_id(Pid, node()).
+
+-spec proc_id(pid(), atom() | kz_term:ne_binary()) -> kz_term:ne_binary().
 proc_id(Pid, Node) -> list_to_binary([kz_term:to_binary(Node), "-", pid_to_list(Pid)]).

--- a/applications/acdc/src/cb_agents.erl
+++ b/applications/acdc/src/cb_agents.erl
@@ -74,15 +74,16 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() -> [?HTTP_GET].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?STATUS_PATH_TOKEN) -> [?HTTP_GET];
 allowed_methods(?STATS_PATH_TOKEN) -> [?HTTP_GET];
 allowed_methods(_UserId) -> [?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?STATUS_PATH_TOKEN, _UserId) -> [?HTTP_GET, ?HTTP_POST];
 allowed_methods(_UserId, ?STATUS_PATH_TOKEN) -> [?HTTP_GET, ?HTTP_POST];
 allowed_methods(_UserId, ?QUEUE_STATUS_PATH_TOKEN) -> [?HTTP_GET, ?HTTP_POST].
@@ -96,11 +97,14 @@ allowed_methods(_UserId, ?QUEUE_STATUS_PATH_TOKEN) -> [?HTTP_GET, ?HTTP_POST].
 %%    /agents/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, ?STATUS_PATH_TOKEN) -> 'true';
 resource_exists(?STATUS_PATH_TOKEN, _) -> 'true';
 resource_exists(_, ?QUEUE_STATUS_PATH_TOKEN) -> 'true'.
@@ -112,10 +116,11 @@ resource_exists(_, ?QUEUE_STATUS_PATH_TOKEN) -> 'true'.
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec content_types_provided(cb_context:context()) -> cb_context:context().
--spec content_types_provided(cb_context:context(), path_token()) -> cb_context:context().
--spec content_types_provided(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 content_types_provided(Context) -> Context.
+
+-spec content_types_provided(cb_context:context(), path_token()) -> cb_context:context().
 content_types_provided(Context, ?STATUS_PATH_TOKEN) -> Context;
 content_types_provided(Context, ?STATS_PATH_TOKEN) ->
     case cb_context:req_value(Context, <<"format">>, ?FORMAT_COMPRESSED) of
@@ -129,6 +134,8 @@ content_types_provided(Context, ?STATS_PATH_TOKEN) ->
                                                  ,[{'to_json', ?JSON_CONTENT_TYPES}]
                                                  )
     end.
+
+-spec content_types_provided(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 content_types_provided(Context, ?STATUS_PATH_TOKEN, _) -> Context;
 content_types_provided(Context, _, ?STATUS_PATH_TOKEN) -> Context;
 content_types_provided(Context, _, ?QUEUE_STATUS_PATH_TOKEN) -> Context.
@@ -143,15 +150,14 @@ content_types_provided(Context, _, ?QUEUE_STATUS_PATH_TOKEN) -> Context.
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) ->
-                      cb_context:context().
--spec validate(cb_context:context(), path_token()) ->
-                      cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) ->
                       cb_context:context().
 validate(Context) ->
     summary(Context).
 
+-spec validate(cb_context:context(), path_token()) ->
+                      cb_context:context().
 validate(Context, PathToken) ->
     validate_agent(Context, PathToken, cb_context:req_verb(Context)).
 
@@ -162,6 +168,8 @@ validate_agent(Context, ?STATS_PATH_TOKEN, ?HTTP_GET) ->
 validate_agent(Context, Id, ?HTTP_GET) ->
     read(Id, Context).
 
+-spec validate(cb_context:context(), path_token(), path_token()) ->
+                      cb_context:context().
 validate(Context, AgentId, PathToken) ->
     validate_agent_action(Context, AgentId, PathToken, cb_context:req_verb(Context)).
 
@@ -464,10 +472,11 @@ format_stats_fold(Stat, Acc) ->
 
 -spec maybe_add_answered(kz_json:object(), kz_json:object()) ->
                                 [{kz_json:path(), non_neg_integer()}].
--spec maybe_add_answered(kz_json:object(), kz_json:object(), kz_term:api_binary()) ->
-                                [{kz_json:path(), non_neg_integer()}].
 maybe_add_answered(Stat, Acc) ->
     maybe_add_answered(Stat, Acc, kz_json:get_value(<<"status">>, Stat)).
+
+-spec maybe_add_answered(kz_json:object(), kz_json:object(), kz_term:api_binary()) ->
+                                [{kz_json:path(), non_neg_integer()}].
 maybe_add_answered(Stat, Acc, <<"handled">>) ->
     add_answered(Stat, Acc);
 maybe_add_answered(Stat, Acc, <<"processed">>) ->

--- a/applications/acdc/src/cb_queues.erl
+++ b/applications/acdc/src/cb_queues.erl
@@ -118,12 +118,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
--spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 
+-spec allowed_methods() -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?STATS_PATH_TOKEN) ->
     [?HTTP_GET];
 allowed_methods(?EAVESDROP_PATH_TOKEN) ->
@@ -131,6 +131,7 @@ allowed_methods(?EAVESDROP_PATH_TOKEN) ->
 allowed_methods(_QueueId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_QueueId, ?ROSTER_PATH_TOKEN) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE];
 allowed_methods(_QueueId, ?EAVESDROP_PATH_TOKEN) ->
@@ -145,13 +146,14 @@ allowed_methods(_QueueId, ?EAVESDROP_PATH_TOKEN) ->
 %%    /queues/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
 
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, ?ROSTER_PATH_TOKEN) -> 'true';
 resource_exists(_, ?EAVESDROP_PATH_TOKEN) -> 'true'.
 
@@ -162,11 +164,13 @@ resource_exists(_, ?EAVESDROP_PATH_TOKEN) -> 'true'.
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec content_types_provided(cb_context:context()) ->
                                     cb_context:context().
+content_types_provided(Context) -> Context.
+
 -spec content_types_provided(cb_context:context(), path_token()) ->
                                     cb_context:context().
-content_types_provided(Context) -> Context.
 content_types_provided(Context, ?STATS_PATH_TOKEN) ->
     cb_context:add_content_types_provided(Context
                                          ,[{'to_json', ?JSON_CONTENT_TYPES}
@@ -183,11 +187,8 @@ content_types_provided(Context, ?STATS_PATH_TOKEN) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) ->
-                      cb_context:context().
--spec validate(cb_context:context(), path_token()) ->
-                      cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) ->
                       cb_context:context().
 validate(Context) ->
     validate_queues(Context, cb_context:req_verb(Context)).
@@ -195,6 +196,8 @@ validate(Context) ->
 validate_queues(Context, ?HTTP_GET) -> summary(Context);
 validate_queues(Context, ?HTTP_PUT) -> validate_request('undefined', Context).
 
+-spec validate(cb_context:context(), path_token()) ->
+                      cb_context:context().
 validate(Context, PathToken) ->
     validate_queue(Context, PathToken, cb_context:req_verb(Context)).
 
@@ -211,6 +214,8 @@ validate_queue(Context, Id, ?HTTP_PATCH) ->
 validate_queue(Context, Id, ?HTTP_DELETE) ->
     read(Id, Context).
 
+-spec validate(cb_context:context(), path_token(), path_token()) ->
+                      cb_context:context().
 validate(Context, Id, Token) ->
     validate_queue_operation(Context, Id, Token, cb_context:req_verb(Context)).
 
@@ -388,21 +393,23 @@ is_valid_endpoint_type(Context, CallMeJObj) ->
 %% If the HTTP verib is PUT, execute the actual action, usually a db save.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec put(cb_context:context()) ->
-                 cb_context:context().
--spec put(cb_context:context(), path_token()) ->
-                 cb_context:context().
--spec put(cb_context:context(), path_token(), path_token()) ->
                  cb_context:context().
 put(Context) ->
     activate_account_for_acdc(Context),
     crossbar_doc:save(Context).
 
+-spec put(cb_context:context(), path_token()) ->
+                 cb_context:context().
 put(Context, ?EAVESDROP_PATH_TOKEN) ->
     Prop = [{<<"Eavesdrop-Call-ID">>, cb_context:req_value(Context, <<"call_id">>)}
             | default_eavesdrop_req(Context)
            ],
     eavesdrop_req(Context, Prop).
+
+-spec put(cb_context:context(), path_token(), path_token()) ->
+                 cb_context:context().
 put(Context, QID, ?EAVESDROP_PATH_TOKEN) ->
     Prop = [{<<"Eavesdrop-Group-ID">>, QID}
             | default_eavesdrop_req(Context)
@@ -458,11 +465,13 @@ filter_response_fields(JObj) ->
 %% (after a merge perhaps).
 %% @end
 %%--------------------------------------------------------------------
+
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, _) ->
     activate_account_for_acdc(Context),
     crossbar_doc:save(Context).
+
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, Id, ?ROSTER_PATH_TOKEN) ->
     activate_account_for_acdc(Context),
     read(Id, crossbar_doc:save(Context)).
@@ -482,11 +491,13 @@ patch(Context, Id) ->
 %% If the HTTP verib is DELETE, execute the actual action, usually a db delete
 %% @end
 %%--------------------------------------------------------------------
+
 -spec delete(cb_context:context(), path_token()) -> cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 delete(Context, _) ->
     activate_account_for_acdc(Context),
     crossbar_doc:delete(Context).
+
+-spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 delete(Context, Id, ?ROSTER_PATH_TOKEN) ->
     activate_account_for_acdc(Context),
     read(Id, crossbar_doc:save(Context)).
@@ -630,12 +641,12 @@ maybe_rm_agents(Id, Context, AgentIds) ->
 
 -spec rm_queue_from_agents(kz_term:ne_binary(), cb_context:context()) ->
                                   cb_context:context().
--spec rm_queue_from_agents(kz_term:ne_binary(), cb_context:context(), kz_json:path()) ->
-                                  cb_context:context().
 rm_queue_from_agents(Id, Context) ->
     Context1 = load_agent_roster(Id, Context),
     rm_queue_from_agents(Id, Context, cb_context:doc(Context1)).
 
+-spec rm_queue_from_agents(kz_term:ne_binary(), cb_context:context(), kz_json:path()) ->
+                                  cb_context:context().
 rm_queue_from_agents(_Id, Context, []) ->
     cb_context:set_resp_status(Context, 'success');
 rm_queue_from_agents(Id, Context, [_|_]=AgentIds) ->

--- a/applications/acdc/src/cf_acdc_agent.erl
+++ b/applications/acdc/src/cf_acdc_agent.erl
@@ -121,9 +121,10 @@ maybe_pause_agent(Call, _AgentId, FromStatus, _Data) ->
     play_agent_invalid(Call).
 
 -spec login_agent(kapps_call:call(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
--spec login_agent(kapps_call:call(), kz_term:ne_binary(), kz_json:object()) -> kz_term:api_ne_binary().
 login_agent(Call, AgentId) ->
     login_agent(Call, AgentId, kz_json:new()).
+
+-spec login_agent(kapps_call:call(), kz_term:ne_binary(), kz_json:object()) -> kz_term:api_ne_binary().
 login_agent(Call, AgentId, Data) ->
     Update = props:filter_undefined(
                [{<<"Account-ID">>, kapps_call:account_id(Call)}
@@ -145,9 +146,10 @@ login_agent(Call, AgentId, Data) ->
     end.
 
 -spec logout_agent(kapps_call:call(), kz_term:ne_binary()) -> 'ok'.
--spec logout_agent(kapps_call:call(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 logout_agent(Call, AgentId) ->
     logout_agent(Call, AgentId, kz_json:new()).
+
+-spec logout_agent(kapps_call:call(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 logout_agent(Call, AgentId, Data) ->
     update_agent_status(Call, AgentId, Data, fun kapi_acdc_agent:publish_logout/1).
 
@@ -222,13 +224,14 @@ find_agent(Call, Endpoint, Owners) ->
 find_agent_owner(Call, 'undefined') -> {'ok', kapps_call:owner_id(Call)};
 find_agent_owner(_Call, EPOwnerId) -> {'ok', EPOwnerId}.
 
--spec play_not_an_agent(kapps_call:call()) -> kapps_call:kapps_api_std_return().
--spec play_agent_invalid(kapps_call:call()) -> kapps_call:kapps_api_std_return().
 
+-spec play_not_an_agent(kapps_call:call()) -> kapps_call:kapps_api_std_return().
 play_not_an_agent(Call) -> kapps_call_command:b_prompt(<<"agent-not_call_center_agent">>, Call).
 play_agent_logged_in_already(Call) -> kapps_call_command:b_prompt(<<"agent-already_logged_in">>, Call).
 play_agent_logged_in(Call) -> kapps_call_command:b_prompt(<<"agent-logged_in">>, Call).
 play_agent_logged_out(Call) -> kapps_call_command:b_prompt(<<"agent-logged_out">>, Call).
 play_agent_resume(Call) -> kapps_call_command:b_prompt(<<"agent-resume">>, Call).
 play_agent_pause(Call) -> kapps_call_command:b_prompt(<<"agent-pause">>, Call).
+
+-spec play_agent_invalid(kapps_call:call()) -> kapps_call:kapps_api_std_return().
 play_agent_invalid(Call) -> kapps_call_command:b_prompt(<<"agent-invalid_choice">>, Call).

--- a/applications/acdc/src/cf_acdc_member.erl
+++ b/applications/acdc/src/cf_acdc_member.erl
@@ -98,9 +98,10 @@ maybe_enter_queue(#member_call{call=Call
                    ).
 
 -spec wait_for_bridge(member_call(), max_wait()) -> 'ok'.
--spec wait_for_bridge(member_call(), max_wait(), kz_time:now()) -> 'ok'.
 wait_for_bridge(MC, Timeout) ->
     wait_for_bridge(MC, Timeout, os:timestamp()).
+
+-spec wait_for_bridge(member_call(), max_wait(), kz_time:now()) -> 'ok'.
 wait_for_bridge(#member_call{call=Call}, Timeout, _Start) when Timeout < 0 ->
     lager:debug("timeout is less than 0: ~p", [Timeout]),
     end_member_call(Call);

--- a/applications/acdc/src/kapi_acdc_queue.erl
+++ b/applications/acdc/src/kapi_acdc_queue.erl
@@ -93,7 +93,6 @@ member_call_v(JObj) ->
     member_call_v(kz_json:to_proplist(JObj)).
 
 -spec member_call_routing_key(kz_term:api_terms()) -> kz_term:ne_binary().
--spec member_call_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 member_call_routing_key(Props) when is_list(Props) ->
     Id = props:get_value(<<"Queue-ID">>, Props, <<"*">>),
     AcctId = props:get_value(<<"Account-ID">>, Props),
@@ -103,6 +102,7 @@ member_call_routing_key(JObj) ->
     AcctId = kz_json:get_value(<<"Account-ID">>, JObj),
     member_call_routing_key(AcctId, Id).
 
+-spec member_call_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 member_call_routing_key(AcctId, QueueId) ->
     <<"acdc.member.call.", AcctId/binary, ".", QueueId/binary>>.
 
@@ -190,7 +190,6 @@ member_call_cancel_v(JObj) ->
     member_call_cancel_v(kz_json:to_proplist(JObj)).
 
 -spec member_call_result_routing_key(kz_term:api_terms()) -> kz_term:ne_binary().
--spec member_call_result_routing_key(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 member_call_result_routing_key(Props) when is_list(Props) ->
     AcctId = props:get_value(<<"Account-ID">>, Props),
     QueueId = props:get_value(<<"Queue-ID">>, Props, <<"*">>),
@@ -202,6 +201,7 @@ member_call_result_routing_key(JObj) ->
     CallId = kz_json:get_value(<<"Call-ID">>, JObj, <<"#">>),
     member_call_result_routing_key(AcctId, QueueId, CallId).
 
+-spec member_call_result_routing_key(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 member_call_result_routing_key(AcctId, QueueId, CallId) ->
     <<"acdc.member.call_result.", AcctId/binary, ".", QueueId/binary, ".", CallId/binary>>.
 
@@ -233,7 +233,6 @@ member_connect_req_v(JObj) ->
     member_connect_req_v(kz_json:to_proplist(JObj)).
 
 -spec member_connect_req_routing_key(kz_term:api_terms()) -> kz_term:ne_binary().
--spec member_connect_req_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 member_connect_req_routing_key(Props) when is_list(Props) ->
     Id = props:get_value(<<"Queue-ID">>, Props, <<"*">>),
     AcctId = props:get_value(<<"Account-ID">>, Props),
@@ -242,6 +241,8 @@ member_connect_req_routing_key(JObj) ->
     Id = kz_json:get_value(<<"Queue-ID">>, JObj, <<"*">>),
     AcctId = kz_json:get_value(<<"Account-ID">>, JObj),
     member_connect_req_routing_key(AcctId, Id).
+
+-spec member_connect_req_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 member_connect_req_routing_key(AcctId, QID) ->
     <<"acdc.member.connect_req.", AcctId/binary, ".", QID/binary>>.
 
@@ -420,8 +421,8 @@ member_hungup_v(JObj) ->
 %% Sync Req/Resp
 %%   Depending on the queue strategy, get the other queue's strategy state
 %%------------------------------------------------------------------------------
+
 -spec sync_req_routing_key(kz_term:api_terms()) -> kz_term:ne_binary().
--spec sync_req_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 sync_req_routing_key(Props) when is_list(Props) ->
     Id = props:get_value(<<"Queue-ID">>, Props, <<"*">>),
     AcctId = props:get_value(<<"Account-ID">>, Props),
@@ -431,6 +432,7 @@ sync_req_routing_key(JObj) ->
     AcctId = kz_json:get_value(<<"Account-ID">>, JObj),
     sync_req_routing_key(AcctId, Id).
 
+-spec sync_req_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 sync_req_routing_key(AcctId, QID) ->
     <<"acdc.queue.sync_req.", AcctId/binary, ".", QID/binary>>.
 
@@ -512,12 +514,15 @@ agent_change_routing_key(AcctId, QueueId) ->
                        ]).
 
 -spec agent_change_available() -> kz_term:ne_binary().
--spec agent_change_ringing() -> kz_term:ne_binary().
--spec agent_change_busy() -> kz_term:ne_binary().
--spec agent_change_unavailable() -> kz_term:ne_binary().
 agent_change_available() -> ?AGENT_CHANGE_AVAILABLE.
+
+-spec agent_change_ringing() -> kz_term:ne_binary().
 agent_change_ringing() -> ?AGENT_CHANGE_RINGING.
+
+-spec agent_change_busy() -> kz_term:ne_binary().
 agent_change_busy() -> ?AGENT_CHANGE_BUSY.
+
+-spec agent_change_unavailable() -> kz_term:ne_binary().
 agent_change_unavailable() -> ?AGENT_CHANGE_UNAVAILABLE.
 
 -define(AGENT_CHANGE_HEADERS, [<<"Account-ID">>, <<"Agent-ID">>, <<"Queue-ID">>, <<"Change">>]).
@@ -548,8 +553,8 @@ agent_change_v(JObj) -> agent_change_v(kz_json:to_proplist(JObj)).
 %%------------------------------------------------------------------------------
 %% Queue Position tracking
 %%------------------------------------------------------------------------------
+
 -spec queue_member_routing_key(kz_term:api_terms()) -> kz_term:ne_binary().
--spec queue_member_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 queue_member_routing_key(Props) when is_list(Props) ->
     Id = props:get_value(<<"Queue-ID">>, Props, <<"*">>),
     AcctId = props:get_value(<<"Account-ID">>, Props),
@@ -559,6 +564,7 @@ queue_member_routing_key(JObj) ->
     AcctId = kz_json:get_value(<<"Account-ID">>, JObj),
     queue_member_routing_key(AcctId, Id).
 
+-spec queue_member_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 queue_member_routing_key(AcctId, QID) ->
     <<"acdc.queue.position.", AcctId/binary, ".", QID/binary>>.
 
@@ -721,10 +727,12 @@ declare_exchanges() ->
 %%------------------------------------------------------------------------------
 %% Publishers for convenience
 %%------------------------------------------------------------------------------
+
 -spec publish_member_call(kz_term:api_terms()) -> 'ok'.
--spec publish_member_call(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_call(JObj) ->
     publish_member_call(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_call(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_call(Props, ContentType) when is_list(Props) ->
     publish_member_call(kz_json:from_list(Props), ContentType);
 publish_member_call(API, ContentType) ->
@@ -734,23 +742,26 @@ publish_member_call(API, ContentType) ->
     amqp_util:callmgr_publish(Payload, ContentType, member_call_routing_key(API), Props).
 
 -spec publish_member_call_cancel(kz_term:api_terms()) -> 'ok'.
--spec publish_member_call_cancel(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_call_cancel(JObj) ->
     publish_member_call_cancel(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_call_cancel(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_call_cancel(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_CALL_CANCEL_VALUES, fun member_call_cancel/1),
     amqp_util:callmgr_publish(Payload, ContentType, member_call_result_routing_key(API)).
 
 -spec publish_shared_member_call(kz_json:object()) -> 'ok'.
--spec publish_shared_member_call(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_shared_member_call(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_shared_member_call(JObj) ->
     publish_shared_member_call(kz_json:get_value(<<"Account-ID">>, JObj)
                               ,kz_json:get_value(<<"Queue-ID">>, JObj)
                               ,JObj
                               ).
+
+-spec publish_shared_member_call(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
 publish_shared_member_call(AcctId, QueueId, JObj) ->
     publish_shared_member_call(AcctId, QueueId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_shared_member_call(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_shared_member_call(AcctId, QueueId, Props, ContentType) when is_list(Props) ->
     publish_shared_member_call(AcctId, QueueId, kz_json:from_list(Props), ContentType);
 publish_shared_member_call(AcctId, QueueId, JObj, ContentType) ->
@@ -762,115 +773,129 @@ publish_shared_member_call(AcctId, QueueId, JObj, ContentType) ->
     amqp_util:targeted_publish(shared_queue_name(AcctId, QueueId), Payload, ContentType, Props).
 
 -spec publish_member_call_failure(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_member_call_failure(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_call_failure(Q, JObj) ->
     publish_member_call_failure(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_call_failure(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_call_failure(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_CALL_FAIL_VALUES, fun member_call_failure/1),
     amqp_util:targeted_publish(Q, Payload, ContentType),
     amqp_util:callmgr_publish(Payload, ContentType, member_call_result_routing_key(API)).
 
 -spec publish_member_call_success(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_member_call_success(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_call_success(Q, JObj) ->
     publish_member_call_success(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_call_success(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_call_success(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_CALL_SUCCESS_VALUES, fun member_call_success/1),
     amqp_util:targeted_publish(Q, Payload, ContentType),
     amqp_util:callmgr_publish(Payload, ContentType, member_call_result_routing_key(API)).
 
 -spec publish_member_connect_req(kz_term:api_terms()) -> 'ok'.
--spec publish_member_connect_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_req(JObj) ->
     publish_member_connect_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_connect_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_req(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_CONNECT_REQ_VALUES, fun member_connect_req/1),
     amqp_util:callmgr_publish(Payload, ContentType, member_connect_req_routing_key(API)).
 
 -spec publish_member_connect_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_member_connect_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_resp(Q, JObj) ->
     publish_member_connect_resp(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_connect_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_resp(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_CONNECT_RESP_VALUES, fun member_connect_resp/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_member_connect_win(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_member_connect_win(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_win(Q, JObj) ->
     publish_member_connect_win(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_connect_win(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_win(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_CONNECT_WIN_VALUES, fun member_connect_win/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_agent_timeout(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_agent_timeout(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_agent_timeout(Q, JObj) ->
     publish_agent_timeout(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_agent_timeout(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_agent_timeout(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?AGENT_TIMEOUT_VALUES, fun agent_timeout/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_member_connect_accepted(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_member_connect_accepted(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_accepted(Q, JObj) ->
     publish_member_connect_accepted(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_connect_accepted(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_accepted(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_CONNECT_ACCEPTED_VALUES, fun member_connect_accepted/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_member_connect_retry(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_member_connect_retry(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_retry(Q, JObj) ->
     publish_member_connect_retry(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_connect_retry(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_retry(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_CONNECT_RETRY_VALUES, fun member_connect_retry/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_member_hungup(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_member_hungup(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_hungup(Q, JObj) ->
     publish_member_hungup(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_member_hungup(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_hungup(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_HUNGUP_VALUES, fun member_hungup/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_sync_req(kz_term:api_terms()) -> 'ok'.
--spec publish_sync_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_sync_req(JObj) ->
     publish_sync_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_sync_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_sync_req(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?SYNC_REQ_VALUES, fun sync_req/1),
     amqp_util:kapps_publish(sync_req_routing_key(API), Payload, ContentType).
 
 -spec publish_sync_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_sync_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_sync_resp(Q, JObj) ->
     publish_sync_resp(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_sync_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_sync_resp(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?SYNC_RESP_VALUES, fun sync_resp/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_agent_change(kz_term:api_terms()) -> 'ok'.
--spec publish_agent_change(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_agent_change(JObj) ->
     publish_agent_change(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_agent_change(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_agent_change(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?AGENT_CHANGE_VALUES, fun agent_change/1),
     amqp_util:kapps_publish(agent_change_publish_key(API), Payload, ContentType).
 
 -spec publish_queue_member_add(kz_term:api_terms()) -> 'ok'.
--spec publish_queue_member_add(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_queue_member_add(JObj) ->
     publish_queue_member_add(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_queue_member_add(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_queue_member_add(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?QUEUE_MEMBER_ADD_VALUES, fun queue_member_add/1),
     amqp_util:kapps_publish(queue_member_routing_key(API), Payload, ContentType).
 
 -spec publish_queue_member_remove(kz_term:api_terms()) -> 'ok'.
--spec publish_queue_member_remove(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_queue_member_remove(JObj) ->
     publish_queue_member_remove(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_queue_member_remove(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_queue_member_remove(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?QUEUE_MEMBER_REMOVE_VALUES, fun queue_member_remove/1),
     amqp_util:kapps_publish(queue_member_routing_key(API), Payload, ContentType).

--- a/applications/acdc/src/kapi_acdc_stats.erl
+++ b/applications/acdc/src/kapi_acdc_stats.erl
@@ -604,179 +604,201 @@ declare_exchanges() ->
     amqp_util:kapps_exchange().
 
 -spec publish_call_waiting(kz_term:api_terms()) -> 'ok'.
--spec publish_call_waiting(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_waiting(JObj) ->
     publish_call_waiting(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_call_waiting(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_waiting(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?WAITING_VALUES, fun call_waiting/1),
     amqp_util:kapps_publish(call_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_call_missed(kz_term:api_terms()) -> 'ok'.
--spec publish_call_missed(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_missed(JObj) ->
     publish_call_missed(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_call_missed(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_missed(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MISS_VALUES, fun call_missed/1),
     amqp_util:kapps_publish(call_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_call_abandoned(kz_term:api_terms()) -> 'ok'.
--spec publish_call_abandoned(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_abandoned(JObj) ->
     publish_call_abandoned(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_call_abandoned(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_abandoned(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?ABANDON_VALUES, fun call_abandoned/1),
     amqp_util:kapps_publish(call_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_call_handled(kz_term:api_terms()) -> 'ok'.
--spec publish_call_handled(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_handled(JObj) ->
     publish_call_handled(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_call_handled(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_handled(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?HANDLED_VALUES, fun call_handled/1),
     amqp_util:kapps_publish(call_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_call_processed(kz_term:api_terms()) -> 'ok'.
--spec publish_call_processed(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_processed(JObj) ->
     publish_call_processed(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_call_processed(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_processed(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?PROCESS_VALUES, fun call_processed/1),
     amqp_util:kapps_publish(call_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_call_flush(kz_term:api_terms()) -> 'ok'.
--spec publish_call_flush(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_flush(JObj) ->
     publish_call_flush(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_call_flush(kz_term:api_terms(), binary()) -> 'ok'.
 publish_call_flush(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?FLUSH_VALUES, fun call_flush/1),
     lager:debug("flush payload ~s: ~s", [call_stat_routing_key(API), Payload]),
     amqp_util:kapps_publish(call_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_update(kz_term:api_terms()) -> 'ok'.
--spec publish_status_update(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_update(JObj) ->
     publish_status_update(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_update(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_update(API, ContentType) ->
     EvtName = status_value(API),
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(EvtName), fun status_update/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_ready(kz_term:api_terms()) -> 'ok'.
--spec publish_status_ready(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_ready(JObj) ->
     publish_status_ready(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_ready(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_ready(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"ready">>), fun status_ready/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_logged_in(kz_term:api_terms()) -> 'ok'.
--spec publish_status_logged_in(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_logged_in(JObj) ->
     publish_status_logged_in(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_logged_in(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_logged_in(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"logged_in">>), fun status_logged_in/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_logged_out(kz_term:api_terms()) -> 'ok'.
--spec publish_status_logged_out(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_logged_out(JObj) ->
     publish_status_logged_out(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_logged_out(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_logged_out(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"logged_out">>), fun status_logged_out/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_pending_logged_out(kz_term:api_terms()) -> 'ok'.
--spec publish_status_pending_logged_out(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_status_pending_logged_out(JObj) ->
     publish_status_pending_logged_out(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_pending_logged_out(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_status_pending_logged_out(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"pending_logged_out">>), fun status_pending_logged_out/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_connecting(kz_term:api_terms()) -> 'ok'.
--spec publish_status_connecting(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_connecting(JObj) ->
     publish_status_connecting(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_connecting(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_connecting(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"connecting">>), fun status_connecting/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_connected(kz_term:api_terms()) -> 'ok'.
--spec publish_status_connected(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_connected(JObj) ->
     publish_status_connected(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_connected(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_connected(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"connected">>), fun status_connected/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_wrapup(kz_term:api_terms()) -> 'ok'.
--spec publish_status_wrapup(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_wrapup(JObj) ->
     publish_status_wrapup(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_wrapup(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_wrapup(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"wrapup">>), fun status_wrapup/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_paused(kz_term:api_terms()) -> 'ok'.
--spec publish_status_paused(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_paused(JObj) ->
     publish_status_paused(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_paused(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_paused(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"paused">>), fun status_paused/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_outbound(kz_term:api_terms()) -> 'ok'.
--spec publish_status_outbound(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_outbound(JObj) ->
     publish_status_outbound(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_outbound(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_outbound(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"outbound">>), fun status_outbound/1),
     amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_current_calls_req(kz_term:api_terms()) -> 'ok'.
--spec publish_current_calls_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_current_calls_req(JObj) ->
     publish_current_calls_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_current_calls_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_current_calls_req(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?CURRENT_CALLS_REQ_VALUES, fun current_calls_req/1),
     amqp_util:kapps_publish(query_call_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_current_calls_err(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_current_calls_err(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_current_calls_err(RespQ, JObj) ->
     publish_current_calls_err(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_current_calls_err(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_current_calls_err(RespQ, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?CURRENT_CALLS_ERR_VALUES, fun current_calls_err/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_current_calls_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_current_calls_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_current_calls_resp(RespQ, JObj) ->
     publish_current_calls_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_current_calls_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_current_calls_resp(RespQ, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?CURRENT_CALLS_RESP_VALUES, fun current_calls_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_status_req(kz_term:api_terms()) -> 'ok'.
--spec publish_status_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_req(JObj) ->
     publish_status_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_req(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_REQ_VALUES, fun status_req/1),
     amqp_util:kapps_publish(query_status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_err(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_status_err(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_err(RespQ, JObj) ->
     publish_status_err(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_err(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_err(RespQ, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_ERR_VALUES, fun status_err/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_status_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_status_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_resp(RespQ, JObj) ->
     publish_status_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_status_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_resp(RespQ, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_RESP_VALUES, fun status_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).

--- a/applications/ananke/src/tasks/ananke_callback_worker.erl
+++ b/applications/ananke/src/tasks/ananke_callback_worker.erl
@@ -34,10 +34,10 @@
 -type state() :: #state{}.
 
 -spec start_link(kz_term:proplist(), pos_integers()) -> {'ok', pid()} | {'error', any()}.
--spec start_link(kz_term:proplist(), pos_integers(), check_fun()) -> {'ok', pid()} | {'error', any()}.
 start_link(Req, [_ | _] = Schedule) ->
     start_link(#state{request = Req, schedule = Schedule}).
 
+-spec start_link(kz_term:proplist(), pos_integers(), check_fun()) -> {'ok', pid()} | {'error', any()}.
 start_link(Req, [_ | _] = Schedule, CheckFun) ->
     start_link(#state{request = Req
                      ,schedule = Schedule

--- a/applications/blackhole/src/bh_context.erl
+++ b/applications/blackhole/src/bh_context.erl
@@ -58,11 +58,12 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec new() -> context().
--spec new(pid(), kz_term:ne_binary()) -> context().
 new()->
     #bh_context{}.
 
+-spec new(pid(), kz_term:ne_binary()) -> context().
 new(SessionPid, SessionId) ->
     Setters = [{fun set_websocket_session_id/2, SessionId}
               ,{fun set_websocket_pid/2, SessionPid}
@@ -74,11 +75,12 @@ new(SessionPid, SessionId) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec from_json(kz_json:object()) -> context().
--spec from_json(context(), kz_json:object()) -> context().
 from_json(JObj) ->
     from_json(new(), JObj).
 
+-spec from_json(context(), kz_json:object()) -> context().
 from_json(Context, JObj) ->
     Rand = kz_binary:rand_hex(16),
     Setters = [{fun set_auth_token/2, kz_json:get_value(<<"auth_token">>, JObj)}

--- a/applications/blackhole/src/blackhole_listener.erl
+++ b/applications/blackhole/src/blackhole_listener.erl
@@ -81,7 +81,6 @@ handle_amqp_event(EventJObj, Props, BasicDeliver) ->
     handle_amqp_event(EventJObj, Props, gen_listener:routing_key_used(BasicDeliver)).
 
 -spec handle_module_req(kz_json:object()) -> 'ok'.
--spec handle_module_req(kz_json:object(), atom(), kz_term:ne_binary(), boolean()) -> 'ok'.
 handle_module_req(EventJObj) ->
     'true' = kapi_websockets:module_req_v(EventJObj),
     lager:debug("recv module_req: ~p", [EventJObj]),
@@ -91,6 +90,7 @@ handle_module_req(EventJObj) ->
                      ,kz_json:is_true(<<"Persist">>, EventJObj, 'true')
                      ).
 
+-spec handle_module_req(kz_json:object(), atom(), kz_term:ne_binary(), boolean()) -> 'ok'.
 handle_module_req(EventJObj, BHModule, <<"start">>, Persist) ->
     case code:which(BHModule) of
         'non_existing' -> send_error_module_resp(EventJObj, <<"module doesn't exist">>);
@@ -355,11 +355,11 @@ add_bh_binding(ETS, Binding) ->
     end.
 
 -spec remove_bh_binding(ets:tid(), bh_event_binding()) -> 'ok' | 'true'.
--spec remove_bh_binding(ets:tid(), bh_event_binding(), binary(), integer()) -> 'ok' | 'true'.
 remove_bh_binding(ETS, Binding) ->
     Key = binding_key(Binding),
     remove_bh_binding(ETS, Binding, Key, ets:update_counter(ETS, Key, -1, {Key, 0})).
 
+-spec remove_bh_binding(ets:tid(), bh_event_binding(), binary(), integer()) -> 'ok' | 'true'.
 remove_bh_binding(ETS, Binding, Key, 0) ->
     lager:debug("blackhole is deleting binding for ~p", [Binding]),
     remove_bh_binding(Binding),

--- a/applications/blackhole/src/blackhole_maintenance.erl
+++ b/applications/blackhole/src/blackhole_maintenance.erl
@@ -21,10 +21,12 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec start_module(kz_term:text()) -> 'ok'.
--spec start_module(kz_term:text(), kz_term:text() | boolean()) -> 'ok'.
 start_module(ModuleBin) ->
     start_module(ModuleBin, 'true').
+
+-spec start_module(kz_term:text(), kz_term:text() | boolean()) -> 'ok'.
 start_module(ModuleBin, Persist) ->
     Req = [{<<"Module">>, ModuleBin}
           ,{<<"Action">>, <<"start">>}
@@ -52,10 +54,12 @@ start_module(ModuleBin, Persist) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec stop_module(kz_term:text()) -> 'ok'.
--spec stop_module(kz_term:text(), kz_term:text() | boolean()) -> 'ok'.
 stop_module(ModuleBin) ->
     stop_module(ModuleBin, 'true').
+
+-spec stop_module(kz_term:text(), kz_term:text() | boolean()) -> 'ok'.
 stop_module(ModuleBin, Persist) ->
     Req = [{<<"Module">>, ModuleBin}
           ,{<<"Action">>, <<"stop">>}

--- a/applications/callflow/src/callflow_maintenance.erl
+++ b/applications/callflow/src/callflow_maintenance.erl
@@ -156,7 +156,6 @@ migrate_recorded_name(Db) ->
     end.
 
 -spec do_recorded_name_migration(kz_term:ne_binary(), kz_json:object()) -> any().
--spec do_recorded_name_migration(kz_term:ne_binary(), kz_json:object(), kz_term:api_binary()) -> any().
 do_recorded_name_migration(Db, VMBox) ->
     VMBoxId = kz_doc:id(VMBox),
     case kz_json:get_value(?RECORDED_NAME_KEY, VMBox) of
@@ -167,6 +166,7 @@ do_recorded_name_migration(Db, VMBox) ->
             {'ok', _} = kz_datamgr:save_doc(Db, kz_json:delete_key(?RECORDED_NAME_KEY, VMBox))
     end.
 
+-spec do_recorded_name_migration(kz_term:ne_binary(), kz_json:object(), kz_term:api_binary()) -> any().
 do_recorded_name_migration(_Db, _MediaId, 'undefined') ->
     lager:info("no owner id on vm box");
 do_recorded_name_migration(Db, MediaId, OwnerId) ->

--- a/applications/callflow/src/cf_exe.erl
+++ b/applications/callflow/src/cf_exe.erl
@@ -120,9 +120,9 @@ update_call(Call, Routines) ->
     gen_server:call(Srv, {'update_call', Routines}).
 
 -spec continue(kapps_call:call() | pid()) -> 'ok'.
--spec continue(kz_term:ne_binary(), kapps_call:call() | pid()) -> 'ok'.
 continue(Srv) -> continue(?DEFAULT_CHILD_KEY, Srv).
 
+-spec continue(kz_term:ne_binary(), kapps_call:call() | pid()) -> 'ok'.
 continue(Key, Srv) when is_pid(Srv) ->
     gen_listener:cast(Srv, {'continue', Key});
 continue(Key, Call) ->
@@ -144,9 +144,9 @@ branch(Flow, Call) ->
     branch(Flow, Srv).
 
 -spec next(kapps_call:call() | pid()) -> kz_term:api_object().
--spec next(kz_term:ne_binary(), kapps_call:call() | pid()) -> kz_term:api_object().
 next(Srv) -> next(?DEFAULT_CHILD_KEY, Srv).
 
+-spec next(kz_term:ne_binary(), kapps_call:call() | pid()) -> kz_term:api_object().
 next(Key, Srv) when is_pid(Srv) ->
     gen_listener:call(Srv, {'next', Key});
 next(Key, Call) ->
@@ -172,10 +172,10 @@ remove_termination_handler(Call, {_,_,_}=Handler) ->
     remove_termination_handler(kapps_call:kvs_fetch('consumer_pid', Call), Handler).
 
 -spec stop(kapps_call:call() | pid()) -> 'ok'.
--spec stop(kapps_call:call() | pid(), kz_term:api_ne_binary()) -> 'ok'.
 stop(Srv) ->
     stop(Srv, 'undefined').
 
+-spec stop(kapps_call:call() | pid(), kz_term:api_ne_binary()) -> 'ok'.
 stop(Srv, Cause) when is_pid(Srv) ->
     gen_listener:cast(Srv, {'stop', Cause});
 stop(Call, Cause) ->
@@ -238,9 +238,8 @@ is_channel_destroyed(Call) ->
     Srv = kapps_call:kvs_fetch('consumer_pid', Call),
     is_channel_destroyed(Srv).
 
--spec callid(kapps_call:call() | pid()) -> kz_term:ne_binary().
--spec callid(kz_term:api_binary(), kapps_call:call() | pid()) -> kz_term:ne_binary().
 
+-spec callid(kapps_call:call() | pid()) -> kz_term:ne_binary().
 callid(Srv) when is_pid(Srv) ->
     CallId = gen_server:call(Srv, 'callid', 1000),
     kz_util:put_callid(CallId),
@@ -249,6 +248,7 @@ callid(Call) ->
     Srv = kapps_call:kvs_fetch('consumer_pid', Call),
     callid(Srv).
 
+-spec callid(kz_term:api_binary(), kapps_call:call() | pid()) -> kz_term:ne_binary().
 callid(_, Call) ->
     callid(Call).
 
@@ -259,11 +259,12 @@ queue_name(Call) ->
     Srv = kapps_call:kvs_fetch('consumer_pid', Call),
     queue_name(Srv).
 
--spec control_queue(kapps_call:call() | pid()) -> kz_term:ne_binary().
--spec control_queue(kz_term:api_binary(), kapps_call:call() | pid()) -> kz_term:ne_binary().
 
+-spec control_queue(kapps_call:call() | pid()) -> kz_term:ne_binary().
 control_queue(Srv) when is_pid(Srv) -> gen_listener:call(Srv, 'control_queue_name');
 control_queue(Call) -> control_queue(kapps_call:kvs_fetch('consumer_pid', Call)).
+
+-spec control_queue(kz_term:api_binary(), kapps_call:call() | pid()) -> kz_term:ne_binary().
 control_queue(_, Call) -> control_queue(Call).
 
 -spec get_branch_keys(kapps_call:call() | pid()) -> {'branch_keys', kz_json:keys()}.
@@ -284,11 +285,11 @@ get_all_branch_keys(Call) ->
 -spec attempt(kapps_call:call() | pid()) ->
                      {'attempt_resp', 'ok'} |
                      {'attempt_resp', {'error', any()}}.
+attempt(Srv) -> attempt(?DEFAULT_CHILD_KEY, Srv).
+
 -spec attempt(kz_term:ne_binary(), kapps_call:call() | pid()) ->
                      {'attempt_resp', 'ok'} |
                      {'attempt_resp', {'error', any()}}.
-attempt(Srv) -> attempt(?DEFAULT_CHILD_KEY, Srv).
-
 attempt(Key, Srv) when is_pid(Srv) ->
     gen_listener:call(Srv, {'attempt', Key});
 attempt(Key, Call) ->
@@ -892,9 +893,10 @@ get_pid({Pid, _}) when is_pid(Pid) -> Pid;
 get_pid(_) -> 'undefined'.
 
 -spec hangup_call(kapps_call:call()) -> 'ok'.
--spec hangup_call(kapps_call:call(), kz_term:api_ne_binary()) -> 'ok'.
 hangup_call(Call) ->
     hangup_call(Call, 'undefined').
+
+-spec hangup_call(kapps_call:call(), kz_term:api_ne_binary()) -> 'ok'.
 hangup_call(Call, Cause) ->
     Cmd = [{<<"Event-Name">>, <<"command">>}
           ,{<<"Event-Category">>, <<"call">>}

--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -284,10 +284,10 @@ update_ccvs(Call) ->
     kapps_call:set_custom_channel_vars(Props, Call).
 
 -spec maybe_start_metaflow(kapps_call:call()) -> kapps_call:call().
--spec maybe_start_metaflow(kapps_call:call(), kz_term:api_binary()) -> kapps_call:call().
 maybe_start_metaflow(Call) ->
     maybe_start_metaflow(Call, kapps_call:custom_channel_var(<<"Metaflow-App">>, Call)).
 
+-spec maybe_start_metaflow(kapps_call:call(), kz_term:api_binary()) -> kapps_call:call().
 maybe_start_metaflow(Call, 'undefined') ->
     maybe_start_endpoint_metaflow(Call, kapps_call:authorizing_id(Call)),
     Call;

--- a/applications/callflow/src/module/cf_directory.erl
+++ b/applications/callflow/src/module/cf_directory.erl
@@ -338,11 +338,12 @@ play_no_users_found(Call) ->
 -spec play_and_collect(kapps_call:call(), kapps_call_command:audio_macro_prompts()) ->
                               {'ok', binary()} |
                               {'error', atom()}.
+play_and_collect(Call, AudioMacro) ->
+    play_and_collect(Call, AudioMacro, 1).
+
 -spec play_and_collect(kapps_call:call(), kapps_call_command:audio_macro_prompts(), non_neg_integer()) ->
                               {'ok', binary()} |
                               {'error', atom()}.
-play_and_collect(Call, AudioMacro) ->
-    play_and_collect(Call, AudioMacro, 1).
 play_and_collect(Call, AudioMacro, NumDigits) ->
     NoopID = kapps_call_command:audio_macro(AudioMacro, Call),
     lager:info("play and collect noopID: ~s", [NoopID]),

--- a/applications/callflow/src/module/cf_dynamic_cid.erl
+++ b/applications/callflow/src/module/cf_dynamic_cid.erl
@@ -57,13 +57,14 @@
 %% Entry point for this module
 %% @end
 %%--------------------------------------------------------------------
+
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
--spec handle(kz_json:object(), kapps_call:call(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> 'ok'.
 handle(Data, Call) ->
     CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
     Action = kz_json:get_ne_binary_value(<<"action">>, Data),
     handle(Data, Call, Action, CaptureGroup).
 
+-spec handle(kz_json:object(), kapps_call:call(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> 'ok'.
 handle(Data, Call, <<"list">>, ?NE_BINARY = _CaptureGroup) ->
     lager:info("user is choosing a caller id for this call from couchdb doc"),
     handle_list(Data, Call);

--- a/applications/callflow/src/module/cf_eavesdrop_feature.erl
+++ b/applications/callflow/src/module/cf_eavesdrop_feature.erl
@@ -78,10 +78,10 @@ build_data({'ok', TargetId, _TargetType}, Call) ->
     build_flow_data(Call, []).
 
 -spec build_flow_data(kapps_call:call(), kz_term:proplist()) -> kz_json:object().
--spec build_flow_data(kapps_call:call(), kz_term:proplist(), kz_term:api_binary()) -> kz_json:object().
 build_flow_data(Call, Data) ->
     build_flow_data(Call, Data, kapps_call:authorizing_type(Call)).
 
+-spec build_flow_data(kapps_call:call(), kz_term:proplist(), kz_term:api_binary()) -> kz_json:object().
 build_flow_data(Call, Data, AuthorizingType)
   when AuthorizingType =:= <<"device">>;
        AuthorizingType =:= <<"mobile">> ->
@@ -123,11 +123,11 @@ find_group_members(GroupId, Call) ->
     end.
 
 -spec lookup_endpoint(kz_term:api_object()) -> target().
--spec lookup_endpoint(kz_json:object(), kz_term:api_binary()) -> target().
 lookup_endpoint('undefined') -> 'error';
 lookup_endpoint(Flow) ->
     lookup_endpoint(Flow, kz_json:get_ne_binary_value(<<"module">>, Flow)).
 
+-spec lookup_endpoint(kz_json:object(), kz_term:api_binary()) -> target().
 lookup_endpoint(Flow, <<"device">> = TargetType) ->
     {'ok', kz_json:get_ne_binary_value([<<"data">>, <<"id">>], Flow), TargetType};
 lookup_endpoint(Flow, <<"user">> = TargetType) ->

--- a/applications/callflow/src/module/cf_group_pickup.erl
+++ b/applications/callflow/src/module/cf_group_pickup.erl
@@ -103,10 +103,11 @@ connect_to_a_channel(Channels, Call) ->
 
 -spec sort_channels(kz_json:objects(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                            {kz_term:ne_binaries(), kz_term:ne_binaries()}.
--spec sort_channels(kz_json:objects(), kz_term:ne_binary(), kz_term:ne_binary(), {kz_term:ne_binaries(), kz_term:ne_binaries()}) ->
-                           {kz_term:ne_binaries(), kz_term:ne_binaries()}.
 sort_channels(Channels, MyUUID, MyMediaServer) ->
     sort_channels(Channels, MyUUID, MyMediaServer, {[], []}).
+
+-spec sort_channels(kz_json:objects(), kz_term:ne_binary(), kz_term:ne_binary(), {kz_term:ne_binaries(), kz_term:ne_binaries()}) ->
+                           {kz_term:ne_binaries(), kz_term:ne_binaries()}.
 sort_channels([], _MyUUID, _MyMediaServer, Acc) -> Acc;
 sort_channels([Channel|Channels], MyUUID, MyMediaServer, Acc) ->
     lager:debug("channel: c: ~s a: ~s n: ~s oleg: ~s", [kz_json:get_ne_binary_value(<<"uuid">>, Channel)

--- a/applications/callflow/src/module/cf_intercept.erl
+++ b/applications/callflow/src/module/cf_intercept.erl
@@ -198,10 +198,11 @@ connect_to_a_channel(Channels, Call) ->
 
 -spec sort_channels(kz_json:objects(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                            {kz_term:ne_binaries(), kz_term:ne_binaries()}.
--spec sort_channels(kz_json:objects(), kz_term:ne_binary(), kz_term:ne_binary(), {kz_term:ne_binaries(), kz_term:ne_binaries()}) ->
-                           {kz_term:ne_binaries(), kz_term:ne_binaries()}.
 sort_channels(Channels, MyUUID, MyMediaServer) ->
     sort_channels(Channels, MyUUID, MyMediaServer, {[], []}).
+
+-spec sort_channels(kz_json:objects(), kz_term:ne_binary(), kz_term:ne_binary(), {kz_term:ne_binaries(), kz_term:ne_binaries()}) ->
+                           {kz_term:ne_binaries(), kz_term:ne_binaries()}.
 sort_channels([], _MyUUID, _MyMediaServer, Acc) -> Acc;
 sort_channels([Channel|Channels], MyUUID, MyMediaServer, Acc) ->
     lager:debug("channel: c: ~s a: ~s n: ~s oleg: ~s", [kz_json:get_ne_binary_value(<<"uuid">>, Channel)

--- a/applications/callflow/src/module/cf_menu.erl
+++ b/applications/callflow/src/module/cf_menu.erl
@@ -472,9 +472,8 @@ recording_media_doc(Type, #cf_menu_data{name=MenuName
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update_doc(kz_term:text(), kz_json:json_term(), menu() | kz_term:ne_binary(),  kapps_call:call() | kz_term:ne_binary()) ->
-                        'ok' | {'error', atom()}.
--spec update_doc(kz_term:proplist(), kz_term:ne_binary(), kapps_call:call() | kz_term:ne_binary()) ->
                         'ok' | {'error', atom()}.
 update_doc(Key, Value, #cf_menu_data{menu_id=Id}, Db) ->
     update_doc(Key, Value, Id, Db);
@@ -491,6 +490,8 @@ update_doc(Key, Value, Id, <<_/binary>> = Db) ->
 update_doc(Key, Value, Id, Call) ->
     update_doc(Key, Value, Id, kapps_call:account_db(Call)).
 
+-spec update_doc(kz_term:proplist(), kz_term:ne_binary(), kapps_call:call() | kz_term:ne_binary()) ->
+                        'ok' | {'error', atom()}.
 update_doc(Updates, Id, <<_/binary>> = Db) ->
     case kz_datamgr:open_doc(Db, Id) of
         {'error', _}=E -> lager:info("unable to update ~s in ~s, ~p", [Id, Db, E]);

--- a/applications/callflow/src/module/cf_nomorobo.erl
+++ b/applications/callflow/src/module/cf_nomorobo.erl
@@ -153,10 +153,10 @@ continue_to_default(Call) ->
     end.
 
 -spec nomorobo_branches({'branch_keys', kz_term:ne_binaries()}) -> kz_term:integers().
--spec nomorobo_branches(kz_term:ne_binaries(), kz_term:integers()) -> kz_term:integers().
 nomorobo_branches({'branch_keys', Keys}) ->
     nomorobo_branches(Keys, []).
 
+-spec nomorobo_branches(kz_term:ne_binaries(), kz_term:integers()) -> kz_term:integers().
 nomorobo_branches([], Branches) ->
     lists:sort(Branches);
 nomorobo_branches([?DEFAULT_CHILD_KEY|Keys], Branches) ->

--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -22,8 +22,8 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
--spec handle(kz_json:object(), kapps_call:call(), kz_term:ne_binary()) -> kapps_call:call().
 handle(Data0, Call) ->
     Label = kz_json:get_ne_binary_value(<<"label">>, Data0, kapps_call:kvs_fetch('cf_flow_name', Call)),
     Origin = <<"callflow : ", Label/binary>>,
@@ -32,6 +32,7 @@ handle(Data0, Call) ->
       handle(Data, Call, get_action(Data))
      ).
 
+-spec handle(kz_json:object(), kapps_call:call(), kz_term:ne_binary()) -> kapps_call:call().
 handle(Data, Call, <<"start">>) ->
     cf_exe:update_call(kapps_call:start_recording(Data, Call));
 

--- a/applications/callflow/src/module/cf_ring_group.erl
+++ b/applications/callflow/src/module/cf_ring_group.erl
@@ -340,9 +340,10 @@ repeats(Data) ->
     max(1, kz_json:get_integer_value(<<"repeats">>, Data, 1)).
 
 -spec group_weight(kz_json:object()) -> group_weight() | 'undefined'.
--spec group_weight(kz_json:object(), Default) -> group_weight() | Default.
 group_weight(Endpoint) ->
     group_weight(Endpoint, 'undefined').
+
+-spec group_weight(kz_json:object(), Default) -> group_weight() | Default.
 group_weight(Endpoint, Default) ->
     case kz_json:get_integer_value(<<"weight">>, Endpoint) of
         'undefined' -> Default;

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -205,23 +205,23 @@ handle(Data, Call) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec check_mailbox(mailbox(), kapps_call:call()) ->
                            'ok' | {'error', 'channel_hungup'}.
--spec check_mailbox(mailbox(), kapps_call:call(), non_neg_integer()) ->
-                           'ok' | {'error', 'channel_hungup'}.
--spec check_mailbox(mailbox(), boolean(), kapps_call:call(), non_neg_integer()) ->
-                           'ok' | {'error', 'channel_hungup'}.
-
 check_mailbox(Box, Call) ->
     %% Wrapper to initalize the attempt counter
     Resp = check_mailbox(Box, Call, 1),
     _ = send_mwi_update(Box, Call),
     Resp.
 
+-spec check_mailbox(mailbox(), kapps_call:call(), non_neg_integer()) ->
+                           'ok' | {'error', 'channel_hungup'}.
 check_mailbox(#mailbox{owner_id=OwnerId}=Box, Call, Loop) ->
     IsOwner = is_owner(Call, OwnerId),
     check_mailbox(Box, IsOwner, Call, Loop).
 
+-spec check_mailbox(mailbox(), boolean(), kapps_call:call(), non_neg_integer()) ->
+                           'ok' | {'error', 'channel_hungup'}.
 check_mailbox(#mailbox{max_login_attempts=MaxLoginAttempts}, _, Call, Loop) when Loop > MaxLoginAttempts ->
     %% if we have exceeded the maximum loop attempts then terminate this call
     lager:info("maximum number of invalid attempts to check mailbox"),
@@ -375,16 +375,17 @@ find_destination_mailbox(#mailbox{max_login_attempts=MaxLoginAttempts}=Box, Call
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec compose_voicemail(mailbox(), kapps_call:call()) ->
-                               'ok' | {'branch', _} |
-                               {'error', 'channel_hungup'}.
--spec compose_voicemail(mailbox(), boolean(), kapps_call:call()) ->
                                'ok' | {'branch', _} |
                                {'error', 'channel_hungup'}.
 compose_voicemail(#mailbox{owner_id=OwnerId}=Box, Call) ->
     IsOwner = is_owner(Call, OwnerId),
     compose_voicemail(Box, IsOwner, Call).
 
+-spec compose_voicemail(mailbox(), boolean(), kapps_call:call()) ->
+                               'ok' | {'branch', _} |
+                               {'error', 'channel_hungup'}.
 compose_voicemail(#mailbox{check_if_owner='true'}=Box, 'true', Call) ->
     lager:info("caller is the owner of this mailbox"),
     lager:info("overriding action as check (instead of compose)"),
@@ -589,9 +590,8 @@ setup_mailbox(#mailbox{media_extension=Ext}=Box, Call) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec main_menu(mailbox(), kapps_call:call()) ->
-                       'ok' | {'error', 'channel_hungup'}.
--spec main_menu(mailbox(), kapps_call:call(), non_neg_integer()) ->
                        'ok' | {'error', 'channel_hungup'}.
 main_menu(#mailbox{is_setup='false'}=Box, Call) ->
     try setup_mailbox(Box, Call) of
@@ -605,6 +605,8 @@ main_menu(#mailbox{is_setup='false'}=Box, Call) ->
     end;
 main_menu(Box, Call) -> main_menu(Box, Call, 1).
 
+-spec main_menu(mailbox(), kapps_call:call(), non_neg_integer()) ->
+                       'ok' | {'error', 'channel_hungup'}.
 main_menu(Box, Call, Loop) when Loop > 4 ->
     %% If there have been too may loops with no action from the caller this
     %% is likely a abandonded channel, terminate
@@ -1005,11 +1007,12 @@ forward_message(AttachmentName, Length, Message, SrcBoxId, #mailbox{mailbox_numb
 -spec message_menu(mailbox(), kapps_call:call()) ->
                           {'error', 'channel_hungup' | 'channel_unbridge' | kz_json:object()} |
                           message_menu_returns().
+message_menu(Box, Call) ->
+    message_menu([{'prompt', <<"vm-message_menu">>}], Box, Call).
+
 -spec message_menu(kapps_call_command:audio_macro_prompts(), mailbox(), kapps_call:call()) ->
                           {'error', 'channel_hungup' | 'channel_unbridge' | kz_json:object()} |
                           message_menu_returns().
-message_menu(Box, Call) ->
-    message_menu([{'prompt', <<"vm-message_menu">>}], Box, Call).
 message_menu(Prompt, #mailbox{keys=#keys{replay=Replay
                                         ,keep=Keep
                                         ,forward=Forward
@@ -1047,15 +1050,16 @@ message_menu(Prompt, #mailbox{keys=#keys{replay=Replay
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec config_menu(mailbox(), kapps_call:call()) ->
-                         'ok' | mailbox() |
-                         {'error', 'channel_hungup'}.
--spec config_menu(mailbox(), kapps_call:call(), pos_integer()) ->
                          'ok' | mailbox() |
                          {'error', 'channel_hungup'}.
 config_menu(Box, Call) ->
     config_menu(Box, Call, 1).
 
+-spec config_menu(mailbox(), kapps_call:call(), pos_integer()) ->
+                         'ok' | mailbox() |
+                         {'error', 'channel_hungup'}.
 config_menu(#mailbox{interdigit_timeout=Interdigit}=Box
            ,Call
            ,Loop
@@ -1311,9 +1315,8 @@ overwrite_unavailable_greeting(AttachmentName, #mailbox{unavailable_media_id=Med
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec record_name(kz_term:ne_binary(), mailbox(), kapps_call:call()) ->
-                         'ok' | mailbox().
--spec record_name(kz_term:ne_binary(), mailbox(), kapps_call:call(), kz_term:ne_binary()) ->
                          'ok' | mailbox().
 record_name(AttachmentName, #mailbox{owner_id='undefined'
                                     ,name_media_id='undefined'
@@ -1338,6 +1341,8 @@ record_name(AttachmentName, #mailbox{owner_id=OwnerId}=Box, Call) ->
     lager:info("owner_id (~s) set on mailbox, saving into owner's doc", [OwnerId]),
     record_name(AttachmentName, Box, Call, OwnerId).
 
+-spec record_name(kz_term:ne_binary(), mailbox(), kapps_call:call(), kz_term:ne_binary()) ->
+                         'ok' | mailbox().
 record_name(AttachmentName, #mailbox{name_media_id=MediaId
                                     ,media_extension=Ext
                                     }=Box, Call, DocId) ->
@@ -1627,11 +1632,11 @@ max_message_count(Call) ->
 
 -spec owner_info(kz_term:ne_binary(), kz_json:object()) ->
                         {kz_term:api_binary(), kz_term:api_binary()}.
--spec owner_info(kz_term:ne_binary(), kz_json:object(), kz_term:api_binary()) ->
-                        {kz_term:api_binary(), kz_term:api_binary()}.
 owner_info(AccountDb, MailboxJObj) ->
     owner_info(AccountDb, MailboxJObj, kz_json:get_ne_value(<<"owner_id">>, MailboxJObj)).
 
+-spec owner_info(kz_term:ne_binary(), kz_json:object(), kz_term:api_binary()) ->
+                        {kz_term:api_binary(), kz_term:api_binary()}.
 owner_info(_AccountDb, MailboxJObj, 'undefined') ->
     {kz_json:get_ne_value(?RECORDED_NAME_KEY, MailboxJObj)
     ,'undefined'
@@ -1710,12 +1715,12 @@ get_mailbox_doc(Db, Id, Data, Call) ->
 -spec get_user_mailbox_doc(kz_json:object(), kapps_call:call()) ->
                                   {'ok', kz_json:object()} |
                                   {'error', any()}.
--spec get_user_mailbox_doc(kz_json:object(), kapps_call:call(), kz_term:api_binary()) ->
-                                  {'ok', kz_json:object()} |
-                                  {'error', any()}.
 get_user_mailbox_doc(Data, Call) ->
     get_user_mailbox_doc(Data, Call, kapps_call:owner_id(Call)).
 
+-spec get_user_mailbox_doc(kz_json:object(), kapps_call:call(), kz_term:api_binary()) ->
+                                  {'ok', kz_json:object()} |
+                                  {'error', any()}.
 get_user_mailbox_doc(Data, Call, 'undefined') ->
     DeviceId = kapps_call:authorizing_id(Call),
     case kz_datamgr:open_cache_doc(kapps_call:account_db(Call), DeviceId) of
@@ -1782,16 +1787,16 @@ try_match_callerid([Box|Boxes], CallerId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec review_recording(kz_term:ne_binary(), boolean(), mailbox(), kapps_call:call()) ->
                               {'ok', 'record' | 'save' | 'no_selection'} |
                               {'branch', kz_json:object()}.
--spec review_recording(kz_term:ne_binary(), boolean(), mailbox(), kapps_call:call(), integer()) ->
-                              {'ok', 'record' | 'save' | 'no_selection'} |
-                              {'branch', kz_json:object()}.
-
 review_recording(AttachmentName, AllowOperator, Box, Call) ->
     review_recording(AttachmentName, AllowOperator, Box, Call, 1).
 
+-spec review_recording(kz_term:ne_binary(), boolean(), mailbox(), kapps_call:call(), integer()) ->
+                              {'ok', 'record' | 'save' | 'no_selection'} |
+                              {'branch', kz_json:object()}.
 review_recording(_, _, _, _, Loop) when Loop > 4 ->
     {'ok', 'no_selection'};
 review_recording(AttachmentName, AllowOperator

--- a/applications/cccp/src/cb_cccps.erl
+++ b/applications/cccp/src/cb_cccps.erl
@@ -64,10 +64,12 @@ init_db() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_CCCPId) ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_POST, ?HTTP_DELETE].
 
@@ -80,9 +82,11 @@ allowed_methods(_CCCPId) ->
 %%    /cccps/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -95,13 +99,16 @@ resource_exists(_) -> 'true'.
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_cccps(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_cccp(Context, Id, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, _Id, ?AUTODIAL) ->
     validate_cccp(Context, ?AUTODIAL, cb_context:req_verb(Context)).
 

--- a/applications/cccp/src/cccp_util.erl
+++ b/applications/cccp/src/cccp_util.erl
@@ -79,12 +79,12 @@ authorize(Value, View) ->
 -spec get_number(kapps_call:call()) ->
                         {'num_to_dial', kz_term:ne_binary()} |
                         'ok'.
--spec get_number(kapps_call:call(), integer()) ->
-                        {'num_to_dial', kz_term:ne_binary()} |
-                        'ok'.
 get_number(Call) ->
     get_number(Call, 3).
 
+-spec get_number(kapps_call:call(), integer()) ->
+                        {'num_to_dial', kz_term:ne_binary()} |
+                        'ok'.
 get_number(Call, 0) ->
     lager:info("run out of attempts amount... hanging up"),
     kapps_call_command:prompt(<<"hotdesk-invalid_entry">>, Call),

--- a/applications/cdr/src/cdr_channel_destroy.erl
+++ b/applications/cdr/src/cdr_channel_destroy.erl
@@ -157,10 +157,10 @@ is_conference(_AccountId, _Timestamp, JObj) ->
     maybe_leak_ccv(JObj, <<"Is-Conference">>, {fun kz_json:is_true/3, 'false'}).
 
 -spec maybe_leak_ccv(kz_json:object(), kz_json:path()) -> kz_json:object().
--spec maybe_leak_ccv(kz_json:object(), kz_json:path(), {fun(), any()}) -> kz_json:object().
 maybe_leak_ccv(JObj, Key) ->
     maybe_leak_ccv(JObj, Key, {fun kz_json:get_value/3, 'undefined'}).
 
+-spec maybe_leak_ccv(kz_json:object(), kz_json:path(), {fun(), any()}) -> kz_json:object().
 maybe_leak_ccv(JObj, Key, {GetFun, Default}) ->
     case GetFun(?CCV(Key), JObj, Default) of
         'undefined' -> JObj;

--- a/applications/conference/src/conf_config_req.erl
+++ b/applications/conference/src/conf_config_req.erl
@@ -264,7 +264,6 @@ get_control_profile(_AccountId, ProfileName) ->
     get_control_profile(ProfileName).
 
 -spec advertise(kz_term:ne_binary()) -> kz_term:api_object().
--spec advertise(kz_term:ne_binary(), kz_term:api_object()) -> kz_term:api_object().
 advertise(?DEFAULT_PROFILE_NAME = ProfileName) ->
     advertise(ProfileName, ?ADVERTISE(ProfileName, ?DEFAULT_ADVERTISE_CONFIG));
 advertise(?PAGE_PROFILE_NAME = ProfileName) ->
@@ -272,11 +271,11 @@ advertise(?PAGE_PROFILE_NAME = ProfileName) ->
 advertise(ProfileName) ->
     advertise(ProfileName, ?ADVERTISE(ProfileName)).
 
+-spec advertise(kz_term:ne_binary(), kz_term:api_object()) -> kz_term:api_object().
 advertise(_ProfileName, 'undefined') -> 'undefined';
 advertise(ProfileName, Advertise) -> kz_json:from_list([{ProfileName, Advertise}]).
 
 -spec chat_permissions(kz_term:ne_binary()) -> kz_term:api_object().
--spec chat_permissions(kz_term:ne_binary(), kz_term:api_object()) -> kz_term:api_object().
 chat_permissions(?DEFAULT_PROFILE_NAME = ProfileName) ->
     chat_permissions(ProfileName, ?CHAT_PERMISSIONS(ProfileName, ?DEFAULT_CHAT_CONFIG));
 chat_permissions(?PAGE_PROFILE_NAME= ProfileName) ->
@@ -284,6 +283,7 @@ chat_permissions(?PAGE_PROFILE_NAME= ProfileName) ->
 chat_permissions(ProfileName) ->
     chat_permissions(ProfileName, ?CHAT_PERMISSIONS(ProfileName)).
 
+-spec chat_permissions(kz_term:ne_binary(), kz_term:api_object()) -> kz_term:api_object().
 chat_permissions(_ProfileName, 'undefined') -> 'undefined';
 chat_permissions(ProfileName, Chat) -> kz_json:from_list([{ProfileName, Chat}]).
 

--- a/applications/conference/src/conf_participant.erl
+++ b/applications/conference/src/conf_participant.erl
@@ -200,9 +200,10 @@ init([Call]) ->
     {'ok', #participant{call=Call}}.
 
 -spec start_sanity_check_timer() -> reference().
--spec start_sanity_check_timer(pos_integer()) -> reference().
 start_sanity_check_timer() ->
     start_sanity_check_timer(kapps_config:get_integer(?CONFIG_CAT, <<"participant_sanity_check_ms">>, ?MILLISECONDS_IN_MINUTE)).
+
+-spec start_sanity_check_timer(pos_integer()) -> reference().
 start_sanity_check_timer(Timeout) ->
     erlang:send_after(Timeout, self(), 'sanity_check').
 

--- a/applications/conference/src/conf_route_req.erl
+++ b/applications/conference/src/conf_route_req.erl
@@ -82,12 +82,12 @@ join_local(Call, Conference, Participant) ->
     conf_participant:join_local(Participant).
 
 -spec maybe_set_name_pronounced(kapps_call:call(), kz_types:server_ref()) -> 'ok'.
--spec maybe_set_name_pronounced(kz_json:api_json_term(), kz_json:api_json_term(), kz_types:server_ref()) -> 'ok'.
 maybe_set_name_pronounced(Call, Participant) ->
     AccountId = kapps_call:custom_sip_header(<<"X-Conf-Values-Pronounced-Name-Account-ID">>, Call),
     MediaId = kapps_call:custom_sip_header(<<"X-Conf-Values-Pronounced-Name-Media-ID">>, Call),
     maybe_set_name_pronounced(AccountId, MediaId, Participant).
 
+-spec maybe_set_name_pronounced(kz_json:api_json_term(), kz_json:api_json_term(), kz_types:server_ref()) -> 'ok'.
 maybe_set_name_pronounced('undefined', _, _) -> 'ok';
 maybe_set_name_pronounced(_, 'undefined', _) -> 'ok';
 maybe_set_name_pronounced(AccountId, MediaId, Participant) ->

--- a/applications/conference/src/conference_maintenance.erl
+++ b/applications/conference/src/conference_maintenance.erl
@@ -32,13 +32,13 @@ blocking_refresh() ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec refresh() -> 'started'.
--spec refresh(kz_term:text()) -> 'ok'.
 
+-spec refresh() -> 'started'.
 refresh() ->
     _ = kz_util:spawn(fun blocking_refresh/0),
     'started'.
 
+-spec refresh(kz_term:text()) -> 'ok'.
 refresh(<<Account/binary>>) ->
     AccountDb = kz_util:format_account_id(Account, 'encoded'),
     Views = kapps_util:get_views_json('conference', "views"),

--- a/applications/conference/src/kapi_conf_participant.erl
+++ b/applications/conference/src/kapi_conf_participant.erl
@@ -58,10 +58,12 @@ declare_exchanges() ->
 %% Publish to the participant
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_dialplan_req(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_dialplan_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_dialplan_req(Queue, JObj) ->
     publish_dialplan_req(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_dialplan_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_dialplan_req(Queue, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DIALPLAN_REQ_VALUES, fun dialplan_req/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).

--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -126,12 +126,12 @@ get_client_ip(Req) ->
     end.
 
 -spec maybe_trace(cowboy_req:req()) -> 'ok'.
--spec maybe_trace(cowboy_req:req(), boolean()) -> 'ok'.
 maybe_trace(Req) ->
     maybe_trace(Req
                ,kapps_config:get_is_true(?CONFIG_CAT, <<"allow_tracing">>, 'false')
                ).
 
+-spec maybe_trace(cowboy_req:req(), boolean()) -> 'ok'.
 maybe_trace(_Req, 'false') -> 'ok';
 maybe_trace(Req, 'true') ->
     case cowboy_req:header(<<"x-trace-request">>, Req) of
@@ -172,7 +172,6 @@ maybe_decode_start_key(Context) ->
 metrics() ->
     {kz_util:bin_usage(), kz_util:mem_usage()}.
 
--spec find_version(kz_term:ne_binary()) -> kz_term:ne_binary().
 -spec find_version(kz_term:ne_binary(), cowboy_req:req()) ->
                           kz_term:ne_binary().
 find_version(Path, Req) ->
@@ -181,6 +180,7 @@ find_version(Path, Req) ->
         Version -> Version
     end.
 
+-spec find_version(kz_term:ne_binary()) -> kz_term:ne_binary().
 find_version(Path) ->
     lager:info("find version in ~s", [Path]),
     case binary:split(Path, <<"/">>, ['global']) of
@@ -219,11 +219,11 @@ maybe_allow_proxy_req(Peer, ForwardIP, 'true') ->
     end.
 
 -spec is_proxied(kz_term:ne_binary()) -> boolean().
--spec is_proxied(kz_term:ne_binary(), kz_term:ne_binaries()) -> boolean().
 is_proxied(Peer) ->
     Proxies = kapps_config:get_ne_binaries(?APP_NAME, <<"reverse_proxies">>, [<<"127.0.0.1">>]),
     is_proxied(Peer, Proxies).
 
+-spec is_proxied(kz_term:ne_binary(), kz_term:ne_binaries()) -> boolean().
 is_proxied(_Peer, []) -> 'false';
 is_proxied(Peer, [Proxy|Rest]) ->
     kz_network_utils:verify_cidr(Peer, kz_network_utils:to_cidr(Proxy))
@@ -263,10 +263,10 @@ rest_terminate(Req, Context, Verb) ->
     'ok'.
 
 -spec pretty_metric(integer()) -> kz_term:ne_binary().
--spec pretty_metric(integer(), boolean()) -> kz_term:ne_binary().
 pretty_metric(N) ->
     pretty_metric(N, kapps_config:get_is_true(?CONFIG_CAT, <<"pretty_metrics">>, 'true')).
 
+-spec pretty_metric(integer(), boolean()) -> kz_term:ne_binary().
 pretty_metric(N, 'false') ->
     kz_term:to_binary(N);
 pretty_metric(N, 'true') when N < 0 ->
@@ -388,11 +388,11 @@ maybe_allow_method(Req, Context, Methods, Verb) ->
 
 -spec malformed_request(cowboy_req:req(), cb_context:context()) ->
                                {boolean(), cowboy_req:req(), cb_context:context()}.
--spec malformed_request(cowboy_req:req(), cb_context:context(), http_method()) ->
-                               {boolean(), cowboy_req:req(), cb_context:context()}.
 malformed_request(Req, Context) ->
     malformed_request(Req, Context, cb_context:req_verb(Context)).
 
+-spec malformed_request(cowboy_req:req(), cb_context:context(), http_method()) ->
+                               {boolean(), cowboy_req:req(), cb_context:context()}.
 malformed_request(Req, Context, ?HTTP_OPTIONS) ->
     {'false', Req, Context};
 malformed_request(Req, Context, _ReqVerb) ->
@@ -429,11 +429,11 @@ valid_content_headers(Req, Context) ->
 
 -spec known_content_type(cowboy_req:req(), cb_context:context()) ->
                                 {boolean(), cowboy_req:req(), cb_context:context()}.
--spec known_content_type(cowboy_req:req(), cb_context:context(), http_method()) ->
-                                {boolean(), cowboy_req:req(), cb_context:context()}.
 known_content_type(Req, Context) ->
     known_content_type(Req, Context, cb_context:req_verb(Context)).
 
+-spec known_content_type(cowboy_req:req(), cb_context:context(), http_method()) ->
+                                {boolean(), cowboy_req:req(), cb_context:context()}.
 known_content_type(Req, Context, ?HTTP_OPTIONS) ->
     {'true', Req, Context};
 known_content_type(Req, Context, ?HTTP_GET) ->
@@ -565,11 +565,11 @@ set_content_type_header(#{headers := Headers}=Req, {Type, SubType, _}) ->
 
 -spec content_types_accepted(content_type(), cowboy_req:req(), cb_context:context()) ->
                                     {content_types_funs(), cowboy_req:req(), cb_context:context()}.
--spec content_types_accepted(content_type(), cowboy_req:req(), cb_context:context(), crossbar_content_handlers()) ->
-                                    {content_types_funs(), cowboy_req:req(), cb_context:context()}.
 content_types_accepted(CT, Req, Context) ->
     content_types_accepted(CT, Req, Context, cb_context:content_types_accepted(Context)).
 
+-spec content_types_accepted(content_type(), cowboy_req:req(), cb_context:context(), crossbar_content_handlers()) ->
+                                    {content_types_funs(), cowboy_req:req(), cb_context:context()}.
 content_types_accepted(CT, Req, Context, []) ->
     lager:debug("no content-types accepted, using defaults"),
     content_types_accepted(CT, Req, cb_context:set_content_types_accepted(Context, ?CONTENT_ACCEPTED));
@@ -757,11 +757,11 @@ from_form(Req0, Context0) ->
 
 -spec create_from_response(cowboy_req:req(), cb_context:context()) ->
                                   {boolean(), cowboy_req:req(), cb_context:context()}.
--spec create_from_response(cowboy_req:req(), cb_context:context(), kz_term:api_binary()) ->
-                                  {boolean(), cowboy_req:req(), cb_context:context()}.
 create_from_response(Req, Context) ->
     create_from_response(Req, Context, cb_context:req_header(Context, <<"accept">>)).
 
+-spec create_from_response(cowboy_req:req(), cb_context:context(), kz_term:api_binary()) ->
+                                  {boolean(), cowboy_req:req(), cb_context:context()}.
 create_from_response(Req, Context, 'undefined') ->
     create_from_response(Req, Context, <<"*/*">>);
 create_from_response(Req, Context, Accept) ->
@@ -808,11 +808,11 @@ to_json(Req, Context, Accept) ->
 
 -spec to_binary(cowboy_req:req(), cb_context:context()) ->
                        {binary() | 'stop', cowboy_req:req(), cb_context:context()}.
--spec to_binary(cowboy_req:req(), cb_context:context(), kz_term:api_ne_binary()) ->
-                       {binary() | 'stop', cowboy_req:req(), cb_context:context()}.
 to_binary(Req, Context) ->
     to_binary(Req, Context, accept_override(Context)).
 
+-spec to_binary(cowboy_req:req(), cb_context:context(), kz_term:api_ne_binary()) ->
+                       {binary() | 'stop', cowboy_req:req(), cb_context:context()}.
 to_binary(Req, Context, 'undefined') ->
     lager:debug("run: to_binary"),
     RespData = cb_context:resp_data(Context),
@@ -878,13 +878,13 @@ send_file(Req, Context) ->
     api_util:create_pull_response(Req, Context, fun api_util:create_resp_file/2).
 
 -spec to_fun(cb_context:context(), kz_term:ne_binary(), atom()) -> atom().
--spec to_fun(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), atom()) -> atom().
 to_fun(Context, Accept, Default) ->
     case binary:split(Accept, <<"/">>) of
         [Major, Minor] -> to_fun(Context, Major, Minor, Default);
         _ -> Default
     end.
 
+-spec to_fun(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), atom()) -> atom().
 to_fun(Context, Major, Minor, Default) ->
     case [F || {F, CTPs} <- cb_context:content_types_provided(Context),
                accept_matches_provided(Major, Minor, CTPs)
@@ -918,14 +918,14 @@ to_csv(Req0, Context0) ->
 
 -spec to_pdf(cowboy_req:req(), cb_context:context()) ->
                     {binary(), cowboy_req:req(), cb_context:context()}.
--spec to_pdf(cowboy_req:req(), cb_context:context(), binary()) ->
-                    {binary(), cowboy_req:req(), cb_context:context()}.
 to_pdf(Req, Context) ->
     lager:debug("run: to_pdf"),
     Event = to_fun_event_name(<<"to_pdf">>, Context),
     {Req1, Context1} = crossbar_bindings:fold(Event, {Req, Context}),
     to_pdf(Req1, Context1, cb_context:resp_data(Context1)).
 
+-spec to_pdf(cowboy_req:req(), cb_context:context(), binary()) ->
+                    {binary(), cowboy_req:req(), cb_context:context()}.
 to_pdf(Req, Context, <<>>) ->
     to_pdf(Req, Context, kz_pdf:error_empty());
 to_pdf(Req, Context, RespData) ->

--- a/applications/crossbar/src/cb_apps_util.erl
+++ b/applications/crossbar/src/cb_apps_util.erl
@@ -242,11 +242,12 @@ is_blacklisted(App, JObj) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec is_filtered(kz_term:ne_binary(), kz_json:object()) -> boolean().
--spec is_filtered(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> boolean().
 is_filtered(AccountId, App) ->
     is_filtered(AccountId, App, kzd_app:name(App)).
 
+-spec is_filtered(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> boolean().
 is_filtered(AccountId, _App, <<"port">>=_AppName) ->
     lager:debug("filtering '~s' application", [_AppName]),
     ResellerId = kz_services:find_reseller_id(AccountId),

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -148,9 +148,10 @@ is_context(#cb_context{}) -> 'true';
 is_context(_) -> 'false'.
 
 -spec req_value(context(), kz_json:path()) -> kz_json:api_json_term().
--spec req_value(context(), kz_json:path(), Default) -> kz_json:json_term() | Default.
 req_value(#cb_context{}=Context, Key) ->
     req_value(Context, Key, 'undefined').
+
+-spec req_value(context(), kz_json:path(), Default) -> kz_json:json_term() | Default.
 req_value(#cb_context{req_data=ReqData
                      ,query_json=QS
                      ,req_json=JObj
@@ -170,80 +171,48 @@ set_accepting_charges(#cb_context{req_json = ReqJObj} = Context) ->
     set_req_json(Context, NewReqJObj).
 
 %% Accessors
+
+
 -spec account_id(context()) -> kz_term:api_ne_binary().
--spec account_name(context()) -> kz_term:api_ne_binary().
--spec account_db(context()) -> kz_term:api_ne_binary().
--spec user_id(context()) -> kz_term:api_ne_binary().
--spec device_id(context()) -> kz_term:api_ne_binary().
--spec reseller_id(context()) -> kz_term:api_ne_binary().
--spec account_modb(context()) -> kz_term:api_ne_binary().
--spec account_modb(context(), kz_time:now() | timeout()) -> kz_term:api_ne_binary().
--spec account_modb(context(), kz_time:year(), kz_time:month()) -> kz_term:api_ne_binary().
--spec account_realm(context()) -> kz_term:api_ne_binary().
--spec account_doc(context()) -> kz_term:api_object().
--spec profile_id(context()) -> kz_term:api_ne_binary().
--spec is_authenticated(context()) -> boolean().
--spec auth_token_type(context()) -> 'x-auth-token' | 'basic' | 'oauth' | 'unknown'.
--spec auth_token(context()) -> kz_term:api_ne_binary().
--spec auth_doc(context()) -> kz_term:api_object().
--spec auth_account_id(context()) -> kz_term:api_ne_binary().
--spec auth_user_id(context()) -> kz_term:api_ne_binary().
--spec req_verb(context()) -> http_method().
--spec req_data(context()) -> kz_json:json_term().
--spec req_files(context()) -> req_files().
--spec req_nouns(context()) -> req_nouns().
--spec req_headers(context()) -> cowboy:http_headers().
--spec req_header(context(), binary()) -> iodata() | 'undefined'.
--spec query_string(context()) -> kz_json:object().
--spec req_param(context(), kz_term:ne_binary()) -> kz_json:api_json_term().
--spec req_param(context(), kz_term:ne_binary(), Default) -> kz_json:json_term() | Default.
--spec client_ip(context()) -> kz_term:api_ne_binary().
--spec req_id(context()) -> kz_term:ne_binary().
--spec auth_account_doc(context()) -> kz_term:api_object().
--spec doc(context()) -> kz_term:api_object() | kz_json:objects().
--spec load_merge_bypass(context()) -> kz_term:api_object().
--spec start(context()) -> kz_time:now().
--spec resp_file(context()) -> binary().
--spec resp_data(context()) -> resp_data().
--spec resp_status(context()) -> crossbar_status().
--spec resp_expires(context()) -> kz_time:datetime().
--spec resp_headers(context()) -> cowboy:http_headers().
--spec api_version(context()) -> kz_term:ne_binary().
--spec resp_etag(context()) -> 'automatic' | string() | kz_term:api_binary().
--spec resp_envelope(context()) -> kz_json:object().
--spec allow_methods(context()) -> http_methods().
--spec allowed_methods(context()) -> http_methods().
--spec method(context()) -> http_method().
--spec req_json(context()) -> kz_json:object().
--spec content_types_accepted(context()) -> crossbar_content_handlers().
--spec content_types_provided(context()) -> crossbar_content_handlers().
--spec languages_provided(context()) -> kz_term:ne_binaries().
--spec encodings_provided(context()) -> kz_term:ne_binaries().
--spec validation_errors(context()) -> kz_json:object().
--spec resp_error_code(context()) -> kz_term:api_integer().
--spec resp_error_msg(context()) -> kz_term:api_ne_binary().
-
-
 account_id(#cb_context{account_id=AcctId}) -> AcctId.
+
+-spec account_name(context()) -> kz_term:api_ne_binary().
 account_name(#cb_context{account_name=Name}) -> Name.
+
+-spec user_id(context()) -> kz_term:api_ne_binary().
 user_id(#cb_context{user_id=UserId}) -> UserId.
+
+-spec device_id(context()) -> kz_term:api_ne_binary().
 device_id(#cb_context{device_id=DeviceId}) -> DeviceId.
+
+-spec reseller_id(context()) -> kz_term:api_ne_binary().
 reseller_id(#cb_context{reseller_id=AcctId}) -> AcctId.
+
+-spec account_db(context()) -> kz_term:api_ne_binary().
 account_db(#cb_context{db_name=AcctDb}) -> AcctDb.
+
+-spec profile_id(context()) -> kz_term:api_ne_binary().
 profile_id(#cb_context{profile_id = Value}) -> Value.
 
+-spec account_modb(context()) -> kz_term:api_ne_binary().
 account_modb(Context) ->
     kazoo_modb:get_modb(account_id(Context)).
+
+-spec account_modb(context(), kz_time:now() | timeout()) -> kz_term:api_ne_binary().
 account_modb(Context, {_,_,_}=Timestamp) ->
     kazoo_modb:get_modb(account_id(Context), Timestamp);
 account_modb(Context, Timestamp) when is_integer(Timestamp), Timestamp > 0 ->
     kazoo_modb:get_modb(account_id(Context), Timestamp).
+
+-spec account_modb(context(), kz_time:year(), kz_time:month()) -> kz_term:api_ne_binary().
 account_modb(Context, Year, Month) ->
     kazoo_modb:get_modb(account_id(Context), Year, Month).
 
+-spec account_realm(context()) -> kz_term:api_ne_binary().
 account_realm(Context) ->
     kz_account:realm(account_doc(Context)).
 
+-spec account_doc(context()) -> kz_term:api_object().
 account_doc(#cb_context{account_id = undefined}) -> undefined;
 account_doc(#cb_context{account_id = AccountId}) ->
     case kz_account:fetch(AccountId) of
@@ -253,6 +222,7 @@ account_doc(#cb_context{account_id = AccountId}) ->
             undefined
     end.
 
+-spec is_authenticated(context()) -> boolean().
 is_authenticated(#cb_context{auth_doc='undefined'}) -> 'false';
 is_authenticated(#cb_context{}) -> 'true'.
 
@@ -291,11 +261,19 @@ is_account_admin(Context) ->
             'false'
     end.
 
+-spec auth_token_type(context()) -> 'x-auth-token' | 'basic' | 'oauth' | 'unknown'.
 auth_token_type(#cb_context{auth_token_type=AuthTokenType}) -> AuthTokenType.
+
+-spec auth_token(context()) -> kz_term:api_ne_binary().
 auth_token(#cb_context{auth_token=AuthToken}) -> AuthToken.
+
+-spec auth_doc(context()) -> kz_term:api_object().
 auth_doc(#cb_context{auth_doc=AuthDoc}) -> AuthDoc.
+
+-spec auth_account_id(context()) -> kz_term:api_ne_binary().
 auth_account_id(#cb_context{auth_account_id=AuthBy}) -> AuthBy.
 
+-spec auth_account_doc(context()) -> kz_term:api_object().
 auth_account_doc(#cb_context{auth_account_id = undefined}) -> undefined;
 auth_account_doc(#cb_context{auth_account_id = AccountId}) ->
     case kz_account:fetch(AccountId) of
@@ -305,6 +283,7 @@ auth_account_doc(#cb_context{auth_account_id = AccountId}) ->
             undefined
     end.
 
+-spec auth_user_id(context()) -> kz_term:api_ne_binary().
 auth_user_id(#cb_context{auth_doc='undefined'}) -> 'undefined';
 auth_user_id(#cb_context{auth_doc=JObj}) ->
     case kz_doc:type(JObj) of
@@ -312,31 +291,79 @@ auth_user_id(#cb_context{auth_doc=JObj}) ->
         _ -> kz_json:get_value(<<"owner_id">>, JObj)
     end.
 
+-spec req_verb(context()) -> http_method().
 req_verb(#cb_context{req_verb=ReqVerb}) -> ReqVerb.
+
+-spec req_data(context()) -> kz_json:json_term().
 req_data(#cb_context{req_data=ReqData}) -> ReqData.
+
+-spec req_files(context()) -> req_files().
 req_files(#cb_context{req_files=ReqFiles}) -> ReqFiles.
+
+-spec req_nouns(context()) -> req_nouns().
 req_nouns(#cb_context{req_nouns=ReqNouns}) -> ReqNouns.
+
+-spec req_headers(context()) -> cowboy:http_headers().
 req_headers(#cb_context{req_headers=Hs}) -> Hs.
+
+-spec req_header(context(), binary()) -> iodata() | 'undefined'.
 req_header(#cb_context{req_headers=Hs}, K) -> maps:get(K, Hs, 'undefined').
+
+-spec query_string(context()) -> kz_json:object().
 query_string(#cb_context{query_json=Q}) -> Q.
+
+-spec req_param(context(), kz_term:ne_binary()) -> kz_json:api_json_term().
 req_param(#cb_context{}=Context, K) -> req_param(Context, K, 'undefined').
+
+-spec req_param(context(), kz_term:ne_binary(), Default) -> kz_json:json_term() | Default.
 req_param(#cb_context{query_json=JObj}, K, Default) -> kz_json:get_value(K, JObj, Default).
+
+-spec client_ip(context()) -> kz_term:api_ne_binary().
 client_ip(#cb_context{client_ip=IP}) -> IP.
+
+-spec req_id(context()) -> kz_term:ne_binary().
 req_id(#cb_context{req_id=ReqId}) -> ReqId.
+
+-spec doc(context()) -> kz_term:api_object() | kz_json:objects().
 doc(#cb_context{doc=Doc}) -> Doc.
+
+-spec load_merge_bypass(context()) -> kz_term:api_object().
 load_merge_bypass(#cb_context{load_merge_bypass=ByPass}) -> ByPass.
+
+-spec start(context()) -> kz_time:now().
 start(#cb_context{start=Start}) -> Start.
+
+-spec resp_file(context()) -> binary().
 resp_file(#cb_context{resp_file=RespFile}) -> RespFile.
+
+-spec resp_data(context()) -> resp_data().
 resp_data(#cb_context{resp_data=RespData}) -> RespData.
+
+-spec resp_status(context()) -> crossbar_status().
 resp_status(#cb_context{resp_status=RespStatus}) -> RespStatus.
+
+-spec resp_expires(context()) -> kz_time:datetime().
 resp_expires(#cb_context{resp_expires=RespExpires}) -> RespExpires.
+
+-spec resp_headers(context()) -> cowboy:http_headers().
 resp_headers(#cb_context{resp_headers=RespHeaders}) -> RespHeaders.
+
+-spec api_version(context()) -> kz_term:ne_binary().
 api_version(#cb_context{api_version=ApiVersion}) -> ApiVersion.
+
+-spec resp_etag(context()) -> 'automatic' | string() | kz_term:api_binary().
 resp_etag(#cb_context{resp_etag=ETag}) -> ETag.
+
+-spec resp_envelope(context()) -> kz_json:object().
 resp_envelope(#cb_context{resp_envelope=E}) -> E.
 
+-spec allow_methods(context()) -> http_methods().
 allow_methods(#cb_context{allow_methods=AMs}) -> AMs.
+
+-spec allowed_methods(context()) -> http_methods().
 allowed_methods(#cb_context{allowed_methods=AMs}) -> AMs.
+
+-spec method(context()) -> http_method().
 method(#cb_context{method=M}) -> M.
 
 -spec pretty_print(context()) -> boolean().
@@ -397,15 +424,28 @@ pagination_page_size(Context, _Version) ->
 should_soft_delete(#cb_context{}=Context) ->
     kz_term:is_true(req_value(Context, <<"should_soft_delete">>, ?SOFT_DELETE)).
 
+-spec req_json(context()) -> kz_json:object().
 req_json(#cb_context{req_json=RJ}) -> RJ.
+
+-spec content_types_accepted(context()) -> crossbar_content_handlers().
 content_types_accepted(#cb_context{content_types_accepted=CTAs}) -> CTAs.
+
+-spec content_types_provided(context()) -> crossbar_content_handlers().
 content_types_provided(#cb_context{content_types_provided=CTPs}) -> CTPs.
+
+-spec languages_provided(context()) -> kz_term:ne_binaries().
 languages_provided(#cb_context{languages_provided=LP}) -> LP.
+
+-spec encodings_provided(context()) -> kz_term:ne_binaries().
 encodings_provided(#cb_context{encodings_provided=EP}) -> EP.
 
+-spec validation_errors(context()) -> kz_json:object().
 validation_errors(#cb_context{validation_errors=Errs}) -> Errs.
 
+-spec resp_error_code(context()) -> kz_term:api_integer().
 resp_error_code(#cb_context{resp_error_code=Code}) -> Code.
+
+-spec resp_error_msg(context()) -> kz_term:api_ne_binary().
 resp_error_msg(#cb_context{resp_error_msg=Msg}) -> Msg.
 
 %% Setters
@@ -420,164 +460,199 @@ setters_fold({F, V}, C) -> F(C, V);
 setters_fold({F, K, V}, C) -> F(C, K, V);
 setters_fold(F, C) when is_function(F, 1) -> F(C).
 
--spec set_account_id(context(), kz_term:ne_binary()) -> context().
--spec set_account_db(context(), kz_term:ne_binary()) -> context().
--spec set_user_id(context(), kz_term:ne_binary()) -> context().
--spec set_device_id(context(), kz_term:ne_binary()) -> context().
--spec set_auth_token(context(), kz_term:ne_binary()) -> context().
--spec set_auth_doc(context(), kz_json:object()) -> context().
--spec set_auth_account_id(context(), kz_term:ne_binary()) -> context().
--spec set_req_verb(context(), http_method()) -> context().
--spec set_req_data(context(), kz_json:json_term()) -> context().
--spec set_req_files(context(), req_files()) -> context().
--spec set_req_nouns(context(), req_nouns()) -> context().
--spec set_req_headers(context(), cowboy:http_headers()) -> context().
--spec set_req_header(context(), kz_term:ne_binary(), iodata()) -> context().
--spec set_query_string(context(), kz_json:object()) -> context().
--spec set_req_id(context(), kz_term:ne_binary()) -> context().
--spec set_doc(context(), kz_json:api_json_term() | kz_json:objects()) -> context().
--spec set_load_merge_bypass(context(), kz_term:api_ne_binary()) -> context().
--spec set_start(context(), kz_time:now()) -> context().
--spec set_resp_file(context(), kz_term:api_binary()) -> context().
--spec set_resp_data(context(), resp_data()) -> context().
--spec set_resp_status(context(), crossbar_status()) -> context().
--spec set_resp_expires(context(), kz_time:datetime()) -> context().
--spec set_api_version(context(), kz_term:ne_binary() | pos_integer()) -> context().
--spec set_resp_etag(context(), kz_term:api_binary()) -> context().
--spec set_resp_envelope(context(), kz_json:object()) -> context().
--spec set_resp_headers(context(), cowboy:http_headers()) -> context().
--spec add_resp_headers(context(), cowboy:http_headers()) -> context().
--spec set_resp_header(context(), kz_term:ne_binary(), kz_term:ne_binary()) -> context().
--spec add_resp_header(context(), kz_term:ne_binary(), kz_term:ne_binary()) -> context().
--spec set_allow_methods(context(), http_methods()) -> context().
--spec set_allowed_methods(context(), http_methods()) -> context().
--spec set_method(context(), http_method()) -> context().
--spec set_req_json(context(), kz_json:object()) -> context().
--spec set_content_types_accepted(context(), crossbar_content_handlers()) -> context().
--spec set_content_types_provided(context(), crossbar_content_handlers()) -> context().
--spec set_languages_provided(context(), kz_term:ne_binaries()) -> context().
--spec set_encodings_provided(context(), kz_term:ne_binaries()) -> context().
--spec set_resp_error_code(context(), integer()) -> context().
--spec set_resp_error_msg(context(), kz_term:api_ne_binary()) -> context().
--spec set_magic_pathed(context(), boolean()) -> context().
--spec set_should_paginate(context(), boolean()) -> context().
--spec set_validation_errors(context(), kz_json:object()) -> context().
--spec set_port(context(), integer()) -> context().
--spec set_raw_path(context(), binary()) -> context().
--spec set_raw_qs(context(), binary()) -> context().
--spec set_client_ip(context(), kz_term:ne_binary()) -> context().
--spec set_profile_id(context(), kz_term:ne_binary()) -> context().
--spec set_account_name(context(), kz_term:api_ne_binary()) -> context().
--spec set_reseller_id(context(), kz_term:api_ne_binary()) -> context().
--spec set_account_modb(context(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) -> context().
--spec set_account_modb(context(), kz_term:ne_binary(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) -> context().
--spec set_auth_token_type(context(), 'x-auth-token' | 'basic' | 'oauth' | 'unknown') -> context().
 
+-spec set_account_id(context(), kz_term:ne_binary()) -> context().
 set_account_id(#cb_context{}=Context, AcctId) ->
     Context#cb_context{account_id=AcctId}.
+
+-spec set_account_name(context(), kz_term:api_ne_binary()) -> context().
 set_account_name(#cb_context{}=Context, Name) ->
     Context#cb_context{account_name=Name}.
+
+-spec set_user_id(context(), kz_term:ne_binary()) -> context().
 set_user_id(#cb_context{}=Context, UserId) ->
     Context#cb_context{user_id=UserId}.
+
+-spec set_device_id(context(), kz_term:ne_binary()) -> context().
 set_device_id(#cb_context{}=Context, DeviceId) ->
     Context#cb_context{device_id=DeviceId}.
+
+-spec set_reseller_id(context(), kz_term:api_ne_binary()) -> context().
 set_reseller_id(#cb_context{}=Context, AcctId) ->
     Context#cb_context{reseller_id=AcctId}.
+
+-spec set_account_db(context(), kz_term:ne_binary()) -> context().
 set_account_db(#cb_context{}=Context, AcctDb) ->
     Context#cb_context{db_name=AcctDb}.
+
+-spec set_account_modb(context(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) -> context().
 set_account_modb(#cb_context{}=Context, Year, Month) ->
     Context#cb_context{db_name=kazoo_modb:get_modb(account_id(Context), Year, Month)}.
+
+-spec set_account_modb(context(), kz_term:ne_binary(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) -> context().
 set_account_modb(#cb_context{}=Context, AcctId, Year, Month) ->
     Context#cb_context{db_name=kazoo_modb:get_modb(AcctId, Year, Month)}.
+
+-spec set_auth_token_type(context(), 'x-auth-token' | 'basic' | 'oauth' | 'unknown') -> context().
 set_auth_token_type(#cb_context{}=Context, AuthTokenType) ->
     Context#cb_context{auth_token_type=AuthTokenType}.
+
+-spec set_auth_token(context(), kz_term:ne_binary()) -> context().
 set_auth_token(#cb_context{}=Context, AuthToken) ->
     Context#cb_context{auth_token=AuthToken}.
+
+-spec set_auth_doc(context(), kz_json:object()) -> context().
 set_auth_doc(#cb_context{}=Context, AuthDoc) ->
     Context#cb_context{auth_doc=AuthDoc}.
+
+-spec set_auth_account_id(context(), kz_term:ne_binary()) -> context().
 set_auth_account_id(#cb_context{}=Context, AuthBy) ->
     Context#cb_context{auth_account_id=AuthBy}.
+
+-spec set_req_verb(context(), http_method()) -> context().
 set_req_verb(#cb_context{}=Context, ReqVerb) ->
     Context#cb_context{req_verb=ReqVerb}.
+
+-spec set_req_data(context(), kz_json:json_term()) -> context().
 set_req_data(#cb_context{}=Context, ReqData) ->
     Context#cb_context{req_data=ReqData}.
+
+-spec set_req_files(context(), req_files()) -> context().
 set_req_files(#cb_context{}=Context, ReqFiles) ->
     Context#cb_context{req_files=ReqFiles}.
+
+-spec set_req_nouns(context(), req_nouns()) -> context().
 set_req_nouns(#cb_context{}=Context, ReqNouns) ->
     Context#cb_context{req_nouns=ReqNouns}.
+
+-spec set_req_headers(context(), cowboy:http_headers()) -> context().
 set_req_headers(#cb_context{}=Context, ReqHs) ->
     Context#cb_context{req_headers=ReqHs}.
+
+-spec set_req_header(context(), kz_term:ne_binary(), iodata()) -> context().
 set_req_header(#cb_context{req_headers=ReqHs}=Context, HKey, HValue) ->
     Context#cb_context{req_headers=maps:put(HKey, HValue, ReqHs)}.
+
+-spec set_query_string(context(), kz_json:object()) -> context().
 set_query_string(#cb_context{}=Context, Q) ->
     Context#cb_context{query_json=Q}.
+
+-spec set_req_id(context(), kz_term:ne_binary()) -> context().
 set_req_id(#cb_context{}=Context, ReqId) ->
     Context#cb_context{req_id=ReqId}.
+
+-spec set_doc(context(), kz_json:api_json_term() | kz_json:objects()) -> context().
 set_doc(#cb_context{}=Context, Doc) ->
     Context#cb_context{doc=Doc}.
+
+-spec set_load_merge_bypass(context(), kz_term:api_ne_binary()) -> context().
 set_load_merge_bypass(#cb_context{}=Context, JObj) ->
     Context#cb_context{load_merge_bypass=JObj}.
+
+-spec set_start(context(), kz_time:now()) -> context().
 set_start(#cb_context{}=Context, Start) ->
     Context#cb_context{start=Start}.
+
+-spec set_resp_file(context(), kz_term:api_binary()) -> context().
 set_resp_file(#cb_context{}=Context, RespFile) ->
     Context#cb_context{resp_file=RespFile}.
+
+-spec set_resp_data(context(), resp_data()) -> context().
 set_resp_data(#cb_context{}=Context, RespData) ->
     Context#cb_context{resp_data=RespData}.
+
+-spec set_resp_status(context(), crossbar_status()) -> context().
 set_resp_status(#cb_context{}=Context, RespStatus) ->
     Context#cb_context{resp_status=RespStatus}.
+
+-spec set_resp_expires(context(), kz_time:datetime()) -> context().
 set_resp_expires(#cb_context{}=Context, RespExpires) ->
     Context#cb_context{resp_expires=RespExpires}.
+
+-spec set_api_version(context(), kz_term:ne_binary() | pos_integer()) -> context().
 set_api_version(#cb_context{}=Context, ApiVersion) ->
     Context#cb_context{api_version=kz_term:to_binary(ApiVersion)}.
+
+-spec set_resp_etag(context(), kz_term:api_binary()) -> context().
 set_resp_etag(#cb_context{}=Context, ETag) ->
     Context#cb_context{resp_etag=ETag}.
+
+-spec set_resp_envelope(context(), kz_json:object()) -> context().
 set_resp_envelope(#cb_context{}=Context, E) ->
     Context#cb_context{resp_envelope=E}.
 
+-spec set_allow_methods(context(), http_methods()) -> context().
 set_allow_methods(#cb_context{}=Context, AMs) ->
     Context#cb_context{allow_methods=AMs}.
+
+-spec set_allowed_methods(context(), http_methods()) -> context().
 set_allowed_methods(#cb_context{}=Context, AMs) ->
     Context#cb_context{allowed_methods=AMs}.
+
+-spec set_method(context(), http_method()) -> context().
 set_method(#cb_context{}=Context, M) ->
     Context#cb_context{method=M}.
 
+-spec set_req_json(context(), kz_json:object()) -> context().
 set_req_json(#cb_context{}=Context, RJ) ->
     Context#cb_context{req_json=RJ}.
+
+-spec set_content_types_accepted(context(), crossbar_content_handlers()) -> context().
 set_content_types_accepted(#cb_context{}=Context, CTAs) ->
     Context#cb_context{content_types_accepted=CTAs}.
+
+-spec set_content_types_provided(context(), crossbar_content_handlers()) -> context().
 set_content_types_provided(#cb_context{}=Context, CTPs) ->
     Context#cb_context{content_types_provided=CTPs}.
+
+-spec set_languages_provided(context(), kz_term:ne_binaries()) -> context().
 set_languages_provided(#cb_context{}=Context, LP) ->
     Context#cb_context{languages_provided=LP}.
+
+-spec set_encodings_provided(context(), kz_term:ne_binaries()) -> context().
 set_encodings_provided(#cb_context{}=Context, EP) ->
     Context#cb_context{encodings_provided=EP}.
+
+-spec set_magic_pathed(context(), boolean()) -> context().
 set_magic_pathed(#cb_context{}=Context, MP) ->
     Context#cb_context{magic_pathed=kz_term:is_true(MP)}.
+
+-spec set_should_paginate(context(), boolean()) -> context().
 set_should_paginate(#cb_context{}=Context, SP) ->
     Context#cb_context{should_paginate=kz_term:is_true(SP)}.
 
+-spec set_resp_error_code(context(), integer()) -> context().
 set_resp_error_code(#cb_context{}=Context, Code) ->
     Context#cb_context{resp_error_code=Code}.
+
+-spec set_resp_error_msg(context(), kz_term:api_ne_binary()) -> context().
 set_resp_error_msg(#cb_context{}=Context, Msg) ->
     Context#cb_context{resp_error_msg=Msg}.
 
+-spec set_resp_headers(context(), cowboy:http_headers()) -> context().
 set_resp_headers(#cb_context{resp_headers=Hs}=Context, Headers) ->
     Context#cb_context{resp_headers=maps:merge(Hs, Headers)}.
+
+-spec set_resp_header(context(), kz_term:ne_binary(), kz_term:ne_binary()) -> context().
 set_resp_header(#cb_context{resp_headers=RespHeaders}=Context, K, V) ->
     Context#cb_context{resp_headers=maps:put(K, V, RespHeaders)}.
 
+-spec add_resp_headers(context(), cowboy:http_headers()) -> context().
 add_resp_headers(#cb_context{resp_headers=RespHeaders}=Context, #{}=Headers) ->
     Context#cb_context{resp_headers=maps:fold(fun add_resp_header_fold/3, RespHeaders, Headers)}.
 
 add_resp_header_fold(K, V, RHs) ->
     maps:put(kz_term:to_lower_binary(K), V, RHs).
 
+-spec add_resp_header(context(), kz_term:ne_binary(), kz_term:ne_binary()) -> context().
 add_resp_header(#cb_context{resp_headers=RespHeaders}=Context, K, V) ->
     Context#cb_context{resp_headers=add_resp_header_fold(K, V, RespHeaders)}.
 
+-spec set_validation_errors(context(), kz_json:object()) -> context().
 set_validation_errors(#cb_context{}=Context, Errors) ->
     Context#cb_context{validation_errors=Errors}.
 
+-spec set_port(context(), integer()) -> context().
 set_port(#cb_context{}=Context, Value) ->
     Context#cb_context{port = Value}.
 -spec set_host_url(context(), binary()) -> context().
@@ -591,18 +666,23 @@ host_url(#cb_context{host_url = Value}) -> Value.
 set_pretty_print(#cb_context{}=Context, Value) ->
     Context#cb_context{pretty_print = Value}.
 
+-spec set_raw_path(context(), binary()) -> context().
 set_raw_path(#cb_context{}=Context, Value) ->
     Context#cb_context{raw_path = Value}.
 
 -spec raw_qs(context()) -> kz_term:api_ne_binary().
 raw_qs(#cb_context{raw_qs=QS}) ->
     QS.
+
+-spec set_raw_qs(context(), binary()) -> context().
 set_raw_qs(#cb_context{}=Context, Value) ->
     Context#cb_context{raw_qs = Value}.
 
+-spec set_client_ip(context(), kz_term:ne_binary()) -> context().
 set_client_ip(#cb_context{}=Context, Value) ->
     Context#cb_context{client_ip = Value}.
 
+-spec set_profile_id(context(), kz_term:ne_binary()) -> context().
 set_profile_id(#cb_context{}=Context, Value) ->
     Context#cb_context{profile_id = Value}.
 
@@ -666,12 +746,12 @@ store(#cb_context{storage=Storage}=Context, Key, Data) ->
 %% Fetches a previously stored value from the current request.
 %% @end
 %%--------------------------------------------------------------------
--spec fetch(context(), any()) -> any().
--spec fetch(context(), any(), any()) -> any().
 
+-spec fetch(context(), any()) -> any().
 fetch(#cb_context{}=Context, Key) ->
     fetch(Context, Key, 'undefined').
 
+-spec fetch(context(), any(), any()) -> any().
 fetch(#cb_context{storage=Storage}, Key, Default) ->
     case props:get_value(Key, Storage) of
         'undefined' -> Default;
@@ -752,22 +832,22 @@ response(#cb_context{resp_error_code=Code
 
 -spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context()) ->
                                    context().
--spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context(), after_fun()) ->
-                                   context().
--spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context(), after_fun(), after_fun()) ->
-                                   context().
--spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context(), after_fun(), after_fun(), boolean()) ->
-                                   context().
 validate_request_data(SchemaId, Context) ->
     validate_request_data(SchemaId, Context, 'undefined').
 
+-spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context(), after_fun()) ->
+                                   context().
 validate_request_data(SchemaId, Context, OnSuccess) ->
     validate_request_data(SchemaId, Context, OnSuccess, 'undefined').
 
+-spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context(), after_fun(), after_fun()) ->
+                                   context().
 validate_request_data(SchemaId, Context, OnSuccess, OnFailure) ->
     SchemaRequired = fetch(Context, 'ensure_valid_schema', ?SHOULD_ENSURE_SCHEMA_IS_VALID),
     validate_request_data(SchemaId, Context, OnSuccess, OnFailure, SchemaRequired).
 
+-spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context(), after_fun(), after_fun(), boolean()) ->
+                                   context().
 validate_request_data('undefined', Context, OnSuccess, _OnFailure, 'false') ->
     lager:error("schema id or schema JSON not defined, continuing anyway"),
     validate_passed(Context, OnSuccess);
@@ -883,9 +963,8 @@ find_schema(Schema=?NE_BINARY) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec add_system_error(atom() | binary(), context()) -> context().
--spec add_system_error(atom() | binary(), kz_term:ne_binary() | kz_json:object(), context()) -> context().
--spec add_system_error(integer(), atom() | kz_term:ne_binary(), kz_term:ne_binary() | kz_json:object(), context()) -> context().
 add_system_error('too_many_requests', Context) ->
     build_system_error(429, 'too_many_requests', <<"too many requests">>, Context);
 add_system_error('no_credit', Context) ->
@@ -931,6 +1010,7 @@ add_system_error('disabled', Context) ->
 add_system_error(Error, Context) ->
     build_system_error(500, Error, kz_term:to_binary(Error), Context).
 
+-spec add_system_error(atom() | binary(), kz_term:ne_binary() | kz_json:object(), context()) -> context().
 add_system_error(Error, <<_/binary>>=Message, Context) ->
     JObj = kz_json:from_list([{<<"message">>, Message}]),
     add_system_error(Error, JObj, Context);
@@ -970,6 +1050,7 @@ add_system_error(Error, JObj, Context) ->
             build_system_error(500, Error, JObj, Context)
     end.
 
+-spec add_system_error(integer(), atom() | kz_term:ne_binary(), kz_term:ne_binary() | kz_json:object(), context()) -> context().
 add_system_error(Code, Error, JObj, Context) ->
     build_system_error(Code, Error, JObj, Context).
 

--- a/applications/crossbar/src/cb_test.erl
+++ b/applications/crossbar/src/cb_test.erl
@@ -2,12 +2,12 @@
 
 -export([start/0, start/1]).
 
--spec start() -> tuple().
--spec start(pos_integer()) -> tuple().
 
+-spec start() -> tuple().
 start() ->
     start(100).
 
+-spec start(pos_integer()) -> tuple().
 start(N) ->
     start(N, N, 0, 0, []).
 

--- a/applications/crossbar/src/crossbar_auth.erl
+++ b/applications/crossbar/src/crossbar_auth.erl
@@ -158,11 +158,11 @@ maybe_create_token(Context, Claims, AuthConfig, Method, 'true') ->
 
 -spec validate_auth_token(map() | kz_term:ne_binary()) ->
                                  {ok, kz_json:object()} | {error, any()}.
--spec validate_auth_token(map() | kz_term:ne_binary(), kz_term:proplist()) ->
-                                 {ok, kz_json:object()} | {error, any()}.
 validate_auth_token(Token) ->
     validate_auth_token(Token, []).
 
+-spec validate_auth_token(map() | kz_term:ne_binary(), kz_term:proplist()) ->
+                                 {ok, kz_json:object()} | {error, any()}.
 validate_auth_token(Token, Options) ->
     case kz_auth:validate_token(Token, Options) of
         {'error', 'no_jwt_signed_token'} -> maybe_db_token(Token);

--- a/applications/crossbar/src/crossbar_config.erl
+++ b/applications/crossbar/src/crossbar_config.erl
@@ -20,10 +20,10 @@
 flush() -> kapps_config:flush(?CONFIG_CAT).
 
 -spec autoload_modules() -> kz_term:ne_binaries().
--spec autoload_modules(kz_term:ne_binaries() | kz_term:atoms()) -> kz_term:ne_binaries().
 autoload_modules() ->
     autoload_modules(?DEFAULT_MODULES).
 
+-spec autoload_modules(kz_term:ne_binaries() | kz_term:atoms()) -> kz_term:ne_binaries().
 autoload_modules(Default) ->
     Modules = kapps_config:get(?CONFIG_CAT, <<"autoload_modules">>, Default),
     remove_versioned_modules(Modules).

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -104,23 +104,23 @@ current_doc_vsn() -> ?CROSSBAR_DOC_VSN.
 %% Failure here returns 410, 500, or 503
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load(kazoo_data:docid() | kazoo_data:docids(), cb_context:context()) ->
                   cb_context:context().
--spec load(kazoo_data:docid() | kazoo_data:docids(), cb_context:context(), load_options()) ->
-                  cb_context:context().
--spec load(kz_term:ne_binary() | kz_term:ne_binaries(), cb_context:context(), load_options(), crossbar_status()) ->
-                  cb_context:context().
-
 load({DocType, DocId}, Context) ->
     load(DocId, Context, [{'doc_type', DocType}]);
 load(DocId, Context) ->
     load(DocId, Context, []).
 
+-spec load(kazoo_data:docid() | kazoo_data:docids(), cb_context:context(), load_options()) ->
+                  cb_context:context().
 load({DocType, DocId}, Context, Options) ->
     load(DocId, Context, [{'doc_type', DocType} | Options]);
 load(DocId, Context, Options) ->
     load(DocId, Context, Options, cb_context:resp_status(Context)).
 
+-spec load(kz_term:ne_binary() | kz_term:ne_binaries(), cb_context:context(), load_options(), crossbar_status()) ->
+                  cb_context:context().
 load(_DocId, Context, _Options, 'error') -> Context;
 load(DocId, Context, Options, _RespStatus) when is_binary(DocId) ->
     case maybe_open_cache_doc(cb_context:account_db(Context), DocId, Options) of
@@ -228,10 +228,10 @@ depluralize_resource_name(Name) ->
     end.
 
 -spec handle_successful_load(cb_context:context(), kz_json:object()) -> cb_context:context().
--spec handle_successful_load(cb_context:context(), kz_json:object(), boolean()) -> cb_context:context().
 handle_successful_load(Context, JObj) ->
     handle_successful_load(Context, JObj, kz_doc:is_soft_deleted(JObj)).
 
+-spec handle_successful_load(cb_context:context(), kz_json:object(), boolean()) -> cb_context:context().
 handle_successful_load(Context, JObj, 'true') ->
     lager:debug("doc ~s(~s) is soft-deleted, returning bad_identifier"
                ,[kz_doc:id(JObj), kz_doc:revision(JObj)]
@@ -256,24 +256,24 @@ handle_successful_load(Context, JObj, 'false') ->
 %% Failure here returns 410, 500, or 503
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load_merge(kz_term:ne_binary(), cb_context:context()) ->
                         cb_context:context().
--spec load_merge(kz_term:ne_binary(), cb_context:context(), kz_term:proplist()) ->
-                        cb_context:context().
--spec load_merge(kz_term:ne_binary(), kz_json:object(), cb_context:context(), kz_term:proplist()) ->
-                        cb_context:context().
--spec load_merge(kz_term:ne_binary(), kz_json:object(), cb_context:context(), kz_term:proplist(), kz_term:api_object()) ->
-                        cb_context:context().
-
 load_merge(DocId, Context) ->
     load_merge(DocId, cb_context:doc(Context), Context, []).
 
+-spec load_merge(kz_term:ne_binary(), cb_context:context(), kz_term:proplist()) ->
+                        cb_context:context().
 load_merge(DocId, Context, Options) ->
     load_merge(DocId, cb_context:doc(Context), Context, Options).
 
+-spec load_merge(kz_term:ne_binary(), kz_json:object(), cb_context:context(), kz_term:proplist()) ->
+                        cb_context:context().
 load_merge(DocId, DataJObj, Context, Options) ->
     load_merge(DocId, DataJObj, Context, Options, cb_context:load_merge_bypass(Context)).
 
+-spec load_merge(kz_term:ne_binary(), kz_json:object(), cb_context:context(), kz_term:proplist(), kz_term:api_object()) ->
+                        cb_context:context().
 load_merge(DocId, DataJObj, Context, Options, 'undefined') ->
     Context1 = load(DocId, Context, Options),
     case success =:= cb_context:resp_status(Context1) of
@@ -290,11 +290,11 @@ load_merge(_DocId, _DataJObj, Context, _Options, BypassJObj) ->
 
 -spec patch_and_validate(kz_term:ne_binary(), cb_context:context(), validate_fun()) ->
                                 cb_context:context().
--spec patch_and_validate(kz_term:ne_binary(), cb_context:context(), validate_fun(), load_options()) ->
-                                cb_context:context().
 patch_and_validate(Id, Context, ValidateFun) ->
     patch_and_validate(Id, Context, ValidateFun, ?TYPE_CHECK_OPTION_ANY).
 
+-spec patch_and_validate(kz_term:ne_binary(), cb_context:context(), validate_fun(), load_options()) ->
+                                cb_context:context().
 patch_and_validate(Id, Context, ValidateFun, LoadOptions) ->
     Context1 = load(Id, Context, LoadOptions),
     patch_and_validate_doc(Id, Context1, ValidateFun, cb_context:resp_status(Context1)).
@@ -322,13 +322,8 @@ patch_the_doc(RequestData, ExistingDoc) ->
 %% Failure here returns 500 or 503
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context()) ->
-                       cb_context:context().
--spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context(), kz_json:json_term() | filter_fun()) ->
-                       cb_context:context().
--spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context(), kz_json:json_term(), pos_integer()) ->
-                       cb_context:context().
--spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context(), kz_json:json_term(), pos_integer(), filter_fun()) ->
                        cb_context:context().
 load_view(View, Options, Context) ->
     load_view(View, Options, Context
@@ -337,6 +332,8 @@ load_view(View, Options, Context) ->
              ,'undefined'
              ).
 
+-spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context(), kz_json:json_term() | filter_fun()) ->
+                       cb_context:context().
 load_view(View, Options, Context, FilterFun)
   when is_function(FilterFun, 2);
        is_function(FilterFun, 3) ->
@@ -350,9 +347,13 @@ load_view(View, Options, Context, StartKey) ->
              ,cb_context:pagination_page_size(Context)
              ).
 
+-spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context(), kz_json:json_term(), pos_integer()) ->
+                       cb_context:context().
 load_view(View, Options, Context, StartKey, PageSize) ->
     load_view(View, Options, Context, StartKey, PageSize, 'undefined').
 
+-spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context(), kz_json:json_term(), pos_integer(), filter_fun()) ->
+                       cb_context:context().
 load_view(View, Options, Context, StartKey, PageSize, FilterFun) ->
     load_view(
       #load_view_params{view = View
@@ -453,11 +454,11 @@ load_view(#load_view_params{view = View
     end.
 
 -spec limit_by_page_size(kz_term:api_binary() | pos_integer()) -> kz_term:api_pos_integer().
--spec limit_by_page_size(cb_context:context(), kz_term:api_binary() | pos_integer()) -> kz_term:api_pos_integer().
 limit_by_page_size('undefined') -> 'undefined';
 limit_by_page_size(N) when is_integer(N) -> N+1;
 limit_by_page_size(<<_/binary>> = B) -> limit_by_page_size(kz_term:to_integer(B)).
 
+-spec limit_by_page_size(cb_context:context(), kz_term:api_binary() | pos_integer()) -> kz_term:api_pos_integer().
 limit_by_page_size(Context, PageSize) ->
     case cb_context:should_paginate(Context) of
         'true' -> limit_by_page_size(PageSize);
@@ -467,10 +468,10 @@ limit_by_page_size(Context, PageSize) ->
     end.
 
 -spec start_key(cb_context:context()) -> kz_json:api_json_term().
--spec start_key(kz_term:proplist(), cb_context:context()) -> kz_json:api_json_term().
 start_key(Context) ->
     cb_context:req_value(Context, <<"start_key">>).
 
+-spec start_key(kz_term:proplist(), cb_context:context()) -> kz_json:api_json_term().
 start_key(Options, Context) ->
     case props:get_value('startkey_fun', Options) of
         'undefined' -> start_key_fun(Options, Context);
@@ -557,18 +558,19 @@ load_attachment(Doc, AName, Options, Context) ->
 %% Failure here returns 500 or 503
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(cb_context:context()) ->
                   cb_context:context().
--spec save(cb_context:context(), kz_term:proplist()) ->
-                  cb_context:context().
--spec save(cb_context:context(), kz_json:object() | kz_json:objects(), kz_term:proplist()) ->
-                  cb_context:context().
-
 save(Context) ->
     save(Context, []).
+
+-spec save(cb_context:context(), kz_term:proplist()) ->
+                  cb_context:context().
 save(Context, Options) ->
     save(Context, cb_context:doc(Context), Options).
 
+-spec save(cb_context:context(), kz_json:object() | kz_json:objects(), kz_term:proplist()) ->
+                  cb_context:context().
 save(Context, [], _Options) ->
     lager:debug("no docs to save"),
     cb_context:set_resp_status(Context, 'success');
@@ -604,19 +606,19 @@ save(Context, JObj, Options) ->
 %% Failure here returns 500 or 503
 %% @end
 %%--------------------------------------------------------------------
+
 -spec ensure_saved(cb_context:context()) ->
                           cb_context:context().
--spec ensure_saved(cb_context:context(), kz_term:proplist()) ->
-                          cb_context:context().
--spec ensure_saved(cb_context:context(), kz_json:object() | kz_json:objects(), kz_term:proplist()) ->
-                          cb_context:context().
-
 ensure_saved(Context) ->
     ensure_saved(Context, []).
 
+-spec ensure_saved(cb_context:context(), kz_term:proplist()) ->
+                          cb_context:context().
 ensure_saved(Context, Options) ->
     ensure_saved(Context, cb_context:doc(Context), Options).
 
+-spec ensure_saved(cb_context:context(), kz_json:object() | kz_json:objects(), kz_term:proplist()) ->
+                          cb_context:context().
 ensure_saved(Context, JObj, Options) ->
     JObj0 = update_pvt_parameters(JObj, Context),
     case kz_datamgr:ensure_saved(cb_context:account_db(Context), JObj0, Options) of
@@ -725,12 +727,12 @@ maybe_delete_doc(Context, DocId) ->
 %% Failure here returns 500 or 503
 %% @end
 %%--------------------------------------------------------------------
--spec delete(cb_context:context()) -> cb_context:context().
--spec delete(cb_context:context(), boolean()) -> cb_context:context().
 
+-spec delete(cb_context:context()) -> cb_context:context().
 delete(Context) ->
     delete(Context, cb_context:should_soft_delete(Context)).
 
+-spec delete(cb_context:context(), boolean()) -> cb_context:context().
 delete(Context, ?SOFT_DELETE) ->
     Doc = cb_context:doc(Context),
     lager:info("soft-deleting doc ~s", [kz_doc:id(Doc)]),
@@ -973,11 +975,11 @@ handle_datamgr_pagination_success([_|_]=JObjs
 
 -spec apply_filter(filter_fun(), kz_json:objects(), cb_context:context(), direction()) ->
                           kz_json:objects().
--spec apply_filter(filter_fun(), kz_json:objects(), cb_context:context(), direction(), boolean()) ->
-                          kz_json:objects().
 apply_filter(FilterFun, JObjs, Context, Direction) ->
     apply_filter(FilterFun, JObjs, Context, Direction, crossbar_filter:is_defined(Context)).
 
+-spec apply_filter(filter_fun(), kz_json:objects(), cb_context:context(), direction(), boolean()) ->
+                          kz_json:objects().
 apply_filter(FilterFun, JObjs, Context, Direction, HasQSFilter) ->
     lager:debug("applying filter fun: ~p, qs filter: ~p to dir ~p", [FilterFun, HasQSFilter, Direction]),
     Filtered0 = [JObj
@@ -1030,11 +1032,11 @@ handle_thing_success(Thing, Context) ->
 
 -spec handle_json_success(kz_json:object() | kz_json:objects(), cb_context:context()) ->
                                  cb_context:context().
--spec handle_json_success(kz_json:object() | kz_json:objects(), cb_context:context(), http_method()) ->
-                                 cb_context:context().
 handle_json_success(JObj, Context) ->
     handle_json_success(JObj, Context, cb_context:req_verb(Context)).
 
+-spec handle_json_success(kz_json:object() | kz_json:objects(), cb_context:context(), http_method()) ->
+                                 cb_context:context().
 handle_json_success([_|_]=JObjs, Context, ?HTTP_PUT) ->
     RespData = [kz_doc:public_fields(JObj)
                 || JObj <- JObjs,

--- a/applications/crossbar/src/crossbar_filter.erl
+++ b/applications/crossbar/src/crossbar_filter.erl
@@ -238,7 +238,6 @@ lowerbound(DocTimestamp, QSTimestamp) ->
     QSTimestamp =< DocTimestamp.
 
 -spec should_filter(binary(), kz_term:ne_binary()) -> boolean().
--spec should_filter(kz_json:object(), kz_term:ne_binary(), kz_json:json_term()) -> boolean().
 should_filter(Val, Val) -> 'true';
 should_filter(Val, FilterVal) ->
     try kz_json:unsafe_decode(FilterVal) of
@@ -251,6 +250,7 @@ should_filter(Val, FilterVal) ->
         _Error -> 'false'
     end.
 
+-spec should_filter(kz_json:object(), kz_term:ne_binary(), kz_json:json_term()) -> boolean().
 should_filter(Doc, Key, Val) ->
     Keys = binary_key_to_json_key(Key),
     should_filter(kz_json:get_binary_value(Keys, Doc, <<>>)

--- a/applications/crossbar/src/crossbar_freeswitch.erl
+++ b/applications/crossbar/src/crossbar_freeswitch.erl
@@ -524,10 +524,11 @@ xml_file_name(?FS_CHATPLAN) -> "chatplan.xml";
 xml_file_name(?FS_DIRECTORY) -> "directory.xml".
 
 -spec xml_file_from_config(?FS_CHATPLAN | ?FS_DIALPLAN | ?FS_DIRECTORY) -> kz_term:ne_binary().
--spec xml_file_from_config(?FS_CHATPLAN | ?FS_DIALPLAN | ?FS_DIRECTORY, kz_term:ne_binary()) -> kz_term:ne_binary().
 xml_file_from_config(Module) ->
     KeyName = <<(kz_term:to_binary(Module))/binary,"_top_dir_file_content">>,
     xml_file_from_config(Module, KeyName).
+
+-spec xml_file_from_config(?FS_CHATPLAN | ?FS_DIALPLAN | ?FS_DIRECTORY, kz_term:ne_binary()) -> kz_term:ne_binary().
 xml_file_from_config(Module, KeyName) ->
     xml_file_from_config(Module, kapps_config:get_binary(?MOD_CONFIG_CAT, KeyName), KeyName).
 

--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -123,12 +123,12 @@ add_missing_modules(Modules, MissingModules) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec refresh() -> 'ok'.
--spec refresh(input_term()) -> 'ok'.
 
+-spec refresh() -> 'ok'.
 refresh() ->
     io:format("please use kapps_maintenance:refresh().").
 
+-spec refresh(input_term()) -> 'ok'.
 refresh(Value) ->
     io:format("please use kapps_maintenance:refresh(~p).", [Value]).
 
@@ -489,10 +489,10 @@ db_system_schemas_exists() ->
     db_exists(?KZ_SCHEMA_DB).
 
 -spec db_exists(kz_term:ne_binary()) -> 'true'.
--spec db_exists(kz_term:ne_binary(), boolean()) -> 'true'.
 db_exists(Database) ->
     db_exists(Database, 'true').
 
+-spec db_exists(kz_term:ne_binary(), boolean()) -> 'true'.
 db_exists(Database, ShouldRetry) ->
     case kz_datamgr:db_exists(Database) of
         'true' -> 'true';
@@ -652,10 +652,11 @@ create_user(Context) ->
     end.
 
 -spec print_account_info(kz_term:ne_binary()) -> {'ok', kz_term:ne_binary()}.
--spec print_account_info(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kz_term:ne_binary()}.
 print_account_info(AccountDb) ->
     AccountId = kz_util:format_account_id(AccountDb, 'raw'),
     print_account_info(AccountDb, AccountId).
+
+-spec print_account_info(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kz_term:ne_binary()}.
 print_account_info(AccountDb, AccountId) ->
     case kz_datamgr:open_doc(AccountDb, AccountId) of
         {'ok', JObj} ->
@@ -699,11 +700,12 @@ maybe_move_account(AccountId, ToAccountId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec descendants_count() -> 'ok'.
--spec descendants_count(kz_term:ne_binary()) -> 'ok'.
 descendants_count() ->
     crossbar_util:descendants_count().
 
+-spec descendants_count(kz_term:ne_binary()) -> 'ok'.
 descendants_count(AccountId) ->
     crossbar_util:descendants_count(AccountId).
 
@@ -945,11 +947,11 @@ maybe_set_api_url(AppUrl, MetaData) ->
     kz_json:set_value(<<"api_url">>, AppUrl, MetaData).
 
 -spec maybe_create_app(file:filename_all(), kz_json:object()) -> 'ok'.
--spec maybe_create_app(file:filename_all(), kz_json:object(), kz_term:ne_binary()) -> 'ok'.
 maybe_create_app(AppPath, MetaData) ->
     {'ok', MasterAccountDb} = kapps_util:get_master_account_db(),
     maybe_create_app(AppPath, MetaData, MasterAccountDb).
 
+-spec maybe_create_app(file:filename_all(), kz_json:object(), kz_term:ne_binary()) -> 'ok'.
 maybe_create_app(AppPath, MetaData, MasterAccountDb) ->
     AppName = kzd_app:name(MetaData),
     case find_app(MasterAccountDb, AppName) of
@@ -1154,15 +1156,18 @@ set_app_field(AppId, Field, Value) ->
     update_app(AppId, [Field], Value).
 
 -spec set_app_label(kz_term:ne_binary(), kz_term:ne_binary()) -> no_return.
--spec set_app_description(kz_term:ne_binary(), kz_term:ne_binary()) -> no_return.
--spec set_app_extended_description(kz_term:ne_binary(), kz_term:ne_binary()) -> no_return.
--spec set_app_features(kz_term:ne_binary(), kz_term:ne_binary()) -> no_return.
 set_app_label(AppId, Value) ->
     update_app(AppId, [<<"i18n">>, <<"en-US">>, <<"label">>], Value).
+
+-spec set_app_description(kz_term:ne_binary(), kz_term:ne_binary()) -> no_return.
 set_app_description(AppId, Value) ->
     update_app(AppId, [<<"i18n">>, <<"en-US">>, <<"description">>], Value).
+
+-spec set_app_extended_description(kz_term:ne_binary(), kz_term:ne_binary()) -> no_return.
 set_app_extended_description(AppId, Value) ->
     update_app(AppId, [<<"i18n">>, <<"en-US">>, <<"extended_description">>], Value).
+
+-spec set_app_features(kz_term:ne_binary(), kz_term:ne_binary()) -> no_return.
 set_app_features(AppId, Value) ->
     Values = [V || V <- binary:split(Value, <<$@>>, [global]),
                    V =/= <<>>

--- a/applications/crossbar/src/crossbar_module_sup.erl
+++ b/applications/crossbar/src/crossbar_module_sup.erl
@@ -35,9 +35,10 @@ start_link() ->
     supervisor:start_link({'local', ?SERVER}, ?MODULE, []).
 
 -spec start_child(module()) -> kz_types:sup_startchild_ret().
--spec start_child(module(), 'worker' | 'supervisor') -> kz_types:sup_startchild_ret().
 start_child(Mod) ->
     start_child(Mod, 'worker').
+
+-spec start_child(module(), 'worker' | 'supervisor') -> kz_types:sup_startchild_ret().
 start_child(Mod, 'worker') ->
     supervisor:start_child(?SERVER, ?WORKER(Mod));
 start_child(Mod, 'supervisor') ->

--- a/applications/crossbar/src/crossbar_services.erl
+++ b/applications/crossbar/src/crossbar_services.erl
@@ -23,12 +23,12 @@
 -type callback() :: fun(() -> cb_context:context()).
 
 -spec maybe_dry_run(cb_context:context(), callback()) -> cb_context:context().
--spec maybe_dry_run(cb_context:context(), callback(), kz_term:ne_binary() | kz_term:proplist()) ->
-                           cb_context:context().
 maybe_dry_run(Context, Callback) ->
     Type = kz_doc:type(cb_context:doc(Context)),
     maybe_dry_run(Context, Callback, Type).
 
+-spec maybe_dry_run(cb_context:context(), callback(), kz_term:ne_binary() | kz_term:proplist()) ->
+                           cb_context:context().
 maybe_dry_run(Context, Callback, Type) when is_binary(Type) ->
     maybe_dry_run(Context, Callback, Type, [], cb_context:accepting_charges(Context));
 maybe_dry_run(Context, Callback, Props) ->
@@ -114,17 +114,18 @@ extract_item_from_category(CategoryKey, ItemKey, ItemJObj, Acc) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec create_transactions(cb_context:context()
                          ,kz_json:object()
                          ,kz_transaction:transactions()) -> kz_transaction:transactions().
--spec create_transactions(cb_context:context()
-                         ,kz_json:object()
-                         ,kz_transaction:transactions()
-                         ,integer()) -> kz_transaction:transactions().
 create_transactions(Context, Item, Acc) ->
     Quantity = kz_json:get_integer_value(<<"activate_quantity">>, Item, 0),
     create_transactions(Context, Item, Acc, Quantity).
 
+-spec create_transactions(cb_context:context()
+                         ,kz_json:object()
+                         ,kz_transaction:transactions()
+                         ,integer()) -> kz_transaction:transactions().
 create_transactions(_Context, _Item, Acc, 0) -> Acc;
 create_transactions(Context, Item, Acc, Quantity) ->
     AccountId = cb_context:account_id(Context),
@@ -166,9 +167,8 @@ dry_run(Services) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec calc_service_updates(cb_context:context(), kz_term:ne_binary()) ->
-                                  kz_services:services() | 'undefined'.
--spec calc_service_updates(cb_context:context(), kz_term:ne_binary(), kz_term:proplist()) ->
                                   kz_services:services() | 'undefined'.
 calc_service_updates(Context, <<"device">>) ->
     DeviceType = kz_device:device_type(cb_context:doc(Context)),
@@ -218,6 +218,8 @@ calc_service_updates(_Context, _Type) ->
     lager:warning("unknown type ~p, cannot calculate service updates", [_Type]),
     'undefined'.
 
+-spec calc_service_updates(cb_context:context(), kz_term:ne_binary(), kz_term:proplist()) ->
+                                  kz_services:services() | 'undefined'.
 calc_service_updates(Context, <<"ips">>, Props) ->
     Services = fetch_service(Context),
     kz_service_ips:reconcile(Services, Props);

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -104,10 +104,11 @@ response(JTerm, Context) ->
 
 -spec response_202(kz_term:api_ne_binary(), cb_context:context()) ->
                           cb_context:context().
--spec response_202(kz_term:api_ne_binary(), kz_json:json_term(), cb_context:context()) ->
-                          cb_context:context().
 response_202(Msg, Context) ->
     response_202(Msg, Msg, Context).
+
+-spec response_202(kz_term:api_ne_binary(), kz_json:json_term(), cb_context:context()) ->
+                          cb_context:context().
 response_202(Msg, JTerm, Context) ->
     create_response('success', Msg, 202, JTerm, Context).
 
@@ -220,10 +221,11 @@ response_deprecated(Context) ->
 
 -spec response_deprecated_redirect(cb_context:context(), kz_term:ne_binary()) ->
                                           cb_context:context().
--spec response_deprecated_redirect(cb_context:context(), kz_term:ne_binary(), kz_json:object()) ->
-                                          cb_context:context().
 response_deprecated_redirect(Context, RedirectUrl) ->
     response_deprecated_redirect(Context, RedirectUrl, kz_json:new()).
+
+-spec response_deprecated_redirect(cb_context:context(), kz_term:ne_binary(), kz_json:object()) ->
+                                          cb_context:context().
 response_deprecated_redirect(Context, RedirectUrl, JObj) ->
     create_response('error', <<"deprecated">>, 301, JObj
                    ,cb_context:add_resp_header(Context, <<"Location">>, RedirectUrl)
@@ -437,10 +439,8 @@ maybe_flush_registration_on_deleted(Realm, _OldDevice, NewDevice) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec move_account(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                          {'ok', kz_json:object()} |
-                          {'error', any()}.
--spec move_account(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binaries()) ->
                           {'ok', kz_json:object()} |
                           {'error', any()}.
 move_account(?MATCH_ACCOUNT_RAW(AccountId), ToAccount=?NE_BINARY) ->
@@ -450,6 +450,9 @@ move_account(?MATCH_ACCOUNT_RAW(AccountId), ToAccount=?NE_BINARY) ->
             move_account(AccountId, JObj, ToAccount, ToTree)
     end.
 
+-spec move_account(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binaries()) ->
+                          {'ok', kz_json:object()} |
+                          {'error', any()}.
 move_account(AccountId, JObj, ToAccount, ToTree) ->
     AccountDb = kz_util:format_account_db(AccountId),
     PreviousTree = kz_account:tree(JObj),
@@ -637,21 +640,22 @@ enable_account(AccountId) ->
 %% Helper to set data for all auth type
 %% @end
 %%--------------------------------------------------------------------
+
 -spec response_auth(kz_json:object()) ->
-                           kz_json:object().
--spec response_auth(kz_json:object(), kz_term:api_binary()) ->
-                           kz_json:object().
--spec response_auth(kz_json:object(), kz_term:api_binary(), kz_term:api_binary()) ->
                            kz_json:object().
 response_auth(JObj) ->
     AccountId = kz_json:get_first_defined([<<"account_id">>, <<"pvt_account_id">>], JObj),
     OwnerId = kz_json:get_first_defined([<<"owner_id">>, <<"user_id">>], JObj),
     response_auth(JObj, AccountId, OwnerId).
 
+-spec response_auth(kz_json:object(), kz_term:api_binary()) ->
+                           kz_json:object().
 response_auth(JObj, AccountId) ->
     OwnerId = kz_json:get_first_defined([<<"owner_id">>, <<"user_id">>], JObj),
     response_auth(JObj, AccountId, OwnerId).
 
+-spec response_auth(kz_json:object(), kz_term:api_binary(), kz_term:api_binary()) ->
+                           kz_json:object().
 response_auth(JObj, AccountId, UserId) ->
     populate_resp(JObj, AccountId, UserId).
 
@@ -738,14 +742,15 @@ change_pvt_enabled(State, AccountId) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_language(kz_term:ne_binary()) -> kz_term:ne_binary().
--spec get_language(kz_term:ne_binary(), kz_term:api_binary()) -> kz_term:ne_binary().
 get_language(AccountId) ->
     case get_account_lang(AccountId) of
         {'ok', Lang} -> Lang;
         'error' -> ?DEFAULT_LANGUAGE
     end.
 
+-spec get_language(kz_term:ne_binary(), kz_term:api_binary()) -> kz_term:ne_binary().
 get_language(AccountId, 'undefined') ->
     case get_account_lang(AccountId) of
         {'ok', Lang} -> Lang;
@@ -942,8 +947,8 @@ get_priv_level_restrictions(Restrictions, PrivLevel) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec descendants_count() -> 'ok'.
--spec descendants_count(kz_term:proplist() | kz_term:ne_binary()) -> 'ok'.
 descendants_count() ->
     Limit = kapps_config:get_integer(?SYSCONFIG_COUCH, <<"default_chunk_size">>, 1000),
     ViewOptions = [{'limit', Limit}
@@ -951,6 +956,7 @@ descendants_count() ->
                   ],
     descendants_count(ViewOptions).
 
+-spec descendants_count(kz_term:proplist() | kz_term:ne_binary()) -> 'ok'.
 descendants_count(<<_/binary>> = Account) ->
     AccountId = kz_util:format_account_id(Account, 'raw'),
     descendants_count([{'key', AccountId}]);
@@ -995,9 +1001,8 @@ handle_no_descendants(ViewOptions) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec format_emergency_caller_id_number(cb_context:context()) ->
-                                               cb_context:context().
--spec format_emergency_caller_id_number(cb_context:context(), kz_json:object()) ->
                                                cb_context:context().
 format_emergency_caller_id_number(Context) ->
     case cb_context:req_value(Context, [<<"caller_id">>, ?KEY_EMERGENCY]) of
@@ -1006,6 +1011,8 @@ format_emergency_caller_id_number(Context) ->
             format_emergency_caller_id_number(Context, Emergency)
     end.
 
+-spec format_emergency_caller_id_number(cb_context:context(), kz_json:object()) ->
+                                               cb_context:context().
 format_emergency_caller_id_number(Context, Emergency) ->
     case kz_json:get_ne_binary_value(<<"number">>, Emergency) of
         'undefined' -> Context;
@@ -1191,14 +1198,12 @@ load_descendants_count(ViewOptions) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec maybe_update_descendants_count(kz_term:ne_binary(), integer()) -> 'ok'.
--spec maybe_update_descendants_count(kz_term:ne_binary(), integer(), integer()) -> 'ok'.
--spec maybe_update_descendants_count(kz_term:ne_binary(), kz_json:object(), integer(), integer()) -> 'ok'.
--spec maybe_update_descendants_count(kz_term:ne_binary(), kz_json:object(), integer(), integer(), integer()) -> 'ok'.
 
+-spec maybe_update_descendants_count(kz_term:ne_binary(), integer()) -> 'ok'.
 maybe_update_descendants_count(AccountId, NewCount) ->
     maybe_update_descendants_count(AccountId, NewCount, 3).
 
+-spec maybe_update_descendants_count(kz_term:ne_binary(), integer(), integer()) -> 'ok'.
 maybe_update_descendants_count(AccountId, _, Try) when Try =< 0 ->
     io:format("too many attempts to update descendants count for ~s~n", [AccountId]);
 maybe_update_descendants_count(AccountId, NewCount, Try) ->
@@ -1209,10 +1214,12 @@ maybe_update_descendants_count(AccountId, NewCount, Try) ->
             maybe_update_descendants_count(AccountId, JObj, NewCount, Try)
     end.
 
+-spec maybe_update_descendants_count(kz_term:ne_binary(), kz_json:object(), integer(), integer()) -> 'ok'.
 maybe_update_descendants_count(AccountId, JObj, NewCount, Try) ->
     OldCount = kz_json:get_integer_value(<<"descendants_count">>, JObj),
     maybe_update_descendants_count(AccountId, JObj, NewCount, OldCount, Try).
 
+-spec maybe_update_descendants_count(kz_term:ne_binary(), kz_json:object(), integer(), integer(), integer()) -> 'ok'.
 maybe_update_descendants_count(_, _, Count, Count, _) -> 'ok';
 maybe_update_descendants_count(AccountId, JObj, NewCount, _, Try) ->
     case update_descendants_count(AccountId, JObj, NewCount) of
@@ -1245,9 +1252,8 @@ update_descendants_count(AccountId, JObj, NewCount) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_validate_quickcall(cb_context:context()) ->
-                                      cb_context:context().
--spec maybe_validate_quickcall(cb_context:context(), crossbar_status()) ->
                                       cb_context:context().
 maybe_validate_quickcall(Context) ->
     case kz_buckets:consume_tokens(?APP_NAME
@@ -1259,6 +1265,8 @@ maybe_validate_quickcall(Context) ->
         'true' -> maybe_validate_quickcall(Context, cb_context:resp_status(Context))
     end.
 
+-spec maybe_validate_quickcall(cb_context:context(), crossbar_status()) ->
+                                      cb_context:context().
 maybe_validate_quickcall(Context, 'success') ->
     AllowAnon = kz_json:is_true(<<"allow_anonymous_quickcalls">>, cb_context:doc(Context)),
 

--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -91,12 +91,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), kz_term:ne_binary()) -> http_methods().
 allowed_methods() ->
     [?HTTP_PUT].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(AccountId) ->
     allowed_methods_on_account(AccountId, kapps_util:get_master_account_id()).
 
@@ -112,6 +112,7 @@ allowed_methods_on_account(_AccountId, {'error', _E}) ->
     lager:info("disallowing DELETE while we can't determine the master account id"),
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_POST, ?HTTP_PATCH].
 
+-spec allowed_methods(path_token(), kz_term:ne_binary()) -> http_methods().
 allowed_methods(_AccountId, ?MOVE) ->
     [?HTTP_POST];
 allowed_methods(_AccountId, ?RESELLER) ->
@@ -131,11 +132,14 @@ allowed_methods(_AccountId, ?PARENTS) -> [?HTTP_GET].
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), kz_term:ne_binary()) -> boolean().
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), kz_term:ne_binary()) -> boolean().
 resource_exists(_, Path) ->
     Paths =  [?CHILDREN
              ,?DESCENDANTS
@@ -157,13 +161,16 @@ resource_exists(_, Path) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate_resource(cb_context:context()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token(), kz_term:ne_binary()) -> cb_context:context().
 validate_resource(Context) ->
     Context.
+
+-spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
 validate_resource(Context, AccountId) ->
     load_account_db(Context, AccountId).
+
+-spec validate_resource(cb_context:context(), path_token(), kz_term:ne_binary()) -> cb_context:context().
 validate_resource(Context, AccountId, _Path) ->
     load_account_db(Context, AccountId).
 
@@ -176,13 +183,9 @@ validate_resource(Context, AccountId, _Path) ->
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) ->
                       cb_context:context().
--spec validate(cb_context:context(), path_token()) ->
-                      cb_context:context().
--spec validate(cb_context:context(), path_token(), kz_term:ne_binary()) ->
-                      cb_context:context().
-
 validate(Context) ->
     validate_accounts(Context, cb_context:req_verb(Context)).
 
@@ -190,6 +193,8 @@ validate(Context) ->
 validate_accounts(Context, ?HTTP_PUT) ->
     validate_request('undefined', prepare_context('undefined', Context)).
 
+-spec validate(cb_context:context(), path_token()) ->
+                      cb_context:context().
 validate(Context, AccountId) ->
     validate_account(Context, AccountId, cb_context:req_verb(Context)).
 
@@ -205,6 +210,8 @@ validate_account(Context, AccountId, ?HTTP_PATCH) ->
 validate_account(Context, AccountId, ?HTTP_DELETE) ->
     validate_delete_request(AccountId, prepare_context(AccountId, Context)).
 
+-spec validate(cb_context:context(), path_token(), kz_term:ne_binary()) ->
+                      cb_context:context().
 validate(Context, AccountId, PathToken) ->
     validate_account_path(Context, AccountId, PathToken, cb_context:req_verb(Context)).
 
@@ -283,8 +290,8 @@ validate_account_path(Context, AccountId, ?TREE, ?HTTP_GET) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, AccountId) ->
     {'ok', Existing} = kz_account:fetch(AccountId),
     Context1 = crossbar_doc:save(Context),
@@ -303,6 +310,7 @@ post(Context, AccountId) ->
         _Status -> Context1
     end.
 
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, AccountId, ?MOVE) ->
     case cb_context:resp_status(Context) of
         'success' -> move_account(Context, AccountId);
@@ -319,13 +327,12 @@ patch(Context, AccountId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec put(cb_context:context()) -> cb_context:context().
--spec put(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
--spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 
+-spec put(cb_context:context()) -> cb_context:context().
 put(Context) ->
     put(Context, 'undefined').
 
+-spec put(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 put(Context, PathAccountId) ->
     JObj = cb_context:doc(Context),
     NewAccountId = kz_doc:id(JObj, kz_datamgr:get_uuid()),
@@ -353,6 +360,7 @@ put(Context, PathAccountId) ->
             cb_context:add_system_error('unspecified_fault', <<"internal error, unable to create the account">>, Context)
     end.
 
+-spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context, _AccountId, ?API_KEY) ->
     C1 = crossbar_doc:save(Context),
     case cb_context:resp_status(C1) of
@@ -376,9 +384,8 @@ put(Context, AccountId, ?RESELLER) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec delete(cb_context:context(), path_token()) -> cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 
+-spec delete(cb_context:context(), path_token()) -> cb_context:context().
 delete(Context, Account) ->
     AccountDb = kz_util:format_account_id(Account, 'encoded'),
     AccountId = kz_util:format_account_id(Account, 'raw'),
@@ -391,6 +398,7 @@ delete(Context, Account) ->
             Context1
     end.
 
+-spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 delete(Context, AccountId, ?RESELLER) ->
     case whs_account_conversion:demote(AccountId) of
         {'error', 'master_account'} -> cb_context:add_system_error('forbidden', Context);
@@ -470,8 +478,8 @@ move_account(Context, AccountId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec prepare_context(kz_term:api_ne_binary(), cb_context:context()) -> cb_context:context().
--spec prepare_context(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary()) -> cb_context:context().
 prepare_context('undefined', Context) ->
     cb_context:set_account_db(Context, ?KZ_ACCOUNTS_DB);
 prepare_context(Account, Context) ->
@@ -479,6 +487,7 @@ prepare_context(Account, Context) ->
     AccountDb = kz_util:format_account_db(Account),
     prepare_context(Context, AccountId, AccountDb).
 
+-spec prepare_context(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary()) -> cb_context:context().
 prepare_context(Context, AccountId, AccountDb) ->
     cb_context:setters(Context, [{fun cb_context:set_account_db/2, AccountDb}
                                 ,{fun cb_context:set_account_id/2, AccountId}
@@ -610,10 +619,6 @@ on_successful_validation(AccountId, Context) ->
 
 -spec maybe_import_enabled(cb_context:context()) ->
                                   cb_context:context().
--spec maybe_import_enabled(cb_context:context(), crossbar_status()) ->
-                                  cb_context:context().
--spec maybe_import_enabled(cb_context:context(), kz_json:object(), kz_term:api_binary()) ->
-                                  cb_context:context().
 maybe_import_enabled(Context) ->
     case cb_context:auth_account_id(Context) =:= cb_context:account_id(Context) of
         'true' ->
@@ -624,6 +629,8 @@ maybe_import_enabled(Context) ->
             maybe_import_enabled(Context, cb_context:resp_status(Context))
     end.
 
+-spec maybe_import_enabled(cb_context:context(), crossbar_status()) ->
+                                  cb_context:context().
 maybe_import_enabled(Context, 'success') ->
     AuthAccountId = cb_context:auth_account_id(Context),
     Doc = cb_context:doc(Context),
@@ -635,6 +642,8 @@ maybe_import_enabled(Context, 'success') ->
         'true' -> maybe_import_enabled(Context, NewDoc, Enabled)
     end.
 
+-spec maybe_import_enabled(cb_context:context(), kz_json:object(), kz_term:api_binary()) ->
+                                  cb_context:context().
 maybe_import_enabled(Context, _, 'undefined') -> Context;
 maybe_import_enabled(Context, Doc, IsEnabled) ->
     NewDoc = case kz_term:is_true(IsEnabled) of
@@ -713,11 +722,12 @@ load_account(AccountId, Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec leak_pvt_fields(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
--spec leak_pvt_fields(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> cb_context:context().
 leak_pvt_fields(AccountId, Context) ->
     leak_pvt_fields(AccountId, Context, cb_context:resp_status(Context)).
 
+-spec leak_pvt_fields(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> cb_context:context().
 leak_pvt_fields(AccountId, Context, 'success') ->
     Routines = [fun leak_pvt_allow_additions/1
                ,fun leak_pvt_superduper_admin/1
@@ -841,10 +851,10 @@ find_reseller_id(Context, PathAccountId) ->
     end.
 
 -spec leak_notification_preference(cb_context:context()) -> cb_context:context().
--spec leak_notification_preference(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 leak_notification_preference(Context) ->
     leak_notification_preference(Context, kz_account:notification_preference(cb_context:doc(Context))).
 
+-spec leak_notification_preference(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 leak_notification_preference(Context, 'undefined') ->
     Context;
 leak_notification_preference(Context, Pref) ->
@@ -853,12 +863,12 @@ leak_notification_preference(Context, Pref) ->
 
 -spec leak_trial_time_left(cb_context:context()) ->
                                   cb_context:context().
--spec leak_trial_time_left(cb_context:context(), kz_json:object(), kz_term:api_integer()) ->
-                                  cb_context:context().
 leak_trial_time_left(Context) ->
     JObj = cb_context:doc(Context),
     leak_trial_time_left(Context, JObj, kz_account:trial_expiration(JObj)).
 
+-spec leak_trial_time_left(cb_context:context(), kz_json:object(), kz_term:api_integer()) ->
+                                  cb_context:context().
 leak_trial_time_left(Context, _JObj, 'undefined') ->
     RespData = kz_json:delete_key(<<"trial_time_left">>
                                  ,cb_context:resp_data(Context)
@@ -1116,12 +1126,13 @@ extract_tree(AccountId, JObjs) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec find_accounts_from_tree(kz_term:ne_binaries(), kz_json:objects(), cb_context:context()) -> kz_json:objects().
--spec find_accounts_from_tree(kz_term:ne_binaries(), kz_json:objects(), kz_term:ne_binary(), kz_json:objects()) -> kz_json:objects().
 find_accounts_from_tree(Tree, JObjs, Context) ->
     AuthAccountId = cb_context:auth_account_id(Context),
     find_accounts_from_tree(lists:reverse(Tree), JObjs, AuthAccountId, []).
 
+-spec find_accounts_from_tree(kz_term:ne_binaries(), kz_json:objects(), kz_term:ne_binary(), kz_json:objects()) -> kz_json:objects().
 find_accounts_from_tree([], _, _, Acc) -> Acc;
 find_accounts_from_tree([AuthAccountId|_], JObjs, AuthAccountId, Acc) ->
     JObj = kz_json:find_value(<<"id">>, AuthAccountId, JObjs),
@@ -1586,12 +1597,12 @@ delete_remove_db(Context) ->
     end.
 
 -spec delete_mod_dbs(cb_context:context()) -> 'true'.
--spec delete_mod_dbs(kz_term:ne_binary(), kz_time:year(), kz_time:month()) -> 'true'.
 delete_mod_dbs(Context) ->
     AccountId = cb_context:account_id(Context),
     {Year, Month, _} = erlang:date(),
     delete_mod_dbs(AccountId, Year, Month).
 
+-spec delete_mod_dbs(kz_term:ne_binary(), kz_time:year(), kz_time:month()) -> 'true'.
 delete_mod_dbs(AccountId, Year, Month) ->
     Db = kz_util:format_account_mod_id(AccountId, Year, Month),
     case kz_datamgr:db_delete(Db) of

--- a/applications/crossbar/src/modules/cb_alerts.erl
+++ b/applications/crossbar/src/modules/cb_alerts.erl
@@ -48,10 +48,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_AlertId) ->
     [?HTTP_GET, ?HTTP_DELETE].
 
@@ -64,9 +66,11 @@ allowed_methods(_AlertId) ->
 %%    /alerts/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -79,10 +83,12 @@ resource_exists(_) -> 'true'.
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_alerts(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_alert(Context, Id, cb_context:req_verb(Context)).
 

--- a/applications/crossbar/src/modules/cb_allotments.erl
+++ b/applications/crossbar/src/modules/cb_allotments.erl
@@ -44,10 +44,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_POST].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?CONSUMED) ->
     [?HTTP_GET].
 
@@ -59,9 +61,11 @@ allowed_methods(?CONSUMED) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(?CONSUMED) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -245,11 +249,12 @@ is_allowed(Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_create_limits_doc(cb_context:context()) -> cb_context:context().
--spec maybe_create_limits_doc(cb_context:context(), pos_integer()) -> cb_context:context().
 maybe_create_limits_doc(Context) ->
     maybe_create_limits_doc(Context, cb_context:resp_error_code(Context)).
 
+-spec maybe_create_limits_doc(cb_context:context(), pos_integer()) -> cb_context:context().
 maybe_create_limits_doc(Context, 404) ->
     Data = cb_context:req_data(Context),
     NewLimits = kz_json:from_list([{<<"pvt_type">>, ?PVT_TYPE}, {<<"_id">>, ?PVT_TYPE}]),

--- a/applications/crossbar/src/modules/cb_api_auth.erl
+++ b/applications/crossbar/src/modules/cb_api_auth.erl
@@ -138,8 +138,6 @@ on_successful_validation(Context) ->
     end.
 
 -spec validate_by_api_key(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
--spec validate_by_api_key(cb_context:context(), kz_term:ne_binary(), kz_json:object() | kz_json:objects()) ->
-                                 cb_context:context().
 validate_by_api_key(Context, ApiKey) ->
     Context1 = crossbar_doc:load_view(?AGG_VIEW_API
                                      ,[{'key', ApiKey}]
@@ -151,6 +149,8 @@ validate_by_api_key(Context, ApiKey) ->
         _Status -> Context1
     end.
 
+-spec validate_by_api_key(cb_context:context(), kz_term:ne_binary(), kz_json:object() | kz_json:objects()) ->
+                                 cb_context:context().
 validate_by_api_key(Context, ApiKey, []) ->
     lager:debug("api key '~s' not associated with any accounts"
                ,[ApiKey]

--- a/applications/crossbar/src/modules/cb_apps_store.erl
+++ b/applications/crossbar/src/modules/cb_apps_store.erl
@@ -57,18 +57,22 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?BLACKLIST) ->
     [?HTTP_GET, ?HTTP_POST];
 allowed_methods(_AppId) ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_POST, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_AppId, ?ICON) ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(_AppId, ?SCREENSHOT, _AppScreenshotIndex) ->
     [?HTTP_GET].
 
@@ -78,13 +82,17 @@ allowed_methods(_AppId, ?SCREENSHOT, _AppScreenshotIndex) ->
 %% Does the path point to a valid resource
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, _) -> 'true'.
+
+-spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 resource_exists(_, _, _) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -92,9 +100,8 @@ resource_exists(_, _, _) -> 'true'.
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
-                                    cb_context:context().
--spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token()) ->
                                     cb_context:context().
 content_types_provided(Context, Id, ?ICON) ->
     Context1 = load_app_from_master_account(Context, Id),
@@ -113,6 +120,8 @@ content_types_provided(Context, Id, ?ICON) ->
     end;
 content_types_provided(Context, _, _) -> Context.
 
+-spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, Id, ?SCREENSHOT, Number) ->
     Context1 = load_app_from_master_account(Context, Id),
     case cb_context:resp_status(Context1) of
@@ -134,11 +143,12 @@ content_types_provided(Context, _, _, _) -> Context.
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec authenticate(cb_context:context()) -> boolean().
--spec authenticate(http_method(), req_nouns()) -> boolean().
 authenticate(Context) ->
     authenticate(cb_context:req_verb(Context), cb_context:req_nouns(Context)).
 
+-spec authenticate(http_method(), req_nouns()) -> boolean().
 authenticate(?HTTP_GET, [{<<"apps_store">>,[_Id, ?ICON]}]) ->
     lager:debug("authenticating request"),
     'true';
@@ -149,10 +159,10 @@ authenticate(_Verb, _Nouns) ->
     'false'.
 
 -spec authorize(cb_context:context()) -> boolean().
--spec authorize(http_method(), req_nouns()) -> boolean().
 authorize(Context) ->
     authorize(cb_context:req_verb(Context), cb_context:req_nouns(Context)).
 
+-spec authorize(http_method(), req_nouns()) -> boolean().
 authorize(?HTTP_GET, [{<<"apps_store">>,[_Id, ?ICON]}]) ->
     lager:debug("authorizing request"),
     'true';
@@ -167,19 +177,19 @@ authorize(_Verb, _Nouns) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     load_apps(Context).
 
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?BLACKLIST) ->
     validate_req(Context, cb_context:req_verb(Context));
 validate(Context, Id) ->
     validate_app(Context, Id, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, AppId, ?ICON) ->
     Context1 = load_app_from_master_account(Context, AppId),
     case cb_context:resp_status(Context1) of
@@ -187,6 +197,7 @@ validate(Context, AppId, ?ICON) ->
         _ -> Context1
     end.
 
+-spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context, AppId, ?SCREENSHOT, Number) ->
     Context1 = load_app_from_master_account(Context, AppId),
     case cb_context:resp_status(Context1) of
@@ -389,11 +400,12 @@ load_apps(Context) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec normalize_apps_result(kz_json:objects()) -> kz_json:objects().
--spec normalize_apps_result(kz_json:objects(), kz_json:objects()) -> kz_json:objects().
 normalize_apps_result(Apps) ->
     normalize_apps_result(Apps, []).
 
+-spec normalize_apps_result(kz_json:objects(), kz_json:objects()) -> kz_json:objects().
 normalize_apps_result([], Acc) -> Acc;
 normalize_apps_result([App|Apps], Acc) ->
     case kzd_app:is_published(App) of
@@ -615,9 +627,8 @@ load_apps_store(Context) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_attachment(cb_context:context(), kz_term:ne_binary()) ->
-                            cb_context:context().
--spec get_attachment(cb_context:context(), kz_term:ne_binary(), kz_json:object(), kz_json:object()) ->
                             cb_context:context().
 get_attachment(Context, Id) ->
     JObj = cb_context:doc(Context),
@@ -629,6 +640,8 @@ get_attachment(Context, Id) ->
             get_attachment(Context, Id, JObj, Attachment)
     end.
 
+-spec get_attachment(cb_context:context(), kz_term:ne_binary(), kz_json:object(), kz_json:object()) ->
+                            cb_context:context().
 get_attachment(Context, Id, JObj, Attachment) ->
     Db = kz_doc:account_db(JObj),
     AppId = kz_doc:id(JObj),

--- a/applications/crossbar/src/modules/cb_auth.erl
+++ b/applications/crossbar/src/modules/cb_auth.erl
@@ -213,10 +213,12 @@ authenticate_nouns(?TOKENINFO_PATH, ?HTTP_POST, [{<<"auth">>, _}]) -> 'true';
 authenticate_nouns(_, _, _) -> 'false'.
 
 -spec validate_resource(cb_context:context()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token(), kz_term:ne_binary()) -> cb_context:context().
 validate_resource(Context) -> cb_context:set_account_db(Context, ?KZ_AUTH_DB).
+
+-spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
 validate_resource(Context, _Path) -> cb_context:set_account_db(Context, ?KZ_AUTH_DB).
+
+-spec validate_resource(cb_context:context(), path_token(), kz_term:ne_binary()) -> cb_context:context().
 validate_resource(Context, _Path, _Id) -> cb_context:set_account_db(Context, ?KZ_AUTH_DB).
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_basic_auth.erl
+++ b/applications/crossbar/src/modules/cb_basic_auth.erl
@@ -41,15 +41,16 @@ init() ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec authenticate(cb_context:context()) ->
-                          'false' |
-                          {'true' | 'stop', cb_context:context()}.
--spec authenticate(cb_context:context(), atom()) ->
                           'false' |
                           {'true' | 'stop', cb_context:context()}.
 authenticate(Context) ->
     authenticate(Context, cb_context:auth_token_type(Context)).
 
+-spec authenticate(cb_context:context(), atom()) ->
+                          'false' |
+                          {'true' | 'stop', cb_context:context()}.
 authenticate(Context, 'basic') ->
     _ = cb_context:put_reqid(Context),
     case kz_buckets:consume_tokens(?APP_NAME

--- a/applications/crossbar/src/modules/cb_blacklists.erl
+++ b/applications/crossbar/src/modules/cb_blacklists.erl
@@ -46,10 +46,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_BlacklistId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -61,9 +63,11 @@ allowed_methods(_BlacklistId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -75,21 +79,22 @@ resource_exists(_) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_set(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, DocId) ->
     validate_set(Context, cb_context:req_verb(Context), DocId).
 
 -spec validate_set(cb_context:context(), path_token()) -> cb_context:context().
--spec validate_set(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate_set(Context, ?HTTP_GET) ->
     summary(Context);
 validate_set(Context, ?HTTP_PUT) ->
     create(Context).
 
+-spec validate_set(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate_set(Context, ?HTTP_GET, DocId) ->
     read(DocId, Context);
 validate_set(Context, ?HTTP_POST, DocId) ->

--- a/applications/crossbar/src/modules/cb_braintree.erl
+++ b/applications/crossbar/src/modules/cb_braintree.erl
@@ -57,8 +57,8 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?CUSTOMER_PATH_TOKEN) ->
     [?HTTP_GET, ?HTTP_POST];
 allowed_methods(?CARDS_PATH_TOKEN) ->
@@ -72,6 +72,7 @@ allowed_methods(?CREDITS_PATH_TOKEN) ->
 allowed_methods(?CLIENT_TOKEN_PATH_TOKEN) ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?CARDS_PATH_TOKEN, _CardId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE];
 allowed_methods(?ADDRESSES_PATH_TOKEN, _AddressId) ->
@@ -87,8 +88,8 @@ allowed_methods(?TRANSACTIONS_PATH_TOKEN, _TransactionId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(?CUSTOMER_PATH_TOKEN) -> 'true';
 resource_exists(?CARDS_PATH_TOKEN) -> 'true';
 resource_exists(?ADDRESSES_PATH_TOKEN) -> 'true';
@@ -96,6 +97,7 @@ resource_exists(?TRANSACTIONS_PATH_TOKEN) -> 'true';
 resource_exists(?CREDITS_PATH_TOKEN) -> 'true';
 resource_exists(?CLIENT_TOKEN_PATH_TOKEN) -> 'true'.
 
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(?CARDS_PATH_TOKEN, _) -> 'true';
 resource_exists(?ADDRESSES_PATH_TOKEN, _) -> 'true';
 resource_exists(?TRANSACTIONS_PATH_TOKEN, _) -> 'true'.
@@ -326,7 +328,6 @@ validate_transaction(Context, TransactionId, ?HTTP_GET) ->
     end.
 
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, ?CUSTOMER_PATH_TOKEN) ->
     try braintree_customer:update(cb_context:fetch(Context, 'braintree')) of
         #bt_customer{}=Customer ->
@@ -342,6 +343,7 @@ post(Context, ?CUSTOMER_PATH_TOKEN) ->
             crossbar_util:response('error', kz_term:to_binary(Error), 500, Reason, Context)
     end.
 
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, ?CARDS_PATH_TOKEN, CardId) ->
     try braintree_card:update(cb_context:fetch(Context, 'braintree')) of
         #bt_card{}=Card ->

--- a/applications/crossbar/src/modules/cb_callflows.erl
+++ b/applications/crossbar/src/modules/cb_callflows.erl
@@ -59,10 +59,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_CallflowId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -74,9 +76,11 @@ allowed_methods(_CallflowId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_CallflowId) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -88,8 +92,8 @@ resource_exists(_CallflowId) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_callflows(Context, cb_context:req_verb(Context)).
 
@@ -98,6 +102,7 @@ validate_callflows(Context, ?HTTP_GET) ->
 validate_callflows(Context, ?HTTP_PUT) ->
     validate_request('undefined', Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, CallflowId) ->
     validate_callflow(Context, CallflowId, cb_context:req_verb(Context)).
 
@@ -439,10 +444,10 @@ ids_in_flow(FlowJObj) ->
     ids_in_data(kz_json:get_values(<<"data">>, FlowJObj)).
 
 -spec ids_in_data({kz_json:json_terms(), kz_json:keys()}) -> kz_term:ne_binaries().
--spec ids_in_data({kz_json:json_terms(), kz_json:keys()}, kz_term:ne_binaries()) -> kz_term:ne_binaries().
 ids_in_data(Values) ->
     ids_in_data(Values, []).
 
+-spec ids_in_data({kz_json:json_terms(), kz_json:keys()}, kz_term:ne_binaries()) -> kz_term:ne_binaries().
 ids_in_data({[], []}, IDs) -> IDs;
 ids_in_data({[V|Vs], [<<"id">>|Ks]}, IDs) ->
     ids_in_data({Vs, Ks}, [V | IDs]);
@@ -455,11 +460,11 @@ ids_in_data({[V|Vs], [K|Ks]}, IDs) ->
     end.
 
 -spec get_metadata(kz_term:api_object(), kz_term:ne_binary()) -> kz_json:object().
--spec get_metadata(kz_json:object(), kz_term:ne_binary(), kz_json:object()) ->
-                          kz_json:object().
 get_metadata('undefined', _Db) -> kz_json:new();
 get_metadata(Flow, Db) -> get_metadata(Flow, Db, kz_json:new()).
 
+-spec get_metadata(kz_json:object(), kz_term:ne_binary(), kz_json:object()) ->
+                          kz_json:object().
 get_metadata(Flow, Db, Metadata) ->
     UpdatedMetadata
         = lists:foldl(fun(ID, MetaAcc) -> create_metadata(Db, ID, MetaAcc) end

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -131,17 +131,20 @@ to_response(Context, _, _) ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?PATH_INTERACTION) ->
     [?HTTP_GET];
 allowed_methods(?PATH_SUMMARY) ->
     [?HTTP_GET];
 allowed_methods(_CDRId) ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?PATH_LEGS, _InteractionId) ->
     [?HTTP_GET].
 
@@ -153,11 +156,14 @@ allowed_methods(?PATH_LEGS, _InteractionId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> boolean().
--spec resource_exists(path_token()) -> boolean().
--spec resource_exists(path_token(), path_token()) -> boolean().
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> boolean().
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> boolean().
 resource_exists(?PATH_LEGS, _) -> 'true';
 resource_exists(_, _) -> 'false'.
 
@@ -196,12 +202,12 @@ provided_types(Context) ->
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_chunk_view(Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?PATH_INTERACTION) ->
     validate_chunk_view(Context);
 validate(Context, ?PATH_SUMMARY) ->
@@ -209,6 +215,7 @@ validate(Context, ?PATH_SUMMARY) ->
 validate(Context, CDRId) ->
     load_cdr(CDRId, Context).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ?PATH_LEGS, InteractionId) ->
     load_legs(InteractionId, Context);
 validate(Context, _, _) ->

--- a/applications/crossbar/src/modules/cb_channels.erl
+++ b/applications/crossbar/src/modules/cb_channels.erl
@@ -52,10 +52,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_UUID) ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_POST].
 
@@ -68,9 +70,11 @@ allowed_methods(_UUID) ->
 %%    /channels/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_UUID) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -98,10 +102,12 @@ content_types_provided(Context) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_channels(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_channel(Context, Id, cb_context:req_verb(Context)).
 
@@ -216,10 +222,10 @@ update(Context, CallId) ->
     end.
 
 -spec maybe_execute_command(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
--spec maybe_execute_command(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 maybe_execute_command(Context, CallId) ->
     maybe_execute_command(Context, CallId, cb_context:req_value(Context, <<"action">>)).
 
+-spec maybe_execute_command(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 maybe_execute_command(Context, Transferor, <<"transfer">>) ->
     maybe_transfer(Context, Transferor);
 maybe_execute_command(Context, CallId, <<"hangup">>) ->
@@ -235,7 +241,6 @@ maybe_execute_command(Context, _CallId, _Command) ->
     crossbar_util:response_invalid_data(cb_context:doc(Context), Context).
 
 -spec validate_action(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
--spec validate_action(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 validate_action(Context, CallId) ->
     Ctx = read(Context, CallId),
     case cb_context:has_errors(Ctx) of
@@ -244,6 +249,7 @@ validate_action(Context, CallId) ->
             validate_action(Ctx, CallId, cb_modules_util:get_request_action(Context))
     end.
 
+-spec validate_action(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 validate_action(Context, _UUID, <<"metaflow">>) ->
     cb_context:validate_request_data(<<"metaflow">>, Context);
 validate_action(Context, _UUID, _Action) ->
@@ -437,7 +443,6 @@ normalize_channel(JObj) ->
      ).
 
 -spec maybe_transfer(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
--spec maybe_transfer(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary()) -> cb_context:context().
 maybe_transfer(Context, Transferor) ->
     Channel = cb_context:resp_data(Context),
     case kz_json:get_value(<<"other_leg_call_id">>, Channel) of
@@ -452,6 +457,7 @@ maybe_transfer(Context, Transferor) ->
             maybe_transfer(Context, Transferor, Transferee)
     end.
 
+-spec maybe_transfer(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary()) -> cb_context:context().
 maybe_transfer(Context, Transferor, Transferee) ->
     case cb_context:req_value(Context, <<"target">>) of
         'undefined' ->

--- a/applications/crossbar/src/modules/cb_clicktocall.erl
+++ b/applications/crossbar/src/modules/cb_clicktocall.erl
@@ -66,13 +66,16 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_C2CId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_C2CId, ?CONNECT_CALL) ->
     [?HTTP_GET, ?HTTP_POST];
 allowed_methods(_C2CId, ?HISTORY) ->
@@ -86,11 +89,14 @@ allowed_methods(_C2CId, ?HISTORY) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, ?CONNECT_CALL) -> 'true';
 resource_exists(_, ?HISTORY) -> 'true'.
 
@@ -145,9 +151,8 @@ is_c2c_url(_Context, _Nouns) -> 'false'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_c2cs(Context, cb_context:req_verb(Context)).
 
@@ -156,6 +161,7 @@ validate_c2cs(Context, ?HTTP_GET) ->
 validate_c2cs(Context, ?HTTP_PUT) ->
     create_c2c(Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_c2c(Context, Id, cb_context:req_verb(Context)).
 
@@ -168,15 +174,17 @@ validate_c2c(Context, Id, ?HTTP_PATCH) ->
 validate_c2c(Context, Id, ?HTTP_DELETE) ->
     load_c2c(Id, Context).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, Id, ?HISTORY) ->
     load_c2c_history(Id, Context);
 validate(Context, Id, ?CONNECT_CALL) ->
     establish_c2c(Id, Context).
 
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, _) ->
     crossbar_doc:save(Context).
+
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, _, ?CONNECT_CALL) ->
     Context.
 
@@ -311,12 +319,12 @@ clear_history_set_type(Context) ->
 %%
 %% @end
 %%-------------------------------------------------------------------
+
 -spec originate_call(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
--spec originate_call(kz_term:ne_binary(), cb_context:context(), kz_term:api_binary()) -> cb_context:context().
--spec originate_call(kz_term:ne_binary(), cb_context:context(), kz_term:api_binary(), boolean()) -> cb_context:context().
 originate_call(C2CId, Context) ->
     originate_call(C2CId, Context, get_c2c_contact(cb_context:req_value(Context, <<"contact">>))).
 
+-spec originate_call(kz_term:ne_binary(), cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 originate_call(_C2CId, Context, 'undefined') ->
     Message = <<"The contact extension for this click to call has not been set">>,
     cb_context:add_validation_error(<<"contact">>
@@ -331,6 +339,7 @@ originate_call(C2CId, Context, Contact) ->
         Whitelist -> originate_call(C2CId, Context, Contact, match_regexps(Whitelist, Contact))
     end.
 
+-spec originate_call(kz_term:ne_binary(), cb_context:context(), kz_term:api_binary(), boolean()) -> cb_context:context().
 originate_call(_C2CId, Context, Contact, 'false') ->
     crossbar_util:response_400(<<"Contact doesnt match whitelist">>, Contact, Context);
 originate_call(C2CId, Context, Contact, 'true') ->

--- a/applications/crossbar/src/modules/cb_comments.erl
+++ b/applications/crossbar/src/modules/cb_comments.erl
@@ -76,10 +76,12 @@ authorize(_) -> 'false'.
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_CommentId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 
@@ -92,9 +94,11 @@ allowed_methods(_CommentId) ->
 %%    /comments/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -107,10 +111,12 @@ resource_exists(_) -> 'true'.
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_comments(set_resource(Context), cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_comment(set_resource(Context), Id, cb_context:req_verb(Context)).
 
@@ -149,8 +155,8 @@ post(Context, Id) ->
 %% If the HTTP verb is DELETE, execute the actual action, usually a db delete
 %% @end
 %%--------------------------------------------------------------------
+
 -spec delete(cb_context:context()) -> cb_context:context().
--spec delete(cb_context:context(), path_token()) -> cb_context:context().
 delete(Context) ->
     Context1 = remove(Context),
     case cb_context:resp_status(Context1) of
@@ -158,6 +164,7 @@ delete(Context) ->
         _Status -> Context1
     end.
 
+-spec delete(cb_context:context(), path_token()) -> cb_context:context().
 delete(Context, Id) ->
     Context1 = remove(Context, Id),
     case cb_context:resp_status(Context1) of
@@ -186,11 +193,12 @@ finish_request(Context) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec set_resource(cb_context:context()) -> cb_context:context().
--spec set_resource(cb_context:context(), req_nouns()) -> cb_context:context().
 set_resource(Context) ->
     set_resource(Context, cb_context:req_nouns(Context)).
 
+-spec set_resource(cb_context:context(), req_nouns()) -> cb_context:context().
 set_resource(Context, [{?COMMENTS, _}, Data | _]) ->
     cb_context:store(Context, 'resource', Data).
 
@@ -291,12 +299,13 @@ update(Context, Id) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec remove(cb_context:context()) -> cb_context:context().
--spec remove(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 remove(Context) ->
     Doc = kz_json:set_value(?COMMENTS, [], cb_context:doc(Context)),
     crossbar_doc:save(cb_context:set_doc(Context, Doc)).
 
+-spec remove(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 remove(Context, Id) ->
     Doc = cb_context:doc(Context),
     Comments = kz_json:get_value(?COMMENTS, Doc, []),
@@ -350,14 +359,15 @@ check_comment_number(Context, Id) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load_doc(cb_context:context()) ->
-                      cb_context:context().
--spec load_doc(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binaries()) ->
                       cb_context:context().
 load_doc(Context) ->
     {Type, Id} = cb_context:fetch(Context, 'resource'),
     load_doc(Context, Type, Id).
 
+-spec load_doc(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binaries()) ->
+                      cb_context:context().
 load_doc(Context, <<"port_requests">>, [Id]) ->
     crossbar_doc:load(Id
                      ,cb_context:set_account_db(Context, ?KZ_PORT_REQUESTS_DB)

--- a/applications/crossbar/src/modules/cb_conferences.erl
+++ b/applications/crossbar/src/modules/cb_conferences.erl
@@ -71,33 +71,42 @@ init() ->
 %%%===================================================================
 
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods() -> [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_ConferenceId) -> [?HTTP_GET, ?HTTP_PATCH, ?HTTP_DELETE, ?HTTP_POST, ?HTTP_PUT].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_ConferenceId, ?PARTICIPANTS) -> [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(_ConferenceId, ?PARTICIPANTS, _ParticipantId) -> [?HTTP_GET, ?HTTP_PUT].
 
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, _) -> 'true'.
+
+-spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 resource_exists(_, _, _) -> 'true'.
 
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_conferences(cb_context:req_verb(Context), Context).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ConferenceId) ->
     validate_conference(cb_context:req_verb(Context), Context, ConferenceId).
+
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ConferenceId, ?PARTICIPANTS) ->
     validate_participants(cb_context:req_verb(Context), Context, ConferenceId).
+
+-spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ConferenceId, ?PARTICIPANTS, ParticipantId) ->
     validate_participant(cb_context:req_verb(Context), Context, ConferenceId, ParticipantId).
 
@@ -158,19 +167,19 @@ post(Context, _ConferenceId) ->
     crossbar_doc:save(Context).
 
 -spec put(cb_context:context()) -> cb_context:context().
--spec put(cb_context:context(), path_token()) -> cb_context:context().
--spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec put(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 put(Context) ->
     crossbar_doc:save(Context).
 
+-spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context, ConferenceId) ->
     handle_conference_action(Context, ConferenceId, cb_modules_util:get_request_action(Context)).
 
+-spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context, ConferenceId, ?PARTICIPANTS) ->
     Action = cb_context:req_value(Context, ?PUT_ACTION),
     handle_participants_action(Context, ConferenceId, Action).
 
+-spec put(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 put(Context, ConferenceId, ?PARTICIPANTS, ParticipantId) ->
     Action = cb_context:req_value(Context, ?PUT_ACTION),
     participant_action(Context, ConferenceId, ParticipantId, Action).
@@ -335,13 +344,13 @@ handle_conference_action(Context, ConferenceId, Action) ->
 
 -spec play(cb_context:context(), path_token(), kz_term:api_object()) ->
                   cb_context:context().
--spec play(cb_context:context(), path_token(), pos_integer(), kz_term:api_object()) ->
-                  cb_context:context().
 play(Context, _ConferenceId, 'undefined') ->
     data_required(Context, <<"play">>);
 play(Context, ConferenceId, Data) ->
     play_media(Context, ConferenceId, kz_json:get_ne_binary_value(<<"media_id">>, Data)).
 
+-spec play(cb_context:context(), path_token(), pos_integer(), kz_term:api_object()) ->
+                  cb_context:context().
 play(Context, _ConferenceId, _ParticipantId, 'undefined') ->
     data_required(Context, <<"play">>);
 play(Context, ConferenceId, ParticipantId, Data) ->
@@ -357,8 +366,6 @@ data_required(Context, Action) ->
 
 -spec play_media(cb_context:context(), path_token(), kz_term:api_ne_binary()) ->
                         cb_context:context().
--spec play_media(cb_context:context(), path_token(), pos_integer(), kz_term:api_ne_binary()) ->
-                        cb_context:context().
 play_media(Context, _ConferenceId, 'undefined') ->
     media_id_required(Context);
 play_media(Context, ConferenceId, MediaId) ->
@@ -371,6 +378,8 @@ play_media(Context, ConferenceId, MediaId) ->
             crossbar_util:response_202(<<"ok">>, Context)
     end.
 
+-spec play_media(cb_context:context(), path_token(), pos_integer(), kz_term:api_ne_binary()) ->
+                        cb_context:context().
 play_media(Context, _ConferenceId, _ParticipantId, 'undefined') ->
     media_id_required(Context);
 play_media(Context, ConferenceId, ParticipantId, MediaId) ->

--- a/applications/crossbar/src/modules/cb_configs.erl
+++ b/applications/crossbar/src/modules/cb_configs.erl
@@ -40,8 +40,9 @@ allowed_methods(_ConfigId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PUT, ?HTTP_PATCH, ?HTTP_DELETE].
 
 -spec resource_exists() -> false.
--spec resource_exists(path_tokens()) -> true.
 resource_exists() -> false.
+
+-spec resource_exists(path_tokens()) -> true.
 resource_exists(_) -> true.
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().

--- a/applications/crossbar/src/modules/cb_connectivity.erl
+++ b/applications/crossbar/src/modules/cb_connectivity.erl
@@ -49,10 +49,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_ConnectivityId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -64,9 +66,11 @@ allowed_methods(_ConnectivityId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -78,9 +82,8 @@ resource_exists(_) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     validate_connectivity_listing(Context, cb_context:req_verb(Context)).
 
@@ -89,6 +92,7 @@ validate_connectivity_listing(Context, ?HTTP_GET) ->
 validate_connectivity_listing(Context, ?HTTP_PUT) ->
     create(Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_connectivity_pbx(Context, Id, cb_context:req_verb(Context)).
 

--- a/applications/crossbar/src/modules/cb_directories.erl
+++ b/applications/crossbar/src/modules/cb_directories.erl
@@ -57,10 +57,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_DirectoryId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -72,9 +74,11 @@ allowed_methods(_DirectoryId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -122,11 +126,12 @@ to_pdf({Req, Context}) ->
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_directories(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_directory(Context, Id, cb_context:req_verb(Context)).
 
@@ -242,12 +247,13 @@ pdf_props(Context) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec pdf_users(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects()) -> any().
--spec pdf_users(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects(), any()) -> any().
 pdf_users(AccountId, SortBy, Users) ->
     AccountDb = kz_util:format_account_id(AccountId, 'encoded'),
     pdf_users(AccountDb, SortBy, Users, []).
 
+-spec pdf_users(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects(), any()) -> any().
 pdf_users(_AccountDb, SortBy, [], Acc) ->
     Users = [{props:get_value([<<"user">>, SortBy], U), U} || U <- Acc],
     [U || {_SortCriterion, U} <- lists:keysort(1, Users)];

--- a/applications/crossbar/src/modules/cb_faxboxes.erl
+++ b/applications/crossbar/src/modules/cb_faxboxes.erl
@@ -88,12 +88,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
--spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 
+-spec allowed_methods() -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_FaxboxId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -106,15 +106,17 @@ allowed_methods(_FaxboxId) ->
 %%    /faxes/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
--spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 
+-spec resource_exists() -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_BoxId) -> 'true'.
 
 -spec validate_resource(cb_context:context()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
 validate_resource(Context) -> Context.
+
+-spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
 validate_resource(Context, FaxboxId) ->
     case kz_datamgr:open_cache_doc(cb_context:account_db(Context), FaxboxId) of
         {'ok', JObj} -> cb_context:store(Context, <<"faxbox">>, JObj);
@@ -131,9 +133,8 @@ validate_resource(Context, FaxboxId) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     validate_faxboxes(Context, cb_context:req_verb(Context)).
 
@@ -142,6 +143,7 @@ validate_faxboxes(Context, ?HTTP_PUT) ->
 validate_faxboxes(Context, ?HTTP_GET) ->
     faxbox_listing(Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_faxbox(Context, Id, cb_context:req_verb(Context)).
 
@@ -388,7 +390,6 @@ is_faxbox_email_global_unique(Email, FaxBoxId) ->
     end.
 
 -spec maybe_reregister_cloud_printer(cb_context:context()) -> cb_context:context().
--spec maybe_reregister_cloud_printer(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
 maybe_reregister_cloud_printer(Context) ->
     CurrentState = kz_json:get_value(<<"pvt_cloud_state">>, cb_context:doc(Context)),
     Ctx = maybe_reregister_cloud_printer(CurrentState, Context),
@@ -402,6 +403,7 @@ maybe_reregister_cloud_printer(Context) ->
         _ -> Ctx1
     end.
 
+-spec maybe_reregister_cloud_printer(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
 maybe_reregister_cloud_printer('undefined', Context) ->
     maybe_register_cloud_printer(Context);
 maybe_reregister_cloud_printer(<<"expired">>, Context) ->

--- a/applications/crossbar/src/modules/cb_faxes.erl
+++ b/applications/crossbar/src/modules/cb_faxes.erl
@@ -90,14 +90,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
--spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 
+-spec allowed_methods() -> http_methods().
 allowed_methods() ->
     [?HTTP_PUT].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?SMTP_LOG) ->
     [?HTTP_GET];
 allowed_methods(?INBOX) ->
@@ -109,6 +107,7 @@ allowed_methods(?OUTBOX) ->
 allowed_methods(?OUTGOING) ->
     [?HTTP_GET, ?HTTP_PUT].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?SMTP_LOG, _AttemptId) ->
     [?HTTP_GET];
 allowed_methods(?INCOMING, _FaxId) ->
@@ -120,6 +119,7 @@ allowed_methods(?OUTBOX, _FaxId) ->
 allowed_methods(?OUTGOING, _FaxJobId) ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(?INBOX, _FaxId, ?ATTACHMENT) ->
     [?HTTP_GET, ?HTTP_DELETE];
 allowed_methods(?OUTBOX, _FaxId, ?ATTACHMENT) ->
@@ -134,25 +134,25 @@ allowed_methods(?OUTBOX, _FaxId, ?ATTACHMENT) ->
 %%    /faxes/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
--spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 
+-spec resource_exists() -> 'true'.
 resource_exists() -> 'true'.
 
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(?SMTP_LOG) -> 'true';
 resource_exists(?INCOMING) -> 'true';
 resource_exists(?INBOX) -> 'true';
 resource_exists(?OUTBOX) -> 'true';
 resource_exists(?OUTGOING) -> 'true'.
 
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(?SMTP_LOG, _Id) -> 'true';
 resource_exists(?INCOMING, _Id) -> 'true';
 resource_exists(?INBOX, _Id) -> 'true';
 resource_exists(?OUTBOX, _Id) -> 'true';
 resource_exists(?OUTGOING, _Id) -> 'true'.
 
+-spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 resource_exists(?INBOX, _Id, ?ATTACHMENT) -> 'true';
 resource_exists(?OUTBOX, _Id, ?ATTACHMENT) -> 'true'.
 
@@ -161,10 +161,10 @@ acceptable_content_types() ->
     ?ACCEPTED_MIME_TYPES.
 
 -spec content_types_accepted(cb_context:context()) -> cb_context:context().
--spec content_types_accepted(cb_context:context(), path_token()) -> cb_context:context().
 content_types_accepted(Context) ->
     maybe_add_types_accepted(Context, cb_context:req_verb(Context)).
 
+-spec content_types_accepted(cb_context:context(), path_token()) -> cb_context:context().
 content_types_accepted(Context, ?OUTGOING) ->
     maybe_add_types_accepted(Context, cb_context:req_verb(Context));
 content_types_accepted(Context, _) -> Context.
@@ -232,14 +232,12 @@ content_types_provided_for_fax(Context) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     create(cb_context:set_account_db(Context, ?KZ_FAXES_DB)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?OUTGOING) ->
     validate_outgoing_fax(Context, cb_context:req_verb(Context));
 validate(Context, ?INCOMING) ->
@@ -251,6 +249,7 @@ validate(Context, ?OUTBOX) ->
 validate(Context, ?SMTP_LOG) ->
     load_smtp_log(Context).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ?SMTP_LOG, Id) ->
     load_smtp_log_doc(Id, Context);
 validate(Context, ?INCOMING, Id) ->
@@ -262,6 +261,7 @@ validate(Context, ?OUTBOX, Id) ->
 validate(Context, ?OUTGOING, Id) ->
     validate_outgoing_fax(Context, Id, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ?INBOX, Id, ?ATTACHMENT) ->
     validate_modb_fax_attachment(Context, Id, ?INBOX, cb_context:req_verb(Context));
 validate(Context, ?OUTBOX, Id, ?ATTACHMENT) ->
@@ -321,13 +321,16 @@ validate_inbox_fax_action(Action, Id, Context) ->
 %% If the HTTP verb is PUT, execute the actual action, usually a db save.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec put(cb_context:context()) -> cb_context:context().
--spec put(cb_context:context(), path_token()) -> cb_context:context().
--spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context) ->
     maybe_save_attachment(crossbar_doc:save(Context)).
+
+-spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context, ?OUTGOING) ->
     maybe_save_attachment(crossbar_doc:save(Context)).
+
+-spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context, ?OUTBOX, Id) ->
     Action = kz_json:get_value(<<"action">>, cb_context:req_json(Context)),
     do_put_action(Context, ?OUTBOX, Action, Id);

--- a/applications/crossbar/src/modules/cb_global_provisioner_templates.erl
+++ b/applications/crossbar/src/modules/cb_global_provisioner_templates.erl
@@ -80,11 +80,11 @@ acceptable_content_types() -> ?MIME_TYPES.
 
 -spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
                                     cb_context:context().
--spec content_types_provided_for_provisioner(cb_context:context(), path_token(), path_token(), http_method()) ->
-                                                    cb_context:context().
 content_types_provided(Context, PT1, PT2) ->
     content_types_provided_for_provisioner(Context, PT1, PT2, cb_context:req_verb(Context)).
 
+-spec content_types_provided_for_provisioner(cb_context:context(), path_token(), path_token(), http_method()) ->
+                                                    cb_context:context().
 content_types_provided_for_provisioner(Context, DocId, ?IMAGE_REQ, ?HTTP_GET) ->
     case kz_datamgr:open_doc(?KZ_PROVISIONER_DB, DocId) of
         {'error', _} -> Context;
@@ -107,11 +107,12 @@ get_content_type(JObj) ->
 %% Add content types accepted by this module
 %% @end
 %%--------------------------------------------------------------------
--spec content_types_accepted(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec content_types_accepted(cb_context:context(), path_token(), path_token(), http_method()) -> cb_context:context().
 
+-spec content_types_accepted(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 content_types_accepted(Context, PT1, PT2) ->
     content_types_accepted(Context, PT1, PT2, cb_context:req_verb(Context)).
+
+-spec content_types_accepted(cb_context:context(), path_token(), path_token(), http_method()) -> cb_context:context().
 content_types_accepted(Context, _, ?IMAGE_REQ, ?HTTP_PUT) ->
     cb_context:set_content_types_accepted(Context, [{'from_binary', ?MIME_TYPES}]);
 content_types_accepted(Context, _, ?IMAGE_REQ, ?HTTP_POST) ->
@@ -128,13 +129,16 @@ content_types_accepted(Context, _, ?IMAGE_REQ, _) ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_TemplateId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_TemplateId, ?IMAGE_REQ) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 
@@ -146,11 +150,14 @@ allowed_methods(_TemplateId, ?IMAGE_REQ) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, ?IMAGE_REQ) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -162,19 +169,22 @@ resource_exists(_, ?IMAGE_REQ) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate_verb(cb_context:context(), http_method()) -> cb_context:context().
 validate(Context) ->
     validate_verb(Context, cb_context:req_verb(Context)).
+
+-spec validate_verb(cb_context:context(), http_method()) -> cb_context:context().
 validate_verb(Context, ?HTTP_GET) ->
     load_provisioner_template_summary(cb_context:set_account_db(Context, ?KZ_PROVISIONER_DB));
 validate_verb(Context, ?HTTP_PUT) ->
     create_provisioner_template(cb_context:set_account_db(Context, ?KZ_PROVISIONER_DB)).
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate_verb(cb_context:context(), http_method(), path_token()) -> cb_context:context().
 validate(Context, DocId) ->
     validate_verb(Context, cb_context:req_verb(Context), DocId).
+
+-spec validate_verb(cb_context:context(), http_method(), path_token()) -> cb_context:context().
 validate_verb(Context, ?HTTP_GET, DocId) ->
     load_provisioner_template(DocId, cb_context:set_account_db(Context, ?KZ_PROVISIONER_DB));
 validate_verb(Context, ?HTTP_POST, DocId) ->
@@ -183,10 +193,11 @@ validate_verb(Context, ?HTTP_DELETE, DocId) ->
     load_provisioner_template(DocId, cb_context:set_account_db(Context, ?KZ_PROVISIONER_DB)).
 
 -spec validate(cb_context:context(), path_token(), kz_term:ne_binary()) -> cb_context:context().
--spec validate_verb(cb_context:context(), http_method(), path_token(), kz_term:ne_binary()) ->
-                           cb_context:context().
 validate(Context, DocId, Noun) ->
     validate_verb(Context, cb_context:req_verb(Context), DocId, Noun).
+
+-spec validate_verb(cb_context:context(), http_method(), path_token(), kz_term:ne_binary()) ->
+                           cb_context:context().
 validate_verb(Context, ?HTTP_GET, DocId, ?IMAGE_REQ) ->
     load_template_image(DocId, cb_context:set_account_db(Context, ?KZ_PROVISIONER_DB));
 validate_verb(Context, ?HTTP_PUT, _DocId, ?IMAGE_REQ) ->

--- a/applications/crossbar/src/modules/cb_groups.erl
+++ b/applications/crossbar/src/modules/cb_groups.erl
@@ -51,10 +51,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_GroupId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -67,9 +69,11 @@ allowed_methods(_GroupId) ->
 %%    /groups/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -82,8 +86,8 @@ resource_exists(_) -> 'true'.
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_groups(Context, cb_context:req_verb(Context)).
 
@@ -92,6 +96,7 @@ validate_groups(Context, ?HTTP_GET) ->
 validate_groups(Context, ?HTTP_PUT) ->
     create(Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_group(Context, Id, cb_context:req_verb(Context)).
 

--- a/applications/crossbar/src/modules/cb_ip_auth.erl
+++ b/applications/crossbar/src/modules/cb_ip_auth.erl
@@ -176,8 +176,8 @@ on_successful_load(Context, _Status, _Doc) ->
 %% Attempt to create a token
 %% @end
 %%--------------------------------------------------------------------
+
 -spec create_fake_token(cb_context:context()) -> cb_context:context().
--spec create_fake_token(cb_context:context(), kz_json:object()) -> cb_context:context().
 create_fake_token(Context) ->
     JObj = cb_context:doc(Context),
     case kz_json:is_empty(JObj) of
@@ -187,6 +187,7 @@ create_fake_token(Context) ->
             cb_context:add_system_error('invalid_credentials', Context)
     end.
 
+-spec create_fake_token(cb_context:context(), kz_json:object()) -> cb_context:context().
 create_fake_token(Context, JObj) ->
     AccountId = kz_json:get_value([<<"value">>, <<"account_id">>], JObj),
     AuthToken = kz_binary:rand_hex(12),

--- a/applications/crossbar/src/modules/cb_ips.erl
+++ b/applications/crossbar/src/modules/cb_ips.erl
@@ -61,11 +61,12 @@ authorize(_Context, _Nouns) -> 'false'.
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_POST].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?ASSIGNED) ->
     [?HTTP_GET];
 allowed_methods(?ZONES) ->
@@ -84,9 +85,11 @@ allowed_methods(_IPAddress) ->
 %%    /dedicated_ips/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -99,18 +102,18 @@ resource_exists(_) -> 'true'.
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     _ = cb_context:put_reqid(Context),
     validate_ips(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, PathToken) ->
     _ = cb_context:put_reqid(Context),
     validate_ips(Context, PathToken, cb_context:req_verb(Context)).
 
 -spec validate_ips(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
--spec validate_ips(cb_context:context(), path_token(), kz_term:ne_binary()) -> cb_context:context().
 validate_ips(Context, ?HTTP_GET) ->
     load_available(Context);
 validate_ips(Context, ?HTTP_PUT) ->
@@ -118,6 +121,7 @@ validate_ips(Context, ?HTTP_PUT) ->
 validate_ips(Context, ?HTTP_POST) ->
     maybe_assign_ips(Context).
 
+-spec validate_ips(cb_context:context(), path_token(), kz_term:ne_binary()) -> cb_context:context().
 validate_ips(Context, ?ASSIGNED, ?HTTP_GET) ->
     load_assigned(Context);
 validate_ips(Context, ?ZONES, ?HTTP_GET) ->
@@ -315,10 +319,10 @@ maybe_assign_ips(Context) ->
     cb_context:validate_request_data(<<"ips">>, Context, OnSuccess).
 
 -spec validate_ips_not_in_use(cb_context:context()) -> cb_context:context().
--spec validate_ips_not_in_use(cb_context:context(), kz_term:ne_binaries()) -> cb_context:context().
 validate_ips_not_in_use(Context) ->
     validate_ips_not_in_use(Context, cb_context:req_value(Context, <<"ips">>)).
 
+-spec validate_ips_not_in_use(cb_context:context(), kz_term:ne_binaries()) -> cb_context:context().
 validate_ips_not_in_use(Context, IPs) ->
     lists:foldl(fun validate_ip_not_in_use/2, Context, IPs).
 

--- a/applications/crossbar/src/modules/cb_ledgers.erl
+++ b/applications/crossbar/src/modules/cb_ledgers.erl
@@ -56,12 +56,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?AVAILABLE) ->
     [?HTTP_GET];
 allowed_methods(?CREDIT) ->
@@ -71,6 +71,7 @@ allowed_methods(?DEBIT) ->
 allowed_methods(_LedgerId) ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_LedgerId, _LedgerEntryId) ->
     [?HTTP_GET].
 
@@ -83,11 +84,14 @@ allowed_methods(_LedgerId, _LedgerEntryId) ->
 %%    /ledgers/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, _) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -146,12 +150,12 @@ authorize_create(Context) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_ledgers(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?CREDIT) ->
     ReqData = cb_context:req_data(Context),
     JObj = kz_json:set_value([<<"usage">>, <<"type">>], ?CREDIT, ReqData),
@@ -174,6 +178,7 @@ validate(Context, Id) ->
                   ],
     crossbar_view:load_modb(Context, ?LEDGER_VIEW, ViewOptions).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, Ledger, Id) ->
     validate_ledger_doc(Context, Ledger, Id, cb_context:req_verb(Context)).
 

--- a/applications/crossbar/src/modules/cb_local_provisioner_templates.erl
+++ b/applications/crossbar/src/modules/cb_local_provisioner_templates.erl
@@ -67,11 +67,12 @@ init() ->
 %% Add content types provided by this module
 %% @end
 %%--------------------------------------------------------------------
+
 -spec content_types_provided(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec content_types_provided_for_provisioner(cb_context:context(), path_token(), path_token(), http_method()) -> cb_context:context().
 content_types_provided(Context, PT1, PT2) ->
     content_types_provided_for_provisioner(Context, PT1, PT2, cb_context:req_verb(Context)).
 
+-spec content_types_provided_for_provisioner(cb_context:context(), path_token(), path_token(), http_method()) -> cb_context:context().
 content_types_provided_for_provisioner(Context, DocId, ?IMAGE_REQ, ?HTTP_GET) ->
     Db = kz_util:format_account_id(cb_context:auth_account_id(Context), 'encoded'),
     case kz_datamgr:open_doc(Db, DocId) of
@@ -91,11 +92,12 @@ content_types_provided_for_provisioner(Context, _, _, _) ->
 %% Add content types accepted by this module
 %% @end
 %%--------------------------------------------------------------------
+
 -spec content_types_accepted(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec content_types_accepted(cb_context:context(), path_token(), path_token(), http_method()) -> cb_context:context().
 content_types_accepted(Context, PT1, PT2) ->
     content_types_accepted(Context, PT1, PT2, cb_context:req_verb(Context)).
 
+-spec content_types_accepted(cb_context:context(), path_token(), path_token(), http_method()) -> cb_context:context().
 content_types_accepted(Context, _, ?IMAGE_REQ, ?HTTP_PUT) ->
     cb_context:set_content_types_accepted(Context, [{'from_binary', ?MIME_TYPES}]);
 content_types_accepted(Context, _, ?IMAGE_REQ, ?HTTP_POST) ->
@@ -112,13 +114,16 @@ content_types_accepted(Context, _, _, _) ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_TemplateId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_TemplateId, ?IMAGE_REQ) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 
@@ -130,11 +135,14 @@ allowed_methods(_TemplateId, ?IMAGE_REQ) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, ?IMAGE_REQ) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -146,25 +154,27 @@ resource_exists(_, ?IMAGE_REQ) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_verb(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, PT1) ->
     validate_verb(Context, PT1, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, PT1, PT2) ->
     validate_verb(Context, PT1, PT2, cb_context:req_verb(Context)).
 
--spec validate_verb(cb_context:context(), http_method()) -> cb_context:context().
--spec validate_verb(cb_context:context(), path_token(), http_method()) -> cb_context:context().
--spec validate_verb(cb_context:context(), path_token(), path_token(), http_method()) -> cb_context:context().
 
+-spec validate_verb(cb_context:context(), http_method()) -> cb_context:context().
 validate_verb(Context, ?HTTP_GET) ->
     load_provisioner_template_summary(Context);
 validate_verb(Context, ?HTTP_PUT) ->
     create_provisioner_template(Context).
 
+-spec validate_verb(cb_context:context(), path_token(), http_method()) -> cb_context:context().
 validate_verb(Context, DocId, ?HTTP_GET) ->
     load_provisioner_template(DocId, Context);
 validate_verb(Context, DocId, ?HTTP_POST) ->
@@ -172,6 +182,7 @@ validate_verb(Context, DocId, ?HTTP_POST) ->
 validate_verb(Context, DocId, ?HTTP_DELETE) ->
     load_provisioner_template(DocId, Context).
 
+-spec validate_verb(cb_context:context(), path_token(), path_token(), http_method()) -> cb_context:context().
 validate_verb(Context, DocId, ?IMAGE_REQ, ?HTTP_GET) ->
     load_template_image(DocId, Context);
 validate_verb(Context, _DocId, ?IMAGE_REQ, ?HTTP_PUT) ->
@@ -267,10 +278,12 @@ load_template_image(DocId, Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec upload_template_image(cb_context:context()) -> cb_context:context().
--spec upload_template_image(cb_context:context(), req_files()) -> cb_context:context().
 upload_template_image(Context) ->
     upload_template_image(Context, cb_context:req_files(Context)).
+
+-spec upload_template_image(cb_context:context(), req_files()) -> cb_context:context().
 upload_template_image(Context, []) ->
     cb_context:add_validation_error(
       <<"file">>

--- a/applications/crossbar/src/modules/cb_local_resources.erl
+++ b/applications/crossbar/src/modules/cb_local_resources.erl
@@ -166,11 +166,12 @@ on_successful_validation(Id, Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_aggregate_resource(cb_context:context()) -> boolean().
--spec maybe_aggregate_resource(cb_context:context(), crossbar_status()) -> boolean().
 maybe_aggregate_resource(Context) ->
     maybe_aggregate_resource(Context, cb_context:resp_status(Context)).
 
+-spec maybe_aggregate_resource(cb_context:context(), crossbar_status()) -> boolean().
 maybe_aggregate_resource(Context, 'success') ->
     case kz_term:is_true(cb_context:fetch(Context, 'aggregate_resource')) of
         'false' ->
@@ -185,12 +186,12 @@ maybe_aggregate_resource(Context, 'success') ->
     end;
 maybe_aggregate_resource(_Context, _Status) -> 'false'.
 
--spec maybe_remove_aggregate(kz_term:ne_binary(), cb_context:context()) -> boolean().
--spec maybe_remove_aggregate(kz_term:ne_binary(), cb_context:context(), crossbar_status()) -> boolean().
 
+-spec maybe_remove_aggregate(kz_term:ne_binary(), cb_context:context()) -> boolean().
 maybe_remove_aggregate(ResourceId, Context) ->
     maybe_remove_aggregate(ResourceId, Context, cb_context:resp_status(Context)).
 
+-spec maybe_remove_aggregate(kz_term:ne_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_remove_aggregate(ResourceId, _Context, 'success') ->
     case kz_datamgr:open_doc(?KZ_SIP_DB, ResourceId) of
         {'ok', JObj} ->

--- a/applications/crossbar/src/modules/cb_media.erl
+++ b/applications/crossbar/src/modules/cb_media.erl
@@ -84,12 +84,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?LANGUAGES) ->
     [?HTTP_GET];
 allowed_methods(?PROMPTS) ->
@@ -97,6 +97,7 @@ allowed_methods(?PROMPTS) ->
 allowed_methods(_MediaId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?LANGUAGES, _Language) ->
     [?HTTP_GET];
 allowed_methods(?PROMPTS, _PromptId) ->
@@ -112,11 +113,14 @@ allowed_methods(_MediaId, ?BIN_DATA) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(?LANGUAGES, _Language) -> 'true';
 resource_exists(?PROMPTS, _PromptId) -> 'true';
 resource_exists(_, ?BIN_DATA) -> 'true'.
@@ -171,11 +175,11 @@ acceptable_content_types() ->
 
 -spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
                                     cb_context:context().
--spec content_types_provided_for_media(cb_context:context(), path_token(), path_token(), http_method()) ->
-                                              cb_context:context().
 content_types_provided(Context, MediaId, ?BIN_DATA) ->
     content_types_provided_for_media(Context, MediaId, ?BIN_DATA, cb_context:req_verb(Context)).
 
+-spec content_types_provided_for_media(cb_context:context(), path_token(), path_token(), http_method()) ->
+                                              cb_context:context().
 content_types_provided_for_media(Context, MediaId, ?BIN_DATA, ?HTTP_GET) ->
     Context1 = load_media_meta(Context, MediaId),
     case cb_context:resp_status(Context1) of
@@ -195,11 +199,11 @@ content_types_provided_for_media(Context, _MediaId, ?BIN_DATA, _Verb) ->
 
 -spec content_types_accepted(cb_context:context(), path_token(), path_token()) ->
                                     cb_context:context().
--spec content_types_accepted_for_upload(cb_context:context(), http_method()) ->
-                                               cb_context:context().
 content_types_accepted(Context, _MediaId, ?BIN_DATA) ->
     content_types_accepted_for_upload(Context, cb_context:req_verb(Context)).
 
+-spec content_types_accepted_for_upload(cb_context:context(), http_method()) ->
+                                               cb_context:context().
 content_types_accepted_for_upload(Context, ?HTTP_POST) ->
     CTA = [{'from_binary', ?MEDIA_MIME_TYPES}],
     cb_context:set_content_types_accepted(Context, CTA);
@@ -214,13 +218,16 @@ content_types_accepted_for_upload(Context, _Verb) ->
 %% [<<"en">>, <<"en-gb;q=0.7">>, <<"da;q=0.5">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec languages_provided(cb_context:context()) -> cb_context:context().
--spec languages_provided(cb_context:context(), path_token()) -> cb_context:context().
--spec languages_provided(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 languages_provided(Context) ->
     Context.
+
+-spec languages_provided(cb_context:context(), path_token()) -> cb_context:context().
 languages_provided(Context, _Id) ->
     Context.
+
+-spec languages_provided(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 languages_provided(Context, _Id, _Path) ->
     Context.
 
@@ -233,12 +240,12 @@ languages_provided(Context, _Id, _Path) ->
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_media_docs(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?LANGUAGES) ->
     load_available_languages(Context);
 validate(Context, ?PROMPTS) ->
@@ -246,6 +253,7 @@ validate(Context, ?PROMPTS) ->
 validate(Context, MediaId) ->
     validate_media_doc(Context, MediaId, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ?LANGUAGES, Language) ->
     load_media_docs_by_language(Context, kz_term:to_lower_binary(Language));
 validate(Context, ?PROMPTS, PromptId) ->
@@ -312,13 +320,13 @@ maybe_normalize_upload(Context, MediaId, FileJObj) ->
 
 -spec normalize_upload(cb_context:context(), kz_term:ne_binary(), kz_json:object()) ->
                               cb_context:context().
--spec normalize_upload(cb_context:context(), kz_term:ne_binary(), kz_json:object(), kz_term:api_binary()) ->
-                              cb_context:context().
 normalize_upload(Context, MediaId, FileJObj) ->
     normalize_upload(Context, MediaId, FileJObj
                     ,kz_json:get_ne_binary_value([<<"headers">>, <<"content_type">>], FileJObj)
                     ).
 
+-spec normalize_upload(cb_context:context(), kz_term:ne_binary(), kz_json:object(), kz_term:api_binary()) ->
+                              cb_context:context().
 normalize_upload(Context, MediaId, FileJObj, UploadContentType) ->
     FromExt = kz_mime:to_extension(UploadContentType),
     ToExt =  ?NORMALIZATION_FORMAT,
@@ -387,7 +395,6 @@ put_media(Context, _AccountId) ->
     lists:foldl(fun(F, C) -> F(C) end, Context, Routines).
 
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, MediaId) ->
     post_media_doc(Context, MediaId, cb_context:account_id(Context)).
 
@@ -415,6 +422,7 @@ post_media_doc(Context, MediaId, _AccountId) ->
                ],
     lists:foldl(fun(F, C) -> F(C) end, Context, Routines).
 
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, MediaId, ?BIN_DATA) ->
     post_media_binary(Context, MediaId, cb_context:account_id(Context)).
 
@@ -527,10 +535,10 @@ delete_type(Context) ->
     delete_type(Prompt or Hard).
 
 -spec delete(cb_context:context(), path_token()) -> cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 delete(Context, _MediaId) ->
     crossbar_doc:delete(Context, delete_type(Context)).
 
+-spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 delete(Context, MediaId, ?BIN_DATA) ->
     delete_media_binary(MediaId, Context, cb_context:account_id(Context)).
 
@@ -540,11 +548,12 @@ delete(Context, MediaId, ?BIN_DATA) ->
 %% Attempt to load a summarized list of media
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load_media_summary(cb_context:context()) -> cb_context:context().
--spec load_media_summary(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 load_media_summary(Context) ->
     load_media_summary(Context, cb_context:account_id(Context)).
 
+-spec load_media_summary(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 load_media_summary(Context, 'undefined') ->
     lager:debug("loading system_config media"),
     fix_start_keys(
@@ -591,10 +600,10 @@ fix_start_keys_fold(Key, JObj) ->
     end.
 
 -spec load_available_languages(cb_context:context()) -> cb_context:context().
--spec load_available_languages(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 load_available_languages(Context) ->
     load_available_languages(Context, cb_context:account_id(Context)).
 
+-spec load_available_languages(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 load_available_languages(Context, 'undefined') ->
     fix_start_keys(
       crossbar_doc:load_view(?CB_LIST_BY_LANG
@@ -625,8 +634,6 @@ normalize_count_results(JObj, [Acc]) ->
 
 -spec load_media_docs_by_language(cb_context:context(), kz_term:ne_binary()) ->
                                          cb_context:context().
--spec load_media_docs_by_language(cb_context:context(), kz_term:ne_binary() | 'null', kz_term:api_binary()) ->
-                                         cb_context:context().
 load_media_docs_by_language(Context, <<"missing">>) ->
     lager:debug("loading media files missing a language"),
     load_media_docs_by_language(Context, 'null', cb_context:account_id(Context));
@@ -634,6 +641,8 @@ load_media_docs_by_language(Context, Language) ->
     lager:debug("loading media files in language ~p", [Language]),
     load_media_docs_by_language(Context, Language, cb_context:account_id(Context)).
 
+-spec load_media_docs_by_language(cb_context:context(), kz_term:ne_binary() | 'null', kz_term:api_binary()) ->
+                                         cb_context:context().
 load_media_docs_by_language(Context, Language, 'undefined') ->
     fix_start_keys(
       crossbar_doc:load_view(?CB_LIST_BY_LANG
@@ -660,13 +669,13 @@ load_media_docs_by_language(Context, Language, _AccountId) ->
      ).
 
 -spec language_start_key(cb_context:context(), kz_term:ne_binary()) -> kz_term:ne_binaries().
--spec language_start_key(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 language_start_key(Context, Language) ->
     case crossbar_doc:start_key(Context) of
         'undefined' -> [Language];
         Key -> language_start_key(Context, Language, binary:split(Key, <<"/">>))
     end.
 
+-spec language_start_key(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 language_start_key(_Context, Language, [Language, Id]) ->
     [Language, Id];
 language_start_key(_Context, Language, _Key) ->
@@ -682,13 +691,14 @@ normalize_language_results(JObj, Acc) ->
 %% Load prompt listing
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load_available_prompts(cb_context:context()) ->
-                                    cb_context:context().
--spec load_available_prompts(cb_context:context(), kz_term:api_binary()) ->
                                     cb_context:context().
 load_available_prompts(Context) ->
     load_available_prompts(Context, cb_context:account_id(Context)).
 
+-spec load_available_prompts(cb_context:context(), kz_term:api_binary()) ->
+                                    cb_context:context().
 load_available_prompts(Context, 'undefined') ->
     fix_prompt_start_keys(
       crossbar_doc:load_view(?CB_LIST_BY_PROMPT
@@ -711,11 +721,11 @@ load_available_prompts(Context, _AccountId) ->
      ).
 
 -spec load_media_docs_by_prompt(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
--spec load_media_docs_by_prompt(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 load_media_docs_by_prompt(Context, PromptId) ->
     lager:debug("loading media files in prompt ~p", [PromptId]),
     load_media_docs_by_prompt(Context, PromptId, cb_context:account_id(Context)).
 
+-spec load_media_docs_by_prompt(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 load_media_docs_by_prompt(Context, PromptId, 'undefined') ->
     fix_prompt_start_keys(
       crossbar_doc:load_view(?CB_LIST_BY_PROMPT
@@ -744,11 +754,11 @@ load_media_docs_by_prompt(Context, PromptId, _AccountId) ->
 
 -spec prompt_start_key(cb_context:context()) ->
                               kz_term:ne_binaries().
--spec prompt_start_key(cb_context:context(), kz_term:api_binary()) ->
-                              kz_term:ne_binaries().
 prompt_start_key(Context) ->
     prompt_start_key(Context, 'undefined').
 
+-spec prompt_start_key(cb_context:context(), kz_term:api_binary()) ->
+                              kz_term:ne_binaries().
 prompt_start_key(Context, PromptId) ->
     case crossbar_doc:start_key(Context) of
         PromptId -> PromptId;
@@ -799,13 +809,14 @@ fix_prompt_start_keys_fold(Key, JObj) ->
 %% Load a media document from the database
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load_media_meta(cb_context:context(), kz_term:ne_binary()) ->
-                             cb_context:context().
--spec load_media_meta(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) ->
                              cb_context:context().
 load_media_meta(Context, MediaId) ->
     load_media_meta(Context, MediaId, cb_context:account_id(Context)).
 
+-spec load_media_meta(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) ->
+                             cb_context:context().
 load_media_meta(Context, MediaId, 'undefined') ->
     crossbar_doc:load(MediaId, cb_context:set_account_db(Context, ?KZ_MEDIA_DB), ?TYPE_CHECK_OPTION(kzd_media:type()));
 load_media_meta(Context, MediaId, _AccountId) ->
@@ -926,9 +937,8 @@ load_media_binary(Context, MediaId) ->
 %% Update the binary attachment of a media doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update_media_binary(cb_context:context(), path_token()) ->
-                                 cb_context:context().
--spec update_media_binary(cb_context:context(), path_token(), req_files()) ->
                                  cb_context:context().
 update_media_binary(Context, MediaId) ->
     update_media_binary(crossbar_util:maybe_remove_attachments(Context)
@@ -936,6 +946,8 @@ update_media_binary(Context, MediaId) ->
                        ,cb_context:req_files(Context)
                        ).
 
+-spec update_media_binary(cb_context:context(), path_token(), req_files()) ->
+                                 cb_context:context().
 update_media_binary(Context, _MediaId, []) -> Context;
 update_media_binary(Context, MediaId, [{Filename, FileObj}|Files]) ->
     Contents = kz_json:get_value(<<"contents">>, FileObj),
@@ -976,10 +988,10 @@ delete_media_binary(MediaId, Context, _AccountId) ->
     end.
 
 -spec is_tts(kz_json:object()) -> boolean().
--spec is_tts(kz_json:object(), kz_term:api_binary()) -> boolean().
 is_tts(JObj) ->
     is_tts(JObj, kz_json:get_ne_value([<<"tts">>, <<"text">>], JObj)).
 
+-spec is_tts(kz_json:object(), kz_term:api_binary()) -> boolean().
 is_tts(_JObj, 'undefined') -> 'false';
 is_tts(JObj, Text) ->
     is_tts_text_changed(JObj, Text =:= kz_json:get_value(<<"pvt_previous_tts">>, JObj)).

--- a/applications/crossbar/src/modules/cb_menus.erl
+++ b/applications/crossbar/src/modules/cb_menus.erl
@@ -50,10 +50,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_MenuId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -65,9 +67,11 @@ allowed_methods(_MenuId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -79,8 +83,8 @@ resource_exists(_) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_menus(Context, cb_context:req_verb(Context)).
 
@@ -89,6 +93,7 @@ validate_menus(Context, ?HTTP_GET) ->
 validate_menus(Context, ?HTTP_PUT) ->
     create_menu(Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, DocId) ->
     validate_menu(Context, DocId, cb_context:req_verb(Context)).
 

--- a/applications/crossbar/src/modules/cb_metaflows.erl
+++ b/applications/crossbar/src/modules/cb_metaflows.erl
@@ -90,7 +90,6 @@ validate_metaflows(Context, ?HTTP_DELETE) ->
     validate_delete_metaflows(Context, thing_doc(Context)).
 
 -spec thing_doc(cb_context:context()) -> kz_term:api_object().
--spec thing_doc(cb_context:context(), kz_term:ne_binary()) -> kz_term:api_object().
 thing_doc(Context) ->
     case cb_context:req_nouns(Context) of
         [{<<"metaflows">>, []}, {_Thing, [ThingId]} | _] ->
@@ -99,6 +98,7 @@ thing_doc(Context) ->
         _Nouns -> 'undefined'
     end.
 
+-spec thing_doc(cb_context:context(), kz_term:ne_binary()) -> kz_term:api_object().
 thing_doc(Context, ThingId) ->
     Context1 = crossbar_doc:load(ThingId, Context, ?TYPE_CHECK_OPTION_ANY),
     case cb_context:resp_status(Context1) of
@@ -128,12 +128,12 @@ validate_delete_metaflows(Context, Doc) ->
 
 -spec validate_set_metaflows(cb_context:context()) ->
                                     cb_context:context().
--spec validate_set_metaflows(cb_context:context(), kz_json:object(), kz_term:api_object()) ->
-                                    cb_context:context().
 validate_set_metaflows(Context) ->
     lager:debug("metaflow data is valid, setting on thing"),
     validate_set_metaflows(Context, cb_context:doc(Context), thing_doc(Context)).
 
+-spec validate_set_metaflows(cb_context:context(), kz_json:object(), kz_term:api_object()) ->
+                                    cb_context:context().
 validate_set_metaflows(Context, Metaflows, 'undefined') ->
     lager:debug("no doc found, using account doc"),
     {'ok', AccountDoc} = kz_account:fetch(cb_context:account_id(Context)),
@@ -155,10 +155,10 @@ post(Context) ->
     after_post(crossbar_doc:save(Context), kz_doc:type(Doc)).
 
 -spec after_post(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
--spec after_post(cb_context:context(), kz_term:ne_binary(), crossbar_status()) -> cb_context:context().
 after_post(Context, DocType) ->
     after_post(Context, DocType, cb_context:resp_status(Context)).
 
+-spec after_post(cb_context:context(), kz_term:ne_binary(), crossbar_status()) -> cb_context:context().
 after_post(Context, <<"account">>, 'success') ->
     _ = cb_accounts:replicate_account_definition(cb_context:doc(Context)),
     lager:debug("saved, returning the metaflows"),
@@ -184,10 +184,10 @@ delete(Context) ->
     after_delete(crossbar_doc:save(Context)).
 
 -spec after_delete(cb_context:context()) -> cb_context:context().
--spec after_delete(cb_context:context(), crossbar_status()) -> cb_context:context().
 after_delete(Context) ->
     after_delete(Context, cb_context:resp_status(Context)).
 
+-spec after_delete(cb_context:context(), crossbar_status()) -> cb_context:context().
 after_delete(Context, 'success') ->
     crossbar_util:response(kz_json:new(), Context);
 after_delete(Context, _RespStatus) ->

--- a/applications/crossbar/src/modules/cb_migrations.erl
+++ b/applications/crossbar/src/modules/cb_migrations.erl
@@ -32,30 +32,32 @@ init() ->
     ok.
 
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_MigrationId) ->
     [?HTTP_GET, ?HTTP_POST].
 
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), http_method()) -> cb_context:context().
 validate(Context) ->
     maybe_create_migration_doc(cb_context:account_db(Context)),
     validate(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?HTTP_GET) ->
     load_migration_list(Context);
 
 validate(Context, MigId) ->
     validate(Context, MigId, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token(), http_method()) -> cb_context:context().
 validate(Context, DocId, ?HTTP_GET) ->
     load_migration_summary(DocId, Context);
 

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -129,11 +129,11 @@ create_call_from_context(Context) ->
     kapps_call:exec(Routines, kapps_call:new()).
 
 -spec request_specific_extraction_funs(cb_context:context()) -> kapps_call:exec_funs().
--spec request_specific_extraction_funs_from_nouns(cb_context:context(), req_nouns()) ->
-                                                         kapps_call:exec_funs().
 request_specific_extraction_funs(Context) ->
     request_specific_extraction_funs_from_nouns(Context, cb_context:req_nouns(Context)).
 
+-spec request_specific_extraction_funs_from_nouns(cb_context:context(), req_nouns()) ->
+                                                         kapps_call:exec_funs().
 request_specific_extraction_funs_from_nouns(Context, ?DEVICES_QCALL_NOUNS(DeviceId, Number)) ->
     NumberURI = build_number_uri(Context, Number),
     [{fun kapps_call:set_authorizing_id/2, DeviceId}
@@ -178,10 +178,10 @@ build_number_uri(Context, Number) ->
     <<UseNumber/binary, "@", Realm/binary>>.
 
 -spec get_endpoints(kapps_call:call(), cb_context:context()) -> kz_json:objects().
--spec get_endpoints(kapps_call:call(), cb_context:context(), req_nouns()) -> kz_json:objects().
 get_endpoints(Call, Context) ->
     get_endpoints(Call, Context, cb_context:req_nouns(Context)).
 
+-spec get_endpoints(kapps_call:call(), cb_context:context(), req_nouns()) -> kz_json:objects().
 get_endpoints(Call, _Context, ?DEVICES_QCALL_NOUNS(DeviceId, Number)) ->
     Properties = kz_json:from_list([{<<"can_call_self">>, 'true'}
                                    ,{<<"suppress_clid">>, 'true'}
@@ -357,10 +357,10 @@ set_quickcall_outbound_call_id(Endpoint) ->
     kz_json:set_value(<<"Outbound-Call-ID">>, CallId, Endpoint).
 
 -spec get_application_data(cb_context:context()) -> kz_json:object().
--spec get_application_data_from_nouns(req_nouns()) -> kz_json:object().
 get_application_data(Context) ->
     get_application_data_from_nouns(cb_context:req_nouns(Context)).
 
+-spec get_application_data_from_nouns(req_nouns()) -> kz_json:object().
 get_application_data_from_nouns(?DEVICES_QCALL_NOUNS(_DeviceId, Number)) ->
     kz_json:from_list([{<<"Route">>, Number}]);
 get_application_data_from_nouns(?USERS_QCALL_NOUNS(_UserId, Number)) ->
@@ -439,10 +439,10 @@ parse_media_type(MediaType) ->
     end.
 
 -spec bucket_name(cb_context:context()) -> kz_term:ne_binary().
--spec bucket_name(kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> kz_term:ne_binary().
 bucket_name(Context) ->
     bucket_name(cb_context:client_ip(Context), cb_context:account_id(Context)).
 
+-spec bucket_name(kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> kz_term:ne_binary().
 bucket_name('undefined', 'undefined') ->
     <<"no_ip/no_account">>;
 bucket_name(IP, 'undefined') ->
@@ -452,13 +452,12 @@ bucket_name('undefined', AccountId) ->
 bucket_name(IP, AccountId) ->
     <<IP/binary, "/", AccountId/binary>>.
 
--spec token_cost(cb_context:context()) -> non_neg_integer().
--spec token_cost(cb_context:context(), non_neg_integer() | kz_json:path()) -> non_neg_integer().
--spec token_cost(cb_context:context(), non_neg_integer(), kz_json:path()) -> non_neg_integer().
 
+-spec token_cost(cb_context:context()) -> non_neg_integer().
 token_cost(Context) ->
     token_cost(Context, 1).
 
+-spec token_cost(cb_context:context(), non_neg_integer() | kz_json:path()) -> non_neg_integer().
 token_cost(Context, <<_/binary>> = Suffix) ->
     token_cost(Context, 1, [Suffix]);
 token_cost(Context, [_|_]=Suffix) ->
@@ -466,6 +465,7 @@ token_cost(Context, [_|_]=Suffix) ->
 token_cost(Context, Default) ->
     token_cost(Context, Default, []).
 
+-spec token_cost(cb_context:context(), non_neg_integer(), kz_json:path()) -> non_neg_integer().
 token_cost(Context, Default, Suffix) when is_integer(Default), Default >= 0 ->
     Costs = kapps_config:get_integer(?CONFIG_CAT, <<"token_costs">>, 1),
     find_token_cost(Costs

--- a/applications/crossbar/src/modules/cb_onboard.erl
+++ b/applications/crossbar/src/modules/cb_onboard.erl
@@ -449,9 +449,8 @@ create_exten_callflow(JObj, Iteration, Context, {Pass, Fail}) ->
 %% the objects.  Starts with the account :)
 %% @end
 %%--------------------------------------------------------------------
--spec populate_new_account(kz_term:proplist(), cb_context:context()) -> cb_context:context().
--spec populate_new_account(kz_term:proplist(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 
+-spec populate_new_account(kz_term:proplist(), cb_context:context()) -> cb_context:context().
 populate_new_account(Props, _) ->
     Context = props:get_value(?KZ_ACCOUNTS_DB, Props),
     Context1 = crossbar_bindings:fold(<<"*.execute.put.accounts">>, [cb_context:set_resp_status(Context, 'error')]),
@@ -481,6 +480,7 @@ populate_new_account(Props, _) ->
             end
     end.
 
+-spec populate_new_account(kz_term:proplist(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 populate_new_account([], _, Results) ->
     Results;
 

--- a/applications/crossbar/src/modules/cb_pivot.erl
+++ b/applications/crossbar/src/modules/cb_pivot.erl
@@ -47,10 +47,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?DEBUG_PATH_TOKEN) ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?DEBUG_PATH_TOKEN, _UUID) ->
     [?HTTP_GET].
 
@@ -63,9 +65,11 @@ allowed_methods(?DEBUG_PATH_TOKEN, _UUID) ->
 %%    /pivot/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(?DEBUG_PATH_TOKEN) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(?DEBUG_PATH_TOKEN, _) -> 'true'.
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -88,13 +88,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?PATH_TOKEN_LAST_SUBMITTED) ->
     [?HTTP_GET];
 allowed_methods(?PORT_SUBMITTED) ->
@@ -114,6 +113,7 @@ allowed_methods(?PORT_UNCONFIRMED) ->
 allowed_methods(_PortRequestId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_PortRequestId, ?PORT_SUBMITTED) ->
     [?HTTP_PATCH];
 allowed_methods(_PortRequestId, ?PORT_PENDING) ->
@@ -133,6 +133,7 @@ allowed_methods(_PortRequestId, ?PATH_TOKEN_LOA) ->
 allowed_methods(_PortRequestId, ?PATH_TOKEN_TIMELINE) ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(_PortRequestId, ?PORT_ATTACHMENT, _AttachmentId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 
@@ -145,14 +146,14 @@ allowed_methods(_PortRequestId, ?PORT_ATTACHMENT, _AttachmentId) ->
 %%    /port_requests/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
 
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_PortRequestId) -> 'true'.
 
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_PortRequestId, ?PORT_SUBMITTED) -> 'true';
 resource_exists(_PortRequestId, ?PORT_PENDING) -> 'true';
 resource_exists(_PortRequestId, ?PORT_SCHEDULED) -> 'true';
@@ -164,6 +165,7 @@ resource_exists(_PortRequestId, ?PATH_TOKEN_LOA) -> 'true';
 resource_exists(_PortRequestId, ?PATH_TOKEN_TIMELINE) -> 'true';
 resource_exists(_PortRequestId, _) -> 'false'.
 
+-spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 resource_exists(_PortRequestId, ?PORT_ATTACHMENT, _AttachmentId) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -179,13 +181,13 @@ acceptable_content_types() -> ?ATTACHMENT_MIME_TYPES.
 
 -spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
                                     cb_context:context().
--spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token()) ->
-                                    cb_context:context().
 content_types_provided(Context, _Id, ?PATH_TOKEN_LOA) ->
     cb_context:add_content_types_provided(Context, [{'to_binary', ?PDF_CONTENT_TYPES}]);
 content_types_provided(Context, _Id, _Path) ->
     Context.
 
+-spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _Id, ?PORT_ATTACHMENT, _AttachmentId) ->
     case cb_context:req_verb(Context) of
         ?HTTP_GET -> content_types_provided_get(Context, _Id, _AttachmentId);
@@ -205,9 +207,8 @@ content_types_provided_get(Context, Id, AttachmentId) ->
 %% Of the form {atom, [{Type, SubType}]} :: {to_json, [{<<"application">>, <<"json">>}]}
 %% @end
 %%--------------------------------------------------------------------
+
 -spec content_types_accepted(cb_context:context(), path_token(), path_token()) ->
-                                    cb_context:context().
--spec content_types_accepted(cb_context:context(), path_token(), path_token(), path_token()) ->
                                     cb_context:context().
 content_types_accepted(Context, _Id, ?PORT_ATTACHMENT) ->
     CTA = [{'from_binary', ?ATTACHMENT_MIME_TYPES}],
@@ -215,6 +216,8 @@ content_types_accepted(Context, _Id, ?PORT_ATTACHMENT) ->
 content_types_accepted(Context, _Id, _) ->
     Context.
 
+-spec content_types_accepted(cb_context:context(), path_token(), path_token(), path_token()) ->
+                                    cb_context:context().
 content_types_accepted(Context, _Id, ?PORT_ATTACHMENT, _AttachmentId) ->
     case cb_context:req_verb(Context) of
         ?HTTP_POST ->
@@ -234,17 +237,14 @@ content_types_accepted(Context, _Id, ?PORT_ATTACHMENT, _AttachmentId) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) ->
-                      cb_context:context().
--spec validate(cb_context:context(), path_token()) ->
-                      cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) ->
-                      cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(), path_token()) ->
                       cb_context:context().
 validate(Context) ->
     validate_port_request(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) ->
+                      cb_context:context().
 validate(Context, ?PATH_TOKEN_LAST_SUBMITTED) ->
     last_submitted(Context);
 validate(Context, ?PORT_UNCONFIRMED = Type) ->
@@ -264,6 +264,8 @@ validate(Context, ?PORT_CANCELED = Type) ->
 validate(Context, Id) ->
     validate_port_request(Context, Id, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token(), path_token()) ->
+                      cb_context:context().
 validate(Context, Id, ?PORT_UNCONFIRMED) ->
     validate_port_request(Context, Id, ?PORT_UNCONFIRMED, cb_context:req_verb(Context));
 validate(Context, Id, ?PORT_SUBMITTED) ->
@@ -285,6 +287,8 @@ validate(Context, Id, ?PATH_TOKEN_LOA) ->
 validate(Context, Id, ?PATH_TOKEN_TIMELINE) ->
     maybe_prepare_timeline(load_port_request(Context, Id)).
 
+-spec validate(cb_context:context(), path_token(), path_token(), path_token()) ->
+                      cb_context:context().
 validate(Context, Id, ?PORT_ATTACHMENT, AttachmentId) ->
     validate_attachment(Context, Id, AttachmentId, cb_context:req_verb(Context)).
 
@@ -304,11 +308,12 @@ get(Context, Id, ?PATH_TOKEN_LOA) ->
 %% If the HTTP verb is PUT, execute the actual action, usually a db save.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec put(cb_context:context()) -> cb_context:context().
--spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context) ->
     save(Context).
 
+-spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context, Id, ?PORT_ATTACHMENT) ->
     [{Filename, FileJObj}] = cb_context:req_files(Context),
     Contents = kz_json:get_value(<<"contents">>, FileJObj),
@@ -390,8 +395,8 @@ date_as_configured_timezone(<<YYYY:4/binary, $-, MM:2/binary, $-, DD:2/binary, $
 %% (after a merge perhaps).
 %% @end
 %%--------------------------------------------------------------------
+
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 post(Context, Id) ->
     Context1 = save(Context),
     case cb_context:resp_status(Context1) of
@@ -403,6 +408,7 @@ post(Context, Id) ->
             Context1
     end.
 
+-spec post(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 post(Context, Id, ?PORT_ATTACHMENT, AttachmentId) ->
     [{_Filename, FileJObj}] = cb_context:req_files(Context),
     Contents = kz_json:get_value(<<"contents">>, FileJObj),
@@ -422,12 +428,14 @@ post(Context, Id, ?PORT_ATTACHMENT, AttachmentId) ->
 %% If the HTTP verb is DELETE, execute the actual action, usually a db delete
 %% @end
 %%--------------------------------------------------------------------
+
 -spec delete(cb_context:context(), path_token()) ->
-                    cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token(), path_token()) ->
                     cb_context:context().
 delete(Context, _Id) ->
     crossbar_doc:delete(Context).
+
+-spec delete(cb_context:context(), path_token(), path_token(), path_token()) ->
+                    cb_context:context().
 delete(Context, Id, ?PORT_ATTACHMENT, AttachmentName) ->
     crossbar_doc:delete_attachment(Id, AttachmentName, Context).
 
@@ -460,17 +468,16 @@ validate_load_summary(Context, <<_/binary>> = Type) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate_port_request(cb_context:context(), http_method()) ->
-                                   cb_context:context().
--spec validate_port_request(cb_context:context(), kz_term:ne_binary(), http_method()) ->
-                                   cb_context:context().
--spec validate_port_request(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), http_method()) ->
                                    cb_context:context().
 validate_port_request(Context, ?HTTP_GET) ->
     summary(Context);
 validate_port_request(Context, ?HTTP_PUT) ->
     create(Context).
 
+-spec validate_port_request(cb_context:context(), kz_term:ne_binary(), http_method()) ->
+                                   cb_context:context().
 validate_port_request(Context, Id, ?HTTP_GET) ->
     read(Context, Id);
 validate_port_request(Context, Id, ?HTTP_POST) ->
@@ -478,6 +485,8 @@ validate_port_request(Context, Id, ?HTTP_POST) ->
 validate_port_request(Context, Id, ?HTTP_DELETE) ->
     is_deletable(load_port_request(Context, Id)).
 
+-spec validate_port_request(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), http_method()) ->
+                                   cb_context:context().
 validate_port_request(Context, Id, ToState=?PORT_SUBMITTED, ?HTTP_PATCH) ->
     patch_then_validate_then_maybe_transition(Context, Id, ToState);
 validate_port_request(Context, Id, ToState=?PORT_PENDING, ?HTTP_PATCH) ->
@@ -533,10 +542,12 @@ validate_attachment(Context, Id, AttachmentId, ?HTTP_DELETE) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec is_deletable(cb_context:context()) -> cb_context:context().
--spec is_deletable(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 is_deletable(Context) ->
     is_deletable(Context, knm_port_request:current_state(cb_context:doc(Context))).
+
+-spec is_deletable(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 is_deletable(Context, ?PORT_UNCONFIRMED) -> Context;
 is_deletable(Context, ?PORT_REJECTED) -> Context;
 is_deletable(Context, ?PORT_CANCELED) -> Context;
@@ -858,8 +869,8 @@ summary_attachments(Context, Id) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec on_successful_validation(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
--spec on_successful_validation(cb_context:context(), kz_term:api_binary(), boolean()) -> cb_context:context().
 on_successful_validation(Context, 'undefined') ->
     on_successful_validation(Context, 'undefined', 'true');
 on_successful_validation(Context, Id) ->
@@ -869,6 +880,7 @@ on_successful_validation(Context, Id) ->
                                       ),
     on_successful_validation(Context1, Id, can_update_port_request(Context1)).
 
+-spec on_successful_validation(cb_context:context(), kz_term:api_binary(), boolean()) -> cb_context:context().
 on_successful_validation(Context, Id, 'true') ->
     JObj = cb_context:doc(Context),
     Numbers = kz_json:get_keys(kz_json:get_value(<<"numbers">>, JObj)),
@@ -899,12 +911,13 @@ on_successful_validation(Context, _Id, 'false') ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec can_update_port_request(cb_context:context()) -> boolean().
--spec can_update_port_request(cb_context:context(), kz_term:ne_binary()) -> boolean().
 can_update_port_request(Context) ->
     lager:debug("port request: ~p", [cb_context:doc(Context)]),
     can_update_port_request(Context, knm_port_request:current_state(cb_context:doc(Context))).
 
+-spec can_update_port_request(cb_context:context(), kz_term:ne_binary()) -> boolean().
 can_update_port_request(_Context, ?PORT_UNCONFIRMED) ->
     'true';
 can_update_port_request(_Context, ?PORT_REJECTED) ->
@@ -933,9 +946,8 @@ successful_validation(Context, _Id) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec check_number_portability(kz_term:api_binary(), kz_term:ne_binary(), cb_context:context()) ->
-                                      cb_context:context().
--spec check_number_portability(kz_term:api_binary(), kz_term:ne_binary(), cb_context:context(), kz_term:ne_binary(), kz_json:object()) ->
                                       cb_context:context().
 check_number_portability(PortId, Number, Context) ->
     E164 = knm_converters:normalize(Number),
@@ -956,6 +968,8 @@ check_number_portability(PortId, Number, Context) ->
             number_validation_error(Context, Number, Message)
     end.
 
+-spec check_number_portability(kz_term:api_binary(), kz_term:ne_binary(), cb_context:context(), kz_term:ne_binary(), kz_json:object()) ->
+                                      cb_context:context().
 check_number_portability(PortId, Number, Context, E164, PortReq) ->
     case {kz_json:get_value(<<"value">>, PortReq) =:= cb_context:account_id(Context)
          ,kz_doc:id(PortReq) =:= PortId
@@ -1076,12 +1090,14 @@ maybe_move_state(Context, PortState) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec generate_loa(cb_context:context()) ->
-                          cb_context:context().
--spec generate_loa(cb_context:context(), crossbar_status()) ->
                           cb_context:context().
 generate_loa(Context) ->
     generate_loa(Context, cb_context:resp_status(Context)).
+
+-spec generate_loa(cb_context:context(), crossbar_status()) ->
+                          cb_context:context().
 generate_loa(Context, 'success') ->
     generate_loa_from_port(Context, cb_context:doc(Context));
 generate_loa(Context, _RespStatus) ->

--- a/applications/crossbar/src/modules/cb_presence.erl
+++ b/applications/crossbar/src/modules/cb_presence.erl
@@ -95,10 +95,12 @@ authorize(_Context, _Nouns, _Verb) -> 'false'.
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_POST].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?MATCH_REPORT_PREFIX) ->
     [?HTTP_GET];
 allowed_methods(_Extension) ->
@@ -112,9 +114,11 @@ allowed_methods(_Extension) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_Extension) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -146,13 +150,14 @@ content_types_provided_for_report(Context, Report) ->
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) ->
-                      cb_context:context().
--spec validate(cb_context:context(), path_token()) ->
                       cb_context:context().
 validate(Context) ->
     validate_thing(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) ->
+                      cb_context:context().
 validate(Context, ?MATCH_REPORT_PREFIX(Report)) ->
     load_report(Context, Report);
 validate(Context, Extension) ->
@@ -239,10 +244,10 @@ extract_subscriptions(JObjs, Fun) ->
     lists:foldl(fun(JObj, Acc) -> Fun(kz_api:remove_defaults(JObj), Acc) end, kz_json:new(), JObjs).
 
 -spec validate_presence_thing(cb_context:context()) -> cb_context:context().
--spec validate_presence_thing(cb_context:context(), req_nouns()) -> cb_context:context().
 validate_presence_thing(Context) ->
     validate_presence_thing(Context, cb_context:req_nouns(Context)).
 
+-spec validate_presence_thing(cb_context:context(), req_nouns()) -> cb_context:context().
 validate_presence_thing(Context, [{<<"presence">>, _}
                                  ,{<<"devices">>, [DeviceId]}
                                  ,{<<"accounts">>, [_AccountId]}

--- a/applications/crossbar/src/modules/cb_profile.erl
+++ b/applications/crossbar/src/modules/cb_profile.erl
@@ -41,11 +41,11 @@ init() ->
 
 -spec req_init({cb_context:context(), cowboy_req:req()}) ->
                       {cb_context:context(), cowboy_req:req()}.
--spec req_init(kz_term:api_binary(), {cb_context:context(), cowboy_req:req()}) ->
-                      {cb_context:context(), cowboy_req:req()}.
 req_init({Context, _} = InitArgs) ->
     req_init(cb_context:profile_id(Context), InitArgs).
 
+-spec req_init(kz_term:api_binary(), {cb_context:context(), cowboy_req:req()}) ->
+                      {cb_context:context(), cowboy_req:req()}.
 req_init('undefined', InitArgs) ->
     InitArgs;
 req_init(ProfileId, InitArgs) ->

--- a/applications/crossbar/src/modules/cb_rate_limits.erl
+++ b/applications/crossbar/src/modules/cb_rate_limits.erl
@@ -183,12 +183,12 @@ validate_delete_rate_limits(Context, ThingId) ->
 
 -spec validate_set_rate_limits(cb_context:context()) ->
                                       cb_context:context().
--spec validate_set_rate_limits(cb_context:context(), kz_term:api_binary()) ->
-                                      cb_context:context().
 validate_set_rate_limits(Context) ->
     lager:debug("rate limits data is valid, setting on thing"),
     validate_set_rate_limits(Context, thing_id(Context)).
 
+-spec validate_set_rate_limits(cb_context:context(), kz_term:api_binary()) ->
+                                      cb_context:context().
 validate_set_rate_limits(Context, 'undefined') ->
     lager:debug("no thing found"),
     crossbar_util:response_faulty_request(Context);

--- a/applications/crossbar/src/modules/cb_rates.erl
+++ b/applications/crossbar/src/modules/cb_rates.erl
@@ -142,13 +142,16 @@ content_types_provided_by_verb(Context, _Verb) ->
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_rates(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_rate(Context, Id, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ?NUMBER, Phonenumber) ->
     validate_number(Phonenumber, Context).
 
@@ -176,11 +179,12 @@ ratedeck_db(Context) ->
     kzd_ratedeck:format_ratedeck_db(RatedeckId).
 
 -spec post(cb_context:context()) -> cb_context:context().
--spec post(cb_context:context(), path_token()) -> cb_context:context().
 post(Context) ->
     _ = init_db(),
     _ = kz_util:spawn(fun upload_csv/1, [Context]),
     crossbar_util:response_202(<<"attempting to insert rates from the uploaded document">>, Context).
+
+-spec post(cb_context:context(), path_token()) -> cb_context:context().
 post(Context, _RateId) ->
     crossbar_doc:save(Context).
 
@@ -282,10 +286,10 @@ doc_updates(Fun, Doc) when is_function(Fun, 1) ->
     Fun(Doc).
 
 -spec ensure_routes_set(kz_json:object()) -> kz_json:object().
--spec ensure_routes_set(kz_json:object(), kz_term:api_binaries()) -> kz_json:object().
 ensure_routes_set(Doc) ->
     ensure_routes_set(Doc, kz_json:get_value(<<"routes">>, Doc)).
 
+-spec ensure_routes_set(kz_json:object(), kz_term:api_binaries()) -> kz_json:object().
 ensure_routes_set(Doc, 'undefined') ->
     add_default_route(Doc, kz_json:get_value(<<"prefix">>, Doc));
 ensure_routes_set(Doc, []) ->

--- a/applications/crossbar/src/modules/cb_recordings.erl
+++ b/applications/crossbar/src/modules/cb_recordings.erl
@@ -61,10 +61,11 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
--spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 
+-spec allowed_methods() -> http_methods().
 allowed_methods() -> [?HTTP_GET].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_RecordingId) -> [?HTTP_GET, ?HTTP_DELETE].
 
 %%--------------------------------------------------------------------
@@ -74,10 +75,11 @@ allowed_methods(_RecordingId) -> [?HTTP_GET, ?HTTP_DELETE].
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 
+-spec resource_exists() -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_RecordingId) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -214,11 +216,11 @@ get_disposition(MediaName, Context) ->
     end.
 
 -spec action_lookup(cb_context:context()) -> atom().
--spec action_lookup(kz_term:proplist(), media_values()) -> atom().
 action_lookup(Context) ->
     Acceptable = acceptable_content_types(Context),
     action_lookup(Acceptable, accept_values(Context)).
 
+-spec action_lookup(kz_term:proplist(), media_values()) -> atom().
 action_lookup(_, [?MEDIA_VALUE(<<"application">>, <<"json">>, _, _, _)|_]) ->
     'read';
 action_lookup(_, [?MEDIA_VALUE(<<"application">>, <<"x-json">>, _, _, _)|_]) ->

--- a/applications/crossbar/src/modules/cb_registrations.erl
+++ b/applications/crossbar/src/modules/cb_registrations.erl
@@ -64,10 +64,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?COUNT_PATH_TOKEN) ->
     [?HTTP_GET];
 allowed_methods(_Username) ->
@@ -79,9 +81,11 @@ allowed_methods(_Username) ->
 %% Does the path point to a valid resource
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(?COUNT_PATH_TOKEN) -> 'true';
 resource_exists(_Username) -> 'true'.
 
@@ -109,8 +113,8 @@ authorize_admin(Context, [{<<"registrations">>, [?COUNT_PATH_TOKEN]}]) ->
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_registrations(Context, cb_context:req_verb(Context)).
 
@@ -120,6 +124,7 @@ validate_registrations(Context, ?HTTP_GET) ->
 validate_registrations(Context, ?HTTP_DELETE) ->
     crossbar_util:response(<<"ok">>, Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?COUNT_PATH_TOKEN) ->
     validate_count(Context);
 validate(Context, Username) ->
@@ -154,11 +159,11 @@ sip_username_exists(Context, Username) ->
     end.
 
 -spec delete(cb_context:context()) -> cb_context:context().
--spec delete(cb_context:context(), path_token()) -> cb_context:context().
 delete(Context) ->
     crossbar_util:flush_registrations(Context),
     crossbar_util:response(<<"ok">>, Context).
 
+-spec delete(cb_context:context(), path_token()) -> cb_context:context().
 delete(Context, Username) ->
     crossbar_util:flush_registration(Username, Context),
     crossbar_util:response(<<"ok">>, Context).

--- a/applications/crossbar/src/modules/cb_resource_selectors.erl
+++ b/applications/crossbar/src/modules/cb_resource_selectors.erl
@@ -52,11 +52,11 @@ init() ->
 
 -spec authorize(cb_context:context()) ->
                        boolean() | {'stop', cb_context:context()}.
--spec authorize(cb_context:context(), req_nouns()) ->
-                       boolean() | {'stop', cb_context:context()}.
 authorize(Context) ->
     authorize(Context, cb_context:req_nouns(Context)).
 
+-spec authorize(cb_context:context(), req_nouns()) ->
+                       boolean() | {'stop', cb_context:context()}.
 authorize(Context, [{<<"resource_selectors">>, _} | _]) ->
     case cb_context:account_id(Context) of
         'undefined' -> maybe_authorize_admin(Context);
@@ -85,13 +85,12 @@ maybe_authorize_admin(Context) ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?RULES) ->
     [?HTTP_GET, ?HTTP_POST];
 allowed_methods(?NAME) ->
@@ -101,11 +100,13 @@ allowed_methods(?RESOURCE) ->
 allowed_methods(_UUID) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?NAME, _SelectorName) ->
     [?HTTP_GET];
 allowed_methods(?RESOURCE, _ResourceId) ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(?RESOURCE, _ResourceId, ?NAME, _SelectorName) ->
     [?HTTP_GET];
 allowed_methods(?NAME, _SelectorName, ?RESOURCE, _ResourceId) ->
@@ -119,20 +120,21 @@ allowed_methods(?NAME, _SelectorName, ?RESOURCE, _ResourceId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token(), path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
 
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(?RULES) -> 'true';
 resource_exists(?NAME) -> 'true';
 resource_exists(?RESOURCE) -> 'true';
 resource_exists(_UUID) -> 'true'.
 
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(?NAME, _SelectorName) -> 'true';
 resource_exists(?RESOURCE, _ResourceId) -> 'true'.
 
+-spec resource_exists(path_token(), path_token(), path_token(), path_token()) -> 'true'.
 resource_exists(?RESOURCE, _ResourceId, ?NAME, _SelectorName) -> 'true';
 resource_exists(?NAME, _SelectorName, ?RESOURCE, _ResourceId) -> 'true'.
 
@@ -145,13 +147,12 @@ resource_exists(?NAME, _SelectorName, ?RESOURCE, _ResourceId) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(),  path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     summary(set_selectors_db(Context), [], <<"resource_selectors/id_listing">>, 'false').
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?RULES) ->
     validate_rules(set_account_db(Context), cb_context:req_verb(Context));
 validate(Context, ?NAME) ->
@@ -161,11 +162,13 @@ validate(Context, ?RESOURCE) ->
 validate(Context, UUID) ->
     validate_doc(set_selectors_db(Context), UUID, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ?NAME, SelectorName) ->
     summary(set_selectors_db(Context), [SelectorName], <<"resource_selectors/name_resource_listing">>, 'true');
 validate(Context, ?RESOURCE, ResourceId) ->
     summary(set_selectors_db(Context), [ResourceId], <<"resource_selectors/resource_name_listing">>, 'true').
 
+-spec validate(cb_context:context(), path_token(), path_token(),  path_token(), path_token()) -> cb_context:context().
 validate(Context, ?RESOURCE, ResourceId, ?NAME, SelectorName) ->
     summary(set_selectors_db(Context), [ResourceId, SelectorName], <<"resource_selectors/resource_name_id_listing">>, 'false');
 validate(Context, ?NAME, SelectorName, ?RESOURCE, ResourceId) ->
@@ -341,11 +344,11 @@ is_global_request(Context) ->
 
 -spec maybe_handle_load_failure(cb_context:context()) ->
                                        cb_context:context().
--spec maybe_handle_load_failure(cb_context:context(), pos_integer()) ->
-                                       cb_context:context().
 maybe_handle_load_failure(Context) ->
     maybe_handle_load_failure(Context, cb_context:resp_error_code(Context)).
 
+-spec maybe_handle_load_failure(cb_context:context(), pos_integer()) ->
+                                       cb_context:context().
 maybe_handle_load_failure(Context, 404) ->
     JObj = kz_doc:set_type(kz_doc:set_id(cb_context:req_data(Context),?RULES_PVT_TYPE), ?RULES_PVT_TYPE),
     cb_context:setters(Context

--- a/applications/crossbar/src/modules/cb_resource_templates.erl
+++ b/applications/crossbar/src/modules/cb_resource_templates.erl
@@ -50,10 +50,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_ResourceTemplateId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -65,9 +67,11 @@ allowed_methods(_ResourceTemplateId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_schemas.erl
+++ b/applications/crossbar/src/modules/cb_schemas.erl
@@ -61,13 +61,16 @@ authenticate_nouns(_) -> 'false'.
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_SchemaName) ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_SchemaName, ?VALIDATION_PATH_TOKEN) ->
     [?HTTP_PUT].
 
@@ -79,11 +82,14 @@ allowed_methods(_SchemaName, ?VALIDATION_PATH_TOKEN) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() ->  'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_SchemaName) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_SchemaName, ?VALIDATION_PATH_TOKEN) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -95,16 +101,17 @@ resource_exists(_SchemaName, ?VALIDATION_PATH_TOKEN) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     lager:debug("load summary of schemas from ~s", [?KZ_SCHEMA_DB]),
     summary(cb_context:set_account_db(Context, ?KZ_SCHEMA_DB)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     read(Id, cb_context:set_account_db(Context, ?KZ_SCHEMA_DB)).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, Id, ?VALIDATION_PATH_TOKEN) ->
     cb_context:validate_request_data(Id, Context, fun on_success/1).
 

--- a/applications/crossbar/src/modules/cb_search.erl
+++ b/applications/crossbar/src/modules/cb_search.erl
@@ -50,11 +50,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?MULTI) ->
     [?HTTP_GET].
 
@@ -67,9 +68,11 @@ allowed_methods(?MULTI) ->
 %%    /skels/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(?MULTI) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -77,11 +80,12 @@ resource_exists(?MULTI) -> 'true'.
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec authorize(cb_context:context()) -> boolean().
--spec authorize(cb_context:context(), path_token()) -> boolean().
 authorize(Context) ->
     cb_context:auth_account_id(Context) =/= 'undefined'.
 
+-spec authorize(cb_context:context(), path_token()) -> boolean().
 authorize(Context, ?MULTI) ->
     cb_context:auth_account_id(Context) =/= 'undefined'.
 
@@ -95,12 +99,13 @@ authorize(Context, ?MULTI) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     Type = cb_context:req_value(Context, <<"t">>),
     validate_search(Context, Type).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?MULTI) ->
     Type = cb_context:req_value(Context, <<"t">>),
     validate_multi(Context, Type).
@@ -114,11 +119,8 @@ validate(Context, ?MULTI) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate_search(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
--spec validate_search(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) ->
-                             cb_context:context().
--spec validate_search(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary()) ->
-                             cb_context:context().
 validate_search(Context, 'undefined') ->
     Message = kz_json:from_list([{<<"message">>, <<"search needs a document type to search on">>}
                                 ,{<<"target">>, ?SEARCHABLE}
@@ -129,6 +131,8 @@ validate_search(Context, <<"account">>=Type) ->
 validate_search(Context, Type) ->
     validate_search(Context, Type, cb_context:req_value(Context, <<"q">>)).
 
+-spec validate_search(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) ->
+                             cb_context:context().
 validate_search(Context, _Type, 'undefined') ->
     NeedViewMsg = kz_json:from_list([{<<"message">>, <<"search needs a view to search in">>}
                                     ,{<<"target">>, available_query_options(cb_context:account_db(Context))}
@@ -143,6 +147,8 @@ validate_search(Context, Type, Query) ->
             Context1
     end.
 
+-spec validate_search(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary()) ->
+                             cb_context:context().
 validate_search(Context, _Type, _Query, 'undefined') ->
     Message = kz_json:from_list([{<<"message">>, <<"search needs a value to search for">>}]),
     cb_context:add_validation_error(<<"v">>, <<"required">>, Message, Context);
@@ -183,12 +189,13 @@ validate_multi(Context, Type, Query) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate_query(cb_context:context(), kz_term:proplist() | kz_term:ne_binary()) -> cb_context:context().
--spec validate_query(cb_context:context(), kz_term:proplist(), kz_term:proplist() | kz_term:ne_binary()) -> cb_context:context().
 validate_query(Context, Query) ->
     QueryOptions = available_query_options(cb_context:account_db(Context)),
     validate_query(Context, QueryOptions, Query).
 
+-spec validate_query(cb_context:context(), kz_term:proplist(), kz_term:proplist() | kz_term:ne_binary()) -> cb_context:context().
 validate_query(Context, Available, []) ->
     case cb_context:resp_status(Context) of
         'success' -> Context;
@@ -238,11 +245,12 @@ available_query_options(AccountDb) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec format_query_options(kz_term:ne_binaries()) -> kz_term:ne_binaries().
--spec format_query_option(kz_term:ne_binary()) -> kz_term:ne_binary().
 format_query_options(Views) ->
     [format_query_option(View) || View <- Views].
 
+-spec format_query_option(kz_term:ne_binary()) -> kz_term:ne_binary().
 format_query_option(<<"search_by_", Name/binary>>) -> Name;
 format_query_option(Name) -> Name.
 
@@ -272,12 +280,13 @@ search(Context, Type, Query, Val, Opts) ->
 %% resource.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec multi_search(cb_context:context(), kz_term:ne_binary(), kz_term:proplist()) -> cb_context:context().
--spec multi_search(cb_context:context(), kz_term:ne_binary(), kz_term:proplist(), kz_json:object()) -> cb_context:context().
 multi_search(Context, Type, Props) ->
     Context1 = cb_context:set_should_paginate(Context, 'false'),
     multi_search(Context1, Type, Props , kz_json:new()).
 
+-spec multi_search(cb_context:context(), kz_term:ne_binary(), kz_term:proplist(), kz_json:object()) -> cb_context:context().
 multi_search(Context, _Type, [], Acc) ->
     cb_context:set_resp_data(Context, Acc);
 multi_search(Context, Type, [{<<"by_", Query/binary>>, Val}|Props], Acc) ->

--- a/applications/crossbar/src/modules/cb_service_plans.erl
+++ b/applications/crossbar/src/modules/cb_service_plans.erl
@@ -55,11 +55,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_POST].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?SYNCHRONIZATION) ->
     [?HTTP_POST];
 allowed_methods(?RECONCILIATION) ->
@@ -72,6 +73,8 @@ allowed_methods(?AVAILABLE) ->
     [?HTTP_GET];
 allowed_methods(_PlanId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?AVAILABLE, _PlanId) ->
     [?HTTP_GET].
 
@@ -84,11 +87,14 @@ allowed_methods(?AVAILABLE, _PlanId) ->
 %%    /service_plans/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, _) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -101,12 +107,12 @@ resource_exists(_, _) -> 'true'.
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     validate_service_plan(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?CURRENT) ->
     cb_context:setters(Context
                       ,[{fun cb_context:set_resp_status/2, 'success'}
@@ -155,7 +161,6 @@ validate(Context, ?AVAILABLE, PlanId) ->
     crossbar_doc:load(PlanId, Context1, ?TYPE_CHECK_OPTION(kzd_service_plan:type())).
 
 -spec validate_service_plan(cb_context:context(), http_method()) -> cb_context:context().
--spec validate_service_plan(cb_context:context(), path_token(), http_method()) -> cb_context:context().
 validate_service_plan(Context, ?HTTP_GET) ->
     crossbar_doc:load_view(?CB_LIST
                           ,[]
@@ -165,6 +170,7 @@ validate_service_plan(Context, ?HTTP_GET) ->
 validate_service_plan(Context, ?HTTP_POST) ->
     maybe_allow_change(Context).
 
+-spec validate_service_plan(cb_context:context(), path_token(), http_method()) -> cb_context:context().
 validate_service_plan(Context, PlanId, ?HTTP_GET) ->
     crossbar_doc:load(PlanId, Context);
 validate_service_plan(Context, PlanId, ?HTTP_POST) ->
@@ -179,10 +185,8 @@ validate_service_plan(Context, PlanId, ?HTTP_DELETE) ->
 %% (after a merge perhaps).
 %% @end
 %%--------------------------------------------------------------------
--spec post(cb_context:context()) -> cb_context:context().
--spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 
+-spec post(cb_context:context()) -> cb_context:context().
 post(Context) ->
     Services = pipe_services(cb_context:account_id(Context)
                             ,[fun(Services) -> add_plans(Context, Services) end
@@ -194,6 +198,7 @@ post(Context) ->
                        ,{fun cb_context:set_resp_status/2, 'success'}
                        ]).
 
+-spec post(cb_context:context(), path_token()) -> cb_context:context().
 post(Context, ?SYNCHRONIZATION) ->
     _ = kz_services:sync(cb_context:account_id(Context)),
     cb_context:set_resp_status(Context, 'success');
@@ -234,6 +239,7 @@ post(Context, PlanId) ->
                        ,{fun cb_context:set_resp_status/2, 'success'}
                        ]).
 
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, PlanId, ?OVERRIDE) ->
     Doc = cb_context:doc(Context),
 
@@ -309,21 +315,22 @@ pipe_services(AccountId, Routines) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec content_types_provided(cb_context:context()) -> cb_context:context().
--spec content_types_provided(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
--spec content_types_provided(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary()) -> cb_context:context().
 content_types_provided(Context) ->
     cb_context:add_content_types_provided(Context
                                          ,[{'to_json', ?JSON_CONTENT_TYPES}
                                           ,{'to_csv', ?CSV_CONTENT_TYPES}
                                           ]).
 
+-spec content_types_provided(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 content_types_provided(Context, _) ->
     cb_context:add_content_types_provided(Context
                                          ,[{'to_json', ?JSON_CONTENT_TYPES}
                                           ,{'to_csv', ?CSV_CONTENT_TYPES}
                                           ]).
 
+-spec content_types_provided(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary()) -> cb_context:context().
 content_types_provided(Context, ?AVAILABLE, _) ->
     cb_context:add_content_types_provided(Context
                                          ,[{'to_json', ?JSON_CONTENT_TYPES}
@@ -363,8 +370,8 @@ is_allowed(Context) ->
 %% Check if you have the permission to update or delete service plans
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_allow_change(cb_context:context()) -> cb_context:context().
--spec maybe_allow_change(cb_context:context(), path_token()) -> cb_context:context().
 maybe_allow_change(Context) ->
     case is_allowed(Context) of
         {'ok', ResellerId} ->
@@ -373,6 +380,7 @@ maybe_allow_change(Context) ->
             cb_context:add_system_error('forbidden', Context)
     end.
 
+-spec maybe_allow_change(cb_context:context(), path_token()) -> cb_context:context().
 maybe_allow_change(Context, PlanId) ->
     case is_allowed(Context) of
         {'ok', ResellerId} ->
@@ -387,13 +395,14 @@ maybe_allow_change(Context, PlanId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec check_plan_ids(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
--spec check_plan_ids(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binaries()) -> cb_context:context().
 check_plan_ids(Context, ResellerId) ->
     ReqData = cb_context:req_data(Context),
     AddPlanIds = kz_json:get_value(<<"add">>, ReqData, []),
     check_plan_ids(maybe_forbid_delete(Context), ResellerId, AddPlanIds).
 
+-spec check_plan_ids(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binaries()) -> cb_context:context().
 check_plan_ids(Context, _ResellerId, []) ->
     Context;
 check_plan_ids(Context, ResellerId, PlanIds) ->

--- a/applications/crossbar/src/modules/cb_services.erl
+++ b/applications/crossbar/src/modules/cb_services.erl
@@ -58,10 +58,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_POST].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?PATH_PLAN) ->
     [?HTTP_GET];
 allowed_methods(?PATH_AUDIT) ->
@@ -78,9 +80,11 @@ allowed_methods(?PATH_STATUS) ->
 %%    /services/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> boolean().
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> boolean().
 resource_exists(?PATH_PLAN) -> 'true';
 resource_exists(?PATH_AUDIT) -> 'true';
 resource_exists(?PATH_STATUS) -> 'true';
@@ -103,9 +107,8 @@ content_types_provided(Context, ?PATH_AUDIT) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     validate_services(Context, cb_context:req_verb(Context)).
 
@@ -130,6 +133,7 @@ validate_services(Context, ?HTTP_POST) ->
             crossbar_util:response('error', kz_term:to_binary(Error), 400, R, Context)
     end.
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?PATH_PLAN) ->
     crossbar_util:response(kz_services:service_plan_json(cb_context:account_id(Context)), Context);
 validate(Context, ?PATH_AUDIT) ->
@@ -149,12 +153,12 @@ validate(Context0, ?PATH_STATUS) ->
 %% the resource into the resp_data, resp_headers, etc...
 %% @end
 %%--------------------------------------------------------------------
--spec get(cb_context:context()) -> cb_context:context().
--spec get(cb_context:context(), path_token()) -> cb_context:context().
 
+-spec get(cb_context:context()) -> cb_context:context().
 get(Context) ->
     Context.
 
+-spec get(cb_context:context(), path_token()) -> cb_context:context().
 get(Context, ?PATH_PLAN) ->
     Context;
 get(Context, ?PATH_AUDIT) ->

--- a/applications/crossbar/src/modules/cb_shared_auth.erl
+++ b/applications/crossbar/src/modules/cb_shared_auth.erl
@@ -79,11 +79,12 @@ resource_exists() -> 'true'.
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec authorize(cb_context:context()) -> boolean().
--spec authorize(cb_context:context(), req_nouns()) -> boolean().
 authorize(Context) ->
     authorize(Context, cb_context:req_nouns(Context)).
 
+-spec authorize(cb_context:context(), req_nouns()) -> boolean().
 authorize(_, [{<<"shared_auth">>, _}]) ->'true';
 authorize(_, _) -> 'false'.
 
@@ -92,11 +93,12 @@ authorize(_, _) -> 'false'.
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec authenticate(cb_context:context()) -> boolean().
--spec authenticate(http_method(), req_nouns()) -> boolean().
 authenticate(Context) ->
     authenticate(cb_context:req_verb(Context), cb_context:req_nouns(Context)).
 
+-spec authenticate(http_method(), req_nouns()) -> boolean().
 authenticate(?HTTP_PUT, [{<<"shared_auth">>, []}]) -> 'true';
 authenticate(_, _) -> 'false'.
 
@@ -125,11 +127,12 @@ authenticate(_, _) -> 'false'.
 %% Failure here returns 400 or 401
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate_request(cb_context:context(), http_method(), kz_term:api_object()) -> cb_context:context().
 validate(Context) ->
     validate_request(Context, cb_context:req_verb(Context), cb_context:auth_doc(Context)).
 
+-spec validate_request(cb_context:context(), http_method(), kz_term:api_object()) -> cb_context:context().
 validate_request(Context, ?HTTP_PUT, _) ->
     _ = cb_context:put_reqid(Context),
     SharedToken = kz_json:get_value(<<"shared_token">>, cb_context:req_data(Context)),

--- a/applications/crossbar/src/modules/cb_skels.erl
+++ b/applications/crossbar/src/modules/cb_skels.erl
@@ -95,10 +95,12 @@ authorize(_) -> 'false'.
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_Thing) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -111,9 +113,11 @@ allowed_methods(_Thing) ->
 %%    /skels/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -186,10 +190,12 @@ encodings_provided(Context) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_skels(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_skel(Context, Id, cb_context:req_verb(Context)).
 

--- a/applications/crossbar/src/modules/cb_sms.erl
+++ b/applications/crossbar/src/modules/cb_sms.erl
@@ -51,10 +51,12 @@ init() ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_SMSId) ->
     [?HTTP_GET, ?HTTP_DELETE].
 
@@ -67,9 +69,11 @@ allowed_methods(_SMSId) ->
 %%    /faxes/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -82,10 +86,12 @@ resource_exists(_) -> 'true'.
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_request(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_sms(Context, Id, cb_context:req_verb(Context)).
 

--- a/applications/crossbar/src/modules/cb_sup.erl
+++ b/applications/crossbar/src/modules/cb_sup.erl
@@ -137,20 +137,20 @@ init() ->
 %% allowed to access the resource, or false if not.
 %% @end
 %%--------------------------------------------------------------------
--spec authorize(cb_context:context()) -> 'false'.
--spec authorize(cb_context:context(), path_token()) -> boolean().
--spec authorize(cb_context:context(), path_token(), path_token()) -> boolean().
--spec authorize(cb_context:context(), path_token(), path_token(), path_token()) -> boolean().
 
+-spec authorize(cb_context:context()) -> 'false'.
 authorize(_Context) ->
     'false'.
 
+-spec authorize(cb_context:context(), path_token()) -> boolean().
 authorize(Context, _Module) ->
     cb_context:is_superduper_admin(Context).
 
+-spec authorize(cb_context:context(), path_token(), path_token()) -> boolean().
 authorize(Context, _Module, _Function) ->
     cb_context:is_superduper_admin(Context).
 
+-spec authorize(cb_context:context(), path_token(), path_token(), path_token()) -> boolean().
 authorize(Context, _Module, _Function, _Args) ->
     cb_context:is_superduper_admin(Context).
 
@@ -161,15 +161,16 @@ authorize(Context, _Module, _Function, _Args) ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(_Module) ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_Module, _Function) ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(_Module, _Function, _Args) ->
     [?HTTP_GET].
 
@@ -182,18 +183,19 @@ allowed_methods(_Module, _Function, _Args) ->
 %%    /sup/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'false'.
--spec resource_exists(path_token()) -> boolean().
--spec resource_exists(path_token(), path_token()) -> boolean().
--spec resource_exists(path_token(), path_token(), kz_term:ne_binaries()) -> boolean().
 resource_exists() -> 'false'.
 
+-spec resource_exists(path_token()) -> boolean().
 resource_exists(ModuleBin) ->
     does_resource_exist(ModuleBin, 'status', []).
 
+-spec resource_exists(path_token(), path_token()) -> boolean().
 resource_exists(ModuleBin, FunctionBin) ->
     does_resource_exist(ModuleBin, FunctionBin, []).
 
+-spec resource_exists(path_token(), path_token(), kz_term:ne_binaries()) -> boolean().
 resource_exists(ModuleBin, FunctionBin, Args) ->
     does_resource_exist(ModuleBin, FunctionBin, Args).
 
@@ -230,16 +232,19 @@ module_name(ModuleBin) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context) -> Context.
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ModuleBin) ->
     validate_sup(Context, module_name(ModuleBin), 'status', []).
+
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ModuleBin, FunctionBin) ->
     validate_sup(Context, module_name(ModuleBin), kz_term:to_atom(FunctionBin), []).
+
+-spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ModuleBin, FunctionBin, Args) ->
     validate_sup(Context, module_name(ModuleBin), kz_term:to_atom(FunctionBin), Args).
 

--- a/applications/crossbar/src/modules/cb_system_configs.erl
+++ b/applications/crossbar/src/modules/cb_system_configs.erl
@@ -60,8 +60,6 @@ init() ->
 -type authorize_return() :: boolean() | {'stop', cb_context:context()}.
 
 -spec authorize(cb_context:context()) -> authorize_return().
--spec authorize(cb_context:context(), path_token()) -> authorize_return().
--spec authorize(cb_context:context(), path_token(), path_token()) -> authorize_return().
 authorize(Context) ->
     case cb_context:is_superduper_admin(Context)
         andalso cb_context:req_nouns(Context) of
@@ -69,7 +67,11 @@ authorize(Context) ->
         [{<<"system_configs">>, _}] -> 'true';
         _ -> {'stop', cb_context:add_system_error('bad_identifier', Context)}
     end.
+
+-spec authorize(cb_context:context(), path_token()) -> authorize_return().
 authorize(Context, _Id) -> authorize(Context).
+
+-spec authorize(cb_context:context(), path_token(), path_token()) -> authorize_return().
 authorize(Context, _Id, _Node) -> authorize(Context).
 
 %%--------------------------------------------------------------------
@@ -79,13 +81,16 @@ authorize(Context, _Id, _Node) -> authorize(Context).
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_SystemConfigId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE, ?HTTP_PUT, ?HTTP_PATCH].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_SystemConfigId, _Node) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE, ?HTTP_PATCH].
 
@@ -98,11 +103,14 @@ allowed_methods(_SystemConfigId, _Node) ->
 %%    /system_configs/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_Id) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_Id, _Node) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -222,10 +230,12 @@ put(Context, _Id) ->
 %% (after a merge perhaps).
 %% @end
 %%--------------------------------------------------------------------
+
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, _Id) ->
     crossbar_doc:save(Context).
+
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, Id, Node) ->
     Ctx = crossbar_doc:save(Context),
     case cb_context:resp_status(Ctx) of
@@ -235,9 +245,10 @@ post(Context, Id, Node) ->
     end.
 
 -spec patch(cb_context:context(), path_token()) -> cb_context:context().
--spec patch(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 patch(Context, Id) ->
     post(Context, Id).
+
+-spec patch(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 patch(Context, Id, Node) ->
     post(Context, Id, Node).
 
@@ -247,18 +258,19 @@ patch(Context, Id, Node) ->
 %% If the HTTP verb is DELETE, execute the actual action, usually a db delete
 %% @end
 %%--------------------------------------------------------------------
+
 -spec delete(cb_context:context(), path_token()) ->
-                    cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token()) ->
-                    cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token(), kz_term:api_object() | kz_json:objects()) ->
                     cb_context:context().
 delete(Context, _Id) ->
     crossbar_doc:delete(Context, ?HARD_DELETE).
 
+-spec delete(cb_context:context(), path_token(), path_token()) ->
+                    cb_context:context().
 delete(Context, Id, Node) ->
     delete(Context, Id, Node, cb_context:doc(Context)).
 
+-spec delete(cb_context:context(), path_token(), path_token(), kz_term:api_object() | kz_json:objects()) ->
+                    cb_context:context().
 delete(Context, Id, _Node, 'undefined') ->
     crossbar_util:response_bad_identifier(Id, Context);
 delete(Context, Id, Node, Doc) ->

--- a/applications/crossbar/src/modules/cb_tasks.erl
+++ b/applications/crossbar/src/modules/cb_tasks.erl
@@ -103,13 +103,16 @@ authorize(Context) ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_TaskId) ->
     [?HTTP_GET, ?HTTP_PATCH, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_TaskId, ?PATH_STOP) ->
     [?HTTP_PATCH];
 allowed_methods(_TaskId, ?PATH_INPUT) ->
@@ -125,11 +128,14 @@ allowed_methods(_TaskId, ?PATH_OUTPUT) ->
 %%    /tasks/task_id => [<<"task_id">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_TaskId) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_TaskId, ?PATH_STOP) -> 'true';
 resource_exists(_TaskId, ?PATH_INPUT) -> 'true';
 resource_exists(_TaskId, ?PATH_OUTPUT) -> 'true'.
@@ -142,11 +148,12 @@ resource_exists(_TaskId, ?PATH_OUTPUT) -> 'true'.
 %% Of the form {atom(), [{Type, SubType}]} :: {to_json, [{<<"application">>, <<"json">>}]}
 %% @end
 %%--------------------------------------------------------------------
+
 -spec content_types_accepted(cb_context:context()) -> cb_context:context().
--spec content_types_accepted(cb_context:context(), path_token()) -> cb_context:context().
 content_types_accepted(Context) ->
     cta(Context, cb_context:req_verb(Context)).
 
+-spec content_types_accepted(cb_context:context(), path_token()) -> cb_context:context().
 content_types_accepted(Context, _TaskId) ->
     cta(Context, cb_context:req_verb(Context)).
 
@@ -165,16 +172,19 @@ cta(Context, _) ->
 %% Of the form {atom(), [{Type, SubType}]} :: {to_json, [{<<"application">>, <<"json">>}]}
 %% @end
 %%--------------------------------------------------------------------
+
 -spec content_types_provided(cb_context:context()) ->
-                                    cb_context:context().
--spec content_types_provided(cb_context:context(), path_token()) ->
-                                    cb_context:context().
--spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
                                     cb_context:context().
 content_types_provided(Context) ->
     ctp(Context).
+
+-spec content_types_provided(cb_context:context(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _TaskId) ->
     ctp(Context).
+
+-spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _TaskId, _CSV) ->
     cb_context:add_content_types_provided(Context, [{'to_csv', ?CSV_CONTENT_TYPES}]).
 
@@ -232,15 +242,16 @@ download_filename(_Context, Name) ->
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_tasks(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, PathToken) ->
     validate_tasks(Context, PathToken, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, TaskId, ?PATH_STOP) ->
     validate_tasks(Context, TaskId, cb_context:req_verb(Context));
 validate(Context, TaskId, CSV) ->
@@ -357,9 +368,8 @@ task_account_id(Context) ->
 %% (after a merge perhaps).
 %% @end
 %%--------------------------------------------------------------------
--spec patch(cb_context:context(), path_token()) -> cb_context:context().
--spec patch(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 
+-spec patch(cb_context:context(), path_token()) -> cb_context:context().
 patch(Context, TaskId) ->
     Req = [{<<"Task-ID">>, TaskId}
            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
@@ -379,6 +389,7 @@ patch(Context, TaskId) ->
             crossbar_util:response(Task, Context)
     end.
 
+-spec patch(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 patch(Context, TaskId, ?PATH_STOP) ->
     Req = [{<<"Task-ID">>, TaskId}
            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
@@ -439,13 +450,13 @@ set_db(Context) ->
 %% Load an instance from the database
 %% @end
 %%--------------------------------------------------------------------
+
 -spec read(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
--spec read(kz_term:ne_binary(), cb_context:context(), kz_term:api_binary()) -> cb_context:context().
--spec read(kz_term:ne_binary(), cb_context:context(), kz_term:api_binary(), kz_term:api_binary()) -> cb_context:context().
 read(TaskId, Context) ->
     AccountId = cb_context:account_id(Context),
     read(TaskId, set_db(Context), AccountId).
 
+-spec read(kz_term:ne_binary(), cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 read(TaskId, Context, 'undefined') ->
     AuthAccountId = cb_context:auth_account_id(Context),
     read(TaskId, Context, AuthAccountId);
@@ -465,6 +476,7 @@ accept_value(Header, 'undefined') -> Header;
 accept_value(_Header, <<"csv">>) -> <<"text/csv">>;
 accept_value(_Header, Tunneled) -> Tunneled.
 
+-spec read(kz_term:ne_binary(), cb_context:context(), kz_term:api_binary(), kz_term:api_binary()) -> cb_context:context().
 read(TaskId, Context, AccountId, Accept) ->
     lager:debug("accept value: ~p", [Accept]),
     read_doc_or_attachment(TaskId, Context, AccountId, cb_modules_util:parse_media_type(Accept)).

--- a/applications/crossbar/src/modules/cb_templates.erl
+++ b/applications/crossbar/src/modules/cb_templates.erl
@@ -76,20 +76,21 @@ resource_exists(_) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate_request(cb_context:context(), http_method(), req_nouns()) -> cb_context:context().
--spec validate_request(cb_context:context(), http_method(), req_nouns(), path_token()) ->
-                              cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     validate_request(Context, cb_context:req_verb(Context), cb_context:req_nouns(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, TemplateName) ->
     validate_request(Context, cb_context:req_verb(Context), cb_context:req_nouns(Context), TemplateName).
 
+-spec validate_request(cb_context:context(), http_method(), req_nouns()) -> cb_context:context().
 validate_request(Context, ?HTTP_GET, [{<<"templates">>, _}]) ->
     summary(Context).
 
+-spec validate_request(cb_context:context(), http_method(), req_nouns(), path_token()) ->
+                              cb_context:context().
 validate_request(Context, ?HTTP_PUT, [{<<"templates">>, _}], TemplateName) ->
     case cb_context:resp_status(load_template_db(TemplateName, Context)) of
         'success' -> cb_context:add_system_error('datastore_conflict', Context);

--- a/applications/crossbar/src/modules/cb_temporal_rules.erl
+++ b/applications/crossbar/src/modules/cb_temporal_rules.erl
@@ -47,10 +47,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_TemporalRuleId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -62,9 +64,11 @@ allowed_methods(_TemporalRuleId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -76,8 +80,8 @@ resource_exists(_) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_rules(Context, cb_context:req_verb(Context)).
 
@@ -86,6 +90,7 @@ validate_rules(Context, ?HTTP_GET) ->
 validate_rules(Context, ?HTTP_PUT) ->
     create(Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_rule(Context, Id, cb_context:req_verb(Context)).
 

--- a/applications/crossbar/src/modules/cb_temporal_rules_sets.erl
+++ b/applications/crossbar/src/modules/cb_temporal_rules_sets.erl
@@ -47,10 +47,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_TemporalRuleSet) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
@@ -62,9 +64,11 @@ allowed_methods(_TemporalRuleSet) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> true.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> true.
 
 %%--------------------------------------------------------------------
@@ -76,21 +80,22 @@ resource_exists(_) -> true.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_set(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, DocId) ->
     validate_set(Context, cb_context:req_verb(Context), DocId).
 
 -spec validate_set(cb_context:context(), path_token()) -> cb_context:context().
--spec validate_set(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate_set(Context, ?HTTP_GET) ->
     summary(Context);
 validate_set(Context, ?HTTP_PUT) ->
     create(Context).
 
+-spec validate_set(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate_set(Context, ?HTTP_GET, DocId) ->
     read(DocId, Context);
 validate_set(Context, ?HTTP_POST, DocId) ->

--- a/applications/crossbar/src/modules/cb_token_auth.erl
+++ b/applications/crossbar/src/modules/cb_token_auth.erl
@@ -105,16 +105,17 @@ authorize(Context) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec authenticate(cb_context:context()) ->
-                          boolean() |
-                          {'true' | 'stop', cb_context:context()}.
--spec authenticate(cb_context:context(), kz_term:api_ne_binary(), atom()) ->
                           boolean() |
                           {'true' | 'stop', cb_context:context()}.
 authenticate(Context) ->
     _ = cb_context:put_reqid(Context),
     authenticate(Context, cb_context:auth_account_id(Context), cb_context:auth_token_type(Context)).
 
+-spec authenticate(cb_context:context(), kz_term:api_ne_binary(), atom()) ->
+                          boolean() |
+                          {'true' | 'stop', cb_context:context()}.
 authenticate(_Context, ?NE_BINARY = _AccountId, 'x-auth-token') -> 'true';
 authenticate(Context, 'undefined', 'x-auth-token') ->
     _ = cb_context:put_reqid(Context),
@@ -138,13 +139,13 @@ authenticate(_Context, _AccountId, _TokenType) -> 'false'.
 -spec early_authenticate(cb_context:context()) ->
                                 boolean() |
                                 {'true', cb_context:context()}.
--spec early_authenticate(cb_context:context(), atom() | kz_term:api_binary()) ->
-                                boolean() |
-                                {'true', cb_context:context()}.
 early_authenticate(Context) ->
     _ = cb_context:put_reqid(Context),
     early_authenticate(Context, cb_context:auth_token_type(Context)).
 
+-spec early_authenticate(cb_context:context(), atom() | kz_term:api_binary()) ->
+                                boolean() |
+                                {'true', cb_context:context()}.
 early_authenticate(Context, 'x-auth-token') ->
     early_authenticate_token(Context, cb_context:auth_token(Context));
 early_authenticate(_Context, _TokenType) -> 'false'.

--- a/applications/crossbar/src/modules/cb_token_restrictions.erl
+++ b/applications/crossbar/src/modules/cb_token_restrictions.erl
@@ -76,10 +76,10 @@ allowed_methods() ->
 resource_exists() -> 'true'.
 
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?HTTP_GET) ->
     load_restrictions(Context);
 validate(Context, ?HTTP_POST) ->

--- a/applications/crossbar/src/modules/cb_transactions.erl
+++ b/applications/crossbar/src/modules/cb_transactions.erl
@@ -73,11 +73,12 @@ flatten(Else, _) -> Else.
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?CURRENT_BALANCE) ->
     [?HTTP_GET];
 allowed_methods(?CREDIT) ->
@@ -98,9 +99,11 @@ allowed_methods(?SUBSCRIPTIONS) ->
 %%    /transactions/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -303,8 +306,8 @@ create_debit_tansaction(Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate_transactions(cb_context:context(), http_method()) -> cb_context:context().
--spec validate_transaction(cb_context:context(), path_token(), http_method()) -> cb_context:context().
 validate_transactions(Context, ?HTTP_GET) ->
     case crossbar_view:time_range(Context) of
         {CreatedFrom, CreatedTo} ->
@@ -313,6 +316,7 @@ validate_transactions(Context, ?HTTP_GET) ->
         Context1 -> Context1
     end.
 
+-spec validate_transaction(cb_context:context(), path_token(), http_method()) -> cb_context:context().
 validate_transaction(Context, ?CURRENT_BALANCE, ?HTTP_GET) ->
     CurrentBalance = case wht_util:current_balance(cb_context:account_id(Context)) of
                          {'ok', Bal} -> Bal;
@@ -346,8 +350,8 @@ validate_transaction(Context, _PathToken, _Verb) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate_credit(cb_context:context()) -> cb_context:context().
--spec validate_credit(cb_context:context(), kz_term:api_float()) -> cb_context:context().
 validate_credit(Context) ->
     Amount = kz_json:get_float_value(<<"amount">>, cb_context:req_data(Context)),
     {'ok', MasterAccountId} = kapps_util:get_master_account_id(),
@@ -364,6 +368,7 @@ validate_credit(Context) ->
             end
     end.
 
+-spec validate_credit(cb_context:context(), kz_term:api_float()) -> cb_context:context().
 validate_credit(Context, 'undefined') ->
     Message = kz_json:from_list([{<<"message">>, <<"Amount is required">>}]),
     cb_context:add_validation_error(<<"amount">>, <<"required">>, Message, Context);
@@ -374,7 +379,6 @@ validate_credit(Context, _) ->
     cb_context:set_resp_status(Context, 'success').
 
 -spec validate_debit(cb_context:context()) -> cb_context:context().
--spec validate_debit(cb_context:context(), kz_term:api_float()) -> cb_context:context().
 validate_debit(Context) ->
     Amount = kz_json:get_float_value(<<"amount">>, cb_context:req_data(Context)),
 
@@ -387,6 +391,7 @@ validate_debit(Context) ->
             end
     end.
 
+-spec validate_debit(cb_context:context(), kz_term:api_float()) -> cb_context:context().
 validate_debit(Context, 'undefined') ->
     Message = kz_json:from_list([{<<"message">>, <<"Amount is required">>}]),
     cb_context:add_validation_error(<<"amount">>, <<"required">>, Message, Context);

--- a/applications/crossbar/src/modules/cb_ubiquiti_util.erl
+++ b/applications/crossbar/src/modules/cb_ubiquiti_util.erl
@@ -28,10 +28,10 @@
 -define(SALT_LENGTH, kapps_config:get_integer(?U_CONFIG_CAT, <<"salt_length">>, 20)).
 
 -spec create_api_token(kz_term:ne_binary()) -> kz_term:ne_binary().
--spec create_api_token(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 create_api_token(ProviderId) ->
     create_api_token(ProviderId, ?SECRET).
 
+-spec create_api_token(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 create_api_token(ProviderId, <<_/binary>> = Secret) ->
     Salt = kz_binary:rand_hex(?SALT_LENGTH),
     ExpireTime = kz_time:current_unix_tstamp() + ?EXPIRES,

--- a/applications/crossbar/src/modules/cb_user_auth.erl
+++ b/applications/crossbar/src/modules/cb_user_auth.erl
@@ -64,9 +64,11 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() -> [?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?RECOVERY) -> [?HTTP_PUT, ?HTTP_POST];
 allowed_methods(_AuthToken) -> [?HTTP_GET].
 
@@ -78,9 +80,11 @@ allowed_methods(_AuthToken) -> [?HTTP_GET].
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_tokens()) -> boolean().
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_tokens()) -> boolean().
 resource_exists(?RECOVERY) -> 'true';
 resource_exists(_AuthToken) -> 'true'.
 
@@ -146,8 +150,8 @@ authenticate_nouns(_Nouns) -> 'false'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     Context1 = consume_tokens(Context),
     case cb_context:resp_status(Context1) of
@@ -185,6 +189,7 @@ validate_action(Context, _Action) ->
     lager:debug("unknown action ~s", [_Action]),
     cb_context:add_system_error(<<"action required">>, Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?RECOVERY) ->
     case cb_context:req_verb(Context) of
         ?HTTP_PUT ->
@@ -200,11 +205,11 @@ validate(Context, AuthToken) ->
     maybe_get_auth_token(Context1, AuthToken).
 
 -spec put(cb_context:context()) -> cb_context:context().
--spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context) ->
     _ = cb_context:put_reqid(Context),
     crossbar_auth:create_auth_token(Context, ?MODULE).
 
+-spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context, ?RECOVERY) ->
     _ = cb_context:put_reqid(Context),
     save_reset_id_then_send_email(Context).
@@ -268,9 +273,8 @@ create_auth_resp(Context, _AccountId, _AuthAccountId) ->
 %% Failure here returns 401
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_authenticate_user(cb_context:context()) -> cb_context:context().
--spec maybe_authenticate_user(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                     cb_context:context().
 maybe_authenticate_user(Context) ->
     JObj = cb_context:doc(Context),
     Credentials = kz_json:get_value(<<"credentials">>, JObj),
@@ -287,6 +291,8 @@ maybe_authenticate_user(Context) ->
             maybe_auth_accounts(Context, Credentials, Method, Accounts)
     end.
 
+-spec maybe_authenticate_user(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                                     cb_context:context().
 maybe_authenticate_user(Context, Credentials, <<"md5">>, ?NE_BINARY=Account) ->
     AccountDb = kz_util:format_account_db(Account),
     Context1 = crossbar_doc:load_view(?ACCT_MD5_LIST

--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -77,23 +77,28 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?MESSAGES_RESOURCE) ->
     [?HTTP_GET];
 allowed_methods(_VMBoxId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE, ?HTTP_PATCH].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_VMBoxId, ?MESSAGES_RESOURCE) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PUT, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(_VMBoxId, ?MESSAGES_RESOURCE, ?BIN_DATA) ->
     [?HTTP_POST];
 allowed_methods(_VMBoxId, ?MESSAGES_RESOURCE, _VMMsgId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(_VMBoxId, ?MESSAGES_RESOURCE, _VMMsgId, ?BIN_DATA) ->
     [?HTTP_GET, ?HTTP_PUT].
 
@@ -105,15 +110,20 @@ allowed_methods(_VMBoxId, ?MESSAGES_RESOURCE, _VMMsgId, ?BIN_DATA) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token(), path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, ?MESSAGES_RESOURCE) -> 'true'.
+
+-spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 resource_exists(_, ?MESSAGES_RESOURCE, _) -> 'true'.
+
+-spec resource_exists(path_token(), path_token(), path_token(), path_token()) -> 'true'.
 resource_exists(_, ?MESSAGES_RESOURCE, _, ?BIN_DATA) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -190,11 +200,8 @@ maybe_add_types_provided(Context, _, _) -> Context.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_vmboxes(Context, cb_context:req_verb(Context)).
 
@@ -203,6 +210,7 @@ validate_vmboxes(Context, ?HTTP_GET) ->
 validate_vmboxes(Context, ?HTTP_PUT) ->
     validate_request('undefined', Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?MESSAGES_RESOURCE) ->
     load_message_summary('undefined', Context);
 validate(Context, DocId) ->
@@ -217,6 +225,7 @@ validate_vmbox(Context, DocId, ?HTTP_PATCH) ->
 validate_vmbox(Context, DocId, ?HTTP_DELETE) ->
     load_vmbox(DocId, Context).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, DocId, ?MESSAGES_RESOURCE) ->
     validate_messages(Context, DocId, cb_context:req_verb(Context)).
 
@@ -251,6 +260,7 @@ validate_messages(Context, DocId, ?HTTP_DELETE) ->
 
     cb_context:set_resp_data(cb_context:set_resp_status(Context, 'success'), ToDelete).
 
+-spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context, DocId, ?MESSAGES_RESOURCE, ?BIN_DATA) ->
     load_messages_binaries(DocId, Context);
 validate(Context, DocId, ?MESSAGES_RESOURCE, MediaId) ->
@@ -284,6 +294,7 @@ validate_message(Context, BoxId, MessageId, ?HTTP_POST) ->
 validate_message(Context, BoxId, MessageId, ?HTTP_DELETE) ->
     load_message(MessageId, BoxId, Context).
 
+-spec validate(cb_context:context(), path_token(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context, DocId, ?MESSAGES_RESOURCE, MediaId, ?BIN_DATA) ->
     load_or_upload(DocId, MediaId, Context, cb_context:req_verb(Context)).
 
@@ -303,9 +314,8 @@ load_or_upload(DocId, MediaId, Context, ?HTTP_GET) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 post(Context, _DocId) ->
     DbDoc = cb_context:fetch(Context, 'db_doc'),
     VMBoxMsgs = kz_json:get_list_value(?VM_KEY_MESSAGES, DbDoc),
@@ -314,6 +324,7 @@ post(Context, _DocId) ->
     %% remove messages array to not let it exposed
     crossbar_util:response(kz_json:delete_key(?VM_KEY_MESSAGES, cb_context:resp_data(C1)), C1).
 
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, OldBoxId, ?MESSAGES_RESOURCE) ->
     AccountId = cb_context:account_id(Context),
     MsgIds = kz_json:get_list_value(?VM_KEY_MESSAGES, cb_context:req_data(Context), []),
@@ -334,6 +345,7 @@ post(Context, OldBoxId, ?MESSAGES_RESOURCE) ->
             update_mwi(C, [OldBoxId | NewBoxIds])
     end.
 
+-spec post(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 post(Context, _DocId, ?MESSAGES_RESOURCE, ?BIN_DATA) ->
     Context;
 post(Context, OldBoxId, ?MESSAGES_RESOURCE, MediaId) ->
@@ -384,9 +396,8 @@ put(Context, _DocId, ?MESSAGES_RESOURCE, MsgID, ?BIN_DATA) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec delete(cb_context:context(), path_token()) -> cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 delete(Context, DocId) ->
     AccountId = cb_context:account_id(Context),
     Msgs = kvm_messages:get(AccountId, DocId),
@@ -395,6 +406,7 @@ delete(Context, DocId) ->
     C = crossbar_doc:delete(Context),
     update_mwi(C, DocId).
 
+-spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 delete(Context, DocId, ?MESSAGES_RESOURCE) ->
     AccountId = cb_context:account_id(Context),
     MsgIds = cb_context:resp_data(Context),
@@ -402,6 +414,7 @@ delete(Context, DocId, ?MESSAGES_RESOURCE) ->
     C = crossbar_util:response(Result, Context),
     update_mwi(C, DocId).
 
+-spec delete(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 delete(Context, DocId, ?MESSAGES_RESOURCE, MediaId) ->
     AccountId = cb_context:account_id(Context),
     case kvm_message:change_folder({?VM_FOLDER_DELETED, 'true'}, MediaId, AccountId, DocId, add_pvt_auth_funs(Context)) of
@@ -513,7 +526,6 @@ get_folder_filter(Context, Default) ->
 -type filter_options() :: kvm_message:vm_folder() | kz_term:ne_binaries().
 
 -spec filter_messages(kz_json:objects(), filter_options(), cb_context:context()) -> kz_term:ne_binaries().
--spec filter_messages(kz_json:objects(), filter_options(), cb_context:context(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 filter_messages(Messages, {?VM_FOLDER_DELETED, _}, Context) ->
     %% move to delete folder and soft-delete
     filter_messages(Messages, ?VM_FOLDER_DELETED, Context, []);
@@ -521,6 +533,8 @@ filter_messages(Messages, Filters, Context) ->
     filter_messages(Messages, Filters, Context, []).
 
 %% Filter by folder
+
+-spec filter_messages(kz_json:objects(), filter_options(), cb_context:context(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 filter_messages([], _Filters, _Context, Selected) -> Selected;
 filter_messages([Mess|Messages], <<"all">> = Filter, Context, Selected) ->
     Id = kzd_box_message:media_id(Mess),
@@ -620,11 +634,12 @@ validate_request(VMBoxId, Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate_unique_vmbox(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
--spec validate_unique_vmbox(kz_term:api_binary(), cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 validate_unique_vmbox(VMBoxId, Context) ->
     validate_unique_vmbox(VMBoxId, Context, cb_context:account_db(Context)).
 
+-spec validate_unique_vmbox(kz_term:api_binary(), cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 validate_unique_vmbox(VMBoxId, Context, 'undefined') ->
     check_vmbox_schema(VMBoxId, Context);
 validate_unique_vmbox(VMBoxId, Context, _AccountDb) ->
@@ -740,13 +755,13 @@ merge_summary_fold(BoxSummary, CountMap) ->
 -type source_id() :: kz_term:api_binary() | kz_term:api_binaries().
 
 -spec maybe_load_vmboxes(source_id(), cb_context:context()) -> cb_context:context().
--spec maybe_load_vmboxes_fold(source_id(), cb_context:context()) -> cb_context:context().
 maybe_load_vmboxes('undefined', Context) -> cb_context:set_resp_status(Context, 'success');
 maybe_load_vmboxes(?NE_BINARY = Id, Context) -> load_vmbox(Id, Context);
 maybe_load_vmboxes(<<>>, Context) -> empty_source_id(Context);
 maybe_load_vmboxes([], Context) -> empty_source_id(Context);
 maybe_load_vmboxes(Ids, Context) -> maybe_load_vmboxes_fold(Ids, Context).
 
+-spec maybe_load_vmboxes_fold(source_id(), cb_context:context()) -> cb_context:context().
 maybe_load_vmboxes_fold('undefined', Context) -> Context;
 maybe_load_vmboxes_fold(?NE_BINARY = Id, Context) -> load_vmbox(Id, Context);
 maybe_load_vmboxes_fold(<<>>, Context) -> empty_source_id(Context);
@@ -1105,8 +1120,8 @@ generate_media_name(CallerId, GregorianSeconds, Ext, Timezone) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec check_uniqueness(kz_term:api_binary(), cb_context:context()) -> boolean().
--spec check_uniqueness(kz_term:api_binary(), cb_context:context(), pos_integer()) -> boolean().
 check_uniqueness(VMBoxId, Context) ->
     try kz_json:get_integer_value(<<"mailbox">>, cb_context:req_data(Context)) of
         Mailbox ->
@@ -1117,6 +1132,7 @@ check_uniqueness(VMBoxId, Context) ->
             'false'
     end.
 
+-spec check_uniqueness(kz_term:api_binary(), cb_context:context(), pos_integer()) -> boolean().
 check_uniqueness(VMBoxId, Context, Mailbox) ->
     ViewOptions = [{'key', Mailbox}],
     case kz_datamgr:get_results(cb_context:account_db(Context)
@@ -1141,8 +1157,8 @@ check_uniqueness(VMBoxId, Context, Mailbox) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update_mwi(cb_context:context(), kz_term:ne_binary() | kz_term:ne_binaries()) -> cb_context:context().
--spec update_mwi(cb_context:context(), kz_term:ne_binary() | kz_term:ne_binaries(), atom()) -> cb_context:context().
 update_mwi(Context, BoxId) when is_binary(BoxId) ->
     update_mwi(Context, [BoxId]);
 update_mwi(Context, []) -> Context;
@@ -1150,6 +1166,7 @@ update_mwi(Context, [BoxId | BoxIds]) ->
     _ = update_mwi(Context, BoxId, cb_context:resp_status(Context)),
     update_mwi(Context, BoxIds).
 
+-spec update_mwi(cb_context:context(), kz_term:ne_binary() | kz_term:ne_binaries(), atom()) -> cb_context:context().
 update_mwi(Context, BoxId, 'success') ->
     AccountId = cb_context:account_id(Context),
     _ = cb_modules_util:update_mwi(BoxId, AccountId),

--- a/applications/crossbar/src/modules/cb_webhooks.erl
+++ b/applications/crossbar/src/modules/cb_webhooks.erl
@@ -141,18 +141,18 @@ authenticate(_Context, _Verb, _Nouns) -> 'false'.
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
--spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 
+-spec allowed_methods() -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_PATCH].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?PATH_TOKEN_ATTEMPTS) ->
     [?HTTP_GET];
 allowed_methods(_WebhookId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_WebhookId, ?PATH_TOKEN_ATTEMPTS) ->
     [?HTTP_GET].
 
@@ -164,11 +164,14 @@ allowed_methods(_WebhookId, ?PATH_TOKEN_ATTEMPTS) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_WebhookId) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_WebhookId, ?PATH_TOKEN_ATTEMPTS) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -180,9 +183,8 @@ resource_exists(_WebhookId, ?PATH_TOKEN_ATTEMPTS) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_webhooks(cb_context:set_account_db(Context, ?KZ_WEBHOOKS_DB), cb_context:req_verb(Context)).
 
@@ -197,6 +199,7 @@ validate_webhooks(Context, ?HTTP_PUT) ->
 validate_webhooks(Context, ?HTTP_PATCH) ->
     validate_collection_patch(Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?PATH_TOKEN_ATTEMPTS) ->
     summary_attempts(Context, 'undefined');
 validate(Context, Id) ->
@@ -212,6 +215,7 @@ validate_webhook(Context, WebhookId, ?HTTP_PATCH) ->
 validate_webhook(Context, WebhookId, ?HTTP_DELETE) ->
     read(WebhookId, Context).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, WebhookId=?NE_BINARY, ?PATH_TOKEN_ATTEMPTS) ->
     summary_attempts(Context, WebhookId).
 
@@ -236,10 +240,10 @@ put(Context) ->
     crossbar_doc:save(cb_context:set_account_db(Context, ?KZ_WEBHOOKS_DB)).
 
 -spec patch(cb_context:context()) -> cb_context:context().
--spec patch(cb_context:context(), path_token()) -> cb_context:context().
 patch(Context) ->
     reenable_hooks(Context).
 
+-spec patch(cb_context:context(), path_token()) -> cb_context:context().
 patch(Context, WebhookId) ->
     post(Context, WebhookId).
 
@@ -289,10 +293,11 @@ create(Context) ->
     cb_context:validate_request_data(<<"webhooks">>, Context, OnSuccess).
 
 -spec validate_collection_patch(cb_context:context()) -> cb_context:context().
--spec validate_collection_patch(cb_context:context(), kz_term:api_boolean()) ->
-                                       cb_context:context().
 validate_collection_patch(Context) ->
     validate_collection_patch(Context, cb_context:req_value(Context, ?REENABLE)).
+
+-spec validate_collection_patch(cb_context:context(), kz_term:api_boolean()) ->
+                                       cb_context:context().
 validate_collection_patch(Context, 'undefined') ->
     Msg = kz_json:from_list([{<<"message">>, <<"re-enable is required to patch collections">>}]),
     cb_context:add_validation_error(?REENABLE, <<"required">>, Msg, Context);
@@ -523,11 +528,11 @@ maybe_update_hook(Context) ->
 
 -spec reenable_hooks(cb_context:context()) ->
                             cb_context:context().
--spec reenable_hooks(cb_context:context(), kz_term:ne_binaries()) ->
-                            cb_context:context().
 reenable_hooks(Context) ->
     reenable_hooks(Context, props:get_value(<<"accounts">>, cb_context:req_nouns(Context))).
 
+-spec reenable_hooks(cb_context:context(), kz_term:ne_binaries()) ->
+                            cb_context:context().
 reenable_hooks(Context, [AccountId]) ->
     handle_resp(Context, send_reenable_req(Context, AccountId, <<"account">>));
 reenable_hooks(Context, [AccountId, ?DESCENDANTS]) ->

--- a/applications/crossbar/src/modules/cb_websockets.erl
+++ b/applications/crossbar/src/modules/cb_websockets.erl
@@ -93,10 +93,12 @@ authorize(Context) ->
 %% going to be responded to.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_SocketId) ->
     [?HTTP_GET].
 
@@ -109,9 +111,11 @@ allowed_methods(_SocketId) ->
 %%    /websockets/foo/bar => [<<"foo">>, <<"bar">>]
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -124,10 +128,12 @@ resource_exists(_) -> 'true'.
 %% Generally, use crossbar_doc to manipulate the cb_context{} record
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_websockets(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, Id) ->
     validate_websocket(Context, Id, cb_context:req_verb(Context)).
 
@@ -243,11 +249,12 @@ websockets_req(Context, Props) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec websockets_resp(cb_context:context(), kz_json:objects()) -> cb_context:context().
--spec websockets_resp(cb_context:context(), kz_json:objects(), any()) -> cb_context:context().
 websockets_resp(Context, JObjs) ->
     websockets_resp(Context, JObjs, []).
 
+-spec websockets_resp(cb_context:context(), kz_json:objects(), any()) -> cb_context:context().
 websockets_resp(Context, [], RespData) ->
     cb_context:setters(Context, [{fun cb_context:set_resp_status/2, 'success'}
                                 ,{fun cb_context:set_resp_data/2, RespData}

--- a/applications/crossbar/src/modules/cb_whitelabel.erl
+++ b/applications/crossbar/src/modules/cb_whitelabel.erl
@@ -74,12 +74,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_POST, ?HTTP_DELETE].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?LOGO_REQ) ->
     [?HTTP_GET, ?HTTP_POST];
 allowed_methods(?ICON_REQ) ->
@@ -91,6 +91,7 @@ allowed_methods(?DOMAINS_REQ) ->
 allowed_methods(_WhitelabelDomain) ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_WhitelabelDomain, ?LOGO_REQ) ->
     [?HTTP_GET];
 allowed_methods(_WhitelabelDomain, ?ICON_REQ) ->
@@ -106,17 +107,18 @@ allowed_methods(_WhitelabelDomain, ?WELCOME_REQ) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
 
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(?LOGO_REQ) -> 'true';
 resource_exists(?ICON_REQ) -> 'true';
 resource_exists(?WELCOME_REQ) -> 'true';
 resource_exists(?DOMAINS_REQ) -> 'true';
 resource_exists(_) -> 'true'.
 
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, ?LOGO_REQ) -> 'true';
 resource_exists(_, ?WELCOME_REQ) -> 'true';
 resource_exists(_, ?ICON_REQ) -> 'true'.
@@ -412,18 +414,18 @@ validate_domains(Context, ?HTTP_POST) ->
 
 -spec load_domains(cb_context:context()) ->
                           cb_context:context().
--spec load_domains(cb_context:context(), kz_term:api_binary()) ->
-                          cb_context:context().
--spec load_domains(cb_context:context(), kz_term:ne_binary(), kz_json:object()) ->
-                          cb_context:context().
 load_domains(Context) ->
     load_domains(Context, find_domain(Context)).
 
+-spec load_domains(cb_context:context(), kz_term:api_binary()) ->
+                          cb_context:context().
 load_domains(Context, 'undefined') ->
     missing_domain_error(Context);
 load_domains(Context, Domain) ->
     load_domains(Context, Domain, system_domains()).
 
+-spec load_domains(cb_context:context(), kz_term:ne_binary(), kz_json:object()) ->
+                          cb_context:context().
 load_domains(Context, Domain, SystemDomains) ->
     AccountDomains = kzd_domains:format(SystemDomains, Domain),
     cb_context:setters(Context
@@ -503,8 +505,6 @@ missing_schema_error(Context) ->
 
 -spec test_account_domains(cb_context:context()) ->
                                   cb_context:context().
--spec test_account_domains(cb_context:context(), kzd_domains:doc()) ->
-                                  cb_context:context().
 test_account_domains(Context) ->
     Context1 = load_domains(Context),
     case cb_context:resp_status(Context1) of
@@ -514,6 +514,8 @@ test_account_domains(Context) ->
             Context1
     end.
 
+-spec test_account_domains(cb_context:context(), kzd_domains:doc()) ->
+                                  cb_context:context().
 test_account_domains(Context, DomainsJObj) ->
     Options = test_network_options(Context),
     TestResults =
@@ -845,8 +847,8 @@ update_whitelabel_binary(AttachType, WhitelabelId, Context) ->
 %% it has an extension (for the associated content type)
 %% @end
 %%--------------------------------------------------------------------
+
 -spec attachment_name(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
--spec attachment_name(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 attachment_name(Filename, CT) ->
     Generators = [fun(A) ->
                           case kz_term:is_empty(A) of
@@ -864,6 +866,7 @@ attachment_name(Filename, CT) ->
                  ],
     lists:foldl(fun(F, A) -> F(A) end, Filename, Generators).
 
+-spec attachment_name(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 attachment_name(AttachType, Filename, CT) ->
     <<AttachType/binary, "-", (attachment_name(Filename, CT))/binary>>.
 

--- a/applications/crossbar/src/modules/provisioner_util.erl
+++ b/applications/crossbar/src/modules/provisioner_util.erl
@@ -69,10 +69,12 @@ cleanse_mac_address(MACAddress) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_provision(cb_context:context()) -> boolean().
--spec maybe_provision(cb_context:context(), crossbar_status()) -> boolean().
 maybe_provision(Context) ->
     maybe_provision(Context, cb_context:resp_status(Context)).
+
+-spec maybe_provision(cb_context:context(), crossbar_status()) -> boolean().
 maybe_provision(Context, 'success') ->
     MACAddress = get_mac_address(Context),
     case MACAddress =/= 'undefined'
@@ -124,10 +126,12 @@ maybe_provision_v5(Context, ?HTTP_POST) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_delete_provision(cb_context:context()) -> boolean().
--spec maybe_delete_provision(cb_context:context(), crossbar_status()) -> boolean().
 maybe_delete_provision(Context) ->
     maybe_delete_provision(Context, cb_context:resp_status(Context)).
+
+-spec maybe_delete_provision(cb_context:context(), crossbar_status()) -> boolean().
 maybe_delete_provision(Context, 'success') ->
     MACAddress = get_mac_address(Context),
     case MACAddress =/= 'undefined'
@@ -191,9 +195,10 @@ maybe_delete_account(Context) ->
     end.
 
 -spec maybe_send_contact_list(cb_context:context()) -> 'ok'.
--spec maybe_send_contact_list(cb_context:context(), crossbar_status()) -> 'ok'.
 maybe_send_contact_list(Context) ->
     maybe_send_contact_list(Context, cb_context:resp_status(Context)).
+
+-spec maybe_send_contact_list(cb_context:context(), crossbar_status()) -> 'ok'.
 maybe_send_contact_list(Context, 'success') ->
     case cb_context:is_context(Context)
         andalso get_provisioning_type()
@@ -382,7 +387,6 @@ do_full_provision(MACAddress, Context) ->
     maybe_send_to_full_provisioner(PartialURL, JObj).
 
 -spec maybe_send_to_full_provisioner(kz_term:ne_binary()) -> boolean().
--spec maybe_send_to_full_provisioner(kz_term:ne_binary(), kz_json:object()) -> boolean().
 maybe_send_to_full_provisioner(PartialURL) ->
     case kapps_config:get_binary(?MOD_CONFIG_CAT, <<"provisioning_url">>) of
         'undefined' -> 'false';
@@ -391,6 +395,7 @@ maybe_send_to_full_provisioner(PartialURL) ->
             send_to_full_provisioner(FullUrl)
     end.
 
+-spec maybe_send_to_full_provisioner(kz_term:ne_binary(), kz_json:object()) -> boolean().
 maybe_send_to_full_provisioner(PartialURL, JObj) ->
     case kapps_config:get_binary(?MOD_CONFIG_CAT, <<"provisioning_url">>) of
         'undefined' -> 'false';
@@ -741,11 +746,13 @@ get_provisioning_type() ->
     end.
 
 %% @public
+
 -spec maybe_sync_sip_data(cb_context:context(), 'user' | 'device') -> 'ok'.
--spec maybe_sync_sip_data(cb_context:context(), 'user' | 'device', boolean() | 'force') -> 'ok'.
 maybe_sync_sip_data(Context, Type) ->
     ShouldSync = cb_context:fetch(Context, 'sync'),
     maybe_sync_sip_data(Context, Type, ShouldSync).
+
+-spec maybe_sync_sip_data(cb_context:context(), 'user' | 'device', boolean() | 'force') -> 'ok'.
 maybe_sync_sip_data(_Context, _Type, 'false') ->
     lager:debug("sync not configured in context for ~s", [_Type]);
 maybe_sync_sip_data(Context, 'device', 'true') ->
@@ -813,12 +820,12 @@ send_check_sync(Username, Realm, MsgId) ->
                                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                               ]).
 
--spec publish_check_sync(kz_term:proplist()) -> 'ok'.
 -spec publish_check_sync(kz_term:api_binary(), kz_term:proplist()) -> 'ok'.
 publish_check_sync('undefined', Req) ->
     publish_check_sync(Req);
 publish_check_sync(MsgId, Req) ->
     publish_check_sync([{<<"Msg-ID">>, MsgId} | Req]).
 
+-spec publish_check_sync(kz_term:proplist()) -> 'ok'.
 publish_check_sync(Req) ->
     kz_amqp_worker:cast(Req, fun kapi_switch:publish_notify/1).

--- a/applications/crossbar/src/modules_v1/cb_devices_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_devices_v1.erl
@@ -66,18 +66,18 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
--spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 
+-spec allowed_methods() -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?STATUS_PATH_TOKEN) ->
     [?HTTP_GET];
 allowed_methods(_) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PUT, ?HTTP_DELETE].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
     [?HTTP_POST].
 
@@ -89,12 +89,14 @@ allowed_methods(_DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
--spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 
+-spec resource_exists() -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_DeviceId, ?CHECK_SYNC_PATH_TOKEN) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -148,9 +150,8 @@ authorize(_Nouns, _Verb) -> 'false'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_devices(Context, cb_context:req_verb(Context)).
 
@@ -159,11 +160,13 @@ validate_devices(Context, ?HTTP_GET) ->
 validate_devices(Context, ?HTTP_PUT) ->
     validate_request('undefined', Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?STATUS_PATH_TOKEN) ->
     validate_device(Context, ?STATUS_PATH_TOKEN, cb_context:req_verb(Context));
 validate(Context, DeviceId) ->
     validate_device(Context, DeviceId, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
     load_device(DeviceId, Context).
 
@@ -206,13 +209,13 @@ post(Context, DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
     crossbar_util:response_202(<<"sync request sent">>, Context).
 
 -spec put(cb_context:context()) -> cb_context:context().
--spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context) ->
     Context1 = crossbar_doc:save(Context),
     _ = maybe_aggregate_device('undefined', Context1),
     _ = kz_util:spawn(fun provisioner_util:maybe_provision/1, [Context1]),
     Context1.
 
+-spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context, DeviceId) ->
     put_action(Context, DeviceId, cb_context:req_value(Context, <<"action">>)).
 
@@ -236,13 +239,14 @@ delete(Context, DeviceId) ->
 %% account summary.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load_device_summary(cb_context:context()) ->
-                                 cb_context:context().
--spec load_device_summary(cb_context:context(), req_nouns()) ->
                                  cb_context:context().
 load_device_summary(Context) ->
     load_device_summary(Context, cb_context:req_nouns(Context)).
 
+-spec load_device_summary(cb_context:context(), req_nouns()) ->
+                                 cb_context:context().
 load_device_summary(Context, [{<<"devices">>, []}
                              ,{<<"users">>, [UserId]}
                               |_]
@@ -588,10 +592,12 @@ is_creds_global_unique(Realm, Username, DeviceId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_aggregate_device(kz_term:api_binary(), cb_context:context()) -> boolean().
--spec maybe_aggregate_device(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_aggregate_device(DeviceId, Context) ->
     maybe_aggregate_device(DeviceId, Context, cb_context:resp_status(Context)).
+
+-spec maybe_aggregate_device(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_aggregate_device(DeviceId, Context, 'success') ->
     case kz_term:is_true(cb_context:fetch(Context, 'aggregate_device'))
         andalso ?DEVICES_ALLOW_AGGREGATES
@@ -612,11 +618,12 @@ maybe_aggregate_device(_, _, _) -> 'false'.
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_remove_aggregate(kz_term:api_binary(), cb_context:context()) -> boolean().
--spec maybe_remove_aggregate(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_remove_aggregate(DeviceId, Context) ->
     maybe_remove_aggregate(DeviceId, Context, cb_context:resp_status(Context)).
 
+-spec maybe_remove_aggregate(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_remove_aggregate('undefined', _Context, _RespStatus) -> 'false';
 maybe_remove_aggregate(DeviceId, _Context, 'success') ->
     case kz_datamgr:open_doc(?KZ_SIP_DB, DeviceId) of

--- a/applications/crossbar/src/modules_v1/cb_limits_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_limits_v1.erl
@@ -176,13 +176,14 @@ on_successful_validation(Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_handle_load_failure(cb_context:context()) ->
-                                       cb_context:context().
--spec maybe_handle_load_failure(cb_context:context(), pos_integer()) ->
                                        cb_context:context().
 maybe_handle_load_failure(Context) ->
     maybe_handle_load_failure(Context, cb_context:resp_error_code(Context)).
 
+-spec maybe_handle_load_failure(cb_context:context(), pos_integer()) ->
+                                       cb_context:context().
 maybe_handle_load_failure(Context, 404) ->
     Data = cb_context:req_data(Context),
     NewLimits = kz_json:from_list([{<<"pvt_type">>, ?PVT_TYPE}

--- a/applications/crossbar/src/modules_v1/cb_lists_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_lists_v1.erl
@@ -49,13 +49,16 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_ListId) ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_POST, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_ListId, _EntryId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE].
 
@@ -67,11 +70,14 @@ allowed_methods(_ListId, _EntryId) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_ListId) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_ListId, _EntryId) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -83,13 +89,16 @@ resource_exists(_ListId, _EntryId) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_lists(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ListId) ->
     validate_list(Context, ListId, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ListId, EntryId) ->
     validate_list_entry(Context, ListId, EntryId, cb_context:req_verb(Context)).
 
@@ -193,22 +202,22 @@ on_entry_successful_validation(_ListId, EntryId, Context) ->
     crossbar_doc:load_merge(EntryId, Context, ?TYPE_CHECK_OPTION(<<"list_entry">>)).
 
 -spec post(cb_context:context()) -> cb_context:context().
--spec post(cb_context:context(), path_token()) -> cb_context:context().
--spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context) ->
     crossbar_doc:save(Context).
 
+-spec post(cb_context:context(), path_token()) -> cb_context:context().
 post(Context, _ListId) ->
     crossbar_doc:save(Context).
 
+-spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 post(Context, _ListId, _EntryId) ->
     crossbar_doc:save(Context).
 
 -spec put(cb_context:context()) -> cb_context:context().
--spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context) ->
     crossbar_doc:save(Context).
 
+-spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context, _ListId) ->
     crossbar_doc:save(Context).
 

--- a/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
@@ -82,12 +82,12 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?CLASSIFIERS) ->
     [?HTTP_GET];
 allowed_methods(?COLLECTION) ->
@@ -95,6 +95,7 @@ allowed_methods(?COLLECTION) ->
 allowed_methods(_) ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_POST, ?HTTP_DELETE].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_, ?ACTIVATE) ->
     [?HTTP_PUT];
 allowed_methods(_, ?RESERVE) ->
@@ -114,13 +115,14 @@ allowed_methods(?COLLECTION, ?ACTIVATE) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> boolean().
 resource_exists() -> 'true'.
 
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
+-spec resource_exists(path_token(), path_token()) -> boolean().
 resource_exists(_, ?ACTIVATE) -> 'true';
 resource_exists(_, ?RESERVE) -> 'true';
 resource_exists(_, ?PORT) -> 'true';
@@ -133,11 +135,12 @@ resource_exists(_, _) -> 'false'.
 %% Ensure we will be able to bill for phone_numbers
 %% @end
 %%--------------------------------------------------------------------
+
 -spec billing(cb_context:context()) -> cb_context:context().
--spec billing(cb_context:context(), req_verb(), req_nouns()) -> cb_context:context().
 billing(Context) ->
     billing(Context, cb_context:req_verb(Context), cb_context:req_nouns(Context)).
 
+-spec billing(cb_context:context(), req_verb(), req_nouns()) -> cb_context:context().
 billing(Context, ?HTTP_GET, [{<<"phone_numbers">>, _}|_]) -> Context;
 billing(Context, _, [{<<"phone_numbers">>, _}|_]) ->
     try kz_services:allow_updates(cb_context:account_id(Context)) of
@@ -156,11 +159,12 @@ billing(Context, _Verb, _Nouns) ->
 %% known, or false if not.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec authenticate(cb_context:context()) -> 'true'.
--spec authenticate(http_method(), req_nouns()) -> 'true'.
 authenticate(Context) ->
     authenticate(cb_context:req_verb(Context), cb_context:req_nouns(Context)).
 
+-spec authenticate(http_method(), req_nouns()) -> 'true'.
 authenticate(?HTTP_GET, [{<<"phone_numbers">>, []}]) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -170,11 +174,12 @@ authenticate(?HTTP_GET, [{<<"phone_numbers">>, []}]) -> 'true'.
 %% allowed to access the resource, or false if not.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec authorize(cb_context:context()) -> 'true'.
--spec authorize(http_method(), req_nouns()) -> 'true'.
 authorize(Context) ->
     authorize(cb_context:req_verb(Context), cb_context:req_nouns(Context)).
 
+-spec authorize(http_method(), req_nouns()) -> 'true'.
 authorize(?HTTP_GET, [{<<"phone_numbers">>,[]}]) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -186,23 +191,23 @@ authorize(?HTTP_GET, [{<<"phone_numbers">>,[]}]) -> 'true'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec validate_1(cb_context:context(), http_method()) -> cb_context:context().
--spec validate_2(cb_context:context(), http_method(), path_token()) -> cb_context:context().
--spec validate_3(cb_context:context(), http_method(), path_token(), path_token()) -> cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     validate_1(Context, cb_context:req_verb(Context)).
+
+-spec validate_1(cb_context:context(), http_method()) -> cb_context:context().
 validate_1(Context, ?HTTP_GET) ->
     case cb_context:account_id(Context) of
         'undefined' -> find_numbers(Context);
         _ -> summary(Context)
     end.
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, PathToken1) ->
     validate_2(Context, cb_context:req_verb(Context), PathToken1).
+
+-spec validate_2(cb_context:context(), http_method(), path_token()) -> cb_context:context().
 validate_2(Context, ?HTTP_PUT, ?COLLECTION) ->
     validate_request(Context);
 validate_2(Context, ?HTTP_POST, ?COLLECTION) ->
@@ -222,8 +227,11 @@ validate_2(Context, ?HTTP_PUT, _Number) ->
 validate_2(Context, ?HTTP_DELETE, _Number) ->
     validate_delete(Context).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, PathToken1, PathToken2) ->
     validate_3(Context, cb_context:req_verb(Context), PathToken1, PathToken2).
+
+-spec validate_3(cb_context:context(), http_method(), path_token(), path_token()) -> cb_context:context().
 validate_3(Context, ?HTTP_PUT, ?COLLECTION, ?ACTIVATE) ->
     validate_request(Context);
 validate_3(Context, ?HTTP_PUT, _Number, ?ACTIVATE) ->
@@ -249,7 +257,6 @@ post(Context, Number) ->
     set_response(Result, Number, Context).
 
 -spec put(cb_context:context(), path_token()) -> cb_context:context().
--spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context, ?COLLECTION) ->
     set_response(collection_process(Context), <<>>, Context);
 put(Context, Number) ->
@@ -260,6 +267,7 @@ put(Context, Number) ->
     Result = knm_number:create(Number, Options),
     set_response(Result, Number, Context).
 
+-spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context, ?COLLECTION, ?ACTIVATE) ->
     set_response(collection_process(Context,?ACTIVATE), <<>>, Context);
 put(Context, Number, ?ACTIVATE) ->
@@ -486,12 +494,11 @@ set_response(CollectionJObjOrUnkown, _, Context) ->
     end.
 
 -spec collection_process(cb_context:context()) -> kz_json:object().
--spec collection_process(cb_context:context(), kz_term:ne_binary() | kz_term:ne_binaries()) -> kz_json:object().
--spec collection_process(cb_context:context(), kz_term:ne_binary() | kz_term:ne_binaries(), kz_term:ne_binary()) -> kz_json:object().
 collection_process(Context) ->
     Numbers = kz_json:get_value(<<"numbers">>, cb_context:req_data(Context), []),
     collection_process(Context, Numbers).
 
+-spec collection_process(cb_context:context(), kz_term:ne_binary() | kz_term:ne_binaries()) -> kz_json:object().
 collection_process(Context, ?ACTIVATE) ->
     Numbers = kz_json:get_value(<<"numbers">>, cb_context:req_data(Context), []),
     collection_process(Context, Numbers, ?ACTIVATE);
@@ -506,6 +513,7 @@ collection_process(Context, Numbers) ->
                ,Numbers
                ).
 
+-spec collection_process(cb_context:context(), kz_term:ne_binary() | kz_term:ne_binaries(), kz_term:ne_binary()) -> kz_json:object().
 collection_process(Context, Numbers, Action) ->
     Base = kz_json:from_list([{<<"success">>, kz_json:new()}
                              ,{<<"error">>, kz_json:new()}
@@ -539,11 +547,8 @@ collection_process_fold(Number, Acc, Context) ->
             kz_json:set_value([<<"error">>, Number], JObj, Acc)
     end.
 
--spec collection_action(cb_context:context(), http_method(), kz_term:ne_binary()) -> knm_number_return().
--spec collection_action(cb_context:context(), http_method(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                               knm_number_return() |
-                               {'ok', kz_json:object()}.
 
+-spec collection_action(cb_context:context(), http_method(), kz_term:ne_binary()) -> knm_number_return().
 collection_action(Context, ?HTTP_PUT, Number) ->
     Options = [{'assign_to', cb_context:account_id(Context)}
               ,{'auth_by', cb_context:auth_account_id(Context)}
@@ -561,6 +566,9 @@ collection_action(Context, ?HTTP_DELETE, Number) ->
               ],
     knm_number:release(Number, Options).
 
+-spec collection_action(cb_context:context(), http_method(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                               knm_number_return() |
+                               {'ok', kz_json:object()}.
 collection_action(Context, ?HTTP_PUT, Number, ?ACTIVATE) ->
     Options = [{'auth_by', cb_context:auth_account_id(Context)}
               ,{'public_fields', kz_json:delete_key(<<"numbers">>, cb_context:doc(Context))}
@@ -572,8 +580,9 @@ collection_action(Context, ?HTTP_PUT, Number, ?ACTIVATE) ->
     end.
 
 -spec has_tokens(cb_context:context()) -> boolean().
--spec has_tokens(cb_context:context(), pos_integer()) -> boolean().
 has_tokens(Context) -> has_tokens(Context, 1).
+
+-spec has_tokens(cb_context:context(), pos_integer()) -> boolean().
 has_tokens(Context, Count) ->
     Name = <<(cb_context:account_id(Context))/binary, "/", ?PHONE_NUMBERS_CONFIG_CAT/binary>>,
     Cost = cb_modules_util:token_cost(Context, Count),

--- a/applications/crossbar/src/modules_v1/cb_users_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_users_v1.erl
@@ -75,16 +75,16 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
--spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 
+-spec allowed_methods() -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE, ?HTTP_PATCH].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_, ?CHANNELS) ->
     [?HTTP_GET];
 allowed_methods(_, ?PHOTO) ->
@@ -94,14 +94,16 @@ allowed_methods(_, ?VCARD) ->
 
 -spec content_types_provided(cb_context:context()) ->
                                     cb_context:context().
--spec content_types_provided(cb_context:context(), path_token()) ->
-                                    cb_context:context().
--spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
-                                    cb_context:context().
 content_types_provided(Context) ->
     Context.
+
+-spec content_types_provided(cb_context:context(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _) ->
     Context.
+
+-spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _, ?VCARD) ->
     cb_context:set_content_types_provided(Context, [{'to_binary', [{<<"text">>, <<"x-vcard">>}
                                                                   ,{<<"text">>, <<"directory">>}]}]);
@@ -116,13 +118,14 @@ content_types_provided(Context, _, _) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
--spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 
+-spec resource_exists() -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_) -> 'true'.
 
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_, ?CHANNELS) -> 'true';
 resource_exists(_, ?VCARD) -> 'true'.
 
@@ -135,15 +138,17 @@ resource_exists(_, ?VCARD) -> 'true'.
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate_resource(cb_context:context()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate_resource(Context) -> Context.
+
+-spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
 validate_resource(Context, UserId) -> validate_user_id(UserId, Context).
+
+-spec validate_resource(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate_resource(Context, UserId, _) -> validate_user_id(UserId, Context).
 
 -spec validate_user_id(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
--spec validate_user_id(kz_term:api_binary(), cb_context:context(), kz_json:object()) -> cb_context:context().
 validate_user_id(UserId, Context) ->
     case kz_datamgr:open_cache_doc(cb_context:account_db(Context), UserId) of
         {'ok', Doc} -> validate_user_id(UserId, Context, Doc);
@@ -156,6 +161,7 @@ validate_user_id(UserId, Context) ->
         {'error', _R} -> crossbar_util:response_db_fatal(Context)
     end.
 
+-spec validate_user_id(kz_term:api_binary(), cb_context:context(), kz_json:object()) -> cb_context:context().
 validate_user_id(UserId, Context, Doc) ->
     case kz_doc:is_soft_deleted(Doc) of
         'true' ->
@@ -225,14 +231,16 @@ authorize_users(_Nouns, _Verb) -> 'false'.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     validate_users(Context, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, UserId) ->
     validate_user(Context, UserId, cb_context:req_verb(Context)).
+
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, UserId, ?CHANNELS) ->
     Options = [{'key', [UserId, <<"device">>]}
               ,'include_docs'

--- a/applications/crossbar/src/modules_v2/cb_devices_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_devices_v2.erl
@@ -76,20 +76,21 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() ->
-                             http_methods().
--spec allowed_methods(path_token()) ->
-                             http_methods().
--spec allowed_methods(path_token(), path_token()) ->
                              http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
 
+-spec allowed_methods(path_token()) ->
+                             http_methods().
 allowed_methods(?STATUS_PATH_TOKEN) ->
     [?HTTP_GET];
 allowed_methods(_DeviceId) ->
     [?HTTP_GET, ?HTTP_PATCH, ?HTTP_POST, ?HTTP_PUT, ?HTTP_DELETE].
 
+-spec allowed_methods(path_token(), path_token()) ->
+                             http_methods().
 allowed_methods(_DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
     [?HTTP_POST].
 
@@ -101,12 +102,14 @@ allowed_methods(_DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
--spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 
+-spec resource_exists() -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_DeviceId) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_DeviceId, ?CHECK_SYNC_PATH_TOKEN) -> 'true'.
 
 %%--------------------------------------------------------------------
@@ -203,9 +206,8 @@ error_no_entity(Context, DeviceId) ->
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_devices(Context, cb_context:req_verb(Context)).
 
@@ -214,6 +216,7 @@ validate_devices(Context, ?HTTP_GET) ->
 validate_devices(Context, ?HTTP_PUT) ->
     validate_request('undefined', Context).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, PathToken) ->
     validate_device(Context, PathToken, cb_context:req_verb(Context)).
 
@@ -233,6 +236,7 @@ validate_device(Context, DeviceId, ?HTTP_DELETE) ->
 validate_patch(Context, DeviceId) ->
     crossbar_doc:patch_and_validate(DeviceId, Context, fun validate_request/2).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
     load_device(DeviceId, Context).
 
@@ -292,7 +296,6 @@ patch(Context, Id) ->
     post(Context, Id).
 
 -spec put(cb_context:context()) -> cb_context:context().
--spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context) ->
     Callback =
         fun() ->
@@ -303,6 +306,7 @@ put(Context) ->
         end,
     crossbar_services:maybe_dry_run(Context, Callback).
 
+-spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context, DeviceId) ->
     put_action(Context, DeviceId, cb_context:req_value(Context, <<"action">>)).
 
@@ -330,13 +334,14 @@ delete(Context, DeviceId) ->
 %% account summary.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load_device_summary(cb_context:context()) ->
-                                 cb_context:context().
--spec load_device_summary(cb_context:context(), req_nouns()) ->
                                  cb_context:context().
 load_device_summary(Context) ->
     load_device_summary(Context, cb_context:req_nouns(Context)).
 
+-spec load_device_summary(cb_context:context(), req_nouns()) ->
+                                 cb_context:context().
 load_device_summary(Context, [{<<"devices">>, []}
                              ,{<<"users">>, [UserId]}
                               |_]
@@ -779,10 +784,12 @@ is_creds_global_unique(Realm, Username, DeviceId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_aggregate_device(kz_term:api_binary(), cb_context:context()) -> boolean().
--spec maybe_aggregate_device(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_aggregate_device(DeviceId, Context) ->
     maybe_aggregate_device(DeviceId, Context, cb_context:resp_status(Context)).
+
+-spec maybe_aggregate_device(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_aggregate_device(DeviceId, Context, 'success') ->
     case kz_term:is_true(cb_context:fetch(Context, 'aggregate_device'))
         andalso ?DEVICES_ALLOW_AGGREGATES
@@ -802,11 +809,12 @@ maybe_aggregate_device(_, _, _) -> 'false'.
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_remove_aggregate(kz_term:api_binary(), cb_context:context()) -> boolean().
--spec maybe_remove_aggregate(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_remove_aggregate(DeviceId, Context) ->
     maybe_remove_aggregate(DeviceId, Context, cb_context:resp_status(Context)).
 
+-spec maybe_remove_aggregate(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_remove_aggregate('undefined', _Context, _RespStatus) -> 'false';
 maybe_remove_aggregate(DeviceId, _Context, 'success') ->
     case kz_datamgr:open_doc(?KZ_SIP_DB, DeviceId) of

--- a/applications/crossbar/src/modules_v2/cb_limits_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_limits_v2.erl
@@ -155,10 +155,10 @@ load_limit(Context) ->
     leak_pvt_fields(crossbar_doc:load(?PVT_TYPE, Context, ?TYPE_CHECK_OPTION(?PVT_TYPE))).
 
 -spec leak_pvt_fields(cb_context:context()) -> cb_context:context().
--spec leak_pvt_fields(cb_context:context(), crossbar_status()) -> cb_context:context().
 leak_pvt_fields(Context) ->
     leak_pvt_fields(Context, cb_context:resp_status(Context)).
 
+-spec leak_pvt_fields(cb_context:context(), crossbar_status()) -> cb_context:context().
 leak_pvt_fields(Context, 'success') ->
     Routines = [fun leak_pvt_allow_postpay/1
                ,fun leak_pvt_max_postpay_amount/1
@@ -201,13 +201,14 @@ on_successful_validation(Context) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_handle_load_failure(cb_context:context()) ->
-                                       cb_context:context().
--spec maybe_handle_load_failure(cb_context:context(), pos_integer()) ->
                                        cb_context:context().
 maybe_handle_load_failure(Context) ->
     maybe_handle_load_failure(Context, cb_context:resp_error_code(Context)).
 
+-spec maybe_handle_load_failure(cb_context:context(), pos_integer()) ->
+                                       cb_context:context().
 maybe_handle_load_failure(Context, 404) ->
     Data = cb_context:req_data(Context),
     NewLimits = kz_json:from_list([{<<"pvt_type">>, ?PVT_TYPE}

--- a/applications/crossbar/src/modules_v2/cb_lists_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_lists_v2.erl
@@ -75,52 +75,64 @@ init() ->
     ].
 
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_ListId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_ListId, ?ENTRIES) ->
     [?HTTP_GET, ?HTTP_PUT, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(_ListId, ?ENTRIES, _ListEntryId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE].
+
+-spec allowed_methods(path_token(), path_token(), path_token(), path_token()) -> http_methods().
 allowed_methods(_ListId, ?ENTRIES, _ListEntryId, ?VCARD) ->
     [?HTTP_GET];
 allowed_methods(_ListId, ?ENTRIES, _ListEntryId, ?PHOTO) ->
     [?HTTP_POST].
 
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token(), path_token(), path_token()) -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_ListId) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_ListId, ?ENTRIES) -> 'true'.
+
+-spec resource_exists(path_token(), path_token(), path_token()) -> 'true'.
 resource_exists(_ListId, ?ENTRIES, _EntryId) -> 'true'.
+
+-spec resource_exists(path_token(), path_token(), path_token(), path_token()) -> 'true'.
 resource_exists(_ListId, ?ENTRIES, _EntryId, ?VCARD) -> 'true'.
 
 -spec content_types_provided(cb_context:context()) ->
                                     cb_context:context().
--spec content_types_provided(cb_context:context(), path_token()) ->
-                                    cb_context:context().
--spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
-                                    cb_context:context().
--spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token()) ->
-                                    cb_context:context().
--spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token(), path_token()) ->
-                                    cb_context:context().
 content_types_provided(Context) ->
     Context.
+
+-spec content_types_provided(cb_context:context(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _) ->
     Context.
+
+-spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _, _) ->
     Context.
+
+-spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _, _, _) ->
     Context.
+
+-spec content_types_provided(cb_context:context(), path_token(), path_token(), path_token(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _, ?ENTRIES, _, ?VCARD) ->
     cb_context:set_content_types_provided(Context
                                          ,[{'to_binary'
@@ -132,18 +144,22 @@ content_types_provided(Context, _, ?ENTRIES, _, ?VCARD) ->
                                          ).
 
 -spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context) ->
     validate_req(cb_context:req_verb(Context), Context, []).
+
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ListId) ->
     validate_req(cb_context:req_verb(Context), Context, [ListId]).
+
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ListId, ?ENTRIES) ->
     validate_req(cb_context:req_verb(Context), Context, [ListId, ?ENTRIES]).
+
+-spec validate(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ListId, ?ENTRIES, EntryId) ->
     validate_req(cb_context:req_verb(Context), Context, [ListId, ?ENTRIES, EntryId]).
+
+-spec validate(cb_context:context(), path_token(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ListId, ?ENTRIES, EntryId, ?VCARD) ->
     validate_req(cb_context:req_verb(Context), Context, [ListId, ?ENTRIES, EntryId, ?VCARD]).
 
@@ -202,34 +218,40 @@ validate_doc(Id, Type, Context) ->
     cb_context:validate_request_data(type_schema_name(Type), Context, OnSuccess).
 
 -spec delete(cb_context:context(), path_token()) -> cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec delete(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 delete(Context, ListId) ->
     _ = delete(Context, ListId, ?ENTRIES),
     Context1 = crossbar_doc:load(ListId, Context, ?TYPE_CHECK_OPTION(?TYPE_LIST_ENTRY)),
     crossbar_doc:delete(Context1).
+
+-spec delete(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 delete(Context, _ListId, ?ENTRIES) ->
     Docs = [kz_json:get_value(<<"id">>, Entry) || Entry <- cb_context:doc(Context)],
     AccountDb = kz_util:format_account_id(cb_context:account_db(Context), 'encoded'),
     %% do we need 'soft' delete as in crossbar_doc?
     kz_datamgr:del_docs(AccountDb, Docs),
     Context.
+
+-spec delete(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 delete(Context, _ListId, ?ENTRIES, _EntryId) ->
     crossbar_doc:delete(Context).
 
 -spec save(cb_context:context()) -> cb_context:context().
--spec save(cb_context:context(), path_token()) -> cb_context:context().
--spec save(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec save(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
--spec save(cb_context:context(), path_token(), path_token(), path_token(), path_token()) -> cb_context:context().
 save(Context) ->
     crossbar_doc:save(Context).
+
+-spec save(cb_context:context(), path_token()) -> cb_context:context().
 save(Context, _) ->
     save(Context).
+
+-spec save(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 save(Context, _, ?ENTRIES) ->
     save(Context).
+
+-spec save(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 save(Context, _, ?ENTRIES, _) ->
     save(Context).
+
+-spec save(cb_context:context(), path_token(), path_token(), path_token(), path_token()) -> cb_context:context().
 save(Context, _, ?ENTRIES, EntryId, ?PHOTO) ->
     %% May be move code from cb_users_v2 to crossbar_doc?
     cb_users_v2:post(Context, EntryId, ?PHOTO).

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -146,12 +146,12 @@ maybe_authorize(_Verb, _Nouns) ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET].
 
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?CARRIERS_INFO) ->
     [?HTTP_GET];
 allowed_methods(?FIX) ->
@@ -169,6 +169,7 @@ allowed_methods(?CHECK) ->
 allowed_methods(_PhoneNumber) ->
     [?HTTP_PUT, ?HTTP_POST, ?HTTP_PATCH, ?HTTP_DELETE, ?HTTP_GET].
 
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(?FIX, _PhoneNumber) ->
     [?HTTP_POST];
 allowed_methods(?COLLECTION, ?ACTIVATE) ->
@@ -192,11 +193,11 @@ allowed_methods(_PhoneNumber, ?IDENTIFY) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> boolean().
 resource_exists() -> 'true'.
 
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(?CARRIERS_INFO) -> 'true';
 resource_exists(?FIX) -> 'true';
 resource_exists(?PREFIX) -> 'true';
@@ -205,6 +206,7 @@ resource_exists(?CHECK) -> 'true';
 resource_exists(?CLASSIFIERS) -> 'true';
 resource_exists(_PhoneNumber) -> 'true'.
 
+-spec resource_exists(path_token(), path_token()) -> boolean().
 resource_exists(?FIX, _PhoneNumber) -> 'true';
 resource_exists(_PhoneNumber, ?ACTIVATE) -> 'true';
 resource_exists(_PhoneNumber, ?RESERVE) -> 'true';
@@ -244,10 +246,8 @@ maybe_allow_updates(Context, _Nouns, _Verb) -> Context.
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     validate_phone_numbers(Context, cb_context:req_verb(Context), cb_context:account_id(Context)).
 
@@ -261,6 +261,7 @@ validate_phone_numbers(Context, ?HTTP_GET, _AccountId) ->
         _Prefix -> maybe_find_numbers(Context)
     end.
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?CARRIERS_INFO) ->
     case pick_account_and_reseller_id(Context) of
         {error, Reason} ->
@@ -303,6 +304,7 @@ validate_number(Context, _Number, ?HTTP_PUT) ->
 validate_number(Context, _Number, ?HTTP_DELETE) ->
     validate_delete(Context).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ?FIX, _Num) ->
     cb_context:set_resp_data(cb_context:set_resp_status(Context, 'success')
                             ,kz_json:new()
@@ -388,7 +390,6 @@ post(Context, Number) ->
     set_response(Result, Context).
 
 -spec put(cb_context:context(), path_token()) -> cb_context:context().
--spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context, ?COLLECTION) ->
     Results = collection_process(Context, ?HTTP_PUT),
     CB = fun() -> ?MODULE:put(cb_context:set_accepting_charges(Context), ?COLLECTION) end,
@@ -405,6 +406,7 @@ put(Context, Number) ->
     CB = fun() -> ?MODULE:put(cb_context:set_accepting_charges(Context), Number) end,
     set_response(Result, Context, CB).
 
+-spec put(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 put(Context, ?COLLECTION, ?ACTIVATE) ->
     Results = collection_process(Context, ?ACTIVATE),
     CB = fun() -> put(cb_context:set_accepting_charges(Context), ?COLLECTION, ?ACTIVATE) end,
@@ -575,11 +577,12 @@ should_include_ports(Context) ->
     kz_term:is_true(cb_context:req_value(Context, <<"include_ports">>, 'true')).
 
 %% @private
+
 -spec maybe_add_port_request_numbers(cb_context:context()) -> kz_json:object().
--spec maybe_add_port_request_numbers(cb_context:context(), boolean()) -> kz_json:object().
 maybe_add_port_request_numbers(Context) ->
     maybe_add_port_request_numbers(Context, should_include_ports(Context)).
 
+-spec maybe_add_port_request_numbers(cb_context:context(), boolean()) -> kz_json:object().
 maybe_add_port_request_numbers(_Context, 'false') -> kz_json:new();
 maybe_add_port_request_numbers(Context, 'true') ->
     AccountId = cb_context:account_id(Context),
@@ -618,14 +621,15 @@ normalize_view_results(JObj, Acc) ->
     ].
 
 %% @private
+
 -spec normalize_port_view_result(kz_json:object()) -> kz_json:object().
--spec normalize_port_view_result(kz_json:key(), kz_json:json_term()) -> kz_json:object().
 normalize_port_view_result(JObj) ->
     Number = kz_json:get_value([<<"key">>, ?PORT_NUMBER_KEY_INDEX], JObj),
     Properties = kz_json:get_value(<<"value">>, JObj),
 
     normalize_port_view_result(Number, Properties).
 
+-spec normalize_port_view_result(kz_json:key(), kz_json:json_term()) -> kz_json:object().
 normalize_port_view_result(Number, Properties) ->
     kz_json:from_list([{Number, Properties}]).
 
@@ -735,11 +739,13 @@ find_prefix(Context) ->
 %% @private
 %% @doc Validates a collection-type numbers field.
 %%--------------------------------------------------------------------
+
 -spec validate_collection_request(cb_context:context()) -> cb_context:context().
--spec validate_collection_request(cb_context:context(), any()) -> cb_context:context().
 validate_collection_request(Context) ->
     Numbers = kz_json:get_value(?COLLECTION_NUMBERS, cb_context:req_data(Context)),
     validate_collection_request(Context, Numbers).
+
+-spec validate_collection_request(cb_context:context(), any()) -> cb_context:context().
 validate_collection_request(Context, 'undefined') ->
     Msg = kz_json:from_list([{<<"message">>, <<"list of numbers missing">>}
                             ]),
@@ -1081,9 +1087,11 @@ maybe_ask_for_state(StateAskedFor) -> [{state, StateAskedFor}].
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec has_tokens(cb_context:context()) -> boolean().
--spec has_tokens(cb_context:context(), pos_integer()) -> boolean().
 has_tokens(Context) -> has_tokens(Context, 1).
+
+-spec has_tokens(cb_context:context(), pos_integer()) -> boolean().
 has_tokens(Context, Count) ->
     Name = <<(cb_context:account_id(Context))/binary, "/", ?PHONE_NUMBERS_CONFIG_CAT/binary>>,
     Cost = cb_modules_util:token_cost(Context, Count),

--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -79,13 +79,16 @@ init() ->
 %% Failure here returns 405
 %% @end
 %%--------------------------------------------------------------------
+
 -spec allowed_methods() -> http_methods().
--spec allowed_methods(path_token()) -> http_methods().
--spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
+
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(_UserId) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE, ?HTTP_PATCH].
+
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_UserId, ?PHOTO) ->
     [?HTTP_GET, ?HTTP_POST, ?HTTP_DELETE];
 allowed_methods(_UserId, ?VCARD) ->
@@ -93,14 +96,16 @@ allowed_methods(_UserId, ?VCARD) ->
 
 -spec content_types_provided(cb_context:context()) ->
                                     cb_context:context().
--spec content_types_provided(cb_context:context(), path_token()) ->
-                                    cb_context:context().
--spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
-                                    cb_context:context().
 content_types_provided(Context) ->
     Context.
+
+-spec content_types_provided(cb_context:context(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _) ->
     Context.
+
+-spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
+                                    cb_context:context().
 content_types_provided(Context, _, ?VCARD) ->
     cb_context:set_content_types_provided(Context, [{'to_binary', [{<<"text">>, <<"x-vcard">>}
                                                                   ,{<<"text">>, <<"directory">>}
@@ -122,12 +127,14 @@ content_types_provided(Context, _, _) ->
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
--spec resource_exists() -> 'true'.
--spec resource_exists(path_token()) -> 'true'.
--spec resource_exists(path_token(), path_token()) -> 'true'.
 
+-spec resource_exists() -> 'true'.
 resource_exists() -> 'true'.
+
+-spec resource_exists(path_token()) -> 'true'.
 resource_exists(_UserId) -> 'true'.
+
+-spec resource_exists(path_token(), path_token()) -> 'true'.
 resource_exists(_UserId, ?VCARD) -> 'true';
 resource_exists(_UserId, ?PHOTO) -> 'true'.
 
@@ -185,17 +192,20 @@ process_billing(Context, _Nouns, _Verb) -> Context.
 %% Failure here returns 404
 %% @end
 %%--------------------------------------------------------------------
+
 -spec validate_resource(cb_context:context()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token(), path_token()) -> cb_context:context().
--spec validate_resource(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate_resource(Context) -> Context.
+
+-spec validate_resource(cb_context:context(), path_token()) -> cb_context:context().
 validate_resource(Context, UserId) -> validate_user_id(UserId, Context).
+
+-spec validate_resource(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate_resource(Context, UserId, _) -> validate_user_id(UserId, Context).
+
+-spec validate_resource(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 validate_resource(Context, UserId, _, _) -> validate_user_id(UserId, Context).
 
 -spec validate_user_id(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
--spec validate_user_id(kz_term:api_binary(), cb_context:context(), kz_json:object()) -> cb_context:context().
 validate_user_id(UserId, Context) ->
     case kz_datamgr:open_cache_doc(cb_context:account_db(Context), UserId) of
         {'ok', Doc} -> validate_user_id(UserId, Context, Doc);
@@ -208,6 +218,7 @@ validate_user_id(UserId, Context) ->
         {'error', _R} -> crossbar_util:response_db_fatal(Context)
     end.
 
+-spec validate_user_id(kz_term:api_binary(), cb_context:context(), kz_json:object()) -> cb_context:context().
 validate_user_id(UserId, Context, Doc) ->
     case kz_doc:is_soft_deleted(Doc) of
         'true' ->
@@ -229,16 +240,16 @@ validate_user_id(UserId, Context, Doc) ->
 %% Failure here returns 400
 %% @end
 %%--------------------------------------------------------------------
--spec validate(cb_context:context()) -> cb_context:context().
--spec validate(cb_context:context(), path_token()) -> cb_context:context().
--spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 
+-spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
     validate_users(Context, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, UserId) ->
     validate_user(Context, UserId, cb_context:req_verb(Context)).
 
+-spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, UserId, ?VCARD) ->
     Context1 = load_user(UserId, Context),
     case cb_context:has_errors(Context1) of
@@ -306,10 +317,10 @@ put(Context) ->
     crossbar_services:maybe_dry_run(Context, Callback).
 
 -spec delete(cb_context:context(), path_token()) -> cb_context:context().
--spec delete(cb_context:context(), kz_term:ne_binary(), path_token()) -> cb_context:context().
 delete(Context, _Id) ->
     crossbar_doc:delete(Context).
 
+-spec delete(cb_context:context(), kz_term:ne_binary(), path_token()) -> cb_context:context().
 delete(Context, UserId, ?PHOTO) ->
     crossbar_doc:delete_attachment(UserId, ?PHOTO, Context).
 
@@ -322,9 +333,8 @@ patch(Context, Id) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec load_attachment(kz_term:ne_binary(), cb_context:context()) ->
-                             cb_context:context().
--spec load_attachment(kz_term:ne_binary(), kz_term:ne_binary(), cb_context:context()) ->
                              cb_context:context().
 load_attachment(AttachmentId, Context) ->
     Headers =
@@ -338,6 +348,8 @@ load_attachment(AttachmentId, Context) ->
                                                 ),
     cb_context:add_resp_headers(LoadedContext, Headers).
 
+-spec load_attachment(kz_term:ne_binary(), kz_term:ne_binary(), cb_context:context()) ->
+                             cb_context:context().
 load_attachment(UserId, AttachmentId, Context) ->
     Context1 = load_user(UserId, Context),
     case cb_context:resp_status(Context1) of
@@ -362,7 +374,6 @@ maybe_update_devices_presence(Context) ->
     end.
 
 -spec update_devices_presence(cb_context:context()) -> 'ok'.
--spec update_devices_presence(cb_context:context(), kz_device:docs()) -> 'ok'.
 update_devices_presence(Context) ->
     case user_devices(Context) of
         {'error', _R} ->
@@ -373,6 +384,7 @@ update_devices_presence(Context) ->
             update_devices_presence(Context, DeviceDocs)
     end.
 
+-spec update_devices_presence(cb_context:context(), kz_device:docs()) -> 'ok'.
 update_devices_presence(Context, DeviceDocs) ->
     lists:foreach(fun(DeviceDoc) -> update_device_presence(Context, DeviceDoc) end
                  ,DeviceDocs

--- a/applications/doodle/src/doodle_exe.erl
+++ b/applications/doodle/src/doodle_exe.erl
@@ -101,9 +101,9 @@ update_call(Call) ->
     gen_server:cast(Srv, {'update_call', Call}).
 
 -spec continue(kapps_call:call() | pid()) -> 'ok'.
--spec continue(kz_term:ne_binary(), kapps_call:call() | pid()) -> 'ok'.
 continue(Srv) -> continue(<<"_">>, Srv).
 
+-spec continue(kz_term:ne_binary(), kapps_call:call() | pid()) -> 'ok'.
 continue(Key, Srv) when is_pid(Srv) ->
     gen_listener:cast(Srv, {'continue', Key});
 continue(Key, Call) ->
@@ -156,9 +156,8 @@ callid_update(CallId, Call) ->
     Srv = kapps_call:kvs_fetch('consumer_pid', Call),
     callid_update(CallId, Srv).
 
--spec callid(kapps_call:call() | pid()) -> kz_term:ne_binary().
--spec callid(kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
 
+-spec callid(kapps_call:call() | pid()) -> kz_term:ne_binary().
 callid(Srv) when is_pid(Srv) ->
     CallId = gen_server:call(Srv, 'callid', ?MILLISECONDS_IN_SECOND),
     kz_util:put_callid(CallId),
@@ -167,6 +166,7 @@ callid(Call) ->
     Srv = kapps_call:kvs_fetch('consumer_pid', Call),
     callid(Srv).
 
+-spec callid(kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
 callid(_, Call) ->
     callid(Call).
 
@@ -177,11 +177,12 @@ queue_name(Call) ->
     Srv = kapps_call:kvs_fetch('consumer_pid', Call),
     queue_name(Srv).
 
--spec control_queue(kapps_call:call() | pid()) -> kz_term:ne_binary().
--spec control_queue(kz_term:api_binary(), kapps_call:call() | pid()) -> kz_term:ne_binary().
 
+-spec control_queue(kapps_call:call() | pid()) -> kz_term:ne_binary().
 control_queue(Srv) when is_pid(Srv) -> gen_listener:call(Srv, 'control_queue_name');
 control_queue(Call) -> control_queue(kapps_call:kvs_fetch('consumer_pid', Call)).
+
+-spec control_queue(kz_term:api_binary(), kapps_call:call() | pid()) -> kz_term:ne_binary().
 control_queue(_, Call) -> control_queue(Call).
 
 -spec get_branch_keys(kapps_call:call() | pid()) -> {'branch_keys', kz_json:path()}.
@@ -201,11 +202,11 @@ get_all_branch_keys(Call) ->
 -spec attempt(kapps_call:call() | pid()) ->
                      {'attempt_resp', 'ok'} |
                      {'attempt_resp', {'error', any()}}.
+attempt(Srv) -> attempt(<<"_">>, Srv).
+
 -spec attempt(kz_json:path(), kapps_call:call() | pid()) ->
                      {'attempt_resp', 'ok'} |
                      {'attempt_resp', {'error', any()}}.
-attempt(Srv) -> attempt(<<"_">>, Srv).
-
 attempt(Key, Srv) when is_pid(Srv) ->
     gen_listener:call(Srv, {'attempt', Key});
 attempt(Key, Call) ->

--- a/applications/doodle/src/doodle_maintenance.erl
+++ b/applications/doodle/src/doodle_maintenance.erl
@@ -131,14 +131,14 @@ replay_sms(AccountId, JObjs) ->
         kapps_config:get_ne_binary(?CONFIG_CAT, <<"default_test_from_number">>, <<"15552220001">>)).
 
 -spec send_outbound_sms(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec send_outbound_sms(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer()) -> 'ok'.
--spec send_outbound_sms(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 send_outbound_sms(To, Msg) ->
     send_outbound_sms(To, ?DEFAULT_FROM, ?DEFAULT_ROUTEID, Msg).
 
+-spec send_outbound_sms(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer()) -> 'ok'.
 send_outbound_sms(To, Msg, Times) ->
     send_outbound_sms(To, ?DEFAULT_FROM, ?DEFAULT_ROUTEID, Msg, Times).
 
+-spec send_outbound_sms(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 send_outbound_sms(To, From, RouteId, Msg) ->
     Payload = [{<<"Message-ID">>, kz_binary:rand_hex(16)}
               ,{<<"System-ID">>, kz_util:node_name()}

--- a/applications/ecallmgr/src/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_command.erl
@@ -941,13 +941,14 @@ get_eavesdrop_app(Node, UUID, JObj, Target) ->
     {<<"eavesdrop">>, Target}.
 
 -type set_headers() :: kz_term:proplist() | [{kz_term:ne_binary(), kz_term:api_binary(), kz_term:ne_binary()},...].
+
 -spec build_set_args(set_headers(), kz_json:object()) ->
-                            kz_term:proplist().
--spec build_set_args(set_headers(), kz_json:object(), kz_term:proplist()) ->
                             kz_term:proplist().
 build_set_args(Headers, JObj) ->
     build_set_args(Headers, JObj, []).
 
+-spec build_set_args(set_headers(), kz_json:object(), kz_term:proplist()) ->
+                            kz_term:proplist().
 build_set_args([], _, Args) ->
     lists:reverse(props:filter_undefined(Args));
 build_set_args([{ApiHeader, Default}|Headers], JObj, Args) ->

--- a/applications/ecallmgr/src/ecallmgr_call_control.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_control.erl
@@ -470,7 +470,7 @@ call_control_ready(#state{call_id=CallId
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec handle_channel_destroyed(state()) -> state().
+
 -spec handle_channel_destroyed(kz_json:object(), state()) -> state().
 handle_channel_destroyed(JObj, State) ->
     case kz_json:is_true(<<"Channel-Is-Loopback">>, JObj, 'false') of
@@ -492,6 +492,7 @@ handle_loopback_destroyed(JObj, State) ->
             handle_channel_destroyed(State)
     end.
 
+-spec handle_channel_destroyed(state()) -> state().
 handle_channel_destroyed(#state{sanity_check_tref=SCTRef
                                ,current_app=CurrentApp
                                ,current_cmd=CurrentCmd
@@ -1113,11 +1114,11 @@ which_call_leg(CmdLeg, OtherLegs, CallId) ->
     end.
 
 -spec maybe_send_error_resp(kz_term:ne_binary(), kz_json:object()) -> 'ok'.
--spec maybe_send_error_resp(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 maybe_send_error_resp(CallId, Cmd) ->
     AppName = kz_json:get_value(<<"Application-Name">>, Cmd),
     maybe_send_error_resp(AppName, CallId, Cmd).
 
+-spec maybe_send_error_resp(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 maybe_send_error_resp(<<"hangup">>, _CallId, _Cmd) -> 'ok';
 maybe_send_error_resp(_, CallId, Cmd) -> send_error_resp(CallId, Cmd).
 
@@ -1131,13 +1132,13 @@ send_error_resp(CallId, Cmd) ->
                    ).
 
 -spec send_error_resp(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> 'ok'.
--spec send_error_resp(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary(), kz_term:api_object()) -> 'ok'.
 send_error_resp(CallId, Cmd, Msg) ->
     case ecallmgr_fs_channel:fetch(CallId) of
         {'ok', Channel} -> send_error_resp(CallId, Cmd, Msg, Channel);
         {'error', 'not_found'} -> send_error_resp(CallId, Cmd, Msg, 'undefined')
     end.
 
+-spec send_error_resp(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary(), kz_term:api_object()) -> 'ok'.
 send_error_resp(CallId, Cmd, Msg, Channel) ->
     CCVs = error_ccvs(Channel),
 

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -1123,12 +1123,12 @@ get_billing_seconds(Props) ->
         Billmsec -> kz_term:to_binary(kz_term:ceiling(Billmsec / 1000))
     end.
 
--spec swap_call_legs(kz_term:proplist() | kz_json:object()) -> kz_term:proplist().
--spec swap_call_legs(kz_term:proplist(), kz_term:proplist()) -> kz_term:proplist().
 
+-spec swap_call_legs(kz_term:proplist() | kz_json:object()) -> kz_term:proplist().
 swap_call_legs(Props) when is_list(Props) -> swap_call_legs(Props, []);
 swap_call_legs(JObj) -> swap_call_legs(kz_json:to_proplist(JObj)).
 
+-spec swap_call_legs(kz_term:proplist(), kz_term:proplist()) -> kz_term:proplist().
 swap_call_legs([], Swap) -> Swap;
 swap_call_legs([{<<"Unique-ID">>, Value}|T], Swap) ->
     swap_call_legs(T, [{<<"Other-Leg-Call-ID">>, Value}|Swap]);
@@ -1172,10 +1172,10 @@ callee_call_event_props(Props) ->
     end.
 
 -spec debug_channel_props(kz_term:proplist()) -> kz_term:proplist().
--spec debug_channel_props(kz_term:proplist(), boolean()) -> kz_term:proplist().
 debug_channel_props(Props) ->
     debug_channel_props(Props, ?DEBUG_CHANNEL).
 
+-spec debug_channel_props(kz_term:proplist(), boolean()) -> kz_term:proplist().
 debug_channel_props(_Props, 'false') -> [];
 debug_channel_props(Props, 'true') ->
     [{<<"Channel-Debug">>

--- a/applications/ecallmgr/src/ecallmgr_conference_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_conference_command.erl
@@ -19,10 +19,10 @@
                         [ecallmgr_util:send_cmd_ret(),...].
 
 -spec exec_cmd(atom(), kz_term:ne_binary(), kz_json:object()) -> api_response().
--spec exec_cmd(atom(), kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> api_response().
 exec_cmd(Node, ConferenceId, JObj) ->
     exec_cmd(Node, ConferenceId, JObj, kz_json:get_value(<<"Conference-ID">>, JObj)).
 
+-spec exec_cmd(atom(), kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> api_response().
 exec_cmd(Node, ConferenceId, JObj, ConferenceId) ->
     App = kz_json:get_value(<<"Application-Name">>, JObj),
     case get_conf_command(App, Node, ConferenceId, JObj) of

--- a/applications/ecallmgr/src/ecallmgr_config.erl
+++ b/applications/ecallmgr/src/ecallmgr_config.erl
@@ -36,13 +36,13 @@
 -type node_specific() :: node() | kz_term:ne_binary().
 -type api_node_specific() :: 'undefined' | node_specific().
 
--spec flush() -> 'ok'.
--spec flush(kz_json:path()) -> 'ok' | {'error', any()}.
 
+-spec flush() -> 'ok'.
 flush() ->
     kz_cache:flush_local(?ECALLMGR_UTIL_CACHE),
     flush('undefined').
 
+-spec flush(kz_json:path()) -> 'ok' | {'error', any()}.
 flush(Key) ->
     flush(Key, 'undefined').
 
@@ -69,29 +69,39 @@ flush(Key, Node) ->
                        ).
 
 -spec flush_default() -> 'ok'.
--spec flush_default(kz_term:api_binary()) -> 'ok'.
 flush_default() ->
     flush('undefined', <<"default">>).
+
+-spec flush_default(kz_term:api_binary()) -> 'ok'.
 flush_default(Key) ->
     flush(Key, <<"default">>).
 
--spec get(kz_json:path()) -> kz_json:api_json_term().
--spec get(kz_json:path(), Default) ->
-                 kz_json:json_term() | Default.
--spec get(kz_json:path(), Default, api_node_specific()) ->
-                 kz_json:json_term() | Default.
 
 -ifdef(TEST).
+
+-spec get(kz_json:path()) -> kz_json:api_json_term().
 get(_) -> undefined.
+
+-spec get(kz_json:path(), Default) ->
+                 kz_json:json_term() | Default.
 get(_, Default) -> Default.
+
+-spec get(kz_json:path(), Default, api_node_specific()) ->
+                 kz_json:json_term() | Default.
 get(_, Default, _) -> Default.
 -else.
+
+-spec get(kz_json:path()) -> kz_json:api_json_term().
 get(Key) ->
     get(Key, 'undefined').
 
+-spec get(kz_json:path(), Default) ->
+                 kz_json:json_term() | Default.
 get(Key, Default) ->
     get(Key, Default, kz_term:to_binary(node())).
 
+-spec get(kz_json:path(), Default, api_node_specific()) ->
+                 kz_json:json_term() | Default.
 get(Key, Default, 'undefined') ->
     get(Key, Default);
 get(Key, Default, Node) when not is_binary(Key) ->
@@ -108,19 +118,22 @@ get(Key, Default, Node) ->
 -endif.
 
 -spec get_default(kz_json:path()) -> kz_json:api_json_term().
--spec get_default(kz_json:path(), Default) -> kz_json:json_term() | Default.
 get_default(Key) ->
     get(Key, 'undefined', <<"default">>).
+
+-spec get_default(kz_json:path(), Default) -> kz_json:json_term() | Default.
 get_default(Key, Default) ->
     get(Key, Default, <<"default">>).
 
 -spec get_json(kz_json:path()) -> kz_term:api_object().
--spec get_json(kz_json:path(), Default) -> kz_json:object() | Default.
--spec get_json(kz_json:path(), Default, api_node_specific()) -> kz_json:object() | Default.
 get_json(Key) ->
     get_json(Key, 'undefined').
+
+-spec get_json(kz_json:path(), Default) -> kz_json:object() | Default.
 get_json(Key, Default) ->
     as_json_value(get(Key, Default), Default).
+
+-spec get_json(kz_json:path(), Default, api_node_specific()) -> kz_json:object() | Default.
 get_json(Key, Default, Node) ->
     as_json_value(get(Key, Default, Node), Default).
 
@@ -133,12 +146,14 @@ as_json_value(V, Default) ->
     end.
 
 -spec get_jsons(kz_json:path()) -> kz_json:objects().
--spec get_jsons(kz_json:path(), Default) -> kz_json:objects() | Default.
--spec get_jsons(kz_json:path(), Default, api_node_specific()) -> kz_json:objects() | Default.
 get_jsons(Key) ->
     get_jsons(Key, []).
+
+-spec get_jsons(kz_json:path(), Default) -> kz_json:objects() | Default.
 get_jsons(Key, Default) ->
     as_jsons_value(get(Key, Default), Default).
+
+-spec get_jsons(kz_json:path(), Default, api_node_specific()) -> kz_json:objects() | Default.
 get_jsons(Key, Default, Node) ->
     as_jsons_value(get(Key, Default, Node), Default).
 
@@ -151,17 +166,17 @@ as_jsons_value(V, Default) when is_list(V) ->
 as_jsons_value(_, Default) -> Default.
 
 -spec get_integer(kz_json:path()) -> kz_term:api_integer().
--spec get_integer(kz_json:path(), Default) -> integer() | Default.
--spec get_integer(kz_json:path(), Default, api_node_specific()) -> integer() | Default.
 get_integer(Key) ->
     get_integer(Key, 'undefined').
 
+-spec get_integer(kz_json:path(), Default) -> integer() | Default.
 get_integer(Key, Default) ->
     case get(Key, Default) of
         Default -> Default;
         N -> kz_term:to_integer(N)
     end.
 
+-spec get_integer(kz_json:path(), Default, api_node_specific()) -> integer() | Default.
 get_integer(Key, Default, Node) ->
     case get(Key, Default, Node) of
         Default -> Default;
@@ -169,17 +184,17 @@ get_integer(Key, Default, Node) ->
     end.
 
 -spec get_boolean(kz_json:path()) -> kz_term:api_boolean().
--spec get_boolean(kz_json:path(), Default) -> boolean() | Default.
--spec get_boolean(kz_json:path(), Default, api_node_specific()) -> boolean() | Default.
 get_boolean(Key) ->
     get_boolean(Key, 'undefined').
 
+-spec get_boolean(kz_json:path(), Default) -> boolean() | Default.
 get_boolean(Key, Default) ->
     case get(Key, Default) of
         Default -> Default;
         N -> kz_term:to_boolean(N)
     end.
 
+-spec get_boolean(kz_json:path(), Default, api_node_specific()) -> boolean() | Default.
 get_boolean(Key, Default, Node) ->
     case get(Key, Default, Node) of
         Default -> Default;
@@ -187,17 +202,17 @@ get_boolean(Key, Default, Node) ->
     end.
 
 -spec is_true(kz_json:path()) -> boolean().
--spec is_true(kz_json:path(), Default) -> boolean() | Default.
--spec is_true(kz_json:path(), Default, api_node_specific()) -> boolean() | Default.
 is_true(Key) ->
     kz_term:is_true(?MODULE:get(Key)).
 
+-spec is_true(kz_json:path(), Default) -> boolean() | Default.
 is_true(Key, Default) ->
     case get(Key, Default) of
         Default -> Default;
         N -> kz_term:is_true(N)
     end.
 
+-spec is_true(kz_json:path(), Default, api_node_specific()) -> boolean() | Default.
 is_true(Key, Default, Node) ->
     case get(Key, Default, Node) of
         Default -> Default;
@@ -205,17 +220,17 @@ is_true(Key, Default, Node) ->
     end.
 
 -spec get_ne_binary(kz_json:path()) -> kz_term:api_ne_binary().
--spec get_ne_binary(kz_json:path(), Default) -> kz_term:ne_binary() | Default.
--spec get_ne_binary(kz_json:path(), Default, api_node_specific()) -> kz_term:ne_binary() | Default.
 get_ne_binary(Key) ->
     get_ne_binary(Key, 'undefined').
 
+-spec get_ne_binary(kz_json:path(), Default) -> kz_term:ne_binary() | Default.
 get_ne_binary(Key, Default) ->
     case get(Key, Default) of
         V=?NE_BINARY -> V;
         _ -> Default
     end.
 
+-spec get_ne_binary(kz_json:path(), Default, api_node_specific()) -> kz_term:ne_binary() | Default.
 get_ne_binary(Key, Default, Node) ->
     case get(Key, Default, Node) of
         V=?NE_BINARY -> V;
@@ -223,11 +238,10 @@ get_ne_binary(Key, Default, Node) ->
     end.
 
 -spec get_ne_binaries(kz_json:path()) -> kz_term:ne_binaries().
--spec get_ne_binaries(kz_json:path(), Default) -> kz_term:ne_binaries() | Default.
--spec get_ne_binaries(kz_json:path(), Default, api_node_specific()) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Key) ->
     get_ne_binaries(Key, []).
 
+-spec get_ne_binaries(kz_json:path(), Default) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Key, Default) ->
     case get(Key, Default) of
         NeBinaries when is_list(NeBinaries) ->
@@ -238,6 +252,7 @@ get_ne_binaries(Key, Default) ->
         _ -> Default
     end.
 
+-spec get_ne_binaries(kz_json:path(), Default, api_node_specific()) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Key, Default, Node) ->
     case get(Key, Default, Node) of
         NeBinaries when is_list(NeBinaries) ->
@@ -248,20 +263,18 @@ get_ne_binaries(Key, Default, Node) ->
         _ -> Default
     end.
 
--spec fetch(kz_json:path()) -> kz_json:api_json_term().
--spec fetch(kz_json:path(), Default) ->
-                   kz_json:json_term() | Default.
--spec fetch(kz_json:path(), Default, api_node_specific() | pos_integer()) ->
-                   kz_json:json_term() | Default.
--spec fetch(kz_json:path(), Default, api_node_specific(), pos_integer()) ->
-                   kz_json:json_term() | Default.
 
+-spec fetch(kz_json:path()) -> kz_json:api_json_term().
 fetch(Key) ->
     fetch(Key, 'undefined').
 
+-spec fetch(kz_json:path(), Default) ->
+                   kz_json:json_term() | Default.
 fetch(Key, Default) ->
     fetch(Key, Default, kz_term:to_binary(node())).
 
+-spec fetch(kz_json:path(), Default, api_node_specific() | pos_integer()) ->
+                   kz_json:json_term() | Default.
 fetch(Key, Default, 'undefined') ->
     fetch(Key, Default);
 fetch(Key, Default, Timeout) when is_integer(Timeout) ->
@@ -273,6 +286,8 @@ fetch(Key, Default, Node) when not is_binary(Node) ->
 fetch(Key, Default, <<_/binary>> = Node) ->
     fetch(Key, Default, Node, ?DEFAULT_FETCH_TIMEOUT).
 
+-spec fetch(kz_json:path(), Default, api_node_specific(), pos_integer()) ->
+                   kz_json:json_term() | Default.
 fetch(Key, Default, Node, RequestTimeout) ->
     Req = [{<<"Category">>, <<"ecallmgr">>}
           ,{<<"Key">>, Key}

--- a/applications/ecallmgr/src/ecallmgr_fs_authn.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_authn.erl
@@ -40,9 +40,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_authz.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_authz.erl
@@ -49,9 +49,8 @@ authorized_log({'true', _}) -> "";
 authorized_log('true') -> "";
 authorized_log('false') -> " not".
 
--spec kill_channel(kzd_freeswitch:data(), atom()) -> 'ok'.
--spec kill_channel(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), atom()) -> 'ok'.
 
+-spec kill_channel(kzd_freeswitch:data(), atom()) -> 'ok'.
 kill_channel(Props, Node) ->
     Direction = kzd_freeswitch:call_direction(Props),
     ResourceType = kzd_freeswitch:resource_type(Props, <<"audio">>),
@@ -59,6 +58,7 @@ kill_channel(Props, Node) ->
     lager:debug("killing unauthorized channel"),
     kill_channel(Direction, ResourceType, CallId, Node).
 
+-spec kill_channel(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), atom()) -> 'ok'.
 kill_channel(_, <<"sms">>, _CallId, _Node) -> 'ok';
 kill_channel(<<"inbound">>, _, CallId, Node) ->
     %% Give any pending route requests a chance to cleanly terminate this call,

--- a/applications/ecallmgr/src/ecallmgr_fs_channel.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channel.erl
@@ -67,9 +67,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 
@@ -81,11 +83,12 @@ start_link(Node, Options) ->
 -spec fetch(kz_term:ne_binary()) ->
                    {'ok', fetch_resp()} |
                    {'error', 'not_found'}.
+fetch(UUID) ->
+    fetch(UUID, 'json').
+
 -spec fetch(kz_term:ne_binary(), channel_format()) ->
                    {'ok', fetch_resp()} |
                    {'error', 'not_found'}.
-fetch(UUID) ->
-    fetch(UUID, 'json').
 fetch(UUID, Format) ->
     case ets:lookup(?CHANNELS_TBL, UUID) of
         [Channel] -> {'ok', format(Format, Channel)};
@@ -95,11 +98,12 @@ fetch(UUID, Format) ->
 -spec fetch_other_leg(kz_term:ne_binary()) ->
                              {'ok', fetch_resp()} |
                              {'error', 'not_found'}.
+fetch_other_leg(UUID) ->
+    fetch_other_leg(UUID, 'json').
+
 -spec fetch_other_leg(kz_term:ne_binary(), channel_format()) ->
                              {'ok', fetch_resp()} |
                              {'error', 'not_found'}.
-fetch_other_leg(UUID) ->
-    fetch_other_leg(UUID, 'json').
 fetch_other_leg(UUID, Format) ->
     case ets:lookup(?CHANNELS_TBL, UUID) of
         [#channel{other_leg=OtherLeg}] -> fetch(OtherLeg, Format);

--- a/applications/ecallmgr/src/ecallmgr_fs_channel_hold.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channel_hold.erl
@@ -37,9 +37,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_channels.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channels.erl
@@ -598,10 +598,10 @@ has_channels_for_owner(OwnerId) ->
     Count > 0.
 
 -spec find_by_authorizing_id(kz_term:ne_binaries()) -> [] | kz_term:proplist().
--spec find_by_authorizing_id(kz_term:ne_binaries(), kz_term:proplist()) -> [] | kz_term:proplist().
 find_by_authorizing_id(AuthIds) ->
     find_by_authorizing_id(AuthIds, []).
 
+-spec find_by_authorizing_id(kz_term:ne_binaries(), kz_term:proplist()) -> [] | kz_term:proplist().
 find_by_authorizing_id([], Acc) -> Acc;
 find_by_authorizing_id([AuthId|AuthIds], Acc) ->
     Pattern = #channel{authorizing_id=AuthId
@@ -857,10 +857,10 @@ max_channel_uptime() ->
     ecallmgr_config:get_integer(?MAX_CHANNEL_UPTIME_KEY, 0).
 
 -spec set_max_channel_uptime(non_neg_integer()) -> 'ok'.
--spec set_max_channel_uptime(non_neg_integer(), boolean()) -> 'ok'.
 set_max_channel_uptime(MaxAge) ->
     set_max_channel_uptime(MaxAge, 'true').
 
+-spec set_max_channel_uptime(non_neg_integer(), boolean()) -> 'ok'.
 set_max_channel_uptime(MaxAge, 'true') ->
     ecallmgr_config:set_default(?MAX_CHANNEL_UPTIME_KEY, kz_term:to_integer(MaxAge));
 set_max_channel_uptime(MaxAge, 'false') ->
@@ -876,9 +876,10 @@ maybe_cleanup_old_channels() ->
     end.
 
 -spec cleanup_old_channels() -> non_neg_integer().
--spec cleanup_old_channels(non_neg_integer()) -> non_neg_integer().
 cleanup_old_channels() ->
     cleanup_old_channels(max_channel_uptime()).
+
+-spec cleanup_old_channels(non_neg_integer()) -> non_neg_integer().
 cleanup_old_channels(MaxAge) ->
     NoOlderThan = kz_time:now_s() - MaxAge,
 

--- a/applications/ecallmgr/src/ecallmgr_fs_conference.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_conference.erl
@@ -56,9 +56,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_conferences_shared.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_conferences_shared.erl
@@ -336,12 +336,13 @@ handle_call_startup(ConferenceNode, JObj, LoopbackCallId, Resp) ->
                              {'ok', kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()} |
                              {'error', 'timeout'} |
                              {'error', kz_term:ne_binary(), kz_term:ne_binary()}.
+wait_for_bowout(LoopbackALeg, LoopbackBLeg, Timeout) ->
+    wait_for_bowout(LoopbackALeg, LoopbackBLeg, Timeout, []).
+
 -spec wait_for_bowout(kz_term:ne_binary(), kz_term:api_ne_binary(), pos_integer(), kz_term:proplist()) ->
                              {'ok', kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()} |
                              {'error', 'timeout'} |
                              {'error', kz_term:ne_binary(), kz_term:ne_binary()}.
-wait_for_bowout(LoopbackALeg, LoopbackBLeg, Timeout) ->
-    wait_for_bowout(LoopbackALeg, LoopbackBLeg, Timeout, []).
 wait_for_bowout(LoopbackALeg, LoopbackBLeg, Timeout, ChannelProps) ->
     Start = kz_time:now_s(),
     receive

--- a/applications/ecallmgr/src/ecallmgr_fs_config.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_config.erl
@@ -37,9 +37,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_event_stream.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_event_stream.erl
@@ -311,13 +311,13 @@ get_event_bindings(#state{bindings=Binding}=State, Acc) when is_binary(Binding) 
                         {'ok', {kz_term:text(), inet:port_number()}} |
                         {'error', any()} |
                         {'EXIT', any()}.
+maybe_bind(Node, Bindings) ->
+    maybe_bind(Node, Bindings, 0).
+
 -spec maybe_bind(atom(), kz_term:atoms(), non_neg_integer()) ->
                         {'ok', {kz_term:text(), inet:port_number()}} |
                         {'error', any()} |
                         {'EXIT', any()}.
-maybe_bind(Node, Bindings) ->
-    maybe_bind(Node, Bindings, 0).
-
 maybe_bind(Node, Bindings, 2) ->
     case catch gen_server:call({'mod_kazoo', Node}, {'event', Bindings}, 2 * ?MILLISECONDS_IN_SECOND) of
         {'ok', {_IP, _Port}}=OK -> OK;

--- a/applications/ecallmgr/src/ecallmgr_fs_msg.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_msg.erl
@@ -55,9 +55,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     NodeBin = kz_term:to_binary(Node),
     gen_listener:start_link(?SERVER
@@ -286,9 +288,6 @@ send_error(Node, JObj, Err) ->
 -spec format_endpoint(kz_json:object(), kz_term:proplist(), kz_json:object()) ->
                              {'ok', kz_term:proplist()} |
                              {'error', kz_term:ne_binary()}.
--spec format_endpoint(kz_json:object(), kz_term:proplist(), kz_json:object(), kz_term:ne_binary()) ->
-                             {'ok', kz_term:proplist()} |
-                             {'error', kz_term:ne_binary()}.
 format_endpoint(Endpoint, Props, JObj) ->
     format_endpoint(
       Endpoint
@@ -297,6 +296,9 @@ format_endpoint(Endpoint, Props, JObj) ->
                    ,kz_json:get_value(<<"Invite-Format">>, Endpoint)
      ).
 
+-spec format_endpoint(kz_json:object(), kz_term:proplist(), kz_json:object(), kz_term:ne_binary()) ->
+                             {'ok', kz_term:proplist()} |
+                             {'error', kz_term:ne_binary()}.
 format_endpoint(Endpoint, Props, JObj, <<"route">>) ->
     CCVs = kz_json:get_value(<<"Custom-Channel-Vars">>, JObj),
     case kz_json:is_true(<<"Bounce-Back">>, CCVs, 'false') of

--- a/applications/ecallmgr/src/ecallmgr_fs_node.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_node.erl
@@ -155,9 +155,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) when is_atom(Node) ->
     QueueName = <<(kz_term:to_binary(Node))/binary
                   ,"-"
@@ -259,9 +261,10 @@ find_srv(Node) when is_atom(Node) ->
     ecallmgr_fs_node_sup:node_srv(ecallmgr_fs_sup:find_node(Node)).
 
 -spec fetch_timeout() -> pos_integer().
--spec fetch_timeout(fs_node()) -> pos_integer().
 fetch_timeout() ->
     ecallmgr_config:get_integer(<<"fetch_timeout">>, ?DEFAULT_FETCH_TIMEOUT).
+
+-spec fetch_timeout(fs_node()) -> pos_integer().
 fetch_timeout(_Node) ->
     %% TODO: eventually expose this timeout via mod_kazoo and decrement a bit.
     fetch_timeout().
@@ -440,10 +443,10 @@ code_change(_OldVsn, State, _Extra) ->
                        {'error', 'retry'}.
 
 -spec run_start_cmds(atom(), kz_term:proplist()) -> kz_term:pid_ref().
--spec run_start_cmds(atom(), kz_term:proplist(), pid()) -> any().
 run_start_cmds(Node, Options) ->
     kz_util:spawn_monitor(fun run_start_cmds/3, [Node, Options, self()]).
 
+-spec run_start_cmds(atom(), kz_term:proplist(), pid()) -> any().
 run_start_cmds(Node, Options, Parent) ->
     kz_util:put_callid(Node),
     timer:sleep(ecallmgr_config:get_integer(<<"fs_cmds_wait_ms">>, 5 * ?MILLISECONDS_IN_SECOND, Node)),
@@ -524,9 +527,10 @@ process_cmd(Node, Options, JObj, Acc0) ->
                  ).
 
 -spec process_cmd(atom(), kz_term:proplist(), kz_term:ne_binary(), kz_json:json_term(), cmd_results()) -> cmd_results().
--spec process_cmd(atom(), kz_term:proplist(), kz_term:ne_binary(), kz_json:json_term(), cmd_results(), 'list'|'binary') -> cmd_results().
 process_cmd(Node, Options, ApiCmd0, ApiArg, Acc) ->
     process_cmd(Node, Options, ApiCmd0, ApiArg, Acc, 'binary').
+
+-spec process_cmd(atom(), kz_term:proplist(), kz_term:ne_binary(), kz_json:json_term(), cmd_results(), 'list'|'binary') -> cmd_results().
 process_cmd(Node, Options, ApiCmd0, ApiArg, Acc, ArgFormat) ->
     execute_command(Node, Options, ApiCmd0, ApiArg, Acc, ArgFormat).
 
@@ -612,9 +616,10 @@ channels_as_json(Node) ->
     end.
 
 -spec probe_capabilities(atom()) -> 'ok'.
--spec probe_capabilities(atom(), kz_json:objects()) -> 'ok'.
 probe_capabilities(Node) ->
     probe_capabilities(Node, ecallmgr_config:get_jsons(<<"capabilities">>, ?DEFAULT_CAPABILITIES)).
+
+-spec probe_capabilities(atom(), kz_json:objects()) -> 'ok'.
 probe_capabilities(Node, PossibleCapabilities) ->
     kz_util:put_callid(Node),
     F = fun(Capability) -> maybe_add_capability(Node, Capability) end,

--- a/applications/ecallmgr/src/ecallmgr_fs_node_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_node_command.erl
@@ -69,9 +69,10 @@ reply_error(Error, EventData, JObj) ->
     kz_amqp_worker:cast(API, fun(P) -> kapi_switch:publish_reply(Queue, P) end).
 
 -spec reply_success(kz_json:object()) -> 'ok'.
--spec reply_success(kz_json:object(), kz_term:proplist()) -> 'ok'.
 reply_success(JObj) ->
     reply_success(JObj, []).
+
+-spec reply_success(kz_json:object(), kz_term:proplist()) -> 'ok'.
 reply_success(JObj, Response) ->
     Values = [{<<"Result">>, <<"success">>}
              ,{<<"Response">>, kz_json:from_list(Response)}

--- a/applications/ecallmgr/src/ecallmgr_fs_nodes.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_nodes.erl
@@ -105,17 +105,17 @@ start_link() ->
                              ], []).
 
 %% returns 'ok' or {'error', some_error_atom_explaining_more}
--spec add(atom()) -> 'ok' | {'error', 'no_connection'}.
--spec add(atom(), kz_term:proplist() | atom()) -> 'ok' | {'error', 'no_connection'}.
--spec add(atom(), atom(), kz_term:proplist() | atom()) -> 'ok' | {'error', 'no_connection'}.
 
+-spec add(atom()) -> 'ok' | {'error', 'no_connection'}.
 add(Node) -> add(Node, []).
 
+-spec add(atom(), kz_term:proplist() | atom()) -> 'ok' | {'error', 'no_connection'}.
 add(Node, Opts) when is_list(Opts) ->
     add(Node, erlang:get_cookie(), Opts);
 add(Node, Cookie) when is_atom(Cookie) ->
     add(Node, Cookie, [{'cookie', Cookie}]).
 
+-spec add(atom(), atom(), kz_term:proplist() | atom()) -> 'ok' | {'error', 'no_connection'}.
 add(Node, Cookie, Opts) when is_atom(Node) ->
     gen_server:call(?SERVER
                    ,{'add_fs_node'
@@ -147,9 +147,9 @@ connected(Verbose) ->
     gen_server:call(?SERVER, {'connected_nodes', Verbose}).
 
 -spec flush() -> 'ok'.
--spec flush(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 flush() -> do_flush(<<>>).
 
+-spec flush(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 flush(User, Realm) ->
     Args = <<"id "
              ,User/binary, " "
@@ -203,12 +203,12 @@ all_nodes_connected() ->
 summary() ->
     print_summary(gen_server:call(?SERVER, 'nodes')).
 
--spec details() -> 'ok'.
--spec details(kz_term:text() | atom()) -> 'ok'.
 
+-spec details() -> 'ok'.
 details() ->
     print_details(gen_server:call(?SERVER, 'nodes')).
 
+-spec details(kz_term:text() | atom()) -> 'ok'.
 details(NodeName) when not is_atom(NodeName) ->
     details(kz_term:to_atom(NodeName, 'true'));
 details(NodeName) when is_atom(NodeName) ->
@@ -263,10 +263,11 @@ remove_capability(Node, Name) ->
 
 -spec get_capability(atom(), kz_term:ne_binary()) ->
                             capability() | kz_term:api_object().
--spec get_capability(atom(), kz_term:ne_binary(), 'json' | 'record') ->
-                            capability() | kz_term:api_object().
 get_capability(Node, Capability) ->
     get_capability(Node, Capability, 'json').
+
+-spec get_capability(atom(), kz_term:ne_binary(), 'json' | 'record') ->
+                            capability() | kz_term:api_object().
 get_capability(Node, Capability, Format) ->
     MatchSpec = [{#capability{node='$1'
                              ,name='$2'
@@ -281,11 +282,11 @@ get_capability(Node, Capability, Format) ->
 
 -spec get_capabilities(atom()) ->
                               kz_json:objects() | capabilities().
--spec get_capabilities(atom(), 'json' | 'record') ->
-                              kz_json:objects() | capabilities().
 get_capabilities(Node) ->
     get_capabilities(Node, 'json').
 
+-spec get_capabilities(atom(), 'json' | 'record') ->
+                              kz_json:objects() | capabilities().
 get_capabilities(Node, Format) ->
     MatchSpec = [{#capability{node='$1'
                              ,_='_'

--- a/applications/ecallmgr/src/ecallmgr_fs_notify.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_notify.erl
@@ -67,9 +67,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_listener:start_link(?SERVER
                            ,[{'responders', ?RESPONDERS}

--- a/applications/ecallmgr/src/ecallmgr_fs_presence.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_presence.erl
@@ -36,9 +36,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_recordings.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_recordings.erl
@@ -34,9 +34,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_resource.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_resource.erl
@@ -48,9 +48,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_listener:start_link(?SERVER
                            ,[{'bindings', ?BINDINGS}

--- a/applications/ecallmgr/src/ecallmgr_fs_route.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_route.erl
@@ -37,9 +37,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_route_sup.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_route_sup.erl
@@ -29,9 +29,11 @@
 %% @public
 %% @doc Starts the supervisor
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     supervisor:start_link(?MODULE, [Node, Options]).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_router_call.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_router_call.erl
@@ -39,9 +39,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_router_text.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_router_text.erl
@@ -39,9 +39,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node) -> start_link(Node, []).
+
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Node, Options) ->
     gen_server:start_link(?SERVER, [Node, Options], []).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -66,7 +66,6 @@ sip_channel_xml(Props) ->
     {'ok', xmerl:export([SectionEl], 'fs_xml')}.
 
 -spec authn_resp_xml(kz_term:api_terms()) -> {'ok', iolist()}.
--spec authn_resp_xml(kz_term:ne_binary(), kz_json:object()) -> {'ok', kz_types:xml_els()}.
 authn_resp_xml([_|_]=RespProp) ->
     authn_resp_xml(props:get_value(<<"Auth-Method">>, RespProp)
                   ,kz_json:from_list(RespProp)
@@ -89,6 +88,7 @@ authn_resp_xml(JObj) ->
             {'ok', xmerl:export([SectionEl], 'fs_xml')}
     end.
 
+-spec authn_resp_xml(kz_term:ne_binary(), kz_json:object()) -> {'ok', kz_types:xml_els()}.
 authn_resp_xml(<<"gsm">>, JObj) ->
     PassEl1 = param_el(<<"password">>, kz_json:get_value(<<"Auth-Password">>, JObj)),
     PassEl2 = param_el(<<"nonce">>, kz_json:get_value(<<"Auth-Nonce">>, JObj)),
@@ -123,8 +123,6 @@ authn_resp_xml(_Method, _JObj) ->
     empty_response().
 
 -spec reverse_authn_resp_xml(kz_term:api_terms()) -> {'ok', iolist()}.
--spec reverse_authn_resp_xml(kz_term:ne_binary(), kz_json:object()) ->
-                                    {'ok', kz_types:xml_els()}.
 reverse_authn_resp_xml([_|_]=RespProp) ->
     reverse_authn_resp_xml(props:get_value(<<"Auth-Method">>, RespProp)
                           ,kz_json:from_list(RespProp)
@@ -139,6 +137,8 @@ reverse_authn_resp_xml(JObj) ->
             {'ok', xmerl:export([SectionEl], 'fs_xml')}
     end.
 
+-spec reverse_authn_resp_xml(kz_term:ne_binary(), kz_json:object()) ->
+                                    {'ok', kz_types:xml_els()}.
 reverse_authn_resp_xml(<<"password">>, JObj) ->
     UserId = kz_json:get_value(<<"User-ID">>, JObj),
 
@@ -229,9 +229,8 @@ route_resp_xml(Section, RespJObj, Props) ->
 
 %% Prop = Route Response
 -type route_resp_fold_acc() :: {pos_integer(), kz_types:xml_els()}.
+
 -spec route_resp_fold(kz_json:object(), route_resp_fold_acc()) ->
-                             route_resp_fold_acc().
--spec route_resp_fold(kz_json:object(), route_resp_fold_acc(), kz_term:ne_binary()) ->
                              route_resp_fold_acc().
 route_resp_fold(RouteJObj, {Idx, Acc}) ->
     case ecallmgr_util:build_channel(RouteJObj) of
@@ -240,6 +239,8 @@ route_resp_fold(RouteJObj, {Idx, Acc}) ->
             route_resp_fold(RouteJObj, {Idx, Acc}, Channel)
     end.
 
+-spec route_resp_fold(kz_json:object(), route_resp_fold_acc(), kz_term:ne_binary()) ->
+                             route_resp_fold_acc().
 route_resp_fold(RouteJObj, {Idx, Acc}, Channel) ->
     RouteJObj1 =
         case kz_json:get_value(<<"Progress-Timeout">>, RouteJObj) of
@@ -728,12 +729,14 @@ acl_node_el(Type, CIDR) ->
                }.
 
 -spec acl_list_el(kz_types:xml_attrib_value()) -> kz_types:xml_el().
--spec acl_list_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value()) -> kz_types:xml_el().
--spec acl_list_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value(), kz_types:xml_els()) -> kz_types:xml_el().
 acl_list_el(Name) ->
     acl_list_el(Name, <<"deny">>).
+
+-spec acl_list_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value()) -> kz_types:xml_el().
 acl_list_el(Name, Default) ->
     acl_list_el(Name, Default, []).
+
+-spec acl_list_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value(), kz_types:xml_els()) -> kz_types:xml_el().
 acl_list_el(Name, Default, Children) ->
     #xmlElement{name='list'
                ,attributes=[xml_attrib('name', Name)
@@ -778,7 +781,6 @@ channel_el(UUID, Desc, Content) ->
                }.
 
 -spec section_el(kz_types:xml_attrib_value(), kz_types:xml_el() | kz_types:xml_els()) -> kz_types:xml_el().
--spec section_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value(), kz_types:xml_el() | kz_types:xml_els()) -> kz_types:xml_el().
 section_el(Name, #xmlElement{}=Content) ->
     section_el(Name, [Content]);
 section_el(Name, Content) ->
@@ -787,6 +789,7 @@ section_el(Name, Content) ->
                ,content=Content
                }.
 
+-spec section_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value(), kz_types:xml_el() | kz_types:xml_els()) -> kz_types:xml_el().
 section_el(Name, Desc, #xmlElement{}=Content) ->
     section_el(Name, Desc, [Content]);
 section_el(Name, Desc, Content) ->
@@ -969,12 +972,12 @@ context_el(Name, Children) ->
                }.
 
 -spec extension_el(kz_types:xml_els()) -> kz_types:xml_el().
--spec extension_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value() | 'undefined', kz_types:xml_els()) -> kz_types:xml_el().
 extension_el(Children) ->
     #xmlElement{name='extension'
                ,content=Children
                }.
 
+-spec extension_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value() | 'undefined', kz_types:xml_els()) -> kz_types:xml_el().
 extension_el(Name, 'undefined', Children) ->
     #xmlElement{name='extension'
                ,attributes=[xml_attrib('name', Name)]
@@ -1008,18 +1011,20 @@ condition_el(Children, Field, Expression) ->
                }.
 
 -spec action_el(kz_types:xml_attrib_value()) -> kz_types:xml_el().
--spec action_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value()) -> kz_types:xml_el().
--spec action_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value(), boolean()) -> kz_types:xml_el().
 action_el(App) ->
     #xmlElement{name='action'
                ,attributes=[xml_attrib('application', App)]
                }.
+
+-spec action_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value()) -> kz_types:xml_el().
 action_el(App, Data) ->
     #xmlElement{name='action'
                ,attributes=[xml_attrib('application', App)
                            ,xml_attrib('data', Data)
                            ]
                }.
+
+-spec action_el(kz_types:xml_attrib_value(), kz_types:xml_attrib_value(), boolean()) -> kz_types:xml_el().
 action_el(App, Data, Inline) ->
     #xmlElement{name='action'
                ,attributes=[xml_attrib('application', App)

--- a/applications/ecallmgr/src/ecallmgr_maintenance.erl
+++ b/applications/ecallmgr/src/ecallmgr_maintenance.erl
@@ -156,11 +156,11 @@ carrier_acls('false') ->
     list_acls(get_acls(), ?FS_CARRIER_ACL_LIST).
 
 -spec test_carrier_ip(kz_term:ne_binary()) -> 'ok'.
--spec test_carrier_ip(kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries()) -> 'ok'.
 test_carrier_ip(IP) ->
     Nodes = ecallmgr_fs_nodes:connected(),
     test_carrier_ip(IP, Nodes).
 
+-spec test_carrier_ip(kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries()) -> 'ok'.
 test_carrier_ip(_, []) -> 'no_return';
 test_carrier_ip(IP, [Node|Nodes]) ->
     _ = test_ip_against_acl(IP, Node, ?FS_CARRIER_ACL_LIST),
@@ -232,11 +232,11 @@ sbc_acls('false') ->
     list_acls(get_acls(), ?FS_SBC_ACL_LIST).
 
 -spec test_sbc_ip(kz_term:ne_binary()) -> 'ok'.
--spec test_sbc_ip(kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries()) -> 'ok'.
 test_sbc_ip(IP) ->
     Nodes = ecallmgr_fs_nodes:connected(),
     test_sbc_ip(IP, Nodes).
 
+-spec test_sbc_ip(kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries()) -> 'ok'.
 test_sbc_ip(_, []) -> 'no_return';
 test_sbc_ip(IP, [Node|Nodes]) ->
     _ = test_ip_against_acl(IP, Node, ?FS_SBC_ACL_LIST),
@@ -717,19 +717,20 @@ disable_local_resource_authz() ->
     io:format("turned off authz for local resources; calls to local resources will no longer require authorization~n").
 
 -spec limit_channel_uptime(kz_term:ne_binary()) -> 'ok'.
--spec limit_channel_uptime(kz_term:ne_binary(), kz_term:ne_binary() | boolean()) -> 'ok'.
 limit_channel_uptime(MaxAge) ->
     limit_channel_uptime(MaxAge, 'true').
+
+-spec limit_channel_uptime(kz_term:ne_binary(), kz_term:ne_binary() | boolean()) -> 'ok'.
 limit_channel_uptime(MaxAge, AsDefault) ->
     ecallmgr_fs_channels:set_max_channel_uptime(kz_term:to_integer(MaxAge), kz_term:is_true(AsDefault)),
     io:format("updating max channel uptime to ~p (use 0 to disable check)~n", [MaxAge]).
 
 -spec hangup_long_running_channels() -> 'ok'.
--spec hangup_long_running_channels(kz_term:text() | pos_integer()) -> 'ok'.
 hangup_long_running_channels() ->
     MaxAge = ecallmgr_fs_channels:max_channel_uptime(),
     hangup_long_running_channels(MaxAge).
 
+-spec hangup_long_running_channels(kz_term:text() | pos_integer()) -> 'ok'.
 hangup_long_running_channels(MaxAge) ->
     io:format("hanging up channels older than ~p seconds~n", [MaxAge]),
     N = ecallmgr_fs_channels:cleanup_old_channels(kz_term:to_integer(MaxAge)),

--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -625,18 +625,18 @@ update_uuid(OldUUID, NewUUID) ->
     bind_to_call_events(NewUUID),
     'ok'.
 
--spec create_uuid(atom()) -> created_uuid().
--spec create_uuid(kz_json:object(), atom()) -> created_uuid().
--spec create_uuid(kz_json:object(), kz_json:object(), atom()) -> created_uuid().
 
+-spec create_uuid(atom()) -> created_uuid().
 create_uuid(_Node) -> {'fs', kz_binary:rand_hex(18)}.
 
+-spec create_uuid(kz_json:object(), atom()) -> created_uuid().
 create_uuid(JObj, Node) ->
     case kz_json:get_binary_value(<<"Outbound-Call-ID">>, JObj) of
         'undefined' -> create_uuid(Node);
         CallId -> {'api', CallId}
     end.
 
+-spec create_uuid(kz_json:object(), kz_json:object(), atom()) -> created_uuid().
 create_uuid(Endpoint, _JObj, Node) ->
     case kz_json:get_binary_value(<<"Outbound-Call-ID">>, Endpoint) of
         'undefined' -> create_uuid(Node);

--- a/applications/ecallmgr/src/ecallmgr_registrar.erl
+++ b/applications/ecallmgr/src/ecallmgr_registrar.erl
@@ -1219,7 +1219,6 @@ get_fs_contact(Props) ->
                             {registrations(), any()}.
 
 -spec print_summary(ets_continuation()) -> 'ok'.
--spec print_summary(ets_continuation(), non_neg_integer()) -> 'ok'.
 print_summary('$end_of_table') ->
     io:format("No registrations found!~n", []);
 print_summary(Match) ->
@@ -1228,6 +1227,7 @@ print_summary(Match) ->
     io:format("+===============================================+========================+========================+==================================+======+~n"),
     print_summary(Match, 0).
 
+-spec print_summary(ets_continuation(), non_neg_integer()) -> 'ok'.
 print_summary('$end_of_table', Count) ->
     io:format("+-----------------------------------------------+------------------------+------------------------+----------------------------------+------+~n"),
     io:format("Found ~p registrations~n", [Count]);
@@ -1256,12 +1256,12 @@ print_summary({[#registration{username=Username
     print_summary(ets:select(Continuation), Count + 1).
 
 -spec print_details(ets_continuation()) -> 'ok'.
--spec print_details(ets_continuation(), non_neg_integer()) -> 'ok'.
 print_details('$end_of_table') ->
     io:format("No registrations found!~n", []);
 print_details(Match) ->
     print_details(Match, 0).
 
+-spec print_details(ets_continuation(), non_neg_integer()) -> 'ok'.
 print_details('$end_of_table', Count) ->
     io:format("~nFound ~p registrations~n", [Count]);
 print_details({[#registration{}=Reg], Continuation}, Count) ->

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -180,12 +180,12 @@ get_interface_list(Node) ->
         _Else -> []
     end.
 
--spec get_interface_properties(atom()) -> kz_term:proplist().
--spec get_interface_properties(atom(), kz_term:ne_binary()) -> kz_term:proplist().
 
+-spec get_interface_properties(atom()) -> kz_term:proplist().
 get_interface_properties(Node) ->
     [{Interface, get_interface_properties(Node, Interface)} || Interface <- get_interface_list(Node)].
 
+-spec get_interface_properties(atom(), kz_term:ne_binary()) -> kz_term:proplist().
 get_interface_properties(Node, Interface) ->
     case freeswitch:api(Node, 'sofia', kz_term:to_list(list_to_binary(["status profile ", Interface]))) of
         {'ok', Response} ->
@@ -225,11 +225,12 @@ get_sip_to(Props, _) ->
     end.
 
 %% retrieves the sip address for the 'from' field
+
 -spec get_sip_from(kz_term:proplist()) -> kz_term:ne_binary().
--spec get_sip_from(kz_term:proplist(), kz_term:api_binary()) -> kz_term:ne_binary().
 get_sip_from(Props) ->
     get_sip_from(Props, kzd_freeswitch:original_call_direction(Props)).
 
+-spec get_sip_from(kz_term:proplist(), kz_term:api_binary()) -> kz_term:ne_binary().
 get_sip_from(Props, <<"outbound">>) ->
     Num = props:get_first_defined([<<"Other-Leg-RDNIS">>
                                   ,<<"Other-Leg-Caller-ID-Number">>
@@ -338,12 +339,12 @@ channel_var_map({Key, <<"ARRAY::", Serialized/binary>>}) ->
 channel_var_map({Key, Other}) -> {Key, Other}.
 
 %% Extract custom channel variables to include in the event
+
 -spec custom_channel_vars(kzd_freeswitch:data()) -> kz_term:proplist().
--spec custom_channel_vars(kz_term:proplist(), kz_term:proplist()) -> kz_term:proplist().
--spec custom_channel_vars_fold({kz_term:ne_binary(), kz_term:ne_binary()}, kz_term:proplist()) -> kz_term:proplist().
 custom_channel_vars(Props) ->
     lists:map(fun channel_var_map/1, custom_channel_vars(Props, [])).
 
+-spec custom_channel_vars(kz_term:proplist(), kz_term:proplist()) -> kz_term:proplist().
 custom_channel_vars(Props, Initial) ->
     CCVs = lists:foldl(fun custom_channel_vars_fold/2, Initial, Props),
     maybe_update_referred_ccv(Props, channel_vars_sort(CCVs)).
@@ -355,6 +356,7 @@ channel_vars_sort(ChannelVars) ->
 -spec channel_var_sort(tuple(), tuple()) -> boolean().
 channel_var_sort({A, _}, {B, _}) -> A =< B.
 
+-spec custom_channel_vars_fold({kz_term:ne_binary(), kz_term:ne_binary()}, kz_term:proplist()) -> kz_term:proplist().
 custom_channel_vars_fold({?GET_CCV(Key), V}, Acc) ->
     [{Key, V} | Acc];
 custom_channel_vars_fold({?CCV(Key), V}, Acc) ->
@@ -367,11 +369,10 @@ custom_channel_vars_fold({?GET_CCV_HEADER(Key), V}, Acc) ->
 custom_channel_vars_fold(_, Acc) -> Acc.
 
 -spec custom_application_vars(kzd_freeswitch:data()) -> kz_term:proplist().
--spec custom_application_vars(kz_term:proplist(), kz_term:proplist()) -> kz_term:proplist().
--spec custom_application_vars_fold({kz_term:ne_binary(), kz_term:ne_binary()}, kz_term:proplist()) -> kz_term:proplist().
 custom_application_vars(Props) ->
     lists:map(fun application_var_map/1, custom_application_vars(Props, [])).
 
+-spec custom_application_vars(kz_term:proplist(), kz_term:proplist()) -> kz_term:proplist().
 custom_application_vars(Props, Initial) ->
     CCVs = lists:foldl(fun custom_application_vars_fold/2, Initial, Props),
     maybe_update_referred_ccv(Props, application_vars_sort(CCVs)).
@@ -383,6 +384,7 @@ application_vars_sort(ApplicationVars) ->
 -spec application_var_sort(tuple(), tuple()) -> boolean().
 application_var_sort({A, _}, {B, _}) -> A =< B.
 
+-spec custom_application_vars_fold({kz_term:ne_binary(), kz_term:ne_binary()}, kz_term:proplist()) -> kz_term:proplist().
 custom_application_vars_fold({?GET_CAV(Key), V}, Acc) ->
     [{Key, V} | Acc];
 custom_application_vars_fold({?CAV(Key), V}, Acc) ->
@@ -464,10 +466,11 @@ varstr_to_proplist(VarStr) ->
     [to_kv(X, "=") || X <- string:tokens(kz_term:to_list(VarStr), ",")].
 
 -spec get_setting(kz_json:path()) -> {'ok', any()}.
--spec get_setting(kz_json:path(), Default) -> {'ok', Default | any()}.
 get_setting(<<"default_ringback">>) ->
     {'ok', ecallmgr_config:get(<<"default_ringback">>, <<"%(2000,4000,440,480)">>)};
 get_setting(Setting) -> {'ok', ecallmgr_config:get(Setting)}.
+
+-spec get_setting(kz_json:path(), Default) -> {'ok', Default | any()}.
 get_setting(Setting, Default) -> {'ok', ecallmgr_config:get(Setting, Default)}.
 
 -spec is_node_up(atom()) -> boolean().
@@ -562,10 +565,10 @@ format_fs_kv(Key, Value, UUID, _) ->
     end.
 
 -spec get_fs_kv(kz_term:ne_binary(), kz_term:ne_binary()) -> binary().
--spec get_fs_kv(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary()) -> binary().
 get_fs_kv(Key, Value) ->
     get_fs_kv(Key, Value, 'undefined').
 
+-spec get_fs_kv(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary()) -> binary().
 get_fs_kv(<<"Hold-Media">>, Media, UUID) ->
     list_to_binary(["hold_music="
                    ,kz_term:to_list(media_path(Media, 'extant', UUID, kz_json:new()))
@@ -659,10 +662,10 @@ maybe_sanitize_fs_value(_, Val) -> Val.
 -type bridge_endpoints() :: [bridge_endpoint()].
 
 -spec build_bridge_string(kz_json:objects()) -> kz_term:ne_binary().
--spec build_bridge_string(kz_json:objects(), kz_term:ne_binary()) -> kz_term:ne_binary().
 build_bridge_string(Endpoints) ->
     build_bridge_string(Endpoints, ?SEPARATOR_SINGLE).
 
+-spec build_bridge_string(kz_json:objects(), kz_term:ne_binary()) -> kz_term:ne_binary().
 build_bridge_string(Endpoints, Seperator) ->
     %% De-dup the bridge strings by matching those with the same
     %%  Invite-Format, To-IP, To-User, To-realm, To-DID, and Route
@@ -670,12 +673,12 @@ build_bridge_string(Endpoints, Seperator) ->
     %% NOTE: dont use binary_join here as it will crash on an empty list...
     kz_binary:join(lists:reverse(BridgeStrings), Seperator).
 
--spec endpoint_jobjs_to_records(kz_json:objects()) -> bridge_endpoints().
--spec endpoint_jobjs_to_records(kz_json:objects(), boolean()) -> bridge_endpoints().
 
+-spec endpoint_jobjs_to_records(kz_json:objects()) -> bridge_endpoints().
 endpoint_jobjs_to_records(Endpoints) ->
     endpoint_jobjs_to_records(Endpoints, 'true').
 
+-spec endpoint_jobjs_to_records(kz_json:objects(), boolean()) -> bridge_endpoints().
 endpoint_jobjs_to_records(Endpoints, IncludeVars) ->
     [BridgeEndpoints
      || {_, BridgeEndpoints} <-
@@ -1069,11 +1072,12 @@ append_channel_vars(Contact, #bridge_endpoint{channel_vars=ChannelVars}) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec create_masquerade_event(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
--spec create_masquerade_event(kz_term:ne_binary(), kz_term:ne_binary(), boolean()) -> kz_term:ne_binary().
 create_masquerade_event(Application, EventName) ->
     create_masquerade_event(Application, EventName, 'true').
 
+-spec create_masquerade_event(kz_term:ne_binary(), kz_term:ne_binary(), boolean()) -> kz_term:ne_binary().
 create_masquerade_event(Application, EventName, Boolean) ->
     Prefix = case Boolean of
                  'true' -> <<"event ">>;

--- a/applications/ecallmgr/src/freeswitch.erl
+++ b/applications/ecallmgr/src/freeswitch.erl
@@ -50,8 +50,9 @@
              ]).
 
 -spec version(atom()) -> fs_api_return().
--spec version(atom(), pos_integer()) -> fs_api_return().
 version(Node) -> ?FS_MODULE:version(Node).
+
+-spec version(atom(), pos_integer()) -> fs_api_return().
 version(Node, Timeout) -> ?FS_MODULE:version(Node, Timeout).
 
 -spec noevents(atom()) -> fs_api_return().
@@ -61,26 +62,31 @@ noevents(Node) -> ?FS_MODULE:noevents(Node).
 close(Node) -> ?FS_MODULE:close(Node).
 
 -spec getpid(atom()) -> fs_api_return().
--spec getpid(atom(), pos_integer()) -> fs_api_return().
 getpid(Node) -> ?FS_MODULE:getpid(Node).
+
+-spec getpid(atom(), pos_integer()) -> fs_api_return().
 getpid(Node, Timeout) -> ?FS_MODULE:getpid(Node, Timeout).
 
 -spec bind(atom(), atom()) -> fs_api_return().
--spec bind(atom(), atom(), pos_integer()) -> fs_api_return().
 bind(Node, Type) -> ?FS_MODULE:bind(Node, Type).
+
+-spec bind(atom(), atom(), pos_integer()) -> fs_api_return().
 bind(Node, Type, Timeout) -> ?FS_MODULE:bind(Node, Type, Timeout).
 
 -spec fetch_reply(atom(), binary(), atom() | binary(), binary() | string()) -> 'ok'.
+fetch_reply(Node, FetchID, Section, Reply) -> ?FS_MODULE:fetch_reply(Node, FetchID, Section, Reply).
+
 -spec fetch_reply(atom(), binary(), atom() | binary(), binary() | string(), pos_integer() | 'infinity') ->
                          'ok' | {'error', 'baduuid'}.
-fetch_reply(Node, FetchID, Section, Reply) -> ?FS_MODULE:fetch_reply(Node, FetchID, Section, Reply).
 fetch_reply(Node, FetchID, Section, Reply, Timeout) -> ?FS_MODULE:fetch_reply(Node, FetchID, Section, Reply, Timeout).
 
 -spec api(atom(), kz_term:text()) -> fs_api_return().
--spec api(atom(), kz_term:text(), kz_term:text()) -> fs_api_return().
--spec api(atom(), kz_term:text(), kz_term:text(), timeout()) -> fs_api_return().
 api(Node, Cmd) -> ?FS_MODULE:api(Node, Cmd).
+
+-spec api(atom(), kz_term:text(), kz_term:text()) -> fs_api_return().
 api(Node, Cmd, Args) -> ?FS_MODULE:api(Node, Cmd, Args).
+
+-spec api(atom(), kz_term:text(), kz_term:text(), timeout()) -> fs_api_return().
 api(Node, Cmd, Args, Timeout) -> ?FS_MODULE:api(Node, Cmd, Args, Timeout).
 
 %% @doc Make a backgrounded API call to FreeSWITCH. The asynchronous reply is
@@ -100,9 +106,11 @@ bgapi(Node, Cmd, Args, Fun, CallBackParams) -> ?FS_MODULE:bgapi(Node, Cmd, Args,
 bgapi(Node, UUID, CallBackParams, Cmd, Args, Fun) -> ?FS_MODULE:bgapi(Node, UUID, CallBackParams, Cmd, Args, Fun).
 
 -type event() :: atom() | kz_json:object().
+
 -spec event(atom(), event() | [event()]) -> 'ok' | {'error', 'timeout' | 'exception'}.
--spec event(atom(), event() | [event()], pos_integer()) -> 'ok' | {'error', 'timeout' | 'exception'}.
 event(Node, Events) -> ?FS_MODULE:event(Node, Events).
+
+-spec event(atom(), event() | [event()], pos_integer()) -> 'ok' | {'error', 'timeout' | 'exception'}.
 event(Node, Events, Timeout) -> ?FS_MODULE:event(Node, Events, Timeout).
 
 -spec nixevent(atom(), event() | [event()]) -> 'ok'.

--- a/applications/ecallmgr/src/mod_kazoo.erl
+++ b/applications/ecallmgr/src/mod_kazoo.erl
@@ -49,9 +49,10 @@
              ]).
 
 -spec version(atom()) -> fs_api_return().
--spec version(atom(), pos_integer()) -> fs_api_return().
 version(Node) ->
     version(Node, ?TIMEOUT).
+
+-spec version(atom(), pos_integer()) -> fs_api_return().
 version(Node, Timeout) ->
     try gen_server:call({'mod_kazoo', Node}, 'version', Timeout) of
         'timeout' -> {'error', 'timeout'};
@@ -79,9 +80,10 @@ close(Node) ->
     gen_server:cast({'mod_kazoo', Node}, 'exit').
 
 -spec getpid(atom()) -> fs_api_return().
--spec getpid(atom(), pos_integer()) -> fs_api_return().
 getpid(Node) ->
     getpid(Node, ?TIMEOUT).
+
+-spec getpid(atom(), pos_integer()) -> fs_api_return().
 getpid(Node, Timeout) ->
     try gen_server:call({'mod_kazoo', Node}, 'getpid', Timeout) of
         'timeout' -> {'error', 'timeout'};
@@ -94,9 +96,10 @@ getpid(Node, Timeout) ->
     end.
 
 -spec bind(atom(), atom()) -> fs_api_return().
--spec bind(atom(), atom(), pos_integer()) -> fs_api_return().
 bind(Node, Type) ->
     bind(Node, Type, ?TIMEOUT).
+
+-spec bind(atom(), atom(), pos_integer()) -> fs_api_return().
 bind(Node, Type, Timeout) ->
     try gen_server:call({'mod_kazoo', Node}, {'bind', Type}, Timeout) of
         'timeout' -> {'error', 'timeout'};
@@ -109,11 +112,11 @@ bind(Node, Type, Timeout) ->
     end.
 
 -spec fetch_reply(atom(), binary(), atom() | binary(), binary() | string()) -> 'ok'.
--spec fetch_reply(atom(), binary(), atom() | binary(), binary() | string(), pos_integer() | 'infinity') ->
-                         'ok' | {'error', 'baduuid'}.
 fetch_reply(Node, FetchID, Section, Reply) ->
     gen_server:cast({'mod_kazoo', Node}, {'fetch_reply', Section, FetchID, Reply}).
 
+-spec fetch_reply(atom(), binary(), atom() | binary(), binary() | string(), pos_integer() | 'infinity') ->
+                         'ok' | {'error', 'baduuid'}.
 fetch_reply(Node, FetchID, Section, Reply, Timeout) ->
     try gen_server:call({'mod_kazoo', Node}, {'fetch_reply', Section, FetchID, Reply}, Timeout) of
         'timeout' -> {'error', 'timeout'};
@@ -126,12 +129,14 @@ fetch_reply(Node, FetchID, Section, Reply, Timeout) ->
     end.
 
 -spec api(atom(), kz_term:text()) -> fs_api_return().
--spec api(atom(), kz_term:text(), kz_term:text()) -> fs_api_return().
--spec api(atom(), kz_term:text(), kz_term:text(), timeout()) -> fs_api_return().
 api(Node, Cmd) ->
     api(Node, Cmd, "").
+
+-spec api(atom(), kz_term:text(), kz_term:text()) -> fs_api_return().
 api(Node, Cmd, Args) ->
     api(Node, Cmd, Args, ?TIMEOUT).
+
+-spec api(atom(), kz_term:text(), kz_term:text(), timeout()) -> fs_api_return().
 api(Node, Cmd, Args, Timeout) when is_atom(Node) ->
     try gen_server:call({'mod_kazoo', Node}, {'api', Cmd, Args}, Timeout) of
         'timeout' -> {'error', 'timeout'};
@@ -280,10 +285,12 @@ bgapi(Node, UUID, CallBackParams, Cmd, Args, Fun) when is_function(Fun, 6) ->
     end.
 
 -type event() :: atom() | kz_json:object().
+
 -spec event(atom(), event() | [event()]) -> 'ok' | {'error', 'timeout' | 'exception'}.
--spec event(atom(), event() | [event()], pos_integer()) -> 'ok' | {'error', 'timeout' | 'exception'}.
 event(Node, Events) ->
     event(Node, Events, ?TIMEOUT).
+
+-spec event(atom(), event() | [event()], pos_integer()) -> 'ok' | {'error', 'timeout' | 'exception'}.
 event(Node, [_|_]=Events, Timeout) ->
     PortOpen = get('port_open'),
     try gen_server:call({'mod_kazoo', Node}, {'event', Events}, Timeout) of

--- a/applications/fax/src/fax_maintenance.erl
+++ b/applications/fax/src/fax_maintenance.erl
@@ -74,10 +74,8 @@ migrate_faxes(Account, Options) ->
     recover_private_media(Account),
     migrate_faxes_to_modb(Account, Options).
 
--spec migrate_private_media(kz_term:ne_binary()) -> 'ok'.
--spec migrate_private_media(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> 'ok'.
--spec maybe_migrate_private_media(kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 
+-spec migrate_private_media(kz_term:ne_binary()) -> 'ok'.
 migrate_private_media(Account) ->
     AccountDb = case kz_datamgr:db_exists(Account) of
                     'true' -> Account;
@@ -93,6 +91,7 @@ migrate_private_media(Account) ->
             io:format("unable to fetch private media files in db ~s: ~p~n", [AccountDb, E3])
     end.
 
+-spec maybe_migrate_private_media(kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 maybe_migrate_private_media(AccountDb, JObj) ->
     DocId = kz_doc:id(JObj),
     case kz_datamgr:open_doc(AccountDb, DocId) of
@@ -103,15 +102,14 @@ maybe_migrate_private_media(AccountDb, JObj) ->
             io:format("document ~s not found in database ~s : ~p~n", [DocId, AccountDb, Error])
     end.
 
+-spec migrate_private_media(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> 'ok'.
 migrate_private_media(AccountDb, Doc, <<"tiff">>) ->
     {'ok', _} = kz_datamgr:ensure_saved(AccountDb, kz_doc:set_type(Doc, <<"fax">>)),
     'ok';
 migrate_private_media(_AccountDb, _JObj, _MediaType) -> 'ok'.
 
--spec recover_private_media(kz_term:ne_binary()) -> 'ok'.
--spec recover_private_media(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> 'ok'.
--spec maybe_recover_private_media(kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 
+-spec recover_private_media(kz_term:ne_binary()) -> 'ok'.
 recover_private_media(Account) ->
     AccountDb = case kz_datamgr:db_exists(Account) of
                     'true' -> Account;
@@ -127,20 +125,20 @@ recover_private_media(Account) ->
             io:format("unable to fetch fax docs in db ~s: ~p~n", [AccountDb, E3])
     end.
 
+-spec maybe_recover_private_media(kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 maybe_recover_private_media(AccountDb, JObj) ->
     {'ok', Doc } = kz_datamgr:open_doc(AccountDb, kz_doc:id(JObj)),
     recover_private_media(AccountDb, Doc, kz_json:get_value(<<"media_type">>, Doc)).
 
+-spec recover_private_media(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> 'ok'.
 recover_private_media(_AccountDb, _Doc, <<"tiff">>) ->
     'ok';
 recover_private_media(AccountDb, Doc, _MediaType) ->
     {'ok', _ } = kz_datamgr:ensure_saved(AccountDb, kz_doc:set_type(Doc, <<"private_media">>)),
     'ok'.
 
--spec migrate_faxes_to_modb(kz_term:ne_binary(),  kz_term:proplist()) -> 'ok'.
--spec maybe_migrate_fax_to_modb(kz_term:ne_binary(), kz_json:object(),  kz_term:proplist()) -> 'ok'.
--spec migrate_fax_to_modb(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(),  kz_term:proplist()) -> 'ok'.
 
+-spec migrate_faxes_to_modb(kz_term:ne_binary(),  kz_term:proplist()) -> 'ok'.
 migrate_faxes_to_modb(Account, Options) ->
     AccountDb = case kz_datamgr:db_exists(Account) of
                     'true' -> Account;
@@ -156,6 +154,7 @@ migrate_faxes_to_modb(Account, Options) ->
             io:format("unable to fetch fax docs in db ~s: ~p~n", [AccountDb, E3])
     end.
 
+-spec maybe_migrate_fax_to_modb(kz_term:ne_binary(), kz_json:object(),  kz_term:proplist()) -> 'ok'.
 maybe_migrate_fax_to_modb(AccountDb, JObj, Options) ->
     DocId = kz_doc:id(JObj),
     case kz_datamgr:open_doc(AccountDb, DocId) of
@@ -175,6 +174,7 @@ maybe_migrate_fax_to_modb(AccountDb, JObj, Options) ->
             io:format("unable to get document ~s for fax migration : ~p",[DocId, E])
     end.
 
+-spec migrate_fax_to_modb(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(),  kz_term:proplist()) -> 'ok'.
 migrate_fax_to_modb(AccountDb, DocId, JObj, Options) ->
     Timestamp = kz_doc:created(JObj, kz_time:now_s()),
     {{Year, Month, _}, _} = calendar:gregorian_seconds_to_datetime(Timestamp),
@@ -201,10 +201,10 @@ migrate_fax_to_modb(AccountDb, DocId, JObj, Options) ->
 flush() -> kz_cache:flush_local(?CACHE_NAME).
 
 -spec account_jobs(kz_term:ne_binary()) -> 'no_return'.
--spec account_jobs(kz_term:ne_binary(), kz_term:ne_binary()) -> 'no_return'.
 account_jobs(AccountId) ->
     account_jobs(AccountId, <<"pending">>).
 
+-spec account_jobs(kz_term:ne_binary(), kz_term:ne_binary()) -> 'no_return'.
 account_jobs(AccountId, State) ->
     io:format("+--------------------------------+-------------------+-----------------+----------------------------------+----------------------------------+----------------------+----------------------+~n", []),
     FormatString = "| ~-30s | ~-17s | ~-15s | ~-32s | ~-32s | ~-20s | ~-20s |~n",
@@ -235,10 +235,10 @@ account_jobs(AccountId, State) ->
     'no_return'.
 
 -spec faxbox_jobs(kz_term:ne_binary()) -> 'no_return'.
--spec faxbox_jobs(kz_term:ne_binary(), kz_term:ne_binary()) -> 'no_return'.
 faxbox_jobs(FaxboxId) ->
     faxbox_jobs(FaxboxId, <<"pending">>).
 
+-spec faxbox_jobs(kz_term:ne_binary(), kz_term:ne_binary()) -> 'no_return'.
 faxbox_jobs(FaxboxId, State) ->
     io:format("+--------------------------------+-------------------+-----------------+----------------------------------+----------------------------------+----------------------+----------------------+~n", []),
     FormatString = "| ~-30s | ~-17s | ~-15s | ~-32s | ~-32s | ~-20s | ~-20s |~n",
@@ -324,7 +324,6 @@ restart_job(JobID) ->
     'no_return'.
 
 -spec update_job(binary(), binary()) -> 'ok' | {'error', any()}.
--spec update_job(binary(), binary(), kz_json:object()) -> 'ok' | {'error', any()}.
 update_job(JobID, State) ->
     case kz_datamgr:open_doc(?KZ_FAXES_DB, JobID) of
         {'error', _}=E -> E;
@@ -332,6 +331,7 @@ update_job(JobID, State) ->
             update_job(JobID, State, JObj)
     end.
 
+-spec update_job(binary(), binary(), kz_json:object()) -> 'ok' | {'error', any()}.
 update_job(JobID, State, JObj) ->
     case kz_json:get_value(<<"pvt_job_status">>, JObj) of
         State ->
@@ -420,7 +420,6 @@ next_key(Bin) ->
     <<Bin/binary, "\ufff0">>.
 
 -spec load_smtp_attachment(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec load_smtp_attachment(kz_term:ne_binary(), kz_term:ne_binary(), binary()) -> 'ok'.
 load_smtp_attachment(DocId, Filename) ->
     case file:read_file(Filename) of
         {'ok', FileContents} ->
@@ -429,6 +428,7 @@ load_smtp_attachment(DocId, Filename) ->
             io:format("error obtaining file ~s contents for docid ~s : ~p~n", [Filename, DocId, Error])
     end.
 
+-spec load_smtp_attachment(kz_term:ne_binary(), kz_term:ne_binary(), binary()) -> 'ok'.
 load_smtp_attachment(DocId, Filename, FileContents) ->
     CT = kz_mime:from_filename(Filename),
     case kz_datamgr:open_cache_doc(?KZ_FAXES_DB, DocId) of

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -451,9 +451,6 @@ check_number(#state{faxbox=FaxBoxDoc, number=Number, errors=Errors}=State) ->
 -spec check_permissions(state()) ->
                                {'ok', state()} |
                                {'error', string(), state()}.
--spec check_permissions(state(), kz_term:ne_binaries()) ->
-                               {'ok', state()} |
-                               {'error', string(), state()}.
 check_permissions(#state{from=_From
                         ,owner_email=OwnerEmail
                         ,faxbox=FaxBoxDoc
@@ -468,6 +465,9 @@ check_permissions(#state{from=_From
             check_permissions(State, Permissions)
     end.
 
+-spec check_permissions(state(), kz_term:ne_binaries()) ->
+                               {'ok', state()} |
+                               {'error', string(), state()}.
 check_permissions(#state{from=From
                         ,owner_email=OwnerEmail
                         ,faxbox=FaxBoxDoc
@@ -894,12 +894,12 @@ maybe_process_image(CT, Body, Size, State) ->
 -spec write_tmp_file(kz_term:ne_binary(), binary() | mimemail:mimetuple()) ->
                             {'ok', kz_term:api_binary()} |
                             {'error', any()}.
--spec write_tmp_file(kz_term:api_binary() , kz_term:ne_binary(), binary() | mimemail:mimetuple()) ->
-                            {'ok', kz_term:api_binary()} |
-                            {'error', any()}.
 write_tmp_file(Extension, Body) ->
     write_tmp_file('undefined', Extension, Body).
 
+-spec write_tmp_file(kz_term:api_binary() , kz_term:ne_binary(), binary() | mimemail:mimetuple()) ->
+                            {'ok', kz_term:api_binary()} |
+                            {'error', any()}.
 write_tmp_file('undefined', Extension, ?NE_BINARY = Body) ->
     Basename = kz_term:to_hex_binary(erlang:md5(Body)),
     Filename = <<"/tmp/email_attachment_", Basename/binary>>,

--- a/applications/fax/src/fax_util.erl
+++ b/applications/fax/src/fax_util.erl
@@ -26,16 +26,16 @@ fax_properties(JObj) ->
 
 -spec collect_channel_props(kz_json:object()) ->
                                    kz_term:proplist().
--spec collect_channel_props(kz_json:object(), kz_term:proplist() | kz_term:ne_binaries()) ->
-                                   kz_term:proplist().
--spec collect_channel_props(kz_json:object(), kz_term:proplist() | kz_term:ne_binaries(), kz_term:proplist()) ->
-                                   kz_term:proplist().
 collect_channel_props(JObj) ->
     collect_channel_props(JObj, ?FAX_CHANNEL_DESTROY_PROPS).
 
+-spec collect_channel_props(kz_json:object(), kz_term:proplist() | kz_term:ne_binaries()) ->
+                                   kz_term:proplist().
 collect_channel_props(JObj, List) ->
     collect_channel_props(JObj, List, []).
 
+-spec collect_channel_props(kz_json:object(), kz_term:proplist() | kz_term:ne_binaries(), kz_term:proplist()) ->
+                                   kz_term:proplist().
 collect_channel_props(JObj, List, Acc) ->
     lists:foldl(fun({Key, Keys}, Acc0) ->
                         collect_channel_props(kz_json:get_value(Key, JObj), Keys, Acc0);
@@ -96,9 +96,6 @@ save_fax_docs([Doc|Docs], FileContents, CT) ->
 -spec save_fax_attachment(kz_term:api_object(), binary(), kz_term:ne_binary())->
                                  {'ok', kz_json:object()} |
                                  {'error', kz_term:ne_binary()}.
--spec save_fax_attachment(kz_term:api_object(), binary(), kz_term:ne_binary(), kz_term:ne_binary(), non_neg_integer())->
-                                 {'ok', kz_json:object()} |
-                                 {'error', kz_term:ne_binary()}.
 save_fax_attachment(JObj, FileContents, CT) ->
     MaxStorageRetry = kapps_config:get_integer(?CONFIG_CAT, <<"max_storage_retry">>, 5),
     ContentsMD5 = kz_term:to_hex_binary(erlang:md5(FileContents)),
@@ -106,6 +103,9 @@ save_fax_attachment(JObj, FileContents, CT) ->
 
     save_fax_attachment(JObj, FileContents, CT, Name, MaxStorageRetry).
 
+-spec save_fax_attachment(kz_term:api_object(), binary(), kz_term:ne_binary(), kz_term:ne_binary(), non_neg_integer())->
+                                 {'ok', kz_json:object()} |
+                                 {'error', kz_term:ne_binary()}.
 save_fax_attachment(JObj, _FileContents, _CT, _Name, 0) ->
     lager:error("max retry saving attachment ~s on fax id ~s rev ~s"
                ,[_Name, kz_doc:id(JObj), kz_doc:revision(JObj)]

--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -478,10 +478,8 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
 -spec attempt_to_acquire_job(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                    {'ok', kz_json:object()} |
-                                    {'error', any()}.
--spec attempt_to_acquire_job(kz_json:object(), kz_term:ne_binary(), kz_term:api_binary()) ->
                                     {'ok', kz_json:object()} |
                                     {'error', any()}.
 attempt_to_acquire_job(Id, Q) ->
@@ -491,6 +489,9 @@ attempt_to_acquire_job(Id, Q) ->
             attempt_to_acquire_job(JObj, Q, kz_json:get_value(<<"pvt_job_status">>, JObj))
     end.
 
+-spec attempt_to_acquire_job(kz_json:object(), kz_term:ne_binary(), kz_term:api_binary()) ->
+                                    {'ok', kz_json:object()} |
+                                    {'error', any()}.
 attempt_to_acquire_job(JObj, Q, <<"locked">>) ->
     kz_datamgr:save_doc(?KZ_FAXES_DB
                        ,kz_json:set_values([{<<"pvt_job_status">>, <<"processing">>}

--- a/applications/fax/src/kapi_xmpp.erl
+++ b/applications/fax/src/kapi_xmpp.erl
@@ -88,8 +88,9 @@ declare_exchanges() ->
 
 
 -spec publish_event(kz_term:api_terms()) -> 'ok'.
--spec publish_event(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_event(Event) -> publish_event(Event, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_event(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_event(Event, ContentType) when is_list(Event) ->
     JID = props:get_value(<<"JID">>, Event),
     EventName = props:get_value(<<"Event-Name">>, Event),

--- a/applications/frontier/src/cb_access_lists.erl
+++ b/applications/frontier/src/cb_access_lists.erl
@@ -86,7 +86,6 @@ validate_acls(Context, ?HTTP_DELETE) ->
     validate_delete_acls(thing_doc(Context)).
 
 -spec thing_doc(cb_context:context()) -> cb_context:context().
--spec thing_doc(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 thing_doc(Context) ->
     case cb_context:req_nouns(Context) of
         [{<<"access_lists">>, []}, {<<"accounts">>, [AccountId]} | _] ->
@@ -102,6 +101,7 @@ thing_doc(Context) ->
                                        )
     end.
 
+-spec thing_doc(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 thing_doc(Context, ThingId, Type) ->
     Context1 = crossbar_doc:load(ThingId, Context, ?TYPE_CHECK_OPTION(Type)),
     case cb_context:resp_status(Context1) of
@@ -121,25 +121,25 @@ thing_id_not_found(Context, ThingId) ->
                                ).
 
 -spec validate_get_acls(cb_context:context()) -> cb_context:context().
--spec validate_get_acls(cb_context:context(), kz_json:object()) -> cb_context:context().
 validate_get_acls(Context) ->
     case cb_context:resp_status(Context) of
         'success' -> validate_get_acls(Context, cb_context:doc(Context));
         _Status -> Context
     end.
 
+-spec validate_get_acls(cb_context:context(), kz_json:object()) -> cb_context:context().
 validate_get_acls(Context, Doc) ->
     AccessLists = kz_json:get_value(<<"access_lists">>, Doc, kz_json:new()),
     crossbar_util:response(AccessLists, Context).
 
 -spec validate_delete_acls(cb_context:context()) -> cb_context:context().
--spec validate_delete_acls(cb_context:context(), kz_term:api_object()) -> cb_context:context().
 validate_delete_acls(Context) ->
     case cb_context:resp_status(Context) of
         'success' -> validate_delete_acls(Context, cb_context:doc(Context));
         _Status -> Context
     end.
 
+-spec validate_delete_acls(cb_context:context(), kz_term:api_object()) -> cb_context:context().
 validate_delete_acls(Context, Doc) ->
     Context1 = crossbar_util:response(kz_json:new()
                                      ,cb_context:set_doc(Context
@@ -149,8 +149,6 @@ validate_delete_acls(Context, Doc) ->
     Context1.
 
 -spec validate_set_acls(cb_context:context()) ->
-                               cb_context:context().
--spec validate_set_acls(cb_context:context(), kz_json:object(), kz_term:api_object()) ->
                                cb_context:context().
 validate_set_acls(Context) ->
     lager:debug("access lists data is valid, setting on thing"),
@@ -162,6 +160,8 @@ validate_set_acls(Context, AccessLists) ->
         _Status -> Context
     end.
 
+-spec validate_set_acls(cb_context:context(), kz_json:object(), kz_term:api_object()) ->
+                               cb_context:context().
 validate_set_acls(Context, AccessLists, Doc) ->
     Doc1 = kz_json:set_value(<<"access_lists">>, AccessLists, Doc),
     Context1 = crossbar_util:response(AccessLists
@@ -181,10 +181,10 @@ post(Context) ->
     after_post(crossbar_doc:save(Context)).
 
 -spec after_post(cb_context:context()) -> cb_context:context().
--spec after_post(cb_context:context(), crossbar_status()) -> cb_context:context().
 after_post(Context) ->
     after_post(Context, cb_context:resp_status(Context)).
 
+-spec after_post(cb_context:context(), crossbar_status()) -> cb_context:context().
 after_post(Context, 'success') ->
     crossbar_util:response(kz_json:get_value(<<"access_lists">>, cb_context:doc(Context))
                           ,Context
@@ -203,10 +203,10 @@ delete(Context) ->
     after_delete(crossbar_doc:save(Context)).
 
 -spec after_delete(cb_context:context()) -> cb_context:context().
--spec after_delete(cb_context:context(), crossbar_status()) -> cb_context:context().
 after_delete(Context) ->
     after_delete(Context, cb_context:resp_status(Context)).
 
+-spec after_delete(cb_context:context(), crossbar_status()) -> cb_context:context().
 after_delete(Context, 'success') ->
     crossbar_util:response(kz_json:new(), Context);
 after_delete(Context, _RespStatus) ->

--- a/applications/frontier/src/frontier_handle_acl.erl
+++ b/applications/frontier/src/frontier_handle_acl.erl
@@ -36,7 +36,6 @@ send_response(Reqest, Responses) ->
     kapi_frontier:publish_acls_resp(ServerID, Resp).
 
 -spec make_section(kz_json:objects(), kz_term:ne_binary()) -> kz_json:object().
--spec make_section(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binaries(), kz_term:api_binary()) -> kz_json:object().
 make_section([], _) ->
     kz_json:new();
 make_section([JObj], Section) ->
@@ -44,6 +43,8 @@ make_section([JObj], Section) ->
     CIDRs = kz_json:get_value([<<"value">>, <<"acls">>, <<"cidrs">>], JObj),
     UserAgent = kz_json:get_value([<<"value">>, <<"acls">>, <<"user_agent">>], JObj),
     make_section(Section, Order, CIDRs, UserAgent).
+
+-spec make_section(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binaries(), kz_term:api_binary()) -> kz_json:object().
 make_section(_, Order, CIDRs, _) when Order =:= 'undefined'
                                       orelse CIDRs =:= 'undefined' ->
     kz_json:new();

--- a/applications/frontier/src/frontier_handle_rate.erl
+++ b/applications/frontier/src/frontier_handle_rate.erl
@@ -320,14 +320,13 @@ build(Method, Acc, JObj, Realm) ->
 -type rates_ret() :: {status(), kz_json:objects()}.
 
 -spec handle_db_response(kz_json:objects(), boolean()) -> rates_ret().
--spec handle_db_response(kz_json:objects(), kz_json:objects(), boolean()) -> rates_ret().
--spec handle_db_response(kz_json:objects(), kz_json:objects(), kz_json:objects(), boolean()) -> rates_ret().
 handle_db_response(JObjs, IncludeRealm) ->
     {DefaultRates, OtherRates} = lists:partition(fun is_device_defaults/1, JObjs),
     {AccountRates, DeviceRates} = lists:partition(fun frontier_utils:is_realm/1, OtherRates),
 
     handle_db_response(AccountRates, DeviceRates, DefaultRates, IncludeRealm).
 
+-spec handle_db_response(kz_json:objects(), kz_json:objects(), kz_json:objects(), boolean()) -> rates_ret().
 handle_db_response(AccountRates, [], DefaultRates, IncludeRealm) ->
     lager:debug("using default rates for the device"),
     handle_db_response(AccountRates, DefaultRates, IncludeRealm);
@@ -335,6 +334,7 @@ handle_db_response(AccountRates, DeviceRates, _DefaultRates, IncludeRealm) ->
     lager:debug("found rates in the device doc"),
     handle_db_response(AccountRates, DeviceRates, IncludeRealm).
 
+-spec handle_db_response(kz_json:objects(), kz_json:objects(), boolean()) -> rates_ret().
 handle_db_response([], DeviceRates, 'true') ->
     {'need_account', DeviceRates};
 handle_db_response(AccountRates, DeviceRates, _IncludeRealm) ->

--- a/applications/frontier/src/kapi_frontier.erl
+++ b/applications/frontier/src/kapi_frontier.erl
@@ -75,8 +75,9 @@ ratelimits_resp(Prop) when is_list(Prop) ->
 ratelimits_resp(JObj) -> ratelimits_resp(kz_json:to_proplist(JObj)).
 
 -spec publish_ratelimits_resp(kz_term:ne_binary(), kz_json:object()) -> ok.
--spec publish_ratelimits_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> ok.
 publish_ratelimits_resp(Srv, JObj) -> publish_ratelimits_resp(Srv, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_ratelimits_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> ok.
 publish_ratelimits_resp(Srv, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?RATELIMITS_RESP_VALUES, fun ratelimits_resp/1),
     amqp_util:targeted_publish(Srv, Payload, ContentType).
@@ -100,8 +101,9 @@ acls_resp(Prop) when is_list(Prop) ->
 acls_resp(JObj) -> acls_resp(kz_json:to_proplist(JObj)).
 
 -spec publish_acls_resp(kz_term:ne_binary(), kz_json:object()) -> ok.
--spec publish_acls_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> ok.
 publish_acls_resp(Srv, JObj) -> publish_acls_resp(Srv, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_acls_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> ok.
 publish_acls_resp(Srv, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?ACL_RESP_VALUES, fun acls_resp/1),
     amqp_util:targeted_publish(Srv, Payload, ContentType).
@@ -140,9 +142,10 @@ flush_v(Prop) when is_list(Prop) ->
 flush_v(JObj) -> flush_v(kz_json:to_proplist(JObj)).
 
 -spec publish_flush(kz_term:api_terms()) -> 'ok'.
--spec publish_flush(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flush(JObj) ->
     publish_flush(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_flush(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flush(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?ACL_FLUSH_VALUES, fun flush/1),
     amqp_util:basic_publish(?ACL_FRONTIER_EXCHANGE, ?ACL_ROUTE_KEY, Payload, ContentType).

--- a/applications/hangups/src/hangups_channel_destroy.erl
+++ b/applications/hangups/src/hangups_channel_destroy.erl
@@ -159,10 +159,12 @@ find_direction(JObj) ->
     kz_call_event:call_direction(JObj, <<"unknown">>).
 
 %% @public
+
 -spec start_meters(kz_term:ne_binary()) -> 'ok'.
--spec start_meters(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 start_meters(HangupCause) ->
     folsom_metrics:new_meter(hangups_util:meter_name(HangupCause)).
+
+-spec start_meters(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 start_meters(AccountId, HangupCause) ->
     folsom_metrics:new_meter(hangups_util:meter_name(HangupCause, AccountId)).
 
@@ -189,10 +191,11 @@ add_to_meters(AccountId, HangupCause) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec notify_meters(kz_term:ne_binary()) -> any().
--spec notify_meters(kz_term:ne_binary(), kz_term:ne_binary()) -> any().
 notify_meters(HangupCause) ->
     folsom_metrics_meter:mark(hangups_util:meter_name(HangupCause)).
 
+-spec notify_meters(kz_term:ne_binary(), kz_term:ne_binary()) -> any().
 notify_meters(AccountId, HangupCause) ->
     folsom_metrics_meter:mark(hangups_util:meter_name(HangupCause, AccountId)).

--- a/applications/hangups/src/hangups_maintenance.erl
+++ b/applications/hangups/src/hangups_maintenance.erl
@@ -25,10 +25,8 @@
 
 -include("hangups.hrl").
 
--spec hangups_summary() -> 'ok'.
--spec hangup_summary(kz_term:ne_binary()) -> 'ok'.
--spec hangup_summary(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 
+-spec hangups_summary() -> 'ok'.
 hangups_summary() ->
     Hangups = [{Name, hangups_query_listener:meter_resp(Name)}
                || Name <- folsom_metrics:get_metrics(),
@@ -36,6 +34,7 @@ hangups_summary() ->
               ],
     print_stats(Hangups).
 
+-spec hangup_summary(kz_term:ne_binary()) -> 'ok'.
 hangup_summary(HangupCause) ->
     HC = kz_term:to_upper_binary(HangupCause),
     io:format("checking hangup summary for ~s~n", [HC]),
@@ -45,6 +44,7 @@ hangup_summary(HangupCause) ->
               ],
     print_stats(Hangups).
 
+-spec hangup_summary(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 hangup_summary(HangupCause, AccountId) ->
     HC = kz_term:to_upper_binary(HangupCause),
     io:format("checking hangup summary for ~s.~s~n", [HC, AccountId]),
@@ -227,8 +227,8 @@ update_monitor_thresholds(HangupCause, ThresholdOnMinute) ->
                ).
 
 %% @public
+
 -spec set_monitor_threshold(kz_term:ne_binary(), kz_term:ne_binary(), float()) -> boolean().
--spec set_monitor_threshold(kz_term:ne_binary(), kz_term:ne_binary(), float(), boolean()) -> boolean().
 set_monitor_threshold(HangupCause, ThresholdName, T) ->
     Threshold = kz_term:to_float(T),
     set_monitor_threshold(kz_term:to_upper_binary(HangupCause)
@@ -237,6 +237,7 @@ set_monitor_threshold(HangupCause, ThresholdName, T) ->
                          ,is_valid_threshold_name(ThresholdName)
                          ).
 
+-spec set_monitor_threshold(kz_term:ne_binary(), kz_term:ne_binary(), float(), boolean()) -> boolean().
 set_monitor_threshold(_HangupCause, ThresholdName, _Threshold, 'false') ->
     io:format("Invalid threshold name (~s), not setting~n", [ThresholdName]),
     'false';

--- a/applications/hangups/src/hangups_monitoring.erl
+++ b/applications/hangups/src/hangups_monitoring.erl
@@ -154,11 +154,11 @@ start_timer() ->
     erlang:send_after(?MILLISECONDS_IN_MINUTE, self(), ?STAT_CHECK_MSG).
 
 -spec check_stats() -> 'ok'.
--spec check_stats(kz_term:ne_binary()) -> 'ok'.
 check_stats() ->
     kz_util:put_callid(?MODULE),
     lists:foreach(fun check_stats/1, hangups_config:monitored_hangup_causes()).
 
+-spec check_stats(kz_term:ne_binary()) -> 'ok'.
 check_stats(HC) ->
     MeterName = hangups_util:meter_name(HC),
     try folsom_metrics_meter:get_values(MeterName) of

--- a/applications/hangups/src/hangups_query_listener.erl
+++ b/applications/hangups/src/hangups_query_listener.erl
@@ -58,7 +58,6 @@ start_link() ->
                                      ], []).
 
 -spec handle_query(kz_json:object(), kz_term:proplist()) -> any().
--spec handle_query(kz_json:object(), kz_term:ne_binary(), boolean()) -> any().
 handle_query(JObj, _Props) ->
     'true' = kapi_hangups:query_req_v(JObj),
     AccountId = kz_json:get_value(<<"Account-ID">>, JObj),
@@ -67,6 +66,7 @@ handle_query(JObj, _Props) ->
 
     handle_query(JObj, N, kz_json:is_true(<<"Raw-Data">>, JObj)).
 
+-spec handle_query(kz_json:object(), kz_term:ne_binary(), boolean()) -> any().
 handle_query(_JObj, _N, 'true') ->
     lager:error("who is using this ?");
 handle_query(JObj, N, 'false') ->
@@ -74,7 +74,6 @@ handle_query(JObj, N, 'false') ->
     publish_resp(JObj, meter_resp(N)).
 
 -spec meter_resp(kz_term:ne_binary()) -> kz_term:proplist().
--spec meter_resp(kz_term:ne_binary(), kz_term:proplist()) -> kz_term:proplist().
 meter_resp(<<"*">>) ->
     [{<<"meters">>, [kz_json:from_list(meter_resp(Name))
                      || {Name, _Info} <- folsom_metrics:get_metrics_info()
@@ -84,6 +83,7 @@ meter_resp(<<"*">>) ->
 meter_resp(N) ->
     meter_resp(N, folsom_metrics_meter:get_values(N)).
 
+-spec meter_resp(kz_term:ne_binary(), kz_term:proplist()) -> kz_term:proplist().
 meter_resp(_, []) -> [];
 meter_resp(N, [_|_]=Values) ->
     Vs = [{kz_term:to_binary(K), V}

--- a/applications/hangups/src/hangups_util.erl
+++ b/applications/hangups/src/hangups_util.erl
@@ -22,10 +22,11 @@
 -define(METER_PREFIX, <<?METER_PREFIX_LIST>>).
 
 -spec meter_name(kz_term:ne_binary()) -> kz_term:ne_binary().
--spec meter_name(kz_term:ne_binary(), kz_term:api_binary()) -> kz_term:ne_binary().
 meter_name(<<"*">>) -> <<"*">>;
 meter_name(HangupCause) ->
     <<?METER_PREFIX_LIST, ".", HangupCause/binary>>.
+
+-spec meter_name(kz_term:ne_binary(), kz_term:api_binary()) -> kz_term:ne_binary().
 meter_name(HangupCause, 'undefined') ->
     meter_name(HangupCause);
 meter_name(HangupCause, AccountId) ->

--- a/applications/hotornot/src/hon_rater.erl
+++ b/applications/hotornot/src/hon_rater.erl
@@ -120,10 +120,10 @@ get_rate_data_from_sorted(RateReq, _ToDID, _FromDID, [Rate|_]) ->
     {'ok', rate_resp(Rate, RateReq)}.
 
 -spec maybe_get_rate_discount(kapi_rate:req()) -> kz_term:api_binary().
--spec maybe_get_rate_discount(kapi_rate:req(), kz_term:api_binary()) -> kz_term:api_binary().
 maybe_get_rate_discount(RateReq) ->
     maybe_get_rate_discount(RateReq, kz_json:get_value(<<"Account-ID">>, RateReq)).
 
+-spec maybe_get_rate_discount(kapi_rate:req(), kz_term:api_binary()) -> kz_term:api_binary().
 maybe_get_rate_discount(_RateReq, 'undefined') -> 'undefined';
 maybe_get_rate_discount(RateReq, AccountId) ->
     AccountDb = kz_util:format_account_id(AccountId, 'encoded'),

--- a/applications/hotornot/src/hon_trie.erl
+++ b/applications/hotornot/src/hon_trie.erl
@@ -63,9 +63,12 @@ trie_proc_name(Ratedeck) ->
     kz_term:to_atom(<<"hon_trie_", RatedeckDb/binary>>, 'true').
 
 -ifdef(TEST).
+
+-spec match_did(kz_term:ne_binary(), kz_term:api_ne_binary()) -> match_return().
 match_did(ToDID, AccountId) ->
     match_did(ToDID, AccountId, ?KZ_RATES_DB).
 
+-spec match_did(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> match_return().
 match_did(ToDID, _AccountId, RatedeckId) ->
     ProcName = trie_proc_name(RatedeckId),
 
@@ -76,10 +79,10 @@ match_did(ToDID, _AccountId, RatedeckId) ->
 -else.
 
 -spec match_did(kz_term:ne_binary(), kz_term:api_ne_binary()) -> match_return().
--spec match_did(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> match_return().
 match_did(ToDID, AccountId) ->
     match_did(ToDID, AccountId, 'undefined').
 
+-spec match_did(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> match_return().
 match_did(ToDID, AccountId, RatedeckId) ->
     Ratedeck = hon_util:account_ratedeck(AccountId, RatedeckId),
     ProcName = trie_proc_name(Ratedeck),

--- a/applications/hotornot/src/hon_trie_lru.erl
+++ b/applications/hotornot/src/hon_trie_lru.erl
@@ -43,10 +43,10 @@
 -type rate_entries() :: [rate_entry()].
 
 -spec start_link(kz_term:ne_binary()) -> {'ok', pid()}.
--spec start_link(kz_term:ne_binary(), pos_integer()) -> {'ok', pid()}.
 start_link(RatedeckDb) ->
     start_link(RatedeckDb, hotornot_config:lru_expires_s()).
 
+-spec start_link(kz_term:ne_binary(), pos_integer()) -> {'ok', pid()}.
 start_link(RatedeckDb, ExpiresS) ->
     ProcName = hon_trie:trie_proc_name(RatedeckDb),
     gen_server:start_link({'local', ProcName}, ?MODULE, [RatedeckDb, ExpiresS], []).

--- a/applications/hotornot/src/hon_util.erl
+++ b/applications/hotornot/src/hon_util.erl
@@ -28,16 +28,16 @@
 
 -spec candidate_rates(kz_term:ne_binary()) ->
                              candidate_rates_return().
--spec candidate_rates(kz_term:ne_binary(), kz_term:api_ne_binary()) ->
-                             candidate_rates_return().
--spec candidate_rates(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
-                             candidate_rates_return().
 candidate_rates(ToDID) ->
     candidate_rates(ToDID, 'undefined', 'undefined').
 
+-spec candidate_rates(kz_term:ne_binary(), kz_term:api_ne_binary()) ->
+                             candidate_rates_return().
 candidate_rates(ToDID, AccountId) ->
     candidate_rates(ToDID, AccountId, 'undefined').
 
+-spec candidate_rates(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
+                             candidate_rates_return().
 candidate_rates(ToDID, AccountId, RatedeckId) ->
     E164 = knm_converters:normalize(ToDID),
     find_candidate_rates(E164, AccountId, RatedeckId).
@@ -67,9 +67,10 @@ find_trie_rates(E164, AccountId, RatedeckId) ->
     end.
 
 -spec maybe_update_trie(kz_term:ne_binary(), candidate_rates_return()) -> 'ok'.
--spec maybe_update_trie(kz_term:ne_binary(), candidate_rates_return(), atom()) -> 'ok'.
 maybe_update_trie(RatedeckId, Candidates) ->
     maybe_update_trie(RatedeckId, Candidates, hotornot_config:trie_module()).
+
+-spec maybe_update_trie(kz_term:ne_binary(), candidate_rates_return(), atom()) -> 'ok'.
 maybe_update_trie(RatedeckId, {'ok', [_|_]=Rates}, 'hon_trie_lru') ->
     hon_trie_lru:cache_rates(RatedeckId, Rates);
 maybe_update_trie(_RatedeckId, _Candidates, _Module) ->
@@ -77,11 +78,11 @@ maybe_update_trie(_RatedeckId, _Candidates, _Module) ->
 
 -spec fetch_candidate_rates(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
                                    candidate_rates_return().
--spec fetch_candidate_rates(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), kz_term:ne_binaries()) ->
-                                   candidate_rates_return().
 fetch_candidate_rates(E164, AccountId, RatedeckId) ->
     fetch_candidate_rates(E164, AccountId, RatedeckId, build_keys(E164)).
 
+-spec fetch_candidate_rates(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), kz_term:ne_binaries()) ->
+                                   candidate_rates_return().
 fetch_candidate_rates(_E164, _AccountId, _RatedeckId, []) ->
     {'error', 'did_too_short'};
 fetch_candidate_rates(E164, AccountId, RatedeckId, Keys) ->
@@ -110,16 +111,21 @@ fetch_rates_from_ratedeck(RatedeckDb, Keys) ->
                            ]
                           ).
 
--spec account_ratedeck(kz_term:api_ne_binary()) -> kz_term:ne_binary().
--spec account_ratedeck(kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> kz_term:ne_binary().
 
 -ifdef(TEST).
+
+-spec account_ratedeck(kz_term:api_ne_binary()) -> kz_term:ne_binary().
 account_ratedeck(_AccountId) -> ?KZ_RATES_DB.
+
+-spec account_ratedeck(kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> kz_term:ne_binary().
 account_ratedeck(_AccountId, _RatedeckId) -> ?KZ_RATES_DB.
 -else.
+
+-spec account_ratedeck(kz_term:api_ne_binary()) -> kz_term:ne_binary().
 account_ratedeck(AccountId) ->
     account_ratedeck(AccountId, 'undefined').
 
+-spec account_ratedeck(kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> kz_term:ne_binary().
 account_ratedeck('undefined', 'undefined') ->
     lager:info("no account supplied, using default ratedeck"),
     hotornot_config:default_ratedeck();

--- a/applications/hotornot/src/hotornot_maintenance.erl
+++ b/applications/hotornot/src/hotornot_maintenance.erl
@@ -33,7 +33,6 @@ local_summary() ->
     io:format("use rates_for_did/1 to see what rates would be used for a DID~n").
 
 -spec trie_rebuild() -> 'ok'.
--spec wait_for_rebuild(pid(), reference()) -> 'ok'.
 trie_rebuild() ->
     case hotornot_config:should_use_trie() of
         'true' ->
@@ -43,6 +42,7 @@ trie_rebuild() ->
             io:format("trie usage is not configured~n")
     end.
 
+-spec wait_for_rebuild(pid(), reference()) -> 'ok'.
 wait_for_rebuild(Pid, Ref) ->
     Timeout = hotornot_config:trie_build_timeout_ms() + 500,
     receive
@@ -56,15 +56,18 @@ wait_for_rebuild(Pid, Ref) ->
     end.
 
 -spec rates_for_did(kz_term:ne_binary()) -> 'ok'.
--spec rates_for_did(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec rates_for_did(kz_term:ne_binary(), kz_term:api_ne_binary(), trunking_options()) -> 'ok'.
--spec rates_for_did(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), trunking_options()) -> 'ok'.
 rates_for_did(DID) ->
     rates_for_did(DID, 'undefined', 'undefined', []).
+
+-spec rates_for_did(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 rates_for_did(DID, AccountId) ->
     rates_for_did(DID, 'undefined', AccountId, []).
+
+-spec rates_for_did(kz_term:ne_binary(), kz_term:api_ne_binary(), trunking_options()) -> 'ok'.
 rates_for_did(DID, Direction, RouteOptions) ->
     rates_for_did(DID, Direction, 'undefined', RouteOptions).
+
+-spec rates_for_did(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), trunking_options()) -> 'ok'.
 rates_for_did(DID, Direction, AccountId, RouteOptions) when is_list(RouteOptions) ->
     case hon_util:candidate_rates(DID, AccountId) of
         {'ok', []} -> io:format("rate lookup had no results~n");

--- a/applications/jonny5/src/j5_flat_rate.erl
+++ b/applications/jonny5/src/j5_flat_rate.erl
@@ -74,11 +74,11 @@ eligible_for_flat_rate(Request) ->
 
 -spec maybe_get_resource_flat_rate(j5_request:request()) ->
                                           {kz_term:ne_binary(), kz_term:ne_binary()}.
--spec maybe_get_resource_flat_rate(j5_request:request(), boolean()) ->
-                                          {kz_term:ne_binary(), kz_term:ne_binary()}.
 maybe_get_resource_flat_rate(Request) ->
     maybe_get_resource_flat_rate(Request, ?SHOULD_LOOKUP_FLAT_RATE).
 
+-spec maybe_get_resource_flat_rate(j5_request:request(), boolean()) ->
+                                          {kz_term:ne_binary(), kz_term:ne_binary()}.
 maybe_get_resource_flat_rate(_Request, 'false') ->
     {?WHITELIST, ?BLACKLIST};
 maybe_get_resource_flat_rate(Request, 'true') ->

--- a/applications/konami/src/konami_code_statem.erl
+++ b/applications/konami/src/konami_code_statem.erl
@@ -475,14 +475,14 @@ arm_bleg(#state{digit_timeout=Timeout}=State) ->
                ,b_leg_armed='true'
                }.
 
--spec maybe_fast_rearm(kz_term:ne_binary(), kz_term:ne_binary(), binary()) -> binary().
--spec maybe_fast_rearm(kz_term:ne_binary(), kz_term:ne_binary(), binary(), boolean()) -> binary().
 
+-spec maybe_fast_rearm(kz_term:ne_binary(), kz_term:ne_binary(), binary()) -> binary().
 maybe_fast_rearm(DTMF, BindingDigit, Collected) ->
     maybe_fast_rearm(DTMF, BindingDigit, Collected
                     ,kapps_config:get_is_true(?CONFIG_CAT, <<"use_fast_rearm">>, 'false')
                     ).
 
+-spec maybe_fast_rearm(kz_term:ne_binary(), kz_term:ne_binary(), binary(), boolean()) -> binary().
 maybe_fast_rearm(DTMF, _BindingDigit, Collected, 'false') -> <<Collected/binary, DTMF/binary>>;
 maybe_fast_rearm(DoubleBindingDigit, DoubleBindingDigit, <<>>, 'true') -> DoubleBindingDigit;
 maybe_fast_rearm(DTMFisBindingDigit, DTMFisBindingDigit, _Collected, 'true') -> <<>>;
@@ -513,11 +513,11 @@ add_bleg_dtmf(#state{b_collected_dtmf=Collected
                }.
 
 -spec maybe_add_call_event_bindings(kz_term:api_ne_binary() | kapps_call:call()) -> 'ok'.
--spec maybe_add_call_event_bindings(kapps_call:call(), listen_on()) -> 'ok'.
 maybe_add_call_event_bindings('undefined') -> 'ok';
 maybe_add_call_event_bindings(<<_/binary>> = Leg) -> konami_event_listener:add_call_binding(Leg);
 maybe_add_call_event_bindings(Call) -> konami_event_listener:add_call_binding(Call).
 
+-spec maybe_add_call_event_bindings(kapps_call:call(), listen_on()) -> 'ok'.
 maybe_add_call_event_bindings(Call, 'a') ->
     konami_event_listener:add_konami_binding(kapps_call:call_id(Call)),
     maybe_add_call_event_bindings(Call);

--- a/applications/konami/src/konami_config.erl
+++ b/applications/konami/src/konami_config.erl
@@ -35,10 +35,10 @@
 -type formatter_fun() :: fun((any()) -> any()).
 
 -spec numbers() -> kz_json:object().
--spec numbers(kz_term:ne_binary()) -> kz_json:object().
 numbers() ->
     kapps_config:get_json(<<"metaflows">>, <<"numbers">>, ?DEFAULT_NUMBERS).
 
+-spec numbers(kz_term:ne_binary()) -> kz_json:object().
 numbers(Account) ->
     case konami_doc(Account) of
         'undefined' -> numbers();
@@ -47,10 +47,10 @@ numbers(Account) ->
     end.
 
 -spec patterns() -> kz_json:object().
--spec patterns(kz_term:ne_binary()) -> kz_json:object().
 patterns() ->
     kapps_config:get_json(<<"metaflows">>, <<"patterns">>, ?DEFAULT_PATTERNS).
 
+-spec patterns(kz_term:ne_binary()) -> kz_json:object().
 patterns(Account) ->
     case konami_doc(Account) of
         'undefined' -> patterns();
@@ -59,11 +59,11 @@ patterns(Account) ->
     end.
 
 -spec binding_digit() -> <<_:8>>.
--spec binding_digit(kz_term:ne_binary()) -> <<_:8>>.
 binding_digit() ->
     BindingDigit = kapps_config:get_ne_binary(<<"metaflows">>, <<"binding_digit">>, ?DEFAULT_BINDING_DIGIT),
     constrain_binding_digit(BindingDigit).
 
+-spec binding_digit(kz_term:ne_binary()) -> <<_:8>>.
 binding_digit(Account) ->
     case konami_doc(Account) of
         'undefined' -> binding_digit();
@@ -79,10 +79,10 @@ constrain_binding_digit(BindingDigit) ->
     end.
 
 -spec timeout() -> non_neg_integer().
--spec timeout(kz_term:ne_binary()) -> non_neg_integer().
 timeout() ->
     kapps_config:get_integer(<<"metaflows">>, <<"digit_timeout_ms">>, ?DEFAULT_DIGIT_TIMEOUT).
 
+-spec timeout(kz_term:ne_binary()) -> non_neg_integer().
 timeout(Account) ->
     case konami_doc(Account) of
         'undefined' -> timeout();
@@ -91,9 +91,10 @@ timeout(Account) ->
     end.
 
 -spec listen_on() -> 'a' | 'b' | 'ab'.
--spec listen_on(kz_term:ne_binary()) -> 'a' | 'b' | 'ab'.
 listen_on() ->
     constrain_listen_on(kapps_config:get_ne_binary(<<"metaflows">>, <<"listen_on">>, ?DEFAULT_LISTEN_ON)).
+
+-spec listen_on(kz_term:ne_binary()) -> 'a' | 'b' | 'ab'.
 listen_on(Account) ->
     case konami_doc(Account) of
         'undefined' -> listen_on();
@@ -112,10 +113,10 @@ constrain_listen_on(_) -> ?DEFAULT_LISTEN_ON.
 identity(X) -> X.
 
 -spec get_attribute(kz_json:object(), kz_term:ne_binary(), default_fun()) -> any().
--spec get_attribute(kz_json:object(), kz_term:ne_binary(), default_fun(), formatter_fun()) -> any().
 get_attribute(JObj, K, DefaultFun) ->
     get_attribute(JObj, K, DefaultFun, fun identity/1).
 
+-spec get_attribute(kz_json:object(), kz_term:ne_binary(), default_fun(), formatter_fun()) -> any().
 get_attribute(JObj, K, DefaultFun, FormatterFun) ->
     case kz_json:get_value(K, JObj) of
         'undefined' -> DefaultFun();

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -22,12 +22,12 @@
 
 -spec handle(kz_json:object(), kapps_call:call()) ->
                     {'continue', kapps_call:call()}.
--spec handle(kz_json:object(), kapps_call:call(), kz_term:ne_binary()) ->
-                    kapps_call:call().
 handle(Data, Call) ->
     Call1 = handle(Data, Call, get_action(kz_json:get_ne_binary_value(<<"action">>, Data))),
     {'continue', Call1}.
 
+-spec handle(kz_json:object(), kapps_call:call(), kz_term:ne_binary()) ->
+                    kapps_call:call().
 handle(Data, Call, <<"start">>) ->
     lager:debug("starting recording, see you on the other side"),
     kapps_call:start_recording(Data, Call);

--- a/applications/konami/src/module/konami_transfer.erl
+++ b/applications/konami/src/module/konami_transfer.erl
@@ -1196,9 +1196,10 @@ handle_transferor_dtmf(Evt
     end.
 
 -spec unbridge(kapps_call:call()) -> 'ok'.
--spec unbridge(kapps_call:call(), kz_term:ne_binary()) -> 'ok'.
 unbridge(Call) ->
     unbridge(Call, kapps_call:call_id(Call)).
+
+-spec unbridge(kapps_call:call(), kz_term:ne_binary()) -> 'ok'.
 unbridge(Call, CallId) ->
     Command = [{<<"Application-Name">>, <<"unbridge">>}
               ,{<<"Insert-At">>, <<"now">>}
@@ -1322,12 +1323,13 @@ transfer_data(Target, Takeback, MOH) ->
       ]).
 
 -spec find_moh(kz_json:object(), kapps_call:call()) -> kz_term:api_binary().
--spec find_moh(kapps_call:call()) -> kz_term:api_binary().
 find_moh(Data, Call) ->
     case kz_json:get_value(<<"moh">>, Data) of
         'undefined' -> find_moh(Call);
         MOH -> MOH
     end.
+
+-spec find_moh(kapps_call:call()) -> kz_term:api_binary().
 find_moh(Call) ->
     {'ok', JObj} = kz_account:fetch(kapps_call:account_id(Call)),
     kz_json:get_value([<<"music_on_hold">>, <<"media_id">>], JObj).
@@ -1397,11 +1399,12 @@ suppress_event(JObj, _EventNode, _OtherNode) ->
                 ]).
 
 -type connect_to() :: 'transferee' | 'transferor'.
+
 -spec handle_real_target(state(), kz_term:ne_binary()) -> state().
--spec handle_real_target(state(), kz_term:ne_binary(), connect_to()) -> state().
 handle_real_target(State, ReplacementId) ->
     handle_real_target(State, ReplacementId, 'transferor').
 
+-spec handle_real_target(state(), kz_term:ne_binary(), connect_to()) -> state().
 handle_real_target(#state{target_a_leg=TargetA
                          ,target_call=TargetCall
                          ,purgatory_ref=Ref

--- a/applications/media_mgr/src/media_mgr_maintenance.erl
+++ b/applications/media_mgr/src/media_mgr_maintenance.erl
@@ -12,19 +12,19 @@
 
 -include("media.hrl").
 
--spec prompt_url(kz_term:ne_binary()) -> 'ok'.
--spec prompt_url(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec prompt_url(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 
+-spec prompt_url(kz_term:ne_binary()) -> 'ok'.
 prompt_url(PromptId) ->
     AccountId = ?KZ_MEDIA_DB,
     Language = kz_media_util:default_prompt_language(),
     prompt_url(PromptId, AccountId, Language).
 
+-spec prompt_url(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 prompt_url(PromptId, AccountId) ->
     Language = kz_media_util:prompt_language(AccountId),
     prompt_url(PromptId, AccountId, Language).
 
+-spec prompt_url(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 prompt_url(PromptId, AccountId, Language) ->
     case kz_media_url:playback(<<"prompt://", AccountId/binary, "/", PromptId/binary, "/", Language/binary>>, kz_json:new()) of
         {'error', _E} ->

--- a/applications/notify/src/notify_fax_util.erl
+++ b/applications/notify/src/notify_fax_util.erl
@@ -65,13 +65,14 @@ get_attachment(UseDb, Category, Props) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec raw_attachment_binary(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                   {'ok', kz_term:ne_binary(), kz_term:ne_binary()}.
--spec raw_attachment_binary(kz_term:ne_binary(), kz_term:ne_binary(), non_neg_integer()) ->
                                    {'ok', kz_term:ne_binary(), kz_term:ne_binary()}.
 raw_attachment_binary(Db, FaxId) ->
     raw_attachment_binary(Db, FaxId, 2).
 
+-spec raw_attachment_binary(kz_term:ne_binary(), kz_term:ne_binary(), non_neg_integer()) ->
+                                   {'ok', kz_term:ne_binary(), kz_term:ne_binary()}.
 raw_attachment_binary(Db, FaxId, Retries) when Retries > 0 ->
     lager:debug("get raw attachment ~s / ~s", [Db, FaxId]),
 

--- a/applications/notify/src/notify_maintenance.erl
+++ b/applications/notify/src/notify_maintenance.erl
@@ -266,12 +266,8 @@ module_exists(Module) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec compare_template_system_config(kz_term:proplist()) -> 'ok'.
--spec compare_template_system_config(kz_term:proplist(), kz_json:object()) -> 'ok'.
--spec compare_template_system_config(kz_term:api_binaries(), kz_term:api_binary(), kz_term:api_binary()) ->
-                                            'default' | 'file' |
-                                            'doc' | 'ok'.
 
+-spec compare_template_system_config(kz_term:proplist()) -> 'ok'.
 compare_template_system_config([]) -> 'ok';
 compare_template_system_config([{FileId, Id}|Match]) ->
     File = [?TEMPLATE_PATH, "/" ,kz_term:to_list(FileId)],
@@ -295,6 +291,7 @@ compare_template_system_config([{FileId, Id}|Match]) ->
             compare_template_system_config(Match)
     end.
 
+-spec compare_template_system_config(kz_term:proplist(), kz_json:object()) -> 'ok'.
 compare_template_system_config([], JObj) ->
     Id = kz_doc:id(JObj),
     case kz_datamgr:save_doc(?SYSTEM_CONFIG_DB, JObj) of
@@ -327,6 +324,9 @@ compare_template_system_config([{Key, FileTemplate}|Props], JObj) ->
             end
     end.
 
+-spec compare_template_system_config(kz_term:api_binaries(), kz_term:api_binary(), kz_term:api_binary()) ->
+                                            'default' | 'file' |
+                                            'doc' | 'ok'.
 compare_template_system_config('undefined', _, _) ->
     io:format("default template is undefined~n");
 compare_template_system_config(_, 'undefined', _) ->

--- a/applications/notify/src/notify_util.erl
+++ b/applications/notify/src/notify_util.erl
@@ -72,9 +72,10 @@ send_email(From, To, Email) ->
     end.
 
 -spec send_update(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec send_update(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary()) -> 'ok'.
 send_update(RespQ, MsgId, Status) ->
     send_update(RespQ, MsgId, Status, 'undefined').
+
+-spec send_update(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary()) -> 'ok'.
 send_update('undefined', _, _, _) -> lager:debug("no response queue to send update");
 send_update(RespQ, MsgId, Status, Msg) ->
     Prop = props:filter_undefined(
@@ -143,20 +144,20 @@ normalize_value(Value) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec compile_default_text_template(atom(), kz_term:ne_binary()) -> {'ok', atom()}.
--spec compile_default_html_template(atom(), kz_term:ne_binary()) -> {'ok', atom()}.
--spec compile_default_subject_template(atom(), kz_term:ne_binary()) -> {'ok', atom()}.
--spec compile_default_template(atom(), kz_term:ne_binary(), atom()) -> {'ok', atom()}.
 
+-spec compile_default_text_template(atom(), kz_term:ne_binary()) -> {'ok', atom()}.
 compile_default_text_template(TemplateModule, Category) ->
     compile_default_template(TemplateModule, Category, 'default_text_template').
 
+-spec compile_default_html_template(atom(), kz_term:ne_binary()) -> {'ok', atom()}.
 compile_default_html_template(TemplateModule, Category) ->
     compile_default_template(TemplateModule, Category, 'default_html_template').
 
+-spec compile_default_subject_template(atom(), kz_term:ne_binary()) -> {'ok', atom()}.
 compile_default_subject_template(TemplateModule, Category) ->
     compile_default_template(TemplateModule, Category, 'default_subject_template').
 
+-spec compile_default_template(atom(), kz_term:ne_binary(), atom()) -> {'ok', atom()}.
 compile_default_template(TemplateModule, Category, Key) ->
     Template = case kapps_config:get_ne_binary(Category, Key) of
                    'undefined' -> get_default_template(Category, Key);
@@ -231,12 +232,12 @@ do_render_template(Template, DefaultTemplate, Props) ->
 %% in the event, parent account notification object, and then default.
 %% @end
 %%--------------------------------------------------------------------
--spec get_service_props(kz_json:object(), kz_term:ne_binary()) -> kz_term:proplist().
--spec get_service_props(kz_json:object(), kz_json:object(), kz_term:ne_binary()) -> kz_term:proplist().
 
+-spec get_service_props(kz_json:object(), kz_term:ne_binary()) -> kz_term:proplist().
 get_service_props(Account, ConfigCat) ->
     get_service_props(kz_json:new(), Account, ConfigCat).
 
+-spec get_service_props(kz_json:object(), kz_json:object(), kz_term:ne_binary()) -> kz_term:proplist().
 get_service_props(Request, Account, ConfigCat) ->
     DefaultUrl = kz_json:get_ne_value(<<"service_url">>, Request
                                      ,kapps_config:get_ne_binary(ConfigCat, <<"default_service_url">>, <<"http://apps.2600hz.com">>)),

--- a/applications/omnipresence/src/kapi_omnipresence.erl
+++ b/applications/omnipresence/src/kapi_omnipresence.erl
@@ -78,9 +78,10 @@ subscribe_v(Prop) when is_list(Prop) ->
 subscribe_v(JObj) -> subscribe_v(kz_json:to_proplist(JObj)).
 
 -spec publish_subscribe(kz_term:api_terms()) -> 'ok'.
--spec publish_subscribe(kz_term:api_terms(), binary()) -> 'ok'.
 publish_subscribe(JObj) ->
     publish_subscribe(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_subscribe(kz_term:api_terms(), binary()) -> 'ok'.
 publish_subscribe(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?SUBSCRIBE_VALUES, fun subscribe/1),
     amqp_util:basic_publish(?OMNIPRESENCE_EXCHANGE, <<>>, Payload, ContentType).
@@ -104,8 +105,9 @@ notify_v(Prop) when is_list(Prop) ->
 notify_v(JObj) -> notify_v(kz_json:to_proplist(JObj)).
 
 -spec publish_notify(kz_term:api_terms()) -> 'ok'.
--spec publish_notify(kz_term:api_terms(), binary()) -> 'ok'.
 publish_notify(JObj) -> publish_notify(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_notify(kz_term:api_terms(), binary()) -> 'ok'.
 publish_notify(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?NOTIFY_VALUES, fun notify/1),
     amqp_util:basic_publish(?OMNIPRESENCE_EXCHANGE, <<>>, Payload, ContentType).
@@ -145,10 +147,10 @@ bind_q(Queue, [_|Restrict], Props) ->
 bind_q(_, [], _) -> 'ok'.
 
 -spec unbind_q(kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
--spec unbind_q(kz_term:ne_binary(), kz_term:atoms() | 'undefined', kz_term:proplist()) -> 'ok'.
 unbind_q(Queue, Props) ->
     unbind_q(Queue, props:get_value('restrict_to', Props), Props).
 
+-spec unbind_q(kz_term:ne_binary(), kz_term:atoms() | 'undefined', kz_term:proplist()) -> 'ok'.
 unbind_q(Queue, 'undefined', Props) ->
     amqp_util:unbind_q_from_exchange(Queue
                                     ,?SUBSCRIBE_RK(Props)

--- a/applications/omnipresence/src/omnip_subscriptions.erl
+++ b/applications/omnipresence/src/omnip_subscriptions.erl
@@ -397,7 +397,6 @@ find_subscriptions(MatchSpec) ->
     end.
 
 -spec search_for_subscriptions(kz_term:ne_binary() | '_', kz_term:ne_binary()) -> subscriptions().
--spec search_for_subscriptions(kz_term:ne_binary() | '_', kz_term:ne_binary(), kz_term:ne_binary() | '_') -> subscriptions().
 search_for_subscriptions(Event, Realm) ->
     MatchSpec =
         #omnip_subscription{realm=kz_term:to_lower_binary(Realm)
@@ -406,6 +405,7 @@ search_for_subscriptions(Event, Realm) ->
                            },
     ets:match_object(table_id(), MatchSpec).
 
+-spec search_for_subscriptions(kz_term:ne_binary() | '_', kz_term:ne_binary(), kz_term:ne_binary() | '_') -> subscriptions().
 search_for_subscriptions(Event, Realm, '_') ->
     search_for_subscriptions(Event, Realm);
 search_for_subscriptions(Event, Realm, Username) ->

--- a/applications/omnipresence/src/omnipresence_maintenance.erl
+++ b/applications/omnipresence/src/omnipresence_maintenance.erl
@@ -32,20 +32,20 @@ count_current_subscriptions() ->
 -define(SUBSCRIPTION_FORMAT_STR, " ~50.s | ~50.s | ~10.s | ~20.s |~n").
 
 -spec current_subscriptions() -> 'ok'.
--spec current_subscriptions(kz_term:ne_binary()) -> 'ok'.
--spec current_subscriptions(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 current_subscriptions() ->
     print_subscriptions(
       omnip_subscriptions:subscriptions_to_json(
         ets:tab2list(omnip_subscriptions:table_id())
        )).
 
+-spec current_subscriptions(kz_term:ne_binary()) -> 'ok'.
 current_subscriptions(Realm) ->
     print_subscriptions(
       omnip_subscriptions:subscriptions_to_json(
         omnip_subscriptions:search_for_subscriptions('_', kz_term:to_binary(Realm))
        )).
 
+-spec current_subscriptions(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 current_subscriptions(Realm, User) ->
     print_subscriptions(
       omnip_subscriptions:subscriptions_to_json(

--- a/applications/pivot/src/pivot_call.erl
+++ b/applications/pivot/src/pivot_call.erl
@@ -86,9 +86,10 @@ start_link(Call, JObj) ->
 stop_call(Srv, Call) -> gen_listener:cast(Srv, {'stop', Call}).
 
 -spec new_request(pid(), kz_term:ne_binary(), http_method()) -> 'ok'.
--spec new_request(pid(), kz_term:ne_binary(), http_method(), kz_json:object()) -> 'ok'.
 new_request(Srv, Uri, Method) ->
     gen_listener:cast(Srv, {'request', Uri, Method}).
+
+-spec new_request(pid(), kz_term:ne_binary(), http_method(), kz_json:object()) -> 'ok'.
 new_request(Srv, Uri, Method, Params) ->
     gen_listener:cast(Srv, {'request', Uri, Method, Params}).
 

--- a/applications/pusher/src/kapi_pusher.erl
+++ b/applications/pusher/src/kapi_pusher.erl
@@ -78,25 +78,28 @@ push_resp_v(JObj) ->
     push_resp_v(kz_json:to_proplist(JObj)).
 
 -spec publish_push_req(kz_term:api_terms()) -> 'ok'.
--spec publish_push_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_push_req(JObj) ->
     publish_push_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_push_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_push_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PUSH_REQ_VALUES, fun push_req/1),
     amqp_util:basic_publish(?PUSH_EXCHANGE, push_routing_key(Req), Payload, ContentType).
 
 -spec publish_push_resp(kz_term:api_terms()) -> 'ok'.
--spec publish_push_resp(kz_term:api_terms(), binary()) -> 'ok'.
 publish_push_resp(JObj) ->
     publish_push_resp(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_push_resp(kz_term:api_terms(), binary()) -> 'ok'.
 publish_push_resp(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PUSH_RESP_VALUES, fun push_resp/1),
     amqp_util:basic_publish(?PUSH_EXCHANGE, push_routing_key(Req), Payload, ContentType).
 
 -spec publish_targeted_push_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_targeted_push_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_targeted_push_resp(RespQ, JObj) ->
     publish_targeted_push_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_targeted_push_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_targeted_push_resp(RespQ, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?PUSH_RESP_VALUES, fun push_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
@@ -112,12 +115,12 @@ push_routing_key(Type, Token) ->
 %% API Helpers
 
 -spec bind_q(kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
--spec bind_q(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binaries()) -> 'ok'.
 bind_q(Queue, Props) ->
     Token = props:get_value('token', Props, <<"*">>),
     Type = props:get_value('type', Props, <<"*">>),
     bind_q(Queue, Type, Token, props:get_value('restrict_to', Props)).
 
+-spec bind_q(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binaries()) -> 'ok'.
 bind_q(Queue, Type, Token, 'undefined') ->
     amqp_util:bind_q_to_exchange(Queue, push_routing_key(Type, Token), ?PUSH_EXCHANGE);
 bind_q(Queue, Type, Token, ['push'|Restrict]) ->
@@ -128,12 +131,12 @@ bind_q(Queue, Type, Token, [_|Restrict]) ->
 bind_q(_Queue, _Type, _Token, []) -> 'ok'.
 
 -spec unbind_q(binary(), kz_term:proplist()) -> 'ok'.
--spec unbind_q(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binaries()) -> 'ok'.
 unbind_q(Queue, Props) ->
     Token = props:get_value('token', Props, <<"*">>),
     Type = props:get_value('type', Props, <<"*">>),
     unbind_q(Queue, Type, Token, props:get_value('restrict_to', Props)).
 
+-spec unbind_q(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binaries()) -> 'ok'.
 unbind_q(Queue, Type, Token, 'undefined') ->
     amqp_util:unbind_q_from_exchange(Queue, push_routing_key(Type, Token), ?PUSH_EXCHANGE);
 unbind_q(Queue, Type, Token, ['push'|Restrict]) ->

--- a/applications/pusher/src/pusher_listener.erl
+++ b/applications/pusher/src/pusher_listener.erl
@@ -78,7 +78,6 @@ handle_reg_success(JObj, _Props) ->
     maybe_process_reg_success(UserAgentProperties, JObj).
 
 -spec maybe_process_reg_success(kz_term:api_object(), kz_json:object()) -> 'ok'.
--spec maybe_process_reg_success(kz_term:api_binary(), kz_json:object(), kz_json:object(), kz_term:proplist()) -> 'ok'.
 maybe_process_reg_success('undefined', _JObj) -> 'ok';
 maybe_process_reg_success(UA, JObj) ->
     Contact = kz_json:get_value(<<"Contact">>, JObj),
@@ -90,6 +89,7 @@ maybe_process_reg_success(UA, JObj) ->
     Token = props:get_value(TokenKey, Params),
     maybe_process_reg_success(Token, kz_json:set_value(<<"Token-Proxy">>, ?TOKEN_PROXY_KEY, UA) , JObj, Params).
 
+-spec maybe_process_reg_success(kz_term:api_binary(), kz_json:object(), kz_json:object(), kz_term:proplist()) -> 'ok'.
 maybe_process_reg_success('undefined', _UA, _JObj, _Params) -> 'ok';
 maybe_process_reg_success(Token, UA, JObj, Params) ->
     case kz_cache:fetch_local(?CACHE_NAME, Token) of
@@ -98,7 +98,6 @@ maybe_process_reg_success(Token, UA, JObj, Params) ->
     end.
 
 -spec maybe_update_push_token(kz_json:object(), kz_json:object(), kz_term:proplist()) -> 'ok'.
--spec maybe_update_push_token(kz_term:api_binary(), kz_term:api_binary(), kz_json:object(), kz_json:object(), kz_term:proplist()) -> 'ok'.
 maybe_update_push_token(UA, JObj, Params) ->
     AccountId = kz_json:get_first_defined([[<<"Custom-Channel-Vars">>, <<"Account-ID">>]
                                           ,<<"Account-ID">>
@@ -109,6 +108,7 @@ maybe_update_push_token(UA, JObj, Params) ->
 
     maybe_update_push_token(AccountId, AuthorizingId, UA, JObj, Params).
 
+-spec maybe_update_push_token(kz_term:api_binary(), kz_term:api_binary(), kz_json:object(), kz_json:object(), kz_term:proplist()) -> 'ok'.
 maybe_update_push_token('undefined', _AuthorizingId, _UA, _JObj, _Params) -> 'ok';
 maybe_update_push_token(_AccountId, 'undefined', _UA, _JObj, _Params) -> 'ok';
 maybe_update_push_token(AccountId, AuthorizingId, UA, JObj, Params) ->

--- a/applications/pusher/src/pusher_maintenance.erl
+++ b/applications/pusher/src/pusher_maintenance.erl
@@ -20,10 +20,10 @@ add_google_app(AppId, Secret) ->
     'ok'.
 
 -spec add_apple_app(binary(), binary()) -> 'ok' | {'error', any()}.
--spec add_apple_app(binary(), binary(), binary()) -> 'ok' | {'error', any()}.
 add_apple_app(AppId, Certfile) ->
     add_apple_app(AppId, Certfile, ?DEFAULT_APNS_HOST).
 
+-spec add_apple_app(binary(), binary(), binary()) -> 'ok' | {'error', any()}.
 add_apple_app(AppId, Certfile, Host) ->
     case file:read_file(Certfile) of
         {'ok', Binary} ->

--- a/applications/pusher/src/pusher_util.erl
+++ b/applications/pusher/src/pusher_util.erl
@@ -62,11 +62,11 @@ keycert_fold(_Entry, KeyCert) ->
     KeyCert.
 
 -spec user_agent_push_properties(kz_term:ne_binary()) -> kz_term:api_object().
--spec user_agent_push_properties(kz_term:ne_binary(), kz_json:objects()) -> kz_term:api_object().
 user_agent_push_properties(UserAgent) ->
     UAs = kapps_config:get_json(?CONFIG_CAT, <<"User-Agents">>, kz_json:new()),
     user_agent_push_properties(UserAgent, kz_json:values(UAs)).
 
+-spec user_agent_push_properties(kz_term:ne_binary(), kz_json:objects()) -> kz_term:api_object().
 user_agent_push_properties(_UserAgent, []) -> 'undefined';
 user_agent_push_properties(UserAgent, [JObj|UAs]) ->
     case re:run(UserAgent, kz_json:get_value(<<"regex">>, JObj, <<"^\$">>)) of

--- a/applications/registrar/src/reg_authn_req.erl
+++ b/applications/registrar/src/reg_authn_req.erl
@@ -485,12 +485,12 @@ encryption_method_map(Props, JObj) ->
     Methods = kz_json:get_value(Key, JObj, []),
     encryption_method_map(Props, Methods).
 
--spec generate_security_ccvs(auth_user()) -> kz_term:proplist().
--spec generate_security_ccvs(auth_user(), kz_term:proplist()) -> kz_term:proplist().
 
+-spec generate_security_ccvs(auth_user()) -> kz_term:proplist().
 generate_security_ccvs(#auth_user{}=User) ->
     generate_security_ccvs(User, []).
 
+-spec generate_security_ccvs(auth_user(), kz_term:proplist()) -> kz_term:proplist().
 generate_security_ccvs(#auth_user{}=User, Acc0) ->
     CCVFuns = [fun maybe_enforce_security/1
               ,fun maybe_set_encryption_flags/1

--- a/applications/registrar/src/reg_route_req.erl
+++ b/applications/registrar/src/reg_route_req.erl
@@ -30,10 +30,10 @@ handle_route_req(JObj, _Props) ->
     end.
 
 -spec maybe_replay_route_req(kz_json:object(), kz_json:object()) -> 'ok'.
--spec maybe_replay_route_req(kz_json:object(), kz_json:object(), kz_term:api_binary()) -> 'ok'.
 maybe_replay_route_req(JObj, CCVs) ->
     maybe_replay_route_req(JObj, CCVs, kz_json:get_value(<<"From-Network-Addr">>, JObj)).
 
+-spec maybe_replay_route_req(kz_json:object(), kz_json:object(), kz_term:api_binary()) -> 'ok'.
 maybe_replay_route_req(_JObj, _CCVs, 'undefined') ->
     lager:debug("failing to reply route req with no IP to use");
 maybe_replay_route_req(JObj, CCVs, IP) ->

--- a/applications/spyvsspy/src/spyvsspy_handlers.erl
+++ b/applications/spyvsspy/src/spyvsspy_handlers.erl
@@ -143,13 +143,13 @@ send_originate_execute(JObj, Q) ->
 
 -spec find_caller_id(kz_json:object()) ->
                             {kz_term:ne_binary(), kz_term:api_binary()}.
--spec find_caller_id(kz_json:object(), kz_term:proplist()) ->
-                            {kz_term:ne_binary(), kz_term:api_binary()}.
 find_caller_id(JObj) ->
     find_caller_id(JObj, [{<<"Outbound-Caller-ID-Name">>, <<"Outbound-Caller-ID-Number">>}
                          ,{<<"Caller-ID-Name">>, <<"Caller-ID-Number">>}
                          ]).
 
+-spec find_caller_id(kz_json:object(), kz_term:proplist()) ->
+                            {kz_term:ne_binary(), kz_term:api_binary()}.
 find_caller_id(_JObj, []) -> {<<"SpyVsSpy">>, <<"01010101">>};
 find_caller_id(JObj, [{KName, KNum}|Ks]) ->
     case kz_json:get_value(KName, JObj) of

--- a/applications/stepswitch/src/kz_srs_util.erl
+++ b/applications/stepswitch/src/kz_srs_util.erl
@@ -50,9 +50,10 @@ get_source(<<"database:", Selector/binary>>) -> {'database', Selector};
 get_source(Type) -> throw({invalid_filter_type, Type}).
 
 -spec get_value(source(), any(), kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> any().
--spec get_value(source(), any(), kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary(), any()) -> any().
 get_value(Type, Resources, Number, OffnetJObj, DB) ->
     get_value(Type, Resources, Number, OffnetJObj, DB, 'undefined').
+
+-spec get_value(source(), any(), kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary(), any()) -> any().
 get_value('number', _Resources, Number, _OffnetJObj, _DB, _Default) ->
     Number;
 get_value('cid_number', _Resources, _Number, OffnetJObj, _DB, _Default) ->

--- a/applications/stepswitch/src/stepswitch_outbound.erl
+++ b/applications/stepswitch/src/stepswitch_outbound.erl
@@ -40,13 +40,14 @@ handle_req(OffnetJObj, _Props) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec handle_audio_req(kapi_offnet_resource:req()) -> any().
--spec handle_audio_req(kz_term:ne_binary(), kapi_offnet_resource:req()) -> any().
 handle_audio_req(OffnetReq) ->
     Number = stepswitch_util:get_outbound_destination(OffnetReq),
     lager:debug("received outbound audio resource request for ~s: ~p", [Number, OffnetReq]),
     handle_audio_req(Number, OffnetReq).
 
+-spec handle_audio_req(kz_term:ne_binary(), kapi_offnet_resource:req()) -> any().
 handle_audio_req(Number, OffnetReq) ->
     case knm_number:lookup_account(Number) of
         {'ok', _AccountId, Props} -> maybe_force_outbound(Props, OffnetReq);

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -497,12 +497,12 @@ resource_classifier_map(Resource, Map) ->
     Resources = maps:get(Classification, Map, []),
     maps:put(Classification, [Resource|Resources], Map).
 
--spec build_endpoints_from_resources(resources(), kz_term:ne_binary(), kapi_offnet_resource:req()) -> kz_json:objects().
--spec build_endpoints_from_resources(resources(), kz_term:ne_binary(), kapi_offnet_resource:req(), kz_json:objects()) -> kz_json:objects().
 
+-spec build_endpoints_from_resources(resources(), kz_term:ne_binary(), kapi_offnet_resource:req()) -> kz_json:objects().
 build_endpoints_from_resources(Resources, Number, OffnetJObj) ->
     build_endpoints_from_resources(Resources, Number, OffnetJObj, []).
 
+-spec build_endpoints_from_resources(resources(), kz_term:ne_binary(), kapi_offnet_resource:req(), kz_json:objects()) -> kz_json:objects().
 build_endpoints_from_resources([], _Number, _OffnetJObj, Endpoints) -> Endpoints;
 build_endpoints_from_resources([Resource|Resources], Number, OffnetJObj, Endpoints) ->
     case maybe_resource_to_endpoints(Resource, Number, OffnetJObj, Endpoints) of
@@ -969,11 +969,12 @@ build_account_dedicated_proxy(Proxy) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec resources_from_jobjs(kz_json:objects()) -> resources().
--spec resources_from_jobjs(kz_json:objects(), resources()) -> resources().
 resources_from_jobjs(JObjs) ->
     resources_from_jobjs(JObjs, []).
 
+-spec resources_from_jobjs(kz_json:objects(), resources()) -> resources().
 resources_from_jobjs([], Resources) -> Resources;
 resources_from_jobjs([JObj|JObjs], Resources) ->
     case kz_json:is_true(<<"enabled">>, JObj, 'true') of
@@ -1290,102 +1291,148 @@ gateway_dialstring(#gateway{route=Route}, _) ->
     lager:debug("using pre-configured gateway route ~s", [Route]),
     Route.
 
--spec get_resrc_id(resource()) -> kz_term:api_binary().
--spec get_resrc_rev(resource()) -> kz_term:api_binary().
--spec get_resrc_name(resource()) -> kz_term:api_binary().
--spec get_resrc_weight(resource()) -> non_neg_integer().
--spec get_resrc_grace_period(resource()) -> non_neg_integer().
--spec get_resrc_flags(resource()) -> list().
--spec get_resrc_rules(resource()) -> list().
--spec get_resrc_raw_rules(resource()) -> list().
--spec get_resrc_cid_rules(resource()) -> list().
--spec get_resrc_cid_raw_rules(resource()) -> list().
--spec get_resrc_gateways(resource()) -> list().
--spec get_resrc_is_emergency(resource()) -> boolean().
--spec get_resrc_require_flags(resource()) -> boolean().
--spec get_resrc_global(resource()) -> boolean().
--spec get_resrc_format_from_uri(resource()) -> boolean().
--spec get_resrc_from_uri_realm(resource()) -> kz_term:api_binary().
--spec get_resrc_from_account_realm(resource()) -> boolean().
--spec get_resrc_fax_option(resource()) -> kz_term:ne_binary() | boolean().
--spec get_resrc_codecs(resource()) -> kz_term:ne_binaries().
--spec get_resrc_bypass_media(resource()) -> boolean().
--spec get_resrc_formatters(resource()) -> kz_term:api_objects().
--spec get_resrc_proxies(resource()) -> kz_term:proplist().
--spec get_resrc_selector_marks(resource()) -> kz_term:proplist().
--spec get_resrc_classifier(resource()) -> kz_term:api_binary().
--spec get_resrc_classifier_enable(resource()) -> boolean().
 
+-spec get_resrc_id(resource()) -> kz_term:api_binary().
 get_resrc_id(#resrc{id=Id}) -> Id.
+
+-spec get_resrc_rev(resource()) -> kz_term:api_binary().
 get_resrc_rev(#resrc{rev=Rev}) -> Rev.
+
+-spec get_resrc_name(resource()) -> kz_term:api_binary().
 get_resrc_name(#resrc{name=Name}) -> Name.
+
+-spec get_resrc_weight(resource()) -> non_neg_integer().
 get_resrc_weight(#resrc{weight=Weight}) -> Weight.
+
+-spec get_resrc_grace_period(resource()) -> non_neg_integer().
 get_resrc_grace_period(#resrc{grace_period=GracePeriod}) -> GracePeriod.
+
+-spec get_resrc_flags(resource()) -> list().
 get_resrc_flags(#resrc{flags=Flags}) -> Flags.
+
+-spec get_resrc_rules(resource()) -> list().
 get_resrc_rules(#resrc{rules=Rules}) -> Rules.
+
+-spec get_resrc_raw_rules(resource()) -> list().
 get_resrc_raw_rules(#resrc{raw_rules=RawRules}) -> RawRules.
+
+-spec get_resrc_cid_rules(resource()) -> list().
 get_resrc_cid_rules(#resrc{cid_rules=CIDRules}) -> CIDRules.
+
+-spec get_resrc_cid_raw_rules(resource()) -> list().
 get_resrc_cid_raw_rules(#resrc{cid_raw_rules=CIDRawRules}) -> CIDRawRules.
+
+-spec get_resrc_gateways(resource()) -> list().
 get_resrc_gateways(#resrc{gateways=Gateways}) -> Gateways.
+
+-spec get_resrc_is_emergency(resource()) -> boolean().
 get_resrc_is_emergency(#resrc{is_emergency=IsEmergency}) -> IsEmergency.
+
+-spec get_resrc_require_flags(resource()) -> boolean().
 get_resrc_require_flags(#resrc{require_flags=RequireFlags}) -> RequireFlags.
+
+-spec get_resrc_global(resource()) -> boolean().
 get_resrc_global(#resrc{global=Global}) -> Global.
+
+-spec get_resrc_format_from_uri(resource()) -> boolean().
 get_resrc_format_from_uri(#resrc{format_from_uri=FormatFromUri}) -> FormatFromUri.
+
+-spec get_resrc_from_uri_realm(resource()) -> kz_term:api_binary().
 get_resrc_from_uri_realm(#resrc{from_uri_realm=FromUriRealm}) -> FromUriRealm.
+
+-spec get_resrc_from_account_realm(resource()) -> boolean().
 get_resrc_from_account_realm(#resrc{from_account_realm=FromAccountRealm}) -> FromAccountRealm.
+
+-spec get_resrc_fax_option(resource()) -> kz_term:ne_binary() | boolean().
 get_resrc_fax_option(#resrc{fax_option=FaxOption}) -> FaxOption.
+
+-spec get_resrc_codecs(resource()) -> kz_term:ne_binaries().
 get_resrc_codecs(#resrc{codecs=Codecs}) -> Codecs.
+
+-spec get_resrc_bypass_media(resource()) -> boolean().
 get_resrc_bypass_media(#resrc{bypass_media=BypassMedia}) -> BypassMedia.
+
+-spec get_resrc_formatters(resource()) -> kz_term:api_objects().
 get_resrc_formatters(#resrc{formatters=Formatters}) -> Formatters.
+
+-spec get_resrc_proxies(resource()) -> kz_term:proplist().
 get_resrc_proxies(#resrc{proxies=Proxies}) -> Proxies.
+
+-spec get_resrc_selector_marks(resource()) -> kz_term:proplist().
 get_resrc_selector_marks(#resrc{selector_marks=Marks}) -> Marks.
+
+-spec get_resrc_classifier(resource()) -> kz_term:api_binary().
 get_resrc_classifier(#resrc{classifier=Classifier}) -> Classifier.
+
+-spec get_resrc_classifier_enable(resource()) -> boolean().
 get_resrc_classifier_enable(#resrc{classifier_enable=Enabled}) -> Enabled.
 
--spec set_resrc_id(resource(), kz_term:api_binary()) -> resource().
--spec set_resrc_rev(resource(), kz_term:api_binary()) -> resource().
--spec set_resrc_name(resource(), kz_term:api_binary()) -> resource().
--spec set_resrc_weight(resource(), non_neg_integer()) -> resource().
--spec set_resrc_grace_period(resource(), non_neg_integer()) -> resource().
--spec set_resrc_flags(resource(), list()) -> resource().
--spec set_resrc_rules(resource(), list()) -> resource().
--spec set_resrc_raw_rules(resource(), list()) -> resource().
--spec set_resrc_cid_rules(resource(), list()) -> resource().
--spec set_resrc_cid_raw_rules(resource(), list()) -> resource().
--spec set_resrc_gateways(resource(), list()) -> resource().
--spec set_resrc_is_emergency(resource(), boolean()) -> resource().
--spec set_resrc_require_flags(resource(), boolean()) -> resource().
--spec set_resrc_global(resource(), boolean()) -> resource().
--spec set_resrc_format_from_uri(resource(), boolean()) -> resource().
--spec set_resrc_from_uri_realm(resource(), kz_term:api_binary()) -> resource().
--spec set_resrc_from_account_realm(resource(), boolean()) -> resource().
--spec set_resrc_fax_option(resource(), kz_term:ne_binary() | boolean()) -> resource().
--spec set_resrc_codecs(resource(), kz_term:ne_binaries()) -> resource().
--spec set_resrc_bypass_media(resource(), boolean()) -> resource().
--spec set_resrc_formatters(resource(), kz_term:api_objects()) -> resource().
--spec set_resrc_proxies(resource(), kz_term:proplist()) -> resource().
--spec set_resrc_selector_marks(resource(), kz_term:proplist()) -> resource().
 
+-spec set_resrc_id(resource(), kz_term:api_binary()) -> resource().
 set_resrc_id(Resource, Id) -> Resource#resrc{id=Id}.
+
+-spec set_resrc_rev(resource(), kz_term:api_binary()) -> resource().
 set_resrc_rev(Resource, Rev) -> Resource#resrc{rev=Rev}.
+
+-spec set_resrc_name(resource(), kz_term:api_binary()) -> resource().
 set_resrc_name(Resource, Name) -> Resource#resrc{name=Name}.
+
+-spec set_resrc_weight(resource(), non_neg_integer()) -> resource().
 set_resrc_weight(Resource, Weight) -> Resource#resrc{weight=Weight}.
+
+-spec set_resrc_grace_period(resource(), non_neg_integer()) -> resource().
 set_resrc_grace_period(Resource, GracePeriod) -> Resource#resrc{grace_period=GracePeriod}.
+
+-spec set_resrc_flags(resource(), list()) -> resource().
 set_resrc_flags(Resource, Flags) -> Resource#resrc{flags=Flags}.
+
+-spec set_resrc_rules(resource(), list()) -> resource().
 set_resrc_rules(Resource, Rules) -> Resource#resrc{rules=Rules}.
+
+-spec set_resrc_raw_rules(resource(), list()) -> resource().
 set_resrc_raw_rules(Resource, RawRules) -> Resource#resrc{raw_rules=RawRules}.
+
+-spec set_resrc_cid_rules(resource(), list()) -> resource().
 set_resrc_cid_rules(Resource, CIDRules) -> Resource#resrc{cid_rules=CIDRules}.
+
+-spec set_resrc_cid_raw_rules(resource(), list()) -> resource().
 set_resrc_cid_raw_rules(Resource, CIDRawRules) -> Resource#resrc{cid_raw_rules=CIDRawRules}.
+
+-spec set_resrc_gateways(resource(), list()) -> resource().
 set_resrc_gateways(Resource, Gateways) -> Resource#resrc{gateways=Gateways}.
+
+-spec set_resrc_is_emergency(resource(), boolean()) -> resource().
 set_resrc_is_emergency(Resource, IsEmergency) -> Resource#resrc{is_emergency=IsEmergency}.
+
+-spec set_resrc_require_flags(resource(), boolean()) -> resource().
 set_resrc_require_flags(Resource, RequireFlags) -> Resource#resrc{require_flags=RequireFlags}.
+
+-spec set_resrc_global(resource(), boolean()) -> resource().
 set_resrc_global(Resource, Global) -> Resource#resrc{global=Global}.
+
+-spec set_resrc_format_from_uri(resource(), boolean()) -> resource().
 set_resrc_format_from_uri(Resource, FormatFromUri) -> Resource#resrc{format_from_uri=FormatFromUri}.
+
+-spec set_resrc_from_uri_realm(resource(), kz_term:api_binary()) -> resource().
 set_resrc_from_uri_realm(Resource, FromUriRealm) -> Resource#resrc{from_uri_realm=FromUriRealm}.
+
+-spec set_resrc_from_account_realm(resource(), boolean()) -> resource().
 set_resrc_from_account_realm(Resource, FromAccountRealm) -> Resource#resrc{from_account_realm=FromAccountRealm}.
+
+-spec set_resrc_fax_option(resource(), kz_term:ne_binary() | boolean()) -> resource().
 set_resrc_fax_option(Resource, FaxOption) -> Resource#resrc{fax_option=FaxOption}.
+
+-spec set_resrc_codecs(resource(), kz_term:ne_binaries()) -> resource().
 set_resrc_codecs(Resource, Codecs) -> Resource#resrc{codecs=Codecs}.
+
+-spec set_resrc_bypass_media(resource(), boolean()) -> resource().
 set_resrc_bypass_media(Resource, BypassMedia) -> Resource#resrc{bypass_media=BypassMedia}.
+
+-spec set_resrc_formatters(resource(), kz_term:api_objects()) -> resource().
 set_resrc_formatters(Resource, Formatters) -> Resource#resrc{formatters=Formatters}.
+
+-spec set_resrc_proxies(resource(), kz_term:proplist()) -> resource().
 set_resrc_proxies(Resource, Proxies) -> Resource#resrc{proxies=Proxies}.
+
+-spec set_resrc_selector_marks(resource(), kz_term:proplist()) -> resource().
 set_resrc_selector_marks(Resource, Marks) -> Resource#resrc{selector_marks=Marks}.

--- a/applications/stepswitch/src/stepswitch_sms.erl
+++ b/applications/stepswitch/src/stepswitch_sms.erl
@@ -333,11 +333,11 @@ send_amqp_sms(Payload, Pool) ->
     end.
 
 -spec maybe_add_broker(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:api_binary()) -> 'ok'.
--spec maybe_add_broker(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:api_binary(), boolean()) -> 'ok'.
 maybe_add_broker(Broker, Exchange, RouteId, ExchangeType, ExchangeOptions, BrokerName) ->
     PoolExists = kz_amqp_sup:pool_pid(?SMS_POOL(Exchange, RouteId, BrokerName)) =/= 'undefined',
     maybe_add_broker(Broker, Exchange, RouteId, ExchangeType, ExchangeOptions, BrokerName, PoolExists).
 
+-spec maybe_add_broker(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:api_binary(), boolean()) -> 'ok'.
 maybe_add_broker(_Broker, _Exchange, _RouteId, _ExchangeType, _ExchangeOptions, _BrokerName, 'true') -> 'ok';
 maybe_add_broker(Broker, Exchange, RouteId, ExchangeType, ExchangeOptions, BrokerName, 'false') ->
     Exchanges = [{Exchange, ExchangeType, ExchangeOptions}],

--- a/applications/stepswitch/src/stepswitch_util.erl
+++ b/applications/stepswitch/src/stepswitch_util.erl
@@ -129,18 +129,18 @@ get_sip_headers(OffnetReq) ->
 maybe_remove_diversions(JObj) ->
     kz_json:delete_key(<<"Diversions">>, JObj).
 
+
 -spec get_diversions(kz_json:object()) ->
                             'undefined' |
                             kz_term:ne_binaries().
--spec get_diversions(kz_term:api_binary(), kz_term:ne_binaries()) ->
-                            'undefined' |
-                            kz_term:ne_binaries().
-
 get_diversions(JObj) ->
     Inception = kz_json:get_value(<<"Inception">>, JObj),
     Diversions = kz_json:get_value(<<"Diversions">>, JObj, []),
     get_diversions(Inception, Diversions).
 
+-spec get_diversions(kz_term:api_binary(), kz_term:ne_binaries()) ->
+                            'undefined' |
+                            kz_term:ne_binaries().
 get_diversions('undefined', _Diversion) -> 'undefined';
 get_diversions(_Inception, []) -> 'undefined';
 get_diversions(Inception, Diversions) ->
@@ -314,11 +314,11 @@ route_by() ->
 
 -spec resources_to_endpoints(stepswitch_resources:resources(), kz_term:ne_binary(), kapi_offnet_resource:req()) ->
                                     kz_json:objects().
--spec resources_to_endpoints(stepswitch_resources:resources(), kz_term:ne_binary(), kapi_offnet_resource:req(), kz_json:objects()) ->
-                                    kz_json:objects().
 resources_to_endpoints(Resources, Number, OffnetJObj) ->
     resources_to_endpoints(Resources, Number, OffnetJObj, []).
 
+-spec resources_to_endpoints(stepswitch_resources:resources(), kz_term:ne_binary(), kapi_offnet_resource:req(), kz_json:objects()) ->
+                                    kz_json:objects().
 resources_to_endpoints([], _Number, _OffnetJObj, Endpoints) ->
     lists:reverse(Endpoints);
 resources_to_endpoints([Resource|Resources], Number, OffnetJObj, Endpoints) ->

--- a/applications/sysconf/src/sysconf_acls.erl
+++ b/applications/sysconf/src/sysconf_acls.erl
@@ -29,8 +29,6 @@ build(Node) ->
 
 -spec collect(kz_json:object(), kz_term:pid_refs()) ->
                      kz_json:object().
--spec collect(kz_json:object(), kz_term:pid_refs(), timeout()) ->
-                     kz_json:object().
 collect(ACLs, PidRefs) ->
     collect(ACLs, PidRefs, request_timeout()).
 
@@ -38,6 +36,8 @@ collect(ACLs, PidRefs) ->
 request_timeout() ->
     ?REQUEST_TIMEOUT + ?REQUEST_TIMEOUT_FUDGE.
 
+-spec collect(kz_json:object(), kz_term:pid_refs(), timeout()) ->
+                     kz_json:object().
 collect(ACLs, [], _Timeout) ->
     lager:debug("acls built with ~p ms to spare", [_Timeout]),
     ACLs;

--- a/applications/tasks/src/modules/kt_compactor.erl
+++ b/applications/tasks/src/modules/kt_compactor.erl
@@ -249,10 +249,10 @@ do_compact_node_db(Compactor) ->
     ] ++ AfterCols.
 
 -spec do_compact_db(kz_term:ne_binary()) -> rows().
--spec do_compact_db(kz_term:ne_binary(), heuristic()) -> rows().
 do_compact_db(Database) ->
     do_compact_db(Database, ?HEUR_RATIO).
 
+-spec do_compact_db(kz_term:ne_binary(), heuristic()) -> rows().
 do_compact_db(Database, Heuristic) ->
     do_compact_db_by_nodes(Database, Heuristic).
 

--- a/applications/tasks/src/modules/kt_rates.erl
+++ b/applications/tasks/src/modules/kt_rates.erl
@@ -390,11 +390,10 @@ maybe_default(0, Default) -> Default;
 maybe_default(Value, _Default) -> Value.
 
 -spec maybe_generate_name(kzd_rate:doc()) -> kz_term:ne_binary().
--spec maybe_generate_name(kzd_rate:doc(), kz_term:api_ne_binary()) -> kz_term:ne_binary().
--spec generate_name(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:ne_binaries()) -> kz_term:ne_binary().
 maybe_generate_name(RateJObj) ->
     maybe_generate_name(RateJObj, kzd_rate:name(RateJObj)).
 
+-spec maybe_generate_name(kzd_rate:doc(), kz_term:api_ne_binary()) -> kz_term:ne_binary().
 maybe_generate_name(RateJObj, 'undefined') ->
     generate_name(kzd_rate:prefix(RateJObj)
                  ,kzd_rate:iso_country_code(RateJObj)
@@ -402,6 +401,7 @@ maybe_generate_name(RateJObj, 'undefined') ->
                  );
 maybe_generate_name(_RateJObj, Name) -> Name.
 
+-spec generate_name(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:ne_binaries()) -> kz_term:ne_binary().
 generate_name(Prefix, 'undefined', []) when is_binary(Prefix) ->
     Prefix;
 generate_name(Prefix, ISO, []) ->
@@ -414,10 +414,10 @@ generate_name(Prefix, ISO, Directions) ->
     <<Direction/binary, "_", ISO/binary, "_", Prefix/binary>>.
 
 -spec maybe_generate_weight(kzd_rate:doc()) -> integer().
--spec maybe_generate_weight(kzd_rate:doc(), kz_term:api_integer()) -> integer().
 maybe_generate_weight(RateJObj) ->
     maybe_generate_weight(RateJObj, kzd_rate:weight(RateJObj, 'undefined')).
 
+-spec maybe_generate_weight(kzd_rate:doc(), kz_term:api_integer()) -> integer().
 maybe_generate_weight(RateJObj, 'undefined') ->
     generate_weight(kzd_rate:prefix(RateJObj)
                    ,kzd_rate:rate_cost(RateJObj)

--- a/applications/tasks/src/modules/kt_resource_selectors.erl
+++ b/applications/tasks/src/modules/kt_resource_selectors.erl
@@ -224,8 +224,9 @@ get_selectors_db(#{account_id := AccountId
     kz_util:format_resource_selectors_db(AccountId).
 
 -spec split_keys(kz_term:ne_binaries(), non_neg_integer()) -> [kz_term:ne_binaries()].
--spec split_keys(kz_term:ne_binaries(), [kz_term:ne_binaries()], non_neg_integer()) -> [kz_term:ne_binaries()].
 split_keys(Keys, BlockSize) -> split_keys(Keys, [], BlockSize).
+
+-spec split_keys(kz_term:ne_binaries(), [kz_term:ne_binaries()], non_neg_integer()) -> [kz_term:ne_binaries()].
 split_keys([], Acc, _BlockSize) -> Acc;
 split_keys(Keys, Acc, BlockSize) when length(Keys) =< BlockSize -> [Keys ++ Acc];
 split_keys(Keys, Acc, BlockSize) ->

--- a/applications/tasks/src/modules/kt_services.erl
+++ b/applications/tasks/src/modules/kt_services.erl
@@ -178,7 +178,6 @@ maybe_integer_to_binary(Item, JObj) ->
 
 
 -spec cleanup_orphaned_services_docs() -> 'ok'.
--spec cleanup_orphaned_services_docs(kz_json:objects()) -> 'ok'.
 cleanup_orphaned_services_docs() ->
     case kz_datamgr:all_docs(?KZ_SERVICES_DB) of
         {'ok', Docs} -> cleanup_orphaned_services_docs(Docs);
@@ -186,6 +185,7 @@ cleanup_orphaned_services_docs() ->
             lager:debug("failed to get all docs from ~s: ~p", [?KZ_SERVICES_DB, _E])
     end.
 
+-spec cleanup_orphaned_services_docs(kz_json:objects()) -> 'ok'.
 cleanup_orphaned_services_docs([]) -> 'ok';
 cleanup_orphaned_services_docs([View|Views]) ->
     cleanup_orphaned_services_doc(View),

--- a/applications/tasks/src/tasks_bindings.erl
+++ b/applications/tasks/src/tasks_bindings.erl
@@ -78,10 +78,10 @@ map(Routing, Payload) ->
     kazoo_bindings:map(Routing, Payload).
 
 -spec pmap(kz_term:ne_binary(), payload()) -> map_results().
--spec pmap(kz_term:ne_binary(), payload(), kazoo_bindings:kz_rt_options()) -> map_results().
 pmap(Routing, Payload) ->
     kazoo_bindings:pmap(Routing, Payload).
 
+-spec pmap(kz_term:ne_binary(), payload(), kazoo_bindings:kz_rt_options()) -> map_results().
 pmap(Routing, Payload, Options) ->
     kazoo_bindings:pmap(Routing, Payload, Options).
 

--- a/applications/teletype/src/teletype_bindings.erl
+++ b/applications/teletype/src/teletype_bindings.erl
@@ -25,9 +25,10 @@ start_link() ->
     'ignore'.
 
 -spec bind(kz_term:ne_binary(), module(), atom()) -> 'ok'.
--spec bind(kz_term:api_binary(), kz_term:api_binary(), module(), atom()) -> 'ok'.
 bind(EventName, Module, Fun) ->
     bind(<<"notification">>, EventName, Module, Fun).
+
+-spec bind(kz_term:api_binary(), kz_term:api_binary(), module(), atom()) -> 'ok'.
 bind(EventCategory, EventName, Module, Fun) ->
     Binding = ?ROUTING_KEY(EventCategory, EventName),
     case kazoo_bindings:bind(Binding, Module, Fun) of

--- a/applications/teletype/src/teletype_port_utils.erl
+++ b/applications/teletype/src/teletype_port_utils.erl
@@ -20,10 +20,10 @@ is_comment_private(DataJObj) ->
     kz_json:is_true([<<"comment">>, <<"superduper_comment">>], DataJObj, 'false').
 
 -spec get_attachments(kz_json:object()) -> attachments().
--spec get_attachments(kz_json:object(), boolean()) -> attachments().
 get_attachments(DataJObj) ->
     get_attachments(DataJObj, teletype_util:is_preview(DataJObj)).
 
+-spec get_attachments(kz_json:object(), boolean()) -> attachments().
 get_attachments(_DataJObj, 'true') -> [];
 get_attachments(DataJObj, 'false') ->
     PortReqId = kz_json:get_value(<<"port_request_id">>, DataJObj),
@@ -42,10 +42,10 @@ get_attachment_fold(Name, Acc, PortReqId, Doc) ->
     [{ContentType, Name, BinAttachment}|Acc].
 
 -spec fix_email(kz_json:object()) -> kz_json:object().
--spec fix_email(kz_json:object(), boolean()) -> kz_json:object().
 fix_email(ReqData) ->
     fix_email(ReqData, 'false').
 
+-spec fix_email(kz_json:object(), boolean()) -> kz_json:object().
 fix_email(ReqData, OnlyAdmin) ->
     AccountId = kz_json:get_value(<<"account_id">>, ReqData),
     Emails = get_emails(ReqData, AccountId, OnlyAdmin),

--- a/applications/teletype/src/teletype_renderer.erl
+++ b/applications/teletype/src/teletype_renderer.erl
@@ -78,10 +78,10 @@ do_render(Renderer, TemplateId, Template, TemplateData) ->
     end.
 
 -spec next_renderer() -> pid().
--spec next_renderer(pos_integer()) -> pid().
 next_renderer() ->
     next_renderer(?MILLISECONDS_IN_SECOND).
 
+-spec next_renderer(pos_integer()) -> pid().
 next_renderer(BackoffMs) ->
     Farm = teletype_farms_sup:render_farm_name(),
     try poolboy:checkout(Farm, false, 2 * ?MILLISECONDS_IN_SECOND) of

--- a/applications/teletype/src/teletype_templates.erl
+++ b/applications/teletype/src/teletype_templates.erl
@@ -147,17 +147,17 @@ preview(TemplateId, Macros, DataJObj) ->
                ).
 
 -spec render(kz_term:ne_binary(), macros()) -> kz_term:proplist().
--spec render(kz_term:ne_binary(), macros(), kz_json:object()) -> kz_term:proplist().
--spec render(kz_term:ne_binary(), macros(), kz_json:object(), boolean()) -> kz_term:proplist().
 render(TemplateId, Macros) ->
     render(TemplateId, Macros, kz_json:new()).
 
+-spec render(kz_term:ne_binary(), macros(), kz_json:object()) -> kz_term:proplist().
 render(TemplateId, Macros, DataJObj) ->
     put('template_id', TemplateId),
     JMacros = kz_json:from_list_recursive(Macros),
     put('macros', JMacros),
     render(TemplateId, Macros, DataJObj, teletype_util:is_preview(DataJObj)).
 
+-spec render(kz_term:ne_binary(), macros(), kz_json:object(), boolean()) -> kz_term:proplist().
 render(TemplateId, Macros, DataJObj, 'false') ->
     case templates_source(TemplateId, DataJObj) of
         'undefined' ->
@@ -175,7 +175,6 @@ render(TemplateId, Macros, DataJObj, 'true') ->
     preview(TemplateId, Macros, DataJObj).
 
 -spec templates_source(kz_term:ne_binary(), kz_term:api_binary() | kz_json:object()) -> kz_term:api_binary().
--spec templates_source(kz_term:ne_binary(), kz_term:api_binary(), kz_term:ne_binary()) -> kz_term:api_binary().
 templates_source(_TemplateId, 'undefined') ->
     lager:warning("no account id for template ~s, no template to process", [_TemplateId]),
     'undefined';
@@ -192,6 +191,7 @@ templates_source(TemplateId, DataJObj) ->
         AccountId -> templates_source(TemplateId, AccountId)
     end.
 
+-spec templates_source(kz_term:ne_binary(), kz_term:api_binary(), kz_term:ne_binary()) -> kz_term:api_binary().
 templates_source(_TemplateId, 'undefined', _ResellerId) ->
     lager:warning("failed to find parent account for template ~s", [_TemplateId]),
     'undefined';
@@ -576,9 +576,8 @@ update_text_attachment(Basename, Acc) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update_attachment(binary(), update_acc(), kz_term:ne_binary()) ->
-                               update_acc().
--spec update_attachment(binary(), update_acc(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                                update_acc().
 update_attachment(Contents, {_IsUpdated, TemplateJObj}=Acc, ContentType) ->
     AttachmentName = attachment_name(ContentType),
@@ -589,6 +588,8 @@ update_attachment(Contents, {_IsUpdated, TemplateJObj}=Acc, ContentType) ->
             update_attachment(Contents, Acc, ContentType, Id, AttachmentName)
     end.
 
+-spec update_attachment(binary(), update_acc(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                               update_acc().
 update_attachment(Contents, {IsUpdated, TemplateJObj}=Acc, ContentType, Id, AName) ->
     lager:debug("attachment ~s doesn't exist for ~s", [AName, Id]),
     case save_attachment(Id, AName, ContentType, Contents) of

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -61,10 +61,11 @@
 
 -spec send_email(email_map(), kz_term:ne_binary(), rendered_templates()) ->
                         'ok' | {'error', any()}.
--spec send_email(email_map(), kz_term:ne_binary(), rendered_templates(), attachments()) ->
-                        'ok' | {'error', any()}.
 send_email(Emails, Subject, RenderedTemplates) ->
     send_email(Emails, Subject, RenderedTemplates, []).
+
+-spec send_email(email_map(), kz_term:ne_binary(), rendered_templates(), attachments()) ->
+                        'ok' | {'error', any()}.
 send_email(Emails, Subject, RenderedTemplates, Attachments) ->
     ?LOG_DEBUG("emails: ~p", [Emails]),
     To = props:get_value(<<"to">>, Emails),
@@ -98,11 +99,11 @@ send_email(Emails, Subject, RenderedTemplates, Attachments) ->
     end.
 
 -spec maybe_log_smtp(email_map(), kz_term:ne_binary(), list(), kz_term:api_binary(), kz_term:api_binary()) -> 'ok'.
--spec maybe_log_smtp(email_map(), kz_term:ne_binary(), list(), kz_term:api_binary(), kz_term:api_binary(), boolean()) -> 'ok'.
 maybe_log_smtp(Emails, Subject, RenderedTemplates, Receipt, Error) ->
     Skip = kz_term:is_true(get('skip_smtp_log')),
     maybe_log_smtp(Emails, Subject, RenderedTemplates, Receipt, Error, Skip).
 
+-spec maybe_log_smtp(email_map(), kz_term:ne_binary(), list(), kz_term:api_binary(), kz_term:api_binary(), boolean()) -> 'ok'.
 maybe_log_smtp(_Emails, _Subject, _RenderedTemplates, _Receipt, _Error, 'true') ->
     lager:debug("skipping smtp log");
 maybe_log_smtp(Emails, Subject, RenderedTemplates, Receipt, Error, 'false') ->
@@ -288,9 +289,10 @@ smtp_tls_option(<<"always">>) -> 'always';
 smtp_tls_option(_) -> 'never'.
 
 -spec add_attachments(attachments()) -> mime_tuples().
--spec add_attachments(attachments(), mime_tuples()) -> mime_tuples().
 add_attachments(Attachments) ->
     add_attachments(Attachments, []).
+
+-spec add_attachments(attachments(), mime_tuples()) -> mime_tuples().
 add_attachments([], Acc) -> Acc;
 add_attachments([{ContentType, Filename, Content}|As], Acc) ->
     [Type, SubType] = binary:split(ContentType, <<"/">>),
@@ -484,11 +486,11 @@ find_account_rep_email(AccountJObj) ->
     find_account_rep_email(kapi_notifications:account_id(AccountJObj)).
 
 -spec find_account_admin_email(kz_term:api_binary()) -> kz_term:api_binaries().
--spec find_account_admin_email(kz_term:api_binary(), kz_term:api_binary()) -> kz_term:api_binaries().
 find_account_admin_email('undefined') -> 'undefined';
 find_account_admin_email(AccountId) ->
     find_account_admin_email(AccountId, find_reseller_id(AccountId)).
 
+-spec find_account_admin_email(kz_term:api_binary(), kz_term:api_binary()) -> kz_term:api_binaries().
 find_account_admin_email('undefined', _Id) ->
     'undefined';
 find_account_admin_email(AccountId, AccountId) ->
@@ -527,11 +529,11 @@ extract_admin_emails(Users) ->
 find_reseller_id(AccountId) -> kz_services:find_reseller_id(AccountId).
 
 -spec find_account_admin(kz_term:api_binary()) -> kz_term:api_object().
--spec find_account_admin(kz_term:ne_binary(), kz_term:ne_binary()) -> 'undefined' | kzd_user:doc().
 find_account_admin('undefined') -> 'undefined';
 find_account_admin(?MATCH_ACCOUNT_RAW(AccountId)) ->
     find_account_admin(AccountId, find_reseller_id(AccountId)).
 
+-spec find_account_admin(kz_term:ne_binary(), kz_term:ne_binary()) -> 'undefined' | kzd_user:doc().
 find_account_admin(AccountId, AccountId) ->
     query_for_account_admin(AccountId);
 find_account_admin(AccountId, ResellerId) ->
@@ -567,11 +569,11 @@ filter_for_admins(Users) ->
     ].
 
 -spec should_handle_notification(kz_json:object()) -> boolean().
--spec should_handle_notification(kz_json:object(), boolean()) -> boolean().
 should_handle_notification(JObj) ->
     DataJObj = kz_json:normalize(JObj),
     should_handle_notification(DataJObj, is_preview(JObj)).
 
+-spec should_handle_notification(kz_json:object(), boolean()) -> boolean().
 should_handle_notification(_JObj, 'true') ->
     lager:debug("notification is a preview, handling"),
     'true';
@@ -643,12 +645,12 @@ get_parent_account_id(AccountId) ->
 
 -spec find_addresses(kz_json:object(), kz_json:object(), kz_term:ne_binary()) ->
                             email_map().
--spec find_addresses(kz_json:object(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binaries(), email_map()) ->
-                            email_map().
 find_addresses(DataJObj, TemplateMetaJObj, ConfigCat) ->
     AddressKeys = [<<"to">>, <<"cc">>, <<"bcc">>, <<"from">>, <<"reply_to">>],
     find_addresses(DataJObj, TemplateMetaJObj, ConfigCat, AddressKeys, []).
 
+-spec find_addresses(kz_json:object(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binaries(), email_map()) ->
+                            email_map().
 find_addresses(_DataJObj, _TemplateMetaJObj, _ConfigCat, [], Acc) -> Acc;
 find_addresses(DataJObj, TemplateMetaJObj, ConfigCat, [Key|Keys], Acc) ->
     find_addresses(DataJObj
@@ -660,8 +662,6 @@ find_addresses(DataJObj, TemplateMetaJObj, ConfigCat, [Key|Keys], Acc) ->
 
 -spec find_address(kz_json:object(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                           {kz_term:ne_binary(), kz_term:api_ne_binaries()}.
--spec find_address(kz_json:object(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary()) ->
-                          {kz_term:ne_binary(), kz_term:api_ne_binaries()}.
 find_address(DataJObj, TemplateMetaJObj, ConfigCat, Key) ->
     find_address(DataJObj
                 ,TemplateMetaJObj
@@ -672,6 +672,8 @@ find_address(DataJObj, TemplateMetaJObj, ConfigCat, Key) ->
                              )
                 ).
 
+-spec find_address(kz_json:object(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary()) ->
+                          {kz_term:ne_binary(), kz_term:api_ne_binaries()}.
 find_address(DataJObj, TemplateMetaJObj, _ConfigCat, Key, 'undefined') ->
     %% ?LOG_DEBUG("email type for '~s' not defined in template, checking just the key", [Key]),
     lager:debug("email type for '~s' not defined in template, checking just the key", [Key]),

--- a/applications/trunkstore/src/trunkstore_maintenance.erl
+++ b/applications/trunkstore/src/trunkstore_maintenance.erl
@@ -19,10 +19,10 @@
 -include("ts.hrl").
 
 -spec flush() -> 'ok'.
--spec flush(kz_term:ne_binary()) -> 'ok'.
 flush() ->
     kz_cache:flush_local(?CACHE_NAME).
 
+-spec flush(kz_term:ne_binary()) -> 'ok'.
 flush(Account) ->
     AccountId = kz_util:format_account_id(Account),
     Flush = kz_cache:filter_local(?CACHE_NAME

--- a/applications/trunkstore/src/ts_callflow.erl
+++ b/applications/trunkstore/src/ts_callflow.erl
@@ -102,11 +102,11 @@ send_park(#ts_callflow_state{route_req_jobj=JObj
     wait_for_win(State, ?WAIT_FOR_WIN_TIMEOUT).
 
 -spec wait_for_win(state(), pos_integer()) -> {'won' | 'lost', state()}.
--spec wait_for_win(state(), pos_integer(), kapps_call_command:request_return()) ->
-                          {'won' | 'lost', state()}.
 wait_for_win(State, Timeout) ->
     wait_for_win(State, Timeout, kapps_call_command:receive_event(Timeout)).
 
+-spec wait_for_win(state(), pos_integer(), kapps_call_command:request_return()) ->
+                          {'won' | 'lost', state()}.
 wait_for_win(State, Timeout, {'ok', JObj}) ->
     case kapi_route:win_v(JObj) of
         'true' -> route_won(State, JObj);
@@ -132,13 +132,13 @@ route_won(#ts_callflow_state{amqp_worker=Worker, kapps_call=Call}=State, RouteWi
 
 -spec wait_for_bridge(state(), kz_term:api_integer()) ->
                              {'hangup' | 'error' | 'bridged', state()}.
--spec wait_for_bridge(state(), kz_term:api_integer(), kapps_call_command:request_return()) ->
-                             {'hangup' | 'error' | 'bridged', state()}.
 wait_for_bridge(State, 'undefined') ->
     wait_for_bridge(State, 20);
 wait_for_bridge(State, Timeout) ->
     wait_for_bridge(State, Timeout, kapps_call_command:receive_event(Timeout * 1000)).
 
+-spec wait_for_bridge(state(), kz_term:api_integer(), kapps_call_command:request_return()) ->
+                             {'hangup' | 'error' | 'bridged', state()}.
 wait_for_bridge(State, Timeout, {'ok', EventJObj}) ->
     case process_event_for_bridge(State, EventJObj) of
         'ignore' -> wait_for_bridge(State, Timeout);
@@ -152,11 +152,11 @@ wait_for_bridge(State, Timeout, {'error', 'timeout'}) ->
 
 -spec process_event_for_bridge(state(), kz_json:object()) ->
                                       'ignore' | {'hangup' | 'error' | 'bridged', state()}.
--spec process_event_for_bridge(state(), kz_json:object(), event_type()) ->
-                                      'ignore' | {'hangup' | 'error' | 'bridged', state()}.
 process_event_for_bridge(State, JObj) ->
     process_event_for_bridge(State, JObj, get_event_type(JObj)).
 
+-spec process_event_for_bridge(state(), kz_json:object(), event_type()) ->
+                                      'ignore' | {'hangup' | 'error' | 'bridged', state()}.
 process_event_for_bridge(#ts_callflow_state{aleg_callid=ALeg} = State
                         ,JObj
                         ,{<<"resource">>, <<"offnet_resp">>, _}
@@ -330,8 +330,9 @@ get_worker_queue(#ts_callflow_state{amqp_worker=Worker}) ->
     gen_listener:queue_name(Worker).
 
 -spec get_aleg_id(state()) -> kz_term:api_binary().
--spec get_bleg_id(state()) -> kz_term:api_binary().
 get_aleg_id(#ts_callflow_state{aleg_callid=ALeg}) -> ALeg.
+
+-spec get_bleg_id(state()) -> kz_term:api_binary().
 get_bleg_id(#ts_callflow_state{bleg_callid=ALeg}) -> ALeg.
 
 -spec get_call_cost(state()) -> float().
@@ -384,9 +385,10 @@ pre_park_action() ->
     end.
 
 -spec is_success(kz_term:ne_binary(), kz_json:object()) -> boolean().
--spec is_success(kz_term:ne_binaries(), kz_json:object(), kz_term:ne_binary()) -> boolean().
 is_success(Key, JObj) ->
     kz_json:get_value(Key, JObj) =:= <<"SUCCESS">>.
+
+-spec is_success(kz_term:ne_binaries(), kz_json:object(), kz_term:ne_binary()) -> boolean().
 is_success(Key, JObj, Default) ->
     kz_json:get_first_defined(Key, JObj, Default) =:= <<"SUCCESS">>.
 

--- a/applications/trunkstore/src/ts_from_offnet.erl
+++ b/applications/trunkstore/src/ts_from_offnet.erl
@@ -307,7 +307,6 @@ get_endpoint_sip_headers(Endpoint, AuthUser, AuthRealm) ->
     [{<<"Custom-SIP-Headers">>, kz_json:from_list(Props)} | Endpoint].
 
 -spec routing_data(kz_term:ne_binary(), kz_term:ne_binary()) -> [{<<_:48,_:_*8>>, any()}].
--spec routing_data(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> [{<<_:48,_:_*8>>, any()}].
 routing_data(ToDID, AccountId) ->
     case ts_util:lookup_did(ToDID, AccountId) of
         {'ok', Settings} ->
@@ -318,6 +317,7 @@ routing_data(ToDID, AccountId) ->
             throw('no_did_found')
     end.
 
+-spec routing_data(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> [{<<_:48,_:_*8>>, any()}].
 routing_data(ToDID, AccountId, Settings) ->
     AuthOpts = kz_json:get_value(<<"auth">>, Settings, kz_json:new()),
     Acct = kz_json:get_value(<<"account">>, Settings, kz_json:new()),

--- a/applications/webhooks/src/webhooks_channel_util.erl
+++ b/applications/webhooks/src/webhooks_channel_util.erl
@@ -101,9 +101,10 @@ format_event(JObj, AccountId, <<"CHANNEL_DESTROY">>) ->
                    ).
 
 -spec base_hook_event(kz_json:object(), kz_term:api_binary()) -> kz_json:object().
--spec base_hook_event(kz_json:object(), kz_term:api_binary(), kz_term:proplist()) -> kz_json:object().
 base_hook_event(JObj, AccountId) ->
     base_hook_event(JObj, AccountId, []).
+
+-spec base_hook_event(kz_json:object(), kz_term:api_binary(), kz_term:proplist()) -> kz_json:object().
 base_hook_event(JObj, AccountId, Acc) ->
     WasGlobal = kz_term:is_true(ccv(JObj, <<"Global-Resource">>)),
 
@@ -141,19 +142,20 @@ resource_used('false', JObj) -> ccv(JObj, <<"Resource-ID">>).
 
 -spec ccv(kz_json:object(), kz_json:path()) ->
                  kz_term:api_binary().
--spec ccv(kz_json:object(), kz_json:path(), Default) ->
-                 kz_term:ne_binary() | Default.
 ccv(JObj, Key) ->
     ccv(JObj, Key, 'undefined').
+
+-spec ccv(kz_json:object(), kz_json:path(), Default) ->
+                 kz_term:ne_binary() | Default.
 ccv(JObj, Key, Default) ->
     kz_call_event:custom_channel_var(JObj, Key, Default).
 
 -spec non_reserved_ccvs(kz_call_event:doc()) -> kz_term:api_object().
--spec non_reserved_ccvs(kz_json:object(), kz_term:api_ne_binaries()) -> kz_term:api_object().
 non_reserved_ccvs(JObj) ->
     CCVs = kz_call_event:custom_channel_vars(JObj, kz_json:new()),
     non_reserved_ccvs(CCVs, kapps_config:get_ne_binaries(<<"call_command">>, <<"reserved_ccv_keys">>)).
 
+-spec non_reserved_ccvs(kz_json:object(), kz_term:api_ne_binaries()) -> kz_term:api_object().
 non_reserved_ccvs(_CCVs, 'undefined') -> 'undefined';
 non_reserved_ccvs(CCVs, Keys) ->
     kz_json:filter(fun({K, _}) -> not lists:member(K, Keys) end, CCVs).

--- a/applications/webhooks/src/webhooks_disabler.erl
+++ b/applications/webhooks/src/webhooks_disabler.erl
@@ -81,7 +81,6 @@ check_failed_attempts() ->
 -type failures() :: [failure()].
 
 -spec find_failures() -> failures().
--spec find_failures([tuple()]) -> failures().
 find_failures() ->
     Keys = kz_cache:fetch_keys_local(?CACHE_NAME),
     find_failures(Keys).
@@ -98,9 +97,10 @@ flush_hooks(HookJObjs) ->
      ).
 
 -spec flush_failures(kz_term:ne_binary()) -> non_neg_integer().
--spec flush_failures(kz_term:ne_binary(), kz_term:api_binary()) -> non_neg_integer().
 flush_failures(AccountId) ->
     flush_failures(AccountId, 'undefined').
+
+-spec flush_failures(kz_term:ne_binary(), kz_term:api_binary()) -> non_neg_integer().
 flush_failures(AccountId, HookId) ->
     FilterFun = fun(K, _V) ->
                         maybe_remove_failure(K, AccountId, HookId)
@@ -123,6 +123,7 @@ maybe_remove_failure(?FAILURE_CACHE_KEY(AccountId, _HookId, _Timestamp)
 maybe_remove_failure(_K, _AccountId, _HookId) ->
     'false'.
 
+-spec find_failures([tuple()]) -> failures().
 find_failures(Keys) ->
     dict:to_list(lists:foldl(fun process_failed_key/2, dict:new(), Keys)).
 

--- a/applications/webhooks/src/webhooks_init.erl
+++ b/applications/webhooks/src/webhooks_init.erl
@@ -22,11 +22,11 @@ start_link() ->
     'ignore'.
 
 -spec do_init() -> 'ok'.
--spec do_init(kz_term:ne_binary()) -> 'ok'.
 do_init() ->
     init_dbs(),
     init_modules().
 
+-spec do_init(kz_term:ne_binary()) -> 'ok'.
 do_init(MasterAccountDb) ->
     init_master_account_db(MasterAccountDb),
     init_modules().
@@ -43,7 +43,6 @@ maybe_init_account(JObj, _Props) ->
         andalso do_init(Database).
 
 -spec init_master_account_db() -> 'ok'.
--spec init_master_account_db(kz_term:ne_binary()) -> 'ok'.
 init_master_account_db() ->
     case kapps_util:get_master_account_db() of
         {'ok', MasterAccountDb} ->
@@ -54,6 +53,7 @@ init_master_account_db() ->
             webhooks_shared_listener:add_account_bindings()
     end.
 
+-spec init_master_account_db(kz_term:ne_binary()) -> 'ok'.
 init_master_account_db(MasterAccountDb) ->
     _ = kz_datamgr:revise_doc_from_file(MasterAccountDb, 'webhooks', <<"webhooks.json">>),
     lager:debug("loaded view into master db ~s", [MasterAccountDb]).

--- a/applications/webhooks/src/webhooks_listener.erl
+++ b/applications/webhooks/src/webhooks_listener.erl
@@ -60,7 +60,6 @@ start_link() ->
                            ).
 
 -spec handle_config(kz_json:object(), kz_term:proplist()) -> 'ok'.
--spec handle_config(kz_json:object(), pid(), kz_term:ne_binary()) -> 'ok'.
 handle_config(JObj, Props) ->
     'true' = kapi_conf:doc_update_v(JObj),
     handle_config(JObj
@@ -68,6 +67,7 @@ handle_config(JObj, Props) ->
                  ,kz_api:event_name(JObj)
                  ).
 
+-spec handle_config(kz_json:object(), pid(), kz_term:ne_binary()) -> 'ok'.
 handle_config(JObj, Srv, ?DOC_CREATED) ->
     case kapi_conf:get_doc(JObj) of
         'undefined' -> find_and_add_hook(JObj, Srv);

--- a/applications/webhooks/src/webhooks_maintenance.erl
+++ b/applications/webhooks/src/webhooks_maintenance.erl
@@ -22,17 +22,16 @@
 -include("webhooks.hrl").
 
 -spec hooks_configured() -> 'ok'.
--spec hooks_configured(kz_term:ne_binary()) -> 'ok'.
 hooks_configured() ->
     webhooks_shared_listener:hooks_configured(),
     'ok'.
 
+-spec hooks_configured(kz_term:ne_binary()) -> 'ok'.
 hooks_configured(AccountId) ->
     webhooks_shared_listener:hooks_configured(AccountId),
     'ok'.
 
 -spec set_failure_expiry(kz_term:ne_binary()) -> 'ok'.
--spec set_failure_expiry(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 set_failure_expiry(Expires) ->
     try kz_term:to_integer(Expires) of
         I ->
@@ -43,6 +42,7 @@ set_failure_expiry(Expires) ->
             io:format("error in expiry time, must be an integer (milliseconds)~n")
     end.
 
+-spec set_failure_expiry(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 set_failure_expiry(Account, Expires) ->
     AccountId = kz_util:format_account_id(Account, 'raw'),
     try kz_term:to_integer(Expires) of
@@ -55,7 +55,6 @@ set_failure_expiry(Account, Expires) ->
     end.
 
 -spec set_disable_threshold(kz_term:ne_binary()) -> 'ok'.
--spec set_disable_threshold(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 set_disable_threshold(Count) ->
     try kz_term:to_integer(Count) of
         I ->
@@ -66,6 +65,7 @@ set_disable_threshold(Count) ->
             io:format("error in count, must be an integer~n")
     end.
 
+-spec set_disable_threshold(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 set_disable_threshold(Account, Count) ->
     AccountId = kz_util:format_account_id(Account, 'raw'),
     try kz_term:to_integer(Count) of
@@ -78,7 +78,6 @@ set_disable_threshold(Account, Count) ->
     end.
 
 -spec failure_status() -> 'ok'.
--spec failure_status(kz_term:ne_binary()) -> 'ok'.
 failure_status() ->
     Failed = webhooks_disabler:find_failures(),
     Sorted = lists:keysort(1, Failed),
@@ -86,6 +85,7 @@ failure_status() ->
     _ = [print_failure_count(AccountId, HookId, Count) || {{AccountId, HookId}, Count} <- Sorted],
     print_failure_footer().
 
+-spec failure_status(kz_term:ne_binary()) -> 'ok'.
 failure_status(Account) ->
     AccountId = kz_util:format_account_id(Account, 'raw'),
     Failed = webhooks_disabler:find_failures(),

--- a/applications/webhooks/src/webhooks_shared_listener.erl
+++ b/applications/webhooks/src/webhooks_shared_listener.erl
@@ -127,7 +127,6 @@ handle_doc_type_update(JObj, _Props) ->
                        ).
 
 -spec hooks_configured() -> 'ok'.
--spec hooks_configured(kz_term:ne_binary()) -> 'ok'.
 hooks_configured() ->
     MatchSpec = [{#webhook{_ = '_'}
                  ,[]
@@ -135,6 +134,7 @@ hooks_configured() ->
                  }],
     print_summary(ets:select(webhooks_util:table_id(), MatchSpec, 1)).
 
+-spec hooks_configured(kz_term:ne_binary()) -> 'ok'.
 hooks_configured(AccountId) ->
     MatchSpec = [{#webhook{account_id = '$1'
                           ,_ = '_'
@@ -147,7 +147,6 @@ hooks_configured(AccountId) ->
 -define(FORMAT_STRING_SUMMARY, "| ~-45s | ~-5s | ~-20s | ~-10s | ~-32s |~n").
 
 -spec print_summary('$end_of_table' | {webhooks(), any()}) -> 'ok'.
--spec print_summary('$end_of_table' | {webhooks(), any()}, non_neg_integer()) -> 'ok'.
 print_summary('$end_of_table') ->
     io:format("no webhooks configured~n", []);
 print_summary(Match) ->
@@ -156,6 +155,7 @@ print_summary(Match) ->
              ),
     print_summary(Match, 0).
 
+-spec print_summary('$end_of_table' | {webhooks(), any()}, non_neg_integer()) -> 'ok'.
 print_summary('$end_of_table', Count) ->
     io:format("found ~p webhooks~n", [Count]);
 print_summary({[#webhook{uri=URI

--- a/applications/webhooks/src/webhooks_util.erl
+++ b/applications/webhooks/src/webhooks_util.erl
@@ -250,10 +250,10 @@ retry_hook(#webhook{retries = Retries} = Hook, EventId, JObj) ->
     do_fire(Hook#webhook{retries = Retries - 1}, EventId, JObj).
 
 -spec successful_hook(webhook(), kz_term:proplist(), kz_http:ret()) -> 'ok'.
--spec successful_hook(webhook(), kz_term:proplist(), kz_http:ret(), boolean()) -> 'ok'.
 successful_hook(Hook, Debug, Resp) ->
     successful_hook(Hook, Debug, Resp, ?SHOULD_LOG_SUCCESS).
 
+-spec successful_hook(webhook(), kz_term:proplist(), kz_http:ret(), boolean()) -> 'ok'.
 successful_hook(_Hook, _Debug, _Resp, 'false') -> 'ok';
 successful_hook(#webhook{account_id = AccountId}, Debug, Resp, 'true') ->
     DebugJObj = debug_resp(Resp, Debug, 'undefined'),
@@ -372,7 +372,6 @@ fix_error_value(E) ->
     kz_term:to_binary(E).
 
 -spec hook_id(kz_json:object()) -> kz_term:ne_binary().
--spec hook_id(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 hook_id(JObj) ->
     hook_id(kz_json:get_first_defined([<<"pvt_account_id">>
                                       ,<<"Account-ID">>
@@ -382,6 +381,7 @@ hook_id(JObj) ->
            ,kz_json:get_first_defined([<<"_id">>, <<"ID">>], JObj)
            ).
 
+-spec hook_id(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 hook_id(AccountId, Id) ->
     <<AccountId/binary, ".", Id/binary>>.
 
@@ -576,8 +576,6 @@ jobj_to_rec(Hook) ->
             }.
 
 -spec init_webhooks() -> 'ok'.
--spec init_webhooks(kz_json:objects()) -> 'ok'.
--spec init_webhooks(kz_json:objects(), kz_time:year(), kz_time:month()) -> 'ok'.
 init_webhooks() ->
     case kz_datamgr:get_results(?KZ_WEBHOOKS_DB
                                ,<<"webhooks/accounts_listing">>
@@ -589,10 +587,12 @@ init_webhooks() ->
         {'error', _E} -> lager:debug("failed to load accounts_listing: ~p", [_E])
     end.
 
+-spec init_webhooks(kz_json:objects()) -> 'ok'.
 init_webhooks(WebHooks) ->
     {{Year, Month, _}, _} = calendar:gregorian_seconds_to_datetime(kz_time:now_s()),
     init_webhooks(WebHooks, Year, Month).
 
+-spec init_webhooks(kz_json:objects(), kz_time:year(), kz_time:month()) -> 'ok'.
 init_webhooks(WebHooks, Year, Month) ->
     _ = [init_webhook(WebHook, Year, Month) || WebHook <- WebHooks],
     'ok'.

--- a/core/braintree/src/braintree_addon.erl
+++ b/core/braintree/src/braintree_addon.erl
@@ -32,12 +32,12 @@ get_quantity(#bt_addon{quantity=Quantity}) ->
 %% Contert the given XML to a customer record
 %% @end
 %%--------------------------------------------------------------------
--spec xml_to_record(bt_xml()) -> bt_addon().
--spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_addon().
 
+-spec xml_to_record(bt_xml()) -> bt_addon().
 xml_to_record(Xml) ->
     xml_to_record(Xml, "/add-on").
 
+-spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_addon().
 xml_to_record(Xml, Base) ->
     #bt_addon{id = kz_xml:get_value([Base, "/id/text()"], Xml)
              ,amount = kz_xml:get_value([Base, "/amount/text()"], Xml)
@@ -53,12 +53,12 @@ xml_to_record(Xml, Base) ->
 %% Contert the given XML to a customer record
 %% @end
 %%--------------------------------------------------------------------
--spec record_to_xml(bt_addon()) -> kz_term:proplist() | bt_xml().
--spec record_to_xml(bt_addon(), boolean()) -> kz_term:proplist() | bt_xml().
 
+-spec record_to_xml(bt_addon()) -> kz_term:proplist() | bt_xml().
 record_to_xml(Addon) ->
     record_to_xml(Addon, false).
 
+-spec record_to_xml(bt_addon(), boolean()) -> kz_term:proplist() | bt_xml().
 record_to_xml(Addon, ToString) ->
     Props = [{'id', Addon#bt_addon.id}
             ,{'amount', Addon#bt_addon.amount}

--- a/core/braintree/src/braintree_address.erl
+++ b/core/braintree/src/braintree_address.erl
@@ -26,12 +26,12 @@
 %% Create the partial url for this module
 %% @end
 %%--------------------------------------------------------------------
--spec url(kz_term:ne_binary()) -> string().
--spec url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
 
+-spec url(kz_term:ne_binary()) -> string().
 url(CustomerId) ->
     lists:append(["/customers/", kz_term:to_list(CustomerId), "/addresses"]).
 
+-spec url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
 url(CustomerId, AddressId) ->
     lists:append(["/customers/", kz_term:to_list(CustomerId), "/addresses/", kz_term:to_list(AddressId)]).
 
@@ -53,15 +53,15 @@ find(CustomerId, AddressId) ->
 %% Creates a new customer using the given record
 %% @end
 %%--------------------------------------------------------------------
--spec create(bt_address()) -> bt_address().
--spec create(nonempty_string() | kz_term:ne_binary(), bt_address()) -> bt_address().
 
+-spec create(bt_address()) -> bt_address().
 create(#bt_address{customer_id=CustomerId}=Address) ->
     Url = url(CustomerId),
     Request = record_to_xml(Address, 'true'),
     Xml = braintree_request:post(Url, Request),
     xml_to_record(Xml).
 
+-spec create(nonempty_string() | kz_term:ne_binary(), bt_address()) -> bt_address().
 create(CustomerId, Address) ->
     create(Address#bt_address{customer_id=CustomerId}).
 
@@ -86,14 +86,14 @@ update(#bt_address{id=AddressId
 %% Deletes a customer id from braintree's system
 %% @end
 %%--------------------------------------------------------------------
--spec delete(bt_address()) -> bt_address().
--spec delete(kz_term:ne_binary() | nonempty_string(), kz_term:ne_binary() | nonempty_string()) ->  bt_address().
 
+-spec delete(bt_address()) -> bt_address().
 delete(#bt_address{customer_id=CustomerId
                   ,id=AddressId
                   }) ->
     delete(CustomerId, AddressId).
 
+-spec delete(kz_term:ne_binary() | nonempty_string(), kz_term:ne_binary() | nonempty_string()) ->  bt_address().
 delete(CustomerId, AddressId) ->
     Url = url(CustomerId, AddressId),
     _ = braintree_request:delete(Url),
@@ -105,12 +105,12 @@ delete(CustomerId, AddressId) ->
 %% Contert the given XML to a customer record
 %% @end
 %%--------------------------------------------------------------------
--spec xml_to_record(bt_xml()) -> bt_address().
--spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_address().
 
+-spec xml_to_record(bt_xml()) -> bt_address().
 xml_to_record(Xml) ->
     xml_to_record(Xml, "/address").
 
+-spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_address().
 xml_to_record(Xml, Base) ->
     #bt_address{id = kz_xml:get_value([Base, "/id/text()"], Xml)
                ,customer_id = kz_xml:get_value([Base, "/customer-id/text()"], Xml)
@@ -136,12 +136,12 @@ xml_to_record(Xml, Base) ->
 %% Contert the given XML to a customer record
 %% @end
 %%--------------------------------------------------------------------
--spec record_to_xml(bt_address()) -> kz_term:proplist() | bt_xml() | 'undefined'.
--spec record_to_xml(bt_address(), boolean()) -> kz_term:proplist() | bt_xml() | 'undefined'.
 
+-spec record_to_xml(bt_address()) -> kz_term:proplist() | bt_xml() | 'undefined'.
 record_to_xml(Address) ->
     record_to_xml(Address, 'false').
 
+-spec record_to_xml(bt_address(), boolean()) -> kz_term:proplist() | bt_xml() | 'undefined'.
 record_to_xml('undefined', _ToString) -> 'undefined';
 record_to_xml(Address, ToString) ->
     Props = [{'first-name', Address#bt_address.first_name}

--- a/core/braintree/src/braintree_card.erl
+++ b/core/braintree/src/braintree_card.erl
@@ -35,16 +35,16 @@
 %% Create the partial url for this module
 %% @end
 %%--------------------------------------------------------------------
--spec url() -> string().
--spec url(kz_term:ne_binary()) -> string().
--spec url(kz_term:ne_binary(), _) -> string().
 
+-spec url() -> string().
 url() ->
     "/payment_methods/".
 
+-spec url(kz_term:ne_binary()) -> string().
 url(Token) ->
     "/payment_methods/" ++ kz_term:to_list(Token).
 
+-spec url(kz_term:ne_binary(), _) -> string().
 url(Token, _) ->
     "/payment_methods/credit_card/" ++ kz_term:to_list(Token).
 
@@ -99,15 +99,15 @@ find(Token) ->
 %% Creates a new credit card using the given record
 %% @end
 %%--------------------------------------------------------------------
--spec create(bt_card()) -> bt_card().
--spec create(string() | kz_term:ne_binary(), bt_card()) -> bt_card().
 
+-spec create(bt_card()) -> bt_card().
 create(#bt_card{}=Card) ->
     Url = url(),
     Request = record_to_xml(Card, 'true'),
     Xml = braintree_request:post(Url, Request),
     xml_to_record(Xml).
 
+-spec create(string() | kz_term:ne_binary(), bt_card()) -> bt_card().
 create(CustomerId, Card) ->
     create(Card#bt_card{customer_id=CustomerId}).
 
@@ -177,11 +177,11 @@ expiring(Start, End) ->
 %% Accessors for field 'make_default'.
 %% @end
 %%--------------------------------------------------------------------
--spec make_default(bt_card()) -> kz_term:api_boolean().
--spec make_default(bt_card(), boolean()) -> bt_card().
 
+-spec make_default(bt_card()) -> kz_term:api_boolean().
 make_default(#bt_card{make_default = Value}) -> Value.
 
+-spec make_default(bt_card(), boolean()) -> bt_card().
 make_default(#bt_card{}=Card, Value) ->
     Card#bt_card{make_default = Value}.
 
@@ -191,12 +191,12 @@ make_default(#bt_card{}=Card, Value) ->
 %% Convert the given XML to a record
 %% @end
 %%--------------------------------------------------------------------
--spec xml_to_record(bt_xml()) -> bt_card().
--spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_card().
 
+-spec xml_to_record(bt_xml()) -> bt_card().
 xml_to_record(Xml) ->
     xml_to_record(Xml, "/credit-card").
 
+-spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_card().
 xml_to_record(Xml, Base) ->
     #bt_card{token = kz_xml:get_value([Base, "/token/text()"], Xml)
             ,bin = kz_xml:get_value([Base, "/bin/text()"], Xml)
@@ -222,12 +222,12 @@ xml_to_record(Xml, Base) ->
 %% Convert the given record to XML
 %% @end
 %%--------------------------------------------------------------------
--spec record_to_xml(bt_card()) -> kz_term:proplist() | bt_xml().
--spec record_to_xml(bt_card(), boolean()) -> kz_term:proplist() | bt_xml().
 
+-spec record_to_xml(bt_card()) -> kz_term:proplist() | bt_xml().
 record_to_xml(Card) ->
     record_to_xml(Card, 'false').
 
+-spec record_to_xml(bt_card(), boolean()) -> kz_term:proplist() | bt_xml().
 record_to_xml(#bt_card{}=Card, ToString) ->
     Props = [{'token', Card#bt_card.token}
             ,{'cardholder-name', Card#bt_card.cardholder_name}

--- a/core/braintree/src/braintree_customer.erl
+++ b/core/braintree/src/braintree_customer.erl
@@ -40,12 +40,12 @@
 %% Create the partial url for this module
 %% @end
 %%--------------------------------------------------------------------
--spec url() -> string().
--spec url(kz_term:ne_binary()) -> string().
 
+-spec url() -> string().
 url() ->
     "/customers/".
 
+-spec url(kz_term:ne_binary()) -> string().
 url(CustomerId) ->
     lists:append(["/customers/", kz_term:to_list(CustomerId)]).
 
@@ -250,12 +250,12 @@ update_subsciption(NewPaymentToken, UpdatedCustomer) ->
     find(UpdatedCustomer).
 
 -spec update_subsciption_with_token(bt_subscription(), kz_term:ne_binary()) -> 'ok'.
--spec update_subsciption_with_token(bt_subscription(), kz_term:ne_binary(), boolean()) -> 'ok'.
 update_subsciption_with_token(Sub, NewPaymentToken) ->
     ShouldUpdate = not braintree_subscription:is_cancelled(Sub)
         andalso not braintree_subscription:is_expired(Sub),
     update_subsciption_with_token(Sub, NewPaymentToken, ShouldUpdate).
 
+-spec update_subsciption_with_token(bt_subscription(), kz_term:ne_binary(), boolean()) -> 'ok'.
 update_subsciption_with_token(Sub, NewPaymentToken, 'true') ->
     SubWithToken = braintree_subscription:update_payment_token(Sub, NewPaymentToken),
     _ = braintree_subscription:update(SubWithToken),
@@ -304,12 +304,12 @@ delete(CustomerId) ->
 %% Convert the given XML to a customer record
 %% @end
 %%--------------------------------------------------------------------
--spec xml_to_record(bt_xml()) -> customer().
--spec xml_to_record(bt_xml(), kz_term:deeplist()) -> customer().
 
+-spec xml_to_record(bt_xml()) -> customer().
 xml_to_record(Xml) ->
     xml_to_record(Xml, "/customer").
 
+-spec xml_to_record(bt_xml(), kz_term:deeplist()) -> customer().
 xml_to_record(Xml, Base) ->
     CreditCardPath = lists:flatten([Base, "/credit-cards/credit-card"]),
     AddressPath = lists:flatten([Base, "/addresses/address"]),
@@ -341,12 +341,12 @@ xml_to_record(Xml, Base) ->
 %% Convert the given record to XML
 %% @end
 %%--------------------------------------------------------------------
--spec record_to_xml(customer()) -> kz_term:proplist() | bt_xml().
--spec record_to_xml(customer(), boolean()) -> kz_term:proplist() | bt_xml().
 
+-spec record_to_xml(customer()) -> kz_term:proplist() | bt_xml().
 record_to_xml(Customer) ->
     record_to_xml(Customer, 'false').
 
+-spec record_to_xml(customer(), boolean()) -> kz_term:proplist() | bt_xml().
 record_to_xml(Customer, ToString) ->
     Props = [{'id', Customer#bt_customer.id}
             ,{'first-name', Customer#bt_customer.first_name}

--- a/core/braintree/src/braintree_discount.erl
+++ b/core/braintree/src/braintree_discount.erl
@@ -28,12 +28,12 @@
 %% Contert the given XML to a customer record
 %% @end
 %%--------------------------------------------------------------------
--spec xml_to_record(bt_xml()) -> bt_discount().
--spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_discount().
 
+-spec xml_to_record(bt_xml()) -> bt_discount().
 xml_to_record(Xml) ->
     xml_to_record(Xml, "/discount").
 
+-spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_discount().
 xml_to_record(Xml, Base) ->
     #bt_discount{id = kz_xml:get_value([Base, "/id/text()"], Xml)
                 ,amount = kz_xml:get_value([Base, "/amount/text()"], Xml)
@@ -49,12 +49,12 @@ xml_to_record(Xml, Base) ->
 %% Contert the given XML to a customer record
 %% @end
 %%--------------------------------------------------------------------
--spec record_to_xml(bt_discount()) -> kz_term:proplist() | bt_xml().
--spec record_to_xml(bt_discount(), boolean()) -> kz_term:proplist() | bt_xml().
 
+-spec record_to_xml(bt_discount()) -> kz_term:proplist() | bt_xml().
 record_to_xml(Discount) ->
     record_to_xml(Discount, false).
 
+-spec record_to_xml(bt_discount(), boolean()) -> kz_term:proplist() | bt_xml().
 record_to_xml(Discount, ToString) ->
     Props = [{'id', Discount#bt_discount.id}
             ,{'amount', Discount#bt_discount.amount}

--- a/core/braintree/src/braintree_subscription.erl
+++ b/core/braintree/src/braintree_subscription.erl
@@ -51,16 +51,16 @@
 %% Create the partial url for this module
 %% @end
 %%--------------------------------------------------------------------
--spec url() -> string().
--spec url(kz_term:ne_binary()) -> string().
--spec url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
 
+-spec url() -> string().
 url() ->
     "/subscriptions/".
 
+-spec url(kz_term:ne_binary()) -> string().
 url(SubscriptionId) ->
     lists:append(["/subscriptions/", kz_term:to_list(SubscriptionId)]).
 
+-spec url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
 url(SubscriptionId, Options) ->
     lists:append(["/subscriptions/"
                  ,kz_term:to_list(SubscriptionId)
@@ -74,12 +74,12 @@ url(SubscriptionId, Options) ->
 %% Creates a new subscription record
 %% @end
 %%--------------------------------------------------------------------
--spec new(kz_term:ne_binary(), kz_term:ne_binary()) -> subscription().
--spec new(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> subscription().
 
+-spec new(kz_term:ne_binary(), kz_term:ne_binary()) -> subscription().
 new(PlanId, PaymentToken) ->
     new(new_subscription_id(), PlanId, PaymentToken).
 
+-spec new(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> subscription().
 new(SubscriptionId, PlanId, PaymentToken) ->
     #bt_subscription{id=SubscriptionId
                     ,payment_token=PaymentToken
@@ -458,12 +458,12 @@ is_expired(#bt_subscription{}) -> 'false'.
 %% Contert the given XML to a subscription record
 %% @end
 %%--------------------------------------------------------------------
--spec xml_to_record(bt_xml()) -> subscription().
--spec xml_to_record(bt_xml(), kz_term:deeplist()) -> subscription().
 
+-spec xml_to_record(bt_xml()) -> subscription().
 xml_to_record(Xml) ->
     xml_to_record(Xml, "/subscription").
 
+-spec xml_to_record(bt_xml(), kz_term:deeplist()) -> subscription().
 xml_to_record(Xml, Base) ->
     AddOnsPath = lists:flatten([Base, "/add-ons/add-on"]),
     DiscountsPath = lists:flatten([Base, "/discounts/discount"]),
@@ -506,12 +506,12 @@ xml_to_record(Xml, Base) ->
 %% Contert the given XML to a subscription record
 %% @end
 %%--------------------------------------------------------------------
--spec record_to_xml(subscription()) -> kz_term:proplist() | bt_xml().
--spec record_to_xml(subscription(), boolean()) -> kz_term:proplist() | bt_xml().
 
+-spec record_to_xml(subscription()) -> kz_term:proplist() | bt_xml().
 record_to_xml(Subscription) ->
     record_to_xml(Subscription, 'false').
 
+-spec record_to_xml(subscription(), boolean()) -> kz_term:proplist() | bt_xml().
 record_to_xml(#bt_subscription{}=Subscription, ToString) ->
     Props = [{'id', Subscription#bt_subscription.id}
             ,{'merchant-account-id', Subscription#bt_subscription.merchant_account_id}

--- a/core/braintree/src/braintree_transaction.erl
+++ b/core/braintree/src/braintree_transaction.erl
@@ -35,16 +35,16 @@
 %% Create the partial url for this module
 %% @end
 %%--------------------------------------------------------------------
--spec url() -> string().
--spec url(kz_term:ne_binary()) -> string().
--spec url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
 
+-spec url() -> string().
 url() ->
     "/transactions/".
 
+-spec url(kz_term:ne_binary()) -> string().
 url(TransactionId) ->
     lists:append(["/transactions/", kz_term:to_list(TransactionId)]).
 
+-spec url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
 url(TransactionId, Options) ->
     lists:append(["/transactions/"
                  ,kz_term:to_list(TransactionId)
@@ -107,9 +107,8 @@ find_by_customer(CustomerId, Min, Max) ->
 %% Creates a new transaction using the given record
 %% @end
 %%--------------------------------------------------------------------
--spec create(bt_transaction()) -> bt_transaction().
--spec create(kz_term:ne_binary(), bt_transaction()) -> bt_transaction().
 
+-spec create(bt_transaction()) -> bt_transaction().
 create(#bt_transaction{amount=Amount}=Transaction) ->
     MaxAmount = kapps_config:get_float(?CONFIG_CAT, <<"max_amount">>, 200.00),
     case kz_term:to_float(Amount) >  MaxAmount of
@@ -121,6 +120,7 @@ create(#bt_transaction{amount=Amount}=Transaction) ->
     Xml = braintree_request:post(Url, Request),
     xml_to_record(Xml).
 
+-spec create(kz_term:ne_binary(), bt_transaction()) -> bt_transaction().
 create(CustomerId, Transaction) ->
     create(Transaction#bt_transaction{customer_id=CustomerId}).
 
@@ -130,24 +130,25 @@ create(CustomerId, Transaction) ->
 %% Create a sale transaction
 %% @end
 %%--------------------------------------------------------------------
+
 -spec sale(bt_transaction()) -> bt_transaction().
--spec sale(kz_term:ne_binary(), bt_transaction()) -> bt_transaction().
 sale(Transaction) ->
     create(Transaction#bt_transaction{type=?BT_TRANS_SALE}).
 
+-spec sale(kz_term:ne_binary(), bt_transaction()) -> bt_transaction().
 sale(CustomerId, Transaction) ->
     create(Transaction#bt_transaction{type=?BT_TRANS_SALE
                                      ,customer_id=CustomerId
                                      }).
 
 -spec quick_sale(kz_term:ne_binary(), number() | kz_term:ne_binary()) -> bt_transaction().
--spec quick_sale(kz_term:ne_binary(), number() | kz_term:ne_binary(), kz_term:proplist()) -> bt_transaction().
 quick_sale(CustomerId, Amount) ->
     case kz_term:to_float(Amount) < ?MIN_AMOUNT of
         'true' -> braintree_util:error_min_amount(?MIN_AMOUNT);
         'false' -> sale(CustomerId, #bt_transaction{amount=kz_term:to_binary(Amount)})
     end.
 
+-spec quick_sale(kz_term:ne_binary(), number() | kz_term:ne_binary(), kz_term:proplist()) -> bt_transaction().
 quick_sale(CustomerId, Amount, Props) ->
     case kz_term:to_float(Amount) < ?MIN_AMOUNT of
         'true' -> braintree_util:error_min_amount(?MIN_AMOUNT);
@@ -162,11 +163,12 @@ quick_sale(CustomerId, Amount, Props) ->
 %% Create a credit transaction
 %% @end
 %%--------------------------------------------------------------------
+
 -spec credit(bt_transaction()) -> bt_transaction().
--spec credit(kz_term:ne_binary(), bt_transaction()) -> bt_transaction().
 credit(Transaction) ->
     create(Transaction#bt_transaction{type=?BT_TRANS_CREDIT}).
 
+-spec credit(kz_term:ne_binary(), bt_transaction()) -> bt_transaction().
 credit(CustomerId, Transaction) ->
     create(Transaction#bt_transaction{type=?BT_TRANS_CREDIT
                                      ,customer_id=CustomerId
@@ -199,12 +201,12 @@ void(TransactionId) ->
 %% Refund a transaction with status: settled or settling
 %% @end
 %%--------------------------------------------------------------------
--spec refund(bt_transaction() | kz_term:ne_binary()) -> bt_transaction().
--spec refund(bt_transaction() | kz_term:ne_binary(), kz_term:api_binary()) -> bt_transaction().
 
+-spec refund(bt_transaction() | kz_term:ne_binary()) -> bt_transaction().
 refund(TransactionId) ->
     refund(TransactionId, 'undefined').
 
+-spec refund(bt_transaction() | kz_term:ne_binary(), kz_term:api_binary()) -> bt_transaction().
 refund(#bt_transaction{id=TransactionId}, Amount) ->
     refund(TransactionId, Amount);
 refund(TransactionId, Amount) ->
@@ -219,12 +221,12 @@ refund(TransactionId, Amount) ->
 %% Contert the given XML to a transaction record
 %% @end
 %%--------------------------------------------------------------------
--spec xml_to_record(bt_xml()) -> bt_transaction().
--spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_transaction().
 
+-spec xml_to_record(bt_xml()) -> bt_transaction().
 xml_to_record(Xml) ->
     xml_to_record(Xml, "/transaction").
 
+-spec xml_to_record(bt_xml(), kz_term:deeplist()) -> bt_transaction().
 xml_to_record(Xml, Base) ->
     AddOnsPath = lists:flatten([Base, "/add-ons/add-on"]),
     DiscountsPath = lists:flatten([Base, "/discounts/discount"]),
@@ -308,12 +310,12 @@ get_transaction_sources([Element|Elements], Sources) ->
 %% Contert the given XML to a transaction record
 %% @end
 %%--------------------------------------------------------------------
--spec record_to_xml(bt_transaction()) -> kz_term:proplist() | bt_xml().
--spec record_to_xml(bt_transaction(), boolean()) -> kz_term:proplist() | bt_xml().
 
+-spec record_to_xml(bt_transaction()) -> kz_term:proplist() | bt_xml().
 record_to_xml(Transaction) ->
     record_to_xml(Transaction, 'false').
 
+-spec record_to_xml(bt_transaction(), boolean()) -> kz_term:proplist() | bt_xml().
 record_to_xml(#bt_transaction{}=Transaction, ToString) ->
     Props = [{'type', Transaction#bt_transaction.type}
             ,{'amount', Transaction#bt_transaction.amount}

--- a/core/gcm/src/gcm.erl
+++ b/core/gcm/src/gcm.erl
@@ -17,12 +17,6 @@
 -record(state, {key :: nonempty_string()
                }).
 
--spec init(any()) -> {ok, #state{}} | {ok, #state{}, non_neg_integer()} | {ok, #state{}, hibernate} | {stop, any()} | ignore.
--spec handle_call(any(), {pid(),any()}, #state{}) -> {reply, any(), #state{}} | {reply, any(), #state{}, non_neg_integer()} | {reply, any(), #state{}, hibernate} | {noreply, #state{}} | {noreply, #state{}, non_neg_integer()} | {noreply, #state{}, hibernate} | {stop, any(), any(), #state{}} | {stop, any(), #state{}}.
--spec handle_cast(any(), #state{}) -> {noreply, #state{}} | {noreply, #state{}, non_neg_integer()} | {noreply, #state{}, hibernate} | {stop, any(), #state{}}.
--spec handle_info(any(), #state{}) -> {noreply, #state{}} | {noreply, #state{}, non_neg_integer()} | {noreply, #state{}, hibernate} | {stop, any(), #state{}}.
--spec terminate(any(), #state{}) -> any().
--spec code_change(any(), #state{}, any()) -> {ok, any()} | {error, any()}.
 
 
 -spec start(atom(), any()) -> {ok, undefined | pid()} | {error, any()}.
@@ -57,11 +51,13 @@ sync_push(Name, RegIds, Message, Retry) ->
 start_link(Name, Key) ->
     gen_server:start_link({local, Name}, ?MODULE, [Key], []).
 
+-spec init(any()) -> {ok, #state{}} | {ok, #state{}, non_neg_integer()} | {ok, #state{}, hibernate} | {stop, any()} | ignore.
 init([Key]) ->
     kz_util:put_callid(?MODULE),
     lager:debug("starting with key ~s", [Key]),
     {ok, #state{key=Key}}.
 
+-spec handle_call(any(), {pid(),any()}, #state{}) -> {reply, any(), #state{}} | {reply, any(), #state{}, non_neg_integer()} | {reply, any(), #state{}, hibernate} | {noreply, #state{}} | {noreply, #state{}, non_neg_integer()} | {noreply, #state{}, hibernate} | {stop, any(), any(), #state{}} | {stop, any(), #state{}}.
 handle_call(stop, _From, State) ->
     {stop, normal, stopped, State};
 
@@ -73,6 +69,7 @@ handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
 
+-spec handle_cast(any(), #state{}) -> {noreply, #state{}} | {noreply, #state{}, non_neg_integer()} | {noreply, #state{}, hibernate} | {stop, any(), #state{}}.
 handle_cast({send, RegIds, Message, Retry}, #state{key=Key} = State) ->
     do_push(RegIds, Message, Key, Retry),
     {noreply, State};
@@ -80,12 +77,15 @@ handle_cast({send, RegIds, Message, Retry}, #state{key=Key} = State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
+-spec handle_info(any(), #state{}) -> {noreply, #state{}} | {noreply, #state{}, non_neg_integer()} | {noreply, #state{}, hibernate} | {stop, any(), #state{}}.
 handle_info(_Info, State) ->
     {noreply, State}.
 
+-spec terminate(any(), #state{}) -> any().
 terminate(_Reason, _State) ->
     ok.
 
+-spec code_change(any(), #state{}, any()) -> {ok, any()} | {error, any()}.
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 

--- a/core/kazoo/src/kazoo_maintenance.erl
+++ b/core/kazoo/src/kazoo_maintenance.erl
@@ -167,18 +167,21 @@ gc_pids(Ps) ->
     lists:foreach(fun (P) -> erlang:garbage_collect(P), timer:sleep(500) end, Ps).
 
 -spec gc_top_mem_consumers() -> 'ok'.
--spec gc_top_mem_consumers(pos_integer()) -> 'ok'.
 gc_top_mem_consumers() ->
     gc_top_mem_consumers(10).
+
+-spec gc_top_mem_consumers(pos_integer()) -> 'ok'.
 gc_top_mem_consumers(N) ->
     {Top, _} = top_mem_consumers(N),
     gc_pids([P || {P,_} <- Top]).
 
 -type consumers() :: {kz_term:proplist_kv(pid(), integer()), kz_term:proplist_kv(pid(), integer())}.
+
 -spec top_mem_consumers() -> consumers().
--spec top_mem_consumers(pos_integer()) -> consumers().
 top_mem_consumers() ->
     top_mem_consumers(10).
+
+-spec top_mem_consumers(pos_integer()) -> consumers().
 top_mem_consumers(Len) when is_integer(Len), Len > 0 ->
     SortHeapDesc =
         lists:reverse(

--- a/core/kazoo/src/kz_doc.erl
+++ b/core/kazoo/src/kz_doc.erl
@@ -96,12 +96,14 @@
 %% parameters on all crossbar documents
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update_pvt_parameters(kz_json:object(), kz_term:api_binary()) ->
-                                   kz_json:object().
--spec update_pvt_parameters(kz_json:object(), kz_term:api_binary(), kz_term:proplist()) ->
                                    kz_json:object().
 update_pvt_parameters(JObj0, DBName) ->
     update_pvt_parameters(JObj0, DBName, []).
+
+-spec update_pvt_parameters(kz_json:object(), kz_term:api_binary(), kz_term:proplist()) ->
+                                   kz_json:object().
 update_pvt_parameters(JObj0, DBName, Options) ->
     Opts = props:insert_value('now', kz_time:now_s(), Options),
     lists:foldl(fun(Fun, JObj) -> Fun(JObj, DBName, Opts) end, JObj0, ?PVT_FUNS).
@@ -175,9 +177,10 @@ add_pvt_modified(JObj, _, Opts) ->
     kz_json:set_value(?KEY_MODIFIED, props:get_value('now', Opts), JObj).
 
 -spec modified(kz_json:object()) -> kz_term:api_integer().
--spec modified(kz_json:object(), Default) -> integer() | Default.
 modified(JObj) ->
     modified(JObj, 'undefined').
+
+-spec modified(kz_json:object(), Default) -> integer() | Default.
 modified(JObj, Default) ->
     kz_json:get_integer_value(?KEY_MODIFIED, JObj, Default).
 
@@ -270,9 +273,10 @@ remove_pvt(<<"pvt_", Key/binary>>) -> Key;
 remove_pvt(Key) -> Key.
 
 -spec attachments(kz_json:object()) -> kz_term:api_object().
--spec attachments(kz_json:object(), Default) -> kz_json:object() | Default.
 attachments(JObj) ->
     attachments(JObj, 'undefined').
+
+-spec attachments(kz_json:object(), Default) -> kz_json:object() | Default.
 attachments(JObj, Default) ->
     A1 = kz_json:get_json_value(?KEY_ATTACHMENTS, JObj, kz_json:new()),
     A2 = kz_json:get_json_value(?KEY_EXTERNAL_ATTACHMENTS, JObj, kz_json:new()),
@@ -282,9 +286,10 @@ attachments(JObj, Default) ->
     end.
 
 -spec stub_attachments(kz_json:object()) -> kz_term:api_object().
--spec stub_attachments(kz_json:object(), Default) -> kz_json:object() | Default.
 stub_attachments(JObj) ->
     stub_attachments(JObj, 'undefined').
+
+-spec stub_attachments(kz_json:object(), Default) -> kz_json:object() | Default.
 stub_attachments(JObj, Default) ->
     case kz_json:get_json_value(?KEY_ATTACHMENTS, JObj, kz_json:new()) of
         ?EMPTY_JSON_OBJECT -> Default;
@@ -292,9 +297,10 @@ stub_attachments(JObj, Default) ->
     end.
 
 -spec external_attachments(kz_json:object()) -> kz_term:api_object().
--spec external_attachments(kz_json:object(), Default) -> kz_json:object() | Default.
 external_attachments(JObj) ->
     external_attachments(JObj, 'undefined').
+
+-spec external_attachments(kz_json:object(), Default) -> kz_json:object() | Default.
 external_attachments(JObj, Default) ->
     case kz_json:get_json_value(?KEY_EXTERNAL_ATTACHMENTS, JObj, kz_json:new()) of
         ?EMPTY_JSON_OBJECT -> Default;
@@ -325,11 +331,10 @@ latest_attachment_id(Doc) ->
             Name
     end.
 
--spec attachment(kz_json:object()) -> kz_term:api_object().
--spec attachment(kz_json:object(), kz_json:path()) -> kz_term:api_object().
--spec attachment(kz_json:object(), kz_json:path(), Default) -> kz_json:object() | Default.
 %% @public
 %% @doc Gets a random attachment from JObj (no order is imposed!)
+
+-spec attachment(kz_json:object()) -> kz_term:api_object().
 attachment(JObj) ->
     case kz_json:get_values(attachments(JObj, kz_json:new())) of
         {[], []} -> 'undefined';
@@ -337,42 +342,50 @@ attachment(JObj) ->
             kz_json:from_list([{AttachmentName, Attachment}])
     end.
 
+-spec attachment(kz_json:object(), kz_json:path()) -> kz_term:api_object().
 attachment(JObj, AName) ->
     attachment(JObj, AName, 'undefined').
+
+-spec attachment(kz_json:object(), kz_json:path(), Default) -> kz_json:object() | Default.
 attachment(JObj, AName, Default) ->
     kz_json:get_json_value(AName, attachments(JObj, kz_json:new()), Default).
 
 -spec attachment_length(kz_json:object(), kz_term:ne_binary()) -> kz_term:api_integer().
--spec attachment_length(kz_json:object(), kz_term:ne_binary(), Default) -> non_neg_integer() | Default.
 attachment_length(JObj, AName) ->
     attachment_length(JObj, AName, 'undefined').
+
+-spec attachment_length(kz_json:object(), kz_term:ne_binary(), Default) -> non_neg_integer() | Default.
 attachment_length(JObj, AName, Default) ->
     attachment_property(JObj, AName, <<"length">>, Default, fun kz_json:get_integer_value/3).
 
 -spec attachment_content_type(kz_json:object()) -> kz_term:api_ne_binary().
--spec attachment_content_type(kz_json:object(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
--spec attachment_content_type(kz_json:object(), kz_term:ne_binary(), Default) -> Default | kz_term:ne_binary().
 attachment_content_type(JObj) ->
     case kz_json:get_values(attachments(JObj, kz_json:new())) of
         {[], []} -> 'undefined';
         {[_Attachment|_], [AName|_]} ->
             attachment_content_type(JObj, AName)
     end.
+
+-spec attachment_content_type(kz_json:object(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
 attachment_content_type(JObj, AName) ->
     attachment_content_type(JObj, AName, 'undefined').
+
+-spec attachment_content_type(kz_json:object(), kz_term:ne_binary(), Default) -> Default | kz_term:ne_binary().
 attachment_content_type(JObj, AName, Default) ->
     attachment_property(JObj, AName, <<"content_type">>, Default, fun kz_json:get_ne_binary_value/3).
 
 -spec attachment_property(kz_json:object(), kz_term:ne_binary(), kz_json:path()) ->
                                  kz_json:api_json_term().
--spec attachment_property(kz_json:object(), kz_term:ne_binary(), kz_json:path(), Default) ->
-                                 Default | kz_json:json_term().
--spec attachment_property(kz_json:object(), kz_term:ne_binary(), kz_json:path(), Default, fun((kz_json:path(), kz_json:object(), Default) -> Default | kz_json:json_term())) ->
-                                 Default | kz_json:json_term().
 attachment_property(JObj, AName, Key) ->
     attachment_property(JObj, AName, Key, 'undefined').
+
+-spec attachment_property(kz_json:object(), kz_term:ne_binary(), kz_json:path(), Default) ->
+                                 Default | kz_json:json_term().
 attachment_property(JObj, AName, Key, Default) ->
     attachment_property(JObj, AName, Key, Default, fun kz_json:get_value/3).
+
+-spec attachment_property(kz_json:object(), kz_term:ne_binary(), kz_json:path(), Default, fun((kz_json:path(), kz_json:object(), Default) -> Default | kz_json:json_term())) ->
+                                 Default | kz_json:json_term().
 attachment_property(JObj, AName, Key, Default, Get) when is_function(Get, 3) ->
     Get(Key, attachment(JObj, AName, kz_json:new()), Default).
 
@@ -414,10 +427,10 @@ delete_revision(JObj) ->
     kz_json:delete_key(?KEY_REV, JObj).
 
 -spec id(kz_json:object()) -> kz_term:api_binary().
--spec id(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 id(JObj) ->
     id(JObj, 'undefined').
 
+-spec id(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 id(JObj, Default) ->
     Id = kz_json:get_first_defined([?KEY_ID
                                    ,<<"id">>
@@ -438,9 +451,10 @@ set_id(JObj, Id) ->
     kz_json:set_value(?KEY_ID, Id, JObj).
 
 -spec type(kz_json:object()) -> kz_term:api_ne_binary().
--spec type(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 type(JObj) ->
     type(JObj, 'undefined').
+
+-spec type(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 type(JObj, Default) ->
     try kz_json:get_ne_binary_value(?KEY_PVT_TYPE, JObj, Default)
     catch 'error':'badarg' ->
@@ -461,9 +475,10 @@ is_soft_deleted(JObj) ->
     kz_json:is_true(?KEY_SOFT_DELETED, JObj).
 
 -spec set_deleted(kz_json:object()) -> kz_json:object().
--spec set_deleted(kz_json:object(), boolean()) -> kz_json:object().
 set_deleted(JObj) ->
     set_deleted(JObj, 'true').
+
+-spec set_deleted(kz_json:object(), boolean()) -> kz_json:object().
 set_deleted(JObj, Bool) when is_boolean(Bool) ->
     kz_json:set_value(?KEY_DELETED, Bool, JObj).
 
@@ -472,9 +487,10 @@ is_deleted(JObj) ->
     kz_json:is_true(?KEY_DELETED, JObj, 'false').
 
 -spec created(kz_json:object()) -> kz_term:api_integer().
--spec created(kz_json:object(), Default) -> integer() | Default.
 created(JObj) ->
     created(JObj, 'undefined').
+
+-spec created(kz_json:object(), Default) -> integer() | Default.
 created(JObj, Default) ->
     kz_json:get_integer_value(?KEY_CREATED, JObj, Default).
 
@@ -483,9 +499,10 @@ set_created(JObj, Timestamp) ->
     kz_json:set_value(?KEY_CREATED, Timestamp, JObj).
 
 -spec account_id(kz_json:object()) -> kz_term:api_ne_binary().
--spec account_id(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 account_id(JObj) ->
     account_id(JObj, 'undefined').
+
+-spec account_id(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 account_id(JObj, Default) ->
     kz_json:get_ne_binary_value(?KEY_ACCOUNT_ID, JObj, Default).
 
@@ -494,9 +511,10 @@ set_account_id(JObj, AccountId) ->
     kz_json:set_value(?KEY_ACCOUNT_ID, AccountId, JObj).
 
 -spec account_db(kz_json:object()) -> kz_term:api_ne_binary().
--spec account_db(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 account_db(JObj) ->
     account_db(JObj, 'undefined').
+
+-spec account_db(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 account_db(JObj, Default) ->
     kz_json:get_ne_binary_value(?KEY_ACCOUNT_DB, JObj, Default).
 
@@ -505,9 +523,10 @@ set_account_db(JObj, AccountDb) ->
     kz_json:set_value(?KEY_ACCOUNT_DB, AccountDb, JObj).
 
 -spec vsn(kz_json:object()) -> kz_term:api_ne_binary().
--spec vsn(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 vsn(JObj) ->
     vsn(JObj, 'undefined').
+
+-spec vsn(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 vsn(JObj, Default) ->
     kz_json:get_ne_binary_value(?KEY_VSN, JObj, Default).
 

--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -344,14 +344,12 @@ format_account_id(Account, Year, Month) when is_integer(Year),
 %% Note: accepts MODbs as well as account IDs/DBs
 %% @end
 %%--------------------------------------------------------------------
--spec format_account_mod_id(kz_term:api_binary()) -> kz_term:api_binary().
--spec format_account_mod_id(kz_term:api_binary(), kz_time:gregorian_seconds() | kz_time:now()) -> kz_term:api_binary().
--spec format_account_mod_id(kz_term:api_binary(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) ->
-                                   kz_term:api_binary().
 
+-spec format_account_mod_id(kz_term:api_binary()) -> kz_term:api_binary().
 format_account_mod_id(Account) ->
     format_account_mod_id(Account, os:timestamp()).
 
+-spec format_account_mod_id(kz_term:api_binary(), kz_time:gregorian_seconds() | kz_time:now()) -> kz_term:api_binary().
 format_account_mod_id(AccountId, {_,_,_}=Timestamp) ->
     {{Year, Month, _}, _} = calendar:now_to_universal_time(Timestamp),
     format_account_id(AccountId, Year, Month);
@@ -359,6 +357,8 @@ format_account_mod_id(AccountId, Timestamp) when is_integer(Timestamp) ->
     {{Year, Month, _}, _} = calendar:gregorian_seconds_to_datetime(Timestamp),
     format_account_id(AccountId, Year, Month).
 
+-spec format_account_mod_id(kz_term:api_binary(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) ->
+                                   kz_term:api_binary().
 format_account_mod_id(AccountId, Year, Month) ->
     format_account_id(AccountId, Year, Month).
 
@@ -380,10 +380,12 @@ format_account_db(AccountId) ->
 %% Note: crashes if given anything but an MODb (in any format).
 %% @end
 %%--------------------------------------------------------------------
+
 -spec format_account_modb(kz_term:ne_binary()) -> kz_term:ne_binary().
--spec format_account_modb(kz_term:ne_binary(), account_format()) -> kz_term:ne_binary().
 format_account_modb(AccountId) ->
     format_account_modb(AccountId, 'raw').
+
+-spec format_account_modb(kz_term:ne_binary(), account_format()) -> kz_term:ne_binary().
 format_account_modb(AccountId, 'raw') ->
     raw_account_modb(AccountId);
 format_account_modb(AccountId, 'unencoded') ->
@@ -429,12 +431,12 @@ is_alphanumeric(_) ->
 %% its own hierarchy.
 %% @end
 %%--------------------------------------------------------------------
--spec is_in_account_hierarchy(kz_term:api_binary(), kz_term:api_binary()) -> boolean().
--spec is_in_account_hierarchy(kz_term:api_binary(), kz_term:api_binary(), boolean()) -> boolean().
 
+-spec is_in_account_hierarchy(kz_term:api_binary(), kz_term:api_binary()) -> boolean().
 is_in_account_hierarchy(CheckFor, InAccount) ->
     is_in_account_hierarchy(CheckFor, InAccount, 'false').
 
+-spec is_in_account_hierarchy(kz_term:api_binary(), kz_term:api_binary(), boolean()) -> boolean().
 is_in_account_hierarchy('undefined', _, _) -> 'false';
 is_in_account_hierarchy(_, 'undefined', _) -> 'false';
 is_in_account_hierarchy(CheckFor, InAccount, IncludeSelf) ->
@@ -574,10 +576,10 @@ set_allow_number_additions(Account, IsAllowed) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec account_update(kz_account:doc()) ->
                             {'ok', kz_json:object()} |
                             {'error', any()}.
--spec account_update(kz_term:ne_binary(), function()) -> 'ok' | {'error', any()}.
 account_update(AccountJObj) ->
     AccountDb = kz_doc:account_db(AccountJObj),
     case kz_datamgr:ensure_saved(AccountDb, AccountJObj) of
@@ -586,6 +588,7 @@ account_update(AccountJObj) ->
             kz_datamgr:ensure_saved(?KZ_ACCOUNTS_DB, SavedJObj)
     end.
 
+-spec account_update(kz_term:ne_binary(), function()) -> 'ok' | {'error', any()}.
 account_update(Account, UpdateFun) ->
     case kz_account:fetch(Account) of
         {'error', _R}=E -> E;
@@ -681,7 +684,6 @@ runs_in(MaxTime, Fun, Arguments)
   when is_number(MaxTime), MaxTime > 0 ->
     runs_in(kz_term:to_integer(MaxTime), Fun, Arguments).
 
--spec spawn(fun(() -> any())) -> pid().
 -spec spawn(fun(), list()) -> pid().
 spawn(Fun, Arguments) ->
     CallId = get_callid(),
@@ -689,6 +691,8 @@ spawn(Fun, Arguments) ->
                          _ = put_callid(CallId),
                          erlang:apply(Fun, Arguments)
                  end).
+
+-spec spawn(fun(() -> any())) -> pid().
 spawn(Fun) ->
     CallId = get_callid(),
     erlang:spawn(fun() ->
@@ -696,7 +700,6 @@ spawn(Fun) ->
                          Fun()
                  end).
 
--spec spawn_link(fun(() -> any())) -> pid().
 -spec spawn_link(fun(), list()) -> pid().
 spawn_link(Fun, Arguments) ->
     CallId = get_callid(),
@@ -704,6 +707,8 @@ spawn_link(Fun, Arguments) ->
                               _ = put_callid(CallId),
                               erlang:apply(Fun, Arguments)
                       end).
+
+-spec spawn_link(fun(() -> any())) -> pid().
 spawn_link(Fun) ->
     CallId = get_callid(),
     erlang:spawn_link(fun() ->
@@ -811,10 +816,10 @@ write_pid(FileName) ->
 
 
 -spec pretty_print_bytes(non_neg_integer()) -> kz_term:ne_binary().
--spec pretty_print_bytes(non_neg_integer(), 'full' | 'truncated') -> kz_term:ne_binary().
 pretty_print_bytes(Bytes) ->
     pretty_print_bytes(Bytes, 'full').
 
+-spec pretty_print_bytes(non_neg_integer(), 'full' | 'truncated') -> kz_term:ne_binary().
 pretty_print_bytes(0, _) -> <<"0B">>;
 pretty_print_bytes(Bytes, Type) ->
     iolist_to_binary(unitfy_bytes(Bytes, Type)).
@@ -853,10 +858,11 @@ mem_usage() ->
     Memory.
 
 -spec node_name() -> binary().
--spec node_hostname() -> binary().
 node_name() ->
     [Name, _Host] = binary:split(kz_term:to_binary(node()), <<"@">>),
     Name.
+
+-spec node_hostname() -> binary().
 node_hostname() ->
     [_Name, Host] = binary:split(kz_term:to_binary(node()), <<"@">>),
     Host.

--- a/core/kazoo_amqp/src/amqp_util.erl
+++ b/core/kazoo_amqp/src/amqp_util.erl
@@ -180,78 +180,94 @@
 %% Publish AMQP messages
 %% @end
 %%------------------------------------------------------------------------------
+
 -spec targeted_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec targeted_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec targeted_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 targeted_publish(Queue, Payload) ->
     targeted_publish(Queue, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec targeted_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 targeted_publish(?NE_BINARY = Queue, Payload, ContentType) ->
     targeted_publish(Queue, Payload, ContentType, []).
+
+-spec targeted_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 targeted_publish(?NE_BINARY = Queue, Payload, ContentType, Options) ->
     basic_publish(?EXCHANGE_TARGETED, Queue, Payload, ContentType, Options).
 
 -spec nodes_publish(amqp_payload()) -> 'ok'.
--spec nodes_publish(amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 nodes_publish(Payload) ->
     nodes_publish(Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec nodes_publish(amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 nodes_publish(Payload, ContentType) ->
     basic_publish(?EXCHANGE_NODES, <<>>, Payload, ContentType, ['maybe_publish']).
 
 -spec kapps_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec kapps_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec kapps_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 kapps_publish(Routing, Payload) ->
     kapps_publish(Routing, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec kapps_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 kapps_publish(Routing, Payload, ContentType) ->
     kapps_publish(Routing, Payload, ContentType, []).
+
+-spec kapps_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 kapps_publish(Routing, Payload, ContentType, Opts) ->
     basic_publish(?EXCHANGE_KAPPS, Routing, Payload, ContentType, Opts).
 
 -spec presence_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec presence_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec presence_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 presence_publish(Routing, Payload) ->
     presence_publish(Routing, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec presence_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 presence_publish(Routing, Payload, ContentType) ->
     presence_publish(Routing, Payload, ContentType, []).
+
+-spec presence_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 presence_publish(Routing, Payload, ContentType, Opts) ->
     basic_publish(?EXCHANGE_PRESENCE, Routing, Payload, ContentType, Opts).
 
 -spec notifications_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec notifications_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec notifications_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 notifications_publish(Routing, Payload) ->
     notifications_publish(Routing, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec notifications_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 notifications_publish(Routing, Payload, ContentType) ->
     notifications_publish(Routing, Payload, ContentType, []).
+
+-spec notifications_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 notifications_publish(Routing, Payload, ContentType, Opts) ->
     basic_publish(?EXCHANGE_NOTIFICATIONS, Routing, Payload, ContentType, Opts).
 
 -spec sysconf_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec sysconf_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec sysconf_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 sysconf_publish(Routing, Payload) ->
     sysconf_publish(Routing, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec sysconf_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 sysconf_publish(Routing, Payload, ContentType) ->
     sysconf_publish(Routing, Payload, ContentType, []).
+
+-spec sysconf_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 sysconf_publish(Routing, Payload, ContentType, Opts) ->
     basic_publish(?EXCHANGE_SYSCONF, Routing, Payload, ContentType, Opts).
 
--spec callmgr_publish(amqp_payload(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec callmgr_publish(amqp_payload(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 %% TODO: The routing key on this function should be the first argument for consistency
+
+-spec callmgr_publish(amqp_payload(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 callmgr_publish(Payload, ContentType, RoutingKey) ->
     basic_publish(?EXCHANGE_CALLMGR, RoutingKey, Payload, ContentType).
+
+-spec callmgr_publish(amqp_payload(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 callmgr_publish(Payload, ContentType, RoutingKey, Opts) ->
     basic_publish(?EXCHANGE_CALLMGR, RoutingKey, Payload, ContentType, Opts).
 
 -spec configuration_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec configuration_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec configuration_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 configuration_publish(RoutingKey, Payload) ->
     configuration_publish(RoutingKey, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec configuration_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 configuration_publish(RoutingKey, Payload, ContentType) ->
     configuration_publish(RoutingKey, Payload, ContentType, []).
+
+-spec configuration_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 configuration_publish(RoutingKey, Payload, ContentType, Props) ->
     basic_publish(?EXCHANGE_CONFIGURATION, RoutingKey, Payload, ContentType, Props).
 
@@ -261,27 +277,31 @@ configuration_publish(RoutingKey, Payload, ContentType, Props) ->
       Type :: kz_term:ne_binary(),
       Id :: kz_term:ne_binary(),
       Payload :: amqp_payload().
--spec document_change_publish(atom(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 document_change_publish(Action, Db, Type, Id, JSON) ->
     document_change_publish(Action, Db, Type, Id, JSON, ?DEFAULT_CONTENT_TYPE).
+
+-spec document_change_publish(atom(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 document_change_publish(Action, Db, Type, Id, Payload, ContentType) ->
     RoutingKey = document_routing_key(Action, Db, Type, Id),
     configuration_publish(RoutingKey, Payload, ContentType).
 
 -spec document_routing_key() -> kz_term:ne_binary().
--spec document_routing_key(atom() | kz_term:ne_binary()) -> kz_term:ne_binary().
--spec document_routing_key(atom() | kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
--spec document_routing_key(atom() | kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
--spec document_routing_key(atom() | kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 document_routing_key() ->
     document_routing_key(<<"*">>).
+
+-spec document_routing_key(atom() | kz_term:ne_binary()) -> kz_term:ne_binary().
 document_routing_key(Action) ->
     document_routing_key(Action, <<"*">>).
+
+-spec document_routing_key(atom() | kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 document_routing_key(Action, Db) ->
     document_routing_key(Action, Db, <<"*">>).
+
+-spec document_routing_key(atom() | kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 document_routing_key(Action, Db, Type) ->
     document_routing_key(Action, Db, Type, <<"*">>).
 
+-spec document_routing_key(atom() | kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 document_routing_key(<<"*">>, Db, Type, Id) ->
     list_to_binary([<<"*.">>, kz_term:to_binary(Db)
                    ,".", kz_term:to_binary(Type)
@@ -313,36 +333,42 @@ document_routing_key(Action, Db, Type, Id) ->
                    ]).
 
 -spec callctl_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec callctl_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec callctl_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 callctl_publish(CtrlQ, Payload) ->
     callctl_publish(CtrlQ, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec callctl_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 callctl_publish(CtrlQ, Payload, ContentType) ->
     callctl_publish(CtrlQ, Payload, ContentType, []).
+
+-spec callctl_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 callctl_publish(CtrlQ, Payload, ContentType, Props) ->
     basic_publish(?EXCHANGE_CALLCTL, CtrlQ, Payload, ContentType, Props).
 
 -spec callevt_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec callevt_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec callevt_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 callevt_publish(RoutingKey, Payload) ->
     callevt_publish(RoutingKey, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec callevt_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 callevt_publish(RoutingKey, Payload, ContentType) ->
     callevt_publish(RoutingKey, Payload, ContentType, []).
+
+-spec callevt_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 callevt_publish(RoutingKey, Payload, ContentType, Prop) ->
     basic_publish(?EXCHANGE_CALLEVT, RoutingKey, Payload, ContentType, Prop).
 
 -spec originate_resource_publish(amqp_payload()) -> 'ok'.
--spec originate_resource_publish(amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 originate_resource_publish(Payload) ->
     originate_resource_publish(Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec originate_resource_publish(amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 originate_resource_publish(Payload, ContentType) ->
     basic_publish(?EXCHANGE_RESOURCE, ?KEY_ORGN_RESOURCE_REQ, Payload, ContentType).
 
 -spec offnet_resource_publish(amqp_payload()) -> 'ok'.
--spec offnet_resource_publish(amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 offnet_resource_publish(Payload) ->
     offnet_resource_publish(Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec offnet_resource_publish(amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 offnet_resource_publish(Payload, ContentType) ->
     basic_publish(?EXCHANGE_RESOURCE, ?KEY_OFFNET_RESOURCE_REQ, Payload, ContentType).
 
@@ -352,11 +378,8 @@ monitor_publish(Payload, ContentType, RoutingKey) ->
     basic_publish(?EXCHANGE_MONITOR, RoutingKey, Payload, ContentType).
 
 -type conf_routing_type() :: 'discovery' | 'event' | 'command' | 'config'.
--spec conference_publish(amqp_payload(), conf_routing_type()) -> 'ok'.
--spec conference_publish(amqp_payload(), conf_routing_type(), kz_term:api_binary()) -> 'ok'.
--spec conference_publish(amqp_payload(), conf_routing_type(), kz_term:api_binary(), kz_term:proplist()) -> 'ok'.
--spec conference_publish(amqp_payload(), conf_routing_type(), kz_term:api_binary(), kz_term:proplist(), kz_term:ne_binary()) -> 'ok'.
 
+-spec conference_publish(amqp_payload(), conf_routing_type()) -> 'ok'.
 conference_publish(Payload, 'discovery') ->
     conference_publish(Payload, 'discovery', <<"*">>);
 conference_publish(Payload, 'event') ->
@@ -366,6 +389,7 @@ conference_publish(Payload, 'config') ->
 conference_publish(Payload, 'command') ->
     conference_publish(Payload, 'command', <<"*">>).
 
+-spec conference_publish(amqp_payload(), conf_routing_type(), kz_term:api_binary()) -> 'ok'.
 conference_publish(Payload, 'discovery', ConfId) ->
     conference_publish(Payload, 'discovery', ConfId, []);
 conference_publish(Payload, 'config', ConfId) ->
@@ -375,6 +399,7 @@ conference_publish(Payload, 'event', ConfId) ->
 conference_publish(Payload, 'command', ConfId) ->
     conference_publish(Payload, 'command', ConfId, []).
 
+-spec conference_publish(amqp_payload(), conf_routing_type(), kz_term:api_binary(), kz_term:proplist()) -> 'ok'.
 conference_publish(Payload, 'discovery', ConfId, Options) ->
     conference_publish(Payload, 'discovery', ConfId, Options, ?DEFAULT_CONTENT_TYPE);
 conference_publish(Payload, 'config', ConfId, Options) ->
@@ -384,6 +409,7 @@ conference_publish(Payload, 'event', ConfId, Options) ->
 conference_publish(Payload, 'command', ConfId, Options) ->
     conference_publish(Payload, 'command', ConfId, Options, ?DEFAULT_CONTENT_TYPE).
 
+-spec conference_publish(amqp_payload(), conf_routing_type(), kz_term:api_binary(), kz_term:proplist(), kz_term:ne_binary()) -> 'ok'.
 conference_publish(Payload, 'discovery', _, Options, ContentType) ->
     basic_publish(?EXCHANGE_CONFERENCE, ?KEY_CONFERENCE_DISCOVERY, Payload, ContentType, Options);
 conference_publish(Payload, 'config', ConfProfile, Options, ContentType) ->
@@ -399,47 +425,54 @@ conference_publish(Payload, 'event', ConfId, CallId, Options, ContentType) ->
     basic_publish(?EXCHANGE_CONFERENCE, RoutingKey, Payload, ContentType, Options).
 
 -spec registrar_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec registrar_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec registrar_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 registrar_publish(Routing, Payload) ->
     registrar_publish(Routing, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec registrar_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 registrar_publish(Routing, Payload, ContentType) ->
     registrar_publish(Routing, Payload, ContentType, []).
+
+-spec registrar_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 registrar_publish(Routing, Payload, ContentType, Opts) ->
     basic_publish(?EXCHANGE_REGISTRAR, Routing, Payload, ContentType, Opts).
 
 -spec leader_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec leader_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec leader_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 leader_publish(Routing, Payload) ->
     leader_publish(Routing, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec leader_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 leader_publish(Routing, Payload, ContentType) ->
     leader_publish(Routing, Payload, ContentType, []).
+
+-spec leader_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 leader_publish(Routing, Payload, ContentType, Opts) ->
     basic_publish(?EXCHANGE_LEADER, Routing, Payload, ContentType, Opts).
 
 -spec tasks_publish(kz_term:ne_binary(), amqp_payload()) -> 'ok'.
--spec tasks_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec tasks_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 tasks_publish(Routing, Payload) ->
     tasks_publish(Routing, Payload, ?DEFAULT_CONTENT_TYPE).
+
+-spec tasks_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 tasks_publish(Routing, Payload, ContentType) ->
     tasks_publish(Routing, Payload, ContentType, []).
+
+-spec tasks_publish(kz_term:ne_binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 tasks_publish(Routing, Payload, ContentType, Opts) ->
     basic_publish(?EXCHANGE_TASKS, Routing, Payload, ContentType, Opts).
 
 
 %% generic publisher for an Exchange.Queue
 %% Use <<"#">> for a default Queue
+
 -spec basic_publish(kz_term:ne_binary(), binary(), amqp_payload()) -> 'ok'.
--spec basic_publish(kz_term:ne_binary(), binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
--spec basic_publish(kz_term:ne_binary(), binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 basic_publish(Exchange, RoutingKey, Payload) ->
     basic_publish(Exchange, RoutingKey, Payload, ?DEFAULT_CONTENT_TYPE).
 
+-spec basic_publish(kz_term:ne_binary(), binary(), amqp_payload(), kz_term:ne_binary()) -> 'ok'.
 basic_publish(Exchange, RoutingKey, Payload, ContentType) ->
     basic_publish(Exchange, RoutingKey, Payload, ContentType, []).
 
+-spec basic_publish(kz_term:ne_binary(), binary(), amqp_payload(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 basic_publish(Exchange, RoutingKey, Payload, ContentType, Prop)
   when is_list(Payload) ->
     basic_publish(Exchange, RoutingKey, iolist_to_binary(Payload), ContentType, Prop);
@@ -557,10 +590,12 @@ tasks_exchange() ->
 
 
 %% A generic Exchange maker
+
 -spec new_exchange(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec new_exchange(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 new_exchange(Exchange, Type) ->
     new_exchange(Exchange, Type, []).
+
+-spec new_exchange(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 new_exchange(Exchange, Type, Options) ->
     ED = #'exchange.declare'{exchange = Exchange
                             ,type = Type
@@ -574,9 +609,10 @@ new_exchange(Exchange, Type, Options) ->
     kz_amqp_channel:command(ED).
 
 -spec declare_exchange(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_amqp_exchange().
--spec declare_exchange(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> kz_amqp_exchange().
 declare_exchange(Exchange, Type) ->
     declare_exchange(Exchange, Type, []).
+
+-spec declare_exchange(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> kz_amqp_exchange().
 declare_exchange(Exchange, Type, Options) ->
     #'exchange.declare'{exchange = Exchange
                        ,type = Type
@@ -594,39 +630,47 @@ declare_exchange(Exchange, Type, Options) ->
 %% Create AMQP queues
 %% @end
 %%------------------------------------------------------------------------------
+
 -spec new_targeted_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_targeted_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_targeted_queue() -> new_targeted_queue(<<>>).
+
+-spec new_targeted_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_targeted_queue(Queue) -> new_queue(Queue, [{'nowait', 'false'}]).
 
 -spec new_nodes_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_nodes_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_nodes_queue() -> new_nodes_queue(<<>>).
+
+-spec new_nodes_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_nodes_queue(Queue) -> new_queue(Queue, [{'nowait', 'false'}]).
 
 -spec new_kapps_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_kapps_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_kapps_queue() -> new_kapps_queue(<<>>).
+
+-spec new_kapps_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_kapps_queue(Queue) -> new_queue(Queue, [{'nowait', 'false'}]).
 
 -spec new_presence_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_presence_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_presence_queue() -> new_presence_queue(<<>>).
+
+-spec new_presence_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_presence_queue(Queue) -> new_queue(Queue, [{'nowait', 'false'}]).
 
 -spec new_registrar_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_registrar_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_registrar_queue() -> new_registrar_queue(<<>>).
+
+-spec new_registrar_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_registrar_queue(Queue) -> new_queue(Queue, [{'nowait', 'false'}]).
 
 -spec new_notifications_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_notifications_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_notifications_queue() -> new_notifications_queue(<<>>).
+
+-spec new_notifications_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_notifications_queue(Queue) -> new_queue(Queue, [{'nowait', 'false'}]).
 
 -spec new_sysconf_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_sysconf_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_sysconf_queue() -> new_sysconf_queue(<<>>).
+
+-spec new_sysconf_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_sysconf_queue(Queue) -> new_queue(Queue, [{'nowait', 'false'}]).
 
 -spec new_callevt_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
@@ -656,8 +700,9 @@ new_callctl_queue(CallID) ->
               ]).
 
 -spec new_resource_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_resource_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_resource_queue() -> new_resource_queue(?RESOURCE_QUEUE_NAME).
+
+-spec new_resource_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_resource_queue(Queue) ->
     new_queue(Queue, [{'exclusive', 'false'}
                      ,{'auto_delete', 'true'}
@@ -665,26 +710,30 @@ new_resource_queue(Queue) ->
                      ]).
 
 -spec new_callmgr_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
--spec new_callmgr_queue(binary(), kz_term:proplist()) -> kz_term:ne_binary() | {'error', any()}.
 new_callmgr_queue(Queue) -> new_callmgr_queue(Queue, []).
+
+-spec new_callmgr_queue(binary(), kz_term:proplist()) -> kz_term:ne_binary() | {'error', any()}.
 new_callmgr_queue(Queue, Opts) -> new_queue(Queue, Opts).
 
 -spec new_configuration_queue(kz_term:ne_binary()) -> kz_term:ne_binary() | {'error', any()}.
--spec new_configuration_queue(kz_term:ne_binary(), kz_term:proplist()) -> kz_term:ne_binary() | {'error', any()}.
 new_configuration_queue(Queue) -> new_configuration_queue(Queue, []).
+
+-spec new_configuration_queue(kz_term:ne_binary(), kz_term:proplist()) -> kz_term:ne_binary() | {'error', any()}.
 new_configuration_queue(Queue, Options) -> new_queue(Queue, Options).
 
 -spec new_monitor_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_monitor_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_monitor_queue() -> new_monitor_queue(<<>>).
+
+-spec new_monitor_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_monitor_queue(Queue) ->
     new_queue(Queue, [{'exclusive', 'false'}
                      ,{'auto_delete', 'true'}
                      ]).
 
 -spec new_conference_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_conference_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_conference_queue() -> new_conference_queue(<<>>).
+
+-spec new_conference_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_conference_queue(Queue) ->
     new_queue(Queue, [{'exclusive', 'false'}
                      ,{'auto_delete', 'true'}
@@ -692,8 +741,9 @@ new_conference_queue(Queue) ->
                      ]).
 
 -spec new_tasks_queue() -> kz_term:ne_binary() | {'error', any()}.
--spec new_tasks_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_tasks_queue() -> new_tasks_queue(<<>>).
+
+-spec new_tasks_queue(binary()) -> kz_term:ne_binary() | {'error', any()}.
 new_tasks_queue(Queue) -> new_queue(Queue, [{'nowait', 'false'}]).
 
 
@@ -701,12 +751,14 @@ new_tasks_queue(Queue) -> new_queue(Queue, [{'nowait', 'false'}]).
 -type new_queue_ret() :: kz_term:api_binary() | integer() |
                          {kz_term:ne_binary(), integer(), integer()} |
                          {'error', any()}.
+
 -spec new_queue() -> new_queue_ret().
--spec new_queue(binary()) -> new_queue_ret().
--spec new_queue(binary(), kz_term:proplist()) -> new_queue_ret().
 new_queue() -> new_queue(new_queue_name()). % lets the client lib create a random queue name
+
+-spec new_queue(binary()) -> new_queue_ret().
 new_queue(Queue) -> new_queue(Queue, []).
 
+-spec new_queue(binary(), kz_term:proplist()) -> new_queue_ret().
 new_queue(<<"amq.", _/binary>>, Options) ->
     new_queue(new_queue_name(), Options);
 new_queue(<<>>, Options) ->
@@ -792,31 +844,44 @@ message_ttl(Args, Acc) ->
 %% Delete AMQP queue
 %% @end
 %%------------------------------------------------------------------------------
+
 -spec delete_targeted_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_nodes_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_kapps_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_presence_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_notifications_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_sysconf_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_callmgr_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_resource_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_configuration_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_conference_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_monitor_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_registrar_queue(kz_term:ne_binary()) -> command_ret().
--spec delete_tasks_queue(kz_term:ne_binary()) -> command_ret().
 delete_targeted_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_nodes_queue(kz_term:ne_binary()) -> command_ret().
 delete_nodes_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_kapps_queue(kz_term:ne_binary()) -> command_ret().
 delete_kapps_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_presence_queue(kz_term:ne_binary()) -> command_ret().
 delete_presence_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_notifications_queue(kz_term:ne_binary()) -> command_ret().
 delete_notifications_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_sysconf_queue(kz_term:ne_binary()) -> command_ret().
 delete_sysconf_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_callmgr_queue(kz_term:ne_binary()) -> command_ret().
 delete_callmgr_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_resource_queue(kz_term:ne_binary()) -> command_ret().
 delete_resource_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_configuration_queue(kz_term:ne_binary()) -> command_ret().
 delete_configuration_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_conference_queue(kz_term:ne_binary()) -> command_ret().
 delete_conference_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_monitor_queue(kz_term:ne_binary()) -> command_ret().
 delete_monitor_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_registrar_queue(kz_term:ne_binary()) -> command_ret().
 delete_registrar_queue(Queue) -> queue_delete(Queue).
+
+-spec delete_tasks_queue(kz_term:ne_binary()) -> command_ret().
 delete_tasks_queue(Queue) -> queue_delete(Queue).
 
 -spec delete_callevt_queue(kz_term:ne_binary()) -> command_ret().
@@ -830,8 +895,9 @@ delete_callctl_queue(CallID, Prop) ->
     queue_delete(list_to_binary([?EXCHANGE_CALLCTL, ".", encode(CallID)]), Prop).
 
 -spec queue_delete(kz_term:ne_binary()) -> command_ret().
--spec queue_delete(kz_term:ne_binary(), kz_term:proplist()) -> command_ret().
 queue_delete(Queue) -> queue_delete(Queue, []).
+
+-spec queue_delete(kz_term:ne_binary(), kz_term:proplist()) -> command_ret().
 queue_delete(Queue, _Prop) when not is_binary(Queue) ->
     {'error', 'invalid_queue_name'};
 queue_delete(Queue, Prop) ->
@@ -848,72 +914,83 @@ queue_delete(Queue, Prop) ->
 %% Bind a Queue to an Exchange (with optional Routing Key)
 %% @end
 %%------------------------------------------------------------------------------
+
 -spec bind_q_to_targeted(kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_targeted(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_targeted(Queue) ->
     bind_q_to_exchange(Queue, Queue, ?EXCHANGE_TARGETED).
+
+-spec bind_q_to_targeted(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_targeted(Queue, Routing) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_TARGETED).
 
 -spec bind_q_to_nodes(kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_nodes(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_nodes(Queue) ->
     bind_q_to_exchange(Queue, Queue, ?EXCHANGE_NODES).
+
+-spec bind_q_to_nodes(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_nodes(Queue, Routing) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_NODES).
 
 -spec bind_q_to_kapps(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_kapps(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_kapps(Queue, Routing) ->
     bind_q_to_kapps(Queue, Routing, []).
+
+-spec bind_q_to_kapps(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_kapps(Queue, Routing, Options) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_KAPPS, Options).
 
 -spec bind_q_to_presence(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_presence(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_presence(Queue, Routing) ->
     bind_q_to_presence(Queue, Routing, []).
+
+-spec bind_q_to_presence(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_presence(Queue, Routing, Options) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_PRESENCE, Options).
 
 -spec bind_q_to_registrar(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_registrar(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_registrar(Queue, Routing) ->
     bind_q_to_registrar(Queue, Routing, []).
+
+-spec bind_q_to_registrar(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_registrar(Queue, Routing, Options) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_REGISTRAR, Options).
 
 -spec bind_q_to_notifications(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_notifications(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_notifications(Queue, Routing) ->
     bind_q_to_notifications(Queue, Routing, []).
+
+-spec bind_q_to_notifications(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_notifications(Queue, Routing, Options) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_NOTIFICATIONS, Options).
 
 -spec bind_q_to_sysconf(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_sysconf(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_sysconf(Queue, Routing) ->
     bind_q_to_sysconf(Queue, Routing, []).
+
+-spec bind_q_to_sysconf(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_sysconf(Queue, Routing, Options) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_SYSCONF, Options).
 
 -spec bind_q_to_callctl(kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_callctl(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_callctl(Queue) ->
     bind_q_to_callctl(Queue, Queue).
+
+-spec bind_q_to_callctl(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_callctl(Queue, Routing) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_CALLCTL).
 
 -spec bind_q_to_callevt(kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_callevt(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_callevt(Queue) ->
     bind_q_to_callevt(Queue, Queue).
+
+-spec bind_q_to_callevt(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_callevt(Queue, Routing) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_CALLEVT).
 
 -spec bind_q_to_resource(kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_resource(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_resource(Queue) -> bind_q_to_resource(Queue, <<"#">>).
+
+-spec bind_q_to_resource(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 bind_q_to_resource(Queue, Routing) -> bind_q_to_exchange(Queue, Routing, ?EXCHANGE_RESOURCE).
 
 -spec bind_q_to_callmgr(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
@@ -932,9 +1009,8 @@ bind_q_to_monitor(Queue, Routing) ->
 unbind_q_from_monitor(Queue, Routing) ->
     unbind_q_from_exchange(Queue, Routing, ?EXCHANGE_MONITOR).
 
--spec bind_q_to_conference(kz_term:ne_binary(), conf_routing_type()) -> 'ok'.
--spec bind_q_to_conference(kz_term:ne_binary(), conf_routing_type(), kz_term:api_binary()) -> 'ok'.
 
+-spec bind_q_to_conference(kz_term:ne_binary(), conf_routing_type()) -> 'ok'.
 bind_q_to_conference(Queue, 'discovery') ->
     bind_q_to_conference(Queue, 'discovery', 'undefined');
 bind_q_to_conference(Queue, 'command') ->
@@ -944,6 +1020,7 @@ bind_q_to_conference(Queue, 'event') ->
 bind_q_to_conference(Queue, 'config') ->
     bind_q_to_conference(Queue, 'config', <<"*">>).
 
+-spec bind_q_to_conference(kz_term:ne_binary(), conf_routing_type(), kz_term:api_binary()) -> 'ok'.
 bind_q_to_conference(Queue, 'discovery', _) ->
     bind_q_to_exchange(Queue, ?KEY_CONFERENCE_DISCOVERY, ?EXCHANGE_CONFERENCE);
 bind_q_to_conference(Queue, 'event', EventKey) ->
@@ -966,18 +1043,20 @@ unbind_q_from_leader(Queue, Bind) ->
     unbind_q_from_exchange(Queue, Bind, ?EXCHANGE_LEADER).
 
 -spec bind_q_to_tasks(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_tasks(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_tasks(Queue, Routing) ->
     bind_q_to_tasks(Queue, Routing, []).
+
+-spec bind_q_to_tasks(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_tasks(Queue, Routing, Options) ->
     bind_q_to_exchange(Queue, Routing, ?EXCHANGE_TASKS, Options).
 
 -spec bind_q_to_exchange(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec bind_q_to_exchange(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_exchange(Queue, _Routing, _Exchange) when not is_binary(Queue) ->
     {'error', 'invalid_queue_name'};
 bind_q_to_exchange(Queue, Routing, Exchange) ->
     bind_q_to_exchange(Queue, Routing, Exchange, []).
+
+-spec bind_q_to_exchange(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q_to_exchange(Queue, Routing, Exchange, Options) ->
     QB = #'queue.bind'{queue = Queue %% what queue does the binding attach to?
                       ,exchange = Exchange %% what exchange does the binding attach to?
@@ -993,9 +1072,8 @@ bind_q_to_exchange(Queue, Routing, Exchange, Options) ->
 %% Unbind a Queue from an Exchange
 %% @end
 %%------------------------------------------------------------------------------
+
 -spec unbind_q_from_conference(kz_term:ne_binary(), conf_routing_type()) ->
-                                      'ok' | {'error', any()}.
--spec unbind_q_from_conference(kz_term:ne_binary(), conf_routing_type(), kz_term:api_binary()) ->
                                       'ok' | {'error', any()}.
 unbind_q_from_conference(Queue, 'discovery') ->
     unbind_q_from_conference(Queue, 'discovery', 'undefined');
@@ -1006,6 +1084,8 @@ unbind_q_from_conference(Queue, 'config') ->
 unbind_q_from_conference(Queue, 'event') ->
     unbind_q_from_conference(Queue, 'event', <<"*">>).
 
+-spec unbind_q_from_conference(kz_term:ne_binary(), conf_routing_type(), kz_term:api_binary()) ->
+                                      'ok' | {'error', any()}.
 unbind_q_from_conference(Queue, 'discovery', _) ->
     unbind_q_from_exchange(Queue, ?KEY_CONFERENCE_DISCOVERY, ?EXCHANGE_CONFERENCE);
 unbind_q_from_conference(Queue, 'event', ConfId) ->
@@ -1103,9 +1183,11 @@ unbind_q_from_exchange(Queue, Routing, Exchange) ->
 %% @end
 %%------------------------------------------------------------------------------
 %% create a consumer for a Queue
+
 -spec basic_consume(kz_term:ne_binary()) -> 'ok' | {'error', any()}.
--spec basic_consume(kz_term:ne_binary(), kz_term:proplist()) -> 'ok' | {'error', any()}.
 basic_consume(Queue) -> basic_consume(Queue, []).
+
+-spec basic_consume(kz_term:ne_binary(), kz_term:proplist()) -> 'ok' | {'error', any()}.
 basic_consume(Queue, Options) ->
     BC = #'basic.consume'{queue = Queue
                          ,consumer_tag = <<>>
@@ -1123,9 +1205,11 @@ basic_consume(Queue, Options) ->
 %% but it does mean the server will not send any more messages for that consumer.
 %% @end
 %%------------------------------------------------------------------------------
+
 -spec basic_cancel() -> 'ok'.
--spec basic_cancel(kz_term:ne_binary()) -> 'ok'.
 basic_cancel() -> kz_amqp_channel:command(#'basic.cancel'{}).
+
+-spec basic_cancel(kz_term:ne_binary()) -> 'ok'.
 basic_cancel(ConsumerTag) -> kz_amqp_channel:command(#'basic.cancel'{consumer_tag=ConsumerTag}).
 
 %%------------------------------------------------------------------------------
@@ -1143,9 +1227,11 @@ confirm_select() -> kz_amqp_channel:command(#'confirm.select'{}).
 %% This method sets flow control
 %% @end
 %%------------------------------------------------------------------------------
+
 -spec flow_control() -> 'ok'.
--spec flow_control(boolean()) -> 'ok'.
 flow_control() -> flow_control('true').
+
+-spec flow_control(boolean()) -> 'ok'.
 flow_control(Active) ->
     kz_amqp_channel:command(#'channel.flow'{active=Active}).
 

--- a/core/kazoo_amqp/src/api/kapi_asr.erl
+++ b/core/kazoo_amqp/src/api/kapi_asr.erl
@@ -142,10 +142,12 @@ declare_exchanges() ->
 %% prepare and publish an asr request
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
     {ok, Payload} = kz_api:prepare_api_payload(Req, ?ASR_REQ_VALUES, fun req/1),
     amqp_util:callctl_publish(?KEY_ASR_REQ, Payload, ContentType).
@@ -155,10 +157,12 @@ publish_req(Req, ContentType) ->
 %% prepare and publish an asr response
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(Queue, JObj) ->
     publish_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(Queue, Resp, ContentType) ->
     {ok, Payload} = kz_api:prepare_api_payload(Resp, ?ASR_RESP_VALUES, fun resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
@@ -168,10 +172,12 @@ publish_resp(Queue, Resp, ContentType) ->
 %% prepare and publish an asr error
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_error(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(Queue, JObj) ->
     publish_error(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(Queue, Error, ContentType) ->
     {ok, Payload} = kz_api:prepare_api_payload(Error, ?ASR_ERROR_VALUES, fun error/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_authn.erl
+++ b/core/kazoo_amqp/src/api/kapi_authn.erl
@@ -171,26 +171,30 @@ declare_exchanges() ->
 %% @doc Publish the JSON iolist() to the proper Exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
     {ok, Payload} = kz_api:prepare_api_payload(Req, ?AUTHN_REQ_VALUES, fun req/1),
     amqp_util:callmgr_publish(Payload, ContentType, get_authn_req_routing(Req)).
 
 -spec publish_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_resp(Queue, JObj) ->
     publish_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_resp(Queue, Resp, ContentType) ->
     {ok, Payload} = kz_api:prepare_api_payload(Resp, ?AUTHN_RESP_VALUES, fun resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
 
 -spec publish_error(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_error(Queue, JObj) ->
     publish_error(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_error(Queue, Resp, ContentType) ->
     {ok, Payload} = kz_api:prepare_api_payload(Resp, ?AUTHN_ERR_VALUES, fun error/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_authz.erl
+++ b/core/kazoo_amqp/src/api/kapi_authz.erl
@@ -210,42 +210,48 @@ declare_exchanges() ->
 %% @doc Publish the JSON iolist() to the proper Exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_authz_req(kz_term:api_terms()) -> 'ok'.
--spec publish_authz_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_authz_req(JObj) ->
     publish_authz_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_authz_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_authz_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?AUTHZ_REQ_VALUES, fun authz_req/1),
     amqp_util:callmgr_publish(Payload, ContentType, ?KEY_AUTHZ_REQ).
 
 -spec publish_authz_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_authz_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_authz_resp(Queue, JObj) ->
     publish_authz_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_authz_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_authz_resp(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?AUTHZ_RESP_VALUES, fun authz_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
 
 -spec publish_balance_check_req(kz_term:api_terms()) -> 'ok'.
--spec publish_balance_check_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_balance_check_req(JObj) ->
     publish_balance_check_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_balance_check_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_balance_check_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?BALANCE_CHECK_REQ_VALUES, fun balance_check_req/1),
     amqp_util:callmgr_publish(Payload, ContentType, ?KEY_BALANCE_CHECK_REQ).
 
 -spec publish_balance_check_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_balance_check_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_balance_check_resp(Queue, JObj) ->
     publish_balance_check_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_balance_check_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_balance_check_resp(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?BALANCE_CHECK_RESP_VALUES, fun balance_check_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
 
 -spec broadcast_authz_resp(kz_term:api_terms()) -> 'ok'.
--spec broadcast_authz_resp(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 broadcast_authz_resp(JObj) ->
     broadcast_authz_resp(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec broadcast_authz_resp(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 broadcast_authz_resp(Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?AUTHZ_RESP_VALUES, fun authz_resp/1),
     amqp_util:callmgr_publish(Payload, ContentType, ?KEY_AUTHZ_BROADCAST).

--- a/core/kazoo_amqp/src/api/kapi_call.erl
+++ b/core/kazoo_amqp/src/api/kapi_call.erl
@@ -331,8 +331,9 @@ declare_exchanges() ->
     amqp_util:callmgr_exchange().
 
 -spec publish_event(kz_term:api_terms()) -> 'ok'.
--spec publish_event(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_event(Event) -> publish_event(Event, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_event(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_event(Event, ContentType) when is_list(Event) ->
     CallId = props:get_first_defined([<<"Origination-Call-ID">>, <<"Call-ID">>, <<"Unique-ID">>], Event),
     EventName = props:get_value(<<"Event-Name">>, Event),
@@ -342,45 +343,51 @@ publish_event(Event, ContentType) ->
     publish_event(kz_json:to_proplist(Event), ContentType).
 
 -spec publish_channel_status_req(kz_term:api_terms()) -> 'ok'.
--spec publish_channel_status_req(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_channel_status_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_channel_status_req(API) ->
     case is_list(API) of
         'true' -> publish_channel_status_req(props:get_value(<<"Call-ID">>, API), API);
         'false' -> publish_channel_status_req(kz_json:get_value(<<"Call-ID">>, API), API)
     end.
+
+-spec publish_channel_status_req(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
 publish_channel_status_req(CallId, JObj) ->
     publish_channel_status_req(CallId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_channel_status_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_channel_status_req(CallId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?CHANNEL_STATUS_REQ_VALUES, fun channel_status_req/1),
     amqp_util:callevt_publish(?CALL_EVENT_ROUTING_KEY('status_req', CallId), Payload, ContentType).
 
 -spec publish_channel_status_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_channel_status_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_channel_status_resp(RespQ, JObj) ->
     publish_channel_status_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_channel_status_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_channel_status_resp(RespQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?CHANNEL_STATUS_RESP_VALUES, fun channel_status_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_query_auth_id_req(kz_term:api_terms()) -> 'ok'.
--spec publish_query_auth_id_req(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_auth_id_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_auth_id_req(API) ->
     case is_list(API) of
         'true' -> publish_query_auth_id_req(props:get_value(<<"Auth-ID">>, API), API);
         'false' -> publish_query_auth_id_req(kz_json:get_value(<<"Auth-ID">>, API), API)
     end.
+
+-spec publish_query_auth_id_req(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
 publish_query_auth_id_req(AuthId, JObj) ->
     publish_query_auth_id_req(AuthId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_auth_id_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_auth_id_req(AuthId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?QUERY_AUTH_ID_REQ_VALUES, fun query_auth_id_req/1),
     amqp_util:callevt_publish(?CALL_EVENT_ROUTING_KEY('status_req', AuthId), Payload, ContentType).
 
 -spec publish_query_auth_id_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_auth_id_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_auth_id_resp(RespQ, JObj) ->
     publish_query_auth_id_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_auth_id_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_auth_id_resp(RespQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?QUERY_AUTH_ID_RESP_VALUES, fun query_auth_id_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
@@ -412,15 +419,15 @@ publish_query_user_channels_req(Req, Username, Realm, ContentType) ->
     amqp_util:callevt_publish(?CALL_EVENT_ROUTING_KEY('status_req', User), Payload, ContentType).
 
 -spec publish_query_user_channels_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_user_channels_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_user_channels_resp(RespQ, JObj) ->
     publish_query_user_channels_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_user_channels_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_user_channels_resp(RespQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?QUERY_USER_CHANNELS_RESP_VALUES, fun query_user_channels_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_query_account_channels_req(kz_term:api_terms()) -> 'ok'.
--spec publish_query_account_channels_req(kz_term:api_terms(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 publish_query_account_channels_req(Props) when is_list(Props) ->
     publish_query_account_channels_req(Props
                                       ,props:get_value(<<"Account-ID">>, Props)
@@ -432,21 +439,24 @@ publish_query_account_channels_req(JObj) ->
                                       ,?DEFAULT_CONTENT_TYPE
                                       ).
 
+-spec publish_query_account_channels_req(kz_term:api_terms(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 publish_query_account_channels_req(Req, AccountId, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?QUERY_ACCOUNT_CHANNELS_REQ_VALUES, fun query_account_channels_req/1),
     amqp_util:callevt_publish(?CALL_EVENT_ROUTING_KEY('status_req', AccountId), Payload, ContentType).
 
 -spec publish_query_account_channels_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_account_channels_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_account_channels_resp(RespQ, JObj) ->
     publish_query_account_channels_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_account_channels_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_account_channels_resp(RespQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?QUERY_ACCOUNT_CHANNELS_RESP_VALUES, fun query_account_channels_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_query_channels_req(kz_term:api_terms()) -> 'ok'.
--spec publish_query_channels_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_channels_req(ApiProps) -> publish_query_channels_req(ApiProps, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_channels_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_channels_req(ApiProps, ContentType) when is_list(ApiProps) ->
     {'ok', Payload} = kz_api:prepare_api_payload(ApiProps, ?QUERY_CHANNELS_REQ_VALUES, fun query_channels_req/1),
     amqp_util:callevt_publish(?CALL_EVENT_ROUTING_KEY('status_req', <<"channels">>), Payload, ContentType);
@@ -454,8 +464,9 @@ publish_query_channels_req(JObj, ContentType) ->
     publish_query_channels_req(kz_json:to_proplist(JObj), ContentType).
 
 -spec publish_query_channels_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_channels_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_channels_resp(RespQ, ApiProps) -> publish_query_channels_resp(RespQ, ApiProps, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_channels_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_channels_resp(RespQ, ApiProps, ContentType) when is_list(ApiProps) ->
     {'ok', Payload} = kz_api:prepare_api_payload(ApiProps, ?QUERY_CHANNELS_RESP_VALUES, fun query_channels_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType);
@@ -463,17 +474,19 @@ publish_query_channels_resp(RespQ, JObj, ContentType) ->
     publish_query_channels_resp(RespQ, kz_json:to_proplist(JObj), ContentType).
 
 -spec publish_usurp_control(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_usurp_control(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_usurp_control(CallId, JObj) ->
     publish_usurp_control(CallId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_usurp_control(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_usurp_control(CallId, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?CALL_USURP_CONTROL_VALUES, fun usurp_control/1),
     amqp_util:callevt_publish(?CALL_EVENT_ROUTING_KEY('usurp_control', CallId), Payload, ContentType).
 
 -spec publish_usurp_publisher(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_usurp_publisher(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_usurp_publisher(CallId, JObj) ->
     publish_usurp_publisher(CallId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_usurp_publisher(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_usurp_publisher(CallId, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?PUBLISHER_USURP_CONTROL_VALUES, fun usurp_publisher/1),
     amqp_util:callevt_publish(?CALL_EVENT_ROUTING_KEY('publisher_usurp', CallId), Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_camping.erl
+++ b/core/kazoo_amqp/src/api/kapi_camping.erl
@@ -61,9 +61,10 @@ declare_exchanges() ->
     amqp_util:callmgr_exchange().
 
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?REQ_VALUES, fun req/1),
     amqp_util:callmgr_publish(Payload, ContentType, ?REQ_ROUTING_KEY(get_account_id(Req))).

--- a/core/kazoo_amqp/src/api/kapi_conf.erl
+++ b/core/kazoo_amqp/src/api/kapi_conf.erl
@@ -155,10 +155,10 @@ doc_type_update_v(JObj) ->
     doc_type_update_v(kz_json:to_proplist(JObj)).
 
 -spec bind_q(binary(), kz_term:proplist()) -> 'ok'.
--spec bind_q(binary(), kz_term:proplist(), kz_term:api_atoms()) -> 'ok'.
 bind_q(Q, Props) ->
     bind_q(Q, Props, props:get_value('restrict_to', Props)).
 
+-spec bind_q(binary(), kz_term:proplist(), kz_term:api_atoms()) -> 'ok'.
 bind_q(Q, Props, 'undefined') ->
     bind_for_doc_changes(Q, Props);
 bind_q(Q, Props, ['doc_updates'|Restrict]) ->
@@ -204,10 +204,10 @@ bind_for_doc_types(Q, Props) ->
     end.
 
 -spec unbind_q(binary(), kz_term:proplist()) -> 'ok'.
--spec unbind_q(binary(), kz_term:proplist(), kz_term:api_atoms()) -> 'ok'.
 unbind_q(Q, Props) ->
     unbind_q(Q, Props, props:get_value('restrict_to', Props)).
 
+-spec unbind_q(binary(), kz_term:proplist(), kz_term:api_atoms()) -> 'ok'.
 unbind_q(Q, Props, 'undefined') ->
     unbind_for_doc_changes(Q, Props);
 unbind_q(Q, Props, ['doc_updates'|Restrict]) ->
@@ -272,25 +272,28 @@ get_routing_key(Props) ->
     amqp_util:document_routing_key(Action, Db, Type, Id).
 
 -spec publish_doc_update(action(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_doc_update(action(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_doc_update(Action, Db, Type, Id, JObj) ->
     publish_doc_update(Action, Db, Type, Id, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_doc_update(action(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_doc_update(Action, Db, Type, Id, Change, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Change, ?CONF_DOC_UPDATE_VALUES, fun doc_update/1),
     amqp_util:document_change_publish(Action, Db, Type, Id, Payload, ContentType).
 
 -spec publish_db_update(action(), kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_db_update(action(), kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_db_update(Action, Db, JObj) ->
     publish_db_update(Action, Db, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_db_update(action(), kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_db_update(Action, Db, Change, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Change, ?CONF_DOC_UPDATE_VALUES, fun doc_update/1),
     amqp_util:document_change_publish(Action, Db, <<"database">>, Db, Payload, ContentType).
 
 -spec publish_doc_type_update(kz_term:api_terms()) -> 'ok'.
--spec publish_doc_type_update(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_doc_type_update(JObj) ->
     publish_doc_type_update(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_doc_type_update(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_doc_type_update(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?DOC_TYPE_UPDATE_VALUES, fun doc_type_update/1),
     amqp_util:configuration_publish(doc_type_update_routing_key(API), Payload, ContentType, [{'mandatory', 'true'}]).

--- a/core/kazoo_amqp/src/api/kapi_conference.erl
+++ b/core/kazoo_amqp/src/api/kapi_conference.erl
@@ -1227,10 +1227,12 @@ declare_exchanges() ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_search_req(kz_term:api_terms()) -> 'ok'.
--spec publish_search_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_search_req(JObj) ->
     publish_search_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_search_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_search_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?SEARCH_REQ_VALUES, fun search_req/1),
     amqp_util:conference_publish(Payload, 'discovery', 'undefined', [], ContentType).
@@ -1240,10 +1242,12 @@ publish_search_req(Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_search_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_search_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_search_resp(Queue, Resp) ->
     publish_search_resp(Queue, Resp, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_search_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_search_resp(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?SEARCH_RESP_VALUES, fun search_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
@@ -1253,10 +1257,12 @@ publish_search_resp(Queue, Resp, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_discovery_req(kz_term:api_terms()) -> 'ok'.
--spec publish_discovery_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_discovery_req(JObj) ->
     publish_discovery_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_discovery_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_discovery_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DISCOVERY_REQ_VALUES, fun discovery_req/1),
     amqp_util:conference_publish(Payload, 'discovery', 'undefined', [], ContentType).
@@ -1266,10 +1272,12 @@ publish_discovery_req(Req, ContentType) ->
 %% Publish the response to requestor
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_discovery_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_discovery_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_discovery_resp(Q, JObj) ->
     publish_discovery_resp(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_discovery_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_discovery_resp(Q, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DISCOVERY_RESP_VALUES, fun discovery_resp/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
@@ -1279,10 +1287,12 @@ publish_discovery_resp(Q, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_add_participant(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_add_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_add_participant(Zone, JObj) ->
     publish_add_participant(Zone, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_add_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_add_participant(Zone, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?ADD_PARTICIPANT_VALUES, fun add_participant/1),
     amqp_util:conference_publish(Payload, 'command', Zone, [], ContentType).
@@ -1292,10 +1302,12 @@ publish_add_participant(Zone, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_deaf_participant(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_deaf_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_deaf_participant(ConferenceId, JObj) ->
     publish_deaf_participant(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_deaf_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_deaf_participant(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DEAF_PARTICIPANT_VALUES, fun deaf_participant/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1305,10 +1317,12 @@ publish_deaf_participant(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_participant_energy(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_participant_energy(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participant_energy(ConferenceId, JObj) ->
     publish_participant_energy(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_participant_energy(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participant_energy(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PARTICIPANT_ENERGY_VALUES, fun participant_energy/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1318,10 +1332,12 @@ publish_participant_energy(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_kick(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_kick(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_kick(ConferenceId, JObj) ->
     publish_kick(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_kick(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_kick(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?KICK_VALUES, fun kick/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1331,10 +1347,12 @@ publish_kick(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_participants_req(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_participants_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participants_req(ConferenceId, JObj) ->
     publish_participants_req(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_participants_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participants_req(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PARTICIPANTS_REQ_VALUES, fun participants_req/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1344,10 +1362,12 @@ publish_participants_req(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_participants_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_participants_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participants_resp(Queue, Resp) ->
     publish_participants_resp(Queue, Resp, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_participants_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participants_resp(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?PARTICIPANTS_RESP_VALUES, fun participants_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
@@ -1357,10 +1377,12 @@ publish_participants_resp(Queue, Resp, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_lock(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_lock(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_lock(ConferenceId, JObj) ->
     publish_lock(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_lock(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_lock(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?LOCK_VALUES, fun lock/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1370,10 +1392,12 @@ publish_lock(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_mute_participant(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_mute_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_mute_participant(ConferenceId, JObj) ->
     publish_mute_participant(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_mute_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_mute_participant(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?MUTE_PARTICIPANT_VALUES, fun mute_participant/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1383,10 +1407,12 @@ publish_mute_participant(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_play(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_play(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_play(ConferenceId, JObj) ->
     publish_play(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_play(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_play(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PLAY_VALUES, fun play/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1396,10 +1422,12 @@ publish_play(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_record(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_record(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_record(ConferenceId, JObj) ->
     publish_record(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_record(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_record(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?RECORD_VALUES, fun record/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1409,10 +1437,12 @@ publish_record(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_recordstop(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_recordstop(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_recordstop(ConferenceId, JObj) ->
     publish_recordstop(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_recordstop(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_recordstop(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?RECORDSTOP_VALUES, fun recordstop/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1422,10 +1452,12 @@ publish_recordstop(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_relate_participants(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_relate_participants(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_relate_participants(ConferenceId, JObj) ->
     publish_relate_participants(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_relate_participants(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_relate_participants(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?RELATE_PARTICIPANTS_VALUES, fun relate_participants/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1435,10 +1467,12 @@ publish_relate_participants(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_set(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_set(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_set(ConferenceId, JObj) ->
     publish_set(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_set(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_set(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?SET_VALUES, fun set/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1448,10 +1482,12 @@ publish_set(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_stop_play(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_stop_play(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_stop_play(ConferenceId, JObj) ->
     publish_stop_play(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_stop_play(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_stop_play(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?STOP_PLAY_VALUES, fun stop_play/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1461,10 +1497,12 @@ publish_stop_play(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_undeaf_participant(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_undeaf_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_undeaf_participant(ConferenceId, JObj) ->
     publish_undeaf_participant(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_undeaf_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_undeaf_participant(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?UNDEAF_PARTICIPANT_VALUES, fun undeaf_participant/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1474,10 +1512,12 @@ publish_undeaf_participant(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_unlock(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_unlock(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_unlock(ConferenceId, JObj) ->
     publish_unlock(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_unlock(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_unlock(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?UNLOCK_VALUES, fun unlock/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1487,10 +1527,12 @@ publish_unlock(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_unmute_participant(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_unmute_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_unmute_participant(ConferenceId, JObj) ->
     publish_unmute_participant(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_unmute_participant(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_unmute_participant(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?UNMUTE_PARTICIPANT_VALUES, fun unmute_participant/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1500,10 +1542,12 @@ publish_unmute_participant(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_participant_volume_in(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_participant_volume_in(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participant_volume_in(ConferenceId, JObj) ->
     publish_participant_volume_in(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_participant_volume_in(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participant_volume_in(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PARTICIPANT_VOLUME_IN_VALUES, fun participant_volume_in/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1513,10 +1557,12 @@ publish_participant_volume_in(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_participant_volume_out(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_participant_volume_out(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participant_volume_out(ConferenceId, JObj) ->
     publish_participant_volume_out(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_participant_volume_out(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participant_volume_out(ConferenceId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PARTICIPANT_VOLUME_OUT_VALUES, fun participant_volume_out/1),
     amqp_util:conference_publish(Payload, 'command', ConferenceId, [], ContentType).
@@ -1526,10 +1572,12 @@ publish_participant_volume_out(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_participant_event(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_participant_event(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participant_event(ConferenceId, CallId, JObj) ->
     publish_participant_event(ConferenceId, CallId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_participant_event(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_participant_event(ConferenceId, CallId, Event, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Event, ?PARTICIPANT_EVENT_VALUES, fun participant_event/1),
     amqp_util:conference_publish(Payload, 'event', ConferenceId, amqp_util:encode(CallId), [], ContentType).
@@ -1539,10 +1587,12 @@ publish_participant_event(ConferenceId, CallId, Event, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_event(kz_term:api_terms()) -> 'ok'.
--spec publish_event(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_event(API) ->
     publish_event(API, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_event(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_event(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?CONFERENCE_EVENT_VALUES, fun event/1),
     amqp_util:conference_publish(Payload, 'event', event_key(API), [], ContentType).
@@ -1576,10 +1626,12 @@ event_key(API) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_error(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(Queue, JObj) ->
     publish_error(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(Queue, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?CONFERENCE_ERROR_VALUES, fun conference_error/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
@@ -1589,10 +1641,12 @@ publish_error(Queue, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_command(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_command(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_command(ConferenceId, JObj) ->
     publish_command(ConferenceId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_command(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_command(ConferenceId, Req, ContentType) ->
     App = props:get_value(<<"Application-Name">>, Req),
     case lists:keyfind(App, 1, ?APPLICTION_MAP) of
@@ -1607,10 +1661,12 @@ publish_command(ConferenceId, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_targeted_command(atom(), kz_term:api_terms()) -> 'ok'.
--spec publish_targeted_command(atom(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_targeted_command(Focus, JObj) ->
     publish_targeted_command(Focus, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_targeted_command(atom(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_targeted_command(Focus, Req, ContentType) ->
     App = props:get_value(<<"Application-Name">>, Req),
     case lists:keyfind(App, 1, ?APPLICTION_MAP) of
@@ -1626,10 +1682,12 @@ publish_targeted_command(Focus, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_config_req(kz_term:api_terms()) -> 'ok'.
--spec publish_config_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_config_req(JObj) ->
     publish_config_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_config_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_config_req(Req, ContentType) ->
     Profile = profile(Req),
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?CONFIG_REQ_VALUES, fun config_req/1),
@@ -1643,10 +1701,12 @@ profile(JObj) -> kz_json:get_value(<<"Profile">>, JObj).
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_config_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_config_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_config_resp(Queue, JObj) ->
     publish_config_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_config_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_config_resp(Queue, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?CONFIG_RESP_VALUES, fun config_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
@@ -1656,18 +1716,21 @@ publish_config_resp(Queue, Req, ContentType) ->
 %% Publish to the conference exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_dial(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_dial(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_dial(Zone, JObj) ->
     publish_dial(Zone, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_dial(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_dial(Zone, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DIAL_VALUES, fun dial/1),
     amqp_util:conference_publish(Payload, 'command', Zone, [], ContentType).
 
 -spec publish_dial_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_dial_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_dial_resp(Queue, JObj) ->
     publish_dial_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_dial_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_dial_resp(Queue, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DIAL_RESP_VALUES, fun dial_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_delegate.erl
+++ b/core/kazoo_amqp/src/api/kapi_delegate.erl
@@ -60,22 +60,24 @@ delegate_v(Prop) when is_list(Prop) ->
 delegate_v(JObj) -> delegate_v(kz_json:to_proplist(JObj)).
 
 -spec bind_q(kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
--spec bind_q(kz_term:ne_binary(), kz_term:ne_binary(), maybe_key()) -> 'ok'.
 bind_q(Q, Props) ->
     App = props:get_binary_value('app_name', Props),
     Key = props:get_value('route_key', Props),
     bind_q(Q, App, Key).
+
+-spec bind_q(kz_term:ne_binary(), kz_term:ne_binary(), maybe_key()) -> 'ok'.
 bind_q(Q, <<_/binary>> = App, 'undefined') ->
     amqp_util:bind_q_to_kapps(Q, ?DELEGATE_ROUTING_KEY(App));
 bind_q(Q, <<_/binary>> = App, <<_/binary>> = Key) ->
     amqp_util:bind_q_to_kapps(Q, ?DELEGATE_ROUTING_KEY(App, Key)).
 
 -spec unbind_q(kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
--spec unbind_q(kz_term:ne_binary(), kz_term:ne_binary(), maybe_key()) -> 'ok'.
 unbind_q(Q, Props) ->
     App = props:get_binary_value('app_name', Props),
     Key = props:get_value('route_key', Props),
     unbind_q(Q, App, Key).
+
+-spec unbind_q(kz_term:ne_binary(), kz_term:ne_binary(), maybe_key()) -> 'ok'.
 unbind_q(Q, <<_/binary>> = App, 'undefined') ->
     amqp_util:unbind_q_from_kapps(Q, ?DELEGATE_ROUTING_KEY(App));
 unbind_q(Q, <<_/binary>> = App, <<_/binary>> = Key) ->
@@ -94,15 +96,16 @@ declare_exchanges() ->
 %% @doc Publish the JSON iolist() to the proper Exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_delegate(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_delegate(kz_term:ne_binary(), kz_term:api_terms(), maybe_key()) -> 'ok'.
--spec publish_delegate(kz_term:ne_binary(), kz_term:api_terms(), maybe_key(), binary()) -> 'ok'.
 publish_delegate(TargetApp, API) ->
     publish_delegate(TargetApp, API, 'undefined').
 
+-spec publish_delegate(kz_term:ne_binary(), kz_term:api_terms(), maybe_key()) -> 'ok'.
 publish_delegate(TargetApp, API, Key) ->
     publish_delegate(TargetApp, API, Key, ?DEFAULT_CONTENT_TYPE).
 
+-spec publish_delegate(kz_term:ne_binary(), kz_term:api_terms(), maybe_key(), binary()) -> 'ok'.
 publish_delegate(<<_/binary>> = TargetApp, API, 'undefined', ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?DELEGATE_VALUES, fun delegate/1),
     amqp_util:kapps_publish(?DELEGATE_ROUTING_KEY(TargetApp), Payload, ContentType);

--- a/core/kazoo_amqp/src/api/kapi_dialplan.erl
+++ b/core/kazoo_amqp/src/api/kapi_dialplan.erl
@@ -1088,14 +1088,14 @@ error_v(Prop) when is_list(Prop) ->
 error_v(JObj) -> error_v(kz_json:to_proplist(JObj)).
 
 %% Takes a generic API JObj, determines what type it is, and calls the appropriate validator
--spec publish_command(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_command(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 
+-spec publish_command(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
 publish_command(CtrlQ, Prop) when is_list(Prop) ->
     publish_command(CtrlQ, Prop, props:get_value(<<"Application-Name">>, Prop));
 publish_command(CtrlQ, JObj) ->
     publish_command(CtrlQ, kz_json:to_proplist(JObj)).
 
+-spec publish_command(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_command(CtrlQ, Prop, DPApp) ->
     {'ok', Payload} = build_command(Prop, DPApp),
     amqp_util:callctl_publish(CtrlQ, Payload, ?DEFAULT_CONTENT_TYPE).
@@ -1124,17 +1124,20 @@ build_command(JObj, DPApp) ->
     build_command(kz_json:to_proplist(JObj), DPApp).
 
 %% sending DP actions to CallControl Queue
+
 -spec publish_action(kz_term:ne_binary(), iodata()) -> 'ok'.
--spec publish_action(kz_term:ne_binary(), iodata(), kz_term:ne_binary()) -> 'ok'.
 publish_action(Queue, JSON) ->
     publish_action(Queue, JSON, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_action(kz_term:ne_binary(), iodata(), kz_term:ne_binary()) -> 'ok'.
 publish_action(Queue, Payload, ContentType) ->
     amqp_util:callctl_publish(Queue, Payload, ContentType).
 
 -spec publish_error(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(CallID, JObj) ->
     publish_error(CallID, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(CallID, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, [{<<"Event-Name">>, <<"dialplan">>}
                                                        | ?ERROR_RESP_VALUES
@@ -1142,17 +1145,19 @@ publish_error(CallID, API, ContentType) ->
     amqp_util:callevt_publish(kapi_call:event_routing_key(<<"diaplan">>, CallID), Payload, ContentType).
 
 -spec publish_originate_ready(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_originate_ready(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_ready(ServerId, JObj) ->
     publish_originate_ready(ServerId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_originate_ready(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_ready(ServerId, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?ORIGINATE_READY_VALUES, fun originate_ready/1),
     amqp_util:targeted_publish(ServerId, Payload, ContentType).
 
 -spec publish_originate_execute(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_originate_execute(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_execute(ServerId, JObj) ->
     publish_originate_execute(ServerId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_originate_execute(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_execute(ServerId, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?ORIGINATE_EXECUTE_VALUES, fun originate_execute/1),
     amqp_util:targeted_publish(ServerId, Payload, ContentType).
@@ -1186,13 +1191,13 @@ terminators(Bin) when is_binary(Bin) ->
 terminators('undefined') -> ?ANY_DIGIT.
 
 -spec terminators_v(kz_term:api_binaries() | binary()) -> boolean().
--spec terminator_v(kz_term:ne_binary()) -> boolean().
 terminators_v(Ts) when is_list(Ts) ->
     lists:all(fun terminator_v/1, Ts);
 terminators_v(<<>>) -> 'true';
 terminators_v(<<"none">>) -> 'true';
 terminators_v(_) -> 'false'.
 
+-spec terminator_v(kz_term:ne_binary()) -> boolean().
 terminator_v(T) -> lists:member(T, ?ANY_DIGIT).
 
 -spec offsite_store_url(kz_term:api_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().

--- a/core/kazoo_amqp/src/api/kapi_fax.erl
+++ b/core/kazoo_amqp/src/api/kapi_fax.erl
@@ -231,28 +231,28 @@ declare_exchanges() ->
     amqp_util:callmgr_exchange().
 
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
 
+-spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Api, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Api, ?FAX_REQ_VALUES, fun req/1),
     amqp_util:callmgr_publish(Payload, ContentType, fax_routing_key()).
 
 -spec publish_query_status(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_status(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_status(Q, JObj) ->
     publish_query_status(Q, JObj, ?DEFAULT_CONTENT_TYPE).
 
+-spec publish_query_status(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_status(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?FAX_QUERY_VALUES, fun query_status/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_status(kz_term:api_terms()) -> 'ok'.
--spec publish_status(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_status(API) ->
     publish_status(API, ?DEFAULT_CONTENT_TYPE).
 
+-spec publish_status(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_status(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?FAX_STATUS_VALUES, fun status/1),
     FaxId = props:get_first_defined([<<"Fax-ID">>,<<"Job-ID">>], API,<<"*">>),
@@ -260,29 +260,29 @@ publish_status(API, ContentType) ->
     amqp_util:basic_publish(?FAX_EXCHANGE, status_routing_key(AccountId, FaxId), Payload, ContentType).
 
 -spec publish_targeted_status(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_targeted_status(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_targeted_status(Q, JObj) ->
     publish_targeted_status(Q, JObj, ?DEFAULT_CONTENT_TYPE).
 
+-spec publish_targeted_status(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_targeted_status(Q, Api, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Api, ?FAX_STATUS_VALUES, fun status/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_start_account(kz_term:api_terms()) -> 'ok'.
--spec publish_start_account(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_start_account(API) ->
     publish_start_account(API, ?DEFAULT_CONTENT_TYPE).
 
+-spec publish_start_account(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_start_account(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?FAX_START_ACCOUNT_VALUES, fun start_account/1),
     AccountId = props:get_value(<<"Account-ID">>, API,<<"*">>),
     amqp_util:basic_publish(?FAX_EXCHANGE, fax_start_key(<<"account">>, AccountId), Payload, ContentType).
 
 -spec publish_start_job(kz_term:api_terms()) -> 'ok'.
--spec publish_start_job(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_start_job(API) ->
     publish_start_job(API, ?DEFAULT_CONTENT_TYPE).
 
+-spec publish_start_job(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_start_job(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?FAX_START_JOB_VALUES, fun start_job/1),
     JobId = props:get_value(<<"Job-ID">>, API,<<"*">>),

--- a/core/kazoo_amqp/src/api/kapi_fs.erl
+++ b/core/kazoo_amqp/src/api/kapi_fs.erl
@@ -55,9 +55,10 @@ declare_exchanges() ->
     amqp_util:callctl_exchange().
 
 -spec publish_req(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Queue, JObj) ->
     publish_req(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Queue, Req, ContentType) ->
     {ok, Payload} = kz_api:prepare_api_payload(Req, ?FS_REQ_VALUES, fun req/1),
     amqp_util:callctl_publish(Queue, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_globals.erl
+++ b/core/kazoo_amqp/src/api/kapi_globals.erl
@@ -333,17 +333,19 @@ declare_exchanges() ->
     amqp_util:new_exchange(?GLOBALS_EXCHANGE, ?GLOBALS_EXCHANGE_TYPE).
 
 -spec publish_targeted_call(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_targeted_call(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_targeted_call(ServerId, JObj) ->
     publish_targeted_call(ServerId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_targeted_call(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_targeted_call(ServerId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?CALL_REQ_VALUES, fun call/1),
     amqp_util:targeted_publish(ServerId, Payload, ContentType).
 
 -spec publish_call(kz_term:api_terms()) -> 'ok'.
--spec publish_call(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_call(JObj) ->
     publish_call(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_call(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_call(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?CALL_REQ_VALUES, fun call/1),
     Name = name(Req),
@@ -351,17 +353,19 @@ publish_call(Req, ContentType) ->
     publish(RoutingKey, Payload, ContentType).
 
 -spec publish_targeted_send(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_targeted_send(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_targeted_send(ServerId, JObj) ->
     publish_targeted_send(ServerId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_targeted_send(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_targeted_send(ServerId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?SEND_REQ_VALUES, fun send/1),
     amqp_util:targeted_publish(ServerId, Payload, ContentType).
 
 -spec publish_send(kz_term:api_terms()) -> 'ok'.
--spec publish_send(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_send(JObj) ->
     publish_send(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_send(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_send(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?SEND_REQ_VALUES, fun send/1),
     Name = name(Req),
@@ -369,51 +373,57 @@ publish_send(Req, ContentType) ->
     publish(RoutingKey, Payload, ContentType).
 
 -spec publish_reply(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_reply(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_reply(ServerId, JObj) ->
     publish_reply(ServerId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_reply(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_reply(ServerId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?REPLY_REQ_VALUES, fun reply_msg/1),
     amqp_util:targeted_publish(ServerId, Payload, ContentType).
 
 -spec publish_register(kz_term:api_terms()) -> 'ok'.
--spec publish_register(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_register(Req) ->
     publish_register(Req, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_register(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_register(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?REGISTER_REQ_VALUES, fun register/1),
     RoutingKey = ?GLOBALS_EVENT_ROUTING_KEY(<<"register">>, name(Req)),
     publish(RoutingKey, Payload, ContentType).
 
 -spec publish_register_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_register_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_register_resp(ServerId, JObj) ->
     publish_register_resp(ServerId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_register_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_register_resp(ServerId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?REGISTER_RESP_VALUES, fun register_resp/1),
     amqp_util:targeted_publish(ServerId, Payload, ContentType).
 
 -spec publish_unregister(kz_term:api_terms()) -> 'ok'.
--spec publish_unregister(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_unregister(Req) ->
     publish_unregister(Req, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_unregister(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_unregister(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?UNREGISTER_REQ_VALUES, fun unregister/1),
     RoutingKey = ?GLOBALS_EVENT_ROUTING_KEY(<<"unregister">>, name(Req)),
     publish(RoutingKey, Payload, ContentType).
 
 -spec publish_query_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_resp(ServerId, JObj) ->
     publish_query_resp(ServerId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_resp(ServerId, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?QUERY_RESP_VALUES, fun query_resp/1),
     amqp_util:targeted_publish(ServerId, Payload, ContentType).
 
 -spec publish_query(kz_term:api_terms()) -> 'ok'.
--spec publish_query(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query(JObj) ->
     publish_query(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(encode_req(Req), ?QUERY_REQ_VALUES, fun query/1),
     Name = name(Req),

--- a/core/kazoo_amqp/src/api/kapi_hangups.erl
+++ b/core/kazoo_amqp/src/api/kapi_hangups.erl
@@ -96,17 +96,19 @@ declare_exchanges() ->
     amqp_util:kapps_exchange().
 
 -spec publish_query_req(kz_term:api_terms()) -> 'ok'.
--spec publish_query_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_req(JObj) ->
     publish_query_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_req(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?QUERY_REQ_VALUES, fun query_req/1),
     amqp_util:kapps_publish(?QUERY_REQ_ROUTING_KEY, Payload, ContentType).
 
 -spec publish_query_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_resp(RespQ, JObj) ->
     publish_query_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_resp(RespQ, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?QUERY_RESP_VALUES, fun query_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_inspector.erl
+++ b/core/kazoo_amqp/src/api/kapi_inspector.erl
@@ -124,33 +124,37 @@ declare_exchanges() ->
     amqp_util:monitor_exchange().
 
 -spec publish_lookup_req(kz_term:api_terms()) -> 'ok'.
--spec publish_lookup_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_lookup_req(JObj) ->
     publish_lookup_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_lookup_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_lookup_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?LOOKUP_REQ_VALUES, fun lookup_req/1),
     amqp_util:monitor_publish(Payload, ContentType, ?CI_AMQP_KEY(<<"lookup">>)).
 
 -spec publish_lookup_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_lookup_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_lookup_resp(RespQ, JObj) ->
     publish_lookup_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_lookup_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_lookup_resp(RespQ, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?LOOKUP_RESP_VALUES, fun lookup_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_filter_req(kz_term:api_terms()) -> 'ok'.
--spec publish_filter_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_filter_req(JObj) ->
     publish_filter_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_filter_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_filter_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?FILTER_REQ_VALUES, fun filter_req/1),
     amqp_util:monitor_publish(Payload, ContentType, ?CI_AMQP_KEY(<<"filter">>)).
 
 -spec publish_filter_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_filter_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_filter_resp(RespQ, JObj) ->
     publish_filter_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_filter_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_filter_resp(RespQ, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?FILTER_RESP_VALUES, fun filter_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_leader.erl
+++ b/core/kazoo_amqp/src/api/kapi_leader.erl
@@ -92,9 +92,10 @@ declare_exchanges() ->
     amqp_util:leader_exchange().
 
 -spec publish_req(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Routing, JObj) ->
     publish_req(Routing, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Routing, Req, ContentType) ->
     {ok, Payload} = kz_api:prepare_api_payload(Req, ?LEADER_REQ_VALUES, fun req/1),
     amqp_util:leader_publish(Routing, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_media.erl
+++ b/core/kazoo_amqp/src/api/kapi_media.erl
@@ -140,25 +140,28 @@ declare_exchanges() ->
     amqp_util:kapps_exchange().
 
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?MEDIA_REQ_VALUES, fun req/1),
     amqp_util:kapps_publish(?MEDIA_REQ_ROUTING_KEY, Payload, ContentType).
 
 -spec publish_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(Queue, JObj) ->
     publish_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?MEDIA_RESP_VALUES, fun resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
 
 -spec publish_error(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(Queue, JObj) ->
     publish_error(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(Queue, Error, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Error, ?MEDIA_ERROR_VALUES, fun error/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_metaflow.erl
+++ b/core/kazoo_amqp/src/api/kapi_metaflow.erl
@@ -234,27 +234,30 @@ declare_exchanges() ->
     amqp_util:new_exchange(?METAFLOW_EXCHANGE, ?METAFLOW_EXCHANGE_TYPE).
 
 -spec publish_flow(kz_term:api_terms()) -> 'ok'.
--spec publish_flow(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flow(JObj) ->
     publish_flow(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_flow(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flow(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?METAFLOW_FLOW_VALUES, fun flow/1),
     RK = ?METAFLOW_FLOW_ROUTING_KEY(rk_call_id(Req)),
     amqp_util:basic_publish(?METAFLOW_EXCHANGE, RK, Payload, ContentType).
 
 -spec publish_action(kz_term:api_terms()) -> 'ok'.
--spec publish_action(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_action(JObj) ->
     publish_action(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_action(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_action(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?METAFLOW_ACTION_VALUES, fun action/1),
     RK = ?METAFLOW_ACTION_ROUTING_KEY(rk_call_id(Req), rk_action(Req)),
     amqp_util:basic_publish(?METAFLOW_EXCHANGE, RK, Payload, ContentType).
 
 -spec publish_bind_req(kz_term:api_terms()) -> 'ok'.
--spec publish_bind_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_bind_req(JObj) ->
     publish_bind_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_bind_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_bind_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?METAFLOW_BIND_REQ_VALUES, fun bind_req/1),
     RK = ?METAFLOW_BIND_REQ_ROUTING_KEY(rk_account_id(Req), rk_binding_leg(Req)),
@@ -281,9 +284,10 @@ rk_binding_leg(JObj) ->
     kz_json:get_value(<<"Binding-Leg">>, JObj).
 
 -spec publish_binding(kz_term:api_terms()) -> 'ok'.
--spec publish_binding(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_binding(API) ->
     publish_binding(API, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_binding(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_binding(API0, ContentType) ->
     API = ensure_callid(API0),
     CallId = rk_call_id(API),
@@ -293,9 +297,10 @@ publish_binding(API0, ContentType) ->
     amqp_util:basic_publish(?METAFLOW_EXCHANGE, RK, Payload, ContentType).
 
 -spec publish_bind_reply(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_bind_reply(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_bind_reply(Q, API) ->
     publish_bind_reply(Q, API, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_bind_reply(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_bind_reply(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?METAFLOW_BIND_VALUES, fun binding/1),
     amqp_util:targeted_publish(Q, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_money.erl
+++ b/core/kazoo_amqp/src/api/kapi_money.erl
@@ -165,36 +165,40 @@ routing_key(Props) ->
                    ]).
 
 -spec publish_credit(kz_term:api_terms()) -> 'ok'.
--spec publish_credit(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_credit(Req) ->
     publish_credit(Req, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_credit(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_credit(Req, ContentType) ->
     RoutingKey = list_to_binary([<<"transaction.credit.">>, props:get_value(<<"Account-ID">>, Req)]),
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?CREDIT_VALUES, fun credit/1),
     amqp_util:configuration_publish(RoutingKey, Payload, ContentType).
 
 -spec publish_debit(kz_term:api_terms()) -> 'ok'.
--spec publish_debit(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_debit(Req) ->
     publish_debit(Req, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_debit(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_debit(Req, ContentType) ->
     RoutingKey = list_to_binary([<<"transaction.debit.">>, props:get_value(<<"Account-ID">>, Req)]),
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DEBIT_VALUES, fun debit/1),
     amqp_util:configuration_publish(RoutingKey, Payload, ContentType).
 
 -spec publish_balance_req(kz_term:api_terms()) -> 'ok'.
--spec publish_balance_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_balance_req(Req) ->
     publish_balance_req(Req, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_balance_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_balance_req(Req, ContentType) ->
     RoutingKey = list_to_binary([<<"transaction.balance.">>, props:get_value(<<"Account-ID">>, Req)]),
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?BALANCE_REQ_VALUES, fun balance_req/1),
     amqp_util:configuration_publish(RoutingKey, Payload, ContentType).
 
 -spec publish_balance_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_balance_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_balance_resp(Queue, Req) ->
     publish_balance_resp(Queue, Req, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_balance_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_balance_resp(Queue, Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?BALANCE_RESP_VALUES, fun balance_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_nodes.erl
+++ b/core/kazoo_amqp/src/api/kapi_nodes.erl
@@ -90,10 +90,12 @@ declare_exchanges() ->
 %% prepare and publish a nodes advertise message
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_advertise(kz_term:api_terms()) -> 'ok'.
--spec publish_advertise(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_advertise(JObj) ->
     publish_advertise(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_advertise(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_advertise(Advertise, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Advertise, ?ADVERTISE_VALUES, fun advertise/1),
     amqp_util:nodes_publish(Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
+++ b/core/kazoo_amqp/src/api/kapi_offnet_resource.erl
@@ -241,111 +241,124 @@ declare_exchanges() ->
     amqp_util:resource_exchange().
 
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
 
+-spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?OFFNET_RESOURCE_REQ_VALUES, fun req/1),
     amqp_util:offnet_resource_publish(Payload, ContentType).
 
 -spec publish_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(TargetQ, JObj) ->
     publish_resp(TargetQ, JObj, ?DEFAULT_CONTENT_TYPE).
 
+-spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(TargetQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?OFFNET_RESOURCE_RESP_VALUES, fun resp/1),
     amqp_util:targeted_publish(TargetQ, Payload, ContentType).
 
 -spec force_outbound(req()) -> boolean().
--spec force_outbound(req(), Default) -> boolean() | Default.
 force_outbound(Req) ->
     force_outbound(Req, 'false').
+
+-spec force_outbound(req(), Default) -> boolean() | Default.
 force_outbound(?REQ_TYPE(JObj), Default) ->
     kz_json:is_true(?KEY_FORCE_OUTBOUND, JObj, Default).
 
 -spec resource_type(req()) -> kz_term:ne_binary().
--spec resource_type(req(), Default) -> kz_term:ne_binary() | Default.
 resource_type(Req) ->
     resource_type(Req, ?RESOURCE_TYPE_AUDIO).
+
+-spec resource_type(req(), Default) -> kz_term:ne_binary() | Default.
 resource_type(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_RESOURCE_TYPE, JObj, Default).
 
 -spec account_id(req()) -> kz_term:api_binary().
--spec account_id(req(), Default) -> kz_term:ne_binary() | Default.
 account_id(Req) ->
     account_id(Req, 'undefined').
+
+-spec account_id(req(), Default) -> kz_term:ne_binary() | Default.
 account_id(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_ACCOUNT_ID, JObj, Default).
 
 -spec hunt_account_id(req()) -> kz_term:api_binary().
--spec hunt_account_id(req(), Default) -> kz_term:ne_binary() | Default.
 hunt_account_id(Req) ->
     hunt_account_id(Req, 'undefined').
+
+-spec hunt_account_id(req(), Default) -> kz_term:ne_binary() | Default.
 hunt_account_id(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_HUNT_ACCOUNT_ID, JObj, Default).
 
 -spec outbound_call_id(req()) -> kz_term:api_binary().
--spec outbound_call_id(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_call_id(Req) ->
     outbound_call_id(Req, 'undefined').
+
+-spec outbound_call_id(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_call_id(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_OUTBOUND_CALL_ID, JObj, Default).
 
 -spec outbound_caller_id_number(req()) -> kz_term:api_binary().
--spec outbound_caller_id_number(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_caller_id_number(Req) ->
     outbound_caller_id_number(Req, 'undefined').
+
+-spec outbound_caller_id_number(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_caller_id_number(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_OUTBOUND_CALLER_ID_NUMBER, JObj, Default).
 
 -spec outbound_caller_id_name(req()) -> kz_term:api_binary().
--spec outbound_caller_id_name(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_caller_id_name(Req) ->
     outbound_caller_id_name(Req, 'undefined').
+
+-spec outbound_caller_id_name(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_caller_id_name(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_OUTBOUND_CALLER_ID_NAME, JObj, Default).
 
 -spec emergency_caller_id_number(req()) -> kz_term:api_binary().
--spec emergency_caller_id_number(req(), Default) -> kz_term:ne_binary() | Default.
 emergency_caller_id_number(Req) ->
     emergency_caller_id_number(Req, 'undefined').
+
+-spec emergency_caller_id_number(req(), Default) -> kz_term:ne_binary() | Default.
 emergency_caller_id_number(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_E_CALLER_ID_NUMBER, JObj, Default).
 
 -spec emergency_caller_id_name(req()) -> kz_term:api_binary().
--spec emergency_caller_id_name(req(), Default) -> kz_term:ne_binary() | Default.
 emergency_caller_id_name(Req) ->
     emergency_caller_id_name(Req, 'undefined').
+
+-spec emergency_caller_id_name(req(), Default) -> kz_term:ne_binary() | Default.
 emergency_caller_id_name(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_E_CALLER_ID_NAME, JObj, Default).
 
 -spec to_did(req()) -> kz_term:api_binary().
--spec to_did(req(), Default) -> kz_term:ne_binary() | Default.
 to_did(Req) ->
     to_did(Req, 'undefined').
+
+-spec to_did(req(), Default) -> kz_term:ne_binary() | Default.
 to_did(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_TO_DID, JObj, Default).
 
 -spec call_id(req()) -> kz_term:api_binary().
--spec call_id(req(), Default) -> kz_term:ne_binary() | Default.
 call_id(Req) ->
     call_id(Req, 'undefined').
+
+-spec call_id(req(), Default) -> kz_term:ne_binary() | Default.
 call_id(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_CALL_ID, JObj, Default).
 
 -spec control_queue(req()) -> kz_term:api_binary().
--spec control_queue(req(), Default) -> kz_term:ne_binary() | Default.
 control_queue(Req) ->
     control_queue(Req, 'undefined').
+
+-spec control_queue(req(), Default) -> kz_term:ne_binary() | Default.
 control_queue(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_CONTROL_QUEUE, JObj, Default).
 
 -spec flags(req()) -> kz_term:ne_binaries().
--spec flags(req(), Default) -> kz_term:ne_binaries() | Default.
 flags(Req) ->
     flags(Req, []).
+
+-spec flags(req(), Default) -> kz_term:ne_binaries() | Default.
 flags(?REQ_TYPE(JObj), Default) ->
     kz_json:get_list_value(?KEY_FLAGS, JObj, Default).
 
@@ -364,30 +377,34 @@ set_outbound_call_id(?REQ_TYPE(JObj), CallId) ->
     ?REQ_TYPE(kz_json:insert_value(?KEY_OUTBOUND_CALL_ID, CallId, JObj)).
 
 -spec custom_channel_vars(req()) -> kz_term:api_object().
--spec custom_channel_vars(req(), Default) -> kz_json:object() | Default.
 custom_channel_vars(Req) ->
     custom_channel_vars(Req, 'undefined').
+
+-spec custom_channel_vars(req(), Default) -> kz_json:object() | Default.
 custom_channel_vars(?REQ_TYPE(JObj), Default) ->
     kz_json:get_json_value(?KEY_CCVS, JObj, Default).
 
 -spec custom_application_vars(req()) -> kz_term:api_object().
--spec custom_application_vars(req(), Default) -> kz_json:object() | Default.
 custom_application_vars(Req) ->
     custom_application_vars(Req, 'undefined').
+
+-spec custom_application_vars(req(), Default) -> kz_json:object() | Default.
 custom_application_vars(?REQ_TYPE(JObj), Default) ->
     kz_json:get_json_value(?KEY_CAVS, JObj, Default).
 
 -spec requestor_custom_channel_vars(req()) -> kz_term:api_object().
--spec requestor_custom_channel_vars(req(), Default) -> kz_json:object() | Default.
 requestor_custom_channel_vars(Req) ->
     requestor_custom_channel_vars(Req, 'undefined').
+
+-spec requestor_custom_channel_vars(req(), Default) -> kz_json:object() | Default.
 requestor_custom_channel_vars(?REQ_TYPE(JObj), Default) ->
     kz_json:get_json_value(?KEY_REQUESTOR_CCVS, JObj, Default).
 
 -spec custom_sip_headers(req()) -> kz_term:api_object().
--spec custom_sip_headers(req(), Default) -> kz_json:object() | Default.
 custom_sip_headers(Req) ->
     custom_sip_headers(Req, 'undefined').
+
+-spec custom_sip_headers(req(), Default) -> kz_json:object() | Default.
 custom_sip_headers(?REQ_TYPE(JObj), Default) ->
     kz_json:get_json_value(?KEY_CSHS, JObj, Default).
 
@@ -397,9 +414,10 @@ custom_sip_header(Req, Header) ->
     kz_json:get_value(Header, SipHeaders).
 
 -spec requestor_custom_sip_headers(req()) -> kz_term:api_object().
--spec requestor_custom_sip_headers(req(), Default) -> kz_json:object() | Default.
 requestor_custom_sip_headers(Req) ->
     requestor_custom_sip_headers(Req, 'undefined').
+
+-spec requestor_custom_sip_headers(req(), Default) -> kz_json:object() | Default.
 requestor_custom_sip_headers(?REQ_TYPE(JObj), Default) ->
     kz_json:get_json_value(?KEY_REQUESTOR_CSHS, JObj, Default).
 
@@ -409,128 +427,146 @@ requestor_custom_sip_header(Req, Header) ->
     kz_json:get_value(Header, SipHeaders).
 
 -spec timeout(req()) -> kz_term:api_integer().
--spec timeout(req(), Default) -> integer() | Default.
 timeout(Req) ->
     timeout(Req, 'undefined').
+
+-spec timeout(req(), Default) -> integer() | Default.
 timeout(?REQ_TYPE(JObj), Default) ->
     kz_json:get_integer_value(?KEY_TIMEOUT, JObj, Default).
 
 -spec ignore_early_media(req()) -> kz_term:api_boolean().
--spec ignore_early_media(req(), Default) -> boolean() | Default.
 ignore_early_media(Req) ->
     ignore_early_media(Req, 'undefined').
+
+-spec ignore_early_media(req(), Default) -> boolean() | Default.
 ignore_early_media(?REQ_TYPE(JObj), Default) ->
     kz_json:is_true(?KEY_IGNORE_EARLY_MEDIA, JObj, Default).
 
 -spec media(req()) -> kz_term:api_binary().
--spec media(req(), Default) -> kz_term:ne_binary() | Default.
 media(Req) ->
     media(Req, 'undefined').
+
+-spec media(req(), Default) -> kz_term:ne_binary() | Default.
 media(?REQ_TYPE(JObj), Default) ->
     kz_json:get_binary_value(?KEY_MEDIA, JObj, Default).
 
 -spec message_id(req()) -> kz_term:api_binary().
--spec message_id(req(), Default) -> kz_term:ne_binary() | Default.
 message_id(Req) ->
     message_id(Req, 'undefined').
+
+-spec message_id(req(), Default) -> kz_term:ne_binary() | Default.
 message_id(?REQ_TYPE(JObj), Default) ->
     kz_json:get_binary_value(?KEY_MESSAGE_ID, JObj, Default).
 
 -spec hold_media(req()) -> kz_term:api_binary().
--spec hold_media(req(), Default) -> kz_term:ne_binary() | Default.
 hold_media(Req) ->
     hold_media(Req, 'undefined').
+
+-spec hold_media(req(), Default) -> kz_term:ne_binary() | Default.
 hold_media(?REQ_TYPE(JObj), Default) ->
     kz_json:get_binary_value(?KEY_HOLD_MEDIA, JObj, Default).
 
 -spec presence_id(req()) -> kz_term:api_binary().
--spec presence_id(req(), Default) -> kz_term:ne_binary() | Default.
 presence_id(Req) ->
     presence_id(Req, 'undefined').
+
+-spec presence_id(req(), Default) -> kz_term:ne_binary() | Default.
 presence_id(?REQ_TYPE(JObj), Default) ->
     kz_json:get_binary_value(?KEY_PRESENCE_ID, JObj, Default).
 
 -spec ringback(req()) -> kz_term:api_binary().
--spec ringback(req(), Default) -> kz_term:ne_binary() | Default.
 ringback(Req) ->
     ringback(Req, 'undefined').
+
+-spec ringback(req(), Default) -> kz_term:ne_binary() | Default.
 ringback(?REQ_TYPE(JObj), Default) ->
     kz_json:get_binary_value(?KEY_RINGBACK, JObj, Default).
 
 -spec fax_identity_number(req()) -> kz_term:api_binary().
--spec fax_identity_number(req(), Default) -> kz_term:ne_binary() | Default.
 fax_identity_number(Req) ->
     fax_identity_number(Req, 'undefined').
+
+-spec fax_identity_number(req(), Default) -> kz_term:ne_binary() | Default.
 fax_identity_number(?REQ_TYPE(JObj), Default) ->
     kz_json:get_binary_value(?KEY_FAX_IDENTITY_NUMBER, JObj, Default).
 
 -spec fax_identity_name(req()) -> kz_term:api_binary().
--spec fax_identity_name(req(), Default) -> kz_term:ne_binary() | Default.
 fax_identity_name(Req) ->
     fax_identity_name(Req, 'undefined').
+
+-spec fax_identity_name(req(), Default) -> kz_term:ne_binary() | Default.
 fax_identity_name(?REQ_TYPE(JObj), Default) ->
     kz_json:get_binary_value(?KEY_FAX_IDENTITY_NAME, JObj, Default).
 
 -spec outbound_callee_id_number(req()) -> kz_term:api_binary().
--spec outbound_callee_id_number(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_callee_id_number(Req) ->
     outbound_callee_id_number(Req, 'undefined').
+
+-spec outbound_callee_id_number(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_callee_id_number(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_OUTBOUND_CALLEE_ID_NUMBER, JObj, Default).
 
 -spec outbound_callee_id_name(req()) -> kz_term:api_binary().
--spec outbound_callee_id_name(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_callee_id_name(Req) ->
     outbound_callee_id_name(Req, 'undefined').
+
+-spec outbound_callee_id_name(req(), Default) -> kz_term:ne_binary() | Default.
 outbound_callee_id_name(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_OUTBOUND_CALLEE_ID_NAME, JObj, Default).
 
 -spec b_leg_events(req()) -> kz_term:api_binaries().
--spec b_leg_events(req(), Default) -> kz_term:ne_binaries() | Default.
 b_leg_events(Req) ->
     b_leg_events(Req, 'undefined').
+
+-spec b_leg_events(req(), Default) -> kz_term:ne_binaries() | Default.
 b_leg_events(?REQ_TYPE(JObj), Default) ->
     kz_json:get_list_value(?KEY_B_LEG_EVENTS, JObj, Default).
 
 -spec from_uri_realm(req()) -> kz_term:api_binary().
--spec from_uri_realm(req(), Default) -> kz_term:ne_binary() | Default.
 from_uri_realm(Req) ->
     from_uri_realm(Req, 'undefined').
+
+-spec from_uri_realm(req(), Default) -> kz_term:ne_binary() | Default.
 from_uri_realm(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_FROM_URI_REALM, JObj, Default).
 
 -spec account_realm(req()) -> kz_term:api_binary().
--spec account_realm(req(), Default) -> kz_term:ne_binary() | Default.
 account_realm(Req) ->
     account_realm(Req, 'undefined').
+
+-spec account_realm(req(), Default) -> kz_term:ne_binary() | Default.
 account_realm(?REQ_TYPE(JObj), Default) ->
     kz_json:get_ne_value(?KEY_ACCOUNT_REALM, JObj, Default).
 
 -spec format_from_uri(req()) -> boolean().
--spec format_from_uri(req(), Default) -> boolean() | Default.
 format_from_uri(Req) ->
     format_from_uri(Req, 'false').
+
+-spec format_from_uri(req(), Default) -> boolean() | Default.
 format_from_uri(?REQ_TYPE(JObj), Default) ->
     kz_json:is_true(?KEY_FORMAT_FROM_URI, JObj, Default).
 
 -spec body(req()) -> kz_term:api_binary().
--spec body(req(), Default) -> kz_term:ne_binary() | Default.
 body(Req) ->
     body(Req, 'undefined').
+
+-spec body(req(), Default) -> kz_term:ne_binary() | Default.
 body(?REQ_TYPE(JObj), Default) ->
     kz_json:get_value(?KEY_BODY, JObj, Default).
 
 -spec bypass_e164(req()) -> boolean().
--spec bypass_e164(req(), Default) -> boolean() | Default.
 bypass_e164(Req) ->
     bypass_e164(Req, 'false').
+
+-spec bypass_e164(req(), Default) -> boolean() | Default.
 bypass_e164(?REQ_TYPE(JObj), Default) ->
     kz_json:is_true(?KEY_BYPASS_E164, JObj, Default).
 
 -spec t38_enabled(req()) -> boolean().
--spec t38_enabled(req(), Default) -> boolean() | Default.
 t38_enabled(Req) ->
     t38_enabled(Req, 'false').
+
+-spec t38_enabled(req(), Default) -> boolean() | Default.
 t38_enabled(?REQ_TYPE(JObj), Default) ->
     kz_json:is_true(?KEY_T38_ENABLED, JObj, Default).
 

--- a/core/kazoo_amqp/src/api/kapi_pivot.erl
+++ b/core/kazoo_amqp/src/api/kapi_pivot.erl
@@ -102,9 +102,10 @@ get_pivot_req_routing(Api) ->
     get_pivot_req_routing(get_from_realm(Api)).
 
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PIVOT_REQ_VALUES, fun req/1),
     amqp_util:callmgr_publish(Payload, ContentType, get_pivot_req_routing(Req)).

--- a/core/kazoo_amqp/src/api/kapi_presence.erl
+++ b/core/kazoo_amqp/src/api/kapi_presence.erl
@@ -75,9 +75,10 @@ search_req_v(JObj) ->
     search_req_v(kz_json:to_proplist(JObj)).
 
 -spec publish_search_req(kz_term:api_terms()) -> 'ok'.
--spec publish_search_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_search_req(JObj) ->
     publish_search_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_search_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_search_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?SEARCH_REQ_VALUES, fun search_req/1),
     amqp_util:presence_publish(search_req_routing_key(Req), Payload, ContentType).
@@ -111,9 +112,10 @@ search_partial_resp_v(JObj) ->
     search_partial_resp_v(kz_json:to_proplist(JObj)).
 
 -spec publish_search_partial_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_search_partial_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_search_partial_resp(Queue, JObj) ->
     publish_search_partial_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_search_partial_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_search_partial_resp(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?SEARCH_PARTIAL_RESP_VALUES, fun search_partial_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
@@ -139,9 +141,10 @@ search_resp_v(JObj) ->
     search_resp_v(kz_json:to_proplist(JObj)).
 
 -spec publish_search_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_search_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_search_resp(Queue, JObj) ->
     publish_search_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_search_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_search_resp(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?SEARCH_RESP_VALUES, fun search_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
@@ -165,9 +168,10 @@ subscribe_v(Prop) when is_list(Prop) ->
 subscribe_v(JObj) -> subscribe_v(kz_json:to_proplist(JObj)).
 
 -spec publish_subscribe(kz_term:api_terms()) -> 'ok'.
--spec publish_subscribe(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_subscribe(JObj) ->
     publish_subscribe(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_subscribe(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_subscribe(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?SUBSCRIBE_VALUES, fun subscribe/1),
     amqp_util:presence_publish(subscribe_routing_key(Req), Payload, ContentType).
@@ -203,15 +207,15 @@ update_v(Prop) when is_list(Prop) ->
 update_v(JObj) -> update_v(kz_json:to_proplist(JObj)).
 
 -spec publish_update(kz_term:api_terms()) -> 'ok'.
--spec publish_update(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_update(JObj) ->
     publish_update(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_update(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_update(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?UPDATE_VALUES, fun update/1),
     amqp_util:presence_publish(update_routing_key(Req), Payload, ContentType).
 
 -spec update_routing_key(kz_term:ne_binary() | kz_term:api_terms()) -> kz_term:ne_binary().
--spec update_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 update_routing_key(Req) when is_list(Req) ->
     update_routing_key(props:get_value(<<"Call-ID">>, Req)
                       ,props:get_value(<<"Presence-ID">>, Req)
@@ -221,6 +225,7 @@ update_routing_key(Req) ->
                       ,kz_json:get_value(<<"Presence-ID">>, Req)
                       ).
 
+-spec update_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 update_routing_key(CallId, PresenceID) ->
     list_to_binary([<<"update.">>
                    ,amqp_util:encode(realm_from_presence_id(PresenceID))
@@ -254,15 +259,15 @@ dialog_v(Prop) when is_list(Prop) ->
 dialog_v(JObj) -> dialog_v(kz_json:to_proplist(JObj)).
 
 -spec publish_dialog(kz_term:api_terms()) -> 'ok'.
--spec publish_dialog(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_dialog(JObj) ->
     publish_dialog(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_dialog(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_dialog(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DIALOG_VALUES, fun dialog/1),
     amqp_util:presence_publish(dialog_routing_key(Req), Payload, ContentType).
 
 -spec dialog_routing_key(kz_term:ne_binary() | kz_term:api_terms()) -> kz_term:ne_binary().
--spec dialog_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 dialog_routing_key(Req) when is_list(Req) ->
     dialog_routing_key(props:get_value(<<"Call-ID">>, Req)
                       ,props:get_value(<<"Presence-ID">>, Req)
@@ -272,6 +277,7 @@ dialog_routing_key(Req) ->
                       ,kz_json:get_value(<<"Presence-ID">>, Req)
                       ).
 
+-spec dialog_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 dialog_routing_key(CallId, PresenceID) ->
     list_to_binary([<<"dialog.">>
                    ,amqp_util:encode(realm_from_presence_id(PresenceID))
@@ -298,8 +304,9 @@ probe_v(Prop) when is_list(Prop) ->
 probe_v(JObj) -> probe_v(kz_json:to_proplist(JObj)).
 
 -spec publish_probe(kz_term:api_terms()) -> 'ok'.
--spec publish_probe(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_probe(JObj) -> publish_probe(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_probe(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_probe(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PROBE_VALUES, fun probe/1),
     amqp_util:presence_publish(probe_routing_key(Req), Payload, ContentType).
@@ -350,8 +357,9 @@ mwi_update_v(Prop) when is_list(Prop) ->
 mwi_update_v(JObj) -> mwi_update_v(kz_json:to_proplist(JObj)).
 
 -spec publish_mwi_update(kz_term:api_terms()) -> 'ok'.
--spec publish_mwi_update(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_mwi_update(JObj) -> publish_mwi_update(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_mwi_update(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_mwi_update(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?MWI_REQ_VALUES, fun mwi_update/1),
     amqp_util:presence_publish(mwi_update_routing_key(Req), Payload, ContentType).
@@ -387,8 +395,9 @@ mwi_unsolicited_update_v(Prop) when is_list(Prop) ->
 mwi_unsolicited_update_v(JObj) -> mwi_unsolicited_update_v(kz_json:to_proplist(JObj)).
 
 -spec publish_unsolicited_mwi_update(kz_term:api_terms()) -> 'ok'.
--spec publish_unsolicited_mwi_update(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_unsolicited_mwi_update(JObj) -> publish_unsolicited_mwi_update(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_unsolicited_mwi_update(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_unsolicited_mwi_update(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?MWI_UNSOLICITED_REQ_VALUES, fun mwi_unsolicited_update/1),
     amqp_util:presence_publish(mwi_unsolicited_update_routing_key(Req), Payload, ContentType).
@@ -424,8 +433,9 @@ mwi_query_v(Prop) when is_list(Prop) ->
 mwi_query_v(JObj) -> mwi_query_v(kz_json:to_proplist(JObj)).
 
 -spec publish_mwi_query(kz_term:api_terms()) -> 'ok'.
--spec publish_mwi_query(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_mwi_query(JObj) -> publish_mwi_query(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_mwi_query(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_mwi_query(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?MWI_QUERY_VALUES, fun mwi_query/1),
     amqp_util:presence_publish(mwi_query_routing_key(Req), Payload, ContentType).
@@ -457,8 +467,9 @@ register_overwrite_v(Prop) when is_list(Prop) ->
 register_overwrite_v(JObj) -> register_overwrite_v(kz_json:to_proplist(JObj)).
 
 -spec publish_register_overwrite(kz_term:api_terms()) -> 'ok'.
--spec publish_register_overwrite(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_register_overwrite(JObj) -> publish_register_overwrite(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_register_overwrite(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_register_overwrite(Req, ContentType) when is_list(Req) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?REGISTER_OVERWRITE_VALUES, fun register_overwrite/1),
     amqp_util:presence_publish(register_overwrite_routing_key(Req), Payload, ContentType);
@@ -493,15 +504,15 @@ reset_v(JObj) ->
     reset_v(kz_json:to_proplist(JObj)).
 
 -spec publish_reset(kz_term:api_terms()) -> 'ok'.
--spec publish_reset(kz_term:api_terms(), binary()) -> 'ok'.
 publish_reset(JObj) ->
     publish_reset(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_reset(kz_term:api_terms(), binary()) -> 'ok'.
 publish_reset(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?RESET_VALUES, fun reset/1),
     amqp_util:presence_publish(reset_routing_key(Req), Payload, ContentType).
 
 -spec reset_routing_key(kz_term:ne_binary() | kz_term:api_terms()) -> kz_term:ne_binary().
--spec reset_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 reset_routing_key(Req) when is_list(Req) ->
     reset_routing_key(props:get_value(<<"Realm">>, Req)
                      ,props:get_value(<<"Username">>, Req)
@@ -511,6 +522,7 @@ reset_routing_key(Req) ->
                      ,kz_json:get_value(<<"Username">>, Req)
                      ).
 
+-spec reset_routing_key(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 reset_routing_key(Realm, Username) when is_binary(Realm) ->
     list_to_binary([<<"presence.reset.">>
                    ,amqp_util:encode(Realm)
@@ -537,9 +549,10 @@ flush_v(Prop) when is_list(Prop) ->
 flush_v(JObj) -> flush_v(kz_json:to_proplist(JObj)).
 
 -spec publish_flush(kz_term:api_terms()) -> 'ok'.
--spec publish_flush(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flush(JObj) ->
     publish_flush(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_flush(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flush(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?FLUSH_VALUES, fun flush/1),
     amqp_util:presence_publish(<<"flush">>, Payload, ContentType).
@@ -563,9 +576,10 @@ sync_v(Prop) when is_list(Prop) ->
 sync_v(JObj) -> sync_v(kz_json:to_proplist(JObj)).
 
 -spec publish_sync(kz_term:api_terms()) -> 'ok'.
--spec publish_sync(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_sync(JObj) ->
     publish_sync(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_sync(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_sync(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?SYNC_VALUES, fun sync/1),
     amqp_util:presence_publish(<<"sync">>, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_rate.erl
+++ b/core/kazoo_amqp/src/api/kapi_rate.erl
@@ -173,26 +173,30 @@ declare_exchanges() ->
 %% @doc Publish the JSON iolist() to the proper Exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?RATE_REQ_VALUES, fun req/1),
     amqp_util:callmgr_publish(Payload, ContentType, ?KEY_RATE_REQ).
 
 -spec publish_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(Queue, JObj) ->
     publish_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?RATE_RESP_VALUES, fun resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
 
 -spec broadcast_resp(kz_term:api_terms()) -> 'ok'.
--spec broadcast_resp(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 broadcast_resp(JObj) ->
     broadcast_resp(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec broadcast_resp(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 broadcast_resp(Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?RATE_RESP_VALUES, fun resp/1),
     amqp_util:callmgr_publish(Payload, ContentType, ?KEY_RATE_BROADCAST).

--- a/core/kazoo_amqp/src/api/kapi_registration.erl
+++ b/core/kazoo_amqp/src/api/kapi_registration.erl
@@ -290,10 +290,12 @@ declare_exchanges() ->
 %% @doc Publish the JSON iolist() to the proper Exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_success(kz_term:api_terms()) -> 'ok'.
--spec publish_success(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_success(JObj) ->
     publish_success(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_success(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_success(Success, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Success, ?REG_SUCCESS_VALUES, fun success/1),
     amqp_util:registrar_publish(get_success_routing(Success), Payload, ContentType).
@@ -302,45 +304,52 @@ publish_success(Success, ContentType) ->
 %% @doc Publish the JSON iolist() to the proper Exchange
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_flush(kz_term:api_terms()) -> 'ok'.
--spec publish_flush(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flush(JObj) ->
     publish_flush(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_flush(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flush(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?REG_FLUSH_VALUES, fun flush/1),
     amqp_util:registrar_publish(get_flush_routing(API), Payload, ContentType).
 
 -spec publish_query_req(kz_term:api_terms()) -> 'ok'.
--spec publish_query_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_req(JObj) ->
     publish_query_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?REG_QUERY_VALUES, fun query_req/1),
     amqp_util:registrar_publish(get_query_routing(Req), Payload, ContentType).
 
 -spec publish_query_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_resp(Queue, JObj) ->
     publish_query_resp(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_resp(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?REG_QUERY_RESP_VALUES, fun query_resp/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
 
 -spec publish_query_err(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_query_err(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_err(Queue, JObj) ->
     publish_query_err(Queue, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_query_err(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_query_err(Queue, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?REG_QUERY_ERR_VALUES, fun query_err/1),
     amqp_util:targeted_publish(Queue, Payload, ContentType).
 
 -spec publish_sync() -> 'ok'.
--spec publish_sync(kz_term:api_terms()) -> 'ok'.
--spec publish_sync(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_sync() ->
     kz_amqp_worker:cast(kz_api:default_headers(<<"KAPI">>, <<"1.0">>), fun publish_sync/1).
+
+-spec publish_sync(kz_term:api_terms()) -> 'ok'.
 publish_sync(JObj) ->
     publish_sync(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_sync(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_sync(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?REG_SYNC_VALUES, fun sync/1),
     amqp_util:registrar_publish(?REG_SYNC_RK, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_resource.erl
+++ b/core/kazoo_amqp/src/api/kapi_resource.erl
@@ -148,16 +148,18 @@
 -define(ORIGINATE_UUID_TYPES, []).
 
 -spec originate_ready(kz_term:api_terms()) -> api_formatter_return().
--spec originate_ready_v(kz_term:api_terms()) -> boolean().
 originate_ready(API) ->
     kapi_dialplan:originate_ready(API).
+
+-spec originate_ready_v(kz_term:api_terms()) -> boolean().
 originate_ready_v(API) ->
     kapi_dialplan:originate_ready_v(API).
 
 -spec originate_execute(kz_term:api_terms()) -> api_formatter_return().
--spec originate_execute_v(kz_term:api_terms()) -> boolean().
 originate_execute(API) ->
     kapi_dialplan:originate_execute(API).
+
+-spec originate_execute_v(kz_term:api_terms()) -> boolean().
 originate_execute_v(API) ->
     kapi_dialplan:originate_execute_v(API).
 
@@ -351,49 +353,55 @@ declare_exchanges() ->
     amqp_util:callmgr_exchange().
 
 -spec publish_originate_req(kz_term:api_terms()) -> 'ok'.
--spec publish_originate_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_req(JObj) ->
     publish_originate_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_originate_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?ORIGINATE_REQ_VALUES, fun originate_req/1),
     amqp_util:callmgr_publish(Payload, ContentType, ?KEY_RESOURCE_REQ, [{'mandatory', 'true'}]).
 
 -spec publish_originate_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_originate_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_resp(TargetQ, JObj) ->
     publish_originate_resp(TargetQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_originate_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_resp(TargetQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?ORIGINATE_RESP_VALUES, fun originate_resp/1),
     amqp_util:targeted_publish(TargetQ, Payload, ContentType).
 
 -spec publish_originate_started(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_originate_started(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_started(TargetQ, JObj) ->
     publish_originate_started(TargetQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_originate_started(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_started(TargetQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?ORIGINATE_STARTED_VALUES, fun originate_started/1),
     amqp_util:targeted_publish(TargetQ, Payload, ContentType).
 
 -spec publish_originate_uuid(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_originate_uuid(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_uuid(TargetQ, JObj) ->
     publish_originate_uuid(TargetQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_originate_uuid(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_originate_uuid(TargetQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?ORIGINATE_UUID_VALUES, fun originate_uuid/1),
     amqp_util:targeted_publish(TargetQ, Payload, ContentType).
 
 -spec publish_eavesdrop_req(kz_term:api_terms()) -> 'ok'.
--spec publish_eavesdrop_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_eavesdrop_req(JObj) ->
     publish_eavesdrop_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_eavesdrop_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_eavesdrop_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?EAVESDROP_REQ_VALUES, fun eavesdrop_req/1),
     amqp_util:callmgr_publish(Payload, ContentType, ?KEY_EAVESDROP_REQ).
 
 -spec publish_eavesdrop_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_eavesdrop_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_eavesdrop_resp(TargetQ, JObj) ->
     publish_eavesdrop_resp(TargetQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_eavesdrop_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_eavesdrop_resp(TargetQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?EAVESDROP_RESP_VALUES, fun eavesdrop_resp/1),
     amqp_util:targeted_publish(TargetQ, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_route.erl
+++ b/core/kazoo_amqp/src/api/kapi_route.erl
@@ -236,25 +236,28 @@ get_route_req_routing(Api) ->
     end.
 
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?ROUTE_REQ_VALUES, fun req/1),
     amqp_util:callmgr_publish(Payload, ContentType, get_route_req_routing(Req)).
 
 -spec publish_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(RespQ, JObj) ->
     publish_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(RespQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?ROUTE_RESP_VALUES, fun resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_win(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_win(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_win(RespQ, JObj) ->
     publish_win(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_win(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_win(RespQ, Win, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Win, ?ROUTE_WIN_VALUES, fun win/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_self.erl
+++ b/core/kazoo_amqp/src/api/kapi_self.erl
@@ -32,9 +32,10 @@ declare_exchanges() ->
     amqp_util:targeted_exchange().
 
 -spec publish_message(kz_term:ne_binary(), kz_json:object()) -> 'ok'.
--spec publish_message(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_message(ServerId, JObj) ->
     publish_message(ServerId, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_message(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_message(ServerId, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, [], fun build/1),
     amqp_util:targeted_publish(ServerId, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_sms.erl
+++ b/core/kazoo_amqp/src/api/kapi_sms.erl
@@ -372,9 +372,10 @@ declare_exchanges() ->
     amqp_util:new_exchange(?SMS_EXCHANGE, <<"topic">>).
 
 -spec publish_message(kz_term:api_terms()) -> 'ok'.
--spec publish_message(kz_term:api_terms(), binary()) -> 'ok'.
 publish_message(JObj) ->
     publish_message(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_message(kz_term:api_terms(), binary()) -> 'ok'.
 publish_message(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?SMS_REQ_VALUES, fun message/1),
     CallId = props:get_value(<<"Call-ID">>, Req),
@@ -383,9 +384,10 @@ publish_message(Req, ContentType) ->
     amqp_util:basic_publish(Exchange, ?SMS_ROUTING_KEY(RouteId, CallId), Payload, ContentType).
 
 -spec publish_inbound(kz_term:api_terms()) -> 'ok'.
--spec publish_inbound(kz_term:api_terms(), binary()) -> 'ok'.
 publish_inbound(JObj) ->
     publish_inbound(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_inbound(kz_term:api_terms(), binary()) -> 'ok'.
 publish_inbound(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?INBOUND_REQ_VALUES, fun inbound/1),
     MessageId = props:get_value(<<"Message-ID">>, Req),
@@ -394,9 +396,10 @@ publish_inbound(Req, ContentType) ->
     amqp_util:basic_publish(Exchange, ?INBOUND_ROUTING_KEY(RouteId, MessageId), Payload, ContentType).
 
 -spec publish_outbound(kz_term:api_terms()) -> 'ok'.
--spec publish_outbound(kz_term:api_terms(), binary()) -> 'ok'.
 publish_outbound(JObj) ->
     publish_outbound(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_outbound(kz_term:api_terms(), binary()) -> 'ok'.
 publish_outbound(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?OUTBOUND_REQ_VALUES, fun outbound/1),
     MessageId = props:get_value(<<"Message-ID">>, Req),
@@ -407,9 +410,10 @@ publish_outbound(Req, ContentType) ->
     amqp_util:basic_publish(Exchange, RK, Payload, ContentType, Opts).
 
 -spec publish_delivery(kz_term:api_terms()) -> 'ok'.
--spec publish_delivery(kz_term:api_terms(), binary()) -> 'ok'.
 publish_delivery(JObj) ->
     publish_delivery(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_delivery(kz_term:api_terms(), binary()) -> 'ok'.
 publish_delivery(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DELIVERY_REQ_VALUES, fun delivery/1),
     CallId = props:get_value(<<"Call-ID">>, Req),
@@ -417,15 +421,15 @@ publish_delivery(Req, ContentType) ->
     amqp_util:basic_publish(Exchange, ?DELIVERY_ROUTING_KEY(CallId), Payload, ContentType).
 
 -spec publish_targeted_delivery(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_targeted_delivery(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_targeted_delivery(RespQ, JObj) ->
     publish_targeted_delivery(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_targeted_delivery(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_targeted_delivery(RespQ, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?DELIVERY_REQ_VALUES, fun delivery/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_resume(kz_term:api_terms() | kz_term:ne_binary()) -> 'ok'.
--spec publish_resume(kz_term:api_terms(), binary()) -> 'ok'.
 publish_resume(SMS) when is_binary(SMS) ->
     Payload = [{<<"SMS-ID">>, SMS}
                | kz_api:default_headers(<<"API">>, <<"0.9.7">>)
@@ -433,6 +437,8 @@ publish_resume(SMS) when is_binary(SMS) ->
     publish_resume(Payload, ?DEFAULT_CONTENT_TYPE);
 publish_resume(JObj) ->
     publish_resume(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_resume(kz_term:api_terms(), binary()) -> 'ok'.
 publish_resume(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?RESUME_REQ_VALUES, fun resume/1),
     CallId = props:get_value(<<"Call-ID">>, Req),

--- a/core/kazoo_amqp/src/api/kapi_switch.erl
+++ b/core/kazoo_amqp/src/api/kapi_switch.erl
@@ -265,17 +265,19 @@ publish_reload_gateways() ->
     amqp_util:basic_publish(?SWITCH_EXCHANGE, ?RELOAD_GATEWAYS_KEY, Payload, ?DEFAULT_CONTENT_TYPE).
 
 -spec publish_fs_xml_flush(kz_term:api_terms()) -> 'ok'.
--spec publish_fs_xml_flush(kz_term:api_terms(), binary()) -> 'ok'.
 publish_fs_xml_flush(JObj) ->
     publish_fs_xml_flush(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_fs_xml_flush(kz_term:api_terms(), binary()) -> 'ok'.
 publish_fs_xml_flush(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?FS_XML_FLUSH_VALUES, fun fs_xml_flush/1),
     amqp_util:basic_publish(?SWITCH_EXCHANGE, ?FS_XML_FLUSH_KEY, Payload, ContentType).
 
 -spec publish_notify(kz_term:api_terms()) -> 'ok'.
--spec publish_notify(kz_term:api_terms(), binary()) -> 'ok'.
 publish_notify(JObj) ->
     publish_notify(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_notify(kz_term:api_terms(), binary()) -> 'ok'.
 publish_notify(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?NOTIFY_VALUES, fun notify/1),
 
@@ -305,9 +307,10 @@ notify_value(API, Key, Get) ->
     Get(Key, API).
 
 -spec publish_command(kz_term:api_terms()) -> 'ok'.
--spec publish_command(kz_term:api_terms(), binary()) -> 'ok'.
 publish_command(JObj) ->
     publish_command(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_command(kz_term:api_terms(), binary()) -> 'ok'.
 publish_command(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?FS_COMMAND_VALUES, fun fs_command/1),
     N = check_fs_node(Req),

--- a/core/kazoo_amqp/src/api/kapi_sysconf.erl
+++ b/core/kazoo_amqp/src/api/kapi_sysconf.erl
@@ -228,17 +228,19 @@ declare_exchanges() ->
     amqp_util:sysconf_exchange().
 
 -spec publish_get_req(kz_term:api_terms()) -> 'ok'.
--spec publish_get_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_get_req(JObj) ->
     publish_get_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_get_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_get_req(Api, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Api, ?SYSCONF_GET_REQ_VALUES, fun get_req/1),
     amqp_util:sysconf_publish(routing_key_get(), Payload, ContentType).
 
 -spec publish_get_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_get_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_get_resp(RespQ, JObj) ->
     publish_get_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_get_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_get_resp(RespQ, Api, ContentType) ->
     PrepareOptions = [{'formatter', fun get_resp/1}
                      ,{'remove_recursive', 'false'}
@@ -247,25 +249,28 @@ publish_get_resp(RespQ, Api, ContentType) ->
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_set_req(kz_term:api_terms()) -> 'ok'.
--spec publish_set_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_set_req(JObj) ->
     publish_set_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_set_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_set_req(Api, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Api, ?SYSCONF_SET_REQ_VALUES, fun set_req/1),
     amqp_util:sysconf_publish(routing_key_set(), Payload, ContentType).
 
 -spec publish_set_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_set_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_set_resp(RespQ, JObj) ->
     publish_set_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_set_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_set_resp(RespQ, Api, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Api, ?SYSCONF_SET_RESP_VALUES, fun set_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
 
 -spec publish_flush_req(kz_term:api_terms()) -> 'ok'.
--spec publish_flush_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flush_req(JObj) ->
     publish_flush_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_flush_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flush_req(Api, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Api, ?SYSCONF_FLUSH_REQ_VALUES, fun flush_req/1),
     amqp_util:sysconf_publish(routing_key_flush(), Payload, ContentType).
@@ -281,22 +286,25 @@ routing_key_flush() ->
 
 
 -spec get_category(kz_json:object()) -> kz_term:api_binary().
--spec get_category(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 get_category(JObj) ->
     get_category(JObj, 'undefined').
+
+-spec get_category(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 get_category(JObj, Default) ->
     kz_json:get_value(?CAT_KEY, JObj, Default).
 
 -spec get_key(kz_json:object()) -> kz_term:api_binary().
--spec get_key(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 get_key(JObj) ->
     get_key(JObj, 'undefined').
+
+-spec get_key(kz_json:object(), Default) -> kz_term:ne_binary() | Default.
 get_key(JObj, Default) ->
     kz_json:get_value(?KEY_KEY, JObj, Default).
 
 -spec get_value(kz_json:object()) -> kz_term:api_object().
--spec get_value(kz_json:object(), Default) -> kz_json:object() | Default.
 get_value(JObj) ->
     get_value(JObj, 'undefined').
+
+-spec get_value(kz_json:object(), Default) -> kz_json:object() | Default.
 get_value(JObj, Default) ->
     kz_json:get_value(?VALUE_KEY, JObj, Default).

--- a/core/kazoo_amqp/src/api/kapi_tasks.erl
+++ b/core/kazoo_amqp/src/api/kapi_tasks.erl
@@ -177,17 +177,19 @@ lookup_resp_v(JObj) ->
     lookup_resp_v(kz_json:to_proplist(JObj)).
 
 -spec publish_lookup_req(kz_term:api_terms()) -> 'ok'.
--spec publish_lookup_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_lookup_req(JObj) ->
     publish_lookup_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_lookup_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_lookup_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?LOOKUP_REQ_VALUES, fun lookup_req/1),
     amqp_util:tasks_publish(?TASKS_AMQP_KEY("lookup"), Payload, ContentType).
 
 -spec publish_lookup_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_lookup_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_lookup_resp(RespQ, JObj) ->
     publish_lookup_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_lookup_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_lookup_resp(RespQ, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?LOOKUP_RESP_VALUES, fun lookup_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
@@ -224,17 +226,19 @@ start_resp_v(JObj) ->
     start_resp_v(kz_json:to_proplist(JObj)).
 
 -spec publish_start_req(kz_term:api_terms()) -> 'ok'.
--spec publish_start_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_start_req(JObj) ->
     publish_start_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_start_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_start_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?START_REQ_VALUES, fun start_req/1),
     amqp_util:tasks_publish(?TASKS_AMQP_KEY("start"), Payload, ContentType).
 
 -spec publish_start_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_start_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_start_resp(RespQ, JObj) ->
     publish_start_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_start_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_start_resp(RespQ, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?START_RESP_VALUES, fun start_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
@@ -271,17 +275,19 @@ stop_resp_v(JObj) ->
     stop_resp_v(kz_json:to_proplist(JObj)).
 
 -spec publish_stop_req(kz_term:api_terms()) -> 'ok'.
--spec publish_stop_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_stop_req(JObj) ->
     publish_stop_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_stop_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_stop_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?STOP_REQ_VALUES, fun stop_req/1),
     amqp_util:tasks_publish(?TASKS_AMQP_KEY("stop"), Payload, ContentType).
 
 -spec publish_stop_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_stop_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_stop_resp(RespQ, JObj) ->
     publish_stop_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_stop_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_stop_resp(RespQ, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?STOP_RESP_VALUES, fun stop_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).
@@ -318,17 +324,19 @@ remove_resp_v(JObj) ->
     remove_resp_v(kz_json:to_proplist(JObj)).
 
 -spec publish_remove_req(kz_term:api_terms()) -> 'ok'.
--spec publish_remove_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_remove_req(JObj) ->
     publish_remove_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_remove_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_remove_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?REMOVE_REQ_VALUES, fun remove_req/1),
     amqp_util:tasks_publish(?TASKS_AMQP_KEY("remove"), Payload, ContentType).
 
 -spec publish_remove_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_remove_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_remove_resp(RespQ, JObj) ->
     publish_remove_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_remove_resp(kz_term:ne_binary(), kz_term:api_terms(), binary()) -> 'ok'.
 publish_remove_resp(RespQ, JObj, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?REMOVE_RESP_VALUES, fun remove_resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).

--- a/core/kazoo_amqp/src/api/kapi_websockets.erl
+++ b/core/kazoo_amqp/src/api/kapi_websockets.erl
@@ -137,17 +137,19 @@ declare_exchanges() ->
     amqp_util:sysconf_exchange().
 
 -spec publish_module_req(kz_term:api_terms()) -> 'ok'.
--spec publish_module_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_module_req(API) ->
     publish_module_req(API, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_module_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_module_req(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MODULE_REQ_VALUES, fun module_req/1),
     amqp_util:kapps_publish(?MODULE_REQ_ROUTING_KEY, Payload, ContentType).
 
 -spec publish_module_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_module_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_module_resp(ServerId, API) ->
     publish_module_resp(ServerId, API, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_module_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_module_resp(ServerId, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MODULE_RESP_VALUES, fun module_resp/1),
     amqp_util:targeted_publish(ServerId, Payload, ContentType).
@@ -157,10 +159,12 @@ publish_module_resp(ServerId, API, ContentType) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_get_req(kz_term:api_terms()) -> 'ok'.
--spec publish_get_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_get_req(JObj) ->
     publish_get_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_get_req(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_get_req(Api, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Api, ?WEBSOCKETS_GET_REQ_VALUES, fun get_req/1),
     amqp_util:sysconf_publish(?KEY_WEBSOCKETS_GET_REQ, Payload, ContentType).
@@ -170,10 +174,12 @@ publish_get_req(Api, ContentType) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_get_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_get_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_get_resp(RespQ, JObj) ->
     publish_get_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_get_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_get_resp(RespQ, Api, ContentType) ->
     PrepareOptions = [{'formatter', fun get_resp/1}
                      ,{'remove_recursive', 'false'}

--- a/core/kazoo_amqp/src/api/kz_api.erl
+++ b/core/kazoo_amqp/src/api/kz_api.erl
@@ -150,14 +150,12 @@ reply_to(JObj) ->
 %%--------------------------------------------------------------------
 -spec default_headers_v(kz_term:api_terms()) -> boolean().
 
--spec default_headers(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
--spec default_headers(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
--spec default_headers(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
--spec default_headers(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
 
+-spec default_headers(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
 default_headers(AppName, AppVsn) ->
     default_headers('undefined', AppName, AppVsn).
 
+-spec default_headers(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
 default_headers(ServerID, AppName, AppVsn) ->
     [{?KEY_SERVER_ID, ServerID}
     ,{?KEY_APP_NAME, AppName}
@@ -165,9 +163,11 @@ default_headers(ServerID, AppName, AppVsn) ->
     ,{?KEY_NODE, kz_term:to_binary(node())}
     ].
 
+-spec default_headers(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
 default_headers(EvtCat, EvtName, AppName, AppVsn) ->
     default_headers(<<>>, EvtCat, EvtName, AppName, AppVsn).
 
+-spec default_headers(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
 default_headers(ServerID, EvtCat, EvtName, AppName, AppVsn) ->
     [{?KEY_SERVER_ID, ServerID}
     ,{?KEY_EVENT_CATEGORY, EvtCat}
@@ -204,13 +204,13 @@ disambiguate_and_publish(ReqJObj, RespJObj, Binding) ->
                              {'remove_recursive', boolean()}.
 -type prepare_options() :: [prepare_option_el()].
 
--spec prepare_api_payload(kz_term:api_terms(), kz_term:proplist()) -> api_formatter_return() | kz_term:proplist().
--spec prepare_api_payload(kz_term:api_terms(), kz_term:proplist(), api_formatter_fun() | prepare_options()) ->
-                                 api_formatter_return() | kz_term:proplist().
 
+-spec prepare_api_payload(kz_term:api_terms(), kz_term:proplist()) -> api_formatter_return() | kz_term:proplist().
 prepare_api_payload(Prop, HeaderValues) ->
     prepare_api_payload(Prop, HeaderValues, []).
 
+-spec prepare_api_payload(kz_term:api_terms(), kz_term:proplist(), api_formatter_fun() | prepare_options()) ->
+                                 api_formatter_return() | kz_term:proplist().
 prepare_api_payload(Prop, HeaderValues, FormatterFun) when is_function(FormatterFun, 1) ->
     prepare_api_payload(Prop, HeaderValues, [{'formatter', FormatterFun}]);
 prepare_api_payload(Prop, HeaderValues, Options) when is_list(Prop) ->
@@ -331,9 +331,10 @@ error_resp_v(JObj) ->
     error_resp_v(kz_json:to_proplist(JObj)).
 
 -spec publish_error(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(TargetQ, JObj) ->
     publish_error(TargetQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_error(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_error(TargetQ, Error, ContentType) ->
     {'ok', Payload} = prepare_api_payload(Error, ?ERROR_RESP_VALUES, fun error_resp/1),
     amqp_util:targeted_publish(TargetQ, Payload, ContentType).

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -262,10 +262,10 @@ reply(From, Msg) -> gen_server:reply(From, Msg).
 -type server_name() :: {'global' | 'local', atom()} | pid().
 
 -spec enter_loop(atom(), list(), any()) -> no_return().
--spec enter_loop(atom(), list(), any(), timeout() | server_name()) -> no_return().
--spec enter_loop(atom(), list(), any(), server_name(), timeout()) -> no_return().
 enter_loop(Module, Options, ModuleState) ->
     enter_loop(Module, Options, ModuleState, self(), 'infinity').
+
+-spec enter_loop(atom(), list(), any(), timeout() | server_name()) -> no_return().
 enter_loop(Module, Options, ModuleState, {Scope, _Name}=ServerName)
   when Scope =:= 'local'
        orelse Scope =:= 'global' ->
@@ -273,6 +273,7 @@ enter_loop(Module, Options, ModuleState, {Scope, _Name}=ServerName)
 enter_loop(Module, Option, ModuleState, Timeout) ->
     enter_loop(Module, Option, ModuleState, self(), Timeout).
 
+-spec enter_loop(atom(), list(), any(), server_name(), timeout()) -> no_return().
 enter_loop(Module, Options, ModuleState, ServerName, Timeout) ->
     {'ok', MyState} = init_state([Module, Options, ModuleState]),
     gen_server:enter_loop(?MODULE, [], MyState, ServerName, Timeout).
@@ -1265,12 +1266,12 @@ maybe_channel_flow(_) -> 'ok'.
 
 -spec maybe_declare_exchanges(declare_exchanges()) ->
                                      command_ret().
--spec maybe_declare_exchanges(kz_amqp_assignment(), declare_exchanges()) ->
-                                     command_ret().
 maybe_declare_exchanges([]) -> 'ok';
 maybe_declare_exchanges(Exchanges) ->
     maybe_declare_exchanges(kz_amqp_assignments:get_channel(), Exchanges).
 
+-spec maybe_declare_exchanges(kz_amqp_assignment(), declare_exchanges()) ->
+                                     command_ret().
 maybe_declare_exchanges(_Channel, []) -> 'ok';
 maybe_declare_exchanges(Channel, [{Ex, Type, Opts} | Exchanges]) ->
     declare_exchange(Channel, amqp_util:declare_exchange(Ex, Type, Opts), Exchanges);
@@ -1310,11 +1311,11 @@ channel_requisition(Params) ->
     end.
 
 -spec maybe_add_broker_connection(binary()) -> boolean().
--spec maybe_add_broker_connection(binary(), non_neg_integer()) -> boolean().
 maybe_add_broker_connection(Broker) ->
     Count = kz_amqp_connections:broker_available_connections(Broker),
     maybe_add_broker_connection(Broker, Count).
 
+-spec maybe_add_broker_connection(binary(), non_neg_integer()) -> boolean().
 maybe_add_broker_connection(Broker, Count) when Count =:= 0 ->
     _Connection = kz_amqp_connections:add(Broker, kz_binary:rand_hex(6), [<<"hidden">>]),
     kz_amqp_channel:requisition(self(), Broker);

--- a/core/kazoo_amqp/src/kz_amqp_channel.erl
+++ b/core/kazoo_amqp/src/kz_amqp_channel.erl
@@ -264,7 +264,6 @@ maybe_split_routing_key(RoutingKey) ->
     {'undefined', RoutingKey}.
 
 -spec command(kz_amqp_command()) -> command_ret().
--spec command(kz_amqp_assignment(), kz_amqp_command()) -> command_ret().
 command(#'exchange.declare'{exchange=_Ex, type=_Ty}=Exchange) ->
     kz_amqp_history:add_exchange(Exchange);
 command(Command) ->
@@ -272,6 +271,7 @@ command(Command) ->
     %% all commands need to block till completion...
     command(kz_amqp_assignments:get_channel(), Command).
 
+-spec command(kz_amqp_assignment(), kz_amqp_command()) -> command_ret().
 command(Assignment, Command) ->
     assert_valid_amqp_method(Command),
     exec_command(Assignment, Command).

--- a/core/kazoo_amqp/src/kz_amqp_connections.erl
+++ b/core/kazoo_amqp/src/kz_amqp_connections.erl
@@ -79,18 +79,15 @@ new(<<_/binary>> = Broker, Zone) ->
 new(Broker, Zone) ->
     new(kz_term:to_binary(Broker), Zone).
 
+
 -spec add(kz_amqp_connection() | kz_term:text()) ->
                  kz_amqp_connection() |
                  {'error', any()}.
+add(Broker) -> add(Broker, 'local').
+
 -spec add(kz_amqp_connection() | kz_term:text(), kz_term:text()) ->
                  kz_amqp_connection() |
                  {'error', any()}.
--spec add(kz_amqp_connection() | kz_term:text(), kz_term:text(), list()) ->
-                 kz_amqp_connection() |
-                 {'error', any()}.
-
-add(Broker) -> add(Broker, 'local').
-
 add(#kz_amqp_connection{broker=Broker, tags=Tags}=Connection, Zone) ->
     case kz_amqp_connection_sup:add(Connection) of
         {'ok', Pid} ->
@@ -109,6 +106,9 @@ add(Broker, Zone) when not is_atom(Zone) ->
 add(Broker, Zone) ->
     add(Broker, Zone, []).
 
+-spec add(kz_amqp_connection() | kz_term:text(), kz_term:text(), list()) ->
+                 kz_amqp_connection() |
+                 {'error', any()}.
 add(Broker, Zone, Tags) ->
     case catch amqp_uri:parse(kz_term:to_list(Broker)) of
         {'EXIT', _R} ->
@@ -428,11 +428,11 @@ wait_for_notification(Timeout) ->
     end.
 
 -spec brokers_with_tag(kz_term:ne_binary()) -> kz_amqp_connections_list().
--spec brokers_with_tag(kz_term:ne_binary(), kz_term:api_boolean()) -> kz_amqp_connections_list().
 brokers_with_tag(Tag) ->
     %% by default we want all the brokers
     brokers_with_tag(Tag, 'undefined').
 
+-spec brokers_with_tag(kz_term:ne_binary(), kz_term:api_boolean()) -> kz_amqp_connections_list().
 brokers_with_tag(Tag, Available) ->
     MatchSpec = [{#kz_amqp_connections{available='$1'
                                       ,_='_'
@@ -457,13 +457,13 @@ broker_with_tag(Tag) ->
         [#kz_amqp_connections{broker=Broker}|_] -> Broker
     end.
 
--spec brokers_for_zone(atom()) -> kz_amqp_connections_list().
--spec brokers_for_zone(atom(), kz_term:api_boolean()) -> kz_amqp_connections_list().
 
+-spec brokers_for_zone(atom()) -> kz_amqp_connections_list().
 brokers_for_zone(Zone) ->
     %% by default we want all the brokers
     brokers_for_zone(Zone, 'undefined').
 
+-spec brokers_for_zone(atom(), kz_term:api_boolean()) -> kz_amqp_connections_list().
 brokers_for_zone(Zone, Available) ->
     MatchSpec = [{#kz_amqp_connections{zone='$1'
                                       ,available='$2'

--- a/core/kazoo_amqp/src/kz_amqp_history.erl
+++ b/core/kazoo_amqp/src/kz_amqp_history.erl
@@ -58,10 +58,10 @@ start_link() ->
     gen_server:start_link({'local', ?SERVER}, ?MODULE, [], []).
 
 -spec add_command(kz_amqp_assignment(), kz_amqp_command()) -> 'ok'.
--spec add_command(kz_amqp_assignment(), kz_amqp_command(), 'sync' | 'async') -> 'ok'.
 add_command(Assignment, Command) ->
     add_command(Assignment, Command, 'async').
 
+-spec add_command(kz_amqp_assignment(), kz_amqp_command(), 'sync' | 'async') -> 'ok'.
 add_command(#kz_amqp_assignment{consumer=Consumer}, Command, Method) ->
     MatchSpec = [{#kz_amqp_history{consumer=Consumer
                                   ,command=Command

--- a/core/kazoo_apps/src/kapps_alert.erl
+++ b/core/kazoo_apps/src/kapps_alert.erl
@@ -43,18 +43,19 @@ fetch(AlertId) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec create(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects(), kz_json:objects()) ->
                     {'ok', kzd_alert:doc()} |
                     {'error', any()}.
+create(Title, Message, From, To) ->
+    create(Title, Message, From, To, []).
+
 -spec create(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects()
             ,kz_json:objects(), kz_term:proplist()
             ) ->
                     {'ok', kz_json:object()} |
                     {'required', kz_term:ne_binary()} |
                     {'error', 'disabled'}.
-create(Title, Message, From, To) ->
-    create(Title, Message, From, To, []).
-
 create('undefined', _Message, _From, _To, _Opts) ->
     {'required', kzd_alert:title()};
 create(_Title, 'undefined', _From, _To, _Opts) ->

--- a/core/kazoo_apps/src/kapps_controller.erl
+++ b/core/kazoo_apps/src/kapps_controller.erl
@@ -77,10 +77,10 @@ restart_app(App) ->
     restart_app(kz_term:to_atom(App, 'true')).
 
 -spec running_apps() -> kz_term:atoms() | string().
--spec running_apps(boolean()) -> kz_term:atoms() | string().
 running_apps() ->
     running_apps('false').
 
+-spec running_apps(boolean()) -> kz_term:atoms() | string().
 running_apps(Verbose) ->
     case kz_term:is_true(Verbose) of
         'true' -> running_apps_verbose();

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -73,8 +73,9 @@ binding({Common, Specific}) when is_atom(Common), is_binary(Specific) ->
     <<CommonPath/binary, ".", Specific/binary>>.
 
 -spec bind(atom() | {atom(), binary()}, module(), atom()) -> any().
--spec unbind(atom() | {atom(), binary()}, module(), atom()) -> any().
 bind(Event, M, F) -> kazoo_bindings:bind(binding(Event), M, F).
+
+-spec unbind(atom() | {atom(), binary()}, module(), atom()) -> any().
 unbind(Event, M, F) -> kazoo_bindings:unbind(binding(Event), M, F).
 
 -define(DEVICES_CB_LIST, <<"devices/crossbar_listing">>).
@@ -238,17 +239,18 @@ blocking_refresh(Pause) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec refresh() -> 'no_return'.
--spec refresh(kz_term:ne_binaries(), kz_term:text() | non_neg_integer()) -> 'no_return'.
--spec refresh(kz_term:ne_binaries(), non_neg_integer(), non_neg_integer()) -> 'no_return'.
 refresh() ->
     Databases = get_databases(),
     refresh(Databases, 2 * ?MILLISECONDS_IN_SECOND).
 
+-spec refresh(kz_term:ne_binaries(), kz_term:text() | non_neg_integer()) -> 'no_return'.
 refresh(Databases, Pause) ->
     Total = length(Databases),
     refresh(Databases, kz_term:to_integer(Pause), Total).
 
+-spec refresh(kz_term:ne_binaries(), non_neg_integer(), non_neg_integer()) -> 'no_return'.
 refresh([], _, _) -> 'no_return';
 refresh([Database|Databases], Pause, Total) ->
     io:format("~p (~p/~p) refreshing database '~s'~n"
@@ -454,9 +456,8 @@ get_medias(Account) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec migrate_limits() -> 'ok'.
--spec migrate_limits(atom() | string() | binary()) -> 'ok'.
 
+-spec migrate_limits() -> 'ok'.
 migrate_limits() ->
     migrate_all_limits(kapps_util:get_all_accounts()).
 
@@ -474,6 +475,7 @@ migrate_limits_fold(AccountDb, Current, Total) ->
         end,
     Current + 1.
 
+-spec migrate_limits(atom() | string() | binary()) -> 'ok'.
 migrate_limits(Account) when not is_binary(Account) ->
     migrate_limits(kz_term:to_binary(Account));
 migrate_limits(Account) ->
@@ -544,9 +546,8 @@ clean_trunkstore_docs(AccountDb, [JObj|JObjs], Trunks, InboundTrunks) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec migrate_media() -> 'ok'.
--spec migrate_media(atom() | string() | binary()) -> 'ok'.
 
+-spec migrate_media() -> 'ok'.
 migrate_media() ->
     Accounts = kapps_util:get_all_accounts(),
     Total = length(Accounts),
@@ -558,6 +559,7 @@ migrate_media_fold(AccountDb, Current, Total) ->
     _ = migrate_media(AccountDb),
     Current + 1.
 
+-spec migrate_media(atom() | string() | binary()) -> 'ok'.
 migrate_media(Account) when not is_binary(Account) ->
     migrate_media(kz_term:to_binary(Account));
 migrate_media(Account) ->
@@ -884,11 +886,8 @@ maybe_delete_db(Database) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec purge_doc_type(kz_term:ne_binaries() | kz_term:ne_binary(), kz_term:ne_binary()) ->
-                            {'ok', kz_json:objects()} |
-                            {'error', _} |
-                            'ok'.
--spec purge_doc_type(kz_term:ne_binaries() | kz_term:ne_binary(), kz_term:ne_binary(), integer()) ->
                             {'ok', kz_json:objects()} |
                             {'error', _} |
                             'ok'.
@@ -917,6 +916,10 @@ purge_doc_type(Type, Account) when not is_binary(Account) ->
                   ,kapps_config:get_integer(?SYSCONFIG_COUCH, <<"default_chunk_size">>, ?MILLISECONDS_IN_SECOND)
                   ).
 
+-spec purge_doc_type(kz_term:ne_binaries() | kz_term:ne_binary(), kz_term:ne_binary(), integer()) ->
+                            {'ok', kz_json:objects()} |
+                            {'error', _} |
+                            'ok'.
 purge_doc_type(Type, Account, ChunkSize) ->
     Db = kz_util:format_account_id(Account, 'encoded'),
     Opts = [{'key', Type}
@@ -933,9 +936,10 @@ purge_doc_type(Type, Account, ChunkSize) ->
     end.
 
 -spec call_id_status(kz_term:ne_binary()) -> 'ok'.
--spec call_id_status(kz_term:ne_binary(), boolean() | kz_term:ne_binary()) -> 'ok'.
 call_id_status(CallId) ->
     call_id_status(CallId, 'false').
+
+-spec call_id_status(kz_term:ne_binary(), boolean() | kz_term:ne_binary()) -> 'ok'.
 call_id_status(CallId, Verbose) ->
     Req = [{<<"Call-ID">>, kz_term:to_binary(CallId)}
            | kz_api:default_headers(<<"shell">>, <<"0">>)

--- a/core/kazoo_apps/src/kapps_util.erl
+++ b/core/kazoo_apps/src/kapps_util.erl
@@ -260,10 +260,11 @@ find_oldest_doc([First|Docs]) ->
 %% in the requested encoding
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_all_accounts() -> kz_term:ne_binaries().
--spec get_all_accounts(kz_util:account_format()) -> kz_term:ne_binaries().
 get_all_accounts() -> get_all_accounts(?REPLICATE_ENCODING).
 
+-spec get_all_accounts(kz_util:account_format()) -> kz_term:ne_binaries().
 get_all_accounts(Encoding) ->
     {'ok', Dbs} = kz_datamgr:db_list([{'startkey', <<"account/">>}
                                      ,{'endkey', <<"account/\ufff0">>}
@@ -273,10 +274,10 @@ get_all_accounts(Encoding) ->
     ].
 
 -spec get_all_accounts_and_mods() -> kz_term:ne_binaries().
--spec get_all_accounts_and_mods(kz_util:account_format()) -> kz_term:ne_binaries().
 get_all_accounts_and_mods() ->
     get_all_accounts_and_mods(?REPLICATE_ENCODING).
 
+-spec get_all_accounts_and_mods(kz_util:account_format()) -> kz_term:ne_binaries().
 get_all_accounts_and_mods(Encoding) ->
     {'ok', Databases} = kz_datamgr:db_info(),
     [format_db(Db, Encoding)
@@ -299,10 +300,10 @@ format_db(Db, Encoding, [{Predicate, Formatter}|Fs]) ->
     end.
 
 -spec get_all_account_mods() -> kz_term:ne_binaries().
--spec get_all_account_mods(kz_util:account_format()) -> kz_term:ne_binaries().
 get_all_account_mods() ->
     get_all_account_mods(?REPLICATE_ENCODING).
 
+-spec get_all_account_mods(kz_util:account_format()) -> kz_term:ne_binaries().
 get_all_account_mods(Encoding) ->
     {'ok', Databases} = kz_datamgr:db_info(),
     [kz_util:format_account_modb(Db, Encoding)
@@ -311,10 +312,10 @@ get_all_account_mods(Encoding) ->
     ].
 
 -spec get_account_mods(kz_term:ne_binary()) -> kz_term:ne_binaries().
--spec get_account_mods(kz_term:ne_binary(), kz_util:account_format()) -> kz_term:ne_binaries().
 get_account_mods(Account) ->
     get_account_mods(Account, ?REPLICATE_ENCODING).
 
+-spec get_account_mods(kz_term:ne_binary(), kz_util:account_format()) -> kz_term:ne_binaries().
 get_account_mods(Account, Encoding) ->
     AccountId = kz_util:format_account_id(Account, Encoding),
     [MOD
@@ -607,12 +608,13 @@ amqp_pool_send(Api, PubFun) when is_function(PubFun, 1) ->
 
 -spec amqp_pool_request(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun()) ->
                                kz_amqp_worker:request_return().
--spec amqp_pool_request(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun(), timeout()) ->
-                               kz_amqp_worker:request_return().
 amqp_pool_request(Api, PubFun, ValidateFun)
   when is_function(PubFun, 1),
        is_function(ValidateFun, 1) ->
     amqp_pool_request(Api, PubFun, ValidateFun, kz_amqp_worker:default_timeout()).
+
+-spec amqp_pool_request(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun(), timeout()) ->
+                               kz_amqp_worker:request_return().
 amqp_pool_request(Api, PubFun, ValidateFun, Timeout)
   when is_function(PubFun, 1),
        is_function(ValidateFun, 1),
@@ -624,12 +626,13 @@ amqp_pool_request(Api, PubFun, ValidateFun, Timeout)
 
 -spec amqp_pool_request_custom(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun(), gen_listener:binding()) ->
                                       kz_amqp_worker:request_return().
--spec amqp_pool_request_custom(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun(), timeout(), gen_listener:binding()) ->
-                                      kz_amqp_worker:request_return().
 amqp_pool_request_custom(Api, PubFun, ValidateFun, Bind)
   when is_function(PubFun, 1),
        is_function(ValidateFun, 1) ->
     amqp_pool_request_custom(Api, PubFun, ValidateFun, kz_amqp_worker:default_timeout(), Bind).
+
+-spec amqp_pool_request_custom(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun(), timeout(), gen_listener:binding()) ->
+                                      kz_amqp_worker:request_return().
 amqp_pool_request_custom(Api, PubFun, ValidateFun, Timeout, Bind)
   when is_function(PubFun, 1),
        is_function(ValidateFun, 1),

--- a/core/kazoo_apps/src/kazoo_apps_init.erl
+++ b/core/kazoo_apps/src/kazoo_apps_init.erl
@@ -96,10 +96,10 @@ log_slow_resolution(Min, Max, Mean, Median) ->
 -type resolutions() :: {Min :: pos_integer(), Max :: pos_integer(), Total:: pos_integer(), Timings :: [pos_integer()]}.
 
 -spec time_hostname_resolutions(pos_integer()) -> resolutions().
--spec time_hostname_resolutions(pos_integer(), pos_integer()) -> resolutions().
 time_hostname_resolutions(HowManyTests) ->
     time_hostname_resolutions(HowManyTests, time_hostname_resolution()).
 
+-spec time_hostname_resolutions(pos_integer(), pos_integer()) -> resolutions().
 time_hostname_resolutions(HowManyTests, InitTime) ->
     lists:foldl(fun time_hostname_resolution/2
                ,{InitTime, InitTime, InitTime, []}

--- a/core/kazoo_apps/src/kz_hooks.erl
+++ b/core/kazoo_apps/src/kz_hooks.erl
@@ -16,29 +16,37 @@
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
 
 -spec register() -> 'true'.
--spec register(kz_term:ne_binary()) -> 'true'.
--spec register(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 register() -> kz_hooks_util:register().
+
+-spec register(kz_term:ne_binary()) -> 'true'.
 register(AccountId) -> kz_hooks_util:register(AccountId).
+
+-spec register(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 register(AccountId, EventName) -> kz_hooks_util:register(AccountId, EventName).
 
 -spec deregister() -> 'true'.
--spec deregister(kz_term:ne_binary()) -> 'true'.
--spec deregister(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 deregister() -> kz_hooks_util:deregister().
+
+-spec deregister(kz_term:ne_binary()) -> 'true'.
 deregister(AccountId) -> kz_hooks_util:deregister(AccountId).
+
+-spec deregister(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 deregister(AccountId, EventName) -> kz_hooks_util:deregister(AccountId, EventName).
 
 -spec register_rr() -> 'true'.
--spec register_rr(kz_term:ne_binary()) -> 'true'.
--spec register_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 register_rr() -> kz_hooks_util:register_rr().
+
+-spec register_rr(kz_term:ne_binary()) -> 'true'.
 register_rr(AccountId) -> kz_hooks_util:register_rr(AccountId).
+
+-spec register_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 register_rr(AccountId, EventName) -> kz_hooks_util:register_rr(AccountId, EventName).
 
 -spec deregister_rr() -> 'true'.
--spec deregister_rr(kz_term:ne_binary()) -> 'true'.
--spec deregister_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 deregister_rr() -> kz_hooks_util:deregister_rr().
+
+-spec deregister_rr(kz_term:ne_binary()) -> 'true'.
 deregister_rr(AccountId) -> kz_hooks_util:deregister_rr(AccountId).
+
+-spec deregister_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 deregister_rr(AccountId, EventName) -> kz_hooks_util:deregister_rr(AccountId, EventName).

--- a/core/kazoo_apps/src/kz_hooks_util.erl
+++ b/core/kazoo_apps/src/kz_hooks_util.erl
@@ -39,32 +39,38 @@
        ,{'p', 'l', {'kz_hook_rr', AccountId, EventName}}).
 
 -spec register() -> 'true'.
--spec register(kz_term:ne_binary()) -> 'true'.
--spec register(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 register() ->
     maybe_add_hook(?HOOK_REG).
+
+-spec register(kz_term:ne_binary()) -> 'true'.
 register(AccountId) ->
     maybe_add_hook(?HOOK_REG(AccountId)).
+
+-spec register(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 register(AccountId, EventName) ->
     maybe_add_hook(?HOOK_REG(AccountId, EventName)).
 
 -spec deregister() -> 'true'.
--spec deregister(kz_term:ne_binary()) -> 'true'.
--spec deregister(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 deregister() ->
     maybe_remove_hook(?HOOK_REG).
+
+-spec deregister(kz_term:ne_binary()) -> 'true'.
 deregister(AccountId) ->
     maybe_remove_hook(?HOOK_REG(AccountId)).
+
+-spec deregister(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 deregister(AccountId, EventName) ->
     maybe_remove_hook(?HOOK_REG(AccountId, EventName)).
 
 -spec registered() -> kz_term:pids().
--spec registered(kz_term:ne_binary()) -> kz_term:pids().
--spec registered(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:pids().
 registered() ->
     gproc:lookup_pids(?HOOK_REG).
+
+-spec registered(kz_term:ne_binary()) -> kz_term:pids().
 registered(AccountId) ->
     gproc:lookup_pids(?HOOK_REG(AccountId)).
+
+-spec registered(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:pids().
 registered(AccountId, EventName) ->
     gproc:lookup_pids(?HOOK_REG(AccountId, EventName)).
 
@@ -87,32 +93,38 @@ all_registered_fold(HookPattern, Acc) ->
     gproc:select(Match) ++ Acc.
 
 -spec register_rr() -> 'true'.
--spec register_rr(kz_term:ne_binary()) -> 'true'.
--spec register_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 register_rr() ->
     maybe_add_hook(?HOOK_REG_RR).
+
+-spec register_rr(kz_term:ne_binary()) -> 'true'.
 register_rr(AccountId) ->
     maybe_add_hook(?HOOK_REG_RR(AccountId)).
+
+-spec register_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 register_rr(AccountId, EventName) ->
     maybe_add_hook(?HOOK_REG_RR(AccountId, EventName)).
 
 -spec deregister_rr() -> 'true'.
--spec deregister_rr(kz_term:ne_binary()) -> 'true'.
--spec deregister_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 deregister_rr() ->
     maybe_remove_hook(?HOOK_REG_RR).
+
+-spec deregister_rr(kz_term:ne_binary()) -> 'true'.
 deregister_rr(AccountId) ->
     maybe_remove_hook(?HOOK_REG_RR(AccountId)).
+
+-spec deregister_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> 'true'.
 deregister_rr(AccountId, EventName) ->
     maybe_remove_hook(?HOOK_REG_RR(AccountId, EventName)).
 
 -spec registered_rr() -> kz_term:pids().
--spec registered_rr(kz_term:ne_binary()) -> kz_term:pids().
--spec registered_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:pids().
 registered_rr() ->
     gproc:lookup_pids(?HOOK_REG_RR).
+
+-spec registered_rr(kz_term:ne_binary()) -> kz_term:pids().
 registered_rr(AccountId) ->
     gproc:lookup_pids(?HOOK_REG_RR(AccountId)).
+
+-spec registered_rr(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:pids().
 registered_rr(AccountId, EventName) ->
     gproc:lookup_pids(?HOOK_REG_RR(AccountId, EventName)).
 
@@ -128,13 +140,13 @@ all_registered_rr() ->
      ).
 
 -spec maybe_add_hook(tuple()) -> 'true'.
--spec maybe_add_hook(tuple(), kz_term:pids()) -> 'true'.
 maybe_add_hook(Hook) ->
     case gproc:lookup_pids(Hook) of
         [] -> hook_it_up(Hook);
         Pids -> maybe_add_hook(Hook, Pids)
     end.
 
+-spec maybe_add_hook(tuple(), kz_term:pids()) -> 'true'.
 maybe_add_hook(Hook, Pids) ->
     lists:member(self(), Pids)
         orelse hook_it_up(Hook).
@@ -159,9 +171,10 @@ maybe_add_binding(?HOOK_REG_RR(_AccountId, EventName)) ->
     maybe_add_binding_to_listener('kz_hooks_shared_listener', EventName).
 
 -spec maybe_add_binding_to_listener(atom()) -> 'ok'.
--spec maybe_add_binding_to_listener(atom(), kz_term:ne_binary() | 'all') -> 'ok'.
 maybe_add_binding_to_listener(ServerName) ->
     maybe_add_binding_to_listener(ServerName, 'all').
+
+-spec maybe_add_binding_to_listener(atom(), kz_term:ne_binary() | 'all') -> 'ok'.
 maybe_add_binding_to_listener(ServerName, EventName) ->
     gen_listener:cast(ServerName, {'maybe_add_binding', EventName}).
 
@@ -192,9 +205,10 @@ maybe_remove_binding(?HOOK_REG_RR(_AccountId, EventName)) ->
     maybe_remove_binding_to_listener('kz_hooks_shared_listener', EventName).
 
 -spec maybe_remove_binding_to_listener(atom()) -> 'ok'.
--spec maybe_remove_binding_to_listener(atom(), kz_term:ne_binary() | 'all') -> 'ok'.
 maybe_remove_binding_to_listener(ServerName) ->
     maybe_remove_binding_to_listener(ServerName, 'all').
+
+-spec maybe_remove_binding_to_listener(atom(), kz_term:ne_binary() | 'all') -> 'ok'.
 maybe_remove_binding_to_listener(ServerName, EventName) ->
     gen_listener:cast(ServerName, {'maybe_remove_binding', EventName}).
 

--- a/core/kazoo_ast/src/cb_api_endpoints.erl
+++ b/core/kazoo_ast/src/cb_api_endpoints.erl
@@ -36,10 +36,10 @@
 -define(X_AUTH_TOKEN_NOT_REQUIRED, "auth_token_header_or_none").
 
 -spec to_ref_doc() -> 'ok'.
--spec to_ref_doc(atom()) -> 'ok'.
 to_ref_doc() ->
     lists:foreach(fun api_to_ref_doc/1, ?MODULE:get()).
 
+-spec to_ref_doc(atom()) -> 'ok'.
 to_ref_doc('crossbar_filter'=Module) ->
     Filters = filters_from_module(Module),
     filters_to_ref_doc(Filters);

--- a/core/kazoo_ast/src/code_usage.erl
+++ b/core/kazoo_ast/src/code_usage.erl
@@ -9,17 +9,17 @@
 -define(DEFAULT_TOP, 25).
 
 -spec tabulate() -> 'ok'.
--spec tabulate(atom() | pos_integer()) -> 'ok'.
--spec tabulate(atom(), pos_integer()) -> 'ok'.
 tabulate() ->
     print_usage(process(), ?DEFAULT_TOP).
 
+-spec tabulate(atom() | pos_integer()) -> 'ok'.
 tabulate(App) when is_atom(App) ->
     tabulate(App, ?DEFAULT_TOP);
 tabulate(Top) when is_integer(Top)
                    andalso Top > 0 ->
     print_usage(process(), Top).
 
+-spec tabulate(atom(), pos_integer()) -> 'ok'.
 tabulate(App, Top) when is_atom(App)
                         andalso is_integer(Top)
                         andalso Top > 0 ->

--- a/core/kazoo_ast/src/kapi_schemas.erl
+++ b/core/kazoo_ast/src/kapi_schemas.erl
@@ -22,9 +22,10 @@
 -type acc() :: #acc{}.
 
 -spec to_schemas() -> 'ok'.
--spec to_schemas(atom()) -> 'ok'.
 to_schemas() ->
     kz_json:foreach(fun update_schema/1, process()).
+
+-spec to_schemas(atom()) -> 'ok'.
 to_schemas(App) ->
     kz_json:foreach(fun update_schema/1, process_app(App)).
 
@@ -69,8 +70,6 @@ existing_schema(Name) ->
     end.
 
 -spec process() -> kz_json:object().
--spec process_app(atom()) -> kz_json:object().
--spec process_module(module()) -> kz_json:object().
 process() ->
     io:format("process kapi modules: "),
     Options = [{'expression', fun expression_to_schema/2}
@@ -84,6 +83,7 @@ process() ->
     io:format(" done~n", []),
     Schemas.
 
+-spec process_app(atom()) -> kz_json:object().
 process_app(App) ->
     io:format("process kapi modules: "),
     Options = [{'expression', fun expression_to_schema/2}
@@ -97,6 +97,7 @@ process_app(App) ->
     io:format(" done~n", []),
     Schemas.
 
+-spec process_module(module()) -> kz_json:object().
 process_module(KapiModule) ->
     io:format("process kapi module ~s: ", [KapiModule]),
     Options = [{'expression', fun expression_to_schema/2}

--- a/core/kazoo_ast/src/kapps_config_usage.erl
+++ b/core/kazoo_ast/src/kapps_config_usage.erl
@@ -27,15 +27,14 @@
                 }.
 
 -spec to_schema_docs() -> 'ok'.
--spec to_schema_docs(atom()) -> 'ok'.
 to_schema_docs() ->
     kz_json:foreach(fun update_schema/1, process_project()).
 
+-spec to_schema_docs(atom()) -> 'ok'.
 to_schema_docs(App) ->
     kz_json:foreach(fun update_schema/1, process_app(App)).
 
 -spec update_schema({file:filename_all(), kz_json:json_term()}) -> 'ok'.
--spec update_schema(kz_json:key(), kz_json:json_object(), file:filename_all()) -> 'ok'.
 update_schema({PrivDir, Schemas}) ->
     ?DEBUG("adding schemas to priv dir ~s~n~p~n", [PrivDir, Schemas]),
 
@@ -44,6 +43,8 @@ update_schema({PrivDir, Schemas}) ->
                     end
                    ,Schemas
                    ).
+
+-spec update_schema(kz_json:key(), kz_json:json_object(), file:filename_all()) -> 'ok'.
 update_schema(Name, AutoGenSchema, PrivDir) ->
     ?DEBUG("~s detected ~p~n", [Name, AutoGenSchema]),
     AccountSchema = account_properties(AutoGenSchema),

--- a/core/kazoo_ast/src/kast_app_deps.erl
+++ b/core/kazoo_ast/src/kast_app_deps.erl
@@ -25,13 +25,13 @@
 
 -spec dot_file() -> 'ok' |
                     {'error', file:posix() | 'badarg' | 'terminated' | 'system_limit'}.
--spec dot_file(atom()) ->
-                      'ok' |
-                      {'error', file:posix() | 'badarg' | 'terminated' | 'system_limit'}.
 dot_file() ->
     Markup = [create_dot_markup(App, remote_apps(App)) || App <- kz_ast_util:project_apps()],
     create_dot_file("kazoo_project", Markup).
 
+-spec dot_file(atom()) ->
+                      'ok' |
+                      {'error', file:posix() | 'badarg' | 'terminated' | 'system_limit'}.
 dot_file(App) ->
     AppDeps = remote_apps(App),
     create_dot_file(App, create_dot_markup(App, AppDeps)).
@@ -141,9 +141,10 @@ start_cache() ->
     {'ok', _Cache} = kz_cache:start_link(?MODULE).
 
 -spec stop_cache() -> 'ok'.
--spec stop_cache(kz_types:server_ref()) -> 'ok'.
 stop_cache() ->
     stop_cache(?MODULE).
+
+-spec stop_cache(kz_types:server_ref()) -> 'ok'.
 stop_cache(Cache) ->
     kz_cache:stop_local(Cache).
 

--- a/core/kazoo_ast/src/kazoo_ast.erl
+++ b/core/kazoo_ast/src/kazoo_ast.erl
@@ -74,11 +74,11 @@ option_to_config({K, V}, Config) ->
     maps:put(K, V, Config).
 
 -spec process_app(atom(), config()) -> config().
--spec process_app_modules(atom(), config()) -> config().
 process_app(App, Config0) ->
     Config2 = process_app_modules(App, callback_application(App, Config0)),
     callback_after_application(App, Config2).
 
+-spec process_app_modules(atom(), config()) -> config().
 process_app_modules(_App, {'skip', Config}) -> Config;
 process_app_modules(App, Config) ->
     try process_modules(kz_ast_util:app_modules(App), Config)

--- a/core/kazoo_ast/src/kz_ast_util.erl
+++ b/core/kazoo_ast/src/kz_ast_util.erl
@@ -132,9 +132,10 @@ default_schema_priv_dir() ->
     kz_term:to_binary(code:priv_dir('crossbar')).
 
 -spec schema_path(binary()) -> file:filename_all().
--spec schema_path(binary(), file:filename_all()) -> file:filename_all().
 schema_path(Base) ->
     schema_path(Base, default_schema_priv_dir()).
+
+-spec schema_path(binary(), file:filename_all()) -> file:filename_all().
 schema_path(Base, PrivDir) ->
     case filename:join([PrivDir
                        ,<<"couchdb">>

--- a/core/kazoo_bindings/src/kazoo_bindings.erl
+++ b/core/kazoo_bindings/src/kazoo_bindings.erl
@@ -129,19 +129,20 @@
 %% is the payload, possibly modified
 %% @end
 %%--------------------------------------------------------------------
+
 -spec map(kz_term:ne_binary(), payload()) -> map_results().
--spec map(kz_term:ne_binary(), payload(), kz_rt_options()) -> map_results().
 map(Routing, Payload) ->
     map_processor(Routing, Payload, rt_options()).
 
+-spec map(kz_term:ne_binary(), payload(), kz_rt_options()) -> map_results().
 map(Routing, Payload, Options) ->
     map_processor(Routing, Payload, rt_options(Options)).
 
 -spec pmap(kz_term:ne_binary(), payload()) -> map_results().
--spec pmap(kz_term:ne_binary(), payload(), kz_rt_options()) -> map_results().
 pmap(Routing, Payload) ->
     pmap_processor(Routing, Payload, rt_options()).
 
+-spec pmap(kz_term:ne_binary(), payload(), kz_rt_options()) -> map_results().
 pmap(Routing, Payload, Options) ->
     pmap_processor(Routing, Payload, rt_options(Options)).
 
@@ -299,15 +300,16 @@ stop() -> gen_server:cast(?SERVER, 'stop').
 -type bind_result() :: 'ok' |
                        {'error', 'exists'}.
 -type bind_results() :: [bind_result()].
+
 -spec bind(kz_term:ne_binary() | kz_term:ne_binaries(), atom(), atom()) ->
-                  bind_result() | bind_results().
--spec bind(kz_term:ne_binary() | kz_term:ne_binaries(), atom(), atom(), any()) ->
                   bind_result() | bind_results().
 bind([_|_]=Bindings, Module, Fun) ->
     [bind(Binding, Module, Fun) || Binding <- Bindings];
 bind(Binding, Module, Fun) when is_binary(Binding) ->
     bind(Binding, Module, Fun, 'undefined').
 
+-spec bind(kz_term:ne_binary() | kz_term:ne_binaries(), atom(), atom(), any()) ->
+                  bind_result() | bind_results().
 bind([_|_]=Bindings, Module, Fun, Payload) ->
     [bind(Binding, Module, Fun, Payload) || Binding <- Bindings];
 bind(Binding, Module, Fun, Payload) ->
@@ -320,13 +322,13 @@ bind(Binding, Module, Fun, Payload) ->
 
 -spec unbind(kz_term:ne_binary() | kz_term:ne_binaries(), atom(), atom()) ->
                     unbind_result() | unbind_results().
--spec unbind(kz_term:ne_binary() | kz_term:ne_binaries(), atom(), atom(), any()) ->
-                    unbind_result() | unbind_results().
 unbind([_|_]=Bindings, Module, Fun) ->
     [unbind(Binding, Module, Fun) || Binding <- Bindings];
 unbind(Binding, Module, Fun) when is_binary(Binding) ->
     unbind(Binding, Module, Fun, 'undefined').
 
+-spec unbind(kz_term:ne_binary() | kz_term:ne_binaries(), atom(), atom(), any()) ->
+                    unbind_result() | unbind_results().
 unbind([_|_]=Bindings, Module, Fun, Payload) ->
     [unbind(Binding, Module, Fun, Payload) || Binding <- Bindings];
 unbind(Binding, Module, Fun, Payload) ->
@@ -548,11 +550,12 @@ flush_mod(ClientMod, #kz_binding{binding=Binding
     end.
 
 -type filter_updates() :: [{kz_term:ne_binary(), {pos_integer(), queue:queue()}}] | [].
+
 -spec filter_bindings(filter_fun()) -> 'ok'.
--spec filter_bindings(filter_fun(), kz_term:ne_binary() | '$end_of_table', filter_updates(), kz_term:ne_binaries()) -> 'ok'.
 filter_bindings(Predicate) ->
     filter_bindings(Predicate, ets:first(table_id()), [], []).
 
+-spec filter_bindings(filter_fun(), kz_term:ne_binary() | '$end_of_table', filter_updates(), kz_term:ne_binaries()) -> 'ok'.
 filter_bindings(_Predicate, '$end_of_table', Updates, Deletes) ->
     _ = [ets:delete(table_id(), DeleteKey) || DeleteKey <- Deletes],
     _ = [ets:update_element(table_id(), Key, Update) || {Key, Update} <- Updates],

--- a/core/kazoo_caches/src/kz_cache.erl
+++ b/core/kazoo_caches/src/kz_cache.erl
@@ -93,12 +93,12 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
--spec start_link(atom()) -> kz_types:startlink_ret().
--spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 
+-spec start_link(atom()) -> kz_types:startlink_ret().
 start_link(Name) when is_atom(Name) ->
     start_link(Name, ?EXPIRE_PERIOD, []).
 
+-spec start_link(atom(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Name, Props) when is_list(Props) ->
     start_link(Name, ?EXPIRE_PERIOD, Props).
 
@@ -134,11 +134,11 @@ maybe_add_db_binding([[]]) -> [[]];
 maybe_add_db_binding(BindingProps) ->
     [?DATABASE_BINDING | BindingProps].
 
--spec store(any(), any()) -> 'ok'.
--spec store(any(), any(), kz_term:proplist()) -> 'ok'.
 
+-spec store(any(), any()) -> 'ok'.
 store(K, V) -> store(K, V, []).
 
+-spec store(any(), any(), kz_term:proplist()) -> 'ok'.
 store(K, V, Props) -> store_local(?SERVER, K, V, Props).
 
 -spec peek(any()) -> {'ok', any()} |
@@ -167,21 +167,21 @@ dump() -> dump('false').
 -spec dump(kz_term:text()) -> 'ok'.
 dump(ShowValue) -> dump_local(?SERVER, ShowValue).
 
+
 -spec wait_for_key(any()) -> {'ok', any()} |
                              {'error', 'timeout'}.
--spec wait_for_key(any(), timeout()) -> {'ok', any()} |
-                                        {'error', 'timeout'}.
-
 wait_for_key(Key) -> wait_for_key(Key, ?DEFAULT_WAIT_TIMEOUT).
 
+-spec wait_for_key(any(), timeout()) -> {'ok', any()} |
+                                        {'error', 'timeout'}.
 wait_for_key(Key, Timeout) -> wait_for_key_local(?SERVER, Key, Timeout).
 
 %% Local cache API
--spec store_local(kz_types:server_ref(), any(), any()) -> 'ok'.
--spec store_local(kz_types:server_ref(), any(), any(), kz_term:proplist()) -> 'ok'.
 
+-spec store_local(kz_types:server_ref(), any(), any()) -> 'ok'.
 store_local(Srv, K, V) -> store_local(Srv, K, V, []).
 
+-spec store_local(kz_types:server_ref(), any(), any(), kz_term:proplist()) -> 'ok'.
 store_local(Srv, K, V, Props) when is_atom(Srv) ->
     case whereis(Srv) of
         'undefined' ->
@@ -319,12 +319,12 @@ display_cache_obj(#cache_obj{key=Key
 
 -spec wait_for_key_local(atom(), any()) -> {'ok', any()} |
                                            {'error', 'timeout'}.
--spec wait_for_key_local(atom(), any(), pos_integer()) ->
-                                {'ok', any()} |
-                                {'error', 'timeout'}.
 wait_for_key_local(Srv, Key) ->
     wait_for_key_local(Srv, Key, ?DEFAULT_WAIT_TIMEOUT).
 
+-spec wait_for_key_local(atom(), any(), pos_integer()) ->
+                                {'ok', any()} |
+                                {'error', 'timeout'}.
 wait_for_key_local(Srv, Key, Timeout) when is_integer(Timeout) ->
     WaitFor = Timeout + 100,
     {'ok', Ref} = gen_server:call(Srv, {'wait_for_key', Key, Timeout}, WaitFor),
@@ -675,7 +675,6 @@ get_props_callback(Props) ->
 get_props_origin(Props) -> props:get_value('origin', Props).
 
 -spec expire_objects(ets:tab(), [ets:tab()]) -> non_neg_integer().
--spec expire_objects(ets:tab(), [ets:tab()], list()) -> non_neg_integer().
 expire_objects(Tab, AuxTables) ->
     Now = kz_time:now_s(),
     FindSpec = [{#cache_obj{key = '$1'
@@ -692,6 +691,7 @@ expire_objects(Tab, AuxTables) ->
                 }],
     expire_objects(Tab, AuxTables, ets:select(Tab, FindSpec)).
 
+-spec expire_objects(ets:tab(), [ets:tab()], list()) -> non_neg_integer().
 expire_objects(_Tab, _AuxTables, []) -> 0;
 expire_objects(Tab, AuxTables, Objects) ->
     _ = maybe_exec_expired_callbacks(Objects),

--- a/core/kazoo_call/src/kapps_call.erl
+++ b/core/kazoo_call/src/kapps_call.erl
@@ -366,22 +366,22 @@ merge(OldJObj, JObj) ->
     kz_json:merge(OldJObj, JObj).
 
 -spec from_originate_uuid(kz_json:object()) -> call().
--spec from_originate_uuid(kz_json:object(), call()) -> call().
 from_originate_uuid(JObj) ->
     from_originate_uuid(JObj, new()).
 
+-spec from_originate_uuid(kz_json:object(), call()) -> call().
 from_originate_uuid(JObj, #kapps_call{}=Call) ->
     'true' = kapi_resource:originate_uuid_v(JObj),
     Call#kapps_call{control_q=kz_json:get_value(<<"Outbound-Call-Control-Queue">>, JObj, control_queue(Call))
                    ,call_id=kz_json:get_value(<<"Outbound-Call-ID">>, JObj, call_id(Call))
                    }.
 
--spec from_originate_ready(kz_json:object()) -> call().
--spec from_originate_ready(kz_json:object(), call()) -> call().
 
+-spec from_originate_ready(kz_json:object()) -> call().
 from_originate_ready(JObj) ->
     from_originate_ready(JObj, new()).
 
+-spec from_originate_ready(kz_json:object(), call()) -> call().
 from_originate_ready(JObj, #kapps_call{}=Call) ->
     'true' = kapi_resource:originate_ready_v(JObj),
     Call#kapps_call{control_q=kz_json:get_value(<<"Control-Queue">>, JObj, control_queue(Call))
@@ -389,10 +389,10 @@ from_originate_ready(JObj, #kapps_call{}=Call) ->
                    }.
 
 -spec from_channel_create(kz_json:object()) -> call().
--spec from_channel_create(kz_json:object(), call()) -> call().
 from_channel_create(JObj) ->
     from_channel_create(JObj, new()).
 
+-spec from_channel_create(kz_json:object(), call()) -> call().
 from_channel_create(JObj, Call) ->
     from_json(JObj, Call).
 
@@ -404,11 +404,12 @@ from_channel_create(JObj, Call) ->
 %% converting to/from json
 %% @end
 %%--------------------------------------------------------------------
+
 -spec from_json(kz_json:object()) -> call().
--spec from_json(kz_json:object(), call()) -> call().
 from_json(JObj) ->
     from_json(JObj, new()).
 
+-spec from_json(kz_json:object(), call()) -> call().
 from_json(JObj, #kapps_call{ccvs=OldCCVs
                            ,cavs=OldCAVs
                            ,kvs=Kvs
@@ -576,12 +577,12 @@ set_other_leg_call_id(CallId, #kapps_call{}=Call) ->
     Call#kapps_call{other_leg_call_id=CallId}.
 
 -spec call_id(call()) -> kz_term:api_binary().
--spec call_id_direct(call()) -> kz_term:api_binary().
 call_id(#kapps_call{call_id=CallId, call_id_helper=Fun}=Call) when is_function(Fun, 2) ->
     Fun(CallId, Call);
 call_id(#kapps_call{call_id=CallId}=Call) ->
     default_helper_function(CallId, Call).
 
+-spec call_id_direct(call()) -> kz_term:api_binary().
 call_id_direct(#kapps_call{call_id=CallId}) ->
     CallId.
 
@@ -602,12 +603,12 @@ set_control_queue(ControlQ, #kapps_call{}=Call) when is_binary(ControlQ) ->
     Call#kapps_call{control_q=ControlQ}.
 
 -spec control_queue(call()) -> kz_term:api_binary().
--spec control_queue_direct(call()) -> kz_term:api_binary().
 control_queue(#kapps_call{control_q=ControlQ, control_q_helper=Fun}=Call) when is_function(Fun, 2) ->
     Fun(ControlQ, Call);
 control_queue(#kapps_call{control_q=ControlQ}=Call) ->
     default_helper_function(ControlQ, Call).
 
+-spec control_queue_direct(call()) -> kz_term:api_binary().
 control_queue_direct(#kapps_call{control_q=ControlQ}) ->
     ControlQ.
 
@@ -1074,10 +1075,10 @@ language(#kapps_call{language=Language}) -> Language.
 -endif.
 
 -spec get_prompt(call(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
--spec get_prompt(call(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> kz_term:api_ne_binary().
 get_prompt(#kapps_call{}=Call, Media) ->
     get_prompt(Call, Media, language(Call)).
 
+-spec get_prompt(call(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> kz_term:api_ne_binary().
 get_prompt(Call, Media, 'undefined') ->
     kz_media_util:get_prompt(Media, language(Call), account_id(Call));
 get_prompt(Call, Media, Language) ->
@@ -1217,9 +1218,10 @@ set_custom_sip_header(Key, Value, #kapps_call{sip_headers=SHs}=Call) ->
     Call#kapps_call{sip_headers=kz_json:set_value(Key, Value, SHs)}.
 
 -spec custom_sip_header(kz_json:path(), call()) -> kz_json:api_json_term().
--spec custom_sip_header(kz_json:path(), Default, call()) -> kz_json:json_term() | Default.
 custom_sip_header(Key, #kapps_call{}=Call) ->
     custom_sip_header(Key, 'undefined', Call).
+
+-spec custom_sip_header(kz_json:path(), Default, call()) -> kz_json:json_term() | Default.
 custom_sip_header(Key, Default, #kapps_call{sip_headers=SHs}) ->
     kz_json:get_value(Key, SHs, Default).
 
@@ -1268,8 +1270,9 @@ kvs_erase(Key, #kapps_call{kvs=Dict}=Call) ->
 kvs_flush(#kapps_call{}=Call) -> Call#kapps_call{kvs=orddict:new()}.
 
 -spec kvs_fetch(any(), call()) -> any().
--spec kvs_fetch(any(), Default, call()) -> any() | Default.
 kvs_fetch(Key, Call) -> kvs_fetch(Key, 'undefined', Call).
+
+-spec kvs_fetch(any(), Default, call()) -> any() | Default.
 kvs_fetch(Key, Default, #kapps_call{kvs=Dict}) ->
     try orddict:fetch(kz_term:to_binary(Key), Dict)
     catch
@@ -1330,9 +1333,10 @@ kvs_update_counter(Key, Number, #kapps_call{kvs=Dict}=Call) ->
     Call#kapps_call{kvs=orddict:update_counter(kz_term:to_binary(Key), Number, Dict)}.
 
 -spec set_dtmf_collection(kz_term:api_binary(), call()) -> call().
--spec set_dtmf_collection(kz_term:api_binary(), kz_term:ne_binary(), call()) -> call().
 set_dtmf_collection(DTMF, Call) ->
     set_dtmf_collection(DTMF, <<"default">>, Call).
+
+-spec set_dtmf_collection(kz_term:api_binary(), kz_term:ne_binary(), call()) -> call().
 set_dtmf_collection('undefined', Collection, Call) ->
     Collections = kvs_fetch(<<"dtmf_collections">>, kz_json:new(), Call),
     kvs_store(<<"dtmf_collections">>
@@ -1347,16 +1351,18 @@ set_dtmf_collection(DTMF, Collection, Call) ->
              ).
 
 -spec get_dtmf_collection(call()) -> kz_term:api_binary().
--spec get_dtmf_collection(kz_term:ne_binary(), call()) -> kz_term:api_binary().
 get_dtmf_collection(Call) ->
     get_dtmf_collection(<<"default">>, Call).
+
+-spec get_dtmf_collection(kz_term:ne_binary(), call()) -> kz_term:api_binary().
 get_dtmf_collection(Collection, Call) ->
     kz_json:get_value(Collection, kvs_fetch(<<"dtmf_collections">>, kz_json:new(), Call)).
 
 -spec add_to_dtmf_collection(kz_term:ne_binary(), call()) -> call().
--spec add_to_dtmf_collection(kz_term:ne_binary(), kz_term:ne_binary(), call()) -> call().
 add_to_dtmf_collection(DTMF, Call) ->
     add_to_dtmf_collection(DTMF, <<"default">>, Call).
+
+-spec add_to_dtmf_collection(kz_term:ne_binary(), kz_term:ne_binary(), call()) -> call().
 add_to_dtmf_collection(DTMF, Collection, Call) ->
     case get_dtmf_collection(Collection, Call) of
         'undefined' -> set_dtmf_collection(DTMF, Collection, Call);
@@ -1367,30 +1373,30 @@ add_to_dtmf_collection(DTMF, Collection, Call) ->
 flush() ->
     kz_cache:flush_local(?KAPPS_CALL_CACHE).
 
--spec cache(call()) -> 'ok'.
--spec cache(call(), kz_term:api_binary()) -> 'ok'.
--spec cache(call(), kz_term:api_binary(), pos_integer()) -> 'ok'.
 
+-spec cache(call()) -> 'ok'.
 cache(Call) ->
     cache(Call, 'undefined', 5 * ?SECONDS_IN_MINUTE).
 
+-spec cache(call(), kz_term:api_binary()) -> 'ok'.
 cache(Call, AppName) ->
     cache(Call, AppName, 5 * ?SECONDS_IN_MINUTE).
 
+-spec cache(call(), kz_term:api_binary(), pos_integer()) -> 'ok'.
 cache(#kapps_call{call_id=CallId}=Call, AppName, Expires) ->
     CacheProps = [{'expires', Expires}],
     kz_cache:store_local(?KAPPS_CALL_CACHE, {?MODULE, 'call', AppName, CallId}, Call, CacheProps).
 
+
 -spec retrieve(kz_term:ne_binary()) ->
                       {'ok', call()} |
                       {'error', 'not_found'}.
--spec retrieve(kz_term:ne_binary(), kz_term:api_binary()) ->
-                      {'ok', call()} |
-                      {'error', 'not_found'}.
-
 retrieve(CallId) ->
     retrieve(CallId, 'undefined').
 
+-spec retrieve(kz_term:ne_binary(), kz_term:api_binary()) ->
+                      {'ok', call()} |
+                      {'error', 'not_found'}.
 retrieve(CallId, AppName) ->
     kz_cache:fetch_local(?KAPPS_CALL_CACHE, {?MODULE, 'call', AppName, CallId}).
 

--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -276,15 +276,14 @@ storage_retries(App) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec presence(kz_term:ne_binary(), kz_term:ne_binary() | kapps_call:call()) -> 'ok'.
--spec presence(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary() | kapps_call:call()) -> 'ok'.
--spec presence(kz_term:ne_binary(), kz_term:ne_binary() , kz_term:api_binary() , kapps_call:call() | 'undefined') -> 'ok'.
--spec presence(kz_term:ne_binary(), kz_term:ne_binary() , kz_term:api_binary() , kz_term:api_binary(), kapps_call:call() | 'undefined') -> 'ok'.
 presence(State, <<_/binary>> = PresenceId) ->
     presence(State, PresenceId, 'undefined');
 presence(State, Call) ->
     presence(State, kapps_call:from(Call)).
 
+-spec presence(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary() | kapps_call:call()) -> 'ok'.
 presence(State, PresenceId, 'undefined') ->
     presence(State, PresenceId, 'undefined', 'undefined');
 presence(State, PresenceId, <<_/binary>> = CallId) ->
@@ -292,9 +291,11 @@ presence(State, PresenceId, <<_/binary>> = CallId) ->
 presence(State, PresenceId, Call) ->
     presence(State, PresenceId, kapps_call:call_id(Call), Call).
 
+-spec presence(kz_term:ne_binary(), kz_term:ne_binary() , kz_term:api_binary() , kapps_call:call() | 'undefined') -> 'ok'.
 presence(State, PresenceId, CallId, Call) ->
     presence(State, PresenceId, CallId, 'undefined', Call).
 
+-spec presence(kz_term:ne_binary(), kz_term:ne_binary() , kz_term:api_binary() , kz_term:api_binary(), kapps_call:call() | 'undefined') -> 'ok'.
 presence(State, PresenceId, CallId, 'undefined', 'undefined') ->
     [User, Realm] = binary:split(PresenceId, <<"@">>),
     Command = props:filter_undefined(
@@ -355,8 +356,7 @@ module_as_app(Call) ->
 %% This request will execute immediately
 %% @end
 %%--------------------------------------------------------------------
--spec channel_status(kapps_call:call()) ->
-                            'ok' | {'error', 'no_channel_id'}.
+
 -spec channel_status(kz_term:api_binary(), kz_term:api_binary()) ->
                             'ok' | {'error', 'no_channel_id'}.
 channel_status('undefined', _) -> {'error', 'no_channel_id'};
@@ -368,9 +368,10 @@ channel_status(Call, SrvQueue) ->
     channel_status(kapps_call:call_id(Call), SrvQueue).
 
 -spec channel_status_command(kz_term:ne_binary() | kapps_call:call()) -> kz_term:proplist().
--spec channel_status_command(kz_term:ne_binary() | kapps_call:call(), kz_term:api_boolean()) -> kz_term:proplist().
 channel_status_command(CallId) ->
     channel_status_command(CallId, 'undefined').
+
+-spec channel_status_command(kz_term:ne_binary() | kapps_call:call(), kz_term:api_boolean()) -> kz_term:proplist().
 channel_status_command(<<_/binary>> = CallId, ActiveOnly) ->
     props:filter_undefined(
       [{<<"Call-ID">>, CallId}
@@ -379,6 +380,8 @@ channel_status_command(<<_/binary>> = CallId, ActiveOnly) ->
 channel_status_command(Call, ActiveOnly) ->
     channel_status_command(kapps_call:call_id(Call), ActiveOnly).
 
+-spec channel_status(kapps_call:call()) ->
+                            'ok' | {'error', 'no_channel_id'}.
 channel_status(Call) ->
     'true' = kapps_call:is_call(Call),
     channel_status(kapps_call:call_id(Call), kapps_call:controller_queue(Call)).
@@ -419,21 +422,24 @@ channel_status_filter([JObj|JObjs]) ->
 %% @end
 %%--------------------------------------------------------------------
 -type relay_fun() :: fun((pid() | atom(), any()) -> any()).
+
 -spec relay_event(pid(), kz_json:object()) -> any().
--spec relay_event(pid(), kz_json:object(), relay_fun()) -> any().
 relay_event(Pid, JObj) ->
     relay_event(Pid, JObj, fun erlang:send/2).
+
+-spec relay_event(pid(), kz_json:object(), relay_fun()) -> any().
 relay_event(Pid, JObj, RelayFun) ->
     RelayFun(Pid, {'amqp_msg', JObj}).
 
 -spec receive_event(timeout()) ->
                            {'ok', kz_json:object()} |
                            {'error', 'timeout'}.
+receive_event(Timeout) -> receive_event(Timeout, 'true').
+
 -spec receive_event(timeout(), boolean()) ->
                            {'ok', kz_json:object()} |
                            {'other', kz_json:object() | any()} |
                            {'error', 'timeout'}.
-receive_event(Timeout) -> receive_event(Timeout, 'true').
 receive_event(T, _) when T =< 0 -> {'error', 'timeout'};
 receive_event(Timeout, IgnoreOthers) ->
     Start = os:timestamp(),
@@ -448,11 +454,11 @@ receive_event(Timeout, IgnoreOthers) ->
 
 -spec audio_macro(audio_macro_prompts(), kapps_call:call()) ->
                          kz_term:ne_binary().
--spec audio_macro(audio_macro_prompts(), kapps_call:call(), kz_json:objects()) ->
-                         binary().
 audio_macro([], Call) -> noop(Call);
 audio_macro(Prompts, Call) -> audio_macro(Prompts, Call, []).
 
+-spec audio_macro(audio_macro_prompts(), kapps_call:call(), kz_json:objects()) ->
+                         binary().
 audio_macro([], Call, Queue) ->
     NoopId = kz_datamgr:get_uuid(),
     Prompts = [kz_json:from_list(
@@ -518,19 +524,22 @@ audio_macro([{'tts', Text, Voice, Lang, Engine}|T], Call, Queue) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec response(kz_term:ne_binary(), kapps_call:call()) ->
-                      {'ok', kz_term:ne_binary()} |
-                      {'error', 'no_response'}.
--spec response(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) ->
-                      {'ok', kz_term:ne_binary()} |
-                      {'error', 'no_response'}.
--spec response(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
                       {'ok', kz_term:ne_binary()} |
                       {'error', 'no_response'}.
 response(Code, Call) ->
     response(Code, 'undefined', Call).
+
+-spec response(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) ->
+                      {'ok', kz_term:ne_binary()} |
+                      {'error', 'no_response'}.
 response(Code, Cause, Call) ->
     response(Code, Cause, 'undefined', Call).
+
+-spec response(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
+                      {'ok', kz_term:ne_binary()} |
+                      {'error', 'no_response'}.
 response(Code, Cause, Media, Call) ->
     kz_call_response:send(Call, Code, Cause, Media).
 
@@ -539,45 +548,49 @@ response(Code, Cause, Media, Call) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec pickup(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec pickup(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec pickup(kz_term:ne_binary(), kz_term:api_binary(), boolean(), kapps_call:call()) -> 'ok'.
--spec pickup(kz_term:ne_binary(), kz_term:api_binary(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
--spec pickup(kz_term:ne_binary(), kz_term:api_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
 
+-spec pickup(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
 pickup(TargetCallId, Call) ->
     Command = pickup_command(TargetCallId, Call),
     send_command(Command, Call).
 
+-spec pickup(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 pickup(TargetCallId, Insert, Call) ->
     Command = pickup_command(TargetCallId, Insert, Call),
     send_command(Command, Call).
 
+-spec pickup(kz_term:ne_binary(), kz_term:api_binary(), boolean(), kapps_call:call()) -> 'ok'.
 pickup(TargetCallId, Insert, ContinueOnFail, Call) ->
     Command = pickup_command(TargetCallId, Insert, ContinueOnFail, Call),
     send_command(Command, Call).
 
+-spec pickup(kz_term:ne_binary(), kz_term:api_binary(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
 pickup(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call) ->
     Command = pickup_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call),
     send_command(Command, Call).
 
+-spec pickup(kz_term:ne_binary(), kz_term:api_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
 pickup(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterPickup, Call) ->
     Command = pickup_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterPickup, Call),
     send_command(Command, Call).
 
 -spec pickup_command(kz_term:ne_binary(), kapps_call:call()) -> kz_term:proplist().
--spec pickup_command(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:proplist().
--spec pickup_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kapps_call:call()) -> kz_term:proplist().
--spec pickup_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) -> kz_term:proplist().
--spec pickup_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> kz_term:proplist().
 pickup_command(TargetCallId, Call) ->
     pickup_command(TargetCallId, <<"tail">>, Call).
+
+-spec pickup_command(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:proplist().
 pickup_command(TargetCallId, Insert, Call) ->
     pickup_command(TargetCallId, Insert, 'false', Call).
+
+-spec pickup_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kapps_call:call()) -> kz_term:proplist().
 pickup_command(TargetCallId, Insert, ContinueOnFail, Call) ->
     pickup_command(TargetCallId, Insert, ContinueOnFail, 'true', Call).
+
+-spec pickup_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) -> kz_term:proplist().
 pickup_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call) ->
     pickup_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, 'false', Call).
+
+-spec pickup_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> kz_term:proplist().
 pickup_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterPickup, Call) ->
     [{<<"Application-Name">>, <<"call_pickup">>}
     ,{<<"Target-Call-ID">>, TargetCallId}
@@ -590,26 +603,30 @@ pickup_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfter
 
 -spec b_pickup(kz_term:ne_binary(), kapps_call:call()) ->
                       {'ok', kz_json:object()}.
--spec b_pickup(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) ->
-                      {'ok', kz_json:object()}.
--spec b_pickup(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kapps_call:call()) ->
-                      {'ok', kz_json:object()}.
--spec b_pickup(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) ->
-                      {'ok', kz_json:object()}.
--spec b_pickup(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) ->
-                      {'ok', kz_json:object()}.
 b_pickup(TargetCallId, Call) ->
     pickup(TargetCallId, Call),
     wait_for_channel_unbridge().
+
+-spec b_pickup(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) ->
+                      {'ok', kz_json:object()}.
 b_pickup(TargetCallId, Insert, Call) ->
     pickup(TargetCallId, Insert, Call),
     wait_for_channel_unbridge().
+
+-spec b_pickup(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kapps_call:call()) ->
+                      {'ok', kz_json:object()}.
 b_pickup(TargetCallId, Insert, ContinueOnFail, Call) ->
     pickup(TargetCallId, Insert, ContinueOnFail, Call),
     wait_for_channel_unbridge().
+
+-spec b_pickup(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) ->
+                      {'ok', kz_json:object()}.
 b_pickup(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call) ->
     pickup(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call),
     wait_for_channel_unbridge().
+
+-spec b_pickup(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) ->
+                      {'ok', kz_json:object()}.
 b_pickup(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterPickup, Call) ->
     pickup(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterPickup, Call),
     wait_for_channel_unbridge().
@@ -619,45 +636,49 @@ b_pickup(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterPickup
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec connect_leg(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec connect_leg(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec connect_leg(kz_term:ne_binary(), kz_term:api_binary(), boolean(), kapps_call:call()) -> 'ok'.
--spec connect_leg(kz_term:ne_binary(), kz_term:api_binary(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
--spec connect_leg(kz_term:ne_binary(), kz_term:api_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
 
+-spec connect_leg(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
 connect_leg(TargetCallId, Call) ->
     Command = connect_leg_command(TargetCallId, Call),
     send_command(Command, Call).
 
+-spec connect_leg(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 connect_leg(TargetCallId, Insert, Call) ->
     Command = connect_leg_command(TargetCallId, Insert, Call),
     send_command(Command, Call).
 
+-spec connect_leg(kz_term:ne_binary(), kz_term:api_binary(), boolean(), kapps_call:call()) -> 'ok'.
 connect_leg(TargetCallId, Insert, ContinueOnFail, Call) ->
     Command = connect_leg_command(TargetCallId, Insert, ContinueOnFail, Call),
     send_command(Command, Call).
 
+-spec connect_leg(kz_term:ne_binary(), kz_term:api_binary(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
 connect_leg(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call) ->
     Command = connect_leg_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call),
     send_command(Command, Call).
 
+-spec connect_leg(kz_term:ne_binary(), kz_term:api_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
 connect_leg(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterConnect_Leg, Call) ->
     Command = connect_leg_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterConnect_Leg, Call),
     send_command(Command, Call).
 
 -spec connect_leg_command(kz_term:ne_binary(), kapps_call:call()) -> kz_term:proplist().
--spec connect_leg_command(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:proplist().
--spec connect_leg_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kapps_call:call()) -> kz_term:proplist().
--spec connect_leg_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) -> kz_term:proplist().
--spec connect_leg_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> kz_term:proplist().
 connect_leg_command(TargetCallId, Call) ->
     connect_leg_command(TargetCallId, <<"tail">>, Call).
+
+-spec connect_leg_command(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:proplist().
 connect_leg_command(TargetCallId, Insert, Call) ->
     connect_leg_command(TargetCallId, Insert, 'false', Call).
+
+-spec connect_leg_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kapps_call:call()) -> kz_term:proplist().
 connect_leg_command(TargetCallId, Insert, ContinueOnFail, Call) ->
     connect_leg_command(TargetCallId, Insert, ContinueOnFail, 'true', Call).
+
+-spec connect_leg_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) -> kz_term:proplist().
 connect_leg_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call) ->
     connect_leg_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, 'false', Call).
+
+-spec connect_leg_command(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> kz_term:proplist().
 connect_leg_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterPickup, Call) ->
     [{<<"Application-Name">>, <<"connect_leg">>}
     ,{<<"Target-Call-ID">>, TargetCallId}
@@ -670,26 +691,30 @@ connect_leg_command(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Park
 
 -spec b_connect_leg(kz_term:ne_binary(), kapps_call:call()) ->
                            {'ok', kz_json:object()}.
--spec b_connect_leg(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) ->
-                           {'ok', kz_json:object()}.
--spec b_connect_leg(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kapps_call:call()) ->
-                           {'ok', kz_json:object()}.
--spec b_connect_leg(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) ->
-                           {'ok', kz_json:object()}.
--spec b_connect_leg(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) ->
-                           {'ok', kz_json:object()}.
 b_connect_leg(TargetCallId, Call) ->
     connect_leg(TargetCallId, Call),
     wait_for_channel_unbridge().
+
+-spec b_connect_leg(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) ->
+                           {'ok', kz_json:object()}.
 b_connect_leg(TargetCallId, Insert, Call) ->
     connect_leg(TargetCallId, Insert, Call),
     wait_for_channel_unbridge().
+
+-spec b_connect_leg(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kapps_call:call()) ->
+                           {'ok', kz_json:object()}.
 b_connect_leg(TargetCallId, Insert, ContinueOnFail, Call) ->
     connect_leg(TargetCallId, Insert, ContinueOnFail, Call),
     wait_for_channel_unbridge().
+
+-spec b_connect_leg(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) ->
+                           {'ok', kz_json:object()}.
 b_connect_leg(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call) ->
     connect_leg(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, Call),
     wait_for_channel_unbridge().
+
+-spec b_connect_leg(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) ->
+                           {'ok', kz_json:object()}.
 b_connect_leg(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterPickup, Call) ->
     connect_leg(TargetCallId, Insert, ContinueOnFail, ContinueOnCancel, ParkAfterPickup, Call),
     wait_for_channel_unbridge().
@@ -741,9 +766,10 @@ redirect_to_node(Contact, Node, Call) ->
 flush_dtmf(Call) -> play(<<"silence_stream://50">>, Call).
 
 -spec send_dtmf(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec send_dtmf(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 send_dtmf(DTMFs, Call) ->
     send_dtmf(DTMFs, 'undefined', Call).
+
+-spec send_dtmf(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 send_dtmf(DTMFs, Duration, Call) ->
     Cmd = send_dtmf_command(DTMFs, Duration),
     send_command(Cmd, Call).
@@ -776,11 +802,12 @@ recv_dtmf_command(DTMFs) ->
 %%   can not be used to set system settings
 %% @end
 %%--------------------------------------------------------------------
+
 -spec set(kz_term:api_object(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
--spec set(kz_term:api_object(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
 set(ChannelVars, CallVars, Call) ->
     set(ChannelVars, CallVars, 'undefined', Call).
 
+-spec set(kz_term:api_object(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
 set('undefined', CallVars, AppVars, Call) -> set(kz_json:new(), CallVars, AppVars, Call);
 set(ChannelVars, 'undefined', AppVars, Call) -> set(ChannelVars, kz_json:new(), AppVars, Call);
 set(ChannelVars, CallVars, AppVars, Call) ->
@@ -814,13 +841,12 @@ set_terminators(Terminators, Call) ->
 %%   can not the switch vars
 %% @end
 %%--------------------------------------------------------------------
+
+
 -spec fetch(kapps_call:call()) -> 'ok'.
--spec fetch(boolean(), kapps_call:call()) -> 'ok'.
-
--spec b_fetch(kapps_call:call()) -> kapps_api_std_return().
--spec b_fetch(boolean(), kapps_call:call()) -> kapps_api_std_return().
-
 fetch(Call) -> fetch('false', Call).
+
+-spec fetch(boolean(), kapps_call:call()) -> 'ok'.
 fetch(FromOtherLeg, Call) ->
     Command = [{<<"Application-Name">>, <<"fetch">>}
               ,{<<"Insert-At">>, <<"now">>}
@@ -828,7 +854,10 @@ fetch(FromOtherLeg, Call) ->
               ],
     send_command(Command, Call).
 
+-spec b_fetch(kapps_call:call()) -> kapps_api_std_return().
 b_fetch(Call) -> b_fetch('false', Call).
+
+-spec b_fetch(boolean(), kapps_call:call()) -> kapps_api_std_return().
 b_fetch(FromOtherLeg, Call) ->
     fetch(FromOtherLeg, Call),
     case wait_for_message(Call, <<"fetch">>) of
@@ -843,14 +872,15 @@ b_fetch(FromOtherLeg, Call) ->
 %% Produces the low level kz_api request to ring the channel
 %% @end
 %%--------------------------------------------------------------------
+
 -spec ring(kapps_call:call()) -> 'ok'.
--spec b_ring(kapps_call:call()) ->
-                    kapps_api_error() |
-                    {'ok', kz_json:object()}.
 ring(Call) ->
     Command = [{<<"Application-Name">>, <<"ring">>}],
     send_command(Command, Call).
 
+-spec b_ring(kapps_call:call()) ->
+                    kapps_api_error() |
+                    {'ok', kz_json:object()}.
 b_ring(Call) ->
     ring(Call),
     wait_for_message(Call, <<"ring">>).
@@ -861,27 +891,27 @@ b_ring(Call) ->
 %% Instructs the switch to expect to receive a fax
 %% @end
 %%--------------------------------------------------------------------
+
 -spec receive_fax(kapps_call:call()) -> 'ok'.
--spec receive_fax(boolean(), kapps_call:call()) -> 'ok'.
--spec receive_fax(boolean() | kz_term:api_binary()
-                 ,boolean() | kz_term:api_binary()
-                 ,kapps_call:call()) -> 'ok'.
--spec receive_fax(boolean() | kz_term:api_binary()
-                 ,boolean() | kz_term:api_binary()
-                 ,kz_term:api_binary()
-                 ,kapps_call:call()) -> 'ok'.
--spec b_receive_fax(kapps_call:call()) -> wait_for_fax_ret().
 receive_fax(Call) ->
     receive_fax(get_default_t38_setting(), Call).
 
+-spec receive_fax(boolean(), kapps_call:call()) -> 'ok'.
 receive_fax(DefaultFlag, Call) ->
     receive_fax(DefaultFlag, 'undefined', 'undefined', Call).
 
+-spec receive_fax(boolean() | kz_term:api_binary()
+                 ,boolean() | kz_term:api_binary()
+                 ,kapps_call:call()) -> 'ok'.
 receive_fax('undefined', 'undefined', Call) ->
     receive_fax(get_default_t38_setting(), 'undefined', 'undefined', Call);
 receive_fax(ResourceFlag, ReceiveFlag, Call) ->
     receive_fax(ResourceFlag, ReceiveFlag, 'undefined', Call).
 
+-spec receive_fax(boolean() | kz_term:api_binary()
+                 ,boolean() | kz_term:api_binary()
+                 ,kz_term:api_binary()
+                 ,kapps_call:call()) -> 'ok'.
 receive_fax(ResourceFlag, ReceiveFlag, LocalFilename, Call) ->
     Commands = props:filter_undefined([{<<"Application-Name">>, <<"receive_fax">>}
                                       ,{<<"Fax-Local-Filename">>, LocalFilename}
@@ -889,6 +919,7 @@ receive_fax(ResourceFlag, ReceiveFlag, LocalFilename, Call) ->
                                       ]),
     send_command(Commands, Call).
 
+-spec b_receive_fax(kapps_call:call()) -> wait_for_fax_ret().
 b_receive_fax(Call) ->
     receive_fax(Call),
     wait_for_fax().
@@ -906,16 +937,18 @@ get_default_t38_setting() ->
 %% Produces the low level kz_api request to answer the channel
 %% @end
 %%--------------------------------------------------------------------
+
 -spec answer(kapps_call:call()) -> 'ok'.
--spec answer_now(kapps_call:call()) -> 'ok'.
--spec b_answer(kapps_call:call()) ->
-                      kapps_api_error() |
-                      {'ok', kz_json:object()}.
 answer(Call) -> send_command([{<<"Application-Name">>, <<"answer">>}], Call).
+
+-spec answer_now(kapps_call:call()) -> 'ok'.
 answer_now(Call) -> send_command([{<<"Application-Name">>, <<"answer">>}
                                  ,{<<"Insert-At">>, <<"now">>}
                                  ], Call).
 
+-spec b_answer(kapps_call:call()) ->
+                      kapps_api_error() |
+                      {'ok', kz_json:object()}.
 b_answer(Call) ->
     answer(Call),
     wait_for_message(Call, <<"answer">>).
@@ -926,12 +959,13 @@ b_answer(Call) ->
 %% Produces the low level kz_api request to echo the channel
 %% @end
 %%--------------------------------------------------------------------
+
 -spec echo(kapps_call:call()) -> 'ok'.
+echo(Call) -> send_command([{<<"Application-Name">>, <<"echo">>}], Call).
+
 -spec b_echo(kapps_call:call()) ->
                     kapps_api_error() |
                     {'ok', kz_json:object()}.
-echo(Call) -> send_command([{<<"Application-Name">>, <<"echo">>}], Call).
-
 b_echo(Call) ->
     echo(Call),
     wait_for_message(Call, <<"echo">>).
@@ -957,25 +991,21 @@ break(Call) ->
 %% This request will execute immediately
 %% @end
 %%--------------------------------------------------------------------
--spec queued_hangup(kapps_call:call()) -> 'ok'.
+
+
 -spec hangup(kapps_call:call()) -> 'ok'.
--spec hangup(boolean(), kapps_call:call()) -> 'ok'.
-
--spec b_hangup(kapps_call:call()) ->
-                      {'ok', 'channel_hungup'}.
--spec b_hangup(boolean(), kapps_call:call()) ->
-                      {'ok', 'channel_hungup' | 'leg_hangup'}.
-
 hangup(Call) ->
     Command = [{<<"Application-Name">>, <<"hangup">>}
               ,{<<"Insert-At">>, <<"now">>}
               ],
     send_command(Command, Call).
 
+-spec queued_hangup(kapps_call:call()) -> 'ok'.
 queued_hangup(Call) ->
     Command = [{<<"Application-Name">>, <<"hangup">>}],
     send_command(Command, Call).
 
+-spec hangup(boolean(), kapps_call:call()) -> 'ok'.
 hangup(OtherLegOnly, Call) when is_boolean(OtherLegOnly) ->
     Command = [{<<"Application-Name">>, <<"hangup">>}
               ,{<<"Other-Leg-Only">>, OtherLegOnly}
@@ -983,9 +1013,14 @@ hangup(OtherLegOnly, Call) when is_boolean(OtherLegOnly) ->
               ],
     send_command(Command, Call).
 
+-spec b_hangup(kapps_call:call()) ->
+                      {'ok', 'channel_hungup'}.
 b_hangup(Call) ->
     hangup(Call),
     wait_for_hangup().
+
+-spec b_hangup(boolean(), kapps_call:call()) ->
+                      {'ok', 'channel_hungup' | 'leg_hangup'}.
 b_hangup('false', Call) ->
     hangup(Call),
     wait_for_hangup();
@@ -999,41 +1034,33 @@ b_hangup('true', Call) ->
 %% Produces the low level kz_api request to page the call
 %% @end
 %%--------------------------------------------------------------------
+
+
 -spec page(kz_json:objects(), kapps_call:call()) -> 'ok'.
--spec page(kz_json:objects(), integer(), kapps_call:call()) -> 'ok'.
--spec page(kz_json:objects(), integer(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
--spec page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
--spec page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
-
--spec b_page(kz_json:objects(), kapps_call:call()) ->
-                    wait_for_application_return().
--spec b_page(kz_json:objects(), integer(), kapps_call:call()) ->
-                    wait_for_application_return().
--spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kapps_call:call()) ->
-                    wait_for_application_return().
--spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
-                    wait_for_application_return().
--spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kapps_call:call()) ->
-                    wait_for_application_return().
--spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) ->
-                    wait_for_application_return().
--spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) ->
-                    wait_for_application_return().
-
 page(Endpoints, Call) ->
     page(Endpoints, ?DEFAULT_TIMEOUT_S, Call).
+
+-spec page(kz_json:objects(), integer(), kapps_call:call()) -> 'ok'.
 page(Endpoints, Timeout, Call) ->
     page(Endpoints, Timeout, 'undefined', Call).
+
+-spec page(kz_json:objects(), integer(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 page(Endpoints, Timeout, CIDName, Call) ->
     page(Endpoints, Timeout, CIDName, 'undefined', Call).
+
+-spec page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 page(Endpoints, Timeout, CIDName, CIDNumber, Call) ->
     page(Endpoints, Timeout, CIDName, CIDNumber, 'undefined', Call).
+
+-spec page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
 page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, Call) ->
     page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, 'undefined', Call).
+
+-spec page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
 page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, CCVs, Call) ->
     page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, CCVs, 'undefined', Call).
+
+-spec page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
 page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, CCVs, Options, Call) ->
     Command = [{<<"Application-Name">>, <<"page">>}
               ,{<<"Endpoints">>, Endpoints}
@@ -1046,18 +1073,38 @@ page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, CCVs, Options, Call) ->
               ],
     send_command(Command, Call).
 
+-spec b_page(kz_json:objects(), kapps_call:call()) ->
+                    wait_for_application_return().
 b_page(Endpoints, Call) ->
     b_page(Endpoints, ?DEFAULT_TIMEOUT_S, Call).
+
+-spec b_page(kz_json:objects(), integer(), kapps_call:call()) ->
+                    wait_for_application_return().
 b_page(Endpoints, Timeout, Call) ->
     b_page(Endpoints, Timeout, 'undefined', Call).
+
+-spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kapps_call:call()) ->
+                    wait_for_application_return().
 b_page(Endpoints, Timeout, CIDName, Call) ->
     b_page(Endpoints, Timeout, CIDName, 'undefined', Call).
+
+-spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
+                    wait_for_application_return().
 b_page(Endpoints, Timeout, CIDName, CIDNumber, Call) ->
     b_page(Endpoints, Timeout, CIDName, CIDNumber, 'undefined', Call).
+
+-spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kapps_call:call()) ->
+                    wait_for_application_return().
 b_page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, Call) ->
     b_page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, 'undefined', Call).
+
+-spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) ->
+                    wait_for_application_return().
 b_page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, CCVs, Call) ->
     b_page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, CCVs, 'undefined', Call).
+
+-spec b_page(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_object(), kz_term:api_object(), kapps_call:call()) ->
+                    wait_for_application_return().
 b_page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, CCVs, Options, Call) ->
     page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, CCVs, Options, Call),
     wait_for_application(Call, <<"page">>).
@@ -1068,31 +1115,7 @@ b_page(Endpoints, Timeout, CIDName, CIDNumber, SIPHeaders, CCVs, Options, Call) 
 %% Produces the low level kz_api request to bridge the call
 %% @end
 %%--------------------------------------------------------------------
--spec bridge(kz_json:objects(), kapps_call:call()) -> 'ok'.
--spec bridge(kz_json:objects(), integer(), kapps_call:call()) -> 'ok'.
--spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
--spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 
--spec b_bridge(kz_json:objects(), kapps_call:call()) ->
-                      kapps_api_bridge_return().
--spec b_bridge(kz_json:objects(), integer(), kapps_call:call()) ->
-                      kapps_api_bridge_return().
--spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kapps_call:call()) ->
-                      kapps_api_bridge_return().
--spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
-                      kapps_api_bridge_return().
--spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
-                      kapps_api_bridge_return().
--spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kapps_call:call()) ->
-                      kapps_api_bridge_return().
--spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_binary(), kapps_call:call()) ->
-                      kapps_api_bridge_return().
--spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
-                      kapps_api_bridge_return().
 
 bridge_command(Endpoints, Call) ->
     bridge_command(Endpoints, ?DEFAULT_TIMEOUT_S, Call).
@@ -1120,52 +1143,90 @@ bridge_command(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHead
     ,{<<"Ignore-Forward">>, IgnoreForward}
     ].
 
+-spec bridge(kz_json:objects(), kapps_call:call()) -> 'ok'.
 bridge(Endpoints, Call) ->
     Command = bridge_command(Endpoints, Call),
     send_command(Command, Call).
+
+-spec bridge(kz_json:objects(), integer(), kapps_call:call()) -> 'ok'.
 bridge(Endpoints, Timeout, Call) ->
     Command = bridge_command(Endpoints, Timeout, Call),
     send_command(Command, Call).
+
+-spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 bridge(Endpoints, Timeout, Strategy, Call) ->
     Command = bridge_command(Endpoints, Timeout, Strategy, Call),
     send_command(Command, Call).
+
+-spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Call) ->
     Command = bridge_command(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Call),
     send_command(Command, Call).
+
+-spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, Call) ->
     Command = bridge_command(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, Call),
     send_command(Command, Call).
+
+-spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kapps_call:call()) -> 'ok'.
 bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, Call) ->
     Command = bridge_command(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, Call),
     send_command(Command, Call).
+
+-spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, IgnoreForward, Call) ->
     Command = bridge_command(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, IgnoreForward, Call),
     send_command(Command, Call).
+
+-spec bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, IgnoreForward, FailOnSingleReject, Call) ->
     Command = bridge_command(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, IgnoreForward, FailOnSingleReject, Call),
     send_command(Command, Call).
 
+-spec b_bridge(kz_json:objects(), kapps_call:call()) ->
+                      kapps_api_bridge_return().
 b_bridge(Endpoints, Call) ->
     bridge(Endpoints, Call),
     b_bridge_wait(?DEFAULT_TIMEOUT_S, Call).
+
+-spec b_bridge(kz_json:objects(), integer(), kapps_call:call()) ->
+                      kapps_api_bridge_return().
 b_bridge(Endpoints, Timeout, Call) ->
     bridge(Endpoints, Timeout, Call),
     b_bridge_wait(Timeout, Call).
+
+-spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kapps_call:call()) ->
+                      kapps_api_bridge_return().
 b_bridge(Endpoints, Timeout, Strategy, Call) ->
     bridge(Endpoints, Timeout, Strategy, Call),
     b_bridge_wait(Timeout, Call).
+
+-spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
+                      kapps_api_bridge_return().
 b_bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Call) ->
     bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Call),
     b_bridge_wait(Timeout, Call).
+
+-spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
+                      kapps_api_bridge_return().
 b_bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, Call) ->
     bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, Call),
     b_bridge_wait(Timeout, Call).
+
+-spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kapps_call:call()) ->
+                      kapps_api_bridge_return().
 b_bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, Call) ->
     bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, Call),
     b_bridge_wait(Timeout, Call).
+
+-spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_binary(), kapps_call:call()) ->
+                      kapps_api_bridge_return().
 b_bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, IgnoreForward, Call) ->
     bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, IgnoreForward, Call),
     b_bridge_wait(Timeout, Call).
+
+-spec b_bridge(kz_json:objects(), integer(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_object(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) ->
+                      kapps_api_bridge_return().
 b_bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, IgnoreForward, FailOnSingleReject, Call) ->
     bridge(Endpoints, Timeout, Strategy, IgnoreEarlyMedia, Ringback, SIPHeaders, IgnoreForward, FailOnSingleReject, Call),
     b_bridge_wait(Timeout, Call).
@@ -1177,25 +1238,29 @@ b_bridge_wait(Timeout, Call) ->
     wait_for_bridge((kz_term:to_integer(Timeout) * ?MILLISECONDS_IN_SECOND) + ?EXTRA_BRIDGE_TIMEOUT , Call).
 
 -spec unbridge(kapps_call:call()) -> 'ok'.
--spec unbridge(kapps_call:call(), kz_term:api_ne_binary()) -> 'ok'.
--spec unbridge(kapps_call:call(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> 'ok'.
 unbridge(Call) ->
     Command = unbridge_command(Call),
     send_command(Command, Call).
+
+-spec unbridge(kapps_call:call(), kz_term:api_ne_binary()) -> 'ok'.
 unbridge(Call, Leg) ->
     Command = unbridge_command(Call, Leg),
     send_command(Command, Call).
+
+-spec unbridge(kapps_call:call(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> 'ok'.
 unbridge(Call, Leg, Insert) ->
     Command = unbridge_command(Call, Leg, Insert),
     send_command(Command, Call).
 
 -spec unbridge_command(kapps_call:call()) -> kz_term:proplist().
--spec unbridge_command(kapps_call:call(), kz_term:api_ne_binary()) -> kz_term:proplist().
--spec unbridge_command(kapps_call:call(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
 unbridge_command(Call) ->
     unbridge_command(Call, <<"Both">>).
+
+-spec unbridge_command(kapps_call:call(), kz_term:api_ne_binary()) -> kz_term:proplist().
 unbridge_command(Call, Leg) ->
     unbridge_command(Call, Leg, <<"now">>).
+
+-spec unbridge_command(kapps_call:call(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> kz_term:proplist().
 unbridge_command(Call, Leg, Insert) ->
     [{<<"Application-Name">>, <<"unbridge">>}
     ,{<<"Insert-At">>, Insert}
@@ -1204,23 +1269,26 @@ unbridge_command(Call, Leg, Insert) ->
     ].
 
 -spec soft_hold(kapps_call:call()) -> 'ok'.
--spec soft_hold(kapps_call:call(), kz_term:api_binary()) -> 'ok'.
 soft_hold(Call) ->
     soft_hold(Call, <<"1">>).
+
+-spec soft_hold(kapps_call:call(), kz_term:api_binary()) -> 'ok'.
 soft_hold(Call, UnholdKey) ->
     Command = soft_hold_command(kapps_call:call_id(Call), UnholdKey),
     send_command(Command, Call).
 
 -spec soft_hold_command(kz_term:ne_binary(), kz_term:ne_binary()) ->
                                kz_term:proplist().
--spec soft_hold_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
-                               kz_term:proplist().
--spec soft_hold_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:ne_binary()) ->
-                               kz_term:proplist().
 soft_hold_command(CallId, UnholdKey) ->
     soft_hold_command(CallId, UnholdKey, 'undefined', 'undefined').
+
+-spec soft_hold_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
+                               kz_term:proplist().
 soft_hold_command(CallId, UnholdKey, AMOH, BMOH) ->
     soft_hold_command(CallId, UnholdKey, AMOH, BMOH, <<"now">>).
+
+-spec soft_hold_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:ne_binary()) ->
+                               kz_term:proplist().
 soft_hold_command(CallId, UnholdKey, AMOH, BMOH, InsertAt) ->
     props:filter_undefined([{<<"Application-Name">>, <<"soft_hold">>}
                            ,{<<"Call-ID">>, CallId}
@@ -1243,28 +1311,24 @@ build_moh_keys(AMOH, BMOH) ->
 %% Produces the low level kz_api request to park the channel
 %% @end
 %%--------------------------------------------------------------------
+
+
+
 -spec hold(kapps_call:call()) -> 'ok'.
--spec hold(kz_term:api_binary(), kapps_call:call()) -> 'ok'.
-
--spec hold_command(kapps_call:call() | kz_term:ne_binary()) ->
-                          kz_json:object().
--spec hold_command(kz_term:api_binary(), kapps_call:call() | kz_term:ne_binary()) ->
-                          kz_json:object().
-
--spec b_hold(kapps_call:call()) ->
-                    kapps_api_std_return().
--spec b_hold(timeout() | kz_term:api_binary(), kapps_call:call()) ->
-                    kapps_api_std_return().
--spec b_hold(timeout(), kz_term:api_binary(), kapps_call:call()) ->
-                    kapps_api_std_return().
-
 hold(Call) -> hold('undefined', Call).
+
+-spec hold(kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 hold(MOH, Call) ->
     Command = hold_command(MOH, Call),
     send_command(Command, Call).
 
+-spec hold_command(kapps_call:call() | kz_term:ne_binary()) ->
+                          kz_json:object().
 hold_command(Call) ->
     hold_command('undefined', Call).
+
+-spec hold_command(kz_term:api_binary(), kapps_call:call() | kz_term:ne_binary()) ->
+                          kz_json:object().
 hold_command(MOH, CallId=?NE_BINARY) ->
     kz_json:from_list(
       [{<<"Application-Name">>, <<"hold">>}
@@ -1277,32 +1341,40 @@ hold_command(MOH, Call) ->
                 ,kapps_call:call_id_direct(Call)
                 ).
 
+-spec b_hold(kapps_call:call()) ->
+                    kapps_api_std_return().
 b_hold(Call) -> b_hold('infinity', 'undefined', Call).
 
+-spec b_hold(timeout() | kz_term:api_binary(), kapps_call:call()) ->
+                    kapps_api_std_return().
 b_hold(Timeout, Call) when is_integer(Timeout);
                            Timeout =:= 'infinity' ->
     b_hold(Timeout, 'undefined', Call);
 b_hold(MOH, Call) -> b_hold('infinity', MOH, Call).
 
+-spec b_hold(timeout(), kz_term:api_binary(), kapps_call:call()) ->
+                    kapps_api_std_return().
 b_hold(Timeout, MOH, Call) ->
     hold(MOH, Call),
     wait_for_message(Call, <<"hold">>, <<"CHANNEL_EXECUTE_COMPLETE">>, <<"call_event">>, Timeout).
 
+
+
 -spec hold_control(kapps_call:call()) -> 'ok'.
--spec hold_control(kz_term:api_binary(), kapps_call:call()) -> 'ok'.
-
--spec hold_control_command(kapps_call:call() | kz_term:ne_binary()) ->
-                                  kz_json:object().
--spec hold_control_command(kz_term:api_binary(), kapps_call:call() | kz_term:ne_binary()) ->
-                                  kz_json:object().
-
 hold_control(Call) -> hold_control(<<"toggle">>, Call).
+
+-spec hold_control(kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 hold_control(Action, Call) ->
     Command = hold_control_command(Action, Call),
     send_command(Command, Call).
 
+-spec hold_control_command(kapps_call:call() | kz_term:ne_binary()) ->
+                                  kz_json:object().
 hold_control_command(Call) ->
     hold_control_command(<<"toggle">>, Call).
+
+-spec hold_control_command(kz_term:api_binary(), kapps_call:call() | kz_term:ne_binary()) ->
+                                  kz_json:object().
 hold_control_command(Action, CallId=?NE_BINARY) ->
     kz_json:from_list(
       [{<<"Application-Name">>, <<"hold_control">>}
@@ -1335,19 +1407,21 @@ park_command(Call) ->
 %% caller.
 %% @end
 %%--------------------------------------------------------------------
+
+
 -spec prompt(kz_term:ne_binary(), kapps_call:call()) -> kz_term:ne_binary().
--spec prompt(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:ne_binary().
-
--spec b_prompt(kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_prompt(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
-
 prompt(Prompt, Call) ->
     play(kapps_call:get_prompt(Call, Prompt), Call).
+
+-spec prompt(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:ne_binary().
 prompt(Prompt, Lang, Call) ->
     play(kapps_call:get_prompt(Call, Prompt, Lang), Call).
 
+-spec b_prompt(kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_prompt(Prompt, Call) ->
     b_play(kapps_call:get_prompt(Call, Prompt), Call).
+
+-spec b_prompt(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_prompt(Prompt, Lang, Call) ->
     b_play(kapps_call:get_prompt(Call, Prompt, Lang), Call).
 
@@ -1359,42 +1433,26 @@ b_prompt(Prompt, Lang, Call) ->
 %% can use to skip playback.
 %% @end
 %%--------------------------------------------------------------------
--spec play(kz_term:ne_binary(), kapps_call:call()) ->
-                  kz_term:ne_binary().
--spec play(kz_term:ne_binary(), kz_term:api_binaries(), kapps_call:call()) ->
-                  kz_term:ne_binary().
--spec play(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) ->
-                  kz_term:ne_binary().
--spec play(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kz_term:api_boolean(), kapps_call:call()) ->
-                  kz_term:ne_binary().
+
+
 
 -spec play_command(kz_term:ne_binary(), kapps_call:call() | kz_term:ne_binary()) ->
                           kz_json:object().
--spec play_command(kz_term:ne_binary(), kz_term:api_binaries(), kapps_call:call() | kz_term:ne_binary()) ->
-                          kz_json:object().
--spec play_command(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call() | kz_term:ne_binary()) ->
-                          kz_json:object().
--spec play_command(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kz_term:api_boolean(), kapps_call:call() | kz_term:ne_binary()) ->
-                          kz_json:object().
-
--spec b_play(kz_term:ne_binary(), kapps_call:call()) ->
-                    kapps_api_std_return().
--spec b_play(kz_term:ne_binary(), kz_term:api_binaries(), kapps_call:call()) ->
-                    kapps_api_std_return().
--spec b_play(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) ->
-                    kapps_api_std_return().
--spec b_play(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kz_term:api_boolean(), kapps_call:call()) ->
-                    kapps_api_std_return().
-
 play_command(Media, Call) ->
     play_command(Media, ?ANY_DIGIT, Call).
 
+-spec play_command(kz_term:ne_binary(), kz_term:api_binaries(), kapps_call:call() | kz_term:ne_binary()) ->
+                          kz_json:object().
 play_command(Media, Terminators, Call) ->
     play_command(Media, Terminators, 'undefined', Call).
 
+-spec play_command(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call() | kz_term:ne_binary()) ->
+                          kz_json:object().
 play_command(Media, Terminators, Leg, Call) ->
     play_command(Media, Terminators, Leg, 'false', Call).
 
+-spec play_command(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kz_term:api_boolean(), kapps_call:call() | kz_term:ne_binary()) ->
+                          kz_json:object().
 play_command(Media, Terminators, Leg, Endless, CallId=?NE_BINARY) ->
     kz_json:from_list(
       [{<<"Application-Name">>, <<"play">>}
@@ -1415,11 +1473,22 @@ play_terminators(Ts) -> lists:usort(Ts).
 play_leg('undefined') -> 'undefined';
 play_leg(Leg) -> kz_binary:ucfirst(Leg).
 
+-spec play(kz_term:ne_binary(), kapps_call:call()) ->
+                  kz_term:ne_binary().
 play(Media, Call) -> play(Media, ?ANY_DIGIT, Call).
+
+-spec play(kz_term:ne_binary(), kz_term:api_binaries(), kapps_call:call()) ->
+                  kz_term:ne_binary().
 play(Media, Terminators, Call) ->
     play(Media, Terminators, 'undefined', Call).
+
+-spec play(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) ->
+                  kz_term:ne_binary().
 play(Media, Terminators, Leg, Call) ->
     play(Media, Terminators, Leg, 'false', Call).
+
+-spec play(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kz_term:api_boolean(), kapps_call:call()) ->
+                  kz_term:ne_binary().
 play(Media, Terminators, Leg, Endless, Call) ->
     NoopId = kz_datamgr:get_uuid(),
     Commands = [kz_json:from_list([{<<"Application-Name">>, <<"noop">>}
@@ -1434,12 +1503,23 @@ play(Media, Terminators, Leg, Endless, Call) ->
     send_command(Command, Call),
     NoopId.
 
+-spec b_play(kz_term:ne_binary(), kapps_call:call()) ->
+                    kapps_api_std_return().
 b_play(Media, Call) ->
     b_play(Media, ?ANY_DIGIT, Call).
+
+-spec b_play(kz_term:ne_binary(), kz_term:api_binaries(), kapps_call:call()) ->
+                    kapps_api_std_return().
 b_play(Media, Terminators, Call) ->
     b_play(Media, Terminators, 'undefined', Call).
+
+-spec b_play(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) ->
+                    kapps_api_std_return().
 b_play(Media, Terminators, Leg, Call) ->
     b_play(Media, Terminators, Leg, 'false', Call).
+
+-spec b_play(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kz_term:api_boolean(), kapps_call:call()) ->
+                    kapps_api_std_return().
 b_play(Media, Terminators, Leg, Endless, Call) ->
     wait_for_noop(Call, play(Media, Terminators, Leg, Endless, Call)).
 
@@ -1451,17 +1531,21 @@ b_play(Media, Terminators, Leg, Endless, Call) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec tts(kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
--spec tts(kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
--spec tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
--spec tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kapps_call:call()) -> kz_term:ne_binary().
--spec tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
 
+-spec tts(kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
 tts(SayMe, Call) -> tts(SayMe, kazoo_tts:default_voice(), Call).
+
+-spec tts(kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
 tts(SayMe, Voice, Call) -> tts(SayMe, Voice, kapps_call:language(Call), Call).
+
+-spec tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
 tts(SayMe, Voice, Lang, Call) -> tts(SayMe, Voice, Lang, ?ANY_DIGIT, Call).
+
+-spec tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kapps_call:call()) -> kz_term:ne_binary().
 tts(SayMe, Voice, Lang, Terminators, Call) ->
     tts(SayMe, Voice, Lang, Terminators, kazoo_tts:default_provider(Call), Call).
+
+-spec tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
 tts(SayMe, Voice, Lang, Terminators, Engine, Call) ->
     NoopId = kz_datamgr:get_uuid(),
 
@@ -1478,18 +1562,22 @@ tts(SayMe, Voice, Lang, Terminators, Engine, Call) ->
     NoopId.
 
 -spec tts_command(kz_term:api_binary(), kapps_call:call()) -> kz_json:object().
--spec tts_command(kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_json:object().
--spec tts_command(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_json:object().
--spec tts_command(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kapps_call:call()) -> kz_json:object().
--spec tts_command(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) -> kz_json:object().
 tts_command(SayMe, Call) ->
     tts_command(SayMe, kazoo_tts:default_voice(), Call).
+
+-spec tts_command(kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_json:object().
 tts_command(SayMe, Voice, Call) ->
     tts_command(SayMe, Voice, kapps_call:language(Call), Call).
+
+-spec tts_command(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_json:object().
 tts_command(SayMe, Voice, Language, Call) ->
     tts_command(SayMe, Voice, Language, ?ANY_DIGIT, Call).
+
+-spec tts_command(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kapps_call:call()) -> kz_json:object().
 tts_command(SayMe, Voice, Language, Terminators, Call) ->
     tts_command(SayMe, Voice, Language, Terminators, kazoo_tts:default_provider(Call), Call).
+
+-spec tts_command(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) -> kz_json:object().
 tts_command(SayMe, Voice, Language, Terminators, Engine, Call) ->
     kz_json:from_list(
       [{<<"Application-Name">>, <<"tts">>}
@@ -1516,20 +1604,24 @@ tts_language(Language, _Call) -> Language.
 tts_engine('undefined', Call) -> kazoo_tts:default_provider(Call);
 tts_engine(Engine, _Call) -> Engine.
 
--spec b_tts(kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_tts(kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kapps_call:call()) -> kapps_api_std_return().
--spec b_tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
 
+-spec b_tts(kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_tts(SayMe, Call) ->
     wait_for_noop(Call, tts(SayMe, Call)).
+
+-spec b_tts(kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_tts(SayMe, Voice, Call) ->
     wait_for_noop(Call, tts(SayMe, Voice, Call)).
+
+-spec b_tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_tts(SayMe, Voice, Lang, Call) ->
     wait_for_noop(Call, tts(SayMe, Voice, Lang, Call)).
+
+-spec b_tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kapps_call:call()) -> kapps_api_std_return().
 b_tts(SayMe, Voice, Lang, Terminators, Call) ->
     wait_for_noop(Call, tts(SayMe, Voice, Lang, Terminators, Call)).
+
+-spec b_tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_tts(SayMe, Voice, Lang, Terminators, Engine, Call) ->
     wait_for_noop(Call, tts(SayMe, Voice, Lang, Terminators, Engine, Call)).
 
@@ -1540,26 +1632,25 @@ b_tts(SayMe, Voice, Lang, Terminators, Engine, Call) ->
 %% A list of keys can be used as the terminator or a silence threshold.
 %% @end
 %%--------------------------------------------------------------------
+
+
 -spec record(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec record(kz_term:ne_binary(), kz_term:binaries(), kapps_call:call()) -> 'ok'.
--spec record(kz_term:ne_binary(), kz_term:binaries(),  kz_term:api_binary() | integer(), kapps_call:call()) -> 'ok'.
--spec record(kz_term:ne_binary(), kz_term:binaries(),  kz_term:api_binary() | integer(), kz_term:api_binary() | integer(), kapps_call:call()) -> 'ok'.
--spec record(kz_term:ne_binary(), kz_term:binaries(),  kz_term:api_binary() | integer(), kz_term:api_binary() | integer(),  kz_term:api_binary() | integer(), kapps_call:call()) -> 'ok'.
-
--spec b_record(kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_record(kz_term:ne_binary(), kz_term:binaries(), kapps_call:call()) -> kapps_api_std_return().
--spec b_record(kz_term:ne_binary(), kz_term:binaries(), kz_term:api_binary() | integer(), kapps_call:call()) -> kapps_api_std_return().
--spec b_record(kz_term:ne_binary(), kz_term:binaries(), kz_term:api_binary() | integer(), kz_term:api_binary() | integer(), kapps_call:call()) -> kapps_api_std_return().
--spec b_record(kz_term:ne_binary(), kz_term:binaries(), kz_term:api_binary() | integer(), kz_term:api_binary() | integer(), kz_term:api_binary() | integer(), kapps_call:call()) -> kapps_api_std_return().
-
 record(MediaName, Call) ->
     record(MediaName, ?ANY_DIGIT, Call).
+
+-spec record(kz_term:ne_binary(), kz_term:binaries(), kapps_call:call()) -> 'ok'.
 record(MediaName, Terminators, Call) ->
     record(MediaName, Terminators, <<"300">>, Call).
+
+-spec record(kz_term:ne_binary(), kz_term:binaries(),  kz_term:api_binary() | integer(), kapps_call:call()) -> 'ok'.
 record(MediaName, Terminators, TimeLimit, Call) ->
     record(MediaName, Terminators, TimeLimit, <<"200">>,  Call).
+
+-spec record(kz_term:ne_binary(), kz_term:binaries(),  kz_term:api_binary() | integer(), kz_term:api_binary() | integer(), kapps_call:call()) -> 'ok'.
 record(MediaName, Terminators, TimeLimit, SilenceThreshold, Call) ->
     record(MediaName, Terminators, TimeLimit, SilenceThreshold, <<"5">>, Call).
+
+-spec record(kz_term:ne_binary(), kz_term:binaries(),  kz_term:api_binary() | integer(), kz_term:api_binary() | integer(),  kz_term:api_binary() | integer(), kapps_call:call()) -> 'ok'.
 record(MediaName, Terminators, TimeLimit, SilenceThreshold, SilenceHits, Call) ->
     Command = [{<<"Application-Name">>, <<"record">>}
               ,{<<"Media-Name">>, MediaName}
@@ -1570,14 +1661,23 @@ record(MediaName, Terminators, TimeLimit, SilenceThreshold, SilenceHits, Call) -
               ],
     send_command(Command, Call).
 
+-spec b_record(kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_record(MediaName, Call) ->
     b_record(MediaName, ?ANY_DIGIT, Call).
+
+-spec b_record(kz_term:ne_binary(), kz_term:binaries(), kapps_call:call()) -> kapps_api_std_return().
 b_record(MediaName, Terminators, Call) ->
     b_record(MediaName, Terminators, <<"300">>, Call).
+
+-spec b_record(kz_term:ne_binary(), kz_term:binaries(), kz_term:api_binary() | integer(), kapps_call:call()) -> kapps_api_std_return().
 b_record(MediaName, Terminators, TimeLimit, Call) ->
     b_record(MediaName, Terminators, TimeLimit, <<"200">>,  Call).
+
+-spec b_record(kz_term:ne_binary(), kz_term:binaries(), kz_term:api_binary() | integer(), kz_term:api_binary() | integer(), kapps_call:call()) -> kapps_api_std_return().
 b_record(MediaName, Terminators, TimeLimit, SilenceThreshold, Call) ->
     b_record(MediaName, Terminators, TimeLimit, SilenceThreshold, <<"5">>, Call).
+
+-spec b_record(kz_term:ne_binary(), kz_term:binaries(), kz_term:api_binary() | integer(), kz_term:api_binary() | integer(), kz_term:api_binary() | integer(), kapps_call:call()) -> kapps_api_std_return().
 b_record(MediaName, Terminators, TimeLimit, SilenceThreshold, SilenceHits, Call) ->
     record(MediaName, Terminators, TimeLimit, SilenceThreshold, SilenceHits, Call),
     wait_for_headless_application(<<"record">>
@@ -1595,12 +1695,14 @@ verify_media_name(JObj, MediaName) ->
     end.
 
 -spec start_record_call(kz_term:proplist(), kapps_call:call()) -> 'ok'.
--spec start_record_call(kz_term:proplist(), kz_term:api_binary() | pos_integer(), kapps_call:call()) -> 'ok'.
--spec start_record_call(kz_term:proplist(), kz_term:api_binary() | pos_integer(), kz_term:ne_binaries(), kapps_call:call()) -> 'ok'.
 start_record_call(Media, Call) ->
     record_call(Media, <<"start">>, Call).
+
+-spec start_record_call(kz_term:proplist(), kz_term:api_binary() | pos_integer(), kapps_call:call()) -> 'ok'.
 start_record_call(Media, TimeLimit, Call) ->
     record_call(Media, <<"start">>, TimeLimit, Call).
+
+-spec start_record_call(kz_term:proplist(), kz_term:api_binary() | pos_integer(), kz_term:ne_binaries(), kapps_call:call()) -> 'ok'.
 start_record_call(Media, TimeLimit, Terminators, Call) ->
     record_call(Media, <<"start">>, TimeLimit, Terminators, Call).
 
@@ -1609,15 +1711,18 @@ stop_record_call(Media, Call) ->
     record_call(Media, <<"stop">>, Call).
 
 -spec record_call(kz_term:proplist(), kapps_call:call()) -> 'ok'.
--spec record_call(kz_term:proplist(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec record_call(kz_term:proplist(), kz_term:ne_binary(),  kz_term:api_binary() | pos_integer(), kapps_call:call()) -> 'ok'.
--spec record_call(kz_term:proplist(), kz_term:ne_binary(),  kz_term:api_binary() | pos_integer(), list(), kapps_call:call()) -> 'ok'.
 record_call(Media, Call) ->
     record_call(Media, <<"start">>, Call).
+
+-spec record_call(kz_term:proplist(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
 record_call(Media, Action, Call) ->
     record_call(Media, Action, 600, Call).
+
+-spec record_call(kz_term:proplist(), kz_term:ne_binary(),  kz_term:api_binary() | pos_integer(), kapps_call:call()) -> 'ok'.
 record_call(Media, Action, TimeLimit, Call) ->
     record_call(Media, Action, TimeLimit, ?ANY_DIGIT, Call).
+
+-spec record_call(kz_term:proplist(), kz_term:ne_binary(),  kz_term:api_binary() | pos_integer(), list(), kapps_call:call()) -> 'ok'.
 record_call(Media, Action, TimeLimit, Terminators, Call) ->
     Limit = props:get_value(<<"Time-Limit">>, Media, kz_term:to_binary(TimeLimit)),
     Command = props:filter_undefined(
@@ -1632,20 +1737,23 @@ record_call(Media, Action, TimeLimit, Terminators, Call) ->
 
 -spec b_record_call(kz_term:proplist(), kapps_call:call()) ->
                            wait_for_headless_application_return().
--spec b_record_call(kz_term:proplist(), kz_term:ne_binary(), kapps_call:call()) ->
-                           wait_for_headless_application_return().
--spec b_record_call(kz_term:proplist(), kz_term:ne_binary(), kz_term:api_binary() | pos_integer(), kapps_call:call()) ->
-                           wait_for_headless_application_return().
--spec b_record_call(kz_term:proplist(), kz_term:ne_binary(), kz_term:api_binary() | pos_integer(), list(), kapps_call:call()) ->
-                           wait_for_headless_application_return().
 b_record_call(MediaName, Call) ->
     record_call(MediaName, Call),
     wait_for_headless_application(<<"record">>, <<"RECORD_STOP">>, <<"call_event">>, 'infinity').
+
+-spec b_record_call(kz_term:proplist(), kz_term:ne_binary(), kapps_call:call()) ->
+                           wait_for_headless_application_return().
 b_record_call(MediaName, Action, Call) ->
     record_call(MediaName, Action, Call),
     wait_for_headless_application(<<"record">>, <<"RECORD_STOP">>, <<"call_event">>, 'infinity').
+
+-spec b_record_call(kz_term:proplist(), kz_term:ne_binary(), kz_term:api_binary() | pos_integer(), kapps_call:call()) ->
+                           wait_for_headless_application_return().
 b_record_call(MediaName, Action, TimeLimit, Call) ->
     b_record_call(MediaName, Action, TimeLimit, ?ANY_DIGIT, Call).
+
+-spec b_record_call(kz_term:proplist(), kz_term:ne_binary(), kz_term:api_binary() | pos_integer(), list(), kapps_call:call()) ->
+                           wait_for_headless_application_return().
 b_record_call(MediaName, Action, TimeLimit, Terminators, Call) ->
     record_call(MediaName, Action, TimeLimit, Terminators, Call),
     wait_for_headless_application(<<"record">>, <<"RECORD_STOP">>, <<"call_event">>, 'infinity').
@@ -1659,22 +1767,21 @@ b_record_call(MediaName, Action, TimeLimit, Terminators, Call) ->
 -type b_store_return() :: {'error', 'timeout' | kz_json:object()} |
                           {'ok', kz_json:object()}.
 
+
+
 -spec store(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec store(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
--spec store(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_json:objects(), kapps_call:call()) -> 'ok'.
--spec store(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_json:objects(), boolean(), kapps_call:call()) -> 'ok'.
-
--spec b_store(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> b_store_return().
--spec b_store(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> b_store_return().
--spec b_store(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects(), kapps_call:call()) -> b_store_return().
--spec b_store(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects(), boolean(), kapps_call:call()) -> b_store_return().
-
 store(MediaName, Transfer, Call) ->
     store(MediaName, Transfer, <<"put">>, Call).
+
+-spec store(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 store(MediaName, Transfer, Method, Call) ->
     store(MediaName, Transfer, Method, [kz_json:new()], Call).
+
+-spec store(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_json:objects(), kapps_call:call()) -> 'ok'.
 store(MediaName, Transfer, Method, Headers, Call) ->
     store(MediaName, Transfer, Method, Headers, 'false', Call).
+
+-spec store(kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_json:objects(), boolean(), kapps_call:call()) -> 'ok'.
 store(MediaName, Transfer, Method, Headers, SuppressReport, Call) ->
     Command = [{<<"Application-Name">>, <<"store">>}
               ,{<<"Media-Name">>, MediaName}
@@ -1686,12 +1793,19 @@ store(MediaName, Transfer, Method, Headers, SuppressReport, Call) ->
               ],
     send_command(Command, Call).
 
+-spec b_store(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> b_store_return().
 b_store(MediaName, Transfer, Call) ->
     b_store(MediaName, Transfer, <<"put">>, Call).
+
+-spec b_store(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> b_store_return().
 b_store(MediaName, Transfer, Method, Call) ->
     b_store(MediaName, Transfer, Method, [kz_json:new()], Call).
+
+-spec b_store(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects(), kapps_call:call()) -> b_store_return().
 b_store(MediaName, Transfer, Method, Headers, Call) ->
     b_store(MediaName, Transfer, Method, Headers, 'false', Call).
+
+-spec b_store(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects(), boolean(), kapps_call:call()) -> b_store_return().
 b_store(MediaName, Transfer, Method, Headers, SuppressReport, Call) ->
     store(MediaName, Transfer, Method, Headers, SuppressReport, Call),
     wait_for_headless_application(<<"store">>).
@@ -1780,82 +1894,92 @@ tones_command(Tones, Call) ->
 %% caller, and collect a number of DTMF events.
 %% @end
 %%--------------------------------------------------------------------
+
+
 -spec prompt_and_collect_digit(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
+prompt_and_collect_digit(Prompt, Call) ->
+    prompt_and_collect_digits(1, 1, Prompt, Call).
+
 -spec prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                ,kapps_call:call()) ->
                                        'ok'.
+prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Call) ->
+    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, 1,  Call).
+
 -spec prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                ,integer(), kapps_call:call()) ->
                                        'ok'.
+prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Call) ->
+    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, 3 * ?MILLISECONDS_IN_SECOND, Call).
+
 -spec prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                ,integer(), integer(), kapps_call:call()) ->
                                        'ok'.
+prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, Call) ->
+    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, 'undefined', Call).
+
 -spec prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                ,integer(), integer(), kz_term:api_binary()
                                ,kapps_call:call()) ->
                                        'ok'.
+prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Call) ->
+    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, <<"\\d+">>, Call).
+
 -spec prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                ,integer(), integer(), kz_term:api_binary()
                                ,kz_term:ne_binary(), kapps_call:call()) ->
                                        'ok'.
+prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, Call) ->
+    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, [<<"#">>], Call).
+
 -spec prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                ,integer(), integer(), kz_term:api_binary()
                                ,kz_term:ne_binary(), kz_term:ne_binaries(), kapps_call:call()) ->
                                        'ok'.
+prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, Terminators, Call) ->
+    play_and_collect_digits(MinDigits, MaxDigits, kapps_call:get_prompt(Call, Prompt), Tries, Timeout, InvalidPrompt, Regex, Terminators, Call).
 
 -spec b_prompt_and_collect_digit(kz_term:ne_binary(), kapps_call:call()) ->
                                         b_play_and_collect_digits_return().
+b_prompt_and_collect_digit(Prompt, Call) ->
+    b_prompt_and_collect_digits(1, 1, Prompt, Call).
+
 -spec b_prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                  ,kapps_call:call()) ->
                                          b_play_and_collect_digits_return().
+b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Call) ->
+    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, 3,  Call).
+
 -spec b_prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                  ,integer(), kapps_call:call()) ->
                                          b_play_and_collect_digits_return().
+b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Call) ->
+    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, ?DEFAULT_COLLECT_TIMEOUT, Call).
+
 -spec b_prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                  ,integer(), integer(), kapps_call:call()) ->
                                          b_play_and_collect_digits_return().
+b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, Call) ->
+    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, 'undefined', Call).
+
 -spec b_prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                  ,integer(), integer(), kz_term:api_binary()
                                  ,kapps_call:call()) ->
                                          b_play_and_collect_digits_return().
+b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Call) ->
+    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, <<"\\d+">>, Call).
+
 -spec b_prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                  ,integer(), integer(), kz_term:api_binary()
                                  ,kz_term:ne_binary(), kapps_call:call()) ->
                                          b_play_and_collect_digits_return().
+b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, Call) ->
+    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, ?ANY_DIGIT, Call).
+
 -spec b_prompt_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                                  ,integer(), integer(), kz_term:api_binary()
                                  ,kz_term:ne_binary(), kz_term:ne_binaries(), kapps_call:call()) ->
                                          b_play_and_collect_digits_return().
-
-prompt_and_collect_digit(Prompt, Call) ->
-    prompt_and_collect_digits(1, 1, Prompt, Call).
-
-prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Call) ->
-    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, 1,  Call).
-prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Call) ->
-    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, 3 * ?MILLISECONDS_IN_SECOND, Call).
-prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, Call) ->
-    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, 'undefined', Call).
-prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Call) ->
-    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, <<"\\d+">>, Call).
-prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, Call) ->
-    prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, [<<"#">>], Call).
-prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, Terminators, Call) ->
-    play_and_collect_digits(MinDigits, MaxDigits, kapps_call:get_prompt(Call, Prompt), Tries, Timeout, InvalidPrompt, Regex, Terminators, Call).
-
-b_prompt_and_collect_digit(Prompt, Call) ->
-    b_prompt_and_collect_digits(1, 1, Prompt, Call).
-b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Call) ->
-    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, 3,  Call).
-b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Call) ->
-    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, ?DEFAULT_COLLECT_TIMEOUT, Call).
-b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, Call) ->
-    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, 'undefined', Call).
-b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Call) ->
-    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, <<"\\d+">>, Call).
-b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, Call) ->
-    b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, InvalidPrompt, Regex, ?ANY_DIGIT, Call).
-
 b_prompt_and_collect_digits(_MinDigits, _MaxDigits, _Prompt, 0, _Timeout, 'undefined', _Regex, _Terminators, _Call) ->
     {'ok', <<>>};
 b_prompt_and_collect_digits(_MinDigits, _MaxDigits, _Prompt, 0, _Timeout, InvalidPrompt, _Regex, _Terminators, Call) ->
@@ -1884,66 +2008,48 @@ b_prompt_and_collect_digits(MinDigits, MaxDigits, Prompt, Tries, Timeout, Invali
         {'error', 'channel_hungup' | 'channel_unbridge' | kz_json:object()} |
         {'ok', binary()}.
 
+
+
 -spec play_and_collect_digit(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
+play_and_collect_digit(Media, Call) ->
+    play_and_collect_digits(1, 1, Media, Call).
+
 -spec play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                              ,kapps_call:call()) ->
                                      'ok'.
+play_and_collect_digits(MinDigits, MaxDigits, Media, Call) ->
+    play_and_collect_digits(MinDigits, MaxDigits, Media, 1,  Call).
+
 -spec play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                              ,integer(), kapps_call:call()) ->
                                      'ok'.
+play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Call) ->
+    play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, 3 * ?MILLISECONDS_IN_SECOND, Call).
+
 -spec play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                              ,integer(), integer(), kapps_call:call()) ->
                                      'ok'.
+play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, Call) ->
+    play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, 'undefined', Call).
+
 -spec play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                              ,integer(), integer(), kz_term:api_binary()
                              ,kapps_call:call()) ->
                                      'ok'.
+play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Call) ->
+    play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, <<"\\d+">>, Call).
+
 -spec play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                              ,integer(), integer(), kz_term:api_binary()
                              ,kz_term:ne_binary(), kapps_call:call()) ->
                                      'ok'.
+play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Regex, Call) ->
+    play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Regex, [<<"#">>], Call).
+
 -spec play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
                              ,integer(), integer(), kz_term:api_binary()
                              ,kz_term:ne_binary(), kz_term:ne_binaries(), kapps_call:call()) ->
                                      'ok'.
-
--spec b_play_and_collect_digit(kz_term:ne_binary(), kapps_call:call()) ->
-                                      b_play_and_collect_digits_return().
--spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
-                               ,kapps_call:call()) ->
-                                       b_play_and_collect_digits_return().
--spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
-                               ,integer(), kapps_call:call()) ->
-                                       b_play_and_collect_digits_return().
--spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
-                               ,integer(), integer(), kapps_call:call()) ->
-                                       b_play_and_collect_digits_return().
--spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
-                               ,integer(), integer(), kz_term:api_binary()
-                               ,kapps_call:call()) ->
-                                       b_play_and_collect_digits_return().
--spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
-                               ,integer(), integer(), kz_term:api_binary()
-                               ,kz_term:ne_binary(), kapps_call:call()) ->
-                                       b_play_and_collect_digits_return().
--spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
-                               ,integer(), integer(), kz_term:api_binary()
-                               ,kz_term:ne_binary(), kz_term:ne_binaries(), kapps_call:call()) ->
-                                       b_play_and_collect_digits_return().
-
-play_and_collect_digit(Media, Call) ->
-    play_and_collect_digits(1, 1, Media, Call).
-
-play_and_collect_digits(MinDigits, MaxDigits, Media, Call) ->
-    play_and_collect_digits(MinDigits, MaxDigits, Media, 1,  Call).
-play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Call) ->
-    play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, 3 * ?MILLISECONDS_IN_SECOND, Call).
-play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, Call) ->
-    play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, 'undefined', Call).
-play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Call) ->
-    play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, <<"\\d+">>, Call).
-play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Regex, Call) ->
-    play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Regex, [<<"#">>], Call).
 play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Regex, Terminators, Call) ->
     Command = [{<<"Application-Name">>, <<"play_and_collect_digits">>}
               ,{<<"Minimum-Digits">>, MinDigits}
@@ -1957,19 +2063,47 @@ play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvali
               ],
     send_command(Command, Call).
 
+-spec b_play_and_collect_digit(kz_term:ne_binary(), kapps_call:call()) ->
+                                      b_play_and_collect_digits_return().
 b_play_and_collect_digit(Media, Call) ->
     b_play_and_collect_digits(1, 1, Media, Call).
+
+-spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
+                               ,kapps_call:call()) ->
+                                       b_play_and_collect_digits_return().
 b_play_and_collect_digits(MinDigits, MaxDigits, Media, Call) ->
     b_play_and_collect_digits(MinDigits, MaxDigits, Media, 3,  Call).
+
+-spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
+                               ,integer(), kapps_call:call()) ->
+                                       b_play_and_collect_digits_return().
 b_play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Call) ->
     b_play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, ?DEFAULT_COLLECT_TIMEOUT, Call).
+
+-spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
+                               ,integer(), integer(), kapps_call:call()) ->
+                                       b_play_and_collect_digits_return().
 b_play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, Call) ->
     b_play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, 'undefined', Call).
+
+-spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
+                               ,integer(), integer(), kz_term:api_binary()
+                               ,kapps_call:call()) ->
+                                       b_play_and_collect_digits_return().
 b_play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Call) ->
     b_play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, <<"[\\d\\*\\#]+">>, Call).
+
+-spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
+                               ,integer(), integer(), kz_term:api_binary()
+                               ,kz_term:ne_binary(), kapps_call:call()) ->
+                                       b_play_and_collect_digits_return().
 b_play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Regex, Call) ->
     b_play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInvalid, Regex, ?ANY_DIGIT, Call).
 
+-spec b_play_and_collect_digits(integer(), integer(), kz_term:ne_binary()
+                               ,integer(), integer(), kz_term:api_binary()
+                               ,kz_term:ne_binary(), kz_term:ne_binaries(), kapps_call:call()) ->
+                                       b_play_and_collect_digits_return().
 b_play_and_collect_digits(_MinDigits, _MaxDigits, _Media, 0, _Timeout, 'undefined', _Regex, _Terminators, _Call) ->
     {'ok', <<>>};
 b_play_and_collect_digits(_MinDigits, _MaxDigits, _Media, 0, _Timeout, MediaInvalid, _Regex, _Terminators, Call) ->
@@ -1999,45 +2133,47 @@ b_play_and_collect_digits(MinDigits, MaxDigits, Media, Tries, Timeout, MediaInva
 %% Produces the low level kz_api request to say text to a caller
 %% @end
 %%--------------------------------------------------------------------
+
+
 -spec say(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec say(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
-
--spec b_say(kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_say(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
-
 say(Say, Call) ->
     say(Say, <<"name_spelled">>, Call).
+
+-spec say(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
 say(Say, Type, Call) ->
     say(Say, Type, <<"pronounced">>, Call).
+
+-spec say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
 say(Say, Type, Method, Call) ->
     say(Say, Type, Method, kapps_call:language(Call), Call).
+
+-spec say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
 say(Say, Type, Method, Language, Call) ->
     say(Say, Type, Method, Language, 'undefined', Call).
+
+-spec say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 say(Say, Type, Method, Language, Gender, Call) ->
     Command = say_command(Say, Type, Method, Language, Gender, Call),
     send_command(Command, Call).
 
--spec say_command(kz_term:ne_binary(), kapps_call:call()) -> kz_json:object().
--spec say_command(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_json:object().
--spec say_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_json:object().
--spec say_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_json:object().
--spec say_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_json:object().
 
+-spec say_command(kz_term:ne_binary(), kapps_call:call()) -> kz_json:object().
 say_command(Say, Call) ->
     say_command(Say, <<"name_spelled">>, Call).
+
+-spec say_command(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_json:object().
 say_command(Say, Type, Call) ->
     say_command(Say, Type, <<"pronounced">>, Call).
+
+-spec say_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_json:object().
 say_command(Say, Type, Method, Call) ->
     say_command(Say, Type, Method, kapps_call:language(Call), Call).
+
+-spec say_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_json:object().
 say_command(Say, Type, Method, Language, Call) ->
     say_command(Say, Type, Method, Language, 'undefined', Call).
 
+-spec say_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_json:object().
 say_command(Say, Type, Method, Language, Gender, Call) ->
     kz_json:from_list(
       [{<<"Application-Name">>, <<"say">>}
@@ -2068,18 +2204,27 @@ say_gender_validate(<<"masculine">> = G) -> G;
 say_gender_validate(<<"feminine">> = G) -> G;
 say_gender_validate(<<"neuter">> = G) -> G.
 
+-spec b_say(kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_say(Say, Call) ->
     say(Say, Call),
     wait_for_say(Call).
+
+-spec b_say(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_say(Say, Type, Call) ->
     say(Say, Type, Call),
     wait_for_say(Call).
+
+-spec b_say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_say(Say, Type, Method, Call) ->
     say(Say, Type, Method, Call),
     wait_for_say(Call).
+
+-spec b_say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_say(Say, Type, Method, Language, Call) ->
     say(Say, Type, Method, Language, Call),
     wait_for_say(Call).
+
+-spec b_say(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_say(Say, Type, Method, Language, Gender, Call) ->
     say(Say, Type, Method, Language, Gender, Call),
     wait_for_say(Call).
@@ -2095,30 +2240,29 @@ wait_for_say(Call) ->
 %% with a conference, with optional entry flags
 %% @end
 %%--------------------------------------------------------------------
+
+
 -spec conference(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec conference(kz_term:ne_binary(), boolean(), kapps_call:call()) -> 'ok'.
--spec conference(kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
--spec conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
--spec conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kz_term:ne_binary(), boolean(), kapps_call:call()) -> 'ok'.
-
--spec b_conference(kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_conference(kz_term:ne_binary(), boolean(), kapps_call:call()) -> kapps_api_std_return().
--spec b_conference(kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) -> kapps_api_std_return().
--spec b_conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> kapps_api_std_return().
--spec b_conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
--spec b_conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kz_term:ne_binary(), boolean(), kapps_call:call()) -> kapps_api_std_return().
-
 conference(ConfId, Call) ->
     conference(ConfId, 'false', Call).
+
+-spec conference(kz_term:ne_binary(), boolean(), kapps_call:call()) -> 'ok'.
 conference(ConfId, Mute, Call) ->
     conference(ConfId, Mute, 'false', Call).
+
+-spec conference(kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
 conference(ConfId, Mute, Deaf, Call) ->
     conference(ConfId, Mute, Deaf, 'false', Call).
+
+-spec conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> 'ok'.
 conference(ConfId, Mute, Deaf, Moderator, Call) ->
     conference(ConfId, Mute, Deaf, Moderator, <<"undefined">>, Call).
+
+-spec conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
 conference(ConfId, Mute, Deaf, Moderator, ProfileName, Call) ->
     conference(ConfId, Mute, Deaf, Moderator, ProfileName, 'false', Call).
+
+-spec conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kz_term:ne_binary(), boolean(), kapps_call:call()) -> 'ok'.
 conference(ConfId, Mute, Deaf, Moderator, ProfileName, Reinvite, Call) ->
     Command = [{<<"Application-Name">>, <<"conference">>}
               ,{<<"Conference-ID">>, ConfId}
@@ -2130,16 +2274,27 @@ conference(ConfId, Mute, Deaf, Moderator, ProfileName, Reinvite, Call) ->
               ],
     send_command(Command, Call).
 
+-spec b_conference(kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_conference(ConfId, Call) ->
     b_conference(ConfId, 'false', Call).
+
+-spec b_conference(kz_term:ne_binary(), boolean(), kapps_call:call()) -> kapps_api_std_return().
 b_conference(ConfId, Mute, Call) ->
     b_conference(ConfId, Mute, 'false', Call).
+
+-spec b_conference(kz_term:ne_binary(), boolean(), boolean(), kapps_call:call()) -> kapps_api_std_return().
 b_conference(ConfId, Mute, Deaf, Call) ->
     b_conference(ConfId, Mute, Deaf, 'false', Call).
+
+-spec b_conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kapps_call:call()) -> kapps_api_std_return().
 b_conference(ConfId, Mute, Deaf, Moderator, Call) ->
     b_conference(ConfId, Mute, Deaf, Moderator, <<"default">>, Call).
+
+-spec b_conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kz_term:ne_binary(), kapps_call:call()) -> kapps_api_std_return().
 b_conference(ConfId, Mute, Deaf, Moderator, Profile, Call) ->
     b_conference(ConfId, Mute, Deaf, Moderator, Profile, 'false', Call).
+
+-spec b_conference(kz_term:ne_binary(), boolean(), boolean(), boolean(), kz_term:ne_binary(), boolean(), kapps_call:call()) -> kapps_api_std_return().
 b_conference(ConfId, Mute, Deaf, Moderator, Profile, Reinvite, Call) ->
     conference(ConfId, Mute, Deaf, Moderator, Profile, Reinvite, Call),
     wait_for_message(Call, <<"conference">>, <<"CHANNEL_EXECUTE">>).
@@ -2150,9 +2305,8 @@ b_conference(ConfId, Mute, Deaf, Moderator, Profile, Reinvite, Call) ->
 %% Produces the low level kz_api request to preform a noop
 %% @end
 %%--------------------------------------------------------------------
--spec noop(kapps_call:call()) -> kz_term:ne_binary().
--spec b_noop(kapps_call:call()) -> kapps_api_std_return().
 
+-spec noop(kapps_call:call()) -> kz_term:ne_binary().
 noop(Call) ->
     NoopId = kz_datamgr:get_uuid(),
     Command = [{<<"Application-Name">>, <<"noop">>}
@@ -2161,6 +2315,7 @@ noop(Call) ->
     send_command(Command, Call),
     NoopId.
 
+-spec b_noop(kapps_call:call()) -> kapps_api_std_return().
 b_noop(Call) -> wait_for_noop(Call, noop(Call)).
 
 %%--------------------------------------------------------------------
@@ -2170,9 +2325,8 @@ b_noop(Call) -> wait_for_noop(Call, noop(Call)).
 %% queue
 %% @end
 %%--------------------------------------------------------------------
--spec flush(kapps_call:call()) -> binary().
--spec b_flush(kapps_call:call()) -> kapps_api_std_return().
 
+-spec flush(kapps_call:call()) -> binary().
 flush(Call) ->
     NoopId = kz_datamgr:get_uuid(),
     Command = [{<<"Application-Name">>, <<"noop">>}
@@ -2182,6 +2336,7 @@ flush(Call) ->
     send_command(Command, Call),
     NoopId.
 
+-spec b_flush(kapps_call:call()) -> kapps_api_std_return().
 b_flush(Call) -> wait_for_noop(Call, flush(Call)).
 
 %%--------------------------------------------------------------------
@@ -2190,17 +2345,12 @@ b_flush(Call) -> wait_for_noop(Call, flush(Call)).
 %%
 %% @end
 %%--------------------------------------------------------------------
+
+
 -spec privacy(kapps_call:call()) -> 'ok'.
--spec privacy(kz_term:api_ne_binary(), kapps_call:call()) -> 'ok'.
-
--spec b_privacy(kapps_call:call()) ->
-                       kapps_api_error() |
-                       {'ok', kz_json:object()}.
--spec b_privacy(kz_term:api_ne_binary(), kapps_call:call()) ->
-                       kapps_api_error() |
-                       {'ok', kz_json:object()}.
-
 privacy(Call) -> privacy(<<"full">>, Call).
+
+-spec privacy(kz_term:api_ne_binary(), kapps_call:call()) -> 'ok'.
 privacy('undefined', Call) -> privacy(Call);
 privacy(Mode, Call) ->
     Command = [{<<"Application-Name">>, <<"privacy">>}
@@ -2208,7 +2358,14 @@ privacy(Mode, Call) ->
               ],
     send_command(Command, Call).
 
+-spec b_privacy(kapps_call:call()) ->
+                       kapps_api_error() |
+                       {'ok', kz_json:object()}.
 b_privacy(Call) -> b_privacy(<<"full">>, Call).
+
+-spec b_privacy(kz_term:api_ne_binary(), kapps_call:call()) ->
+                       kapps_api_error() |
+                       {'ok', kz_json:object()}.
 b_privacy('undefined', Call) -> b_privacy(Call);
 b_privacy(Mode, Call) ->
     privacy(Mode, Call),
@@ -2236,14 +2393,6 @@ b_privacy(Mode, Call) ->
 %%--------------------------------------------------------------------
 -type collect_digits_return() :: {'error','channel_hungup' | 'channel_unbridge' | kz_json:object()} |
                                  {'ok', binary()}.
--spec collect_digits(integer() | kz_term:ne_binary(), kapps_call:call()) -> collect_digits_return().
--spec collect_digits(integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), kapps_call:call()) -> collect_digits_return().
--spec collect_digits(integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), kapps_call:call()) ->
-                            collect_digits_return().
--spec collect_digits(integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) ->
-                            collect_digits_return().
--spec collect_digits(integer(), integer(), integer(), kz_term:api_binary(), list(), kapps_call:call()) ->
-                            collect_digits_return().
 
 -record(wcc_collect_digits, {max_digits :: pos_integer()
                             ,timeout = ?DEFAULT_DIGIT_TIMEOUT :: timeout()
@@ -2256,12 +2405,14 @@ b_privacy(Mode, Call) ->
                             }).
 -type wcc_collect_digits() :: #wcc_collect_digits{}.
 
+-spec collect_digits(integer() | kz_term:ne_binary(), kapps_call:call()) -> collect_digits_return().
 collect_digits(MaxDigits, Call) ->
     do_collect_digits(#wcc_collect_digits{max_digits=kz_term:to_integer(MaxDigits)
                                          ,call=Call
                                          ,after_timeout=?DEFAULT_DIGIT_TIMEOUT
                                          }).
 
+-spec collect_digits(integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), kapps_call:call()) -> collect_digits_return().
 collect_digits(MaxDigits, Timeout, Call) ->
     do_collect_digits(#wcc_collect_digits{max_digits=kz_term:to_integer(MaxDigits)
                                          ,timeout=kz_term:to_integer(Timeout)
@@ -2269,6 +2420,8 @@ collect_digits(MaxDigits, Timeout, Call) ->
                                          ,after_timeout=kz_term:to_integer(Timeout)
                                          }).
 
+-spec collect_digits(integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), kapps_call:call()) ->
+                            collect_digits_return().
 collect_digits(MaxDigits, Timeout, Interdigit, Call) ->
     do_collect_digits(#wcc_collect_digits{max_digits=kz_term:to_integer(MaxDigits)
                                          ,timeout=kz_term:to_integer(Timeout)
@@ -2277,6 +2430,8 @@ collect_digits(MaxDigits, Timeout, Interdigit, Call) ->
                                          ,after_timeout=kz_term:to_integer(Timeout)
                                          }).
 
+-spec collect_digits(integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), integer() | kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) ->
+                            collect_digits_return().
 collect_digits(MaxDigits, Timeout, Interdigit, NoopId, Call) ->
     do_collect_digits(#wcc_collect_digits{max_digits=kz_term:to_integer(MaxDigits)
                                          ,timeout=kz_term:to_integer(Timeout)
@@ -2285,6 +2440,8 @@ collect_digits(MaxDigits, Timeout, Interdigit, NoopId, Call) ->
                                          ,call=Call
                                          }).
 
+-spec collect_digits(integer(), integer(), integer(), kz_term:api_binary(), list(), kapps_call:call()) ->
+                            collect_digits_return().
 collect_digits(MaxDigits, Timeout, Interdigit, NoopId, Terminators, Call) ->
     do_collect_digits(#wcc_collect_digits{max_digits=kz_term:to_integer(MaxDigits)
                                          ,timeout=kz_term:to_integer(Timeout)
@@ -2350,15 +2507,15 @@ do_collect_digits(#wcc_collect_digits{max_digits=MaxDigits
                                         {'continue'} |
                                         {'decrement'} |
                                         {'error', any()}.
+handle_collect_digit_event(JObj, NoopId) ->
+    handle_collect_digit_event(JObj, NoopId, get_event_type(JObj)).
+
 -spec handle_collect_digit_event(kz_json:object(), kz_term:api_binary(), {kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()}) ->
                                         {'dtmf', kz_term:ne_binary()} |
                                         {'noop_complete'} |
                                         {'continue'} |
                                         {'decrement'} |
                                         {'error', any()}.
-handle_collect_digit_event(JObj, NoopId) ->
-    handle_collect_digit_event(JObj, NoopId, get_event_type(JObj)).
-
 handle_collect_digit_event(_JObj, _NoopId, {<<"call_event">>, <<"CHANNEL_DESTROY">>, _}) ->
     lager:debug("channel was hungup while collecting digits"),
     {'error', 'channel_hungup'};
@@ -2400,22 +2557,24 @@ handle_collect_digit_event(_JObj, _NoopId, _EventType) ->
 %% for the optional timeout period then errors are returned.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec wait_for_message(kapps_call:call(), binary()) ->
                               kapps_api_std_return().
--spec wait_for_message(kapps_call:call(), binary(), kz_term:ne_binary()) ->
-                              kapps_api_std_return().
--spec wait_for_message(kapps_call:call(), binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                              kapps_api_std_return().
--spec wait_for_message(kapps_call:call(), binary(), kz_term:ne_binary(), kz_term:ne_binary(), timeout()) ->
-                              kapps_api_std_return().
-
 wait_for_message(Call, Application) ->
     wait_for_message(Call, Application, <<"CHANNEL_EXECUTE_COMPLETE">>).
+
+-spec wait_for_message(kapps_call:call(), binary(), kz_term:ne_binary()) ->
+                              kapps_api_std_return().
 wait_for_message(Call, Application, Event) ->
     wait_for_message(Call, Application, Event, <<"call_event">>).
+
+-spec wait_for_message(kapps_call:call(), binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                              kapps_api_std_return().
 wait_for_message(Call, Application, Event, Type) ->
     wait_for_message(Call, Application, Event, Type, ?DEFAULT_MESSAGE_TIMEOUT).
 
+-spec wait_for_message(kapps_call:call(), binary(), kz_term:ne_binary(), kz_term:ne_binary(), timeout()) ->
+                              kapps_api_std_return().
 wait_for_message(Call, Application, Event, Type, Timeout) ->
     Start = os:timestamp(),
     case receive_event(Timeout) of
@@ -2444,22 +2603,24 @@ wait_for_message(Call, Application, Event, Type, Timeout) ->
 %%--------------------------------------------------------------------
 -type wait_for_application_return() :: {'error', 'timeout' | kz_json:object()} |
                                        {'ok', kz_json:object()}.
+
 -spec wait_for_application(kapps_call:call(), kz_term:ne_binary()) ->
                                   wait_for_application_return().
--spec wait_for_application(kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                  wait_for_application_return().
--spec wait_for_application(kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                  wait_for_application_return().
--spec wait_for_application(kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), timeout()) ->
-                                  wait_for_application_return().
-
 wait_for_application(Call, Application) ->
     wait_for_application(Call, Application, <<"CHANNEL_EXECUTE_COMPLETE">>).
+
+-spec wait_for_application(kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                                  wait_for_application_return().
 wait_for_application(Call, Application, Event) ->
     wait_for_application(Call, Application, Event, <<"call_event">>).
+
+-spec wait_for_application(kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                                  wait_for_application_return().
 wait_for_application(Call, Application, Event, Type) ->
     wait_for_application(Call, Application, Event, Type, ?DEFAULT_APPLICATION_TIMEOUT).
 
+-spec wait_for_application(kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), timeout()) ->
+                                  wait_for_application_return().
 wait_for_application(Call, Application, Event, Type, Timeout) ->
     Start = os:timestamp(),
     case receive_event(Timeout) of
@@ -2491,18 +2652,31 @@ wait_for_application(Call, Application, Event, Type, Timeout) ->
 
 -type wait_for_headless_application_return() :: {'error', 'timeout' | kz_json:object()} |
                                                 {'ok', kz_json:object()}.
+
 -spec wait_for_headless_application(kz_term:ne_binary()) ->
                                            wait_for_headless_application_return().
+wait_for_headless_application(Application) ->
+    wait_for_headless_application(Application, <<"CHANNEL_EXECUTE_COMPLETE">>).
+
 -spec wait_for_headless_application(kz_term:ne_binary(), headless_event()) ->
                                            wait_for_headless_application_return().
+wait_for_headless_application(Application, Event) ->
+    wait_for_headless_application(Application, Event, <<"call_event">>).
+
 -spec wait_for_headless_application(kz_term:ne_binary(), headless_event(), kz_term:ne_binary()) ->
                                            wait_for_headless_application_return().
+wait_for_headless_application(Application, Event, Type) ->
+    wait_for_headless_application(Application, Event, Type, ?DEFAULT_APPLICATION_TIMEOUT).
+
 -spec wait_for_headless_application(kz_term:ne_binary()
                                    ,headless_event()
                                    ,kz_term:ne_binary()
                                    ,timeout()
                                    ) ->
                                            wait_for_headless_application_return().
+wait_for_headless_application(Application, Event, Type, Timeout) ->
+    wait_for_headless_application(Application, Event, Type, fun(_) -> 'true' end, Timeout).
+
 -spec wait_for_headless_application(kz_term:ne_binary()
                                    ,headless_event()
                                    ,kz_term:ne_binary()
@@ -2510,16 +2684,6 @@ wait_for_application(Call, Application, Event, Type, Timeout) ->
                                    ,timeout()
                                    ) ->
                                            wait_for_headless_application_return().
-
-wait_for_headless_application(Application) ->
-    wait_for_headless_application(Application, <<"CHANNEL_EXECUTE_COMPLETE">>).
-wait_for_headless_application(Application, Event) ->
-    wait_for_headless_application(Application, Event, <<"call_event">>).
-wait_for_headless_application(Application, Event, Type) ->
-    wait_for_headless_application(Application, Event, Type, ?DEFAULT_APPLICATION_TIMEOUT).
-wait_for_headless_application(Application, Event, Type, Timeout) ->
-    wait_for_headless_application(Application, Event, Type, fun(_) -> 'true' end, Timeout).
-
 wait_for_headless_application(Application, {StartEv, StopEv}=Event, Type, Fun, Timeout) ->
     Start = os:timestamp(),
     case receive_event(Timeout) of
@@ -2606,15 +2770,16 @@ wait_for_dtmf(Timeout) ->
 %% Waits for and determines the status of the bridge command
 %% @end
 %%--------------------------------------------------------------------
+
 -spec wait_for_bridge(timeout(), kapps_call:call()) ->
-                             kapps_api_bridge_return().
--spec wait_for_bridge(timeout(), 'undefined' | fun((kz_json:object()) -> any()), kapps_call:call()) ->
                              kapps_api_bridge_return().
 wait_for_bridge(0, Call) ->
     wait_for_bridge(?BRIDGE_DEFAULT_TIMEOUT, 'undefined', Call);
 wait_for_bridge(Timeout, Call) ->
     wait_for_bridge(Timeout, 'undefined', Call).
 
+-spec wait_for_bridge(timeout(), 'undefined' | fun((kz_json:object()) -> any()), kapps_call:call()) ->
+                             kapps_api_bridge_return().
 wait_for_bridge(Timeout, _, _) when Timeout < 0 ->
     {'error', 'timeout'};
 wait_for_bridge(Timeout, Fun, Call) ->
@@ -2722,14 +2887,15 @@ wait_for_channel_bridge() ->
 %% Wait forever for the channel to hangup
 %% @end
 %%--------------------------------------------------------------------
+
 -spec wait_for_hangup() -> {'ok', 'channel_hungup'} |
                            {'error', 'timeout'}.
--spec wait_for_hangup(timeout()) ->
-                             {'ok', 'channel_hungup'} |
-                             {'error', 'timeout'}.
 wait_for_hangup() ->
     wait_for_hangup('infinity').
 
+-spec wait_for_hangup(timeout()) ->
+                             {'ok', 'channel_hungup'} |
+                             {'error', 'timeout'}.
 wait_for_hangup(Timeout) ->
     Start = os:timestamp(),
     receive
@@ -2753,14 +2919,15 @@ wait_for_hangup(Timeout) ->
 %% Wait forever for the channel to hangup
 %% @end
 %%--------------------------------------------------------------------
+
 -spec wait_for_unbridge() ->   {'ok', 'leg_hungup'} |
-                               {'error', 'timeout'}.
--spec wait_for_unbridge(timeout()) ->
-                               {'ok', 'leg_hungup'} |
                                {'error', 'timeout'}.
 wait_for_unbridge() ->
     wait_for_unbridge('infinity').
 
+-spec wait_for_unbridge(timeout()) ->
+                               {'ok', 'leg_hungup'} |
+                               {'error', 'timeout'}.
 wait_for_unbridge(Timeout) ->
     Start = os:timestamp(),
     case receive_event(Timeout) of
@@ -2806,8 +2973,9 @@ wait_for_application_or_dtmf(Application, Timeout) ->
 -define(WAIT_FOR_FAX_TIMEOUT, kapps_config:get_integer(<<"fax">>, <<"wait_for_fax_timeout_ms">>, ?MILLISECONDS_IN_HOUR)).
 
 -spec wait_for_fax() -> wait_for_fax_ret().
--spec wait_for_fax(timeout()) -> wait_for_fax_ret().
 wait_for_fax() -> wait_for_fax(?WAIT_FOR_FAX_TIMEOUT).
+
+-spec wait_for_fax(timeout()) -> wait_for_fax_ret().
 wait_for_fax(Timeout) ->
     Start = os:timestamp(),
     case receive_event(Timeout) of
@@ -3071,13 +3239,14 @@ wait_for_fax_detection(Timeout, Call) ->
 %% for the optional timeout period then errors are returned.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec wait_for_unparked_call(kapps_call:call()) ->
                                     kapps_api_std_return().
--spec wait_for_unparked_call(kapps_call:call(), timeout()) ->
-                                    kapps_api_std_return().
-
 wait_for_unparked_call(Call) ->
     wait_for_unparked_call(Call, ?DEFAULT_MESSAGE_TIMEOUT).
+
+-spec wait_for_unparked_call(kapps_call:call(), timeout()) ->
+                                    kapps_api_std_return().
 wait_for_unparked_call(Call, Timeout) ->
     Start = os:timestamp(),
     case receive_event(Timeout) of
@@ -3205,33 +3374,37 @@ maybe_add_debug_data(JObj, Call) ->
     end.
 
 -spec attended_transfer(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec attended_transfer(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 attended_transfer(To, Call) ->
     attended_transfer(To, 'undefined', Call).
+
+-spec attended_transfer(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 attended_transfer(To, TransferLeg, Call) ->
     Command = transfer_command(<<"attended">>, To, TransferLeg, Call),
     send_command(Command, Call).
 
 -spec blind_transfer(kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec blind_transfer(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 blind_transfer(To, Call) ->
     blind_transfer(To, 'undefined', Call).
+
+-spec blind_transfer(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 blind_transfer(To, TransferLeg, Call) ->
     Command = transfer_command(<<"blind">>, To, TransferLeg, Call),
     send_command(Command, Call).
 
 -spec transfer(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
--spec transfer(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 transfer(TransferType, To, Call) ->
     transfer(TransferType, To, 'undefined', Call).
+
+-spec transfer(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
 transfer(TransferType, To, TransferLeg, Call) ->
     Command = transfer_command(TransferType, To, TransferLeg, Call),
     send_command(Command, Call).
 
 -spec transfer_command(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:api_terms().
--spec transfer_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_term:api_terms().
 transfer_command(TransferType, TransferTo, Call) ->
     transfer_command(TransferType, TransferTo, 'undefined', Call).
+
+-spec transfer_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_term:api_terms().
 transfer_command(TransferType, TransferTo, TransferLeg, Call) ->
     kz_json:from_list(
       [{<<"Application-Name">>, <<"transfer">>}

--- a/core/kazoo_call/src/kapps_conference.erl
+++ b/core/kazoo_call/src/kapps_conference.erl
@@ -246,12 +246,12 @@ to_proplist(#kapps_conference{}=Conference) ->
 is_conference(#kapps_conference{}) -> 'true';
 is_conference(_) -> 'false'.
 
--spec from_conference_doc(kz_json:object()) -> conference().
--spec from_conference_doc(kz_json:object(), conference()) -> conference().
 
+-spec from_conference_doc(kz_json:object()) -> conference().
 from_conference_doc(JObj) ->
     from_conference_doc(JObj, #kapps_conference{}).
 
+-spec from_conference_doc(kz_json:object(), conference()) -> conference().
 from_conference_doc(JObj, Conference) ->
     Member = kz_json:get_json_value(<<"member">>, JObj),
     Moderator = kz_json:get_json_value(<<"moderator">>, JObj),
@@ -601,12 +601,12 @@ kvs_update_counter(Key, Number, #kapps_conference{kvs=Dict}=Conference) ->
 -spec flush() -> 'ok'.
 flush() -> kz_cache:flush_local(?KAPPS_CALL_CACHE).
 
--spec cache(conference()) -> 'ok'.
--spec cache(conference(), pos_integer()) -> 'ok'.
 
+-spec cache(conference()) -> 'ok'.
 cache(#kapps_conference{}=Conference) ->
     cache(Conference, 300 * ?MILLISECONDS_IN_SECOND).
 
+-spec cache(conference(), pos_integer()) -> 'ok'.
 cache(#kapps_conference{id=ConferenceId}=Conference, Expires) ->
     CacheProps = [{'expires', Expires}],
     kz_cache:store_local(?KAPPS_CALL_CACHE, {?MODULE, 'conference', ConferenceId}, Conference, CacheProps).

--- a/core/kazoo_call/src/kapps_conference_command.erl
+++ b/core/kazoo_call/src/kapps_conference_command.erl
@@ -84,11 +84,12 @@ participant_energy(ParticipantId, EnergyLevel, Conference) ->
               ],
     send_command(Command, Conference).
 
--spec kick(kapps_conference:conference()) -> 'ok'.
--spec kick(non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
 
+-spec kick(kapps_conference:conference()) -> 'ok'.
 kick(Conference) ->
     kick('undefined', Conference).
+
+-spec kick(non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
 kick(ParticipantId, Conference) ->
     Command = [{<<"Application-Name">>, <<"kick">>}
               ,{<<"Participant-ID">>, ParticipantId}
@@ -107,11 +108,12 @@ mute_participant(ParticipantId, Conference) ->
               ],
     send_command(Command, Conference).
 
--spec prompt(kz_term:ne_binary(), kapps_conference:conference()) -> 'ok'.
--spec prompt(kz_term:ne_binary(), non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
 
+-spec prompt(kz_term:ne_binary(), kapps_conference:conference()) -> 'ok'.
 prompt(Media, Conference) ->
     prompt(Media, 'undefined', Conference).
+
+-spec prompt(kz_term:ne_binary(), non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
 prompt(Media, ParticipantId, Conference) ->
     Prompt = get_media_prompt(Media, Conference),
     play(Prompt, ParticipantId, Conference).
@@ -121,22 +123,24 @@ get_media_prompt(Media, Conference) ->
     Call = kapps_conference:call(Conference),
     kapps_call:get_prompt(Call, Media).
 
--spec play_command(kz_term:ne_binary()) -> kz_term:proplist().
--spec play_command(kz_term:ne_binary(), non_neg_integer() | 'undefined') -> kz_term:proplist().
 
+-spec play_command(kz_term:ne_binary()) -> kz_term:proplist().
 play_command(Media) ->
     play_command(Media, 'undefined').
+
+-spec play_command(kz_term:ne_binary(), non_neg_integer() | 'undefined') -> kz_term:proplist().
 play_command(Media, ParticipantId) ->
     [{<<"Application-Name">>, <<"play">>}
     ,{<<"Media-Name">>, Media}
     ,{<<"Participant-ID">>, ParticipantId}
     ].
 
--spec play(kz_term:ne_binary(), kapps_conference:conference()) -> 'ok'.
--spec play(kz_term:ne_binary(), non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
 
+-spec play(kz_term:ne_binary(), kapps_conference:conference()) -> 'ok'.
 play(Media, Conference) ->
     play(Media, 'undefined', Conference).
+
+-spec play(kz_term:ne_binary(), non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
 play(Media, ParticipantId, Conference) ->
     Command = play_command(Media, ParticipantId),
     send_command(Command, Conference).
@@ -151,12 +155,12 @@ recordstop(Conference) ->
     Command = [{<<"Application-Name">>, <<"recordstop">>}],
     send_command(Command, Conference).
 
--spec relate_participants(non_neg_integer(), non_neg_integer(), kapps_conference:conference()) -> 'ok'.
--spec relate_participants(non_neg_integer(), non_neg_integer(), kz_term:api_binary(), kapps_conference:conference()) -> 'ok'.
 
+-spec relate_participants(non_neg_integer(), non_neg_integer(), kapps_conference:conference()) -> 'ok'.
 relate_participants(ParticipantId, OtherParticipantId, Conference) ->
     relate_participants(ParticipantId, OtherParticipantId, 'undefined', Conference).
 
+-spec relate_participants(non_neg_integer(), non_neg_integer(), kz_term:api_binary(), kapps_conference:conference()) -> 'ok'.
 relate_participants(ParticipantId, OtherParticipantId, Relationship, Conference) ->
     Command = [{<<"Application-Name">>, <<"relate_participants">>}
               ,{<<"Participant-ID">>, ParticipantId}
@@ -165,16 +169,16 @@ relate_participants(ParticipantId, OtherParticipantId, Relationship, Conference)
               ],
     send_command(Command, Conference).
 
--spec stop_play(kapps_conference:conference()) -> 'ok'.
--spec stop_play(non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
--spec stop_play(non_neg_integer() | 'undefined', kz_term:api_binary(), kapps_conference:conference()) -> 'ok'.
 
+-spec stop_play(kapps_conference:conference()) -> 'ok'.
 stop_play(Conference) ->
     stop_play('undefined', Conference).
 
+-spec stop_play(non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
 stop_play(ParticipantId, Conference) ->
     stop_play(ParticipantId, undefined, Conference).
 
+-spec stop_play(non_neg_integer() | 'undefined', kz_term:api_binary(), kapps_conference:conference()) -> 'ok'.
 stop_play(ParticipantId, Affects, Conference) ->
     Command = [{<<"Application-Name">>, <<"stop_play">>}
               ,{<<"Participant-ID">>, ParticipantId}
@@ -218,18 +222,18 @@ participant_volume_out(ParticipantId, VolumeOut,Conference) ->
     send_command(Command, Conference).
 
 -spec dial(kz_json:objects(), kapps_conference:conference()) -> 'ok'.
--spec dial(kz_json:objects(), kz_term:api_ne_binary(), kapps_conference:conference()) -> 'ok'.
--spec dial(kz_json:objects(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), kapps_conference:conference()) -> 'ok'.
--spec dial(kz_json:objects(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), kz_term:api_object(), kapps_conference:conference() | kz_term:ne_binary()) -> 'ok'.
 dial(Endpoints, Conference) when is_list(Endpoints) ->
     dial(Endpoints, 'undefined', 'undefined', Conference).
 
+-spec dial(kz_json:objects(), kz_term:api_ne_binary(), kapps_conference:conference()) -> 'ok'.
 dial(Endpoints, CallerIdNumber, Conference) when is_list(Endpoints) ->
     dial(Endpoints, CallerIdNumber, 'undefined', Conference).
 
+-spec dial(kz_json:objects(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), kapps_conference:conference()) -> 'ok'.
 dial(Endpoints, CallerIdNumber, CallerIdName, ConferenceId) ->
     dial(Endpoints, CallerIdNumber, CallerIdName, 'undefined', ConferenceId).
 
+-spec dial(kz_json:objects(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), kz_term:api_object(), kapps_conference:conference() | kz_term:ne_binary()) -> 'ok'.
 dial(Endpoints, CallerIdNumber, CallerIdName, CCVs, ConferenceId)
   when is_list(Endpoints),
        is_binary(ConferenceId) ->

--- a/core/kazoo_call/src/kapps_sms_command.erl
+++ b/core/kazoo_call/src/kapps_sms_command.erl
@@ -55,21 +55,24 @@ default_application_timeout() ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
+
 -spec send_sms(kz_json:objects(), kapps_call:call()) -> 'ok'.
--spec send_sms(kz_json:objects(), binary(), kapps_call:call()) -> 'ok'.
-
--spec b_send_sms(kz_json:objects(), kapps_call:call()) -> kapps_api_sms_return().
--spec b_send_sms(kz_json:objects(), binary(), kapps_call:call()) -> kapps_api_sms_return().
--spec b_send_sms(kz_json:objects(), binary(), integer(), kapps_call:call()) -> kapps_api_sms_return().
-
 send_sms(Endpoints, Call) -> send_sms(Endpoints, ?DEFAULT_STRATEGY, Call).
+
+-spec send_sms(kz_json:objects(), binary(), kapps_call:call()) -> 'ok'.
 send_sms(EndpointList, Strategy, Call) ->
     Endpoints = create_sms_endpoints(EndpointList, []),
     API = create_sms(Call),
     send(Strategy, API, Endpoints).
 
+-spec b_send_sms(kz_json:objects(), kapps_call:call()) -> kapps_api_sms_return().
 b_send_sms(Endpoints, Call) -> b_send_sms(Endpoints, ?DEFAULT_STRATEGY, Call).
+
+-spec b_send_sms(kz_json:objects(), binary(), kapps_call:call()) -> kapps_api_sms_return().
 b_send_sms(Endpoints, Strategy, Call) -> b_send_sms(Endpoints, Strategy, ?DEFAULT_MESSAGE_TIMEOUT, Call).
+
+-spec b_send_sms(kz_json:objects(), binary(), integer(), kapps_call:call()) -> kapps_api_sms_return().
 b_send_sms(EndpointList, Strategy, Timeout, Call) ->
     Endpoints = create_sms_endpoints(EndpointList, []),
     API = create_sms(Call),
@@ -198,11 +201,11 @@ send_amqp_sms(Payload, Pool) ->
     end.
 
 -spec maybe_add_broker(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:ne_binary()) -> 'ok'.
--spec maybe_add_broker(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:ne_binary(), kz_term:api_pid()) -> 'ok'.
 maybe_add_broker(Broker, Exchange, RouteId, ExchangeType, ExchangeOptions, BrokerName) ->
     PoolPid = kz_amqp_sup:pool_pid(?SMS_POOL(Exchange, RouteId, BrokerName)),
     maybe_add_broker(Broker, Exchange, RouteId, ExchangeType, ExchangeOptions, BrokerName, PoolPid).
 
+-spec maybe_add_broker(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:ne_binary(), kz_term:api_pid()) -> 'ok'.
 maybe_add_broker(Broker, Exchange, RouteId, ExchangeType, ExchangeOptions, BrokerName, 'undefined') ->
     Exchanges = [{Exchange, ExchangeType, ExchangeOptions}],
     kz_amqp_sup:add_amqp_pool(?SMS_POOL(Exchange, RouteId, BrokerName), Broker, 5, 5, [], Exchanges, 'true'),
@@ -301,10 +304,11 @@ extract_device_registrar_fold(JObj, Set) ->
 
 -spec get_correlated_msg_type(kz_json:object()) ->
                                      {kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()}.
--spec get_correlated_msg_type(kz_term:ne_binary(), kz_json:object()) ->
-                                     {kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()}.
 get_correlated_msg_type(JObj) ->
     get_correlated_msg_type(<<"Call-ID">>, JObj).
+
+-spec get_correlated_msg_type(kz_term:ne_binary(), kz_json:object()) ->
+                                     {kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()}.
 get_correlated_msg_type(Key, JObj) ->
     {C, N} = kz_util:get_event_type(JObj),
     {C, N, kz_json:get_value(Key, JObj)}.

--- a/core/kazoo_call/src/kz_call_response.erl
+++ b/core/kazoo_call/src/kz_call_response.erl
@@ -29,19 +29,16 @@ config_doc_id() ->
 %% played as part of the error.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec send(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary()) ->
                   {'ok', kz_term:ne_binary()} |
                   {'error', 'no_response'}.
--spec send(kz_term:ne_binary() | kapps_call:call(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
-                  {'ok', kz_term:ne_binary()} |
-                  {'error', 'no_response'}.
--spec send(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
-                  {'ok', kz_term:ne_binary()} |
-                  {'error', 'no_response'}.
-
 send(CallId, CtrlQ, Code) ->
     send(CallId, CtrlQ, Code, 'undefined').
 
+-spec send(kz_term:ne_binary() | kapps_call:call(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
+                  {'ok', kz_term:ne_binary()} |
+                  {'error', 'no_response'}.
 send(<<_/binary>> = CallId, CtrlQ, Code, Cause) ->
     send(CallId, CtrlQ, Code, Cause, 'undefined');
 send(Call, Code, Cause, Media) ->
@@ -49,6 +46,9 @@ send(Call, Code, Cause, Media) ->
     CtrlQ = kapps_call:control_queue(Call),
     send(CallId, CtrlQ, Code, Cause, Media).
 
+-spec send(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
+                  {'ok', kz_term:ne_binary()} |
+                  {'error', 'no_response'}.
 send(_, _, 'undefined', 'undefined', 'undefined') ->
     {'error', 'no_response'};
 send(CallId, CtrlQ, 'undefined', 'undefined', Media) ->

--- a/core/kazoo_call/src/kzc_recording.erl
+++ b/core/kazoo_call/src/kzc_recording.erl
@@ -154,10 +154,10 @@ handle_call_event(JObj, Props) ->
     end.
 
 -spec init([kapps_call:call() | kz_json:object()]) -> {'ok', state()}.
--spec init(kapps_call:call(), kz_json:object()) -> {'ok', state()}.
 init([Call, Data]) ->
     init(Call, Data).
 
+-spec init(kapps_call:call(), kz_json:object()) -> {'ok', state()}.
 init(Call, Data) ->
     kapps_call:put_callid(Call),
     lager:info("starting event listener for record_call"),

--- a/core/kazoo_config/src/kapps_account_config.erl
+++ b/core/kazoo_config/src/kapps_account_config.erl
@@ -39,10 +39,12 @@
 %% Get a non-empty configuration key for a given category and cast it as a binary
 %% @end
 %%-----------------------------------------------------------------------------
+
 -spec get_ne_binary(api_account(), kz_term:ne_binary(), kz_json:path()) -> kz_term:api_ne_binary().
--spec get_ne_binary(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> kz_term:ne_binary() | Default.
 get_ne_binary(Account, Category, Path) ->
     get_ne_binary(Account, Category, Path, undefined).
+
+-spec get_ne_binary(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> kz_term:ne_binary() | Default.
 get_ne_binary(Account, Category, Path, Default) ->
     Value = get(Account, Category, Path, Default),
     case kz_term:is_empty(Value) of
@@ -57,10 +59,12 @@ get_ne_binary(Account, Category, Path, Default) ->
 %% a list of binary
 %% @end
 %%-----------------------------------------------------------------------------
+
 -spec get_ne_binaries(api_account(), kz_term:ne_binary(), kz_json:path()) -> kz_term:ne_binaries().
--spec get_ne_binaries(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Account, Category, Path) ->
     get_ne_binaries(Account, Category, Path, undefined).
+
+-spec get_ne_binaries(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Account, Category, Path, Default) ->
     Values = get(Account, Category, Path, Default),
     case kz_term:is_ne_binaries(Values) of
@@ -98,13 +102,14 @@ to_pos_integer(Value, Default) ->
 %% Will search the account db first, then system_config for values.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_global(api_account(), kz_term:ne_binary(), kz_json:path()) ->
-                        kz_json:json_term().
--spec get_global(api_account(), kz_term:ne_binary(), kz_json:path(), kz_json:api_json_term()) ->
                         kz_json:json_term().
 get_global(Account, Category, Key) ->
     get_global(Account, Category, Key, undefined).
 
+-spec get_global(api_account(), kz_term:ne_binary(), kz_json:path(), kz_json:api_json_term()) ->
+                        kz_json:json_term().
 get_global(Account, Category, Key, Default) ->
     case load_config_from_account(account_id(Account), Category) of
         {ok, JObj} ->
@@ -256,16 +261,16 @@ get_global_from_doc(Category, Key, Default, JObj) ->
             Value
     end.
 
--spec get(api_account(), kz_term:ne_binary()) -> kz_json:object().
--spec get(api_account(), kz_term:ne_binary(), kz_json:path()) -> kz_json:api_json_term().
--spec get(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> kz_json:json_term() | Default.
 
+-spec get(api_account(), kz_term:ne_binary(), kz_json:path()) -> kz_json:api_json_term().
 get(Account, Category, Key) ->
     get(Account, Category, Key, undefined).
 
+-spec get(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> kz_json:json_term() | Default.
 get(Account, Category, Key, Default) ->
     kz_json:get_value(Key, get(Account, Category), Default).
 
+-spec get(api_account(), kz_term:ne_binary()) -> kz_json:object().
 get(Account, Category) ->
     case load_config_from_account(account_id(Account), Category) of
         {ok, JObj} -> JObj;

--- a/core/kazoo_config/src/kapps_config.erl
+++ b/core/kazoo_config/src/kapps_config.erl
@@ -73,19 +73,21 @@
 %% Get a configuration key for a given category and cast it as a list
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_string(config_category(), config_key()) -> kz_term:api_string().
--spec get_string(config_category(), config_key(), Default) ->
-                        nonempty_string() | Default.
--spec get_string(config_category(), config_key(), Default, kz_term:ne_binary()) ->
-                        nonempty_string() | Default.
 
+-spec get_string(config_category(), config_key()) -> kz_term:api_string().
 get_string(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
         Else -> kz_term:to_list(Else)
     end.
+
+-spec get_string(config_category(), config_key(), Default) ->
+                        nonempty_string() | Default.
 get_string(Category, Key, Default) ->
     get_string(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_string(config_category(), config_key(), Default, kz_term:ne_binary()) ->
+                        nonempty_string() | Default.
 get_string(Category, Key, Default, Node) ->
     kz_term:to_list(get(Category, Key, Default, Node)).
 
@@ -95,17 +97,19 @@ get_string(Category, Key, Default, Node) ->
 %% Get a configuration key for a given category and cast it as a binary
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_binary(config_category(), config_key()) -> kz_term:api_binary().
--spec get_binary(config_category(), config_key(), Default) -> binary() | Default.
--spec get_binary(config_category(), config_key(), Default, kz_term:ne_binary()) -> binary() | Default.
 
+-spec get_binary(config_category(), config_key()) -> kz_term:api_binary().
 get_binary(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
         Else -> kz_term:to_binary(Else)
     end.
+
+-spec get_binary(config_category(), config_key(), Default) -> binary() | Default.
 get_binary(Category, Key, Default) ->
     get_binary(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_binary(config_category(), config_key(), Default, kz_term:ne_binary()) -> binary() | Default.
 get_binary(Category, Key, Default, Node) ->
     kz_term:to_binary(get(Category, Key, Default, Node)).
 
@@ -115,13 +119,9 @@ get_binary(Category, Key, Default, Node) ->
 %% Get a configuration key for a given category and cast it as a json
 %% @end
 %%-----------------------------------------------------------------------------
+
 -spec get_json(config_category(), config_key()) ->
                       kz_term:api_object().
--spec get_json(config_category(), config_key(), Default) ->
-                      kz_json:object() | Default.
--spec get_json(config_category(), config_key(), Default, kz_term:ne_binary()) ->
-                      kz_json:object() | Default.
-
 get_json(Category, Key) ->
     V = get(Category, Key),
     as_json_value(V, undefined).
@@ -134,19 +134,20 @@ as_json_value(V, Default) ->
         'false' -> Default
     end.
 
+-spec get_json(config_category(), config_key(), Default) ->
+                      kz_json:object() | Default.
 get_json(Category, Key, Default) ->
     get_json(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_json(config_category(), config_key(), Default, kz_term:ne_binary()) ->
+                      kz_json:object() | Default.
 get_json(Category, Key, Default, Node) ->
     V = get(Category, Key, Default, Node),
     as_json_value(V, Default).
 
+
 -spec get_jsons(config_category(), config_key()) ->
                        kz_json:objects().
--spec get_jsons(config_category(), config_key(), Default) ->
-                       kz_json:objects() | Default.
--spec get_jsons(config_category(), config_key(), Default, kz_term:ne_binary()) ->
-                       kz_json:objects() | Default.
-
 get_jsons(Category, Key) ->
     V = get(Category, Key),
     as_jsons_value(V, []).
@@ -159,8 +160,13 @@ as_jsons_value(V, Default) ->
         false -> Default
     end.
 
+-spec get_jsons(config_category(), config_key(), Default) ->
+                       kz_json:objects() | Default.
 get_jsons(Category, Key, Default) ->
     get_jsons(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_jsons(config_category(), config_key(), Default, kz_term:ne_binary()) ->
+                       kz_json:objects() | Default.
 get_jsons(Category, Key, Default, Node) ->
     V = get(Category, Key, Default, Node),
     as_jsons_value(V, Default).
@@ -171,17 +177,19 @@ get_jsons(Category, Key, Default, Node) ->
 %% Get a configuration key for a given category and cast it as a atom
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_atom(config_category(), config_key()) -> kz_term:api_atom().
--spec get_atom(config_category(), config_key(), Default) -> atom() | Default.
--spec get_atom(config_category(), config_key(), Default, kz_term:ne_binary()) -> atom() | Default.
 
+-spec get_atom(config_category(), config_key()) -> kz_term:api_atom().
 get_atom(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
         Else -> kz_term:to_atom(Else, 'true')
     end.
+
+-spec get_atom(config_category(), config_key(), Default) -> atom() | Default.
 get_atom(Category, Key, Default) ->
     get_atom(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_atom(config_category(), config_key(), Default, kz_term:ne_binary()) -> atom() | Default.
 get_atom(Category, Key, Default, Node) ->
     kz_term:to_atom(get(Category, Key, Default, Node), 'true').
 
@@ -191,18 +199,19 @@ get_atom(Category, Key, Default, Node) ->
 %% Get a configuration key for a given category and cast it as a integer
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_integer(config_category(), config_key()) -> kz_term:api_integer().
--spec get_integer(config_category(), config_key(), Default) -> integer() | Default.
--spec get_integer(config_category(), config_key(), Default, kz_term:ne_binary()) -> integer() | Default.
 
+-spec get_integer(config_category(), config_key()) -> kz_term:api_integer().
 get_integer(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
         Else -> kz_term:to_integer(Else)
     end.
 
+-spec get_integer(config_category(), config_key(), Default) -> integer() | Default.
 get_integer(Category, Key, Default) ->
     get_integer(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_integer(config_category(), config_key(), Default, kz_term:ne_binary()) -> integer() | Default.
 get_integer(Category, Key, Default, Node) ->
     case get(Category, Key, Default, Node) of
         'undefined' -> 'undefined';
@@ -215,17 +224,19 @@ get_integer(Category, Key, Default, Node) ->
 %% Get a configuration key for a given category and cast it as a pos_integer
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_pos_integer(config_category(), config_key()) -> kz_term:api_pos_integer().
--spec get_pos_integer(config_category(), config_key(), Default) -> pos_integer() | Default.
--spec get_pos_integer(config_category(), config_key(), Default, kz_term:ne_binary()) -> pos_integer() | Default.
 
+-spec get_pos_integer(config_category(), config_key()) -> kz_term:api_pos_integer().
 get_pos_integer(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
         Else -> to_pos_integer(Else, undefined)
     end.
+
+-spec get_pos_integer(config_category(), config_key(), Default) -> pos_integer() | Default.
 get_pos_integer(Category, Key, Default) ->
     get_pos_integer(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_pos_integer(config_category(), config_key(), Default, kz_term:ne_binary()) -> pos_integer() | Default.
 get_pos_integer(Category, Key, Default, Node) ->
     to_pos_integer(get(Category, Key, Default, Node), Default).
 
@@ -242,17 +253,19 @@ to_pos_integer(Value, Default) ->
 %% Get a configuration key for a given category and cast it as a pos_integer
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_non_neg_integer(config_category(), config_key()) -> kz_term:api_non_neg_integer().
--spec get_non_neg_integer(config_category(), config_key(), Default) -> non_neg_integer() | Default.
--spec get_non_neg_integer(config_category(), config_key(), Default, kz_term:ne_binary()) -> non_neg_integer() | Default.
 
+-spec get_non_neg_integer(config_category(), config_key()) -> kz_term:api_non_neg_integer().
 get_non_neg_integer(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
         Else -> to_non_neg_integer(Else, undefined)
     end.
+
+-spec get_non_neg_integer(config_category(), config_key(), Default) -> non_neg_integer() | Default.
 get_non_neg_integer(Category, Key, Default) ->
     get_non_neg_integer(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_non_neg_integer(config_category(), config_key(), Default, kz_term:ne_binary()) -> non_neg_integer() | Default.
 get_non_neg_integer(Category, Key, Default, Node) ->
     to_non_neg_integer(get(Category, Key, Default, Node), Default).
 
@@ -269,17 +282,19 @@ to_non_neg_integer(Value, Default) ->
 %% Get a configuration key for a given category and cast it as a float
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_float(config_category(), config_key()) -> kz_term:api_float().
--spec get_float(config_category(), config_key(), Default) -> float() | Default.
--spec get_float(config_category(), config_key(), Default, kz_term:ne_binary()) -> float() | Default.
 
+-spec get_float(config_category(), config_key()) -> kz_term:api_float().
 get_float(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
         Else -> kz_term:to_float(Else)
     end.
+
+-spec get_float(config_category(), config_key(), Default) -> float() | Default.
 get_float(Category, Key, Default) ->
     get_float(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_float(config_category(), config_key(), Default, kz_term:ne_binary()) -> float() | Default.
 get_float(Category, Key, Default, Node) ->
     kz_term:to_float(get(Category, Key, Default, Node)).
 
@@ -289,17 +304,19 @@ get_float(Category, Key, Default, Node) ->
 %% Get a configuration key for a given category and cast it as a is_false
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_is_false(config_category(), config_key()) -> kz_term:api_boolean().
--spec get_is_false(config_category(), config_key(), Default) -> boolean() | Default.
--spec get_is_false(config_category(), config_key(), Default, kz_term:ne_binary()) -> boolean() | Default.
 
+-spec get_is_false(config_category(), config_key()) -> kz_term:api_boolean().
 get_is_false(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
         Else -> kz_term:is_false(Else)
     end.
+
+-spec get_is_false(config_category(), config_key(), Default) -> boolean() | Default.
 get_is_false(Category, Key, Default) ->
     get_is_false(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_is_false(config_category(), config_key(), Default, kz_term:ne_binary()) -> boolean() | Default.
 get_is_false(Category, Key, Default, Node) ->
     kz_term:is_false(get(Category, Key, Default, Node)).
 
@@ -309,28 +326,32 @@ get_is_false(Category, Key, Default, Node) ->
 %% Get a configuration key for a given category and cast it as a is_true
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_is_true(config_category(), config_key()) -> kz_term:api_boolean().
--spec get_is_true(config_category(), config_key(), Default) -> boolean() | Default.
--spec get_is_true(config_category(), config_key(), Default, kz_term:ne_binary()) -> boolean() | Default.
 
+-spec get_is_true(config_category(), config_key()) -> kz_term:api_boolean().
 get_is_true(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
         Else -> kz_term:is_true(Else)
     end.
+
+-spec get_is_true(config_category(), config_key(), Default) -> boolean() | Default.
 get_is_true(Category, Key, Default) ->
     get_is_true(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_is_true(config_category(), config_key(), Default, kz_term:ne_binary()) -> boolean() | Default.
 get_is_true(Category, Key, Default, Node) ->
     kz_term:is_true(get(Category, Key, Default, Node)).
 
--spec get_ne_binary_or_ne_binaries(config_category(), config_key()) -> kz_term:api_ne_binary() | kz_term:ne_binaries().
--spec get_ne_binary_or_ne_binaries(config_category(), config_key(), Default) -> kz_term:ne_binary() | kz_term:ne_binaries() | Default.
--spec get_ne_binary_or_ne_binaries(config_category(), config_key(), Default, kz_term:ne_binary()) -> kz_term:ne_binary() | kz_term:ne_binaries() | Default.
 
+-spec get_ne_binary_or_ne_binaries(config_category(), config_key()) -> kz_term:api_ne_binary() | kz_term:ne_binaries().
 get_ne_binary_or_ne_binaries(Category, Key) ->
     get_ne_binary_or_ne_binaries(Category, Key, 'undefined').
+
+-spec get_ne_binary_or_ne_binaries(config_category(), config_key(), Default) -> kz_term:ne_binary() | kz_term:ne_binaries() | Default.
 get_ne_binary_or_ne_binaries(Category, Key, Default) ->
     get_ne_binary_or_ne_binaries(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_ne_binary_or_ne_binaries(config_category(), config_key(), Default, kz_term:ne_binary()) -> kz_term:ne_binary() | kz_term:ne_binaries() | Default.
 get_ne_binary_or_ne_binaries(Category, Key, Default, Node) ->
     ValueOrValues = get(Category, Key, Default, Node),
     case kz_term:is_empty(ValueOrValues) of
@@ -346,14 +367,16 @@ get_ne_binary_or_ne_binaries(Category, Key, Default, Node) ->
             end
     end.
 
--spec get_ne_binary(config_category(), config_key()) -> kz_term:api_ne_binary().
--spec get_ne_binary(config_category(), config_key(), Default) -> kz_term:ne_binary() | Default.
--spec get_ne_binary(config_category(), config_key(), Default, kz_term:ne_binary()) -> kz_term:ne_binary() | Default.
 
+-spec get_ne_binary(config_category(), config_key()) -> kz_term:api_ne_binary().
 get_ne_binary(Category, Key) ->
     get_ne_binary(Category, Key, 'undefined').
+
+-spec get_ne_binary(config_category(), config_key(), Default) -> kz_term:ne_binary() | Default.
 get_ne_binary(Category, Key, Default) ->
     get_ne_binary(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_ne_binary(config_category(), config_key(), Default, kz_term:ne_binary()) -> kz_term:ne_binary() | Default.
 get_ne_binary(Category, Key, Default, Node) ->
     Value = get(Category, Key, Default, Node),
     case kz_term:is_empty(Value) of
@@ -361,14 +384,16 @@ get_ne_binary(Category, Key, Default, Node) ->
         'false' -> kz_term:to_binary(Value)
     end.
 
--spec get_ne_binaries(config_category(), config_key()) -> kz_term:api_ne_binaries().
--spec get_ne_binaries(config_category(), config_key(), Default) -> kz_term:ne_binaries() | Default.
--spec get_ne_binaries(config_category(), config_key(), Default, kz_term:ne_binary()) -> kz_term:ne_binaries() | Default.
 
+-spec get_ne_binaries(config_category(), config_key()) -> kz_term:api_ne_binaries().
 get_ne_binaries(Category, Key) ->
     get_ne_binaries(Category, Key, 'undefined').
+
+-spec get_ne_binaries(config_category(), config_key(), Default) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Category, Key, Default) ->
     get_ne_binaries(Category, Key, Default, kz_term:to_binary(node())).
+
+-spec get_ne_binaries(config_category(), config_key(), Default, kz_term:ne_binary()) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Category, Key, Default, Node) ->
     Values = get(Category, Key, Default, Node),
     case kz_term:is_empty(Values) of
@@ -388,16 +413,16 @@ get_ne_binaries(Category, Key, Default, Node) ->
 %%  explicitly for the node
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_node_value(config_category(), config_key()) -> any() | 'undefined'.
--spec get_node_value(config_category(), config_key(), Default) -> any() | Default.
--spec get_node_value(config_category(), config_key(), Default, kz_term:ne_binary() | atom()) -> any() | Default.
 
+-spec get_node_value(config_category(), config_key()) -> any() | 'undefined'.
 get_node_value(Category, Key) ->
     get_node_value(Category, Key, 'undefined').
 
+-spec get_node_value(config_category(), config_key(), Default) -> any() | Default.
 get_node_value(Category, Key, Default) ->
     get_node_value(Category, Key, Default, node()).
 
+-spec get_node_value(config_category(), config_key(), Default, kz_term:ne_binary() | atom()) -> any() | Default.
 get_node_value(Category, Key, Default, Node) when not is_list(Key) ->
     get_node_value(Category, [kz_term:to_binary(Key)], Default, Node);
 get_node_value(Category, Keys, Default, Node) when not is_binary(Category) ->
@@ -423,16 +448,16 @@ get_node_value(Category, Keys, Default, Node) ->
 %% node but if there is not then use the default value.
 %% @end
 %%-----------------------------------------------------------------------------
--spec get(config_category(), config_key()) -> any() | 'undefined'.
--spec get(config_category(), config_key(), Default) -> any() | Default.
--spec get(config_category(), config_key(), Default, kz_term:ne_binary() | atom()) -> any() | Default.
 
+-spec get(config_category(), config_key()) -> any() | 'undefined'.
 get(Category, Key) ->
     get(Category, Key, 'undefined').
 
+-spec get(config_category(), config_key(), Default) -> any() | Default.
 get(Category, Key, Default) ->
     get(Category, Key, Default, node()).
 
+-spec get(config_category(), config_key(), Default, kz_term:ne_binary() | atom()) -> any() | Default.
 get(Category, Key, Default, 'undefined') ->
     get(Category, Key, Default, ?KEY_DEFAULT);
 get(Category, Key, Default, Node) when not is_list(Key) ->
@@ -453,15 +478,16 @@ get(Category, Keys, Default, Node) ->
             Default
     end.
 
--spec get_current(config_category(), config_key()) -> any() | 'undefined'.
--spec get_current(config_category(), config_key(), Default) -> any() | Default.
--spec get_current(config_category(), config_key(), Default, kz_term:ne_binary() | atom()) -> any() | Default.
 
+-spec get_current(config_category(), config_key()) -> any() | 'undefined'.
 get_current(Category, Key) ->
     get_current(Category, Key, 'undefined').
+
+-spec get_current(config_category(), config_key(), Default) -> any() | Default.
 get_current(Category, Key, Default) ->
     get_current(Category, Key, Default, node()).
 
+-spec get_current(config_category(), config_key(), Default, kz_term:ne_binary() | atom()) -> any() | Default.
 get_current(Category, Key, Default, 'undefined') ->
     get_current(Category, Key, Default, ?KEY_DEFAULT);
 get_current(Category, Key, Default, Node) when not is_list(Key) ->
@@ -544,29 +570,29 @@ get_all_default_kvs(JObj) ->
 %% @doc
 %% @end
 %%-----------------------------------------------------------------------------
+
 -spec set_string(config_category(), config_key(), kz_term:text() | binary() | string()) ->
                         {'ok', kz_json:object()}.
--spec set_integer(config_category(), config_key(), kz_term:text() | integer()) ->
-                         {'ok', kz_json:object()}.
--spec set_float(config_category(), config_key(), kz_term:text() | float()) ->
-                       {'ok', kz_json:object()}.
--spec set_boolean(config_category(), config_key(), kz_term:text() | boolean()) ->
-                         {'ok', kz_json:object()}.
--spec set_json(config_category(), config_key(), kz_term:text() | kz_json:object()) ->
-                      {'ok', kz_json:object()}.
-
 set_string(Category, Key, Value) ->
     set(Category, Key, kz_term:to_binary(Value)).
 
+-spec set_integer(config_category(), config_key(), kz_term:text() | integer()) ->
+                         {'ok', kz_json:object()}.
 set_integer(Category, Key, Value) ->
     set(Category, Key, kz_term:to_integer(Value)).
 
+-spec set_float(config_category(), config_key(), kz_term:text() | float()) ->
+                       {'ok', kz_json:object()}.
 set_float(Category, Key, Value) ->
     set(Category, Key, kz_term:to_float(Value)).
 
+-spec set_boolean(config_category(), config_key(), kz_term:text() | boolean()) ->
+                         {'ok', kz_json:object()}.
 set_boolean(Category, Key, Value) ->
     set(Category, Key, kz_term:to_boolean(Value)).
 
+-spec set_json(config_category(), config_key(), kz_term:text() | kz_json:object()) ->
+                      {'ok', kz_json:object()}.
 set_json(Category, Key, Value) ->
     set(Category, Key, kz_json:decode(Value)).
 
@@ -595,11 +621,12 @@ set_default(Category, Key, Value) ->
 -spec update_default(config_category(), config_key(), kz_json:json_term()) ->
                             {'ok', kz_json:object()} | 'ok' |
                             {'error', any()}.
+update_default(Category, Key, Value) ->
+    update_default(Category, Key, Value, []).
+
 -spec update_default(config_category(), config_key(), kz_json:json_term(), update_options()) ->
                             {'ok', kz_json:object()} | 'ok' |
                             {'error', any()}.
-update_default(Category, Key, Value) ->
-    update_default(Category, Key, Value, []).
 update_default(Category, Key, Value, Options) ->
     update_category(Category, Key, Value, ?KEY_DEFAULT, Options).
 
@@ -675,21 +702,22 @@ update_category(Category, JObj, PvtFields) ->
 -endif.
 
 %% @private
+
 -spec maybe_save_category(kz_term:ne_binary(), kz_json:object(), kz_term:api_object()) ->
-                                 {'ok', kz_json:object()} |
-                                 {'error', 'conflict'}.
--spec maybe_save_category(kz_term:ne_binary(), kz_json:object(), kz_term:api_object(), boolean()) ->
-                                 {'ok', kz_json:object()} |
-                                 {'error', 'conflict'}.
--spec maybe_save_category(kz_term:ne_binary(), kz_json:object(), kz_term:api_object(), boolean(), boolean()) ->
                                  {'ok', kz_json:object()} |
                                  {'error', 'conflict'}.
 maybe_save_category(Category, JObj, PvtFields) ->
     maybe_save_category(Category, JObj, PvtFields, 'false').
 
+-spec maybe_save_category(kz_term:ne_binary(), kz_json:object(), kz_term:api_object(), boolean()) ->
+                                 {'ok', kz_json:object()} |
+                                 {'error', 'conflict'}.
 maybe_save_category(Category, JObj, PvtFields, Looped) ->
     maybe_save_category(Category, JObj, PvtFields, Looped, is_locked()).
 
+-spec maybe_save_category(kz_term:ne_binary(), kz_json:object(), kz_term:api_object(), boolean(), boolean()) ->
+                                 {'ok', kz_json:object()} |
+                                 {'error', 'conflict'}.
 maybe_save_category(_, JObj, _, _, 'true') ->
     lager:warning("failed to update category, system config database is locked!"),
     lager:warning("please update /etc/kazoo/config.ini or use 'sup kapps_config lock_db <boolean>' to enable system config writes."),
@@ -734,11 +762,12 @@ update_pvt_fields(Category, JObj, PvtFields) ->
 %% Lock configuration document
 %% @end
 %%-----------------------------------------------------------------------------
+
 -spec lock_db() -> 'ok'.
--spec lock_db(kz_term:text() | boolean()) -> 'ok'.
 lock_db() ->
     lock_db('true').
 
+-spec lock_db(kz_term:text() | boolean()) -> 'ok'.
 lock_db('true') ->
     kz_config:set('kazoo_apps', 'lock_system_config', 'true');
 lock_db('false') ->
@@ -776,10 +805,10 @@ flush(Category) ->
     kz_datamgr:flush_cache_doc(?KZ_CONFIG_DB, Category).
 
 -spec flush(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
--spec flush(kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries(), kz_term:api_ne_binary()) -> 'ok'.
 flush(Category, Key) ->
     flush(Category, Key, ?KEY_DEFAULT).
 
+-spec flush(kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries(), kz_term:api_ne_binary()) -> 'ok'.
 flush(Category, Key, 'undefined') ->
     flush(Category, Key);
 flush(Category, Key, <<"undefined">>) ->
@@ -809,12 +838,14 @@ flush(Category, Keys, Node) ->
 %% 3. from a flat file
 %% @end
 %%-----------------------------------------------------------------------------
+
 -spec get_category(kz_term:ne_binary()) -> fetch_ret().
--spec get_category(kz_term:ne_binary(), boolean()) -> fetch_ret().
 get_category(Category) ->
     get_category(Category, 'true').
 
 -ifdef(TEST).
+
+-spec get_category(kz_term:ne_binary(), boolean()) -> fetch_ret().
 get_category(Category, _)
   when Category =:= <<"test_account_config">>;
        Category =:= <<"test_account_config_sub_empty">>;
@@ -827,6 +858,8 @@ get_category(Category, _)
 get_category(_, _) ->
     {'error', 'not_found'}.
 -else.
+
+-spec get_category(kz_term:ne_binary(), boolean()) -> fetch_ret().
 get_category(Category, 'true') ->
     kz_datamgr:open_cache_doc(?KZ_CONFIG_DB, Category, [{'cache_failures', ['not_found']}]);
 get_category(Category, 'false') ->

--- a/core/kazoo_config/src/kz_config.erl
+++ b/core/kazoo_config/src/kz_config.erl
@@ -143,8 +143,8 @@ get_node_section_name() ->
 %% Set or unset enviroment variables
 %% @end
 %%--------------------------------------------------------------------
+
 -spec set(section(), atom(), term()) -> 'ok'.
--spec set({section(), kz_term:proplist()}, kz_term:proplist()) -> 'ok'.
 set(Section, Key, Value) ->
     Props = load(),
     case props:get_value(Section, Props) of
@@ -156,6 +156,7 @@ set(Section, Key, Value) ->
             set({Section, NewSection}, props:delete(Section, Props))
     end.
 
+-spec set({section(), kz_term:proplist()}, kz_term:proplist()) -> 'ok'.
 set(NewSection, Props) ->
     NewProps = props:insert_value(NewSection, Props),
     application:set_env(?APP, ?MODULE, NewProps).

--- a/core/kazoo_couch/src/kazoo_couch.erl
+++ b/core/kazoo_couch/src/kazoo_couch.erl
@@ -75,22 +75,22 @@ get_db(Server, DbName) ->
     kz_couch_util:get_db(Server, DbName).
 
 -spec get_admin_dbs() -> kz_term:ne_binary().
--spec get_admin_dbs(couch_version() | kz_data:connection()) -> kz_term:ne_binary().
 get_admin_dbs() ->
     #{server := {_App, #server{}=Conn}} = kzs_plan:plan(),
     get_admin_dbs(Conn).
 
+-spec get_admin_dbs(couch_version() | kz_data:connection()) -> kz_term:ne_binary().
 get_admin_dbs(#server{}=Server) ->
     get_admin_dbs(server_version(Server));
 get_admin_dbs('bigcouch') -> <<"dbs">>;
 get_admin_dbs(_Driver) -> <<"_dbs">>.
 
 -spec get_admin_nodes() -> kz_term:ne_binary().
--spec get_admin_nodes(couch_version() | kz_data:connection()) -> kz_term:ne_binary().
 get_admin_nodes() ->
     #{server := {_App, #server{}=Conn}} = kzs_plan:plan(),
     get_admin_nodes(Conn).
 
+-spec get_admin_nodes(couch_version() | kz_data:connection()) -> kz_term:ne_binary().
 get_admin_nodes(#server{}=Server) ->
     get_admin_nodes(server_version(Server));
 get_admin_nodes('bigcouch') -> <<"nodes">>;

--- a/core/kazoo_couch/src/kz_couch_attachments.erl
+++ b/core/kazoo_couch/src/kz_couch_attachments.erl
@@ -37,12 +37,12 @@ stream_attachment(#server{}=Conn, DbName, DocId, AName, Caller) ->
 -spec put_attachment(server(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                             {'ok', kz_json:object()} |
                             couchbeam_error().
--spec put_attachment(server(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
-                            {'ok', kz_json:object()} |
-                            couchbeam_error().
 put_attachment(#server{}=Conn, DbName, DocId, AName, Contents) ->
     put_attachment(#server{}=Conn, DbName, DocId, AName, Contents, []).
 
+-spec put_attachment(server(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
+                            {'ok', kz_json:object()} |
+                            couchbeam_error().
 put_attachment(#server{}=Conn, DbName, DocId, AName, Contents, Options) ->
     Db = kz_couch_util:get_db(Conn, DbName),
     do_put_attachment(Db, DocId, AName, Contents, Options).
@@ -50,12 +50,12 @@ put_attachment(#server{}=Conn, DbName, DocId, AName, Contents, Options) ->
 -spec delete_attachment(server(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                                {'ok', kz_json:object()} |
                                couchbeam_error().
--spec delete_attachment(server(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
-                               {'ok', kz_json:object()} |
-                               couchbeam_error().
 delete_attachment(#server{}=Conn, DbName, DocId, AName) ->
     delete_attachment(#server{}=Conn, DbName, DocId, AName, []).
 
+-spec delete_attachment(server(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
+                               {'ok', kz_json:object()} |
+                               couchbeam_error().
 delete_attachment(#server{}=Conn, DbName, DocId, AName, Options) ->
     Db = kz_couch_util:get_db(Conn, DbName),
     do_del_attachment(Db, DocId, AName,  kz_couch_util:maybe_add_rev(Db, DocId, Options)).

--- a/core/kazoo_couch/src/kz_couch_util.erl
+++ b/core/kazoo_couch/src/kz_couch_util.erl
@@ -196,11 +196,12 @@ db_url(#server{}=Conn, DbName) ->
 %% returns the #db{} record
 %% @end
 %%------------------------------------------------------------------------------
+
 -spec get_db(kz_data:connection(), kz_term:ne_binary()) -> db().
--spec get_db(kz_data:connection(), kz_term:ne_binary(), couch_version()) -> db().
 get_db(Conn, DbName) ->
     get_db(Conn, DbName, kazoo_couch:server_version(Conn)).
 
+-spec get_db(kz_data:connection(), kz_term:ne_binary(), couch_version()) -> db().
 get_db(Conn, DbName, Driver) ->
     ConnToUse =
         case is_admin_db(DbName, Driver) of

--- a/core/kazoo_couch/src/kz_couch_view.erl
+++ b/core/kazoo_couch/src/kz_couch_view.erl
@@ -42,11 +42,12 @@ design_info(#server{}=Conn, DBName, Design) ->
 -spec all_design_docs(kz_data:connection(), kz_term:ne_binary()) ->
                              {'ok', kz_json:objects()} |
                              couchbeam_error().
+all_design_docs(#server{}=Conn, DBName) ->
+    all_design_docs(#server{}=Conn, DBName, []).
+
 -spec all_design_docs(kz_data:connection(), kz_term:ne_binary(), view_options()) ->
                              {'ok', kz_json:objects()} |
                              couchbeam_error().
-all_design_docs(#server{}=Conn, DBName) ->
-    all_design_docs(#server{}=Conn, DBName, []).
 all_design_docs(#server{}=Conn, DBName, Options) ->
     Db = kz_couch_util:get_db(Conn, DBName),
     Filter = props:set_values([{'startkey', <<"_design/">>}

--- a/core/kazoo_csv/src/kz_csv.erl
+++ b/core/kazoo_csv/src/kz_csv.erl
@@ -314,10 +314,12 @@ consume(Bin, {Acc,Sep,AccBin}) ->
     end.
 
 %% @private
+
 -spec find_position(kz_term:ne_binary(), kz_term:ne_binaries()) -> pos_integer().
--spec find_position(kz_term:ne_binary(), kz_term:ne_binaries(), pos_integer()) -> pos_integer().
 find_position(Item, Items) ->
     find_position(Item, Items, 1).
+
+-spec find_position(kz_term:ne_binary(), kz_term:ne_binaries(), pos_integer()) -> pos_integer().
 find_position(Item, [Item|_], Pos) -> Pos;
 find_position(Item, [_|Items], N) ->
     find_position(Item, Items, N+1).

--- a/core/kazoo_data/src/kazoo_data_config.erl
+++ b/core/kazoo_data/src/kazoo_data_config.erl
@@ -12,9 +12,10 @@
 -compile({no_auto_import,[get/1]}).
 
 -spec get_pos_integer(kz_term:ne_binary()) -> kz_term:api_pos_integer().
--spec get_pos_integer(kz_term:ne_binary(), Default) -> pos_integer() | Default.
 get_pos_integer(Key) ->
     get_pos_integer(Key, 'undefined').
+
+-spec get_pos_integer(kz_term:ne_binary(), Default) -> pos_integer() | Default.
 get_pos_integer(Key, Default) ->
     case get(Key) of
         'undefined' -> Default;
@@ -22,9 +23,10 @@ get_pos_integer(Key, Default) ->
     end.
 
 -spec get_ne_binary(kz_term:ne_binary()) -> kz_term:api_ne_binary().
--spec get_ne_binary(kz_term:ne_binary(), Default) -> kz_term:ne_binary() | Default.
 get_ne_binary(Key) ->
     get_ne_binary(Key, 'undefined').
+
+-spec get_ne_binary(kz_term:ne_binary(), Default) -> kz_term:ne_binary() | Default.
 get_ne_binary(Key, Default) ->
     case get(Key) of
         'undefined' -> Default;
@@ -33,9 +35,10 @@ get_ne_binary(Key, Default) ->
     end.
 
 -spec get_ne_binaries(kz_term:ne_binary()) -> kz_term:api_ne_binaries().
--spec get_ne_binaries(kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Key) ->
     get_ne_binaries(Key, 'undefined').
+
+-spec get_ne_binaries(kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Key, Default) ->
     case get(Key) of
         'undefined' -> Default;
@@ -44,9 +47,10 @@ get_ne_binaries(Key, Default) ->
     end.
 
 -spec get_json(kz_term:ne_binary()) -> kz_term:api_object().
--spec get_json(kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 get_json(Key) ->
     get_json(Key, 'undefined').
+
+-spec get_json(kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 get_json(Key, Default) ->
     case get(Key) of
         'undefined' -> Default;
@@ -55,9 +59,10 @@ get_json(Key, Default) ->
     end.
 
 -spec get_is_true(kz_term:ne_binary()) -> boolean().
--spec get_is_true(kz_term:ne_binary(), Default) -> boolean() | Default.
 get_is_true(Key) ->
     get_is_true(Key, 'false').
+
+-spec get_is_true(kz_term:ne_binary(), Default) -> boolean() | Default.
 get_is_true(Key, Default) ->
     case get(Key) of
         'undefined' -> Default;

--- a/core/kazoo_data/src/kazoo_data_maintenance.erl
+++ b/core/kazoo_data/src/kazoo_data_maintenance.erl
@@ -37,16 +37,16 @@ flush_data_plans() ->
     io:format("flushed all data plans~n").
 
 -spec flush_docs() -> 'ok'.
--spec flush_docs(kz_term:ne_binary()) -> 'ok'.
--spec flush_docs(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 flush_docs() ->
     _ = kz_datamgr:flush_cache_docs(),
     io:format("flushed all cached docs~n").
 
+-spec flush_docs(kz_term:ne_binary()) -> 'ok'.
 flush_docs(Account) ->
     _ = kz_datamgr:flush_cache_docs(kz_util:format_account_db(Account)),
     io:format("flushed all docs cached for account ~s~n", [Account]).
 
+-spec flush_docs(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 flush_docs(Account, DocId) ->
     _ = kz_datamgr:flush_cache_doc(kz_util:format_account_db(Account), DocId),
     io:format("flushed cached doc ~s for account ~s~n", [DocId, Account]).
@@ -56,10 +56,10 @@ trace_module(Module) ->
     start_trace([{'module', kz_term:to_atom(Module)}]).
 
 -spec trace_function(kz_term:ne_binary()) -> 'ok'.
--spec trace_function(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 trace_function(Function) ->
     start_trace([{'function', kz_term:to_atom(Function)}]).
 
+-spec trace_function(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 trace_function(Module, Function) ->
     start_trace([{'module', kz_term:to_atom(Module)}
                 ,{'function', kz_term:to_atom(Function)}

--- a/core/kazoo_data/src/kz_data_tracing.erl
+++ b/core/kazoo_data/src/kz_data_tracing.erl
@@ -63,30 +63,30 @@
 -spec trace_file() ->
                         {'ok', trace_ref()} |
                         {'error', trace_error()}.
--spec trace_file(filters()) ->
-                        {'ok', trace_ref()} |
-                        {'error', trace_error()}.
--spec trace_file(filters(), file:filename_all()) ->
-                        {'ok', trace_ref()} |
-                        {'error', trace_error()}.
--spec trace_file(filters(), file:filename_all(), list()) ->
-                        {'ok', trace_ref()} |
-                        {'error', trace_error()}.
--spec trace_file(filters(), file:filename_all(), list(), atom()) ->
-                        {'ok', trace_ref()} |
-                        {'error', trace_error()}.
 trace_file() ->
     trace_file([{'function', '*'}]).
 
+-spec trace_file(filters()) ->
+                        {'ok', trace_ref()} |
+                        {'error', trace_error()}.
 trace_file(Filters) ->
     trace_file(Filters, <<"/tmp/", (kz_binary:rand_hex(16))/binary, ".log">>).
 
+-spec trace_file(filters(), file:filename_all()) ->
+                        {'ok', trace_ref()} |
+                        {'error', trace_error()}.
 trace_file(Filters, Filename) ->
     trace_file(Filters, Filename, ?DEFAULT_TRACE_PROPS(?DEFAULT_TRACE_OUTPUT_FORMAT)).
 
+-spec trace_file(filters(), file:filename_all(), list()) ->
+                        {'ok', trace_ref()} |
+                        {'error', trace_error()}.
 trace_file(Filters, Filename, Format) ->
     trace_file(Filters, Filename, Format, 'debug').
 
+-spec trace_file(filters(), file:filename_all(), list(), atom()) ->
+                        {'ok', trace_ref()} |
+                        {'error', trace_error()}.
 trace_file(Filters, Filename, Format, LogLevel) ->
     gen_server:call(?MODULE
                    ,{'trace_file'

--- a/core/kazoo_data/src/kz_dataconnections.erl
+++ b/core/kazoo_data/src/kz_dataconnections.erl
@@ -54,16 +54,16 @@ add(#data_connection{tag='undefined'}=Connection) ->
 add(#data_connection{}=Connection) ->
     gen_server:cast(?SERVER, {'add_connection', Connection}).
 
--spec wait_for_connection() -> 'ok' | 'no_connection'.
--spec wait_for_connection(any()) -> 'ok' | 'no_connection'.
--spec wait_for_connection(any(), timeout()) -> 'ok' | 'no_connection'.
 
+-spec wait_for_connection() -> 'ok' | 'no_connection'.
 wait_for_connection() ->
     wait_for_connection('local').
 
+-spec wait_for_connection(any()) -> 'ok' | 'no_connection'.
 wait_for_connection(Tag) ->
     wait_for_connection(Tag, 'infinity').
 
+-spec wait_for_connection(any(), timeout()) -> 'ok' | 'no_connection'.
 wait_for_connection(_Tag, 0) -> 'no_connection';
 wait_for_connection(Tag, Timeout) ->
     Start = os:timestamp(),
@@ -100,12 +100,13 @@ get_server(Tag) ->
         _ -> 'undefined'
     end.
 
+
 -spec test_conn() -> {'ok', kz_json:object()} |
                      {'error', any()}.
+test_conn() -> test_conn('local').
+
 -spec test_conn(term()) -> {'ok', kz_json:object()} |
                            {'error', any()}.
-
-test_conn() -> test_conn('local').
 test_conn(Tag) ->
     case get_server(Tag) of
         'undefined' -> {'error', 'server_not_available'};

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -180,12 +180,12 @@ revise_views_from_folder(DbName, App) ->
 %% priv/couchdb/ into a given database
 %% @end
 %%--------------------------------------------------------------------
--spec revise_docs_from_folder(kz_term:ne_binary(), atom(), kz_term:ne_binary() | nonempty_string()) -> 'ok'.
--spec revise_docs_from_folder(kz_term:ne_binary(), atom(), kz_term:ne_binary() | nonempty_string(), boolean()) -> 'ok'.
 
+-spec revise_docs_from_folder(kz_term:ne_binary(), atom(), kz_term:ne_binary() | nonempty_string()) -> 'ok'.
 revise_docs_from_folder(DbName, App, Folder) ->
     revise_docs_from_folder(DbName, App, Folder, 'false').
 
+-spec revise_docs_from_folder(kz_term:ne_binary(), atom(), kz_term:ne_binary() | nonempty_string(), boolean()) -> 'ok'.
 revise_docs_from_folder(DbName, App, Folder, Sleep) ->
     case code:priv_dir(App) of
         {'error', 'bad_name'} ->
@@ -402,12 +402,12 @@ db_view_cleanup(DbName) ->
 -spec db_view_update(kz_term:ne_binary(), views_listing()) ->
                             boolean() |
                             {'error', 'invalid_db_name'}.
--spec db_view_update(kz_term:ne_binary(), views_listing(), boolean()) ->
-                            boolean() |
-                            {'error', 'invalid_db_name'}.
 db_view_update(DbName, Views) ->
     db_view_update(DbName, Views, 'false').
 
+-spec db_view_update(kz_term:ne_binary(), views_listing(), boolean()) ->
+                            boolean() |
+                            {'error', 'invalid_db_name'}.
 db_view_update(DbName, Views0, Remove) when ?VALID_DBNAME(DbName) ->
     case lists:keymap(fun maybe_adapt_multilines/1, 2, Views0) of
         [] -> 'false';
@@ -466,12 +466,12 @@ db_replicate(JObj) ->
 %% Detemine if a database exists
 %% @end
 %%--------------------------------------------------------------------
--spec db_create(kz_term:text()) -> boolean().
--spec db_create(kz_term:text(), kzs_db:db_create_options()) -> boolean().
 
+-spec db_create(kz_term:text()) -> boolean().
 db_create(DbName) ->
     db_create(DbName, []).
 
+-spec db_create(kz_term:text(), kzs_db:db_create_options()) -> boolean().
 db_create(DbName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_create(kzs_plan:plan(DbName), DbName, Options);
 db_create(DbName, Options) ->
@@ -502,11 +502,12 @@ db_compact(DbName) ->
 %% Delete a database (takes an 'encoded' DbName)
 %% @end
 %%--------------------------------------------------------------------
+
 -spec db_delete(kz_term:text()) -> boolean().
--spec db_delete(kz_term:text(), db_delete_options()) -> boolean().
 db_delete(DbName) ->
     db_delete(DbName, []).
 
+-spec db_delete(kz_term:text(), db_delete_options()) -> boolean().
 db_delete(DbName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_delete(kzs_plan:plan(DbName), DbName, Options);
 db_delete(DbName, Options) ->
@@ -521,12 +522,13 @@ db_delete(DbName, Options) ->
 %% Archive a database (takes an 'encoded' DbName)
 %% @end
 %%--------------------------------------------------------------------
+
 -spec db_archive(kz_term:ne_binary()) -> 'ok' | data_error().
--spec db_archive(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok' | data_error().
 db_archive(DbName) ->
     Folder = kazoo_data_config:get_ne_binary(<<"default_archive_folder">>, <<"/tmp">>),
     db_archive(DbName, filename:join([<<Folder/binary, "/", DbName/binary, ".json">>])).
 
+-spec db_archive(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok' | data_error().
 db_archive(DbName, Filename) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_archive(kzs_plan:plan(DbName), DbName, Filename);
 db_archive(DbName, Filename) ->
@@ -554,10 +556,8 @@ db_import(DbName, ArchiveFile) ->
 %% fetch a cached doc or open it if not available.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec open_cache_doc(kz_term:text(), docid()) ->
-                            {'ok', kz_json:object()} |
-                            data_error().
--spec open_cache_doc(kz_term:text(), docid(), kz_term:proplist()) ->
                             {'ok', kz_json:object()} |
                             data_error().
 open_cache_doc(DbName, {DocType, DocId}) ->
@@ -565,6 +565,9 @@ open_cache_doc(DbName, {DocType, DocId}) ->
 open_cache_doc(DbName, DocId) ->
     open_cache_doc(DbName, DocId, []).
 
+-spec open_cache_doc(kz_term:text(), docid(), kz_term:proplist()) ->
+                            {'ok', kz_json:object()} |
+                            data_error().
 open_cache_doc(DbName, {DocType, DocId}, Options) ->
     open_cache_doc(DbName, DocId, maybe_add_doc_type(DocType, Options));
 open_cache_doc(DbName, DocId, Options) when ?VALID_DBNAME(DbName) ->
@@ -625,8 +628,9 @@ flush_cache_doc(DbName, Doc, Options) ->
     end.
 
 -spec flush_cache_docs() -> 'ok'.
--spec flush_cache_docs(kz_term:text()) -> 'ok' | {'error', 'invalid_db_name'}.
 flush_cache_docs() -> kzs_cache:flush_cache_docs().
+
+-spec flush_cache_docs(kz_term:text()) -> 'ok' | {'error', 'invalid_db_name'}.
 flush_cache_docs(DbName) ->
     case maybe_convert_dbname(DbName) of
         {'ok', Db} -> kzs_cache:flush_cache_docs(Db);
@@ -653,20 +657,20 @@ flush_cache_docs(DbName) ->
 -define(OPEN_DOC_LOG(DbName, DocId, Options), ok).
 -endif.
 
+
 -spec open_doc(kz_term:text(), docid()) ->
                       {'ok', kz_json:object()} |
                       data_error() |
                       {'error', 'not_found'}.
--spec open_doc(kz_term:text(), docid(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      data_error() |
-                      {'error', 'not_found'}.
-
 open_doc(DbName, {DocType, DocId}) ->
     open_doc(DbName, DocId, [{'doc_type', DocType}]);
 open_doc(DbName, DocId) ->
     open_doc(DbName, DocId, []).
 
+-spec open_doc(kz_term:text(), docid(), kz_term:proplist()) ->
+                      {'ok', kz_json:object()} |
+                      data_error() |
+                      {'error', 'not_found'}.
 open_doc(DbName, {DocType, DocId}, Options) ->
     open_doc(DbName, DocId, maybe_add_doc_type(DocType, Options));
 open_doc(DbName, DocId, Options) when ?VALID_DBNAME(DbName) ->
@@ -686,17 +690,18 @@ open_doc(DbName, DocId, Options) ->
 %% So: match both error tuple & each JSON of the list.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec open_docs(kz_term:text(), docids()) ->
                        {'ok', kz_json:objects()} |
                        data_error() |
                        {'error', 'not_found'}.
+open_docs(DbName, DocIds) ->
+    open_docs(DbName, DocIds, []).
+
 -spec open_docs(kz_term:text(), docids(), kz_term:proplist()) ->
                        {'ok', kz_json:objects()} |
                        data_error() |
                        {'error', 'not_found'}.
-
-open_docs(DbName, DocIds) ->
-    open_docs(DbName, DocIds, []).
 open_docs(DbName, DocIds, Options) ->
     read_chunked(fun do_open_docs/3, DbName, DocIds, Options).
 
@@ -744,18 +749,18 @@ read_chunked_results(DocIds, {error, Reason}, Acc) ->
 %% Note: no guaranty on order of results is provided.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec open_cache_docs(kz_term:text(), docids()) ->
                              {'ok', kz_json:objects()} |
                              data_error() |
                              {'error', 'not_found'}.
+open_cache_docs(DbName, DocIds) ->
+    open_cache_docs(DbName, DocIds, []).
+
 -spec open_cache_docs(kz_term:text(), docids(), kz_term:proplist()) ->
                              {'ok', kz_json:objects()} |
                              data_error() |
                              {'error', 'not_found'}.
-
-open_cache_docs(DbName, DocIds) ->
-    open_cache_docs(DbName, DocIds, []).
-
 open_cache_docs(DbName, DocIds, Options) when ?VALID_DBNAME(DbName) ->
     read_chunked(fun kzs_cache:open_cache_docs/3, DbName, DocIds, Options);
 open_cache_docs(DbName, DocIds, Options) ->
@@ -765,16 +770,16 @@ open_cache_docs(DbName, DocIds, Options) ->
     end.
 
 
+
 -spec all_docs(kz_term:text()) ->
                       {'ok', kz_json:objects()} |
                       data_error().
--spec all_docs(kz_term:text(), kz_term:proplist()) ->
-                      {'ok', kz_json:objects()} |
-                      data_error().
-
 all_docs(DbName) ->
     all_docs(DbName, []).
 
+-spec all_docs(kz_term:text(), kz_term:proplist()) ->
+                      {'ok', kz_json:objects()} |
+                      data_error().
 all_docs(DbName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_view:all_docs(kzs_plan:plan(DbName, Options), DbName, Options);
 all_docs(DbName, Options) ->
@@ -783,23 +788,23 @@ all_docs(DbName, Options) ->
         {'error', _}=E -> E
     end.
 
--spec db_list() -> {'ok', kz_term:ne_binaries()} | data_error().
--spec db_list(kz_term:proplist()) -> {'ok', kz_term:ne_binaries()} | data_error().
 
+-spec db_list() -> {'ok', kz_term:ne_binaries()} | data_error().
 db_list() ->
     db_list([]).
 
+-spec db_list(kz_term:proplist()) -> {'ok', kz_term:ne_binaries()} | data_error().
 db_list(Options) ->
     kzs_db:db_list(kzs_plan:plan(), Options).
 
+
 -spec all_design_docs(kz_term:text()) -> {'ok', kz_json:objects()} |
                                          data_error().
--spec all_design_docs(kz_term:text(), kz_term:proplist()) -> {'ok', kz_json:objects()} |
-                                                             data_error().
-
 all_design_docs(DbName) ->
     all_design_docs(DbName, []).
 
+-spec all_design_docs(kz_term:text(), kz_term:proplist()) -> {'ok', kz_json:objects()} |
+                                                             data_error().
 all_design_docs(DbName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_view:all_design_docs(kzs_plan:plan(DbName), DbName, Options);
 all_design_docs(DbName, Options) ->
@@ -855,16 +860,16 @@ save_doc(DbName, Doc) ->
 %% revision and tries saving again. Otherwise return.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec ensure_saved(kz_term:text(), kz_json:object()) ->
                           {'ok', kz_json:object()} |
                           data_error().
--spec ensure_saved(kz_term:text(), kz_json:object(), kz_term:proplist()) ->
-                          {'ok', kz_json:object()} |
-                          data_error().
-
 ensure_saved(DbName, Doc) ->
     ensure_saved(DbName, Doc, []).
 
+-spec ensure_saved(kz_term:text(), kz_json:object(), kz_term:proplist()) ->
+                          {'ok', kz_json:object()} |
+                          data_error().
 ensure_saved(DbName, Doc, Options) when ?VALID_DBNAME(DbName) ->
     kzs_doc:ensure_saved(kzs_plan:plan(DbName, Doc), DbName, Doc, Options);
 ensure_saved(DbName, Doc, Options) ->
@@ -903,16 +908,16 @@ maybe_revert_publish('true') ->
 maybe_revert_publish('false') ->
     suppress_change_notice().
 
+
 -spec save_docs(kz_term:text(), kz_json:objects()) ->
                        {'ok', kz_json:objects()} |
                        data_error().
--spec save_docs(kz_term:text(), kz_json:objects(), kz_term:proplist()) ->
-                       {'ok', kz_json:objects()} |
-                       data_error().
-
 save_docs(DbName, Docs) when is_list(Docs) ->
     save_docs(DbName, Docs, []).
 
+-spec save_docs(kz_term:text(), kz_json:objects(), kz_term:proplist()) ->
+                       {'ok', kz_json:objects()} |
+                       data_error().
 save_docs(DbName, [Doc|_]=Docs, Options)
   when is_list(Docs), ?VALID_DBNAME(DbName) ->
     OldSetting = maybe_toggle_publish(Options),
@@ -935,22 +940,22 @@ save_docs(DbName, Docs, Options) when is_list(Docs) ->
 %% @end
 %%--------------------------------------------------------------------
 -type update_props() :: [{kz_json:path(), kz_json:json_term()}].
+
 -spec update_doc(kz_term:ne_binary(), docid(), update_props()) ->
                         {'ok', kz_json:object()} |
                         data_error().
--spec update_doc(kz_term:ne_binary(), docid(), update_props(), kz_term:proplist()) ->
-                        {'ok', kz_json:object()} |
-                        data_error().
--spec update_doc(kz_term:ne_binary(), docid(), update_props(), kz_term:proplist(), kz_term:proplist()) ->
-                        {'ok', kz_json:object()} |
-                        data_error().
-
 update_doc(DbName, Id, UpdateProps) ->
     update_doc(DbName, Id, UpdateProps, []).
 
+-spec update_doc(kz_term:ne_binary(), docid(), update_props(), kz_term:proplist()) ->
+                        {'ok', kz_json:object()} |
+                        data_error().
 update_doc(DbName, Id, UpdateProps, CreateProps) ->
     update_doc(DbName, Id, UpdateProps, CreateProps, []).
 
+-spec update_doc(kz_term:ne_binary(), docid(), update_props(), kz_term:proplist(), kz_term:proplist()) ->
+                        {'ok', kz_json:object()} |
+                        data_error().
 update_doc(DbName, Id, UpdateProps, CreateProps, ExtraUpdateProps)
   when is_list(UpdateProps),
        is_list(CreateProps),
@@ -1101,12 +1106,12 @@ put_attachment(DbName, DocId, AName, Contents, Options) ->
 -spec delete_attachment(kz_term:text(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                                {'ok', kz_json:object()} |
                                data_error().
--spec delete_attachment(kz_term:text(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
-                               {'ok', kz_json:object()} |
-                               data_error().
 delete_attachment(DbName, DocId, AName) ->
     delete_attachment(DbName, DocId, AName, []).
 
+-spec delete_attachment(kz_term:text(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
+                               {'ok', kz_json:object()} |
+                               data_error().
 delete_attachment(DbName, DocId, AName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_attachments:delete_attachment(kzs_plan:plan(DbName, DocId), DbName, DocId, AName, Options);
 delete_attachment(DbName, DocId, AName, Options) ->
@@ -1119,13 +1124,13 @@ delete_attachment(DbName, DocId, AName, Options) ->
                             {'ok', kz_term:ne_binary()} |
                             {'proxy', tuple()} |
                             {'error', any()}.
+attachment_url(DbName, DocId, AttachmentId) ->
+    attachment_url(DbName, DocId, AttachmentId, []).
+
 -spec attachment_url(kz_term:text(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
                             {'ok', kz_term:ne_binary()} |
                             {'proxy', tuple()} |
                             {'error', any()}.
-attachment_url(DbName, DocId, AttachmentId) ->
-    attachment_url(DbName, DocId, AttachmentId, []).
-
 attachment_url(DbName, {DocType, DocId}, AttachmentId, Options) when ?VALID_DBNAME(DbName) ->
     attachment_url(DbName, DocId, AttachmentId, maybe_add_doc_type(DocType, Options));
 attachment_url(DbName, DocId, AttachmentId, Options) when ?VALID_DBNAME(DbName) ->
@@ -1223,18 +1228,16 @@ add_required_option({Key, Fun}, {JObj, Options}=Acc) ->
 %% {Total, Offset, Meta, Rows}
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_all_results(kz_term:ne_binary(), kz_term:ne_binary()) -> get_results_return().
--spec get_results(kz_term:ne_binary(), kz_term:ne_binary()) -> get_results_return().
--spec get_results(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) -> get_results_return().
--spec get_results_count(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                               {'ok', integer()} |
-                               data_error().
 get_all_results(DbName, DesignDoc) ->
     get_results(DbName, DesignDoc, []).
 
+-spec get_results(kz_term:ne_binary(), kz_term:ne_binary()) -> get_results_return().
 get_results(DbName, DesignDoc) ->
     get_results(DbName, DesignDoc, []).
 
+-spec get_results(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) -> get_results_return().
 get_results(DbName, DesignDoc, Options) when ?VALID_DBNAME(DbName) ->
     ?GET_RESULTS(DbName, DesignDoc, Options),
     Opts = maybe_add_doc_type_from_view(DesignDoc, Options),
@@ -1250,6 +1253,9 @@ get_results(DbName, DesignDoc, Options) ->
         {'error', _}=E -> E
     end.
 
+-spec get_results_count(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
+                               {'ok', integer()} |
+                               data_error().
 get_results_count(DbName, DesignDoc, Options) ->
     ?GET_RESULTS(DbName, DesignDoc, Options),
     Opts = maybe_add_doc_type_from_view(DesignDoc, Options),
@@ -1266,10 +1272,11 @@ maybe_create_view(DbName, Plan, DesignDoc, Options) ->
 
 -spec get_result_keys(kz_term:ne_binary(), kz_term:ne_binary()) ->
                              {'ok', kz_term:ne_binaries() | [kz_term:ne_binaries()]} | data_error().
--spec get_result_keys(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                             {'ok', kz_term:ne_binaries() | [kz_term:ne_binaries()]} | data_error().
 get_result_keys(DbName, DesignDoc) ->
     get_result_keys(DbName, DesignDoc, []).
+
+-spec get_result_keys(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
+                             {'ok', kz_term:ne_binaries() | [kz_term:ne_binaries()]} | data_error().
 get_result_keys(DbName, DesignDoc, Options) ->
     ?GET_RESULTS(DbName, DesignDoc, Options),
     Opts = maybe_add_doc_type_from_view(DesignDoc, Options),
@@ -1286,10 +1293,11 @@ get_result_keys(JObjs) ->
 
 -spec get_result_ids(kz_term:ne_binary(), kz_term:ne_binary()) ->
                             {'ok', kz_term:ne_binaries()} | data_error().
--spec get_result_ids(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                            {'ok', kz_term:ne_binaries()} | data_error().
 get_result_ids(DbName, DesignDoc) ->
     get_result_ids(DbName, DesignDoc, []).
+
+-spec get_result_ids(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
+                            {'ok', kz_term:ne_binaries()} | data_error().
 get_result_ids(DbName, DesignDoc, Options) ->
     ?GET_RESULTS(DbName, DesignDoc, Options),
     Opts = maybe_add_doc_type_from_view(DesignDoc, Options),
@@ -1358,13 +1366,15 @@ get_result_docs(DbName, DesignDoc, Keys) ->
     end.
 
 -spec get_uuid() -> kz_term:ne_binary().
--spec get_uuid(pos_integer()) -> kz_term:ne_binary().
 get_uuid() -> get_uuid(?UUID_SIZE).
+
+-spec get_uuid(pos_integer()) -> kz_term:ne_binary().
 get_uuid(N) -> kz_binary:rand_hex(N).
 
 -spec get_uuids(pos_integer()) -> kz_term:ne_binaries().
--spec get_uuids(pos_integer(), pos_integer()) -> kz_term:ne_binaries().
 get_uuids(Count) -> get_uuids(Count, ?UUID_SIZE).
+
+-spec get_uuids(pos_integer(), pos_integer()) -> kz_term:ne_binaries().
 get_uuids(Count, Size) -> [get_uuid(Size) || _ <- lists:seq(1, Count)].
 
 %%%===================================================================
@@ -1411,12 +1421,12 @@ maybe_convert_dbname(DbName) ->
 -spec copy_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
                       {'ok', kz_json:object()} |
                       data_error().
--spec copy_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), docid(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      data_error().
 copy_doc(FromDB, FromId, ToDB, Options) ->
     copy_doc(FromDB, FromId, ToDB, FromId, Options).
 
+-spec copy_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), docid(), kz_term:proplist()) ->
+                      {'ok', kz_json:object()} |
+                      data_error().
 copy_doc(FromDB, {DocType, FromId}, ToDB, ToId, Options) ->
     copy_doc(FromDB, FromId, ToDB, ToId, maybe_add_doc_type(DocType, Options));
 copy_doc(FromDB, FromId, ToDB, {DocType, ToId}, Options) ->
@@ -1434,12 +1444,12 @@ copy_doc(FromDB, FromId, ToDB, ToId, Options) ->
 -spec move_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
                       {'ok', kz_json:object()} |
                       data_error().
--spec move_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), docid(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      data_error().
 move_doc(FromDB, FromId, ToDB, Options) ->
     move_doc(FromDB, FromId, ToDB, FromId, Options).
 
+-spec move_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), docid(), kz_term:proplist()) ->
+                      {'ok', kz_json:object()} |
+                      data_error().
 move_doc(FromDB, {DocType, FromId}, ToDB, ToId, Options) ->
     move_doc(FromDB, FromId, ToDB, ToId, maybe_add_doc_type(DocType, Options));
 move_doc(FromDB, FromId, ToDB, {DocType, ToId}, Options) ->

--- a/core/kazoo_data/src/kzs_cache.erl
+++ b/core/kazoo_data/src/kzs_cache.erl
@@ -152,7 +152,6 @@ remove_cache_options(Options) ->
     props:delete_keys(['cache_failures'], Options).
 
 -spec maybe_cache_failure(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), data_error()) -> 'ok'.
--spec maybe_cache_failure(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), data_error(), kz_term:atoms()) -> 'ok'.
 maybe_cache_failure(DbName, DocId, Options, {'error', _}=Error) ->
     case props:get_value('cache_failures', Options) of
         ErrorCodes when is_list(ErrorCodes) ->
@@ -162,6 +161,7 @@ maybe_cache_failure(DbName, DocId, Options, {'error', _}=Error) ->
         _ -> 'ok'
     end.
 
+-spec maybe_cache_failure(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), data_error(), kz_term:atoms()) -> 'ok'.
 maybe_cache_failure(DbName, DocId, _Options, {'error', ErrorCode}=Error, ErrorCodes) ->
     _ = lists:member(ErrorCode, ErrorCodes)
         andalso add_to_doc_cache(DbName, DocId, Error),

--- a/core/kazoo_data/src/kzs_doc.erl
+++ b/core/kazoo_data/src/kzs_doc.erl
@@ -159,11 +159,11 @@ prepare_doc_for_del(Server, DbName, Doc) ->
       ]).
 
 -spec prepare_doc_for_save(kz_term:ne_binary(), kz_json:object()) -> {kz_json:object(), kz_json:object()}.
--spec prepare_doc_for_save(kz_term:ne_binary(), kz_json:object(), boolean()) -> {kz_json:object(), kz_json:object()}.
 prepare_doc_for_save(Db, JObj) ->
     Doc = kz_json:delete_key(<<"id">>, JObj),
     prepare_doc_for_save(Db, Doc, kz_term:is_empty(kz_doc:id(Doc))).
 
+-spec prepare_doc_for_save(kz_term:ne_binary(), kz_json:object(), boolean()) -> {kz_json:object(), kz_json:object()}.
 prepare_doc_for_save(_Db, JObj, 'true') ->
     prepare_publish(maybe_set_docid(JObj));
 prepare_doc_for_save(Db, JObj, 'false') ->
@@ -175,10 +175,10 @@ prepare_publish(JObj) ->
     {maybe_tombstone(JObj), kz_json:from_list(kzs_publish:publish_fields(JObj))}.
 
 -spec maybe_tombstone(kz_json:object()) -> kz_json:object().
--spec maybe_tombstone(kz_json:object(), boolean()) -> kz_json:object().
 maybe_tombstone(JObj) ->
     maybe_tombstone(JObj, kz_json:is_true(<<"_deleted">>, JObj, 'false')).
 
+-spec maybe_tombstone(kz_json:object(), boolean()) -> kz_json:object().
 maybe_tombstone(JObj, 'true') ->
     kz_json:from_list(
       [{<<"_id">>, kz_doc:id(JObj)}

--- a/core/kazoo_data/src/kzs_plan.erl
+++ b/core/kazoo_data/src/kzs_plan.erl
@@ -199,12 +199,12 @@ dataplan_match(Classification, Plan, AccountId) ->
              }
     end.
 
--spec dataplan_type_match(kz_term:ne_binary(), kz_term:ne_binary(), map()) -> map().
--spec dataplan_type_match(kz_term:ne_binary(), kz_term:ne_binary(), map(), kz_term:api_binary()) -> map().
 
+-spec dataplan_type_match(kz_term:ne_binary(), kz_term:ne_binary(), map()) -> map().
 dataplan_type_match(Classification, DocType, Plan) ->
     dataplan_type_match(Classification, DocType, Plan, 'undefined').
 
+-spec dataplan_type_match(kz_term:ne_binary(), kz_term:ne_binary(), map(), kz_term:api_binary()) -> map().
 dataplan_type_match(Classification, DocType, Plan, AccountId) ->
     #{<<"plan">> := #{Classification := #{<<"types">> := Types
                                          ,<<"connection">> := CCon

--- a/core/kazoo_data/src/kzs_publish.erl
+++ b/core/kazoo_data/src/kzs_publish.erl
@@ -107,13 +107,13 @@ do_publish_db(DbName, Action) ->
 -endif.
 
 -spec publish_fields(kz_json:object()) -> kz_term:proplist().
--spec publish_fields(kz_json:object(), kz_json:object()) -> kz_json:object().
 publish_fields(Doc) ->
     [{Key, V} ||
         Key <- ?PUBLISH_FIELDS,
         kz_term:is_not_empty(V = kz_json:get_value(Key, Doc))
     ].
 
+-spec publish_fields(kz_json:object(), kz_json:object()) -> kz_json:object().
 publish_fields(Doc, JObj) ->
     kz_json:set_values(publish_fields(Doc), JObj).
 

--- a/core/kazoo_documents/src/kz_account.erl
+++ b/core/kazoo_documents/src/kz_account.erl
@@ -182,9 +182,10 @@ fetch_name(Account) ->
     end.
 
 -spec name(doc()) -> kz_term:api_ne_binary().
--spec name(doc(), Default) -> kz_term:ne_binary() | Default.
 name(JObj) ->
     name(JObj, 'undefined').
+
+-spec name(doc(), Default) -> kz_term:ne_binary() | Default.
 name(JObj, Default) ->
     kz_json:get_value(?NAME, JObj, Default).
 
@@ -216,10 +217,12 @@ fetch_realm(Account) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec realm(doc()) -> kz_term:api_ne_binary().
--spec realm(doc(), Default) -> kz_term:ne_binary() | Default.
 realm(JObj) ->
     realm(JObj, 'undefined').
+
+-spec realm(doc(), Default) -> kz_term:ne_binary() | Default.
 realm(JObj, Default) ->
     kz_json:get_ne_value(?REALM, JObj, Default).
 
@@ -237,10 +240,12 @@ set_realm(JObj, Realm) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec language(doc()) -> kz_term:api_ne_binary().
--spec language(doc(), Default) -> kz_term:ne_binary() | Default.
 language(JObj) ->
     language(JObj, 'undefined').
+
+-spec language(doc(), Default) -> kz_term:ne_binary() | Default.
 language(JObj, Default) ->
     kz_json:get_ne_binary_value(?LANGUAGE, JObj, Default).
 
@@ -510,10 +515,12 @@ get_parent_account_id(AccountId) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec tree(doc()) -> kz_term:ne_binaries().
--spec tree(doc(), Default) -> kz_term:ne_binaries() | Default.
 tree(JObj) ->
     tree(JObj, []).
+
+-spec tree(doc(), Default) -> kz_term:ne_binaries() | Default.
 tree(JObj, Default) ->
     kz_json:get_list_value(?TREE, JObj, Default).
 
@@ -643,10 +650,10 @@ set_allow_number_additions(JObj, IsAllowed) ->
     kz_json:set_value(?ALLOW_NUMBER_ADDITIONS, kz_term:is_true(IsAllowed), JObj).
 
 -spec trial_expiration(doc()) -> kz_term:api_integer().
--spec trial_expiration(doc(), Default) -> integer() | Default.
 trial_expiration(JObj) ->
     trial_expiration(JObj, 'undefined').
 
+-spec trial_expiration(doc(), Default) -> integer() | Default.
 trial_expiration(JObj, Default) ->
     kz_json:get_integer_value(?KEY_TRIAL_EXPIRATION, JObj, Default).
 
@@ -665,10 +672,12 @@ set_trial_expiration(JObj, Expiration) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec trial_time_left(doc()) -> integer().
--spec trial_time_left(doc(), kz_time:gregorian_seconds()) -> integer().
 trial_time_left(JObj) ->
     trial_time_left(JObj, kz_time:now_s()).
+
+-spec trial_time_left(doc(), kz_time:gregorian_seconds()) -> integer().
 trial_time_left(JObj, Now) ->
     case trial_expiration(JObj) of
         'undefined' -> 0;
@@ -680,10 +689,12 @@ trial_time_left(JObj, Now) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec trial_has_expired(doc()) -> boolean().
--spec trial_has_expired(doc(), kz_time:gregorian_seconds()) -> boolean().
 trial_has_expired(JObj) ->
     trial_has_expired(JObj, kz_time:now_s()).
+
+-spec trial_has_expired(doc(), kz_time:gregorian_seconds()) -> boolean().
 trial_has_expired(JObj, Now) ->
     trial_expiration(JObj) =/= 'undefined'
         andalso trial_time_left(JObj, Now) =< 0.
@@ -760,10 +771,12 @@ set_reseller_id(JObj, ResellerId) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec dial_plan(doc()) -> kz_term:api_object().
--spec dial_plan(doc(), Default) -> kz_json:object() | Default.
 dial_plan(JObj) ->
     dial_plan(JObj, 'undefined').
+
+-spec dial_plan(doc(), Default) -> kz_json:object() | Default.
 dial_plan(JObj, Default) ->
     kz_json:get_json_value(?KEY_DIAL_PLAN, JObj, Default).
 
@@ -782,9 +795,9 @@ fax_settings(JObj) ->
     end.
 
 -spec preflow_id(doc()) -> kz_term:api_ne_binary().
--spec preflow_id(doc(), Default) -> kz_term:ne_binary() | Default.
 preflow_id(Doc) ->
     preflow_id(Doc, 'undefined').
 
+-spec preflow_id(doc(), Default) -> kz_term:ne_binary() | Default.
 preflow_id(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"preflow">>, <<"always">>], Doc, Default).

--- a/core/kazoo_documents/src/kz_call_event.erl
+++ b/core/kazoo_documents/src/kz_call_event.erl
@@ -53,9 +53,10 @@
 -export_type([doc/0]).
 
 -spec call_direction(doc()) -> kz_term:api_binary().
--spec call_direction(doc(), Default) -> kz_term:ne_binary() | Default.
 call_direction(JObj) ->
     call_direction(JObj, 'undefined').
+
+-spec call_direction(doc(), Default) -> kz_term:ne_binary() | Default.
 call_direction(JObj, Default) ->
     kz_json:get_ne_binary_value(<<"Call-Direction">>, JObj, Default).
 
@@ -68,9 +69,10 @@ other_leg_call_id(JObj) ->
     kz_json:get_ne_binary_value(<<"Other-Leg-Call-ID">>, JObj).
 
 -spec other_leg_destination_number(doc()) -> kz_term:api_binary().
--spec other_leg_destination_number(doc(), Default) -> kz_term:ne_binary() | Default.
 other_leg_destination_number(JObj) ->
     other_leg_destination_number(JObj, 'undefined').
+
+-spec other_leg_destination_number(doc(), Default) -> kz_term:ne_binary() | Default.
 other_leg_destination_number(JObj, Default) ->
     kz_json:get_ne_binary_value(<<"Other-Leg-Destination-Number">>, JObj, Default).
 
@@ -83,38 +85,38 @@ channel_name(JObj) ->
     kz_json:get_ne_binary_value(<<"Channel-Name">>, JObj).
 
 -spec custom_channel_vars(doc()) -> kz_term:api_object().
--spec custom_channel_vars(doc(), Default) -> kz_json:object() | Default.
 custom_channel_vars(JObj) ->
     custom_channel_vars(JObj, 'undefined').
 
+-spec custom_channel_vars(doc(), Default) -> kz_json:object() | Default.
 custom_channel_vars(JObj, Default) ->
     kz_json:get_json_value(<<"Custom-Channel-Vars">>, JObj, Default).
 
 -spec custom_channel_var(doc(), kz_json:path()) ->
                                 kz_term:api_binary().
--spec custom_channel_var(doc(), kz_json:path(), Default) ->
-                                kz_term:ne_binary() | Default.
 custom_channel_var(JObj, Key) ->
     custom_channel_var(JObj, Key, 'undefined').
 
+-spec custom_channel_var(doc(), kz_json:path(), Default) ->
+                                kz_term:ne_binary() | Default.
 custom_channel_var(JObj, Key, Default) ->
     kz_json:get_ne_binary_value([<<"Custom-Channel-Vars">>, Key], JObj, Default).
 
 -spec custom_application_vars(doc()) -> kz_term:api_object().
--spec custom_application_vars(doc(), Default) -> kz_json:object() | Default.
 custom_application_vars(JObj) ->
     custom_application_vars(JObj, 'undefined').
 
+-spec custom_application_vars(doc(), Default) -> kz_json:object() | Default.
 custom_application_vars(JObj, Default) ->
     kz_json:get_json_value(<<"Custom-Application-Vars">>, JObj, Default).
 
 -spec custom_application_var(doc(), kz_json:path()) ->
                                     kz_term:api_binary().
--spec custom_application_var(doc(), kz_json:path(), Default) ->
-                                    kz_term:ne_binary() | Default.
 custom_application_var(JObj, Key) ->
     custom_application_var(JObj, Key, 'undefined').
 
+-spec custom_application_var(doc(), kz_json:path(), Default) ->
+                                    kz_term:ne_binary() | Default.
 custom_application_var(JObj, Key, Default) ->
     kz_json:get_ne_binary_value([<<"Custom-Application-Vars">>, Key], JObj, Default).
 
@@ -145,9 +147,10 @@ event_name(JObj) ->
     kz_json:get_ne_binary_value(<<"Event-Name">>, JObj).
 
 -spec hangup_cause(doc()) -> kz_term:api_binary().
--spec hangup_cause(doc(), Default) -> kz_term:ne_binary() | Default.
 hangup_cause(JObj) ->
     hangup_cause(JObj, 'undefined').
+
+-spec hangup_cause(doc(), Default) -> kz_term:ne_binary() | Default.
 hangup_cause(JObj, Default) ->
     kz_json:get_ne_binary_value(<<"Hangup-Cause">>, JObj, Default).
 
@@ -184,9 +187,10 @@ response_code(JObj) ->
     kz_json:get_ne_binary_value(<<"Response-Code">>, JObj).
 
 -spec account_id(doc()) -> kz_term:api_binary().
--spec account_id(doc(), Default) -> kz_term:ne_binary() | Default.
 account_id(JObj) ->
     account_id(JObj, 'undefined').
+
+-spec account_id(doc(), Default) -> kz_term:ne_binary() | Default.
 account_id(JObj, Default) ->
     custom_channel_var(JObj, <<"Account-ID">>, Default).
 
@@ -211,9 +215,10 @@ duration_seconds(JObj) ->
     kz_json:get_integer_value(<<"Duration-Seconds">>, JObj).
 
 -spec is_call_forwarded(doc()) -> kz_term:api_boolean().
--spec is_call_forwarded(doc(), Default) -> boolean() | Default.
 is_call_forwarded(JObj) ->
     is_call_forwarded(JObj, 'undefined').
+
+-spec is_call_forwarded(doc(), Default) -> boolean() | Default.
 is_call_forwarded(JObj, Default) ->
     case custom_channel_var(JObj, <<"Call-Forward">>, Default) of
         'undefined' -> Default;

--- a/core/kazoo_documents/src/kz_custom_sip_headers.erl
+++ b/core/kazoo_documents/src/kz_custom_sip_headers.erl
@@ -12,10 +12,10 @@
 -define(OUT, <<"out">>).
 
 -spec inbound(kz_json:object()) -> kz_term:api_object().
--spec inbound(kz_json:object(), Default) -> kz_json:object() | Default.
 inbound(CSH) ->
     inbound(CSH, 'undefined').
 
+-spec inbound(kz_json:object(), Default) -> kz_json:object() | Default.
 inbound(CSH, Default) ->
     LegacyCSH = kz_json:filter(fun filter_csh/1, CSH),
     InCSH = kz_json:get_value(?IN, CSH, kz_json:new()),
@@ -28,16 +28,18 @@ inbound(CSH, Default) ->
     end.
 
 -spec inbound_header(kz_json:object(), kz_json:key()) -> kz_json:json_term() | 'undefined'.
--spec inbound_header(kz_json:object(), kz_json:key(), Default) -> kz_json:json_term() | Default.
 inbound_header(DeviceJObj, Name) ->
     inbound_header(DeviceJObj, Name, 'undefined').
+
+-spec inbound_header(kz_json:object(), kz_json:key(), Default) -> kz_json:json_term() | Default.
 inbound_header(DeviceJObj, Name, Default) ->
     kz_json:get_ne_value(Name, inbound(DeviceJObj), Default).
 
 -spec outbound_header(kz_json:object(), kz_json:key()) -> kz_json:json_term() | 'undefined'.
--spec outbound_header(kz_json:object(), kz_json:key(), Default) -> kz_json:json_term() | Default.
 outbound_header(DeviceJObj, Name) ->
     outbound_header(DeviceJObj, Name, 'undefined').
+
+-spec outbound_header(kz_json:object(), kz_json:key(), Default) -> kz_json:json_term() | Default.
 outbound_header(DeviceJObj, Name, Default) ->
     kz_json:get_ne_value(Name, outbound(DeviceJObj), Default).
 
@@ -47,10 +49,10 @@ filter_csh({<<"out">>, _}) -> 'false';
 filter_csh(_) -> 'true'.
 
 -spec outbound(kz_json:object()) -> kz_term:api_object().
--spec outbound(kz_json:object(), Default) -> kz_json:object() | Default.
 outbound(CSH) ->
     outbound(CSH, 'undefined').
 
+-spec outbound(kz_json:object(), Default) -> kz_json:object() | Default.
 outbound(CSH, Default) ->
     LegacyCSH = kz_json:filter(fun filter_csh/1, CSH),
     OutCSH = kz_json:get_value(?OUT, CSH, kz_json:new()),

--- a/core/kazoo_documents/src/kz_device.erl
+++ b/core/kazoo_documents/src/kz_device.erl
@@ -97,58 +97,58 @@ is_device(Doc) ->
     kz_doc:type(Doc) =:= type().
 
 -spec sip_username(doc()) -> kz_term:api_binary().
--spec sip_username(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_username(DeviceJObj) ->
     sip_username(DeviceJObj, 'undefined').
 
+-spec sip_username(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_username(DeviceJObj, Default) ->
     kz_json:get_value(?USERNAME, DeviceJObj, Default).
 
 -spec sip_password(doc()) -> kz_term:api_binary().
--spec sip_password(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_password(DeviceJObj) ->
     sip_password(DeviceJObj, 'undefined').
 
+-spec sip_password(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_password(DeviceJObj, Default) ->
     kz_json:get_value(?PASSWORD, DeviceJObj, Default).
 
 -spec sip_method(doc()) -> kz_term:api_binary().
--spec sip_method(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_method(DeviceJObj) ->
     sip_method(DeviceJObj, 'undefined').
 
+-spec sip_method(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_method(DeviceJObj, Default) ->
     kz_json:get_value(?METHOD, DeviceJObj, Default).
 
 -spec sip_realm(doc()) -> kz_term:api_binary().
--spec sip_realm(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_realm(DeviceJObj) ->
     sip_realm(DeviceJObj, 'undefined').
 
+-spec sip_realm(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_realm(DeviceJObj, Default) ->
     kz_json:get_value(?REALM, DeviceJObj, Default).
 
 -spec sip_ip(doc()) -> kz_term:api_binary().
--spec sip_ip(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_ip(DeviceJObj) ->
     sip_ip(DeviceJObj, 'undefined').
 
+-spec sip_ip(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_ip(DeviceJObj, Default) ->
     kz_json:get_value(?IP, DeviceJObj, Default).
 
 -spec sip_invite_format(doc()) -> kz_term:api_binary().
--spec sip_invite_format(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_invite_format(DeviceJObj) ->
     sip_invite_format(DeviceJObj, 'undefined').
 
+-spec sip_invite_format(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_invite_format(DeviceJObj, Default) ->
     kz_json:get_value(?INVITE_FORMAT, DeviceJObj, Default).
 
 -spec sip_route(doc()) -> kz_term:api_binary().
--spec sip_route(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_route(DeviceJObj) ->
     sip_route(DeviceJObj, 'undefined').
 
+-spec sip_route(doc(), Default) -> kz_term:ne_binary() | Default.
 sip_route(DeviceJObj, Default) ->
     kz_json:get_value(?ROUTE, DeviceJObj, Default).
 
@@ -161,44 +161,46 @@ set_custom_sip_headers(DeviceJObj, CSH) ->
     kz_json:set_value(?CUSTOM_SIP_HEADERS, CSH, DeviceJObj).
 
 -spec custom_sip_headers_inbound(doc()) -> kz_term:api_object().
--spec custom_sip_headers_inbound(doc(), Default) -> kz_json:object() | Default.
 custom_sip_headers_inbound(DeviceJObj) ->
     custom_sip_headers_inbound(DeviceJObj, 'undefined').
 
+-spec custom_sip_headers_inbound(doc(), Default) -> kz_json:object() | Default.
 custom_sip_headers_inbound(DeviceJObj, Default) ->
     CSH = custom_sip_headers(DeviceJObj),
     kz_custom_sip_headers:inbound(CSH, Default).
 
 -spec custom_sip_header_inbound(doc(), kz_json:key()) -> kz_json:json_term() | 'undefined'.
--spec custom_sip_header_inbound(doc(), kz_json:key(), Default) -> kz_json:json_term() | Default.
 custom_sip_header_inbound(DeviceJObj, Name) ->
     custom_sip_header_inbound(DeviceJObj, Name, 'undefined').
+
+-spec custom_sip_header_inbound(doc(), kz_json:key(), Default) -> kz_json:json_term() | Default.
 custom_sip_header_inbound(DeviceJObj, Name, Default) ->
     CSH = custom_sip_headers(DeviceJObj),
     kz_custom_sip_headers:inbound_header(CSH, Name, Default).
 
 -spec custom_sip_header_outbound(doc(), kz_json:key()) -> kz_json:json_term() | 'undefined'.
--spec custom_sip_header_outbound(doc(), kz_json:key(), Default) -> kz_json:json_term() | Default.
 custom_sip_header_outbound(DeviceJObj, Name) ->
     custom_sip_header_outbound(DeviceJObj, Name, 'undefined').
+
+-spec custom_sip_header_outbound(doc(), kz_json:key(), Default) -> kz_json:json_term() | Default.
 custom_sip_header_outbound(DeviceJObj, Name, Default) ->
     CSH = custom_sip_headers(DeviceJObj),
     kz_custom_sip_headers:outbound_header(CSH, Name, Default).
 
 -spec custom_sip_headers_outbound(doc()) -> kz_term:api_object().
--spec custom_sip_headers_outbound(doc(), Default) -> kz_json:object() | Default.
 custom_sip_headers_outbound(DeviceJObj) ->
     custom_sip_headers_outbound(DeviceJObj, 'undefined').
 
+-spec custom_sip_headers_outbound(doc(), Default) -> kz_json:object() | Default.
 custom_sip_headers_outbound(DeviceJObj, Default) ->
     CSH = custom_sip_headers(DeviceJObj),
     kz_custom_sip_headers:outbound(CSH, Default).
 
 -spec sip_settings(doc()) -> kz_term:api_object().
--spec sip_settings(doc(), Default) -> kz_json:object() | Default.
 sip_settings(DeviceJObj) ->
     sip_settings(DeviceJObj, 'undefined').
 
+-spec sip_settings(doc(), Default) -> kz_json:object() | Default.
 sip_settings(DeviceJObj, Default) ->
     kz_json:get_value(?SIP, DeviceJObj, Default).
 
@@ -247,9 +249,10 @@ set_sip_settings(DeviceJObj, SipJObj) ->
     kz_json:set_value(?SIP, SipJObj, DeviceJObj).
 
 -spec presence_id(doc()) -> kz_term:api_binary().
--spec presence_id(doc(), Default) -> kz_term:ne_binary() | Default.
 presence_id(DeviceJObj) ->
     presence_id(DeviceJObj, sip_username(DeviceJObj)).
+
+-spec presence_id(doc(), Default) -> kz_term:ne_binary() | Default.
 presence_id(DeviceJObj, Default) ->
     kz_json:get_binary_value(?PRESENCE_ID, DeviceJObj, Default).
 
@@ -261,9 +264,10 @@ set_presence_id(DeviceJObj, Id) ->
                      ).
 
 -spec name(doc()) -> kz_term:api_binary().
--spec name(doc(), Default) -> kz_term:ne_binary() | Default.
 name(DeviceJObj) ->
     name(DeviceJObj, 'undefined').
+
+-spec name(doc(), Default) -> kz_term:ne_binary() | Default.
 name(DeviceJObj, Default) ->
     kz_json:get_value(?NAME, DeviceJObj, Default).
 
@@ -272,9 +276,10 @@ set_name(DeviceJObj, Name) ->
     kz_json:set_value(?NAME, Name, DeviceJObj).
 
 -spec mac_address(doc()) -> kz_term:api_binary().
--spec mac_address(doc(), Default) -> kz_term:ne_binary() | Default.
 mac_address(DeviceJObj) ->
     mac_address(DeviceJObj, 'undefined').
+
+-spec mac_address(doc(), Default) -> kz_term:ne_binary() | Default.
 mac_address(DeviceJObj, Default) ->
     kz_json:get_value(?MAC_ADDRESS, DeviceJObj, Default).
 
@@ -283,9 +288,10 @@ set_mac_address(DeviceJObj, MacAddress) ->
     kz_json:set_value(?MAC_ADDRESS, MacAddress, DeviceJObj).
 
 -spec language(doc()) -> kz_term:api_binary().
--spec language(doc(), Default) -> kz_term:ne_binary() | Default.
 language(DeviceJObj) ->
     language(DeviceJObj, 'undefined').
+
+-spec language(doc(), Default) -> kz_term:ne_binary() | Default.
 language(DeviceJObj, Default) ->
     kz_json:get_ne_value(?LANGUAGE, DeviceJObj, Default).
 
@@ -294,9 +300,10 @@ set_language(DeviceJObj, Language) ->
     kz_json:set_value(?LANGUAGE, Language, DeviceJObj).
 
 -spec device_type(doc()) -> kz_term:api_binary().
--spec device_type(doc(), Default) -> kz_term:ne_binary() | Default.
 device_type(DeviceJObj) ->
     device_type(DeviceJObj, 'undefined').
+
+-spec device_type(doc(), Default) -> kz_term:ne_binary() | Default.
 device_type(DeviceJObj, Default) ->
     kz_json:get_value(?DEVICE_TYPE, DeviceJObj, Default).
 
@@ -308,9 +315,10 @@ set_device_type(DeviceJObj, MacAddress) ->
 type() -> <<"device">>.
 
 -spec owner_id(doc()) -> kz_term:api_binary().
--spec owner_id(doc(), Default) -> kz_term:ne_binary() | Default.
 owner_id(DeviceJObj) ->
     owner_id(DeviceJObj, 'undefined').
+
+-spec owner_id(doc(), Default) -> kz_term:ne_binary() | Default.
 owner_id(DeviceJObj, Default) ->
     kz_json:get_value(?KEY_OWNER_ID, DeviceJObj, Default).
 
@@ -320,9 +328,10 @@ set_owner_id(DeviceJObj, OwnerId) ->
 
 
 -spec enabled(doc()) -> boolean().
--spec enabled(doc(), boolean()) -> boolean().
 enabled(DeviceJObj) ->
     enabled(DeviceJObj, 'true').
+
+-spec enabled(doc(), boolean()) -> boolean().
 enabled(DeviceJObj, Default) ->
     kz_json:get_value(?ENABLED, DeviceJObj, Default).
 

--- a/core/kazoo_documents/src/kz_notification.erl
+++ b/core/kazoo_documents/src/kz_notification.erl
@@ -178,23 +178,25 @@ set_reply_to(JObj, ReplyTo) ->
     kz_json:set_value(?REPLY_TO, ReplyTo, JObj).
 
 -spec set_base_properties(doc()) -> doc().
--spec set_base_properties(doc(), kz_term:api_binary()) -> doc().
 set_base_properties(JObj) ->
     set_base_properties(JObj, id(JObj)).
 
+-spec set_base_properties(doc(), kz_term:api_binary()) -> doc().
 set_base_properties(JObj, Id) ->
     kz_json:set_values([{<<"pvt_type">>, ?PVT_TYPE}
                        ,{<<"_id">>, db_id(Id)}
                        ], JObj).
 
 -spec pvt_type() -> kz_term:ne_binary().
--spec pvt_type(doc()) -> kz_term:ne_binary().
 pvt_type() -> ?PVT_TYPE.
+
+-spec pvt_type(doc()) -> kz_term:ne_binary().
 pvt_type(JObj) -> kz_doc:type(JObj, ?PVT_TYPE).
 
 -spec is_enabled(doc()) -> boolean().
--spec is_enabled(doc(), Default) -> boolean() | Default.
 is_enabled(JObj) ->
     is_enabled(JObj, 'true').
+
+-spec is_enabled(doc(), Default) -> boolean() | Default.
 is_enabled(JObj, Default) ->
     kz_json:is_true(<<"enabled">>, JObj, Default).

--- a/core/kazoo_documents/src/kzd_alert.erl
+++ b/core/kazoo_documents/src/kzd_alert.erl
@@ -85,15 +85,16 @@ fetch(<<_/binary>> = AlertId) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec title() -> kz_term:ne_binary().
--spec title(doc()) -> kz_term:api_binary().
--spec title(doc(), Default) -> kz_term:ne_binary() | Default.
 title() ->
     ?TITLE.
 
+-spec title(doc()) -> kz_term:api_binary().
 title(JObj) ->
     title(JObj, 'undefined').
 
+-spec title(doc(), Default) -> kz_term:ne_binary() | Default.
 title(JObj, Default) ->
     kz_json:get_value(?TITLE, JObj, Default).
 
@@ -106,15 +107,16 @@ set_title(JObj, Title) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec category() -> kz_term:ne_binary().
--spec category(doc()) -> kz_term:api_binary().
--spec category(doc(), Default) -> kz_term:ne_binary() | Default.
 category() ->
     ?CATEGORY.
 
+-spec category(doc()) -> kz_term:api_binary().
 category(JObj) ->
     category(JObj, 'undefined').
 
+-spec category(doc(), Default) -> kz_term:ne_binary() | Default.
 category(JObj, Default) ->
     kz_json:get_value(?CATEGORY, JObj, Default).
 
@@ -127,15 +129,16 @@ set_category(JObj, Category) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec message() -> kz_term:ne_binary().
--spec message(doc()) -> kz_term:api_binary().
--spec message(doc(), Default) -> kz_term:ne_binary() | Default.
 message() ->
     ?MESSAGE.
 
+-spec message(doc()) -> kz_term:api_binary().
 message(JObj) ->
     message(JObj, 'undefined').
 
+-spec message(doc(), Default) -> kz_term:ne_binary() | Default.
 message(JObj, Default) ->
     kz_json:get_value(?MESSAGE, JObj, Default).
 
@@ -148,15 +151,16 @@ set_message(JObj, Message) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec metadata() -> kz_term:ne_binary().
--spec metadata(doc()) -> kz_json:object().
--spec metadata(doc(), Default) ->  kz_json:object() | Default.
 metadata() ->
     ?METADATA.
 
+-spec metadata(doc()) -> kz_json:object().
 metadata(JObj) ->
     metadata(JObj, kz_json:new()).
 
+-spec metadata(doc(), Default) ->  kz_json:object() | Default.
 metadata(JObj, Default) ->
     kz_json:get_value(?METADATA, JObj, Default).
 
@@ -169,15 +173,16 @@ set_metadata(JObj, Metadata) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec level() -> kz_term:ne_binary().
--spec level(doc()) -> kz_term:api_binary().
--spec level(doc(), Default) -> kz_term:ne_binary() | Default.
 level() ->
     ?LEVEL.
 
+-spec level(doc()) -> kz_term:api_binary().
 level(JObj) ->
     level(JObj, <<"info">>).
 
+-spec level(doc(), Default) -> kz_term:ne_binary() | Default.
 level(JObj, Default) ->
     kz_json:get_value(?LEVEL, JObj, Default).
 
@@ -190,15 +195,16 @@ set_level(JObj, Level) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec from() -> kz_term:ne_binary().
--spec from(doc()) -> kz_json:objects().
--spec from(doc(), Default) ->  kz_json:objects() | Default.
 from() ->
     ?FROM.
 
+-spec from(doc()) -> kz_json:objects().
 from(JObj) ->
     from(JObj, kz_json:new()).
 
+-spec from(doc(), Default) ->  kz_json:objects() | Default.
 from(JObj, Default) ->
     kz_json:get_value(?FROM, JObj, Default).
 
@@ -211,15 +217,16 @@ set_from(JObj, From) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec to() -> kz_term:ne_binary().
--spec to(doc()) -> kz_json:objects().
--spec to(doc(), Default) ->  kz_json:objects() | Default.
 to() ->
     ?TO.
 
+-spec to(doc()) -> kz_json:objects().
 to(JObj) ->
     to(JObj, []).
 
+-spec to(doc(), Default) ->  kz_json:objects() | Default.
 to(JObj, Default) ->
     kz_json:get_value(?TO, JObj, Default).
 
@@ -232,15 +239,16 @@ set_to(JObj, To) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec expiration_date() -> kz_term:ne_binary().
--spec expiration_date(doc()) -> kz_json:object().
--spec expiration_date(doc(), Default) ->  kz_json:object() | Default.
 expiration_date() ->
     ?EXPIRATION_DATE.
 
+-spec expiration_date(doc()) -> kz_json:object().
 expiration_date(JObj) ->
     expiration_date(JObj, kz_json:new()).
 
+-spec expiration_date(doc(), Default) ->  kz_json:object() | Default.
 expiration_date(JObj, Default) ->
     kz_json:get_value(?EXPIRATION_DATE, JObj, Default).
 

--- a/core/kazoo_documents/src/kzd_apps_store.erl
+++ b/core/kazoo_documents/src/kzd_apps_store.erl
@@ -68,11 +68,12 @@ id() -> ?ID.
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec apps(kz_json:object()) -> kz_json:object().
--spec apps(kz_json:object(), any()) -> kz_json:object().
 apps(JObj) ->
     kz_json:get_value(?APPS, JObj, kz_json:new()).
 
+-spec apps(kz_json:object(), any()) -> kz_json:object().
 apps(JObj, Default) ->
     kz_json:get_value(?APPS, JObj, Default).
 
@@ -86,11 +87,12 @@ set_apps(JObj, Data) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec blacklist(kz_json:object()) -> kz_term:ne_binaries().
--spec blacklist(kz_json:object(), Default) -> kz_term:ne_binaries() | Default.
 blacklist(JObj) ->
     kz_json:get_value(?BLACKLIST, JObj, []).
 
+-spec blacklist(kz_json:object(), Default) -> kz_term:ne_binaries() | Default.
 blacklist(JObj, Default) ->
     kz_json:get_value(?BLACKLIST, JObj, Default).
 

--- a/core/kazoo_documents/src/kzd_audit_log.erl
+++ b/core/kazoo_documents/src/kzd_audit_log.erl
@@ -54,9 +54,10 @@ audit_account_ids(JObj) ->
     kz_json:get_keys(?KEY_AUDIT, JObj).
 
 -spec audit_account_id(doc(), kz_term:ne_binary()) -> kz_term:api_object().
--spec audit_account_id(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 audit_account_id(JObj, AccountId) ->
     audit_account_id(JObj, AccountId, 'undefined').
+
+-spec audit_account_id(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 audit_account_id(JObj, AccountId, Default) ->
     kz_json:get_json_value([?KEY_AUDIT, AccountId], JObj, Default).
 
@@ -97,9 +98,9 @@ authenticating_user_account_name(JObj) ->
     kz_json:get_value([?KEY_AUTHENTICATING_USER, ?KEY_ACCOUNT_NAME], JObj).
 
 -spec type() -> kz_term:ne_binary().
--spec type(doc()) -> kz_term:api_binary().
 type() -> ?PVT_TYPE.
 
+-spec type(doc()) -> kz_term:api_binary().
 type(JObj) -> kz_doc:type(JObj).
 
 -spec new() -> doc().
@@ -121,8 +122,6 @@ set_audit_account(JObj, AccountId, AuditJObj) ->
     kz_json:set_value([?KEY_AUDIT, AccountId], NewAudit, JObj).
 
 -spec save(kz_services:services(), doc()) -> 'ok'.
--spec save(kz_services:services(), doc(), kz_term:ne_binary()) -> 'ok'.
--spec save(kz_services:services(), doc(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 save(Services, AuditLog) ->
     case kz_services:have_quantities_changed(Services) of
         'true' ->
@@ -133,9 +132,11 @@ save(Services, AuditLog) ->
             lager:debug("nothing has changed for service account ~s, ignoring audit log", [kz_services:account_id(Services)])
     end.
 
+-spec save(kz_services:services(), doc(), kz_term:ne_binary()) -> 'ok'.
 save(Services, AuditLog, MasterAccountId) ->
     save(Services, AuditLog, MasterAccountId, kz_services:account_id(Services)).
 
+-spec save(kz_services:services(), doc(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 save(Services, AuditLog, MasterAccountId, MasterAccountId) ->
     lager:debug("maybe saving master audit log for ~s", [kz_services:account_id(Services)]),
     maybe_save_master_audit_log(Services, AuditLog, MasterAccountId);
@@ -158,12 +159,12 @@ maybe_save_audit_log_to_reseller(Services, AuditLog, MasterAccountId, AccountId,
     end.
 
 -spec maybe_save_master_audit_log(kz_services:services(), doc(), kz_term:ne_binary()) -> 'ok'.
--spec maybe_save_master_audit_log(kz_services:services(), doc(), kz_term:ne_binary(), boolean()) -> 'ok'.
 maybe_save_master_audit_log(Services, AuditLog, MasterAccountId) ->
     maybe_save_master_audit_log(Services, AuditLog, MasterAccountId
                                ,kapps_config:get_is_true(<<"services">>, <<"should_save_master_audit_logs">>, 'false')
                                ).
 
+-spec maybe_save_master_audit_log(kz_services:services(), doc(), kz_term:ne_binary(), boolean()) -> 'ok'.
 maybe_save_master_audit_log(_Services, _AuditLog, _MasterAccountId, 'false') ->
     lager:debug("reached master account, not saving audit log");
 maybe_save_master_audit_log(Services, AuditLog, MasterAccountId, 'true') ->

--- a/core/kazoo_documents/src/kzd_call_recording.erl
+++ b/core/kazoo_documents/src/kzd_call_recording.erl
@@ -43,9 +43,9 @@ new() ->
     kz_doc:set_type(kz_json_schema:default_object(?SCHEMA), type()).
 
 -spec type() -> kz_term:ne_binary().
--spec type(doc()) -> kz_term:ne_binary().
 type() -> ?PVT_TYPE.
 
+-spec type(doc()) -> kz_term:ne_binary().
 type(Doc) ->
     kz_doc:type(Doc, ?PVT_TYPE).
 

--- a/core/kazoo_documents/src/kzd_callflow.erl
+++ b/core/kazoo_documents/src/kzd_callflow.erl
@@ -96,10 +96,12 @@ is_feature_code(Doc) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec flow(doc()) -> kz_term:api_object().
--spec flow(doc(), Default) -> kz_json:object() | Default.
 flow(Doc) ->
     flow(Doc, 'undefined').
+
+-spec flow(doc(), Default) -> kz_json:object() | Default.
 flow(Doc, Default) ->
     kz_json:get_json_value(?FLOW, Doc, Default).
 

--- a/core/kazoo_documents/src/kzd_domains.erl
+++ b/core/kazoo_documents/src/kzd_domains.erl
@@ -73,9 +73,10 @@ default() ->
     kz_json:load_fixture_from_file(?APP, "fixtures", "domains.json").
 
 -spec cname(doc()) -> kz_term:api_object().
--spec cname(doc(), Default) -> kz_json:object() | Default.
 cname(Domains) ->
     cname(Domains, 'undefined').
+
+-spec cname(doc(), Default) -> kz_json:object() | Default.
 cname(Domains, Default) ->
     kz_json:get_json_value(?KEY_CNAME, Domains, Default).
 
@@ -84,17 +85,18 @@ cname_hosts(Domains) ->
     kz_json:get_keys(?KEY_CNAME, Domains).
 
 -spec cname_host(doc(), kz_term:ne_binary()) -> kz_term:api_object().
--spec cname_host(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 cname_host(Domains, Host) ->
     cname_host(Domains, Host, 'undefined').
+
+-spec cname_host(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 cname_host(Domains, Host, Default) ->
     kz_json:get_value([?KEY_CNAME, Host], Domains, Default).
 
 -spec cname_host_mappings(doc(), kz_term:ne_binary()) -> kz_term:ne_binaries().
--spec cname_host_mappings(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 cname_host_mappings(Domains, Host) ->
     cname_host_mappings(Domains, Host, []).
 
+-spec cname_host_mappings(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 cname_host_mappings(Domains, Host, Default) ->
     kz_json:get_value([?KEY_CNAME, Host, ?KEY_MAPPINGS], Domains, Default).
 
@@ -107,9 +109,10 @@ add_cname_host(Domains, Host, Settings) ->
     kz_json:set_value([?KEY_CNAME, Host], Settings, Domains).
 
 -spec a_record(doc()) -> kz_term:api_object().
--spec a_record(doc(), Default) -> kz_json:object() | Default.
 a_record(Domains) ->
     a_record(Domains, 'undefined').
+
+-spec a_record(doc(), Default) -> kz_json:object() | Default.
 a_record(Domains, Default) ->
     kz_json:get_json_value(?KEY_A_RECORD, Domains, Default).
 
@@ -118,17 +121,18 @@ a_record_hosts(Domains) ->
     kz_json:get_keys(?KEY_A_RECORD, Domains).
 
 -spec a_record_host(doc(), kz_term:ne_binary()) -> kz_term:api_object().
--spec a_record_host(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 a_record_host(Domains, Host) ->
     a_record_host(Domains, Host, 'undefined').
+
+-spec a_record_host(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 a_record_host(Domains, Host, Default) ->
     kz_json:get_value([?KEY_A_RECORD, Host], Domains, Default).
 
 -spec a_record_host_mappings(doc(), kz_term:ne_binary()) -> kz_term:ne_binaries().
--spec a_record_host_mappings(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 a_record_host_mappings(Domains, Host) ->
     a_record_host_mappings(Domains, Host, []).
 
+-spec a_record_host_mappings(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 a_record_host_mappings(Domains, Host, Default) ->
     kz_json:get_value([?KEY_A_RECORD, Host, ?KEY_MAPPINGS], Domains, Default).
 
@@ -141,9 +145,10 @@ add_a_record_host(Domains, Host, Settings) ->
     kz_json:set_value([?KEY_A_RECORD, Host], Settings, Domains).
 
 -spec naptr(doc()) -> kz_term:api_object().
--spec naptr(doc(), Default) -> kz_json:object() | Default.
 naptr(Domains) ->
     naptr(Domains, 'undefined').
+
+-spec naptr(doc(), Default) -> kz_json:object() | Default.
 naptr(Domains, Default) ->
     kz_json:get_json_value(?KEY_NAPTR, Domains, Default).
 
@@ -152,17 +157,18 @@ naptr_hosts(Domains) ->
     kz_json:get_keys(?KEY_NAPTR, Domains).
 
 -spec naptr_host(doc(), kz_term:ne_binary()) -> kz_term:api_object().
--spec naptr_host(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 naptr_host(Domains, Host) ->
     naptr_host(Domains, Host, 'undefined').
+
+-spec naptr_host(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 naptr_host(Domains, Host, Default) ->
     kz_json:get_value([?KEY_NAPTR, Host], Domains, Default).
 
 -spec naptr_host_mappings(doc(), kz_term:ne_binary()) -> kz_term:ne_binaries().
--spec naptr_host_mappings(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 naptr_host_mappings(Domains, Host) ->
     naptr_host_mappings(Domains, Host, []).
 
+-spec naptr_host_mappings(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 naptr_host_mappings(Domains, Host, Default) ->
     kz_json:get_value([?KEY_NAPTR, Host, ?KEY_MAPPINGS], Domains, Default).
 
@@ -175,9 +181,10 @@ add_naptr_host(Domains, Host, Settings) ->
     kz_json:set_value([?KEY_NAPTR, Host], Settings, Domains).
 
 -spec srv(doc()) -> kz_term:api_object().
--spec srv(doc(), Default) -> kz_json:object() | Default.
 srv(Domains) ->
     srv(Domains, 'undefined').
+
+-spec srv(doc(), Default) -> kz_json:object() | Default.
 srv(Domains, Default) ->
     kz_json:get_json_value(?KEY_SRV, Domains, Default).
 
@@ -186,17 +193,18 @@ srv_hosts(Domains) ->
     kz_json:get_keys(?KEY_SRV, Domains).
 
 -spec srv_host(doc(), kz_term:ne_binary()) -> kz_term:api_object().
--spec srv_host(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 srv_host(Domains, Host) ->
     srv_host(Domains, Host, 'undefined').
+
+-spec srv_host(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 srv_host(Domains, Host, Default) ->
     kz_json:get_value([?KEY_SRV, Host], Domains, Default).
 
 -spec srv_host_mappings(doc(), kz_term:ne_binary()) -> kz_term:ne_binaries().
--spec srv_host_mappings(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 srv_host_mappings(Domains, Host) ->
     srv_host_mappings(Domains, Host, []).
 
+-spec srv_host_mappings(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binaries() | Default.
 srv_host_mappings(Domains, Host, Default) ->
     kz_json:get_value([?KEY_SRV, Host, ?KEY_MAPPINGS], Domains, Default).
 
@@ -210,10 +218,11 @@ add_srv_host(Domains, Host, Settings) ->
 
 -spec save(doc()) -> {'ok', doc()} |
                      {'error', any()}.
--spec save(doc(), kz_term:api_object()) -> {'ok', doc()} |
-                                           {'error', any()}.
 save(Domains) ->
     save(Domains, 'undefined').
+
+-spec save(doc(), kz_term:api_object()) -> {'ok', doc()} |
+                                           {'error', any()}.
 save(Domains, PvtFields) ->
     case is_valid(Domains) of
         'true' ->
@@ -238,10 +247,11 @@ try_save(Domains, PvtFields) ->
 
 -spec is_valid(doc()) ->
                       'true' | {'false', _}.
--spec is_valid(doc(), {'ok', kz_json:object()} | {'error', any()}) ->
-                      'true' | {'false', any()}.
 is_valid(Domains) ->
     is_valid(Domains, kz_json_schema:load(<<"domains">>)).
+
+-spec is_valid(doc(), {'ok', kz_json:object()} | {'error', any()}) ->
+                      'true' | {'false', any()}.
 is_valid(_Domains, {'error', E}) ->
     lager:warning("failed to find domains JSON schema"),
     {'false', E};

--- a/core/kazoo_documents/src/kzd_fax.erl
+++ b/core/kazoo_documents/src/kzd_fax.erl
@@ -70,65 +70,74 @@ new() ->
 type() -> ?PVT_TYPE.
 
 -spec owner_id(doc()) -> kz_term:api_binary().
--spec owner_id(doc(), Default) -> kz_term:ne_binary() | Default.
 owner_id(FaxDoc) ->
     owner_id(FaxDoc, 'undefined').
+
+-spec owner_id(doc(), Default) -> kz_term:ne_binary() | Default.
 owner_id(FaxDoc, Default) ->
     kz_json:get_value(?KEY_OWNER_ID, FaxDoc, Default).
 
 -spec faxbox_id(doc()) -> kz_term:api_binary().
--spec faxbox_id(doc(), Default) -> kz_term:ne_binary() | Default.
 faxbox_id(FaxDoc) ->
     faxbox_id(FaxDoc, 'undefined').
+
+-spec faxbox_id(doc(), Default) -> kz_term:ne_binary() | Default.
 faxbox_id(FaxDoc, Default) ->
     kz_json:get_value(?KEY_FAXBOX_ID, FaxDoc, Default).
 
 -spec timezone(doc()) -> kz_term:api_binary().
--spec timezone(doc(), Default) -> kz_term:ne_binary() | Default.
 timezone(FaxDoc) ->
     timezone(FaxDoc, 'undefined').
+
+-spec timezone(doc(), Default) -> kz_term:ne_binary() | Default.
 timezone(FaxDoc, Default) ->
     kz_json:get_value(?KEY_TIMEZONE, FaxDoc, Default).
 
 -spec retries(doc()) -> kz_term:api_integer().
--spec retries(doc(), Default) -> integer() | Default.
 retries(FaxDoc) ->
     retries(FaxDoc, 'undefined').
+
+-spec retries(doc(), Default) -> integer() | Default.
 retries(FaxDoc, Default) ->
     kz_json:get_integer_value(?KEY_RETRIES, FaxDoc, Default).
 
 -spec attempts(doc()) -> kz_term:api_integer().
--spec attempts(doc(), Default) -> integer() | Default.
 attempts(FaxDoc) ->
     attempts(FaxDoc, 'undefined').
+
+-spec attempts(doc(), Default) -> integer() | Default.
 attempts(FaxDoc, Default) ->
     kz_json:get_integer_value(?KEY_ATTEMPTS, FaxDoc, Default).
 
 -spec from_number(doc()) -> kz_term:api_binary().
--spec from_number(doc(), Default) -> kz_term:api_binary() | Default.
 from_number(FaxDoc) ->
     from_number(FaxDoc, 'undefined').
+
+-spec from_number(doc(), Default) -> kz_term:api_binary() | Default.
 from_number(FaxDoc, Default) ->
     kz_json:get_value(?KEY_FROM_NUMBER, FaxDoc, Default).
 
 -spec to_number(doc()) -> kz_term:api_binary().
--spec to_number(doc(), Default) -> kz_term:api_binary() | Default.
 to_number(FaxDoc) ->
     to_number(FaxDoc, 'undefined').
+
+-spec to_number(doc(), Default) -> kz_term:api_binary() | Default.
 to_number(FaxDoc, Default) ->
     kz_json:get_value(?KEY_TO_NUMBER, FaxDoc, Default).
 
 -spec from_name(doc()) -> kz_term:api_binary().
--spec from_name(doc(), Default) -> kz_term:api_binary() | Default.
 from_name(FaxDoc) ->
     from_name(FaxDoc, 'undefined').
+
+-spec from_name(doc(), Default) -> kz_term:api_binary() | Default.
 from_name(FaxDoc, Default) ->
     kz_json:get_value(?KEY_FROM_NAME, FaxDoc, Default).
 
 -spec to_name(doc()) -> kz_term:api_binary().
--spec to_name(doc(), Default) -> kz_term:api_binary() | Default.
 to_name(FaxDoc) ->
     to_name(FaxDoc, 'undefined').
+
+-spec to_name(doc(), Default) -> kz_term:api_binary() | Default.
 to_name(FaxDoc, Default) ->
     kz_json:get_value(?KEY_TO_NAME, FaxDoc, Default).
 
@@ -137,9 +146,10 @@ notifications(FaxDoc) ->
     kz_json:get_value(?KEY_NOTIFICATIONS, FaxDoc, kz_json:new()).
 
 -spec folder(doc()) -> kz_term:api_binary().
--spec folder(doc(), Default) -> kz_term:api_binary() | Default.
 folder(FaxDoc) ->
     folder(FaxDoc, 'undefined').
+
+-spec folder(doc(), Default) -> kz_term:api_binary() | Default.
 folder(FaxDoc, Default) ->
     kz_json:get_value(?KEY_FOLDER, FaxDoc, Default).
 
@@ -152,16 +162,18 @@ document_url(FaxDoc) ->
     kz_json:get_value(?KEY_DOCUMENT_URL, FaxDoc).
 
 -spec identity_name(doc()) -> kz_term:api_binary().
--spec identity_name(doc(), Default) -> kz_term:api_binary() | Default.
 identity_name(FaxDoc) ->
     identity_name(FaxDoc, 'undefined').
+
+-spec identity_name(doc(), Default) -> kz_term:api_binary() | Default.
 identity_name(FaxDoc, Default) ->
     kz_json:get_value(?KEY_IDENTITY_NAME, FaxDoc, Default).
 
 -spec identity_number(doc()) -> kz_term:api_binary().
--spec identity_number(doc(), Default) -> kz_term:api_binary() | Default.
 identity_number(FaxDoc) ->
     identity_number(FaxDoc, 'undefined').
+
+-spec identity_number(doc(), Default) -> kz_term:api_binary() | Default.
 identity_number(FaxDoc, Default) ->
     kz_json:get_value(?KEY_IDENTITY_NUMBER, FaxDoc, Default).
 
@@ -178,36 +190,41 @@ result(FaxDoc) ->
     kz_json:get_first_defined([?KEY_RX_RESULT, ?KEY_TX_RESULT], FaxDoc, kz_json:new()).
 
 -spec job_node(doc()) -> kz_term:api_binary().
--spec job_node(doc(), Default) -> kz_term:api_binary() | Default.
 job_node(FaxDoc) ->
     job_node(FaxDoc, 'undefined').
+
+-spec job_node(doc(), Default) -> kz_term:api_binary() | Default.
 job_node(FaxDoc, Default) ->
     kz_json:get_value(?KEY_JOB_NODE, FaxDoc, Default).
 
 -spec job_status(doc()) -> kz_term:api_binary().
--spec job_status(doc(), Default) -> kz_term:api_binary() | Default.
 job_status(FaxDoc) ->
     job_status(FaxDoc, 'undefined').
+
+-spec job_status(doc(), Default) -> kz_term:api_binary() | Default.
 job_status(FaxDoc, Default) ->
     kz_json:get_value(?KEY_JOB_STATUS, FaxDoc, Default).
 
 -spec size(doc()) -> kz_term:api_integer().
--spec size(doc(), Default) -> integer() | Default.
 size(FaxDoc) ->
     size(FaxDoc, 'undefined').
+
+-spec size(doc(), Default) -> integer() | Default.
 size(FaxDoc, Default) ->
     kz_json:get_integer_value(?KEY_SIZE, FaxDoc, Default).
 
 -spec pages(doc()) -> kz_term:api_integer().
--spec pages(doc(), Default) -> integer() | Default.
 pages(FaxDoc) ->
     pages(FaxDoc, 'undefined').
+
+-spec pages(doc(), Default) -> integer() | Default.
 pages(FaxDoc, Default) ->
     kz_json:get_integer_value(?KEY_PAGES, FaxDoc, Default).
 
 -spec retry_after(doc()) -> kz_term:api_integer().
--spec retry_after(doc(), Default) -> integer() | Default.
 retry_after(FaxDoc) ->
     retry_after(FaxDoc, 'undefined').
+
+-spec retry_after(doc(), Default) -> integer() | Default.
 retry_after(FaxDoc, Default) ->
     kz_json:get_integer_value(?KEY_RETRY_AFTER, FaxDoc, Default).

--- a/core/kazoo_documents/src/kzd_fax_box.erl
+++ b/core/kazoo_documents/src/kzd_fax_box.erl
@@ -34,9 +34,10 @@ new() ->
 type() -> ?PVT_TYPE.
 
 -spec owner_id(doc()) -> kz_term:api_binary().
--spec owner_id(doc(), Default) -> kz_term:ne_binary() | Default.
 owner_id(Box) ->
     owner_id(Box, 'undefined').
+
+-spec owner_id(doc(), Default) -> kz_term:ne_binary() | Default.
 owner_id(Box, Default) ->
     kz_json:get_value(?KEY_OWNER_ID, Box, Default).
 
@@ -60,8 +61,9 @@ owner_timezone(Box, Default) ->
     end.
 
 -spec retries(doc()) -> kz_term:api_integer().
--spec retries(doc(), Default) -> integer() | Default.
 retries(Box) ->
     retries(Box, 'undefined').
+
+-spec retries(doc(), Default) -> integer() | Default.
 retries(Box, Default) ->
     kz_json:get_integer_value(?KEY_RETRIES, Box, Default).

--- a/core/kazoo_documents/src/kzd_freeswitch.erl
+++ b/core/kazoo_documents/src/kzd_freeswitch.erl
@@ -63,9 +63,10 @@
 -define(CCV_HEADER(Key), <<"variable_sip_h_X-", ?CHANNEL_VAR_PREFIX, Key/binary>>).
 
 -spec caller_id_name(data()) -> kz_term:api_binary().
--spec caller_id_name(data(), Default) -> kz_term:ne_binary() | Default.
 caller_id_name(Props) ->
     caller_id_name(Props, 'undefined').
+
+-spec caller_id_name(data(), Default) -> kz_term:ne_binary() | Default.
 caller_id_name(Props, Default) ->
     props:get_first_defined([<<"variable_origination_caller_id_name">>
                             ,<<"variable_effective_caller_id_name">>
@@ -76,9 +77,10 @@ caller_id_name(Props, Default) ->
                            ).
 
 -spec caller_id_number(data()) -> kz_term:api_binary().
--spec caller_id_number(data(), Default) -> kz_term:ne_binary() | Default.
 caller_id_number(Props) ->
     caller_id_number(Props, 'undefined').
+
+-spec caller_id_number(data(), Default) -> kz_term:ne_binary() | Default.
 caller_id_number(Props, Default) ->
     props:get_first_defined([<<"variable_origination_caller_id_number">>
                             ,<<"variable_effective_caller_id_number">>
@@ -89,9 +91,10 @@ caller_id_number(Props, Default) ->
                            ).
 
 -spec callee_id_name(data()) -> kz_term:api_binary().
--spec callee_id_name(data(), Default) -> kz_term:ne_binary() | Default.
 callee_id_name(Props) ->
     callee_id_name(Props, 'undefined').
+
+-spec callee_id_name(data(), Default) -> kz_term:ne_binary() | Default.
 callee_id_name(Props, Default) ->
     props:get_first_defined([<<"variable_origination_callee_id_name">>
                             ,<<"variable_effective_callee_id_name">>
@@ -102,9 +105,10 @@ callee_id_name(Props, Default) ->
                            ).
 
 -spec callee_id_number(data()) -> kz_term:api_binary().
--spec callee_id_number(data(), Default) -> kz_term:ne_binary() | Default.
 callee_id_number(Props) ->
     callee_id_number(Props, 'undefined').
+
+-spec callee_id_number(data(), Default) -> kz_term:ne_binary() | Default.
 callee_id_number(Props, Default) ->
     props:get_first_defined([<<"variable_origination_callee_id_number">>
                             ,<<"variable_effective_callee_id_number">>
@@ -151,10 +155,10 @@ call_direction(Props) ->
                            ).
 
 -spec resource_type(data()) -> kz_term:api_binary().
--spec resource_type(data(), Default) -> kz_term:ne_binary() | Default.
 resource_type(Props) ->
     resource_type(Props, 'undefined').
 
+-spec resource_type(data(), Default) -> kz_term:ne_binary() | Default.
 resource_type(Props, Default) ->
     props:get_value(<<"Resource-Type">>, Props, Default).
 
@@ -171,18 +175,18 @@ hunt_destination_number(Props) ->
     props:get_value(<<"Hunt-Destination-Number">>, Props).
 
 -spec is_channel_recovering(data()) -> boolean().
--spec is_channel_recovering(data(), boolean()) -> boolean().
 is_channel_recovering(Props) ->
     is_channel_recovering(Props, 'false').
 
+-spec is_channel_recovering(data(), boolean()) -> boolean().
 is_channel_recovering(Props, Default) ->
     props:is_true(<<"variable_recovered">>, Props, Default).
 
 -spec is_consuming_global_resource(data()) -> kz_term:api_boolean().
--spec is_consuming_global_resource(data(), kz_term:api_boolean()) -> kz_term:api_boolean().
 is_consuming_global_resource(Props) ->
     is_consuming_global_resource(Props, 'undefined').
 
+-spec is_consuming_global_resource(data(), kz_term:api_boolean()) -> kz_term:api_boolean().
 is_consuming_global_resource(Props, Default) ->
     kz_term:is_true(ccv(Props, <<"Global-Resource">>, Default)).
 
@@ -349,12 +353,12 @@ channel_var_map({Key, <<"ARRAY::", Serialized/binary>>}) ->
 channel_var_map({Key, Other}) -> {Key, Other}.
 
 %% Extract custom channel variables to include in the event
+
 -spec ccvs(kz_term:proplist()) -> kz_term:proplist().
--spec custom_channel_vars(kz_term:proplist(), kz_term:proplist()) -> kz_term:proplist().
--spec custom_channel_vars_fold({kz_term:ne_binary(), kz_term:ne_binary()}, kz_term:proplist()) -> kz_term:proplist().
 ccvs(Props) ->
     lists:map(fun channel_var_map/1, custom_channel_vars(Props, [])).
 
+-spec custom_channel_vars(kz_term:proplist(), kz_term:proplist()) -> kz_term:proplist().
 custom_channel_vars(Props, Initial) ->
     CCVs = lists:foldl(fun custom_channel_vars_fold/2, Initial, Props),
     maybe_update_referred_ccv(Props, channel_vars_sort(CCVs)).
@@ -366,6 +370,7 @@ channel_vars_sort(ChannelVars) ->
 -spec channel_var_sort(tuple(), tuple()) -> boolean().
 channel_var_sort({A, _}, {B, _}) -> A =< B.
 
+-spec custom_channel_vars_fold({kz_term:ne_binary(), kz_term:ne_binary()}, kz_term:proplist()) -> kz_term:proplist().
 custom_channel_vars_fold({?CCV(Key), V}, Acc) ->
     [{Key, V} | Acc];
 custom_channel_vars_fold({<<?CHANNEL_VAR_PREFIX, Key/binary>>, V}, Acc) ->
@@ -431,9 +436,10 @@ conference_uuid(Props) ->
     props:get_ne_binary_value(<<"Conference-Unique-ID">>, Props).
 
 -spec join_time(data()) -> kz_time:gregorian_seconds().
--spec join_time(data(), Default) -> kz_time:gregorian_seconds() | Default.
 join_time(Props) ->
     join_time(Props, kz_time:now_s()).
+
+-spec join_time(data(), Default) -> kz_time:gregorian_seconds() | Default.
 join_time(Props, Default) ->
     props:get_integer_value(<<"Join-Time">>, Props, Default).
 
@@ -484,8 +490,9 @@ switch_nodename(Props) ->
     props:get_atom_value(<<"Switch-Nodename">>, Props).
 
 -spec hostname(data()) -> kz_term:api_ne_binary().
--spec hostname(data(), Default) -> kz_term:ne_binary() | Default.
 hostname(Props) ->
     hostname(Props, 'undefined').
+
+-spec hostname(data(), Default) -> kz_term:ne_binary() | Default.
 hostname(Props, Default) ->
     props:get_ne_binary_value(<<"FreeSWITCH-Hostname">>, Props, Default).

--- a/core/kazoo_documents/src/kzd_item_plan.erl
+++ b/core/kazoo_documents/src/kzd_item_plan.erl
@@ -134,51 +134,58 @@ keys(ItemPlan) ->
     kz_json:get_keys(ItemPlan).
 
 -spec minimum(doc()) -> integer().
--spec minimum(doc(), Default) -> integer() | Default.
 minimum(ItemPlan) ->
     minimum(ItemPlan, 0).
+
+-spec minimum(doc(), Default) -> integer() | Default.
 minimum(ItemPlan, Default) ->
     kz_json:get_integer_value(?MINIMUM, ItemPlan, Default).
 
 -spec flat_rates(doc()) -> kz_json:object().
--spec flat_rates(doc(), Default) -> kz_json:object() | Default.
 flat_rates(ItemPlan) ->
     flat_rates(ItemPlan, kz_json:new()).
+
+-spec flat_rates(doc(), Default) -> kz_json:object() | Default.
 flat_rates(ItemPlan, Default) ->
     kz_json:get_json_value(?FLAT_RATES, ItemPlan, Default).
 
 -spec rates(doc()) -> kz_json:object().
--spec rates(doc(), Default) -> kz_json:object() | Default.
 rates(ItemPlan) ->
     rates(ItemPlan, kz_json:new()).
+
+-spec rates(doc(), Default) -> kz_json:object() | Default.
 rates(ItemPlan, Default) ->
     kz_json:get_json_value(?RATES, ItemPlan, Default).
 
 -spec rate(doc()) -> kz_term:api_float().
--spec rate(doc(), Default) -> float() | Default.
 rate(ItemPlan) ->
     rate(ItemPlan, 'undefined').
+
+-spec rate(doc(), Default) -> float() | Default.
 rate(ItemPlan, Default) ->
     kz_json:get_float_value(?RATE, ItemPlan, Default).
 
 -spec exceptions(doc()) -> kz_term:ne_binaries().
--spec exceptions(doc(), Default) -> kz_term:ne_binaries() | Default.
 exceptions(ItemPlan) ->
     exceptions(ItemPlan, []).
+
+-spec exceptions(doc(), Default) -> kz_term:ne_binaries() | Default.
 exceptions(ItemPlan, Default) ->
     kz_json:get_value(?EXCEPTIONS, ItemPlan, Default).
 
 -spec should_cascade(doc()) -> boolean().
--spec should_cascade(doc(), Default) -> boolean() | Default.
 should_cascade(ItemPlan) ->
     should_cascade(ItemPlan, 'false').
+
+-spec should_cascade(doc(), Default) -> boolean() | Default.
 should_cascade(ItemPlan, Default) ->
     kz_json:is_true(?CASCADE, ItemPlan, Default).
 
 -spec masquerade_as(doc()) -> kz_term:api_binary().
--spec masquerade_as(doc(), Default) -> kz_term:ne_binary() | Default.
 masquerade_as(ItemPlan) ->
     masquerade_as(ItemPlan, 'undefined').
+
+-spec masquerade_as(doc(), Default) -> kz_term:ne_binary() | Default.
 masquerade_as(ItemPlan, Default) ->
     kz_json:get_ne_value(?MASQUERADE, ItemPlan, Default).
 
@@ -190,30 +197,34 @@ name(ItemPlan) ->
     end.
 
 -spec discounts(doc()) -> kz_json:object().
--spec discounts(doc(), Default) -> kz_json:object() | Default.
 discounts(ItemPlan) ->
     discounts(ItemPlan, kz_json:new()).
+
+-spec discounts(doc(), Default) -> kz_json:object() | Default.
 discounts(ItemPlan, Default) ->
     kz_json:get_json_value(?DISCOUNTS, ItemPlan, Default).
 
 -spec single_discount(doc()) -> kz_term:api_object().
--spec single_discount(doc(), Default) -> kz_json:object() | Default.
 single_discount(ItemPlan) ->
     single_discount(ItemPlan, 'undefined').
+
+-spec single_discount(doc(), Default) -> kz_json:object() | Default.
 single_discount(ItemPlan, Default) ->
     kz_json:get_json_value([?DISCOUNTS, ?SINGLE], ItemPlan, Default).
 
 -spec cumulative_discount(doc()) -> kz_term:api_object().
--spec cumulative_discount(doc(), Default) -> kz_json:object() | Default.
 cumulative_discount(ItemPlan) ->
     cumulative_discount(ItemPlan, 'undefined').
+
+-spec cumulative_discount(doc(), Default) -> kz_json:object() | Default.
 cumulative_discount(ItemPlan, Default) ->
     kz_json:get_json_value([?DISCOUNTS, ?CUMULATIVE], ItemPlan, Default).
 
 -spec activation_charge(doc()) -> float().
--spec activation_charge(doc(), Default) -> float() | Default.
 activation_charge(ItemPlan) ->
     activation_charge(ItemPlan, 0.0).
+
+-spec activation_charge(doc(), Default) -> float() | Default.
 activation_charge(ItemPlan, Default) ->
     kz_json:get_float_value(?ACTIVATION_CHARGE, ItemPlan, Default).
 

--- a/core/kazoo_documents/src/kzd_media.erl
+++ b/core/kazoo_documents/src/kzd_media.erl
@@ -33,9 +33,10 @@ new() ->
 type() -> ?PVT_TYPE.
 
 -spec prompt_id(doc()) -> kz_term:api_ne_binary().
--spec prompt_id(doc(), Default) -> kz_term:ne_binary() | Default.
 prompt_id(Doc) ->
     prompt_id(Doc, 'undefined').
+
+-spec prompt_id(doc(), Default) -> kz_term:ne_binary() | Default.
 prompt_id(Doc, Default) ->
     kz_json:get_ne_binary_value(?PROMPT_ID, Doc, Default).
 
@@ -44,15 +45,17 @@ is_prompt(Doc) ->
     prompt_id(Doc) =/= 'undefined'.
 
 -spec language(doc()) -> kz_term:api_ne_binary().
--spec language(doc(), Default) -> kz_term:ne_binary() | Default.
 language(Doc) ->
     language(Doc, 'undefined').
+
+-spec language(doc(), Default) -> kz_term:ne_binary() | Default.
 language(Doc, Default) ->
     kz_json:get_ne_binary_value(?LANGUAGE, Doc, Default).
 
 -spec content_type(doc()) -> kz_term:api_ne_binary().
--spec content_type(doc(), Default) -> kz_term:ne_binary() | Default.
 content_type(Doc) ->
     content_type(Doc, 'undefined').
+
+-spec content_type(doc(), Default) -> kz_term:ne_binary() | Default.
 content_type(Doc, Default) ->
     kz_json:get_ne_binary_value(<<"content_type">>, Doc, Default).

--- a/core/kazoo_documents/src/kzd_metaflow.erl
+++ b/core/kazoo_documents/src/kzd_metaflow.erl
@@ -21,23 +21,26 @@ new() ->
     kz_json_schema:default_object(?SCHEMA).
 
 -spec binding_digit(doc()) -> kz_term:ne_binary().
--spec binding_digit(doc(), Default) -> kz_term:ne_binary() | Default.
 binding_digit(Doc) ->
     binding_digit(Doc, <<"*">>).
+
+-spec binding_digit(doc(), Default) -> kz_term:ne_binary() | Default.
 binding_digit(Doc, Default) ->
     kz_json:get_ne_binary_value(<<"binding_digit">>, Doc, Default).
 
 -spec digit_timeout(doc()) -> kz_term:api_integer().
--spec digit_timeout(doc(), Default) -> non_neg_integer() | Default.
 digit_timeout(Doc) ->
     digit_timeout(Doc, 0).
+
+-spec digit_timeout(doc(), Default) -> non_neg_integer() | Default.
 digit_timeout(Doc, Default) ->
     kz_json:get_integer_value(<<"digit_timeout">>, Doc, Default).
 
 -spec listen_on(doc()) -> kz_term:api_ne_binary().
--spec listen_on(doc(), Default) -> kz_term:ne_binary() | Default.
 listen_on(Doc) ->
     listen_on(Doc, 'undefined').
+
+-spec listen_on(doc(), Default) -> kz_term:ne_binary() | Default.
 listen_on(Doc, Default) ->
     kz_json:get_ne_binary_value(<<"listen_on">>, Doc, Default).
 

--- a/core/kazoo_documents/src/kzd_rate.erl
+++ b/core/kazoo_documents/src/kzd_rate.erl
@@ -64,10 +64,10 @@ maybe_fix_direction(Rate) ->
     end.
 
 -spec ensure_id(doc()) -> doc().
--spec ensure_id(doc(), kz_term:api_ne_binary()) -> doc().
 ensure_id(Rate) ->
     ensure_id(Rate, kz_json:get_ne_binary_value(<<"_id">>, Rate)).
 
+-spec ensure_id(doc(), kz_term:api_ne_binary()) -> doc().
 ensure_id(Rate, 'undefined') ->
     ID = list_to_binary([iso_country_code(Rate, <<"XX">>)
                         ,<<"-">>
@@ -79,9 +79,10 @@ ensure_id(Rate, ID) ->
     kz_doc:set_id(Rate, ID).
 
 -spec minimum(doc()) -> integer().
--spec minimum(doc(), integer()) -> integer().
 minimum(Rate) ->
     minimum(Rate, 0).
+
+-spec minimum(doc(), integer()) -> integer().
 minimum(Rate, Default) ->
     kz_json:get_integer_value(<<"minimum">>, Rate, Default).
 
@@ -90,9 +91,10 @@ set_minimum(Rate, Minimum) when is_integer(Minimum) ->
     kz_json:set_value(<<"minimum">>, Minimum, Rate).
 
 -spec increment(doc()) -> integer().
--spec increment(doc(), integer()) -> integer().
 increment(Rate) ->
     increment(Rate, 0).
+
+-spec increment(doc(), integer()) -> integer().
 increment(Rate, Default) ->
     kz_json:get_integer_value(<<"rate_increment">>, Rate, Default).
 
@@ -101,16 +103,18 @@ set_increment(Rate, Increment) when is_integer(Increment) ->
     kz_json:set_value(<<"rate_increment">>, Increment, Rate).
 
 -spec no_charge(doc()) -> integer().
--spec no_charge(doc(), integer()) -> integer().
 no_charge(Rate) ->
     no_charge(Rate, 0).
+
+-spec no_charge(doc(), integer()) -> integer().
 no_charge(Rate, Default) ->
     kz_json:get_integer_value(<<"rate_nocharge_time">>, Rate, Default).
 
 -spec surcharge(doc()) -> kz_transaction:units().
--spec surcharge(doc(), float()) -> kz_transaction:units().
 surcharge(Rate) ->
     surcharge(Rate, 0.0).
+
+-spec surcharge(doc(), float()) -> kz_transaction:units().
 surcharge(Rate, Default) ->
     Surcharge = kz_json:get_float_value(<<"rate_surcharge">>, Rate, Default),
     wht_util:dollars_to_units(Surcharge).
@@ -120,9 +124,10 @@ set_surcharge(Rate, Surcharge) when is_float(Surcharge) ->
     kz_json:set_value(<<"rate_surcharge">>, Surcharge, Rate).
 
 -spec private_surcharge(doc()) -> kz_transaction:units().
--spec private_surcharge(doc(), float()) -> kz_transaction:units().
 private_surcharge(Rate) ->
     private_surcharge(Rate, 0.0).
+
+-spec private_surcharge(doc(), float()) -> kz_transaction:units().
 private_surcharge(Rate, Default) ->
     Surcharge = kz_json:get_float_value(<<"pvt_rate_surcharge">>, Rate, Default),
     wht_util:dollars_to_units(Surcharge).
@@ -132,9 +137,10 @@ set_private_surcharge(Rate, Surcharge) when is_float(Surcharge) ->
     kz_json:set_value(<<"pvt_rate_surcharge">>, Surcharge, Rate).
 
 -spec rate_cost(doc()) -> kz_transaction:units().
--spec rate_cost(doc(), float()) -> kz_transaction:units().
 rate_cost(Rate) ->
     rate_cost(Rate, 0.0).
+
+-spec rate_cost(doc(), float()) -> kz_transaction:units().
 rate_cost(Rate, Default) ->
     Cost = kz_json:get_float_value(<<"rate_cost">>, Rate, Default),
     wht_util:dollars_to_units(Cost).
@@ -144,9 +150,10 @@ set_rate_cost(Rate, Cost) when is_float(Cost) ->
     kz_json:set_value(<<"rate_cost">>, Cost, Rate).
 
 -spec private_cost(doc()) -> kz_transaction:units().
--spec private_cost(doc(), float()) -> kz_transaction:units().
 private_cost(Rate) ->
     private_cost(Rate, 0.0).
+
+-spec private_cost(doc(), float()) -> kz_transaction:units().
 private_cost(Rate, Default) ->
     Cost = kz_json:get_float_value(<<"pvt_internal_rate_cost">>, Rate, Default),
     wht_util:dollars_to_units(Cost).
@@ -156,16 +163,18 @@ set_private_cost(Rate, Cost) when is_float(Cost) ->
     kz_json:set_value(<<"pvt_internal_rate_cost">>, Cost, Rate).
 
 -spec version(doc()) -> kz_term:api_ne_binary().
--spec version(doc(), Default) -> kz_term:ne_binary() | Default.
 version(Rate) ->
     version(Rate, 'undefined').
+
+-spec version(doc(), Default) -> kz_term:ne_binary() | Default.
 version(Rate, Default) ->
     kz_json:get_ne_binary_value(<<"rate_version">>, Rate, Default).
 
 -spec prefix(doc()) -> kz_term:api_ne_binary().
--spec prefix(doc(), Default) -> kz_term:ne_binary() | Default.
 prefix(Rate) ->
     prefix(Rate, 'undefined').
+
+-spec prefix(doc(), Default) -> kz_term:ne_binary() | Default.
 prefix(Rate, Default) ->
     kz_json:get_ne_binary_value(<<"prefix">>, Rate, Default).
 
@@ -174,9 +183,10 @@ set_prefix(Rate, Prefix) when is_binary(Prefix) ->
     kz_json:set_value(<<"prefix">>, Prefix, Rate).
 
 -spec name(doc()) -> kz_term:api_ne_binary().
--spec name(doc(), Default) -> kz_term:ne_binary() | Default.
 name(Rate) ->
     name(Rate, 'undefined').
+
+-spec name(doc(), Default) -> kz_term:ne_binary() | Default.
 name(Rate, Default) ->
     kz_json:get_ne_binary_value(<<"rate_name">>, Rate, Default).
 
@@ -185,9 +195,10 @@ set_name(Rate, ?NE_BINARY = Name) ->
     kz_json:set_value(<<"rate_name">>, Name, Rate).
 
 -spec ratedeck(doc()) -> kz_term:api_ne_binary().
--spec ratedeck(doc(), Default) -> kz_term:ne_binary() | Default.
 ratedeck(Rate) ->
     ratedeck(Rate, 'undefined').
+
+-spec ratedeck(doc(), Default) -> kz_term:ne_binary() | Default.
 ratedeck(Rate, Default) ->
     kz_json:get_ne_binary_value(<<"ratedeck_id">>, Rate, Default).
 
@@ -196,9 +207,10 @@ set_ratedeck(Rate, Deck) ->
     kz_json:set_value(<<"ratedeck_id">>, Deck, Rate).
 
 -spec description(doc()) -> kz_term:api_ne_binary().
--spec description(doc(), Default) -> kz_term:ne_binary() | Default.
 description(Rate) ->
     description(Rate, 'undefined').
+
+-spec description(doc(), Default) -> kz_term:ne_binary() | Default.
 description(Rate, Default) ->
     kz_json:get_ne_binary_value(<<"description">>, Rate, Default).
 
@@ -207,9 +219,10 @@ set_description(Rate, Description) when is_binary(Description) ->
     kz_json:set_value(<<"description">>, Description, Rate).
 
 -spec weight(doc()) -> pos_integer().
--spec weight(doc(), Default) -> pos_integer() | Default.
 weight(Rate) ->
     weight(Rate, 1).
+
+-spec weight(doc(), Default) -> pos_integer() | Default.
 weight(Rate, Default) ->
     case kz_json:get_integer_value(<<"weight">>, Rate, Default) of
         Default -> Default;
@@ -226,12 +239,13 @@ constrain_weight(X) when X =< 0 -> 1;
 constrain_weight(X) when X >= 100 -> 100;
 constrain_weight(X) -> X.
 
--spec direction(doc()) -> kz_term:ne_binaries().
--spec direction(doc(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 -define(BOTH_DIRECTIONS, [<<"inbound">>, <<"outbound">>]).
 
+-spec direction(doc()) -> kz_term:ne_binaries().
 direction(Rate) ->
     direction(Rate, ?BOTH_DIRECTIONS).
+
+-spec direction(doc(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 direction(Rate, Default) ->
     case kz_json:get_value(<<"direction">>, Rate) of
         <<"inbound">>=V -> [V];
@@ -247,9 +261,10 @@ set_direction(Rate, Direction) when is_binary(Direction) ->
     set_direction(Rate, [Direction]).
 
 -spec options(doc()) -> kz_term:ne_binaries().
--spec options(doc(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 options(Rate) ->
     options(Rate, []).
+
+-spec options(doc(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 options(Rate, Default) ->
     kz_json:get_list_value(<<"options">>, Rate, Default).
 
@@ -258,9 +273,10 @@ set_options(Rate, Options) when is_list(Options) ->
     kz_json:set_value(<<"options">>, Options, Rate).
 
 -spec routes(doc()) -> kz_term:ne_binaries().
--spec routes(doc(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 routes(Rate) ->
     routes(Rate, []).
+
+-spec routes(doc(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 routes(Rate, Default) ->
     kz_json:get_list_value(<<"routes">>, Rate, Default).
 
@@ -269,16 +285,18 @@ set_routes(Rate, Routes) when is_list(Routes) ->
     kz_json:set_value(<<"routes">>, Routes, Rate).
 
 -spec account_id(doc()) -> kz_term:api_ne_binary().
--spec account_id(doc(), Default) -> kz_term:ne_binary() | Default.
 account_id(Rate) ->
     account_id(Rate, 'undefined').
+
+-spec account_id(doc(), Default) -> kz_term:ne_binary() | Default.
 account_id(Rate, Default) ->
     kz_json:get_ne_binary_value(<<"account_id">>, Rate, Default).
 
 -spec iso_country_code(doc()) -> kz_term:api_ne_binary().
--spec iso_country_code(doc(), Default) -> kz_term:ne_binary() | Default.
 iso_country_code(Rate) ->
     iso_country_code(Rate, 'undefined').
+
+-spec iso_country_code(doc(), Default) -> kz_term:ne_binary() | Default.
 iso_country_code(Rate, Default) ->
     kz_json:get_ne_binary_value(<<"iso_country_code">>, Rate, Default).
 
@@ -287,16 +305,19 @@ set_iso_country_code(Rate, Code) when is_binary(Code) ->
     kz_json:set_value(<<"iso_country_code">>, Code, Rate).
 
 -spec type() -> kz_term:ne_binary().
--spec type(doc()) -> kz_term:ne_binary().
--spec set_type(doc()) -> doc().
 type() -> <<"rate">>.
+
+-spec type(doc()) -> kz_term:ne_binary().
 type(Doc) -> kz_doc:type(Doc, type()).
+
+-spec set_type(doc()) -> doc().
 set_type(Doc) -> kz_doc:set_type(Doc, type()).
 
 -spec carrier(doc()) -> kz_term:ne_binary().
--spec carrier(doc(), Default) -> kz_term:ne_binary() | Default.
 carrier(Rate) ->
     carrier(Rate, <<"default">>).
+
+-spec carrier(doc(), Default) -> kz_term:ne_binary() | Default.
 carrier(Rate, Default) ->
     kz_json:get_ne_binary_value(<<"pvt_carrier">>, Rate, Default).
 
@@ -305,9 +326,10 @@ set_carrier(Rate, Carrier) when is_binary(Carrier) ->
     kz_json:set_value(<<"pvt_carrier">>, Carrier, Rate).
 
 -spec rate_suffix(doc()) -> kz_term:ne_binary().
--spec rate_suffix(doc(), Default) -> kz_term:ne_binary() | Default.
 rate_suffix(Rate) ->
     rate_suffix(Rate, 'undefined').
+
+-spec rate_suffix(doc(), Default) -> kz_term:ne_binary() | Default.
 rate_suffix(Rate, Default) ->
     case kz_json:get_ne_binary_value(<<"rate_suffix">>, Rate, Default) of
         'undefined' -> <<>>;

--- a/core/kazoo_documents/src/kzd_resource.erl
+++ b/core/kazoo_documents/src/kzd_resource.erl
@@ -21,22 +21,24 @@ new() ->
     kz_doc:set_type(kz_json_schema:default_object(?SCHEMA), type()).
 
 -spec type() -> kz_term:ne_binary().
--spec type(doc()) -> kz_term:ne_binary().
 type() -> ?PVT_TYPE.
 
+-spec type(doc()) -> kz_term:ne_binary().
 type(Doc) ->
     kz_doc:type(Doc, ?PVT_TYPE).
 
 -spec flat_rate_whitelist(doc()) -> kz_term:api_ne_binary().
--spec flat_rate_whitelist(doc(), Default) -> kz_term:ne_binary() | Default.
 flat_rate_whitelist(Doc) ->
     flat_rate_whitelist(Doc, 'undefined').
+
+-spec flat_rate_whitelist(doc(), Default) -> kz_term:ne_binary() | Default.
 flat_rate_whitelist(Doc, Default) ->
     kz_json:get_ne_binary_value(<<"flat_rate_whitelist">>, Doc, Default).
 
 -spec flat_rate_blacklist(doc()) -> kz_term:api_ne_binary().
--spec flat_rate_blacklist(doc(), Default) -> kz_term:ne_binary() | Default.
 flat_rate_blacklist(Doc) ->
     flat_rate_blacklist(Doc, 'undefined').
+
+-spec flat_rate_blacklist(doc(), Default) -> kz_term:ne_binary() | Default.
 flat_rate_blacklist(Doc, Default) ->
     kz_json:get_ne_binary_value(<<"flat_rate_blacklist">>, Doc, Default).

--- a/core/kazoo_documents/src/kzd_service_plan.erl
+++ b/core/kazoo_documents/src/kzd_service_plan.erl
@@ -69,16 +69,18 @@ type() -> <<"service_plan">>.
 all_items_key() -> ?ALL.
 
 -spec account_id(doc()) -> kz_term:api_binary().
--spec account_id(doc(), Default) -> kz_term:ne_binary() | Default.
 account_id(Plan) ->
     account_id(Plan, 'undefined').
+
+-spec account_id(doc(), Default) -> kz_term:ne_binary() | Default.
 account_id(Plan, Default) ->
     kz_json:get_value(<<"account_id">>, Plan, Default).
 
 -spec overrides(doc()) -> kz_json:object().
--spec overrides(doc(), Default) -> kz_json:object() | Default.
 overrides(Plan) ->
     overrides(Plan, kz_json:new()).
+
+-spec overrides(doc(), Default) -> kz_json:object() | Default.
 overrides(Plan, Default) ->
     kz_json:get_json_value(<<"overrides">>, Plan, Default).
 
@@ -87,18 +89,20 @@ merge_overrides(Plan, Overrides) ->
     kz_json:merge(Plan, kz_json:from_list([{?PLAN, Overrides}])).
 
 -spec item_activation_charge(doc(), kz_term:ne_binary(), kz_term:ne_binary()) -> float().
--spec item_activation_charge(doc(), kz_term:ne_binary(), kz_term:ne_binary(), Default) -> float() | Default.
 item_activation_charge(Plan, Category, Item) ->
     item_activation_charge(Plan, Category, Item, 0.0).
+
+-spec item_activation_charge(doc(), kz_term:ne_binary(), kz_term:ne_binary(), Default) -> float() | Default.
 item_activation_charge(Plan, Category, Item, Default) ->
     Path = [?PLAN, Category, Item],
     ItemConfig = kz_json:get_json_value(Path, Plan, kz_json:new()),
     kzd_item_plan:activation_charge(ItemConfig, Default).
 
 -spec category_activation_charge(doc(), kz_term:ne_binary()) -> float().
--spec category_activation_charge(doc(), kz_term:ne_binary(), Default) -> float() | Default.
 category_activation_charge(Plan, Category) ->
     category_activation_charge(Plan, Category, 0.0).
+
+-spec category_activation_charge(doc(), kz_term:ne_binary(), Default) -> float() | Default.
 category_activation_charge(Plan, Category, Default) ->
     item_activation_charge(Plan, Category, ?ALL, Default).
 
@@ -107,9 +111,10 @@ categories(Plan) ->
     kz_json:get_keys(?PLAN, Plan).
 
 -spec category(doc(), kz_term:ne_binary()) -> kz_term:api_object().
--spec category(doc(), kz_term:ne_binary(), Default) -> kz_term:api_object() | Default.
 category(Plan, CategoryId) ->
     category(Plan, CategoryId, 'undefined').
+
+-spec category(doc(), kz_term:ne_binary(), Default) -> kz_term:api_object() | Default.
 category(Plan, CategoryId, Default) ->
     kz_json:get_json_value([?PLAN, CategoryId], Plan, Default).
 
@@ -134,9 +139,10 @@ bookkeeper(Plan, BookkeeperId) ->
     kz_json:get_json_value(BookkeeperId, bookkeepers(Plan), kz_json:new()).
 
 -spec item_minimum(doc(), kz_term:ne_binary(), kz_term:ne_binary()) -> integer().
--spec item_minimum(doc(), kz_term:ne_binary(), kz_term:ne_binary(), Default) -> integer() | Default.
 item_minimum(Plan, CategoryId, ItemId) ->
     item_minimum(Plan, CategoryId, ItemId, 0).
+
+-spec item_minimum(doc(), kz_term:ne_binary(), kz_term:ne_binary(), Default) -> integer() | Default.
 item_minimum(Plan, CategoryId, ItemId, Default) ->
     kzd_item_plan:minimum(
       kz_json:get_json_value([?PLAN, CategoryId, ItemId]
@@ -158,10 +164,11 @@ item_name(Plan, CategoryId, ItemId) ->
 
 -spec item_exceptions(doc(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                              kz_term:ne_binaries().
--spec item_exceptions(doc(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binaries()) ->
-                             kz_term:ne_binaries().
 item_exceptions(Plan, CategoryId, ItemId) ->
     item_exceptions(Plan, CategoryId, ItemId, []).
+
+-spec item_exceptions(doc(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binaries()) ->
+                             kz_term:ne_binaries().
 item_exceptions(Plan, CategoryId, ItemId, Default) ->
     Item = kz_json:get_json_value([?PLAN, CategoryId, ItemId]
                                  ,Plan
@@ -170,23 +177,26 @@ item_exceptions(Plan, CategoryId, ItemId, Default) ->
     kzd_item_plan:exceptions(Item, Default).
 
 -spec item_plan(doc(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_json:object().
--spec item_plan(doc(), kz_term:ne_binary(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 item_plan(Plan, CategoryId, ItemId) ->
     item_plan(Plan, CategoryId, ItemId, kz_json:new()).
+
+-spec item_plan(doc(), kz_term:ne_binary(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 item_plan(Plan, CategoryId, ItemId, Default) ->
     kz_json:get_json_value([?PLAN, CategoryId, ItemId], Plan, Default).
 
 -spec category_plan(doc(), kz_term:ne_binary()) -> kz_json:object().
--spec category_plan(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 category_plan(Plan, CategoryId) ->
     category_plan(Plan, CategoryId, kz_json:new()).
+
+-spec category_plan(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 category_plan(Plan, CategoryId, Default) ->
     item_plan(Plan, CategoryId, ?ALL, Default).
 
 -spec plan(doc()) -> kz_json:object().
--spec plan(doc(), Default) -> kz_json:object() | Default.
 plan(Plan) ->
     plan(Plan, kz_json:new()).
+
+-spec plan(doc(), Default) -> kz_json:object() | Default.
 plan(Plan, Default) ->
     kz_json:get_json_value(?PLAN, Plan, Default).
 
@@ -195,9 +205,10 @@ set_plan(Plan, P) ->
     kz_json:set_value(?PLAN, P, Plan).
 
 -spec grouping_category(doc()) -> kz_term:api_ne_binary().
--spec grouping_category(doc(), Default) -> kz_term:ne_binary() | Default.
 grouping_category(ServicePlan) ->
     grouping_category(ServicePlan, 'undefined').
+
+-spec grouping_category(doc(), Default) -> kz_term:ne_binary() | Default.
 grouping_category(ServicePlan, Default) ->
     kz_json:get_ne_binary_value(<<"category">>, ServicePlan, Default).
 

--- a/core/kazoo_documents/src/kzd_services.erl
+++ b/core/kazoo_documents/src/kzd_services.erl
@@ -65,9 +65,10 @@
 -define(REASON_CODE, <<"pvt_status_reason_code">>).
 
 -spec billing_id(doc()) -> kz_term:api_binary().
--spec billing_id(doc(), Default) -> kz_term:ne_binary() | Default.
 billing_id(JObj) ->
     billing_id(JObj, kz_doc:account_id(JObj)).
+
+-spec billing_id(doc(), Default) -> kz_term:ne_binary() | Default.
 billing_id(JObj, Default) ->
     kz_json:get_value(?BILLING_ID, JObj, Default).
 
@@ -76,64 +77,73 @@ set_billing_id(JObj, BillingId) ->
     kz_json:set_value(?BILLING_ID, BillingId, JObj).
 
 -spec is_reseller(doc()) -> boolean().
--spec is_reseller(doc(), Default) -> boolean() | Default.
 is_reseller(JObj) ->
     is_reseller(JObj, 'false').
+
+-spec is_reseller(doc(), Default) -> boolean() | Default.
 is_reseller(JObj, Default) ->
     kz_json:is_true(?IS_RESELLER, JObj, Default).
 
 -spec reseller_id(doc()) -> kz_term:api_binary().
--spec reseller_id(doc(), Default) -> kz_term:ne_binary() | Default.
 reseller_id(JObj) ->
     reseller_id(JObj, 'undefined').
+
+-spec reseller_id(doc(), Default) -> kz_term:ne_binary() | Default.
 reseller_id(JObj, Default) ->
     kz_json:get_value(?RESELLER_ID, JObj, Default).
 
 -spec is_dirty(doc()) -> boolean().
--spec is_dirty(doc(), Default) -> boolean() | Default.
 is_dirty(JObj) ->
     is_dirty(JObj, 'false').
+
+-spec is_dirty(doc(), Default) -> boolean() | Default.
 is_dirty(JObj, Default) ->
     kz_json:is_true(?IS_DIRTY, JObj, Default).
 
 -spec is_deleted(doc()) -> boolean().
--spec is_deleted(doc(), Default) -> boolean() | Default.
 is_deleted(JObj) ->
     is_deleted(JObj, 'false').
+
+-spec is_deleted(doc(), Default) -> boolean() | Default.
 is_deleted(JObj, Default) ->
     kz_json:is_true(?IS_DELETED, JObj, Default).
 
 -spec status(doc()) -> kz_term:ne_binary().
--spec status(doc(), Default) -> kz_term:ne_binary() | Default.
 status(JObj) ->
     status(JObj, status_good()).
+
+-spec status(doc(), Default) -> kz_term:ne_binary() | Default.
 status(JObj, Default) ->
     kz_json:get_value(?STATUS, JObj, Default).
 
 -spec tree(doc()) -> kz_term:ne_binaries().
--spec tree(doc(), Default) -> kz_term:ne_binaries() | Default.
 tree(JObj) ->
     tree(JObj, []).
+
+-spec tree(doc(), Default) -> kz_term:ne_binaries() | Default.
 tree(JObj, Default) ->
     kz_json:get_value(?TREE, JObj, Default).
 
 -spec reason(doc()) -> kz_term:ne_binaries().
--spec reason(doc(), Default) -> kz_term:ne_binaries() | Default.
 reason(JObj) ->
     reason(JObj, 'undefined').
+
+-spec reason(doc(), Default) -> kz_term:ne_binaries() | Default.
 reason(JObj, Default) ->
     kz_json:get_value(?REASON, JObj, Default).
 
 -spec reason_code(doc()) -> kz_term:ne_binaries().
--spec reason_code(doc(), Default) -> kz_term:ne_binaries() | Default.
 reason_code(JObj) ->
     reason_code(JObj, 'undefined').
+
+-spec reason_code(doc(), Default) -> kz_term:ne_binaries() | Default.
 reason_code(JObj, Default) ->
     kz_json:get_value(?REASON_CODE, JObj, Default).
 
 -spec type() -> kz_term:ne_binary().
--spec type(kz_json:object()) -> kz_term:ne_binary().
 type() -> <<"service">>.
+
+-spec type(kz_json:object()) -> kz_term:ne_binary().
 type(JObj) ->
     kz_doc:type(JObj, type()).
 
@@ -144,9 +154,10 @@ status_good() -> <<"good_standing">>.
 status_delinquent() -> <<"delinquent">>.
 
 -spec plans(doc()) -> kz_json:object().
--spec plans(doc(), Default) -> kz_json:object() | Default.
 plans(JObj) ->
     plans(JObj, kz_json:new()).
+
+-spec plans(doc(), Default) -> kz_json:object() | Default.
 plans(JObj, Default) ->
     kz_json:get_json_value(?PLANS, JObj, Default).
 
@@ -155,51 +166,58 @@ plan_ids(JObj) ->
     kz_json:get_keys(?PLANS, JObj).
 
 -spec plan(doc(), kz_term:ne_binary()) -> kz_json:object().
--spec plan(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 plan(JObj, PlanId) ->
     plan(JObj, PlanId, kz_json:new()).
+
+-spec plan(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 plan(JObj, PlanId, Default) ->
     kz_json:get_json_value([?PLANS, PlanId], JObj, Default).
 
 -spec plan_account_id(doc(), kz_term:ne_binary()) -> kz_term:api_binary().
--spec plan_account_id(doc(), kz_term:ne_binary(), Default) -> kz_term:api_binary() | Default.
 plan_account_id(JObj, PlanId) ->
     plan_account_id(JObj, PlanId, 'undefined').
+
+-spec plan_account_id(doc(), kz_term:ne_binary(), Default) -> kz_term:api_binary() | Default.
 plan_account_id(JObj, PlanId, Default) ->
     kzd_service_plan:account_id(plan(JObj, PlanId), Default).
 
 -spec plan_overrides(doc(), kz_term:ne_binary()) -> kz_json:object().
--spec plan_overrides(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 plan_overrides(JObj, PlanId) ->
     plan_overrides(JObj, PlanId, kz_json:new()).
+
+-spec plan_overrides(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 plan_overrides(JObj, PlanId, Default) ->
     kzd_service_plan:overrides(plan(JObj, PlanId), Default).
 
 -spec quantities(doc()) -> kz_json:object().
--spec quantities(doc(), Default) -> kz_json:object() | Default.
 quantities(JObj) ->
     quantities(JObj, kz_json:new()).
+
+-spec quantities(doc(), Default) -> kz_json:object() | Default.
 quantities(JObj, Default) ->
     kz_json:get_json_value(?QUANTITIES, JObj, Default).
 
 -spec category_quantities(doc(), kz_term:ne_binary()) -> kz_json:object().
--spec category_quantities(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 category_quantities(JObj, CategoryId) ->
     category_quantities(JObj, CategoryId, kz_json:new()).
+
+-spec category_quantities(doc(), kz_term:ne_binary(), Default) -> kz_json:object() | Default.
 category_quantities(JObj, CategoryId, Default) ->
     kz_json:get_json_value([?QUANTITIES, CategoryId], JObj, Default).
 
 -spec item_quantity(doc(), kz_term:ne_binary(), kz_term:ne_binary()) -> integer().
--spec item_quantity(doc(), kz_term:ne_binary(), kz_term:ne_binary(), Default) -> integer() | Default.
 item_quantity(JObj, CategoryId, ItemId) ->
     item_quantity(JObj, CategoryId, ItemId, 0).
+
+-spec item_quantity(doc(), kz_term:ne_binary(), kz_term:ne_binary(), Default) -> integer() | Default.
 item_quantity(JObj, CategoryId, ItemId, Default) ->
     kz_json:get_integer_value([?QUANTITIES, CategoryId, ItemId], JObj, Default).
 
 -spec transactions(doc()) -> kz_json:objects().
--spec transactions(doc(), Default) -> kz_json:objects() | Default.
 transactions(JObj) ->
     transactions(JObj, []).
+
+-spec transactions(doc(), Default) -> kz_json:objects() | Default.
 transactions(JObj, Default) ->
     kz_json:get_value(?TRANSACTIONS, JObj, Default).
 

--- a/core/kazoo_documents/src/kzd_skel.erl
+++ b/core/kazoo_documents/src/kzd_skel.erl
@@ -18,8 +18,8 @@ new() ->
     kz_doc:set_type(kz_json_schema:default_object(?SCHEMA), type()).
 
 -spec type() -> kz_term:ne_binary().
--spec type(doc()) -> kz_term:ne_binary().
 type() -> ?PVT_TYPE.
 
+-spec type(doc()) -> kz_term:ne_binary().
 type(Doc) ->
     kz_doc:type(Doc, ?PVT_TYPE).

--- a/core/kazoo_documents/src/kzd_user.erl
+++ b/core/kazoo_documents/src/kzd_user.erl
@@ -53,16 +53,18 @@ fetch(_, _) ->
     {'error', 'invalid_parameters'}.
 
 -spec email(doc()) -> kz_term:api_binary().
--spec email(doc(), Default) -> kz_term:ne_binary() | Default.
 email(User) ->
     email(User, 'undefined').
+
+-spec email(doc(), Default) -> kz_term:ne_binary() | Default.
 email(User, Default) ->
     kz_json:get_ne_binary_value(?KEY_EMAIL, User, Default).
 
 -spec voicemail_notification_enabled(doc()) -> boolean().
--spec voicemail_notification_enabled(doc(), Default) -> boolean() | Default.
 voicemail_notification_enabled(User) ->
     voicemail_notification_enabled(User, 'false').
+
+-spec voicemail_notification_enabled(doc(), Default) -> boolean() | Default.
 voicemail_notification_enabled(User, Default) ->
     kz_json:is_true(<<"vm_to_email_enabled">>, User, Default).
 
@@ -232,9 +234,10 @@ timezone(JObj, Default) ->
     end.
 
 -spec presence_id(doc()) -> kz_term:api_binary().
--spec presence_id(doc(), Default) -> kz_term:ne_binary() | Default.
 presence_id(UserJObj) ->
     presence_id(UserJObj, 'undefined').
+
+-spec presence_id(doc(), Default) -> kz_term:ne_binary() | Default.
 presence_id(UserJObj, Default) ->
     kz_json:get_binary_value(?KEY_PRESENCE_ID, UserJObj, Default).
 
@@ -246,9 +249,10 @@ set_presence_id(UserJObj, Id) ->
                      ).
 
 -spec is_enabled(doc()) -> boolean().
--spec is_enabled(doc(), Default) -> boolean() | Default.
 is_enabled(JObj) ->
     is_enabled(JObj, 'true').
+
+-spec is_enabled(doc(), Default) -> boolean() | Default.
 is_enabled(JObj, Default) ->
     kz_json:is_true(?KEY_IS_ENABLED, JObj, Default).
 
@@ -314,25 +318,26 @@ name(Doc) ->
     >>.
 
 -spec first_name(doc()) -> kz_term:api_binary().
--spec first_name(doc(), Default) -> kz_term:ne_binary() | Default.
 first_name(Doc) ->
     first_name(Doc, 'undefined').
 
+-spec first_name(doc(), Default) -> kz_term:ne_binary() | Default.
 first_name(Doc, Default) ->
     kz_json:get_binary_value(?KEY_FIRST_NAME, Doc, Default).
 
 -spec last_name(doc()) -> kz_term:api_binary().
--spec last_name(doc(), Default) -> kz_term:ne_binary() | Default.
 last_name(Doc) ->
     last_name(Doc, 'undefined').
 
+-spec last_name(doc(), Default) -> kz_term:ne_binary() | Default.
 last_name(Doc, Default) ->
     kz_json:get_binary_value(?KEY_LAST_NAME, Doc, Default).
 
 -spec priv_level(doc()) -> kz_term:api_binary().
--spec priv_level(doc(), Default) -> kz_term:ne_binary() | Default.
 priv_level(Doc) ->
     priv_level(Doc, <<"user">>).
+
+-spec priv_level(doc(), Default) -> kz_term:ne_binary() | Default.
 priv_level(Doc, Default) ->
     kz_json:get_binary_value(?KEY_PRIV_LEVEL, Doc, Default).
 
@@ -343,16 +348,18 @@ set_priv_level(<<"admin">>=LVL, Doc) ->
     kz_json:set_value(?KEY_PRIV_LEVEL, LVL, Doc).
 
 -spec call_restrictions(doc()) -> kz_term:api_object().
--spec call_restrictions(doc(), Default) -> kz_json:object() | Default.
 call_restrictions(Doc) ->
     call_restrictions(Doc, 'undefined').
+
+-spec call_restrictions(doc(), Default) -> kz_json:object() | Default.
 call_restrictions(Doc, Default) ->
     kz_json:get_json_value(?KEY_CALL_RESTRICTIONS, Doc, Default).
 
 -spec classifier_restriction(doc(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
--spec classifier_restriction(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binary() | Default.
 classifier_restriction(Doc, Classifier) ->
     classifier_restriction(Doc, Classifier, 'undefined').
+
+-spec classifier_restriction(doc(), kz_term:ne_binary(), Default) -> kz_term:ne_binary() | Default.
 classifier_restriction(Doc, Classifier, Default) ->
     kz_json:get_ne_binary_value([?KEY_CALL_RESTRICTIONS
                                 ,Classifier

--- a/core/kazoo_documents/src/kzd_voicemail_box.erl
+++ b/core/kazoo_documents/src/kzd_voicemail_box.erl
@@ -60,9 +60,10 @@ new() ->
 type() -> ?PVT_TYPE.
 
 -spec notification_emails(doc()) -> kz_term:ne_binaries().
--spec notification_emails(doc(), Default) -> kz_term:ne_binaries() | Default.
 notification_emails(Box) ->
     notification_emails(Box, []).
+
+-spec notification_emails(doc(), Default) -> kz_term:ne_binaries() | Default.
 notification_emails(Box, Default) ->
     case kz_json:get_list_value(?KEY_NOTIFY_EMAILS, Box) of
         'undefined' ->
@@ -81,9 +82,10 @@ set_notification_emails(Box, Emails) ->
     kz_json:set_value(?KEY_NOTIFY_EMAILS, Emails, Box).
 
 -spec owner_id(doc()) -> kz_term:api_binary().
--spec owner_id(doc(), Default) -> kz_term:ne_binary() | Default.
 owner_id(Box) ->
     owner_id(Box, 'undefined').
+
+-spec owner_id(doc(), Default) -> kz_term:ne_binary() | Default.
 owner_id(Box, Default) ->
     kz_json:get_value(?KEY_OWNER_ID, Box, Default).
 
@@ -107,51 +109,58 @@ owner_timezone(Box, Default) ->
     end.
 
 -spec skip_instructions(doc()) -> boolean().
--spec skip_instructions(doc(), Default) -> boolean() | Default.
 skip_instructions(Box) ->
     skip_instructions(Box, 'false').
+
+-spec skip_instructions(doc(), Default) -> boolean() | Default.
 skip_instructions(Box, Default) ->
     kz_json:is_true(?KEY_SKIP_INSTRUCTIONS, Box, Default).
 
 -spec skip_greeting(doc()) -> boolean().
--spec skip_greeting(doc(), Default) -> boolean() | Default.
 skip_greeting(Box) ->
     skip_greeting(Box, 'false').
+
+-spec skip_greeting(doc(), Default) -> boolean() | Default.
 skip_greeting(Box, Default) ->
     kz_json:is_true(?KEY_SKIP_GREETING, Box, Default).
 
 -spec pin(doc()) -> kz_term:api_binary().
--spec pin(doc(), Default) -> kz_term:ne_binary() | Default.
 pin(Box) ->
     pin(Box, 'undefined').
+
+-spec pin(doc(), Default) -> kz_term:ne_binary() | Default.
 pin(Box, Default) ->
     kz_json:get_binary_value(?KEY_PIN, Box, Default).
 
 -spec mailbox_number(doc()) -> kz_term:api_binary().
--spec mailbox_number(doc(), Default) -> kz_term:ne_binary() | Default.
 mailbox_number(Box) ->
     mailbox_number(Box, 'undefined').
+
+-spec mailbox_number(doc(), Default) -> kz_term:ne_binary() | Default.
 mailbox_number(Box, Default) ->
     kz_json:get_binary_value(?KEY_MAILBOX_NUMBER, Box, Default).
 
 -spec pin_required(doc()) -> boolean().
--spec pin_required(doc(), Default) -> boolean() | Default.
 pin_required(Box) ->
     pin_required(Box, 'false').
+
+-spec pin_required(doc(), Default) -> boolean() | Default.
 pin_required(Box, Default) ->
     kz_json:is_true(?KEY_PIN_REQUIRED, Box, Default).
 
 -spec check_if_owner(doc()) -> boolean().
--spec check_if_owner(doc(), Default) -> boolean() | Default.
 check_if_owner(Box) ->
     check_if_owner(Box, 'false').
+
+-spec check_if_owner(doc(), Default) -> boolean() | Default.
 check_if_owner(Box, Default) ->
     kz_json:is_true(?KEY_CHECK_IF_OWNER, Box, Default).
 
 -spec is_setup(doc()) -> boolean().
--spec is_setup(doc(), Default) -> boolean() | Default.
 is_setup(Box) ->
     is_setup(Box, 'false').
+
+-spec is_setup(doc(), Default) -> boolean() | Default.
 is_setup(Box, Default) ->
     kz_json:is_true(?KEY_IS_SETUP, Box, Default).
 

--- a/core/kazoo_documents/src/kzd_webhook.erl
+++ b/core/kazoo_documents/src/kzd_webhook.erl
@@ -46,9 +46,10 @@
 -define(INCLUDE_INTERNAL, <<"include_internal_legs">>).
 
 -spec is_enabled(doc()) -> boolean().
--spec is_enabled(doc(), Default) -> boolean() | Default.
 is_enabled(Hook) ->
     is_enabled(Hook, 'true').
+
+-spec is_enabled(doc(), Default) -> boolean() | Default.
 is_enabled(Hook, Default) ->
     kz_json:is_true(?IS_ENABLED, Hook, Default).
 
@@ -60,9 +61,10 @@ enable(Hook) ->
                      ).
 
 -spec disable(doc()) -> doc().
--spec disable(doc(), kz_term:api_binary()) -> doc().
 disable(Hook) ->
     disable(Hook, 'undefined').
+
+-spec disable(doc(), kz_term:api_binary()) -> doc().
 disable(Hook, Reason) ->
     kz_json:set_values(
       props:filter_undefined(
@@ -73,9 +75,10 @@ disable(Hook, Reason) ->
      ).
 
 -spec disabled_message(doc()) -> kz_term:api_binary().
--spec disabled_message(doc(), Default) -> kz_term:ne_binary() | Default.
 disabled_message(Hook) ->
     disabled_message(Hook, 'undefined').
+
+-spec disabled_message(doc(), Default) -> kz_term:ne_binary() | Default.
 disabled_message(Hook, Default) ->
     kz_json:get_value(?DISABLED_MESSAGE, Hook, Default).
 
@@ -85,16 +88,17 @@ is_auto_disabled(Hook) ->
         andalso disabled_message(Hook) =/= 'undefined'.
 
 -spec type() -> kz_term:ne_binary().
--spec type(doc()) -> kz_term:api_binary().
 type() -> ?TYPE.
 
+-spec type(doc()) -> kz_term:api_binary().
 type(Hook) ->
     kz_doc:type(Hook).
 
 -spec name(doc()) -> kz_term:api_binary().
--spec name(doc(), Default) -> kz_term:ne_binary() | Default.
 name(Hook) ->
     name(Hook, 'undefined').
+
+-spec name(doc(), Default) -> kz_term:ne_binary() | Default.
 name(Hook, Default) ->
     kz_json:get_value(?NAME, Hook, Default).
 
@@ -103,9 +107,10 @@ set_name(Hook, Name) ->
     kz_json:set_value(?NAME, Name, Hook).
 
 -spec uri(doc()) -> kz_term:api_binary().
--spec uri(doc(), Default) -> kz_term:ne_binary() | Default.
 uri(Hook) ->
     uri(Hook, 'undefined').
+
+-spec uri(doc(), Default) -> kz_term:ne_binary() | Default.
 uri(Hook, Default) ->
     kz_json:get_value(?URI, Hook, Default).
 
@@ -114,9 +119,10 @@ set_uri(Hook, Uri) ->
     kz_json:set_value(?URI, Uri, Hook).
 
 -spec event(doc()) -> kz_term:api_binary().
--spec event(doc(), Default) -> kz_term:ne_binary() | Default.
 event(Hook) ->
     event(Hook, 'undefined').
+
+-spec event(doc(), Default) -> kz_term:ne_binary() | Default.
 event(Hook, Default) ->
     kz_json:get_value(?EVENT, Hook, Default).
 
@@ -127,9 +133,10 @@ set_event(Hook, Event) ->
 -type http_verb() :: 'get' | 'post'.
 
 -spec verb(doc()) -> http_verb().
--spec verb(doc(), Default) -> http_verb() | Default.
 verb(Hook) ->
     verb(Hook, 'get').
+
+-spec verb(doc(), Default) -> http_verb() | Default.
 verb(Hook, Default) ->
     case kz_json:get_value(?VERB, Hook) of
         'undefined' -> Default;
@@ -153,9 +160,10 @@ set_verb(Hook, Verb) when Verb =:= 'get'
 -type retry_range() :: 1..5.
 
 -spec retries(doc()) -> retry_range().
--spec retries(doc(), retry_range()) -> retry_range().
 retries(Hook) ->
     retries(Hook, 3).
+
+-spec retries(doc(), retry_range()) -> retry_range().
 retries(Hook, Default) ->
     constrain_retries(
       kz_json:get_integer_value(?RETRIES, Hook, Default)
@@ -171,9 +179,10 @@ set_retries(Hook, Retries) when is_integer(Retries) ->
     kz_json:set_value(?RETRIES, constrain_retries(Retries), Hook).
 
 -spec custom_data(doc()) -> kz_term:api_object().
--spec custom_data(doc(), Default) -> kz_json:object() | Default.
 custom_data(Hook) ->
     custom_data(Hook, 'undefined').
+
+-spec custom_data(doc(), Default) -> kz_json:object() | Default.
 custom_data(Hook, Default) ->
     kz_json:get_ne_json_value(?CUSTOM_DATA, Hook, Default).
 
@@ -182,9 +191,10 @@ set_custom_data(Hook, Custom) ->
     kz_json:set_value(?CUSTOM_DATA, Custom, Hook).
 
 -spec modifiers(doc()) -> kz_term:api_object().
--spec modifiers(doc(), Default) -> kz_json:object() | Default.
 modifiers(Hook) ->
     modifiers(Hook, 'undefined').
+
+-spec modifiers(doc(), Default) -> kz_json:object() | Default.
 modifiers(Hook, Default) ->
     kz_json:get_ne_json_value(?MODIFIERS, Hook, Default).
 

--- a/core/kazoo_endpoint/src/kz_attributes.erl
+++ b/core/kazoo_endpoint/src/kz_attributes.erl
@@ -51,10 +51,12 @@ temporal_rules(Call) ->
 %% @doc
 %% @end
 %%-----------------------------------------------------------------------------
+
 -spec groups(kapps_call:call()) -> kz_json:objects().
--spec groups(kapps_call:call(), kz_term:proplist()) -> kz_json:objects().
 groups(Call) ->
     groups(Call, []).
+
+-spec groups(kapps_call:call(), kz_term:proplist()) -> kz_json:objects().
 groups(Call, ViewOptions) ->
     AccountDb = kapps_call:account_db(Call),
     case kz_datamgr:get_results(AccountDb, <<"attributes/groups">>, ViewOptions) of
@@ -376,9 +378,8 @@ determine_callee_attribute(Call) ->
 %% @doc
 %% @end
 %%-----------------------------------------------------------------------------
--spec moh_attributes(kz_term:ne_binary(), kapps_call:call()) -> kz_term:api_binary().
--spec moh_attributes(kz_term:api_binary() | kz_json:object(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:api_binary().
 
+-spec moh_attributes(kz_term:ne_binary(), kapps_call:call()) -> kz_term:api_binary().
 moh_attributes(Attribute, Call) ->
     case kz_endpoint:get(Call) of
         {'error', _R} -> 'undefined';
@@ -387,6 +388,7 @@ moh_attributes(Attribute, Call) ->
             maybe_normalize_moh_attribute(Value, Attribute, Call)
     end.
 
+-spec moh_attributes(kz_term:api_binary() | kz_json:object(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:api_binary().
 moh_attributes('undefined', _, _) -> 'undefined';
 moh_attributes(EndpointId, Attribute, Call) when is_binary(EndpointId) ->
     case kz_endpoint:get(EndpointId, Call) of
@@ -414,9 +416,8 @@ maybe_normalize_moh_attribute(Value, Attribute, _) ->
 %% @doc
 %% @end
 %%-----------------------------------------------------------------------------
--spec owner_id(kapps_call:call()) -> kz_term:api_ne_binary().
--spec owner_id(kz_term:api_ne_binary(), kapps_call:call()) -> kz_term:api_ne_binary().
 
+-spec owner_id(kapps_call:call()) -> kz_term:api_ne_binary().
 owner_id(Call) ->
     case kz_endpoint:get(Call) of
         {'error', _} -> 'undefined';
@@ -429,6 +430,7 @@ owner_id(Call) ->
             end
     end.
 
+-spec owner_id(kz_term:api_ne_binary(), kapps_call:call()) -> kz_term:api_ne_binary().
 owner_id('undefined', _Call) -> 'undefined';
 owner_id(ObjectId, Call) ->
     AccountDb = kapps_call:account_db(Call),
@@ -506,9 +508,8 @@ maybe_fix_presence_id_realm(PresenceId, Endpoint, Call) ->
 %% @doc
 %% @end
 %%-----------------------------------------------------------------------------
--spec owned_by(kz_term:api_binary(), kapps_call:call()) -> kz_term:api_binaries().
--spec owned_by(kz_term:api_binary() | kz_term:api_binaries(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:api_binaries().
 
+-spec owned_by(kz_term:api_binary(), kapps_call:call()) -> kz_term:api_binaries().
 owned_by('undefined', _) -> [];
 owned_by(OwnerId, Call) ->
     AccountDb = kapps_call:account_db(Call),
@@ -522,6 +523,7 @@ owned_by(OwnerId, Call) ->
             []
     end.
 
+-spec owned_by(kz_term:api_binary() | kz_term:api_binaries(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:api_binaries().
 owned_by('undefined', _, _) -> [];
 owned_by([_|_]=OwnerIds, Type, Call) ->
     Keys = [[OwnerId, Type] || OwnerId <- OwnerIds],
@@ -529,9 +531,8 @@ owned_by([_|_]=OwnerIds, Type, Call) ->
 owned_by(OwnerId, Type, Call) ->
     owned_by_query([{'key', [OwnerId, Type]}], Call).
 
--spec owned_by_docs(kz_term:api_binary(), kapps_call:call()) -> kz_term:api_objects().
--spec owned_by_docs(kz_term:api_binary() | kz_term:api_binaries(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:api_objects().
 
+-spec owned_by_docs(kz_term:api_binary(), kapps_call:call()) -> kz_term:api_objects().
 owned_by_docs('undefined', _) -> [];
 owned_by_docs(OwnerId, Call) ->
     AccountDb = kapps_call:account_db(Call),
@@ -546,6 +547,7 @@ owned_by_docs(OwnerId, Call) ->
             []
     end.
 
+-spec owned_by_docs(kz_term:api_binary() | kz_term:api_binaries(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:api_objects().
 owned_by_docs('undefined', _, _) -> [];
 owned_by_docs([_|_]=OwnerIds, Type, Call) ->
     Keys = [[OwnerId, Type] || OwnerId <- OwnerIds],
@@ -554,9 +556,10 @@ owned_by_docs(OwnerId, Type, Call) ->
     owned_by_query([{'key', [OwnerId, Type]}, 'include_docs'], Call, <<"doc">>).
 
 -spec owned_by_query(list(), kapps_call:call()) -> kz_term:api_binaries().
--spec owned_by_query(list(), kapps_call:call(), kz_term:ne_binary()) -> kz_term:api_binaries().
 owned_by_query(ViewOptions, Call) ->
     owned_by_query(ViewOptions, Call, <<"value">>).
+
+-spec owned_by_query(list(), kapps_call:call(), kz_term:ne_binary()) -> kz_term:api_binaries().
 owned_by_query(ViewOptions, Call, ViewKey) ->
     AccountDb = kapps_call:account_db(Call),
     case kz_datamgr:get_results(AccountDb, <<"attributes/owned">>, ViewOptions) of

--- a/core/kazoo_endpoint/src/kz_formatters.erl
+++ b/core/kazoo_endpoint/src/kz_formatters.erl
@@ -102,10 +102,6 @@ maybe_apply_formatters_fold(JObj, JObjKeys, MetaKey, [_|_]=Formatters) ->
 
 -spec maybe_apply_formatters(kz_json:object(), kz_term:ne_binary(), kz_json:objects()) ->
                                     kz_json:object().
--spec maybe_apply_formatters(kz_json:object(), kz_term:ne_binary(), kz_json:json_term(), kz_json:objects()) ->
-                                    kz_json:object().
--spec maybe_apply_formatters(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects()) ->
-                                    kz_json:object().
 maybe_apply_formatters(JObj, <<"Request">> = RequestKey, Formatters) ->
     [RequestUser, RequestRealm] = binary:split(kz_json:get_value(<<"Request">>, JObj), <<"@">>),
     maybe_apply_formatters(JObj, RequestKey, RequestUser, RequestRealm, Formatters);
@@ -118,6 +114,8 @@ maybe_apply_formatters(JObj, <<"From">> = FromKey, Formatters) ->
 maybe_apply_formatters(JObj, <<_/binary>> = Key, Formatters) ->
     maybe_apply_formatters(JObj, Key, kz_json:get_value(Key, JObj), Formatters).
 
+-spec maybe_apply_formatters(kz_json:object(), kz_term:ne_binary(), kz_json:json_term(), kz_json:objects()) ->
+                                    kz_json:object().
 maybe_apply_formatters(JObj, _Key, _Value, []) -> JObj;
 maybe_apply_formatters(JObj, Key, Value, [_|_]=Formatters) ->
     Funs = [fun maybe_strip/4
@@ -210,6 +208,8 @@ maybe_match(JObj, Key, Value, Formatter) ->
         'nomatch' -> 'false'
     end.
 
+-spec maybe_apply_formatters(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects()) ->
+                                    kz_json:object().
 maybe_apply_formatters(JObj, _Key, _User, _Realm, []) -> JObj;
 maybe_apply_formatters(JObj, Key, User, Realm, Formatters) ->
     Funs = [fun maybe_strip/5
@@ -318,21 +318,21 @@ maybe_match(Regex, Value) ->
         'nomatch' -> 'nomatch'
     end.
 
--spec apply_formatter(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
-                             kz_json:object().
--spec apply_formatter(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
-                             kz_json:object().
 apply_formatter(Captured, Formatter) ->
     list_to_binary([kz_json:get_binary_value(<<"prefix">>, Formatter, <<>>)
                    ,Captured
                    ,kz_json:get_binary_value(<<"suffix">>, Formatter, <<>>)
                    ]).
 
+-spec apply_formatter(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
+                             kz_json:object().
 apply_formatter(JObj, Key, Captured, Formatter) ->
     Value = apply_formatter(Captured, Formatter),
     lager:debug("updating ~s to '~s'", [Key, Value]),
     kz_json:set_value(Key, Value, JObj).
 
+-spec apply_formatter(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
+                             kz_json:object().
 apply_formatter(JObj, Key, Captured, Realm, Formatter) ->
     User = apply_formatter(Captured, Formatter),
     lager:debug("updating ~s user to '~s'@~s", [Key, User, Realm]),

--- a/core/kazoo_globals/src/kz_global.erl
+++ b/core/kazoo_globals/src/kz_global.erl
@@ -89,10 +89,10 @@ new_global(Name, Pid, Zone, Queue, State, Timestamp) ->
               }.
 
 -spec update_with_pid_ref(global(), kz_term:pid_ref()) -> global().
--spec update_with_pid_ref(global(), pid(), reference()) -> global().
 update_with_pid_ref(Global, {Pid, Ref}) ->
     update_with_pid_ref(Global, Pid, Ref).
 
+-spec update_with_pid_ref(global(), pid(), reference()) -> global().
 update_with_pid_ref(Global, Pid, Ref)
   when is_pid(Pid)
        andalso is_reference(Ref)

--- a/core/kazoo_globals/src/kz_global_proxy.erl
+++ b/core/kazoo_globals/src/kz_global_proxy.erl
@@ -31,10 +31,10 @@ start_link(Global) ->
     gen_server:start_link(?MODULE, [Global], []).
 
 -spec stop(pid()) -> 'ok'.
--spec stop(pid(), any()) -> 'ok'.
 stop(Pid) ->
     stop(Pid, 'normal').
 
+-spec stop(pid(), any()) -> 'ok'.
 stop(Pid, Reason) ->
     gen_server:cast(Pid, {'$proxy_stop', Reason}).
 

--- a/core/kazoo_globals/src/kz_globals.erl
+++ b/core/kazoo_globals/src/kz_globals.erl
@@ -846,10 +846,10 @@ delete_by_node(Node) ->
     lager:info("deleted ~p proxies for expired node ~p", [length(_Res), Node]).
 
 -spec delete_global(kz_global:global(), term()) -> 'ok' | 'true'.
--spec delete_global(kz_global:global(), term(), atom()) -> 'ok' | 'true'.
 delete_global(Global, Reason) ->
     delete_global(Global, Reason, kz_global:node(Global)).
 
+-spec delete_global(kz_global:global(), term(), atom()) -> 'ok' | 'true'.
 delete_global(Global, Reason, Node) when Node =:= node() ->
     do_amqp_unregister(Global, Reason);
 delete_global(Global, _Reason, _Node) ->
@@ -857,26 +857,26 @@ delete_global(Global, _Reason, _Node) ->
     ets:delete(?TAB_NAME, kz_global:name(Global)).
 
 -spec remonitor_globals() -> 'ok'.
--spec remonitor_globals('$end_of_table' | {[kz_global:global()], ets:continuation()}) ->
-                               'ok'.
 remonitor_globals() ->
     remonitor_globals(
       ets:select(table_id(), [{'_', [], ['$_']}], 1)
      ).
 
+-spec remonitor_globals('$end_of_table' | {[kz_global:global()], ets:continuation()}) ->
+                               'ok'.
 remonitor_globals('$end_of_table') -> 'ok';
 remonitor_globals({[Global], Continuation}) ->
     remonitor_global(Global),
     remonitor_globals(ets:select(Continuation)).
 
 -spec remonitor_global(kz_global:global()) -> 'true'.
--spec remonitor_global(kz_global:global(), boolean(), boolean()) -> 'true'.
 remonitor_global(Global) ->
     remonitor_global(Global
                     ,erlang:is_process_alive(kz_global:pid(Global))
                     ,kz_global:is_local(Global)
                     ).
 
+-spec remonitor_global(kz_global:global(), boolean(), boolean()) -> 'true'.
 remonitor_global(Global, 'false', _IsLocal) ->
     lager:info("global ~p(~p) down, cleaning up"
               ,[kz_global:pid(Global), kz_global:name(Global)]

--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -906,23 +906,23 @@ from_json(JObj, State) ->
             ,roles=kz_json:to_proplist(kz_json:get_json_value(<<"Roles">>, JObj, kz_json:new()))
             }.
 
--spec kapps_from_json(kz_term:api_terms()) -> kz_types:kapps_info().
--spec whapp_from_json(binary(), kz_json:object()) -> {binary(), kz_types:whapp_info()}.
--spec whapp_info_from_json(kz_term:ne_binary(), kz_json:object()) -> kz_types:whapp_info().
--spec whapp_info_from_json(kz_term:ne_binary(), kz_types:whapp_info(), {kz_json:json_terms(), kz_json:keys()}) -> kz_types:whapp_info().
 
+-spec kapps_from_json(kz_term:api_terms()) -> kz_types:kapps_info().
 kapps_from_json(Whapps) when is_list(Whapps) ->
     [{Whapp, #whapp_info{}} || Whapp <- Whapps];
 kapps_from_json(JObj) ->
     Keys = kz_json:get_keys(JObj),
     [whapp_from_json(Key, JObj) || Key <- Keys].
 
+-spec whapp_from_json(binary(), kz_json:object()) -> {binary(), kz_types:whapp_info()}.
 whapp_from_json(Key, JObj) ->
     {Key, whapp_info_from_json(Key, kz_json:get_value(Key, JObj))}.
 
+-spec whapp_info_from_json(kz_term:ne_binary(), kz_json:object()) -> kz_types:whapp_info().
 whapp_info_from_json(Key, JObj) ->
     whapp_info_from_json(Key, #whapp_info{}, kz_json:get_values(JObj)).
 
+-spec whapp_info_from_json(kz_term:ne_binary(), kz_types:whapp_info(), {kz_json:json_terms(), kz_json:keys()}) -> kz_types:whapp_info().
 whapp_info_from_json(_Key, Info, {[], []}) -> Info;
 whapp_info_from_json(Key, Info, {[V | V1], [<<"Roles">> | K1]}) ->
     whapp_info_from_json(Key, Info#whapp_info{roles=V}, {V1, K1});
@@ -933,17 +933,17 @@ whapp_info_from_json(Key, Info, {[V | V1], [<<"Startup">> | K1]}) ->
 whapp_info_from_json(Key, Info, {[_V | V1], [_K | K1]}) ->
     whapp_info_from_json(Key, Info, {V1, K1}).
 
--spec kapps_to_json(kz_types:kapps_info()) -> kz_json:object().
--spec whapp_to_json({kz_term:ne_binary(), kz_types:whapp_info()}) -> {kz_term:ne_binary(), kz_json:object()}.
--spec whapp_info_to_json(kz_types:whapp_info()) -> kz_json:object().
 
+-spec kapps_to_json(kz_types:kapps_info()) -> kz_json:object().
 kapps_to_json(Whapps) ->
     List = [whapp_to_json(Whapp) || Whapp <- Whapps],
     kz_json:from_list(List).
 
+-spec whapp_to_json({kz_term:ne_binary(), kz_types:whapp_info()}) -> {kz_term:ne_binary(), kz_json:object()}.
 whapp_to_json({K, Info}) ->
     {K, whapp_info_to_json(Info)}.
 
+-spec whapp_info_to_json(kz_types:whapp_info()) -> kz_json:object().
 whapp_info_to_json(#whapp_info{startup=Start, roles=Roles}) ->
     kz_json:from_list(
       [{<<"Startup">>, Start}
@@ -1091,11 +1091,11 @@ pool_states() ->
     lists:keysort(1, [pool_state(Pool) || {Pool, _Pid} <- kz_amqp_sup:pools()]).
 
 -spec pool_state(atom()) -> {kz_term:ne_binary(), kz_term:ne_binary()}.
--spec pool_state(atom(), atom(), integer(), integer(), integer()) -> {kz_term:ne_binary(), kz_term:ne_binary()}.
 pool_state(Name) ->
     {PoolState, Workers, OverFlow, Monitors} = poolboy:status(Name),
     pool_state(Name, PoolState, Workers, OverFlow, Monitors).
 
+-spec pool_state(atom(), atom(), integer(), integer(), integer()) -> {kz_term:ne_binary(), kz_term:ne_binary()}.
 pool_state(Name, State, Workers, Overflow, Monitors) ->
     {kz_term:to_binary(Name)
     ,iolist_to_binary(

--- a/core/kazoo_globals/src/kz_nodes_bindings.erl
+++ b/core/kazoo_globals/src/kz_nodes_bindings.erl
@@ -15,14 +15,14 @@
 -type bind_result() :: kazoo_bindings:bind_result().
 
 -spec bind(atom()) -> bind_result().
--spec bind(atom(), atom()) -> bind_result().
--spec bind(atom(), atom(), atom()) -> bind_result().
 bind(App) ->
     bind(App, App).
 
+-spec bind(atom(), atom()) -> bind_result().
 bind(App, Module) ->
     bind(App, Module, ?DEFAULT_FUNCTION).
 
+-spec bind(atom(), atom(), atom()) -> bind_result().
 bind(App, Module, Function)
   when is_atom(App)
        andalso is_atom(Module)
@@ -37,14 +37,14 @@ bind(App, Module, Function)
     end.
 
 -spec unbind(atom()) -> kazoo_bindings:unbind_result().
--spec unbind(atom(), atom()) -> kazoo_bindings:unbind_result().
--spec unbind(atom(), atom(), atom()) -> kazoo_bindings:unbind_result().
 unbind(App) ->
     unbind(App, App).
 
+-spec unbind(atom(), atom()) -> kazoo_bindings:unbind_result().
 unbind(App, Module) ->
     unbind(App, Module, ?DEFAULT_FUNCTION).
 
+-spec unbind(atom(), atom(), atom()) -> kazoo_bindings:unbind_result().
 unbind(App, Module, Function)
   when is_atom(App)
        andalso is_atom(Module)

--- a/core/kazoo_ips/src/kz_ips.erl
+++ b/core/kazoo_ips/src/kz_ips.erl
@@ -24,14 +24,14 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec available() -> {'ok', kz_json:objects()} |
                      {'error', any()}.
+available() -> available('undefined').
+
 -spec available(kz_term:api_binary()) ->
                        {'ok', kz_json:objects()} |
                        {'error', any()}.
-
-available() -> available('undefined').
-
 available(Zone) -> available(Zone, 1).
 
 -spec available(kz_term:api_binary(), non_neg_integer()) ->

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -28,13 +28,14 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get(kz_term:ne_binary()) -> {'ok', kz_json:object()} |
                                   {'error', atom()}.
--spec get(kz_term:ne_binary(), kz_time:api_seconds(), kz_time:api_seconds()) -> {'ok', kz_json:object()} |
-                                                                                {'error', atom()}.
 get(Account) ->
     get(Account, undefined, undefined).
 
+-spec get(kz_term:ne_binary(), kz_time:api_seconds(), kz_time:api_seconds()) -> {'ok', kz_json:object()} |
+                                                                                {'error', atom()}.
 get(Account, undefined, undefined) ->
     case kazoo_modb:get_results(Account, ?TOTAL_BY_SERVICE_LEGACY, [group]) of
         {'error', _R}=Error -> Error;

--- a/core/kazoo_maintenance/src/kapps_config_maint_listener.erl
+++ b/core/kazoo_maintenance/src/kapps_config_maint_listener.erl
@@ -254,8 +254,8 @@ remove_system_media_ref(Key, Value, Acc) -> kz_json:set_value(Key, Value, Acc).
 %% default_timezone
 %% @end
 %%--------------------------------------------------------------------
+
 -spec accounts_config_deprecate_timezone_for_default_timezone() -> 'ok'.
--spec accounts_config_deprecate_timezone_for_default_timezone(kz_json:object()) -> 'ok'.
 accounts_config_deprecate_timezone_for_default_timezone() ->
     case kz_datamgr:open_cache_doc(?KZ_CONFIG_DB, <<"accounts">>) of
         {'ok', AccountsConfig} ->
@@ -264,6 +264,7 @@ accounts_config_deprecate_timezone_for_default_timezone() ->
             lager:warning("unable to fetch system_config/accounts: ~p", [E])
     end.
 
+-spec accounts_config_deprecate_timezone_for_default_timezone(kz_json:object()) -> 'ok'.
 accounts_config_deprecate_timezone_for_default_timezone(AccountsConfig) ->
     PublicFields = kz_doc:public_fields(AccountsConfig),
     case kz_json:get_keys(PublicFields) of
@@ -281,13 +282,13 @@ deprecate_timezone_for_default_timezone(Nodes, AccountsConfig) ->
 
 -spec deprecate_timezone_for_node(kz_json:key(), kz_json:object()) ->
                                          kz_json:object().
--spec deprecate_timezone_for_node(kz_json:key(), kz_json:object(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
-                                         kz_json:object().
 deprecate_timezone_for_node(Node, AccountsConfig) ->
     Timezone = kz_json:get_value([Node, <<"timezone">>], AccountsConfig),
     DefaultTimezone = kz_json:get_value([Node, <<"default_timezone">>], AccountsConfig),
     deprecate_timezone_for_node(Node, AccountsConfig, Timezone, DefaultTimezone).
 
+-spec deprecate_timezone_for_node(kz_json:key(), kz_json:object(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
+                                         kz_json:object().
 deprecate_timezone_for_node(_Node, AccountsConfig, 'undefined', _Default) ->
     AccountsConfig;
 deprecate_timezone_for_node(Node, AccountsConfig, Timezone, 'undefined') ->

--- a/core/kazoo_media/src/kazoo_media_maintenance.erl
+++ b/core/kazoo_media/src/kazoo_media_maintenance.erl
@@ -55,10 +55,10 @@ set_account_language(Account, Language) ->
     end.
 
 -spec import_prompts(file:filename_all()) -> 'ok'.
--spec import_prompts(file:filename_all(), kz_term:text()) -> 'ok'.
 import_prompts(DirPath) ->
     import_prompts(DirPath, kz_media_util:default_prompt_language()).
 
+-spec import_prompts(file:filename_all(), kz_term:text()) -> 'ok'.
 import_prompts(DirPath, Lang) ->
     case filelib:is_dir(DirPath) of
         'false' ->
@@ -91,13 +91,12 @@ import_prompts_from_files(Files, Lang) ->
         (Err = (catch import_prompt(File, Lang))) =/= 'ok'
     ].
 
--spec import_prompt(file:filename_all()) -> 'ok' | {'error', any()}.
--spec import_prompt(file:filename_all(), kz_term:text()) -> 'ok' | {'error', any()}.
--spec import_prompt(file:filename_all(), kz_term:text(), kz_term:ne_binary()) -> 'ok' | {'error', any()}.
 
+-spec import_prompt(file:filename_all()) -> 'ok' | {'error', any()}.
 import_prompt(Path) ->
     import_prompt(Path, kz_media_util:default_prompt_language()).
 
+-spec import_prompt(file:filename_all(), kz_term:text()) -> 'ok' | {'error', any()}.
 import_prompt(Path, Lang) ->
     kz_datamgr:db_create(?KZ_MEDIA_DB),
     timer:sleep(250),
@@ -110,6 +109,7 @@ import_prompt(Path, Lang) ->
             Error
     end.
 
+-spec import_prompt(file:filename_all(), kz_term:text(), kz_term:ne_binary()) -> 'ok' | {'error', any()}.
 import_prompt(Path0, Lang0, Contents) ->
     Lang = kz_term:to_binary(Lang0),
     Path = kz_term:to_binary(Path0),
@@ -188,12 +188,12 @@ media_description(PromptName, Lang) ->
 -spec upload_prompt(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
                            'ok' |
                            {'error', any()}.
--spec upload_prompt(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), non_neg_integer()) ->
-                           'ok' |
-                           {'error', any()}.
 upload_prompt(ID, AttachmentName, Contents, Options) ->
     upload_prompt(ID, AttachmentName, Contents, Options, 3).
 
+-spec upload_prompt(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), non_neg_integer()) ->
+                           'ok' |
+                           {'error', any()}.
 upload_prompt(_ID, _AttachmentName, _Contents, _Options, 0) ->
     io:format("  retries exceeded for uploading ~s to ~s~n", [_AttachmentName, _ID]),
     {'error', 'retries_exceeded'};
@@ -254,10 +254,10 @@ refresh() ->
     'ok'.
 
 -spec maybe_migrate_system_config(kz_term:ne_binary()) -> 'ok'.
--spec maybe_migrate_system_config(kz_term:ne_binary(), boolean()) -> 'ok'.
 maybe_migrate_system_config(ConfigId) ->
     maybe_migrate_system_config(ConfigId, 'false').
 
+-spec maybe_migrate_system_config(kz_term:ne_binary(), boolean()) -> 'ok'.
 maybe_migrate_system_config(ConfigId, DeleteAfter) ->
     case kz_datamgr:open_doc(?KZ_CONFIG_DB, ConfigId) of
         {'error', 'not_found'} -> 'ok';

--- a/core/kazoo_media/src/kz_media_file.erl
+++ b/core/kazoo_media/src/kz_media_file.erl
@@ -160,9 +160,6 @@ find_attachment([Db, Id, Attachment, Options]) ->
 -spec maybe_find_attachment(kz_term:ne_binary(), kz_term:ne_binary()) ->
                                    {'ok', {kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()}} |
                                    {'error', 'not_found' | 'no_data'}.
--spec maybe_find_attachment(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
-                                   {'ok', {kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()}} |
-                                   {'error', 'not_found' | 'no_data'}.
 maybe_find_attachment(?MEDIA_DB = Db, Id) ->
     maybe_find_attachment_in_db(Db, Id);
 maybe_find_attachment(Db, Id) ->
@@ -181,6 +178,9 @@ maybe_find_attachment_in_db(Db, Id) ->
             maybe_find_attachment(Db, Id, JObj)
     end.
 
+-spec maybe_find_attachment(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
+                                   {'ok', {kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()}} |
+                                   {'error', 'not_found' | 'no_data'}.
 maybe_find_attachment(Db, Id, JObj) ->
     lager:debug("trying to find first attachment on doc ~s in db ~s", [Id, Db]),
     case kz_doc:attachment_names(JObj) of

--- a/core/kazoo_media/src/kz_media_map.erl
+++ b/core/kazoo_media/src/kz_media_map.erl
@@ -302,16 +302,16 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
 -spec init_map() -> 'ok'.
--spec init_map(kz_term:ne_binary()) -> 'ok'.
--spec init_map(kz_term:ne_binary(), kz_term:ne_binary(), binary(), pos_integer(), fun()) -> 'ok'.
--spec init_map(kz_term:ne_binary(), kz_term:ne_binary(), binary(), pos_integer(), fun(), kz_json:objects()) -> 'ok'.
 init_map() ->
     init_map(?KZ_MEDIA_DB).
 
+-spec init_map(kz_term:ne_binary()) -> 'ok'.
 init_map(Db) ->
     init_map(Db, <<"media/crossbar_listing">>, <<>>, 50, fun gen_listener:cast/2).
 
+-spec init_map(kz_term:ne_binary(), kz_term:ne_binary(), binary(), pos_integer(), fun()) -> 'ok'.
 init_map(Db, View, StartKey, Limit, SendFun) ->
     Options = [{'startkey', StartKey}
               ,{'limit', Limit+1}
@@ -323,6 +323,7 @@ init_map(Db, View, StartKey, Limit, SendFun) ->
         {'error', _E} -> lager:debug("error loading ~s in ~s: ~p", [View, Db, _E])
     end.
 
+-spec init_map(kz_term:ne_binary(), kz_term:ne_binary(), binary(), pos_integer(), fun(), kz_json:objects()) -> 'ok'.
 init_map(Db, View, _StartKey, Limit, SendFun, ViewResults) ->
     try lists:split(Limit, ViewResults) of
         {Results, []} ->
@@ -340,10 +341,10 @@ init_map(Db, View, _StartKey, Limit, SendFun, ViewResults) ->
     end.
 
 -spec add_mapping(kz_term:ne_binary(), fun(), kz_json:objects()) -> 'ok'.
--spec add_mapping(kz_term:ne_binary(), fun(), kz_json:objects(), pid()) -> 'ok'.
 add_mapping(Db, SendFun, JObjs) ->
     add_mapping(Db, SendFun, JObjs, whereis(?MODULE)).
 
+-spec add_mapping(kz_term:ne_binary(), fun(), kz_json:objects(), pid()) -> 'ok'.
 add_mapping(Db, _SendFun, JObjs, Srv) when Srv =:= self() ->
     AccountId = kz_util:format_account_id(Db, 'raw'),
     _ = [maybe_add_prompt(AccountId, kz_json:get_value(<<"doc">>, JObj))
@@ -356,7 +357,6 @@ add_mapping(Db, SendFun, JObjs, Srv) ->
     'ok'.
 
 -spec maybe_add_prompt(kz_term:ne_binary(), kz_json:object()) -> 'ok'.
--spec maybe_add_prompt(kz_term:ne_binary(), kz_json:object(), kz_term:api_binary()) -> 'ok'.
 maybe_add_prompt(AccountId, JObj) ->
     maybe_add_prompt(AccountId
                     ,JObj
@@ -367,6 +367,7 @@ maybe_add_prompt(AccountId, JObj) ->
                                               )
                     ).
 
+-spec maybe_add_prompt(kz_term:ne_binary(), kz_json:object(), kz_term:api_binary()) -> 'ok'.
 maybe_add_prompt(?KZ_MEDIA_DB, JObj, 'undefined') ->
     Id = kz_doc:id(JObj),
     MapId = mapping_id(?KZ_MEDIA_DB, Id),
@@ -403,19 +404,20 @@ maybe_add_prompt(AccountId, JObj, PromptId) ->
     insert_map(UpdatedMap).
 
 -spec insert_map(media_map()) -> 'ok' | 'true'.
--spec insert_map(media_map(), pid()) -> 'ok' | 'true'.
 insert_map(Map) ->
     insert_map(Map, whereis(?MODULE)).
+
+-spec insert_map(media_map(), pid()) -> 'ok' | 'true'.
 insert_map(Map, Srv) when Srv =:= self() ->
     ets:insert(table_id(), Map);
 insert_map(Map, Srv) ->
     gen_listener:call(Srv, {'insert_map', Map}).
 
 -spec get_map(kz_term:ne_binary()) -> media_map().
--spec get_map(kz_term:ne_binary(), kz_term:ne_binary()) -> media_map().
 get_map(PromptId) ->
     get_map(?KZ_MEDIA_DB, PromptId).
 
+-spec get_map(kz_term:ne_binary(), kz_term:ne_binary()) -> media_map().
 get_map(?KZ_MEDIA_DB = Db, PromptId) ->
     MapId = mapping_id(Db, PromptId),
     case ets:lookup(table_id(), MapId) of
@@ -448,10 +450,10 @@ init_account_map(AccountId, PromptId) ->
     new_map(AccountMap).
 
 -spec new_map(media_map()) -> 'true'.
--spec new_map(media_map(), pid()) -> 'true'.
 new_map(Map) ->
     new_map(Map, whereis(?MODULE)).
 
+-spec new_map(media_map(), pid()) -> 'true'.
 new_map(Map, Srv) when Srv =:= self() ->
     ets:insert_new(table_id(), Map);
 new_map(Map, Srv) ->
@@ -481,15 +483,15 @@ load_account_map(AccountId, PromptId) ->
     get_map(AccountId, PromptId).
 
 -spec default_language_keys(kz_term:ne_binary()) -> kz_term:ne_binaries().
--spec language_keys(kz_term:ne_binary()) -> kz_term:ne_binaries().
--spec language_keys(kz_term:ne_binary(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 default_language_keys(Language) ->
     DefaultLanguage = kz_media_util:default_prompt_language(),
     language_keys(Language) ++ [DefaultLanguage].
 
+-spec language_keys(kz_term:ne_binary()) -> kz_term:ne_binaries().
 language_keys(Language) ->
     language_keys(Language, []).
 
+-spec language_keys(kz_term:ne_binary(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 language_keys(<<Primary:2/binary>>, Acc) ->
     lists:reverse([Primary | Acc]);
 language_keys(<<Primary:2/binary, "-", _Secondary:2/binary>> = Lang, Acc) ->

--- a/core/kazoo_media/src/kz_media_url.erl
+++ b/core/kazoo_media/src/kz_media_url.erl
@@ -18,14 +18,14 @@
 -type build_media_url() :: kz_term:api_binary() | kz_term:binaries() | kz_json:object().
 -type build_media_url_ret() :: kz_term:ne_binary() | {'error', atom()}.
 
--spec playback(build_media_url()) -> build_media_url_ret().
--spec playback(build_media_url(), kz_json:object()) -> build_media_url_ret().
 
+-spec playback(build_media_url()) -> build_media_url_ret().
 playback('undefined') ->
     {'error', 'invalid_media_name'};
 playback(Arg) ->
     playback(Arg, kz_json:new()).
 
+-spec playback(build_media_url(), kz_json:object()) -> build_media_url_ret().
 playback('undefined', _) ->
     {'error', 'invalid_media_name'};
 playback(<<"tts://", Id/binary>>, Options) ->
@@ -56,17 +56,17 @@ playback(Doc, JObj) ->
 
 -spec store(kz_json:object(), kz_term:ne_binary()) ->
                    build_media_url_ret().
--spec store(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary()) ->
-                   build_media_url_ret().
--spec store(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary(), kz_term:proplist()) ->
-                   build_media_url_ret().
 store(JObj, AName) ->
     Media = kz_media_util:store_path_from_doc(JObj, AName),
     kz_media_file:get_uri(Media, ?STREAM_TYPE_STORE).
 
+-spec store(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary()) ->
+                   build_media_url_ret().
 store(Db, Id, Attachment) ->
     store(Db, Id, Attachment, []).
 
+-spec store(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary(), kz_term:proplist()) ->
+                   build_media_url_ret().
 store(Db, {Type, Id}, Attachment, Options) ->
     store(Db, Id, Attachment, [{'doc_type', Type} | Options]);
 store(Db, ?NE_BINARY = Id, Attachment, Options) ->

--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -72,13 +72,13 @@
 
 -spec normalize_media(kz_term:ne_binary(), kz_term:ne_binary(), binary()) ->
                              normalized_media().
--spec normalize_media(kz_term:ne_binary(), kz_term:ne_binary(), binary(), normalization_options()) ->
-                             normalized_media().
 normalize_media(FromFormat, FromFormat, FileContents) ->
     {'ok', FileContents};
 normalize_media(FromFormat, ToFormat, FileContents) ->
     normalize_media(FromFormat, ToFormat, FileContents, default_normalization_options(ToFormat)).
 
+-spec normalize_media(kz_term:ne_binary(), kz_term:ne_binary(), binary(), normalization_options()) ->
+                             normalized_media().
 normalize_media(FromFormat, ToFormat, FileContents, Options) ->
     FileName = tmp_file(FromFormat),
     case file:write_file(FileName, FileContents) of
@@ -382,10 +382,10 @@ max_recording_time_limit() ->
 %%     base_url(Host, Port).
 
 -spec base_url(kz_term:text(), kz_term:text()) -> kz_term:ne_binary().
--spec base_url(kz_term:text(), kz_term:text(), atom()) -> kz_term:ne_binary().
 base_url(Host, Port) ->
     base_url(Host, Port, 'proxy_playback').
 
+-spec base_url(kz_term:text(), kz_term:text(), atom()) -> kz_term:ne_binary().
 base_url(Host, Port, 'proxy_playback') ->
     case ?AUTH_PLAYBACK of
         'false' -> build_url(Host, Port, [], []);
@@ -418,9 +418,9 @@ convert_stream_type(<<"store">>) -> <<"store">>;
 convert_stream_type(_) -> <<"single">>.
 
 -spec media_path(kz_term:api_binary()) -> kz_term:api_binary().
--spec media_path(kz_term:api_binary(), kz_term:api_ne_binary()) -> kz_term:api_binary().
 media_path(Path) -> media_path(Path, 'undefined').
 
+-spec media_path(kz_term:api_binary(), kz_term:api_ne_binary()) -> kz_term:api_binary().
 media_path('undefined', _AccountId) -> 'undefined';
 media_path(<<>>, _AccountId) -> 'undefined';
 media_path(<<"/system_media", _/binary>> = Path, _AccountId) -> Path;
@@ -440,11 +440,12 @@ media_path(Path, AccountId) when is_binary(AccountId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec prompt_path(kz_term:ne_binary()) -> kz_term:ne_binary().
--spec prompt_path(kz_term:api_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 prompt_path(PromptId) ->
     prompt_path(?KZ_MEDIA_DB, PromptId).
 
+-spec prompt_path(kz_term:api_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 prompt_path('undefined', PromptId) ->
     prompt_path(?KZ_MEDIA_DB, PromptId);
 prompt_path(Db, <<"/system_media/", PromptId/binary>>) ->
@@ -453,9 +454,9 @@ prompt_path(Db, PromptId) ->
     kz_binary:join([<<>>, Db, PromptId], <<"/">>).
 
 -spec prompt_id(kz_term:ne_binary()) -> kz_term:ne_binary().
--spec prompt_id(kz_term:ne_binary(), kz_term:api_binary()) -> kz_term:ne_binary().
 prompt_id(PromptId) -> prompt_id(PromptId, 'undefined').
 
+-spec prompt_id(kz_term:ne_binary(), kz_term:api_binary()) -> kz_term:ne_binary().
 prompt_id(<<"/system_media/", PromptId/binary>>, Lang) ->
     prompt_id(PromptId, Lang);
 prompt_id(PromptId, 'undefined') -> PromptId;
@@ -463,23 +464,21 @@ prompt_id(PromptId, <<>>) -> PromptId;
 prompt_id(PromptId, Lang) ->
     filename:join([Lang, PromptId]).
 
+
 -spec get_prompt(kz_term:ne_binary()) ->
                         kz_term:api_ne_binary().
--spec get_prompt(kz_term:ne_binary(), kz_term:api_ne_binary()) ->
-                        kz_term:api_ne_binary().
--spec get_prompt(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
-                        kz_term:api_ne_binary().
--spec get_prompt(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), boolean()) ->
-                        kz_term:api_ne_binary().
-
 get_prompt(Name) ->
     get_prompt(Name, 'undefined').
 
+-spec get_prompt(kz_term:ne_binary(), kz_term:api_ne_binary()) ->
+                        kz_term:api_ne_binary().
 get_prompt(Name, 'undefined') ->
     get_prompt(Name, default_prompt_language(), 'undefined');
 get_prompt(Name, <<_/binary>> = Lang) ->
     get_prompt(Name, Lang, 'undefined').
 
+-spec get_prompt(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
+                        kz_term:api_ne_binary().
 get_prompt(<<"prompt://", _/binary>> = PromptId, _Lang, _AccountId) ->
     lager:debug("prompt is already encoded: ~s", [PromptId]),
     PromptId;
@@ -490,6 +489,8 @@ get_prompt(PromptId, Lang, 'undefined') ->
 get_prompt(PromptId, Lang, <<_/binary>> = AccountId) ->
     get_prompt(PromptId, Lang, AccountId, ?USE_ACCOUNT_OVERRIDES).
 
+-spec get_prompt(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), boolean()) ->
+                        kz_term:api_ne_binary().
 get_prompt(<<"prompt://", _/binary>> = PromptId, _Lang, _AccountId, _UseOverride) ->
     lager:debug("prompt is already encoded: ~s", [PromptId]),
     PromptId;
@@ -500,11 +501,10 @@ get_prompt(PromptId, Lang, _AccountId, 'false') ->
     lager:debug("account overrides not enabled; ignoring account prompt for ~s", [PromptId]),
     kz_binary:join([<<"prompt:/">>, ?KZ_MEDIA_DB, PromptId, Lang], <<"/">>).
 
+%% tries account default, then system
+
 -spec get_account_prompt(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:ne_binary()) ->
                                 kz_term:api_ne_binary().
--spec get_account_prompt(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                kz_term:api_ne_binary().
-%% tries account default, then system
 get_account_prompt(Name, 'undefined', AccountId) ->
     PromptId = prompt_id(Name),
     lager:debug("getting account prompt for '~s'", [PromptId]),
@@ -546,6 +546,8 @@ get_account_prompt(Name, Lang, AccountId) ->
         {'ok', _} -> prompt_path(AccountId, PromptId)
     end.
 
+-spec get_account_prompt(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                                kz_term:api_ne_binary().
 get_account_prompt(Name, 'undefined', AccountId, OriginalLang) ->
     PromptId = prompt_id(Name),
     lager:debug("getting account prompt for '~s'", [PromptId]),
@@ -640,9 +642,10 @@ get_system_prompt(Name, Lang) ->
     end.
 
 -spec default_prompt_language() -> kz_term:ne_binary().
--spec default_prompt_language(kz_term:api_binary()) -> kz_term:ne_binary().
 default_prompt_language() ->
     default_prompt_language(<<"en-us">>).
+
+-spec default_prompt_language(kz_term:api_binary()) -> kz_term:ne_binary().
 default_prompt_language(Default) ->
     kz_term:to_lower_binary(
       kapps_config:get_ne_binary(?CONFIG_CAT, ?PROMPT_LANGUAGE_KEY, Default)

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -47,13 +47,13 @@
 -spec get_results(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
                          {'ok', kz_json:objects()} |
                          {'error', atom()}.
--spec get_results(kz_term:ne_binary(), kz_term:ne_binary(), view_options(), atom(), non_neg_integer()) ->
-                         {'ok', kz_json:objects()} |
-                         {'error', atom()}.
 get_results(Account, View, ViewOptions) ->
     MaxRetries = props:get_integer_value('max_retries', ViewOptions, ?MAX_RETRIES),
     get_results(Account, View, ViewOptions, 'first_try', MaxRetries).
 
+-spec get_results(kz_term:ne_binary(), kz_term:ne_binary(), view_options(), atom(), non_neg_integer()) ->
+                         {'ok', kz_json:objects()} |
+                         {'error', atom()}.
 get_results(_Account, _View, _ViewOptions, Reason, Retry) when Retry =< 0 ->
     lager:debug("max retries to get view ~s/~s results: ~p", [_Account, _View, Reason]),
     {'error', Reason};
@@ -109,13 +109,8 @@ get_results_missing_db(Account, View, ViewOptions, Retry) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec open_doc(kz_term:ne_binary(), kazoo_data:docid()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
--spec open_doc(kz_term:ne_binary(), kazoo_data:docid(), integer() | view_options()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
--spec open_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) ->
                       {'ok', kz_json:object()} |
                       {'error', atom()}.
 open_doc(Account, {_, ?MATCH_MODB_PREFIX(Year,Month,_)} = DocId) ->
@@ -128,6 +123,9 @@ open_doc(Account, DocId) ->
     AccountMODb = get_modb(Account),
     couch_open(AccountMODb, DocId).
 
+-spec open_doc(kz_term:ne_binary(), kazoo_data:docid(), integer() | view_options()) ->
+                      {'ok', kz_json:object()} |
+                      {'error', atom()}.
 open_doc(Account, DocId, Options)
   when is_list(Options) ->
     AccountMODb = get_modb(Account, Options),
@@ -137,6 +135,9 @@ open_doc(Account, DocId, Timestamp)
     AccountMODb = get_modb(Account, Timestamp),
     couch_open(AccountMODb, DocId).
 
+-spec open_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) ->
+                      {'ok', kz_json:object()} |
+                      {'error', atom()}.
 open_doc(Account, DocId, Year, Month) ->
     AccountMODb = get_modb(Account, Year, Month),
     couch_open(AccountMODb, DocId).
@@ -163,18 +164,16 @@ couch_open(AccountMODb, DocId, Options) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save_doc(kz_term:ne_binary(), kz_json:object()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
--spec save_doc(kz_term:ne_binary(), kz_json:object(), kz_time:now() | kz_time:gregorian_seconds() | kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
--spec save_doc(kz_term:ne_binary(), kz_json:object(), kz_time:year() | kz_term:ne_binary() | kz_time:now(), kz_time:month() | kz_term:ne_binary() | kz_term:proplist()) ->
                       {'ok', kz_json:object()} |
                       {'error', atom()}.
 save_doc(Account, Doc) ->
     save_doc(Account, Doc, []).
 
+-spec save_doc(kz_term:ne_binary(), kz_json:object(), kz_time:now() | kz_time:gregorian_seconds() | kz_term:proplist()) ->
+                      {'ok', kz_json:object()} |
+                      {'error', atom()}.
 save_doc(Account, Doc, Options) when is_list(Options) ->
     AccountMODb = get_modb(Account),
     MaxRetries = props:get_integer_value('max_retries', Options, ?MAX_RETRIES),
@@ -182,6 +181,9 @@ save_doc(Account, Doc, Options) when is_list(Options) ->
 save_doc(Account, Doc, Timestamp) ->
     save_doc(Account, Doc, Timestamp, []).
 
+-spec save_doc(kz_term:ne_binary(), kz_json:object(), kz_time:year() | kz_term:ne_binary() | kz_time:now(), kz_time:month() | kz_term:ne_binary() | kz_term:proplist()) ->
+                      {'ok', kz_json:object()} |
+                      {'error', atom()}.
 save_doc(Account, Doc, Timestamp, Options) when is_list(Options) ->
     AccountMODb = get_modb(Account, Timestamp),
     MaxRetries = props:get_integer_value('max_retries', Options, ?MAX_RETRIES),
@@ -357,11 +359,8 @@ maybe_create_destination_db(FromDb, FromId, ToDb, Options) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_modb(kz_term:ne_binary()) -> kz_term:ne_binary().
--spec get_modb(kz_term:ne_binary(), view_options() | kz_time:gregorian_seconds() | kz_time:now()) ->
-                      kz_term:ne_binary().
--spec get_modb(kz_term:ne_binary(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) ->
-                      kz_term:ne_binary().
 get_modb(?MATCH_MODB_SUFFIX_RAW(_,_,_) = AccountMODb) ->
     AccountMODb;
 get_modb(?MATCH_MODB_SUFFIX_ENCODED(_,_,_) = AccountMODb) ->
@@ -373,6 +372,8 @@ get_modb(Account) ->
     {Year, Month, _} = erlang:date(),
     get_modb(AccountDb, Year, Month).
 
+-spec get_modb(kz_term:ne_binary(), view_options() | kz_time:gregorian_seconds() | kz_time:now()) ->
+                      kz_term:ne_binary().
 get_modb(Account, ViewOptions) when is_list(ViewOptions) ->
     AccountDb = kz_util:format_account_db(Account),
     case {props:get_value('month', ViewOptions)
@@ -390,6 +391,8 @@ get_modb(Account, ViewOptions) when is_list(ViewOptions) ->
 get_modb(Account, Timestamp) ->
     kz_util:format_account_mod_id(Account, Timestamp).
 
+-spec get_modb(kz_term:ne_binary(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) ->
+                      kz_term:ne_binary().
 get_modb(?MATCH_MODB_SUFFIX_RAW(_,_,_) = AccountMODb, _Year, _Month) ->
     AccountMODb;
 get_modb(?MATCH_MODB_SUFFIX_ENCODED(_,_,_) = AccountMODb, _Year, _Month) ->
@@ -570,13 +573,14 @@ delete_if_orphaned(AccountMODb, 'true') ->
 
 
 %% @public
+
 -spec get_range(kz_term:ne_binary(), kz_time:gregorian_seconds(), kz_time:gregorian_seconds()) ->
-                       kz_term:ne_binaries().
--spec get_range(kz_term:ne_binary(), kz_term:ne_binary(), kz_time:gregorian_seconds(), kz_time:gregorian_seconds()) ->
                        kz_term:ne_binaries().
 get_range(AccountId, From, To) ->
     get_range(<<"any">>, AccountId, From, To).
 
+-spec get_range(kz_term:ne_binary(), kz_term:ne_binary(), kz_time:gregorian_seconds(), kz_time:gregorian_seconds()) ->
+                       kz_term:ne_binaries().
 get_range(Type, AccountId, From, To) ->
     {{FromYear, FromMonth, _}, _} = calendar:gregorian_seconds_to_datetime(From),
     {{ToYear,   ToMonth,   _}, _} = calendar:gregorian_seconds_to_datetime(To),

--- a/core/kazoo_modb/src/kazoo_modb_maintenance.erl
+++ b/core/kazoo_modb/src/kazoo_modb_maintenance.erl
@@ -45,11 +45,10 @@
                     ]).
 
 -spec delete_modbs(kz_term:ne_binary()) -> 'ok' | 'no_return'.
--spec delete_modbs(kz_term:ne_binary(), boolean() | kz_term:ne_binary()) -> 'ok' | 'no_return'.
--spec delete_modbs(kz_term:ne_binary() | kz_time:year(), kz_term:ne_binary() | kz_time:month(), boolean()) -> 'ok' | 'no_return'.
 delete_modbs(Period) ->
     delete_modbs(Period, 'true').
 
+-spec delete_modbs(kz_term:ne_binary(), boolean() | kz_term:ne_binary()) -> 'ok' | 'no_return'.
 delete_modbs(Period, ShouldArchive) ->
     Regex = <<"(2[0-9]{3})(0[1-9]|1[0-2])">>,
     case re:run(Period, Regex, [{'capture', 'all', 'binary'}]) of
@@ -59,6 +58,7 @@ delete_modbs(Period, ShouldArchive) ->
             io:format("period '~s' does not match YYYYMM format~n", [Period])
     end.
 
+-spec delete_modbs(kz_term:ne_binary() | kz_time:year(), kz_term:ne_binary() | kz_time:month(), boolean()) -> 'ok' | 'no_return'.
 delete_modbs(<<_/binary>> = Year, Month, ShouldArchive) ->
     delete_modbs(kz_term:to_integer(Year), Month, ShouldArchive);
 delete_modbs(Year, <<_/binary>> = Month, ShouldArchive) ->
@@ -103,9 +103,10 @@ delete_modb(?MATCH_MODB_SUFFIX_ENCODED(_,_,_) = AccountModb, ShouldArchive) ->
     timer:sleep(5 * ?MILLISECONDS_IN_SECOND).
 
 -spec archive_modbs() -> 'no_return'.
--spec archive_modbs(kz_term:text()) -> 'no_return'.
 archive_modbs() ->
     do_archive_modbs(kapps_util:get_all_account_mods(), 'undefined').
+
+-spec archive_modbs(kz_term:text()) -> 'no_return'.
 archive_modbs(AccountId) ->
     do_archive_modbs(kapps_util:get_account_mods(AccountId), kz_term:to_binary(AccountId)).
 

--- a/core/kazoo_modb/src/kazoo_modb_util.erl
+++ b/core/kazoo_modb/src/kazoo_modb_util.erl
@@ -17,12 +17,12 @@
         ]).
 
 -spec prev_year_month(kz_term:ne_binary()) -> {kz_time:year(), kz_time:month()}.
--spec prev_year_month(kz_term:ne_binary() | kz_time:year(), kz_term:ne_binary() | kz_time:month()) ->
-                             {kz_time:year(), kz_time:month()}.
 prev_year_month(AccountMod) ->
     {_AccountId, Year, Month} = split_account_mod(AccountMod),
     prev_year_month(Year, Month).
 
+-spec prev_year_month(kz_term:ne_binary() | kz_time:year(), kz_term:ne_binary() | kz_time:month()) ->
+                             {kz_time:year(), kz_time:month()}.
 prev_year_month(<<_/binary>> = Year, Month) ->
     prev_year_month(kz_term:to_integer(Year), Month);
 prev_year_month(Year, <<_/binary>> = Month) ->

--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -294,9 +294,10 @@ disconnect(Number) ->
     end.
 
 -spec prefix(options()) -> kz_term:ne_binary().
--spec prefix(options(), kz_term:ne_binary()) -> kz_term:ne_binary().
 prefix(Options) ->
     props:get_ne_binary_value('prefix', Options).
+
+-spec prefix(options(), kz_term:ne_binary()) -> kz_term:ne_binary().
 prefix(Options, Default) ->
     props:get_ne_binary_value('prefix', Options, Default).
 

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -317,10 +317,8 @@ process_xml_content_tag(Prefix, Quantity, #xmlElement{name='content'
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec process_xml_numbers(kz_term:ne_binary(), pos_integer(), 'undefined' | kz_types:xml_el()) ->
-                                 {'ok', kz_json:object()} |
-                                 {'error', any()}.
--spec process_xml_numbers(kz_term:ne_binary(), pos_integer(), 'undefined' | kz_types:xml_els(), kz_term:proplist()) ->
                                  {'ok', kz_json:object()} |
                                  {'error', any()}.
 process_xml_numbers(_Prefix, _Quantity, 'undefined') ->
@@ -330,6 +328,9 @@ process_xml_numbers(Prefix, Quantity, #xmlElement{name='numbers'
                                                  }) ->
     process_xml_numbers(Prefix, Quantity, kz_xml:elements(Content), []).
 
+-spec process_xml_numbers(kz_term:ne_binary(), pos_integer(), 'undefined' | kz_types:xml_els(), kz_term:proplist()) ->
+                                 {'ok', kz_json:object()} |
+                                 {'error', any()}.
 process_xml_numbers(_Prefix, 0, _Els, Acc) ->
     {'ok', kz_json:from_list(Acc)};
 process_xml_numbers(_Prefix, _Quantity, [#xmlElement{name='response'

--- a/core/kazoo_number_manager/src/kapi_discovery.erl
+++ b/core/kazoo_number_manager/src/kapi_discovery.erl
@@ -200,33 +200,37 @@ declare_exchanges() ->
     amqp_util:new_exchange(?DISCOVERY_EXCHANGE, ?DISCOVERY_EXCHANGE_TYPE).
 
 -spec publish_flush(kz_term:api_terms()) -> 'ok'.
--spec publish_flush(kz_term:api_terms(), binary()) -> 'ok'.
 publish_flush(JObj) ->
     publish_flush(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_flush(kz_term:api_terms(), binary()) -> 'ok'.
 publish_flush(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DISCOVERY_FLUSH_VALUES, fun flush/1),
     amqp_util:basic_publish(?DISCOVERY_EXCHANGE, ?DISCOVERY_FLUSH_RK, Payload, ContentType).
 
 -spec publish_req(kz_term:api_terms()) -> 'ok'.
--spec publish_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_req(JObj) ->
     publish_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?DISCOVERY_REQ_VALUES, fun req/1),
     amqp_util:basic_publish(?DISCOVERY_EXCHANGE, ?DISCOVERY_REQ_RK, Payload, ContentType).
 
 -spec publish_number_req(kz_term:api_terms()) -> 'ok'.
--spec publish_number_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_number_req(JObj) ->
     publish_number_req(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_number_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_number_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?NUMBER_REQ_VALUES, fun number_req/1),
     amqp_util:basic_publish(?DISCOVERY_EXCHANGE, ?NUMBER_REQ_RK, Payload, ContentType).
 
 -spec publish_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
--spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(RespQ, JObj) ->
     publish_resp(RespQ, JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_resp(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_resp(RespQ, Resp, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Resp, ?DISCOVERY_RESP_VALUES, fun resp/1),
     amqp_util:targeted_publish(RespQ, Payload, ContentType).

--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -234,14 +234,15 @@ update_number_services_view(?MATCH_ACCOUNT_ENCODED(_)=AccountDb) ->
     end.
 
 %% @public
+
 -spec fix_accounts_numbers([kz_term:ne_binary()]) -> 'ok'.
--spec fix_account_numbers(kz_term:ne_binary()) -> 'ok'.
 fix_accounts_numbers(Accounts) ->
     AccountDbs = lists:usort([kz_util:format_account_db(Account) || Account <- Accounts]),
     _ = purge_discovery(),
     _ = purge_deleted(),
     foreach_pause_in_between(?TIME_BETWEEN_ACCOUNTS_MS, fun fix_account_numbers/1, AccountDbs).
 
+-spec fix_account_numbers(kz_term:ne_binary()) -> 'ok'.
 fix_account_numbers(AccountDb = ?MATCH_ACCOUNT_ENCODED(A,B,Rest)) ->
     ?SUP_LOG_DEBUG("########## fixing [~s] ##########", [AccountDb]),
     ?SUP_LOG_DEBUG("[~s] getting numbers from account db", [AccountDb]),
@@ -312,7 +313,6 @@ migrate(Account) ->
     'ok'.
 
 -spec migrate_unassigned_numbers() -> 'ok'.
--spec migrate_unassigned_numbers(kz_term:ne_binary(), integer()) -> 'ok'.
 migrate_unassigned_numbers() ->
     ?SUP_LOG_DEBUG("********** fixing unassigned numbers **********", []),
     pforeach(fun migrate_unassigned_numbers/1, knm_util:get_all_number_dbs()),
@@ -330,6 +330,7 @@ migrate_unassigned_numbers(<<?KNM_DB_PREFIX, Suffix/binary>>) ->
 migrate_unassigned_numbers(Number) ->
     migrate_unassigned_numbers(knm_converters:to_db(Number)).
 
+-spec migrate_unassigned_numbers(kz_term:ne_binary(), integer()) -> 'ok'.
 migrate_unassigned_numbers(NumberDb, Offset) ->
     ViewOptions = [{limit, kz_datamgr:max_bulk_insert()}
                   ,{skip, Offset}

--- a/core/kazoo_number_manager/src/knm_errors.erl
+++ b/core/kazoo_number_manager/src/knm_errors.erl
@@ -119,18 +119,19 @@ by_carrier(Carrier, E, Number) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec to_json(reason()) ->
-                     error().
--spec to_json(reason(), kz_term:api_ne_binary()) ->
-                     error().
--spec to_json(reason(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
                      error().
 to_json(Reason)->
     to_json(Reason, 'undefined').
 
+-spec to_json(reason(), kz_term:api_ne_binary()) ->
+                     error().
 to_json(Reason, Num)->
     to_json(Reason, Num, 'undefined').
 
+-spec to_json(reason(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
+                     error().
 to_json('number_is_porting', Num=?NE_BINARY, _) ->
     Message = <<"number ", Num/binary, " is porting">>,
     build_error(400, 'number_is_porting', Message, Num);

--- a/core/kazoo_number_manager/src/knm_number.erl
+++ b/core/kazoo_number_manager/src/knm_number.erl
@@ -121,11 +121,12 @@ is_number(_) -> 'false'.
 %% Note: get/1,2 should not throw, instead returns: {ok,_} | {error,_} | ...
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get(kz_term:ne_binary()) -> knm_number_return().
--spec get(kz_term:ne_binary(), knm_number_options:options()) -> knm_number_return().
 get(Num) ->
     get(Num, knm_number_options:default()).
 
+-spec get(kz_term:ne_binary(), knm_number_options:options()) -> knm_number_return().
 get(Num, Options) ->
     case knm_numbers:get([Num], Options) of
         #{ok := [Number]} -> {ok, Number};
@@ -293,11 +294,12 @@ ensure_number_is_not_porting(Num, Options) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec move(kz_term:ne_binary(), kz_term:ne_binary()) -> knm_number_return().
--spec move(kz_term:ne_binary(), kz_term:ne_binary(), knm_number_options:options()) -> knm_number_return().
 move(Num, MoveTo) ->
     move(Num, MoveTo, knm_number_options:default()).
 
+-spec move(kz_term:ne_binary(), kz_term:ne_binary(), knm_number_options:options()) -> knm_number_return().
 move(Num, MoveTo, Options) ->
     ?TRY3(move, Num, MoveTo, Options).
 
@@ -308,12 +310,13 @@ move(Num, MoveTo, Options) ->
 %% Note: will always result in a phone_number save.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update(kz_term:ne_binary(), knm_phone_number:set_functions()) -> knm_number_return().
--spec update(kz_term:ne_binary(), knm_phone_number:set_functions(), knm_number_options:options()) ->
-                    knm_number_return().
 update(Num, Routines) ->
     update(Num, Routines, knm_number_options:default()).
 
+-spec update(kz_term:ne_binary(), knm_phone_number:set_functions(), knm_number_options:options()) ->
+                    knm_number_return().
 update(Num, Routines, Options) ->
     ?TRY3(update, Num, Routines, Options).
 
@@ -332,11 +335,12 @@ reconcile(DID, Options) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec release(kz_term:ne_binary()) -> knm_number_return().
--spec release(kz_term:ne_binary(), knm_number_options:options()) -> knm_number_return().
 release(Num) ->
     release(Num, knm_number_options:default()).
 
+-spec release(kz_term:ne_binary(), knm_number_options:options()) -> knm_number_return().
 release(Num, Options) ->
     ?TRY2(release, Num, Options).
 
@@ -356,11 +360,12 @@ delete(Num, Options) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec assign_to_app(kz_term:ne_binary(), kz_term:api_ne_binary()) -> knm_number_return().
--spec assign_to_app(kz_term:ne_binary(), kz_term:api_ne_binary(), knm_number_options:options()) -> knm_number_return().
 assign_to_app(Num, App) ->
     assign_to_app(Num, App, knm_number_options:default()).
 
+-spec assign_to_app(kz_term:ne_binary(), kz_term:api_ne_binary(), knm_number_options:options()) -> knm_number_return().
 assign_to_app(Num, App, Options) ->
     ?TRY3(assign_to_app, Num, App, Options).
 
@@ -563,9 +568,10 @@ force_local_outbound() ->
     knm_config:should_force_local_outbound().
 
 -spec phone_number(knm_number()) -> knm_phone_number:knm_phone_number().
+phone_number(#knm_number{knm_phone_number=PhoneNumber}) -> PhoneNumber.
+
 -spec set_phone_number(knm_number(), knm_phone_number:knm_phone_number()) ->
                               knm_number().
-phone_number(#knm_number{knm_phone_number=PhoneNumber}) -> PhoneNumber.
 set_phone_number(Number, PhoneNumber) ->
     Number#knm_number{knm_phone_number=PhoneNumber}.
 
@@ -584,10 +590,10 @@ add_transaction(#knm_number{transactions=Transactions}=Number, Transaction) ->
     Number#knm_number{transactions=[Transaction|Transactions]}.
 
 -spec charges(knm_number(), kz_term:ne_binary()) -> non_neg_integer().
--spec set_charges(knm_number(), kz_term:ne_binary(), non_neg_integer()) -> knm_number().
 charges(#knm_number{charges=Charges}, Key) ->
     props:get_value(Key, Charges, 0).
 
+-spec set_charges(knm_number(), kz_term:ne_binary(), non_neg_integer()) -> knm_number().
 set_charges(#knm_number{charges=Charges}=Number, Key, Amount) ->
     Number#knm_number{charges=props:set_value(Key, Amount, Charges)}.
 

--- a/core/kazoo_number_manager/src/knm_number_options.erl
+++ b/core/kazoo_number_manager/src/knm_number_options.erl
@@ -98,9 +98,10 @@ to_phone_number_setters(Options) ->
     ].
 
 -spec dry_run(options()) -> boolean().
--spec dry_run(options(), Default) -> boolean() | Default.
 dry_run(Options) ->
     dry_run(Options, 'false').
+
+-spec dry_run(options(), Default) -> boolean() | Default.
 dry_run(Options, Default) ->
     R = props:get_is_true('dry_run', Options, Default),
     _ = R
@@ -108,9 +109,10 @@ dry_run(Options, Default) ->
     R.
 
 -spec batch_run(options()) -> boolean().
--spec batch_run(options(), Default) -> boolean() | Default.
 batch_run(Options) ->
     batch_run(Options, 'false').
+
+-spec batch_run(options(), Default) -> boolean() | Default.
 batch_run(Options, Default) ->
     R = props:get_is_true(batch_run, Options, Default),
     _ = R
@@ -125,16 +127,18 @@ mdn_run(Options) ->
     R.
 
 -spec assign_to(options()) -> kz_term:api_binary().
--spec assign_to(options(), Default) -> kz_term:ne_binary() | Default.
 assign_to(Options) ->
     assign_to(Options, 'undefined').
+
+-spec assign_to(options(), Default) -> kz_term:ne_binary() | Default.
 assign_to(Options, Default) ->
     props:get_binary_value('assign_to', Options, Default).
 
 -spec auth_by(options()) -> kz_term:api_binary().
--spec auth_by(options(), Default) -> kz_term:ne_binary() | Default.
 auth_by(Options) ->
     auth_by(Options, 'undefined').
+
+-spec auth_by(options(), Default) -> kz_term:ne_binary() | Default.
 auth_by(Options, Default) ->
     props:get_binary_value('auth_by', Options, Default).
 
@@ -143,9 +147,10 @@ public_fields(Options) ->
     props:get_value('public_fields', Options, kz_json:new()).
 
 -spec state(options()) -> kz_term:api_binary().
--spec state(options(), Default) -> kz_term:ne_binary() | Default.
 state(Options) ->
     state(Options, 'undefined').
+
+-spec state(options(), Default) -> kz_term:ne_binary() | Default.
 state(Options, Default) ->
     props:get_binary_value('state', Options, Default).
 

--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -159,27 +159,35 @@ prev_assigned_to(#{todo := Ns}) ->
     end.
 
 %% @public
+
 -spec options(t()) -> options().
--spec options(options(), t()) -> t().
 options(#{options := V}) -> V.
+
+-spec options(options(), t()) -> t().
 options(V, T) -> T#{options => V}.
 
 %% @public
+
 -spec plan(t()) -> plan().
--spec plan(plan(), t()) -> t().
 plan(#{plan := V}) -> V.
+
+-spec plan(plan(), t()) -> t().
 plan(V, T) -> T#{plan => V}.
 
 %% @public
+
 -spec services(t()) -> services().
--spec services(services(), t()) -> t().
 services(#{services := V}) -> V.
+
+-spec services(services(), t()) -> t().
 services(V, T) -> T#{services => V}.
 
 %% @public
+
 -spec transactions(t()) -> transactions().
--spec transactions(transactions(), t()) -> t().
 transactions(#{transactions := V}) -> V.
+
+-spec transactions(transactions(), t()) -> t().
 transactions(V, T) -> T#{transactions => V}.
 
 %% @public
@@ -187,15 +195,19 @@ transactions(V, T) -> T#{transactions => V}.
 transaction(V, T=#{transactions := Vs}) -> T#{transactions => [V | Vs]}.
 
 %% @public
+
 -spec charges(t()) -> charges().
--spec charges(charges(), t()) -> t().
 charges(#{charges := V}) -> V.
+
+-spec charges(charges(), t()) -> t().
 charges(V, T) -> T#{charges => V}.
 
 %% @public
+
 -spec charge(kz_term:ne_binary(), t()) -> non_neg_integer().
--spec charge(kz_term:ne_binary(), non_neg_integer(), t()) -> t().
 charge(K, #{charges := Vs}) -> props:get_value(K, Vs, 0).
+
+-spec charge(kz_term:ne_binary(), non_neg_integer(), t()) -> t().
 charge(K, V, T=#{charges := Vs}) -> T#{charges => [{K, V} | Vs]}.
 
 %% @public
@@ -232,9 +244,11 @@ ko(N, Reason, T) ->
 %% Note: each number in `Nums' has to be normalized.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get(kz_term:ne_binaries()) -> ret().
--spec get(kz_term:ne_binaries(), knm_number_options:options()) -> ret().
 get(Nums) -> get(Nums, knm_number_options:default()).
+
+-spec get(kz_term:ne_binaries(), knm_number_options:options()) -> ret().
 get(Nums, Options) -> ret(do_get(Nums, Options)).
 
 -spec do_get(kz_term:ne_binaries(), knm_number_options:options()) -> t().
@@ -246,10 +260,11 @@ do_get(Nums, Options) ->
          ]).
 
 -spec do_get_pn(kz_term:ne_binaries(), knm_number_options:options()) -> t_pn().
--spec do_get_pn(kz_term:ne_binaries(), knm_number_options:options(), reason_t()) -> t_pn().
 do_get_pn(Nums, Options) ->
     {Yes, No} = are_reconcilable(Nums),
     do(fun knm_phone_number:fetch/1, new(Options, Yes, No)).
+
+-spec do_get_pn(kz_term:ne_binaries(), knm_number_options:options(), reason_t()) -> t_pn().
 do_get_pn(Nums, Options, Error) ->
     {Yes, No} = are_reconcilable(Nums),
     do(fun knm_phone_number:fetch/1, new(Options, Yes, No, Error)).
@@ -326,11 +341,12 @@ create(Nums, Options) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec move(kz_term:ne_binaries(), kz_term:ne_binary()) -> ret().
--spec move(kz_term:ne_binaries(), kz_term:ne_binary(), knm_number_options:options()) -> ret().
 move(Nums, MoveTo) ->
     move(Nums, MoveTo, knm_number_options:default()).
 
+-spec move(kz_term:ne_binaries(), kz_term:ne_binary(), knm_number_options:options()) -> ret().
 move(Nums, ?MATCH_ACCOUNT_RAW(MoveTo), Options0) ->
     Options = [{assign_to, MoveTo} | Options0],
     {TFound, NotFounds} = take_not_founds(do_get(Nums, Options)),
@@ -347,12 +363,14 @@ move(Nums, ?MATCH_ACCOUNT_RAW(MoveTo), Options0) ->
 %% Note: will always result in a phone_number save.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update(kz_term:ne_binaries(), knm_phone_number:set_functions()) -> ret().
--spec update(kz_term:ne_binaries(), knm_phone_number:set_functions(), knm_number_options:options()) -> ret().
 update(Nums, Routines) ->
     update(Nums, Routines, knm_number_options:default()).
 
 -ifdef(TEST).
+
+-spec update(kz_term:ne_binaries(), knm_phone_number:set_functions(), knm_number_options:options()) -> ret().
 update([?NE_BINARY|_]=Nums, Routines, Options) ->
     Reason = not_reconcilable,  %% FIXME: unify to atom OR knm_error.
     do_update(do_get_pn(Nums, Options, Reason), Routines);
@@ -365,6 +383,8 @@ update(Ns, Updates, Options) ->
     T1 = do_in_wrap(fun (T) -> knm_phone_number:setters(T, Routines) end, T0),
     ret(do(fun save_numbers/1, T1)).
 -else.
+
+-spec update(kz_term:ne_binaries(), knm_phone_number:set_functions(), knm_number_options:options()) -> ret().
 update(Nums, Routines, Options) ->
     Reason = not_reconcilable,  %% FIXME: unify to atom OR knm_error.
     do_update(do_get_pn(Nums, Options, Reason), Routines).
@@ -382,11 +402,12 @@ do_update(T0, Routines) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec release(kz_term:ne_binaries()) -> ret().
--spec release(kz_term:ne_binaries(), knm_number_options:options()) -> ret().
 release(Nums) ->
     release(Nums, knm_number_options:default()).
 
+-spec release(kz_term:ne_binaries(), knm_number_options:options()) -> ret().
 release(Nums, Options) ->
     ret(pipe(do_get_pn(Nums, Options)
             ,[fun try_release/1
@@ -452,11 +473,12 @@ reserve(Nums, Options) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec assign_to_app(kz_term:ne_binaries(), kz_term:api_ne_binary()) -> ret().
--spec assign_to_app(kz_term:ne_binaries(), kz_term:api_ne_binary(), knm_number_options:options()) -> ret().
 assign_to_app(Nums, App) ->
     assign_to_app(Nums, App, knm_number_options:default()).
 
+-spec assign_to_app(kz_term:ne_binaries(), kz_term:api_ne_binary(), knm_number_options:options()) -> ret().
 assign_to_app(Nums, App, Options) ->
     Setters = [{fun knm_phone_number:set_used_by/2, App}],
     ret(pipe(do_get_pn(Nums, Options)
@@ -528,11 +550,14 @@ account_listing(AccountDb=?MATCH_ACCOUNT_ENCODED(_,_,_)) ->
 
 %% @private
 -type reason_t() :: atom() | fun((num())-> knm_errors:error()).
+
 -spec new(knm_number_options:options(), nums()) -> t().
--spec new(knm_number_options:options(), nums(), nums()) -> t().
--spec new(knm_number_options:options(), nums(), nums(), reason_t()) -> t().
 new(Options, ToDos) -> new(Options, ToDos, []).
+
+-spec new(knm_number_options:options(), nums(), nums()) -> t().
 new(Options, ToDos, KOs) -> new(Options, ToDos, KOs, not_reconcilable).
+
+-spec new(knm_number_options:options(), nums(), nums(), reason_t()) -> t().
 new(Options, ToDos, KOs, Reason) ->
     #{todo => ToDos
      ,ok => []

--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -187,10 +187,9 @@ from_number_with_options(DID, Options) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec fetch(kz_term:ne_binary()) -> knm_phone_number_return();
            (knm_numbers:collection()) -> knm_numbers:collection().
--spec fetch(kz_term:ne_binary(), knm_number_options:options()) -> knm_phone_number_return().
-
 fetch(?NE_BINARY=Num) ->
     fetch(Num, knm_number_options:default());
 fetch(T0=#{todo := Nums, options := Options}) ->
@@ -347,6 +346,8 @@ split_by_prevassignedto(PNs) ->
     lists:foldl(F, #{}, PNs).
 
 -ifdef(TEST).
+
+-spec fetch(kz_term:ne_binary(), knm_number_options:options()) -> knm_phone_number_return().
 fetch(Num, Options) ->
     case test_fetch(Num) of
         {error, _}=E -> E;
@@ -412,6 +413,8 @@ test_fetch(?TEST_PORT_IN3_NUM) -> {ok, ?PORT_IN3_NUMBER};
 test_fetch(_DID=?NE_BINARY) ->
     {error, not_found}.
 -else.
+
+-spec fetch(kz_term:ne_binary(), knm_number_options:options()) -> knm_phone_number_return().
 fetch(Num=?NE_BINARY, Options) ->
     NormalizedNum = knm_converters:normalize(Num),
     NumberDb = knm_converters:to_db(NormalizedNum),
@@ -1788,10 +1791,6 @@ database_error(NumOrNums, E, T) ->
     Reason = knm_errors:to_json(A, B, C),
     knm_numbers:ko(NumOrNums, Reason, T).
 
--spec save_docs(kz_term:ne_binary(), kz_json:objects()) -> {ok, kz_json:objects()} |
-                                                   {error, kz_data:data_errors()}.
--spec delete_docs(kz_term:ne_binary(), kz_term:ne_binaries()) -> {ok, kz_json:objects()} |
-                                                 {error, kz_data:data_errors()}.
 -ifdef(TEST).
 mock_docs_return(?NE_BINARY=Id) ->
     kz_json:from_list(
@@ -1801,16 +1800,25 @@ mock_docs_return(?NE_BINARY=Id) ->
 mock_docs_return(Doc) ->
     mock_docs_return(kz_doc:id(Doc)).
 
+-spec save_docs(kz_term:ne_binary(), kz_json:objects()) -> {ok, kz_json:objects()} |
+                                                   {error, kz_data:data_errors()}.
 save_docs(?NE_BINARY, Docs) ->
     {ok, [mock_docs_return(Doc) || Doc <- Docs]}.
 
+-spec delete_docs(kz_term:ne_binary(), kz_term:ne_binaries()) -> {ok, kz_json:objects()} |
+                                                 {error, kz_data:data_errors()}.
 delete_docs(?NE_BINARY, Ids) ->
     {ok, [mock_docs_return(Id) || Id <- Ids]}.
 -else.
+
+-spec delete_docs(kz_term:ne_binary(), kz_term:ne_binaries()) -> {ok, kz_json:objects()} |
+                                                 {error, kz_data:data_errors()}.
 delete_docs(Db, Ids) ->
     %% Note: deleting unexisting docs returns ok.
     kz_datamgr:del_docs(Db, Ids).
 
+-spec save_docs(kz_term:ne_binary(), kz_json:objects()) -> {ok, kz_json:objects()} |
+                                                   {error, kz_data:data_errors()}.
 save_docs(Db, Docs) ->
     kz_datamgr:save_docs(Db, Docs).
 -endif.

--- a/core/kazoo_number_manager/src/knm_search.erl
+++ b/core/kazoo_number_manager/src/knm_search.erl
@@ -367,27 +367,29 @@ quantity(Options) ->
     min(Quantity, ?MAX_SEARCH).
 
 -spec prefix(options()) -> kz_term:ne_binary().
--spec prefix(options(), kz_term:ne_binary()) -> kz_term:ne_binary().
 prefix(Options) ->
     props:get_ne_binary_value('prefix', Options).
+
+-spec prefix(options(), kz_term:ne_binary()) -> kz_term:ne_binary().
 prefix(Options, Default) ->
     props:get_ne_binary_value('prefix', Options, Default).
 
 -spec query_options(options()) -> kz_term:api_object().
--spec query_options(options(), kz_term:api_object()) -> kz_term:api_object().
 query_options(Options) ->
     props:get_value('query_options', Options).
+
+-spec query_options(options(), kz_term:api_object()) -> kz_term:api_object().
 query_options(Options, Default) ->
     props:get_value('query_options', Options, Default).
 
 -spec normalized_prefix(options()) -> kz_term:ne_binary().
--spec normalized_prefix(options(), kz_term:ne_binary()) -> kz_term:ne_binary().
 normalized_prefix(Options) ->
     JObj = query_options(Options, kz_json:new()),
     Dialcode = dialcode(Options),
     Prefix = kz_json:get_ne_binary_value(<<"Prefix">>, JObj, prefix(Options)),
     normalized_prefix(Options, <<Dialcode/binary, Prefix/binary>>).
 
+-spec normalized_prefix(options(), kz_term:ne_binary()) -> kz_term:ne_binary().
 normalized_prefix(Options, Default) ->
     props:get_ne_binary_value('normalized_prefix', Options, Default).
 

--- a/core/kazoo_number_manager/src/knm_services.erl
+++ b/core/kazoo_number_manager/src/knm_services.erl
@@ -30,22 +30,26 @@
 %% @end
 %%--------------------------------------------------------------------
 -type set_feature() :: {kz_term:ne_binary(), kz_json:object()}.
+
 -spec activate_feature(knm_number:knm_number(), set_feature() | kz_term:ne_binary()) ->
                               knm_number:knm_number().
--spec do_activate_feature(knm_number:knm_number(), set_feature()) ->
-                                 knm_number:knm_number().
-
 activate_feature(Number, Feature=?NE_BINARY) ->
     activate_feature(Number, {Feature, kz_json:new()});
 activate_feature(Number, FeatureToSet={?NE_BINARY,_}) ->
     do_activate_feature(Number, FeatureToSet).
 
 -ifdef(TEST).
+
+-spec do_activate_feature(knm_number:knm_number(), set_feature()) ->
+                                 knm_number:knm_number().
 do_activate_feature(Number, {Feature,FeatureData}) ->
     %% Adding feature regardless of service plan
     PN = knm_phone_number:set_feature(knm_number:phone_number(Number), Feature, FeatureData),
     knm_number:set_phone_number(Number, PN).
 -else.
+
+-spec do_activate_feature(knm_number:knm_number(), set_feature()) ->
+                                 knm_number:knm_number().
 do_activate_feature(Number, FeatureToSet) ->
     Services = fetch_services(Number),
     BillingId = kz_services:get_billing_id(Services),

--- a/core/kazoo_number_manager/src/knm_telnyx_util.erl
+++ b/core/kazoo_number_manager/src/knm_telnyx_util.erl
@@ -65,11 +65,12 @@ did(Number) ->
 
 
 -spec req(atom(), [nonempty_string()]) -> kz_json:object().
--spec req(atom(), [nonempty_string()], kz_json:object()) -> kz_json:object().
 req(Method, Path) ->
     req(Method, Path, kz_json:new()).
 
 -ifdef(TEST).
+
+-spec req(atom(), [nonempty_string()], kz_json:object()) -> kz_json:object().
 req('post', ["number_searches"], JObj) ->
     case kz_json:get_value([<<"search_descriptor">>, <<"prefix">>], JObj) of
         <<"800">> -> rep_fixture("telnyx_tollfree_search.json");
@@ -103,6 +104,8 @@ rep_fixture(Fixture) ->
     rep({'ok', 200, [], list_to_binary(knm_util:fixture(Fixture))}).
 
 -else.
+
+-spec req(atom(), [nonempty_string()], kz_json:object()) -> kz_json:object().
 req('delete'=_Method, Path, EmptyJObj) ->
     Url = ?URL(Path),
     Headers = http_headers(EmptyJObj),
@@ -196,12 +199,12 @@ maybe_filter_rates('true', JObj) ->
     kz_json:set_value(<<"result">>, Results, JObj).
 
 -spec maybe_apply_limit(kz_json:object()) -> kz_json:object().
--spec maybe_apply_limit(kz_json:object(), kz_term:ne_binary()) -> kz_json:object().
 maybe_apply_limit(JObj) ->
     maybe_apply_limit(maybe_apply_limit(JObj, <<"result">>)
                      ,<<"inexplicit_result">>
                      ).
 
+-spec maybe_apply_limit(kz_json:object(), kz_term:ne_binary()) -> kz_json:object().
 maybe_apply_limit(JObj, ResultField) ->
     Limit = kz_json:get_integer_value(<<"limit">>, JObj, 100),
     Result = take(Limit, kz_json:get_value(ResultField, JObj, [])),

--- a/core/kazoo_number_manager/src/knm_vitelity_util.erl
+++ b/core/kazoo_number_manager/src/knm_vitelity_util.erl
@@ -72,9 +72,10 @@ get_query_value(<<"type">>=Key, Options) -> ?QUERY_VALUE(Key, Options);
 get_query_value(<<"withrates">>=Key, Options) -> ?QUERY_VALUE(Key, Options).
 
 -spec default_options() -> qs_options().
--spec default_options(kz_term:proplist()) -> qs_options().
 default_options() ->
     default_options([]).
+
+-spec default_options(kz_term:proplist()) -> qs_options().
 default_options(Options) ->
     [{'login', get_query_value(<<"login">>, Options)}
     ,{'pass', get_query_value(<<"pass">>, Options)}

--- a/core/kazoo_number_manager/src/providers/knm_cnam_notifier.erl
+++ b/core/kazoo_number_manager/src/providers/knm_cnam_notifier.erl
@@ -22,12 +22,13 @@
 %% produce notifications if the cnam object changes
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(knm_number:knm_number()) -> knm_number:knm_number().
--spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number) ->
     State = knm_phone_number:state(knm_number:phone_number(Number)),
     save(Number, State).
 
+-spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number, ?NUMBER_STATE_RESERVED) ->
     handle(Number);
 save(Number, ?NUMBER_STATE_IN_SERVICE) ->
@@ -136,12 +137,13 @@ support_depreciated_cnam(Number) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec publish_cnam_update(knm_number:knm_number()) -> 'ok'.
--spec publish_cnam_update(knm_number:knm_number(), boolean()) -> 'ok'.
 publish_cnam_update(Number) ->
     DryRun = knm_phone_number:dry_run(knm_number:phone_number(Number)),
     publish_cnam_update(Number, DryRun).
 
+-spec publish_cnam_update(knm_number:knm_number(), boolean()) -> 'ok'.
 publish_cnam_update(_Number, 'true') -> 'ok';
 publish_cnam_update(Number, 'false') ->
     PhoneNumber = knm_number:phone_number(Number),

--- a/core/kazoo_number_manager/src/providers/knm_dash_e911.erl
+++ b/core/kazoo_number_manager/src/providers/knm_dash_e911.erl
@@ -41,14 +41,15 @@
 %% provision e911 or remove the number depending on the state
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(knm_number:knm_number()) ->
-                  knm_number:knm_number().
--spec save(knm_number:knm_number(), kz_term:api_binary()) ->
                   knm_number:knm_number().
 save(Number) ->
     State = knm_phone_number:state(knm_number:phone_number(Number)),
     save(Number, State).
 
+-spec save(knm_number:knm_number(), kz_term:api_binary()) ->
+                  knm_number:knm_number().
 save(Number, ?NUMBER_STATE_RESERVED) ->
     maybe_update_e911(Number);
 save(Number, ?NUMBER_STATE_IN_SERVICE) ->
@@ -152,12 +153,13 @@ maybe_update_e911(Number, Address) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update_e911(knm_number:knm_number(), kz_json:object()) -> kz_json:object().
--spec update_e911(knm_number:knm_number(), kz_json:object(), boolean()) -> kz_json:object().
 update_e911(Number, Address) ->
     DryRun = knm_phone_number:dry_run(knm_number:phone_number(Number)),
     update_e911(Number, Address, DryRun).
 
+-spec update_e911(knm_number:knm_number(), kz_json:object(), boolean()) -> kz_json:object().
 update_e911(_Number, Address, 'true') -> Address;
 update_e911(Number, Address, 'false') ->
     Num = knm_phone_number:number(knm_number:phone_number(Number)),
@@ -205,12 +207,13 @@ is_valid_location(Location) ->
     end.
 
 %% @private
+
 -spec parse_response(kz_types:xml_el()) -> location_response().
--spec parse_response(kz_term:ne_binary(), kz_types:xml_el()) -> location_response().
 parse_response(Response) ->
     StatusCode = kz_xml:get_value("//Location/status/code/text()", Response),
     parse_response(StatusCode, Response).
 
+-spec parse_response(kz_term:ne_binary(), kz_types:xml_el()) -> location_response().
 parse_response(<<"GEOCODED">>, Response) ->
     {'geocoded',    location_xml_to_json_address(xmerl_xpath:string("//Location", Response))};
 parse_response(<<"PROVISIONED">>, Response) ->

--- a/core/kazoo_number_manager/src/providers/knm_failover.erl
+++ b/core/kazoo_number_manager/src/providers/knm_failover.erl
@@ -23,11 +23,12 @@
 %% add the failover route (for in service numbers only)
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(knm_number:knm_number()) -> knm_number:knm_number().
--spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(N) ->
     save(N, knm_phone_number:state(knm_number:phone_number(N))).
 
+-spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(N, ?NUMBER_STATE_IN_SERVICE) -> update_failover(N);
 save(N, _) -> delete(N).
 

--- a/core/kazoo_number_manager/src/providers/knm_port_notifier.erl
+++ b/core/kazoo_number_manager/src/providers/knm_port_notifier.erl
@@ -25,13 +25,14 @@
 %% produce notifications if the porting object changes
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(knm_number:knm_number()) -> knm_number:knm_number().
--spec save(knm_number:knm_number(), kz_term:ne_binary(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(N) ->
     PN = knm_number:phone_number(N),
     State = kz_json:get_ne_binary_value(?PVT_STATE, knm_phone_number:doc(PN)),
     save(N, knm_phone_number:state(PN), State).
 
+-spec save(knm_number:knm_number(), kz_term:ne_binary(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number, ?NUMBER_STATE_PORT_IN, ?NUMBER_STATE_IN_SERVICE) ->
     Port = case feature(Number) of
                undefined -> kz_json:new();
@@ -76,12 +77,12 @@ maybe_port_feature(Number) ->
 
 -spec maybe_port_changed(knm_number:knm_number(), kz_json:object()) ->
                                 knm_number:knm_number().
--spec maybe_port_changed(knm_number:knm_number(), kz_json:object(), boolean()) ->
-                                knm_number:knm_number().
 maybe_port_changed(Number, Port) ->
     DryRun = knm_phone_number:dry_run(knm_number:phone_number(Number)),
     maybe_port_changed(Number, Port, DryRun).
 
+-spec maybe_port_changed(knm_number:knm_number(), kz_json:object(), boolean()) ->
+                                knm_number:knm_number().
 maybe_port_changed(Number, _Port, 'true') -> Number;
 maybe_port_changed(Number, Port, 'false') ->
     CurrentPort = feature(Number),

--- a/core/kazoo_number_manager/src/providers/knm_prepend.erl
+++ b/core/kazoo_number_manager/src/providers/knm_prepend.erl
@@ -23,12 +23,13 @@
 %% add the prepend route (for in service numbers only)
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(knm_number:knm_number()) -> knm_number:knm_number().
--spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number) ->
     State = knm_phone_number:state(knm_number:phone_number(Number)),
     save(Number, State).
 
+-spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number, ?NUMBER_STATE_IN_SERVICE) ->
     update_prepend(Number);
 save(Number, _State) ->

--- a/core/kazoo_number_manager/src/providers/knm_providers.erl
+++ b/core/kazoo_number_manager/src/providers/knm_providers.erl
@@ -437,10 +437,8 @@ do_exec(T0=#{todo := Ns}, Action) ->
         end,
     lists:foldl(F, T0, Ns).
 
--spec exec(knm_number:knm_number(), exec_action()) -> knm_number:knm_number().
--spec exec(knm_number:knm_number(), exec_action(), kz_term:ne_binaries()) ->
-                  knm_number:knm_number().
 
+-spec exec(knm_number:knm_number(), exec_action()) -> knm_number:knm_number().
 exec(Number, Action=delete) ->
     RequestedModules = requested_modules(Number),
     ?LOG_DEBUG("deleting feature providers: ~s", [?PP(RequestedModules)]),
@@ -488,6 +486,8 @@ split_requests(Number) ->
     F = fun (Feature) -> lists:member(Feature, AllowedModules) end,
     lists:partition(F, RequestedModules).
 
+-spec exec(knm_number:knm_number(), exec_action(), kz_term:ne_binaries()) ->
+                  knm_number:knm_number().
 exec(Number, _, []) -> Number;
 exec(Number, Action, [Provider|Providers]) ->
     case apply_action(Number, Action, Provider) of

--- a/core/kazoo_number_manager/src/providers/knm_telnyx_cnam.erl
+++ b/core/kazoo_number_manager/src/providers/knm_telnyx_cnam.erl
@@ -22,12 +22,13 @@
 %% produce notifications if the cnam object changes
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(knm_number:knm_number()) -> knm_number:knm_number().
--spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number) ->
     State = knm_phone_number:state(knm_number:phone_number(Number)),
     save(Number, State).
 
+-spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number, ?NUMBER_STATE_RESERVED) ->
     handle(Number);
 save(Number, ?NUMBER_STATE_IN_SERVICE) ->

--- a/core/kazoo_number_manager/src/providers/knm_telnyx_e911.erl
+++ b/core/kazoo_number_manager/src/providers/knm_telnyx_e911.erl
@@ -31,12 +31,13 @@
 %% provision e911 or remove the number depending on the state
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(knm_number:knm_number()) -> knm_number:knm_number().
--spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number) ->
     State = knm_phone_number:state(knm_number:phone_number(Number)),
     save(Number, State).
 
+-spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number, ?NUMBER_STATE_RESERVED) ->
     maybe_update_e911(Number);
 save(Number, ?NUMBER_STATE_IN_SERVICE) ->
@@ -78,14 +79,15 @@ feature(Number) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_update_e911(knm_number:knm_number()) -> knm_number:knm_number().
--spec maybe_update_e911(knm_number:knm_number(), boolean()) -> knm_number:knm_number().
 maybe_update_e911(Number) ->
     IsDryRun = knm_phone_number:dry_run(knm_number:phone_number(Number)),
     maybe_update_e911(Number, (IsDryRun
                                orelse ?IS_SANDBOX_PROVISIONING_TRUE
                               )).
 
+-spec maybe_update_e911(knm_number:knm_number(), boolean()) -> knm_number:knm_number().
 maybe_update_e911(Number, 'true') ->
     CurrentE911 = feature(Number),
     E911 = kz_json:get_ne_value(?FEATURE_E911, knm_phone_number:doc(knm_number:phone_number(Number))),

--- a/core/kazoo_number_manager/src/providers/knm_vitelity_cnam.erl
+++ b/core/kazoo_number_manager/src/providers/knm_vitelity_cnam.erl
@@ -22,12 +22,13 @@
 %% produce notifications if the cnam object changes
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(knm_number:knm_number()) -> knm_number:knm_number().
--spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number) ->
     State = knm_phone_number:state(knm_number:phone_number(Number)),
     save(Number, State).
 
+-spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number, ?NUMBER_STATE_RESERVED) ->
     handle_outbound_cnam(Number);
 save(Number, ?NUMBER_STATE_IN_SERVICE) ->
@@ -190,12 +191,13 @@ check_outbound_response_tag(Number, NewCNAM, Children) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec handle_inbound_cnam(knm_number:knm_number()) -> knm_number:knm_number().
--spec handle_inbound_cnam(knm_number:knm_number(), boolean()) -> knm_number:knm_number().
 handle_inbound_cnam(Number) ->
     IsDryRun = knm_phone_number:dry_run(knm_number:phone_number(Number)),
     handle_inbound_cnam(Number, IsDryRun).
 
+-spec handle_inbound_cnam(knm_number:knm_number(), boolean()) -> knm_number:knm_number().
 handle_inbound_cnam(Number, 'true') ->
     Doc = knm_phone_number:doc(knm_number:phone_number(Number)),
     case kz_json:is_true([?FEATURE_CNAM, ?CNAM_INBOUND_LOOKUP], Doc) of

--- a/core/kazoo_number_manager/src/providers/knm_vitelity_e911.erl
+++ b/core/kazoo_number_manager/src/providers/knm_vitelity_e911.erl
@@ -28,12 +28,13 @@
 %% provision e911 or remove the number depending on the state
 %% @end
 %%--------------------------------------------------------------------
+
 -spec save(knm_number:knm_number()) -> knm_number:knm_number().
--spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number) ->
     State = knm_phone_number:state(knm_number:phone_number(Number)),
     save(Number, State).
 
+-spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
 save(Number, ?NUMBER_STATE_RESERVED) ->
     maybe_update_e911(Number);
 save(Number, ?NUMBER_STATE_IN_SERVICE) ->
@@ -109,12 +110,13 @@ feature(Number) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_update_e911(knm_number:knm_number()) -> knm_number:knm_number().
--spec maybe_update_e911(knm_number:knm_number(), boolean()) -> knm_number:knm_number().
 maybe_update_e911(Number) ->
     IsDryRun = knm_phone_number:dry_run(knm_number:phone_number(Number)),
     maybe_update_e911(Number, IsDryRun).
 
+-spec maybe_update_e911(knm_number:knm_number(), boolean()) -> knm_number:knm_number().
 maybe_update_e911(Number, 'true') ->
     CurrentE911 = feature(Number),
     E911 = kz_json:get_ne_value(?FEATURE_E911, knm_phone_number:doc(knm_number:phone_number(Number))),

--- a/core/kazoo_oauth/src/kazoo_oauth_client.erl
+++ b/core/kazoo_oauth/src/kazoo_oauth_client.erl
@@ -12,9 +12,6 @@
 
 -spec authenticate(kz_json:object()) -> {'ok', kz_json:object()} |
                                         {'error', kz_term:ne_binary()}.
--spec authenticate(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
-                          {'ok', kz_json:object()} |
-                          {'error', kz_term:ne_binary()}.
 authenticate(JObj) ->
     case {kz_json:get_value(<<"access_token">>, JObj)
          ,kz_json:get_value(<<"provider">>, JObj)
@@ -29,6 +26,9 @@ authenticate(JObj) ->
         {AccessToken, ProviderId} -> authenticate(AccessToken, ProviderId, JObj)
     end.
 
+-spec authenticate(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
+                          {'ok', kz_json:object()} |
+                          {'error', kz_term:ne_binary()}.
 authenticate(AccessToken, ProviderId, JObj) ->
     case kazoo_oauth_util:verify_token(ProviderId, AccessToken) of
         {'ok', Token} -> maybe_add_oauth_user(JObj, Token);

--- a/core/kazoo_oauth/src/kazoo_oauth_util.erl
+++ b/core/kazoo_oauth/src/kazoo_oauth_util.erl
@@ -113,10 +113,10 @@ pem_to_rsa(PemFileContents) ->
     public_key:pem_entry_decode(RSAEntry).
 
 -spec jwt(oauth_service_app(), kz_json:json_term()) -> kz_term:ne_binary().
--spec jwt(oauth_service_app(), kz_json:json_term(), kz_term:ne_binary()) -> kz_term:ne_binary().
 jwt(#oauth_service_app{email=AccountEmail}=App, Scope) ->
     jwt(App, Scope, AccountEmail).
 
+-spec jwt(oauth_service_app(), kz_json:json_term(), kz_term:ne_binary()) -> kz_term:ne_binary().
 jwt(#oauth_service_app{private_key=PrivateKey
                       ,public_key=PublicKey
                       ,provider=#oauth_provider{auth_url=URL}

--- a/core/kazoo_perf/src/kz_tracers.erl
+++ b/core/kazoo_perf/src/kz_tracers.erl
@@ -32,9 +32,10 @@ add_trace(Pid, CollectFor) ->
     'ok'.
 
 -spec gen_load(non_neg_integer()) -> 'ok'.
--spec gen_load(non_neg_integer(), non_neg_integer()) -> 'ok'.
 gen_load(N) ->
     gen_load(N, 1000).
+
+-spec gen_load(non_neg_integer(), non_neg_integer()) -> 'ok'.
 gen_load(N, D) ->
     Start = os:timestamp(),
     _ = rand:seed('exsplus', Start),

--- a/core/kazoo_proper/src/pqc_cb_accounts.erl
+++ b/core/kazoo_proper/src/pqc_cb_accounts.erl
@@ -57,10 +57,10 @@ delete_account(API, AccountId) ->
     pqc_cb_api:make_request([200], fun kz_http:delete/2, URL, RequestHeaders).
 
 -spec cleanup_accounts(kz_term:ne_binaries()) -> 'ok'.
--spec cleanup_accounts(pqc_cb_api:state(), kz_term:ne_binaries()) -> 'ok'.
 cleanup_accounts(AccountNames) ->
     cleanup_accounts(pqc_cb_api:authenticate(), AccountNames).
 
+-spec cleanup_accounts(pqc_cb_api:state(), kz_term:ne_binaries()) -> 'ok'.
 cleanup_accounts(API, AccountNames) ->
     _ = [cleanup_account(API, AccountName) || AccountName <- AccountNames],
     kt_cleanup:cleanup_soft_deletes(?KZ_ACCOUNTS_DB).

--- a/core/kazoo_proper/src/pqc_cb_api.erl
+++ b/core/kazoo_proper/src/pqc_cb_api.erl
@@ -62,7 +62,6 @@ authenticate() ->
     create_api_state(Resp, RequestId, Trace).
 
 -spec api_key() -> kz_term:ne_binary().
--spec api_key(kz_term:ne_binary()) -> kz_term:ne_binary().
 api_key() ->
     case kapps_util:get_master_account_id() of
         {'ok', MasterAccountId} ->
@@ -72,6 +71,7 @@ api_key() ->
             throw('no_master_account')
     end.
 
+-spec api_key(kz_term:ne_binary()) -> kz_term:ne_binary().
 api_key(MasterAccountId) ->
     case kz_account:fetch(MasterAccountId) of
         {'ok', MasterAccount} ->
@@ -104,10 +104,10 @@ v2_base_url() -> ?API_BASE.
 auth_account_id(#{'account_id' := AccountId}) -> AccountId.
 
 -spec request_headers(state()) -> kz_term:proplist().
--spec request_headers(state(), kz_term:proplist()) -> kz_term:proplist().
 request_headers(API) ->
     request_headers(API, []).
 
+-spec request_headers(state(), kz_term:proplist()) -> kz_term:proplist().
 request_headers(#{'auth_token' := AuthToken
                  ,'request_id' := RequestId
                  }
@@ -121,12 +121,12 @@ request_headers(#{'auth_token' := AuthToken
                     ).
 
 -spec default_request_headers() -> kz_term:proplist().
--spec default_request_headers(kz_term:ne_binary()) -> kz_term:proplist().
 default_request_headers() ->
     [{<<"content-type">>, <<"application/json">>}
     ,{<<"accept">>, <<"application/json">>}
     ].
 
+-spec default_request_headers(kz_term:ne_binary()) -> kz_term:proplist().
 default_request_headers(RequestId) ->
     NowMS = kz_time:now_ms(),
     APIRequestID = kz_term:to_list(RequestId) ++ "-" ++ integer_to_list(NowMS),
@@ -144,12 +144,13 @@ default_request_headers(RequestId) ->
 
 -spec make_request(expected_codes(), fun_2(), string(), kz_term:proplist()) ->
                           response().
--spec make_request(expected_codes(), fun_3(), string(), kz_term:proplist(), iodata()) ->
-                          response().
 make_request(ExpectedCodes, HTTP, URL, RequestHeaders) ->
     ?INFO("~p: ~s", [HTTP, URL]),
     ?DEBUG("headers: ~p", [RequestHeaders]),
     handle_response(ExpectedCodes, HTTP(URL, RequestHeaders)).
+
+-spec make_request(expected_codes(), fun_3(), string(), kz_term:proplist(), iodata()) ->
+                          response().
 make_request(ExpectedCodes, HTTP, URL, RequestHeaders, RequestBody) ->
     ?INFO("~p: ~s", [HTTP, URL]),
     ?DEBUG("headers: ~p", [RequestHeaders]),
@@ -158,10 +159,11 @@ make_request(ExpectedCodes, HTTP, URL, RequestHeaders, RequestBody) ->
 
 -spec create_envelope(kz_json:json_term()) ->
                              kz_json:object().
--spec create_envelope(kz_json:json_term(), kz_json:object()) ->
-                             kz_json:object().
 create_envelope(Data) ->
     create_envelope(Data, kz_json:new()).
+
+-spec create_envelope(kz_json:json_term(), kz_json:object()) ->
+                             kz_json:object().
 create_envelope(Data, Envelope) ->
     kz_json:set_value(<<"data">>, Data, Envelope).
 

--- a/core/kazoo_proper/src/pqc_cb_ips.erl
+++ b/core/kazoo_proper/src/pqc_cb_ips.erl
@@ -45,18 +45,18 @@
 -type dedicated() :: #dedicated{}.
 
 -spec ips_url() -> string().
--spec ips_url(pqc_cb_accounts:account_id()) -> string().
 ips_url() ->
     string:join([pqc_cb_api:v2_base_url(), "ips"], "/").
 
+-spec ips_url(pqc_cb_accounts:account_id()) -> string().
 ips_url(AccountId) ->
     string:join([pqc_cb_accounts:account_url(AccountId), "ips"], "/").
 
 -spec ip_url(kz_term:text()) -> string().
--spec ip_url(pqc_cb_accounts:account_id(), kz_term:text()) -> string().
 ip_url(IP) ->
     string:join([pqc_cb_api:v2_base_url(), "ips", kz_term:to_list(IP)], "/").
 
+-spec ip_url(pqc_cb_accounts:account_id(), kz_term:text()) -> string().
 ip_url(AccountId, IP) ->
     string:join([pqc_cb_accounts:account_url(AccountId), "ips", kz_term:to_list(IP)], "/").
 
@@ -268,13 +268,13 @@ delete_ip(API, ?DEDICATED(IP, _Host, _Zone)) ->
 -define(DEDICATED_IPS, [?DEDICATED(<<"1.2.3.4">>, <<"a.host.com">>, <<"zone-1">>)]).
 
 -spec cleanup() -> any().
--spec cleanup(pqc_cb_api:state()) -> any().
 cleanup() ->
     ?INFO("CLEANUP ALL THE THINGS"),
     kz_data_tracing:clear_all_traces(),
 
     cleanup(pqc_cb_api:authenticate()).
 
+-spec cleanup(pqc_cb_api:state()) -> any().
 cleanup(API) ->
     ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
     _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),

--- a/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
+++ b/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
@@ -78,13 +78,14 @@ activate_number(API, AccountId, Number) ->
                            ).
 
 -spec number_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
--spec number_url(kz_term:ne_binary(), kz_term:ne_binary(), string()) -> string().
 number_url(AccountId, Number) ->
     string:join([pqc_cb_accounts:account_url(AccountId)
                 ,"phone_numbers", kz_term:to_list(kz_http_util:urlencode(Number))
                 ]
                ,"/"
                ).
+
+-spec number_url(kz_term:ne_binary(), kz_term:ne_binary(), string()) -> string().
 number_url(AccountId, Number, PathToken) ->
     string:join([pqc_cb_accounts:account_url(AccountId)
                 ,"phone_numbers", kz_term:to_list(kz_http_util:urlencode(Number))
@@ -135,10 +136,10 @@ initial_state() ->
     pqc_kazoo_model:new(API).
 
 -spec command(any()) -> proper_types:type().
--spec command(any(), boolean()) -> proper_types:type().
 command(Model) ->
     command(Model, pqc_kazoo_model:has_accounts(Model)).
 
+-spec command(any(), boolean()) -> proper_types:type().
 command(Model, 'false') ->
     pqc_cb_accounts:command(Model, name());
 command(Model, 'true') ->

--- a/core/kazoo_proper/src/pqc_cb_rates.erl
+++ b/core/kazoo_proper/src/pqc_cb_rates.erl
@@ -56,11 +56,11 @@ upload_rate(API, RateDoc) ->
 
 -spec upload_csv(pqc_cb_api:state(), iodata()) ->
                         {'ok', kz_term:api_ne_binary()}.
--spec upload_csv(pqc_cb_api:state(), iodata(), kz_term:api_ne_binary()) ->
-                        {'ok', kz_term:api_ne_binary()}.
 upload_csv(API, CSV) ->
     upload_csv(API, CSV, 'undefined').
 
+-spec upload_csv(pqc_cb_api:state(), iodata(), kz_term:api_ne_binary()) ->
+                        {'ok', kz_term:api_ne_binary()}.
 upload_csv(API, CSV, _RatedeckId) ->
     CreateResp = pqc_cb_tasks:create(API, "category=rates&action=import", CSV),
     TaskId = kz_json:get_ne_binary_value([<<"data">>, <<"_read_only">>, <<"id">>]
@@ -173,9 +173,10 @@ get_rate(API, RateDoc) ->
                            ).
 
 -spec get_rates(pqc_cb_api:state()) -> pqc_cb_api:response().
--spec get_rates(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 get_rates(API) ->
     get_rates(API, ?KZ_RATES_DB).
+
+-spec get_rates(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 get_rates(API, RatedeckId) ->
     ?INFO("getting rates for ratedeck ~s", [RatedeckId]),
     pqc_cb_api:make_request([200]
@@ -275,13 +276,13 @@ init() ->
     ?INFO("INIT FINISHED").
 
 -spec cleanup() -> any().
--spec cleanup(pqc_cb_api:state()) -> any().
 cleanup() ->
     ?INFO("CLEANUP ALL THE THINGS"),
     kz_data_tracing:clear_all_traces(),
     pqc_cb_service_plans:cleanup(),
     cleanup(pqc_cb_api:authenticate()).
 
+-spec cleanup(pqc_cb_api:state()) -> any().
 cleanup(API) ->
     ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
     _ = [?MODULE:delete_rate(API, RatedeckId) || RatedeckId <- ?RATEDECK_NAMES],

--- a/core/kazoo_proper/src/pqc_kazoo_model.erl
+++ b/core/kazoo_proper/src/pqc_kazoo_model.erl
@@ -110,10 +110,10 @@ pp(#kazoo_model{accounts=Account
 api(#kazoo_model{'api'=API}) -> API.
 
 -spec ratedeck(model()) -> rate_data().
--spec ratedeck(model(), kz_term:ne_binary()) -> rate_data().
 ratedeck(Model) ->
     ratedeck(Model, ?KZ_RATES_DB).
 
+-spec ratedeck(model(), kz_term:ne_binary()) -> rate_data().
 ratedeck(#kazoo_model{'ratedecks'=Ratedecks}, Name) ->
     maps:get(Name, Ratedecks, #{}).
 
@@ -301,13 +301,13 @@ add_number_to_account(#kazoo_model{'numbers'=Numbers}=Model, AccountId, Number, 
     Model#kazoo_model{'numbers'=Numbers#{Number => NumberData}}.
 
 -spec add_service_plan(model() | service_plans(), kzd_service_plan:doc()) -> model() | service_plans().
--spec add_service_plan(model(), kz_term:ne_binary(), kzd_service_plan:doc()) -> model().
 add_service_plan(#kazoo_model{'service_plans'=Plans}=Model, ServicePlan) ->
     Model#kazoo_model{'service_plans'=add_service_plan(Plans, ServicePlan)};
 add_service_plan(Plans, ServicePlan) ->
     Id = kz_doc:id(ServicePlan),
     lists:ukeysort(1, [{Id, ServicePlan} | Plans]).
 
+-spec add_service_plan(model(), kz_term:ne_binary(), kzd_service_plan:doc()) -> model().
 add_service_plan(Model, AccountId, ServicePlan) ->
     add_service_plan_to_account(add_service_plan(Model, ServicePlan)
                                ,AccountId

--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -105,9 +105,10 @@ maybe_add_ext(Schema) ->
     end.
 
 -spec flush() -> 'ok'.
--spec flush(kz_term:ne_binary()) -> 'ok'.
 flush() ->
     kz_datamgr:flush_cache_docs(?KZ_SCHEMA_DB).
+
+-spec flush(kz_term:ne_binary()) -> 'ok'.
 flush(Schema) ->
     kz_datamgr:flush_cache_doc(?KZ_SCHEMA_DB, Schema).
 
@@ -176,9 +177,6 @@ maybe_default(Key, Default, JObj) ->
 -spec validate(kz_term:ne_binary() | kz_json:object(), kz_json:object()) ->
                       {'ok', kz_json:object()} |
                       jesse_error:error().
--spec validate(kz_term:ne_binary() | kz_json:object(), kz_json:object(), jesse_options()) ->
-                      {'ok', kz_json:object()} |
-                      jesse_error:error().
 validate(SchemaJObj, DataJObj) ->
     validate(SchemaJObj, DataJObj, ?DEFAULT_OPTIONS).
 
@@ -188,6 +186,9 @@ validate(SchemaJObj, DataJObj) ->
 -define(DEFAULT_LOADER, fun load/1).
 -endif.
 
+-spec validate(kz_term:ne_binary() | kz_json:object(), kz_json:object(), jesse_options()) ->
+                      {'ok', kz_json:object()} |
+                      jesse_error:error().
 validate(<<_/binary>> = Schema, DataJObj, Options) ->
     Fun = props:get_value('schema_loader_fun', Options, ?DEFAULT_LOADER),
     {'ok', SchemaJObj} = Fun(Schema),
@@ -205,21 +206,21 @@ validate(SchemaJObj, DataJObj, Options0) when is_list(Options0) ->
 
 -spec errors_to_jobj([jesse_error:error_reason()]) ->
                             validation_errors().
--spec errors_to_jobj([jesse_error:error_reason()], options()) ->
-                            validation_errors().
 errors_to_jobj(Errors) ->
     errors_to_jobj(Errors, [{'version', ?CURRENT_VERSION}]).
 
+-spec errors_to_jobj([jesse_error:error_reason()], options()) ->
+                            validation_errors().
 errors_to_jobj(Errors, Options) ->
     [error_to_jobj(Error, Options) || Error <- Errors].
 
 -spec error_to_jobj(jesse_error:error_reason()) ->
                            validation_error().
--spec error_to_jobj(jesse_error:error_reason(), options()) ->
-                           validation_error().
 error_to_jobj(Error) ->
     error_to_jobj(Error, [{'version', ?CURRENT_VERSION}]).
 
+-spec error_to_jobj(jesse_error:error_reason(), options()) ->
+                           validation_error().
 error_to_jobj({'data_invalid'
               ,_FailedSchemaJObj
               ,'external_error'

--- a/core/kazoo_services/src/bookkeepers/kz_bookkeeper_braintree.erl
+++ b/core/kazoo_services/src/bookkeepers/kz_bookkeeper_braintree.erl
@@ -74,8 +74,8 @@ customer_has_card(Customer, AccountId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec sync(kz_service_items:items(), kz_term:ne_binary()) -> bookkeeper_sync_result().
--spec sync(kz_service_item:items(), kz_term:ne_binary(), updates()) -> bookkeeper_sync_result().
 sync(Items, AccountId) ->
     ItemList = kz_service_items:to_list(Items),
     case fetch_bt_customer(AccountId, ItemList =/= []) of
@@ -84,6 +84,7 @@ sync(Items, AccountId) ->
             sync(ItemList, AccountId, #kz_service_updates{bt_customer=Customer})
     end.
 
+-spec sync(kz_service_item:items(), kz_term:ne_binary(), updates()) -> bookkeeper_sync_result().
 sync([], _AccountId, #kz_service_updates{bt_subscriptions=Subscriptions}) ->
     _ = [braintree_subscription:update(Subscription)
          || #kz_service_update{bt_subscription=Subscription} <- Subscriptions
@@ -150,12 +151,13 @@ subscriptions(AccountId) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec commit_transactions(kz_term:ne_binary(),kz_transactions:kz_transactions()) -> 'ok' | 'error'.
--spec commit_transactions(kz_term:ne_binary(), kz_transactions:kz_transactions(), integer()) -> 'ok' | 'error'.
 commit_transactions(BillingId, Transactions) ->
     _ = kz_transactions:save(Transactions),
     commit_transactions(BillingId, Transactions, 3).
 
+-spec commit_transactions(kz_term:ne_binary(), kz_transactions:kz_transactions(), integer()) -> 'ok' | 'error'.
 commit_transactions(BillingId, Transactions, Try) when Try > 0 ->
     case kz_services:fetch_services_doc(BillingId, true) of
         {'error', _E} ->
@@ -185,11 +187,12 @@ commit_transactions(BillingId, _Transactions, _Try) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec charge_transactions(kz_term:ne_binary(), kz_json:objects()) -> kz_json:objects().
--spec charge_transactions(kz_term:ne_binary(), kz_json:objects(), dict:dict()) -> kz_json:objects().
 charge_transactions(BillingId, Transactions) ->
     charge_transactions(BillingId, Transactions, dict:new()).
 
+-spec charge_transactions(kz_term:ne_binary(), kz_json:objects(), dict:dict()) -> kz_json:objects().
 charge_transactions(BillingId, [], Dict) ->
     dict:fold(
       fun(Code, JObjs, Acc) when Code =:= ?CODE_TOPUP ->
@@ -322,12 +325,12 @@ convert_transaction(BTTransaction) ->
 
 -spec set_reason_and_code(kz_json:object(), kz_transaction:transaction()) ->
                                  kz_transaction:transaction().
--spec set_reason_and_code(kz_json:object(), kz_transaction:transaction(), kz_term:api_pos_integer()) ->
-                                 kz_transaction:transaction().
 set_reason_and_code(BTTransaction, Transaction) ->
     Code = kz_json:get_integer_value(<<"purchase_order">>, BTTransaction),
     set_reason_and_code(BTTransaction, Transaction, Code).
 
+-spec set_reason_and_code(kz_json:object(), kz_transaction:transaction(), kz_term:api_pos_integer()) ->
+                                 kz_transaction:transaction().
 set_reason_and_code(BTTransaction, Transaction, 'undefined') ->
     IsApi = kz_json:is_true(<<"is_api">>, BTTransaction),
     IsRecurring = kz_json:is_true(<<"is_recurring">>, BTTransaction),

--- a/core/kazoo_services/src/kazoo_services_maintenance.erl
+++ b/core/kazoo_services/src/kazoo_services_maintenance.erl
@@ -121,12 +121,12 @@ refresh() ->
 %% full reseller tree (as it normally does when changes occur)
 %% @end
 %%--------------------------------------------------------------------
--spec reconcile() -> 'no_return'.
--spec reconcile(kz_term:text()) -> 'no_return'.
 
+-spec reconcile() -> 'no_return'.
 reconcile() ->
     reconcile('all').
 
+-spec reconcile(kz_term:text()) -> 'no_return'.
 reconcile('all') ->
     Accounts = kapps_util:get_all_accounts('raw'),
     Total = length(Accounts),

--- a/core/kazoo_services/src/kz_service_items.erl
+++ b/core/kazoo_services/src/kz_service_items.erl
@@ -35,8 +35,8 @@ empty() ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_updated_items(items(), items()) -> items().
--spec get_updated_items(any(), kz_service_item:item(), items(), items()) -> items().
 get_updated_items(UpdatedItems, ExistingItems) ->
     dict:fold(fun(Key, UpdatedItem, DifferingItems) ->
                       get_updated_items(Key, UpdatedItem, ExistingItems, DifferingItems)
@@ -45,6 +45,7 @@ get_updated_items(UpdatedItems, ExistingItems) ->
              ,UpdatedItems
              ).
 
+-spec get_updated_items(any(), kz_service_item:item(), items(), items()) -> items().
 get_updated_items(Key, UpdatedItem, ExistingItems, DifferingItems) ->
     case get_item(Key, ExistingItems) of
         'error' -> DifferingItems;

--- a/core/kazoo_services/src/kz_service_plan.erl
+++ b/core/kazoo_services/src/kz_service_plan.erl
@@ -60,11 +60,8 @@ activation_charges(CategoryId, ItemId, ServicePlan) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec create_items(kzd_service_plan:doc(), kz_service_items:items(), kz_services:services()) ->
-                          kz_service_items:items().
--spec create_items(kzd_service_plan:doc(), kz_service_items:items(), kz_services:services()
-                  ,kz_term:ne_binary(), kz_term:ne_binary()
-                  ) ->
                           kz_service_items:items().
 create_items(ServicePlan, ServiceItems, Services) ->
     lists:foldl(fun({CategoryId, ItemId}, SIs) ->
@@ -74,6 +71,10 @@ create_items(ServicePlan, ServiceItems, Services) ->
                ,get_plan_items(ServicePlan, Services)
                ).
 
+-spec create_items(kzd_service_plan:doc(), kz_service_items:items(), kz_services:services()
+                  ,kz_term:ne_binary(), kz_term:ne_binary()
+                  ) ->
+                          kz_service_items:items().
 create_items(ServicePlan, ServiceItems, Services, CategoryId, ItemId) ->
     ItemPlan = kzd_service_plan:item(ServicePlan, CategoryId, ItemId),
     create_items(ServicePlan, ServiceItems, Services, CategoryId, ItemId, ItemPlan).
@@ -302,14 +303,14 @@ get_quantity_rate(Quantity, ItemPlan) ->
 %% summation.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_item_quantity(kz_term:ne_binary(), kz_term:ne_binary(), kzd_item_plan:doc(), kz_services:services()) ->
                                integer().
--spec get_item_quantity(kz_term:ne_binary(), kz_term:ne_binary(), kzd_item_plan:doc(), kz_services:services(), kz_term:ne_binary()) ->
-                               integer().
-
 get_item_quantity(CategoryId, ItemId, ItemPlan, Services) ->
     get_item_quantity(CategoryId, ItemId, ItemPlan, Services, kzd_service_plan:all_items_key()).
 
+-spec get_item_quantity(kz_term:ne_binary(), kz_term:ne_binary(), kzd_item_plan:doc(), kz_services:services(), kz_term:ne_binary()) ->
+                               integer().
 get_item_quantity(CategoryId, AllItems, ItemPlan, Services, AllItems) ->
     Exceptions = kzd_item_plan:exceptions(ItemPlan),
 

--- a/core/kazoo_services/src/services/kz_service_devices.erl
+++ b/core/kazoo_services/src/services/kz_service_devices.erl
@@ -21,8 +21,8 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec reconcile(kz_services:services()) -> kz_services:services().
--spec reconcile(kz_services:services(), kz_term:api_binary() | kz_json:object()) -> kz_services:services().
 reconcile(Services) ->
     AccountId = kz_services:account_id(Services),
     AccountDb = kz_util:format_account_id(AccountId, 'encoded'),
@@ -44,6 +44,7 @@ reconcile(Services) ->
                        )
     end.
 
+-spec reconcile(kz_services:services(), kz_term:api_binary() | kz_json:object()) -> kz_services:services().
 reconcile(Services, 'undefined') ->
     Services;
 reconcile(Services, <<_/binary>> = DeviceType) ->

--- a/core/kazoo_services/src/services/kz_service_ips.erl
+++ b/core/kazoo_services/src/services/kz_service_ips.erl
@@ -18,9 +18,8 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec reconcile(kz_services:services()) -> kz_services:services().
--spec reconcile(kz_services:services(), kz_term:api_binary() | kz_term:proplist()) ->
-                       kz_services:services().
 reconcile(Services) ->
     AccountId = kz_services:account_id(Services),
     case kz_ips:assigned(AccountId) of
@@ -32,6 +31,8 @@ reconcile(Services) ->
             kz_services:update(<<"ips">>, <<"dedicated">>, length(JObjs), S)
     end.
 
+-spec reconcile(kz_services:services(), kz_term:api_binary() | kz_term:proplist()) ->
+                       kz_services:services().
 reconcile(Services, 'undefined') -> Services;
 reconcile(Services0, IpType) when is_binary(IpType) ->
     Services1 = reconcile(Services0),

--- a/core/kazoo_services/src/services/kz_service_ledgers.erl
+++ b/core/kazoo_services/src/services/kz_service_ledgers.erl
@@ -20,8 +20,8 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec reconcile(kz_services:services()) -> kz_services:services().
--spec reconcile(kz_services:services(), kz_term:ne_binary() | kz_term:proplist()) -> kz_services:services().
 reconcile(Services) ->
     AccountId = kz_services:account_id(Services),
     case kz_ledgers:get(AccountId) of
@@ -32,6 +32,7 @@ reconcile(Services) ->
             reconcile_account(Services, JObjs)
     end.
 
+-spec reconcile(kz_services:services(), kz_term:ne_binary() | kz_term:proplist()) -> kz_services:services().
 reconcile(Services, Type) when is_binary(Type) ->
     Services1 = reconcile(Services),
     Quantity = kz_services:updated_quantity(?CATEGORY, Type, Services1),

--- a/core/kazoo_services/src/services/kz_service_phone_numbers.erl
+++ b/core/kazoo_services/src/services/kz_service_phone_numbers.erl
@@ -39,8 +39,8 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec reconcile(kz_services:services()) -> kz_services:services().
--spec reconcile(kz_services:services(), pns()) -> kz_services:services().
 reconcile(Services) ->
     AccountDb = kz_util:format_account_db(kz_services:account_id(Services)),
     case kz_datamgr:get_results(AccountDb, <<"numbers/reconcile_services">>) of
@@ -53,6 +53,7 @@ reconcile(Services) ->
             maps:fold(F, reset(Services), ?MAP_CATEGORIES)
     end.
 
+-spec reconcile(kz_services:services(), pns()) -> kz_services:services().
 reconcile(Services, PNs) ->
     update_numbers(Services, PNs).
 

--- a/core/kazoo_services/src/services/kz_service_ratedeck.erl
+++ b/core/kazoo_services/src/services/kz_service_ratedeck.erl
@@ -22,8 +22,8 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec reconcile(kz_services:services()) -> kz_services:services().
--spec reconcile(kz_services:services(), kz_term:api_binary()) -> kz_services:services().
 reconcile(Services) ->
     ServicePlanJObj = kz_services:service_plan_json(Services),
     %% TODO: resolve conflict when there is more than one ratedeck
@@ -40,6 +40,7 @@ reconcile(Services) ->
             Services
     end.
 
+-spec reconcile(kz_services:services(), kz_term:api_binary()) -> kz_services:services().
 reconcile(Services, 'undefined') -> kz_services:reset_category(?SERVICE_CATEGORY, Services);
 reconcile(Services, RatedeckId) -> kz_services:update(?SERVICE_CATEGORY, RatedeckId, 1, Services).
 

--- a/core/kazoo_services/src/services/kz_service_ratedeck_name.erl
+++ b/core/kazoo_services/src/services/kz_service_ratedeck_name.erl
@@ -22,8 +22,8 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec reconcile(kz_services:services()) -> kz_services:services().
--spec reconcile(kz_services:services(), kz_term:api_binary()) -> kz_services:services().
 reconcile(Services) ->
     ServicePlanJObj = kz_services:service_plan_json(Services),
     %% TODO: resolve conflict when there is more than one ratedeck
@@ -40,6 +40,7 @@ reconcile(Services) ->
             Services
     end.
 
+-spec reconcile(kz_services:services(), kz_term:api_binary()) -> kz_services:services().
 reconcile(Services, 'undefined') ->
     kz_services:reset_category(?SERVICE_CATEGORY, Services);
 reconcile(Services, RatedeckName) ->

--- a/core/kazoo_services/src/services/kz_service_ui_apps.erl
+++ b/core/kazoo_services/src/services/kz_service_ui_apps.erl
@@ -23,8 +23,8 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec reconcile(kz_services:services()) -> kz_services:services().
--spec reconcile(kz_services:services(), kz_term:ne_binary()) -> kz_services:services().
 reconcile(Services) ->
     AccountId = kz_services:account_id(Services),
     case kz_datamgr:open_doc(?ACCOUNTS_DB, AccountId) of
@@ -49,6 +49,7 @@ reconcile_account(Services, AccountDoc) ->
                  ,kz_json:get_value(<<"ui_apps">>, AccountDoc, kz_json:new())
                  ).
 
+-spec reconcile(kz_services:services(), kz_term:ne_binary()) -> kz_services:services().
 reconcile(Services, AppName) ->
     %% Because you can only be charged once for an app
     NewServices = kz_services:reset_category(?CATEGORY, Services),

--- a/core/kazoo_services/src/services/kz_service_users.erl
+++ b/core/kazoo_services/src/services/kz_service_users.erl
@@ -21,8 +21,8 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec reconcile(kz_services:services()) -> kz_services:services().
--spec reconcile(kz_services:services(), kz_term:ne_binary()) -> kz_services:services().
 reconcile(Services) ->
     AccountId = kz_services:account_id(Services),
     AccountDb = kz_util:format_account_id(AccountId, 'encoded'),
@@ -42,6 +42,7 @@ reconcile(Services) ->
                         end, kz_services:reset_category(?SERVICE_CATEGORY, Services), JObjs)
     end.
 
+-spec reconcile(kz_services:services(), kz_term:ne_binary()) -> kz_services:services().
 reconcile(Services0, UserType) ->
     Services1 = reconcile(Services0),
     Quantity = kz_services:updated_quantity(?SERVICE_CATEGORY, UserType, Services1),

--- a/core/kazoo_services/src/services/kz_service_whitelabel.erl
+++ b/core/kazoo_services/src/services/kz_service_whitelabel.erl
@@ -24,8 +24,8 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec reconcile(kz_services:services()) -> kz_services:services().
--spec reconcile(kz_services:services(), kz_term:ne_binary()) -> kz_services:services().
 reconcile(Services) ->
     AccountId = kz_services:account_id(Services),
     AccountDb = kz_util:format_account_id(AccountId, 'encoded'),
@@ -42,6 +42,7 @@ reconcile(Services) ->
              )
     end.
 
+-spec reconcile(kz_services:services(), kz_term:ne_binary()) -> kz_services:services().
 reconcile(Services0, ?ITEM=Item) ->
     Services1 = reconcile(Services0),
     Quantity = kz_services:updated_quantity(?CATEGORY, Item, Services1),

--- a/core/kazoo_sip/src/kzsip_diversion.erl
+++ b/core/kazoo_sip/src/kzsip_diversion.erl
@@ -45,29 +45,36 @@
 -spec new() -> diversion().
 new() -> kz_json:new().
 
--spec reason(diversion()) -> kz_term:api_binary().
--spec counter(diversion()) -> non_neg_integer().
--spec limit(diversion()) -> kz_term:api_integer().
--spec privacy(diversion()) -> kz_term:api_binary().
--spec screen(diversion()) -> kz_term:api_binary().
--spec extensions(diversion()) -> kz_term:api_list().
--spec address(diversion()) -> kz_term:api_binary().
--spec user(diversion()) -> kz_term:api_binary().
 
+-spec user(diversion()) -> kz_term:api_binary().
 user(JObj) ->
     kzsip_uri:user(kzsip_uri:parse(address(JObj))).
+
+-spec address(diversion()) -> kz_term:api_binary().
 address(JObj) ->
     kz_json:get_ne_binary_value(?PARAM_ADDRESS, JObj).
+
+-spec reason(diversion()) -> kz_term:api_binary().
 reason(JObj) ->
     kz_json:get_ne_binary_value(?PARAM_REASON, JObj).
+
+-spec counter(diversion()) -> non_neg_integer().
 counter(JObj) ->
     kz_json:get_integer_value(?PARAM_COUNTER, JObj, 0).
+
+-spec limit(diversion()) -> kz_term:api_integer().
 limit(JObj) ->
     kz_json:get_integer_value(?PARAM_LIMIT, JObj).
+
+-spec privacy(diversion()) -> kz_term:api_binary().
 privacy(JObj) ->
     kz_json:get_ne_binary_value(?PARAM_PRIVACY, JObj).
+
+-spec screen(diversion()) -> kz_term:api_binary().
 screen(JObj) ->
     kz_json:get_ne_binary_value(?PARAM_SCREEN, JObj).
+
+-spec extensions(diversion()) -> kz_term:api_list().
 extensions(JObj) ->
     case kz_json:get_ne_value(?PARAM_EXTENSION, JObj) of
         'undefined' -> 'undefined';
@@ -82,19 +89,22 @@ extensions_fold({K, ?SOLO_EXTENSION}, Acc) ->
 extensions_fold({_K, _V}=Extention, Acc) ->
     [Extention | Acc].
 
--spec set_user(diversion(), kz_term:ne_binary()) -> diversion().
--spec set_address(diversion(), kz_term:ne_binary()) -> diversion().
--spec set_reason(diversion(), kz_term:ne_binary()) -> diversion().
--spec set_counter(diversion(), non_neg_integer()) -> diversion().
 
+-spec set_user(diversion(), kz_term:ne_binary()) -> diversion().
 set_user(JObj, User) ->
     Address = kzsip_uri:parse(address(JObj)),
     Address1 = kzsip_uri:set_user(Address, User),
     set_address(JObj, list_to_binary([<<"<">>, kzsip_uri:encode(Address1), <<">">>])).
+
+-spec set_address(diversion(), kz_term:ne_binary()) -> diversion().
 set_address(JObj, Address) ->
     kz_json:set_value(?PARAM_ADDRESS, Address, JObj).
+
+-spec set_reason(diversion(), kz_term:ne_binary()) -> diversion().
 set_reason(JObj, Reason) ->
     kz_json:set_value(?PARAM_REASON, Reason, JObj).
+
+-spec set_counter(diversion(), non_neg_integer()) -> diversion().
 set_counter(JObj, Counter) ->
     kz_json:set_value(?PARAM_COUNTER, Counter, JObj).
 
@@ -163,7 +173,6 @@ parse_params(Params, JObj) ->
     end.
 
 -spec parse_param(kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
--spec parse_param(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 parse_param(Param, JObj) ->
     case binary:split(Param, <<"=">>, ['trim']) of
         [Name, Value] ->
@@ -172,6 +181,7 @@ parse_param(Param, JObj) ->
             add_extension(kz_binary:strip(Extension), JObj)
     end.
 
+-spec parse_param(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 parse_param(?PARAM_REASON, Value, JObj) ->
     kz_json:set_value(?PARAM_REASON, parse_reason_param(Value), JObj);
 parse_param(?PARAM_COUNTER, Value, JObj) ->

--- a/core/kazoo_sip/src/kzsip_uri.erl
+++ b/core/kazoo_sip/src/kzsip_uri.erl
@@ -103,25 +103,29 @@ parse_until(C, Bin) ->
     end.
 
 -spec scheme(sip_uri()) -> scheme().
--spec set_scheme(sip_uri(), scheme()) -> sip_uri().
 scheme(#sip_uri{scheme=S}) -> S.
+
+-spec set_scheme(sip_uri(), scheme()) -> sip_uri().
 set_scheme(#sip_uri{}=Sip, S) ->
     Sip#sip_uri{scheme=S}.
 
 -spec user(sip_uri()) -> kz_term:ne_binary().
--spec set_user(sip_uri(), kz_term:ne_binary()) -> sip_uri().
 user(#sip_uri{user=U}) -> U.
+
+-spec set_user(sip_uri(), kz_term:ne_binary()) -> sip_uri().
 set_user(#sip_uri{}=Sip, U) ->
     Sip#sip_uri{user=U}.
 
 -spec host(sip_uri()) -> kz_term:ne_binary().
--spec set_host(sip_uri(), kz_term:ne_binary()) -> sip_uri().
 host(#sip_uri{host=H}) -> H.
+
+-spec set_host(sip_uri(), kz_term:ne_binary()) -> sip_uri().
 set_host(#sip_uri{}=Sip, H) ->
     Sip#sip_uri{host=H}.
 
 -spec port(sip_uri()) -> pos_integer().
--spec set_port(sip_uri(), pos_integer()) -> sip_uri().
 port(#sip_uri{port=P}) -> P.
+
+-spec set_port(sip_uri(), pos_integer()) -> sip_uri().
 set_port(#sip_uri{}=Sip, P) ->
     Sip#sip_uri{port=P}.

--- a/core/kazoo_speech/src/kazoo_asr.erl
+++ b/core/kazoo_speech/src/kazoo_asr.erl
@@ -21,20 +21,24 @@ default_locale() ->
 %%------------------------------------------------------------------------------
 %% Transcribe the audio binary
 %%------------------------------------------------------------------------------
+
 -spec freeform(binary()) -> asr_resp().
--spec freeform(binary(), kz_term:ne_binary()) -> asr_resp().
--spec freeform(binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> asr_resp().
--spec freeform(binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> asr_resp().
--spec freeform(binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:ne_binary()) -> asr_resp().
 freeform(Content) ->
     freeform(Content, default_mime_type()).
+
+-spec freeform(binary(), kz_term:ne_binary()) -> asr_resp().
 freeform(Content, ContentType) ->
     freeform(Content, ContentType, default_locale()).
+
+-spec freeform(binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> asr_resp().
 freeform(Content, ContentType, Locale) ->
     freeform(Content, ContentType, Locale, []).
+
+-spec freeform(binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> asr_resp().
 freeform(Content, ContentType, Locale, Options) ->
     freeform(Content, ContentType, Locale, Options, default_provider()).
 
+-spec freeform(binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:ne_binary()) -> asr_resp().
 freeform(Content, ContentType, Locale, Options, ASRProvider) ->
     try (kz_term:to_atom(<<"kazoo_asr_", ASRProvider/binary>>, 'true')):freeform(Content, ContentType, Locale, Options)
     catch
@@ -46,20 +50,24 @@ freeform(Content, ContentType, Locale, Options, ASRProvider) ->
 %%------------------------------------------------------------------------------
 %% Transcribe the audio binary
 %%------------------------------------------------------------------------------
+
 -spec commands(kz_term:ne_binary(), kz_term:ne_binaries()) -> asr_resp().
--spec commands(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary()) -> asr_resp().
--spec commands(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary(), kz_term:ne_binary()) -> asr_resp().
--spec commands(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> asr_resp().
--spec commands(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:ne_binary()) -> asr_resp().
 commands(Bin, Commands) ->
     commands(Bin, Commands, default_mime_type()).
+
+-spec commands(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary()) -> asr_resp().
 commands(Bin, Commands, ContentType) ->
     commands(Bin, Commands, ContentType, default_locale()).
+
+-spec commands(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary(), kz_term:ne_binary()) -> asr_resp().
 commands(Bin, Commands, ContentType, Locale) ->
     commands(Bin, Commands, ContentType, Locale, []).
+
+-spec commands(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> asr_resp().
 commands(Bin, Commands, ContentType, Locale, Options) ->
     commands(Bin, Commands, ContentType, Locale, Options, default_provider()).
 
+-spec commands(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), kz_term:ne_binary()) -> asr_resp().
 commands(Bin, Commands, ContentType, Locale, Options, ASRProvider) ->
     try (kz_term:to_atom(<<"kazoo_asr_", ASRProvider/binary>>, 'true')):commands(Bin, Commands, ContentType, Locale, Options)
     catch

--- a/core/kazoo_speech/src/kazoo_tts.erl
+++ b/core/kazoo_speech/src/kazoo_tts.erl
@@ -50,10 +50,10 @@ cache_time_ms() ->
     kapps_config:get_integer(?MOD_CONFIG_CAT, <<"tts_cache">>, ?MILLISECONDS_IN_HOUR).
 
 -spec default_provider() -> kz_term:ne_binary().
--spec default_provider(kapps_call:call()) -> kz_term:ne_binary().
 default_provider() ->
     kapps_config:get_binary(?MOD_CONFIG_CAT, <<"tts_provider">>, <<"flite">>).
 
+-spec default_provider(kapps_call:call()) -> kz_term:ne_binary().
 default_provider(Call) ->
     Default = default_provider(),
     kapps_account_config:get_global(Call, ?MOD_CONFIG_CAT, <<"tts_provider">>, Default).

--- a/core/kazoo_stats/src/kazoo_stats.erl
+++ b/core/kazoo_stats/src/kazoo_stats.erl
@@ -44,9 +44,11 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link() -> kz_types:startlink_ret().
--spec start_link(pos_integer()) -> kz_types:startlink_ret().
 start_link() -> start_link(?SEND_INTERVAL).
+
+-spec start_link(pos_integer()) -> kz_types:startlink_ret().
 start_link(Send_stats) ->
     gen_server:start_link({'local', ?SERVER}, ?MODULE, [Send_stats], []).
 
@@ -59,9 +61,9 @@ getdb() ->
     gen_server:call(?SERVER, 'get_db').
 
 -spec increment_counter(any()) -> 'ok'.
--spec increment_counter(any(), any()) -> 'ok'.
 increment_counter(Item) -> send_counter(Item, 1).
 
+-spec increment_counter(any(), any()) -> 'ok'.
 increment_counter(Realm, Item) ->
     gen_server:cast(?SERVER, {'add', Realm, Item, 1}).
 

--- a/core/kazoo_stdlib/src/kz_binary.erl
+++ b/core/kazoo_stdlib/src/kz_binary.erl
@@ -60,10 +60,11 @@ pad_left(Bin, _Size, _Value) -> Bin.
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec join([kz_term:text()]) -> binary().
--spec join([kz_term:text()], iodata() | char()) -> binary().
 
+-spec join([kz_term:text()]) -> binary().
 join(Bins) -> join(Bins, <<", ">>).
+
+-spec join([kz_term:text()], iodata() | char()) -> binary().
 join([], _) -> <<>>;
 join([Bin], _) -> kz_term:to_binary(Bin);
 join([Bin|Bins], Sep) ->
@@ -86,10 +87,10 @@ remove_white_spaces(Bin) ->
     << <<X>> || <<X>> <= Bin, X =/= $\s >>.
 
 -spec clean(binary()) -> binary().
--spec clean(binary(), kz_term:proplist()) -> binary().
 clean(Bin) ->
     clean(Bin, []).
 
+-spec clean(binary(), kz_term:proplist()) -> binary().
 clean(Bin, Opts) ->
     Routines = [fun remove_white_spaces/2],
     lists:foldl(fun(F, B) -> F(B, Opts) end, Bin, Routines).
@@ -98,11 +99,9 @@ clean(Bin, Opts) ->
 -type strip_options() :: [strip_option()].
 
 -spec strip(binary()) -> binary().
--spec strip(binary(), strip_option() | strip_options()) -> binary().
--spec strip_left(binary(), char() | binary()) -> binary().
--spec strip_right(binary(), char() | binary()) -> binary().
 strip(B) -> strip(B, 'both').
 
+-spec strip(binary(), strip_option() | strip_options()) -> binary().
 strip(B, 'left') -> strip_left(B, $\s);
 strip(B, 'right') -> strip_right(B, $\s);
 strip(B, 'both') -> strip_right(strip_left(B, $\s), $\s);
@@ -110,9 +109,11 @@ strip(B, C) when is_integer(C) -> strip_right(strip_left(B, C), C);
 strip(B, Cs) when is_list(Cs) ->
     lists:foldl(fun(C, Acc) -> strip(Acc, C) end, B, Cs).
 
+-spec strip_left(binary(), char() | binary()) -> binary().
 strip_left(<<C, B/binary>>, C) -> strip_left(B, C);
 strip_left(B, _) -> B.
 
+-spec strip_right(binary(), char() | binary()) -> binary().
 strip_right(C, C) -> <<>>;
 strip_right(<<C, B/binary>>, C) ->
     case strip_right(B, C) of
@@ -129,11 +130,12 @@ strip_right(<<>>, _) -> <<>>.
 %% Ensure a binary is a maximum given size, truncating it if not.
 %% @end
 %%--------------------------------------------------------------------
+
 -spec truncate(binary(), non_neg_integer()) -> binary().
--spec truncate(binary(), non_neg_integer(), 'left' | 'right') -> binary().
 truncate(Bin, Size) ->
     truncate(Bin, Size, 'right').
 
+-spec truncate(binary(), non_neg_integer(), 'left' | 'right') -> binary().
 truncate(Bin, Size, 'left') ->
     truncate_left(Bin, Size);
 truncate(Bin, Size, 'right') ->
@@ -177,10 +179,10 @@ from_hex(Bin) ->
     kz_term:to_binary(from_hex_string(kz_term:to_list(Bin))).
 
 -spec from_hex_string(list()) -> list().
--spec from_hex_string(list(), list()) -> list().
 from_hex_string(Str) ->
     from_hex_string(Str, []).
 
+-spec from_hex_string(list(), list()) -> list().
 from_hex_string([], Acc) -> lists:reverse(Acc);
 from_hex_string([Div, Rem | T], Acc) ->
     Lo = hex_char_to_binary(Rem),

--- a/core/kazoo_stdlib/src/kz_term.erl
+++ b/core/kazoo_stdlib/src/kz_term.erl
@@ -158,12 +158,12 @@ shuffle_list(List) when is_list(List) ->
     randomize_list(round(math:log(length(List)) + 0.5), List).
 
 -spec randomize_list(list()) -> list().
--spec randomize_list(pos_integer(), list()) -> list().
 randomize_list(List) ->
     D = lists:keysort(1, [{rand:uniform(), A} || A <- List]),
     {_, D1} = lists:unzip(D),
     D1.
 
+-spec randomize_list(pos_integer(), list()) -> list().
 randomize_list(1, List) -> randomize_list(List);
 randomize_list(T, List) ->
     lists:foldl(fun(_E, Acc) ->
@@ -185,9 +185,9 @@ to_hex_binary(S) ->
 
 
 -spec to_integer(string() | binary() | integer() | float()) -> integer().
--spec to_integer(string() | binary() | integer() | float(), 'strict' | 'notstrict') -> integer().
 to_integer(X) -> to_integer(X, 'notstrict').
 
+-spec to_integer(string() | binary() | integer() | float(), 'strict' | 'notstrict') -> integer().
 to_integer(X, _) when is_integer(X) -> X;
 to_integer(X, 'strict') when is_float(X) -> erlang:error('badarg');
 to_integer(X, 'notstrict') when is_float(X) -> round(X);
@@ -204,9 +204,9 @@ to_integer(X, S) when is_list(X) ->
     end.
 
 -spec to_float(string() | binary() | integer() | float()) -> float().
--spec to_float(string() | binary() | integer() | float(), 'strict' | 'notstrict') -> float().
 to_float(X) -> to_float(X, 'notstrict').
 
+-spec to_float(string() | binary() | integer() | float(), 'strict' | 'notstrict') -> float().
 to_float(X, _) when is_float(X) -> X;
 to_float(X, strict) when is_binary(X) -> binary_to_float(X);
 to_float(X, notstrict) when is_binary(X) ->

--- a/core/kazoo_stdlib/src/kz_time.erl
+++ b/core/kazoo_stdlib/src/kz_time.erl
@@ -120,10 +120,10 @@ pretty_print_datetime({{Y,Mo,D},{H,Mi,S}}) ->
                                   )).
 
 -spec rfc1036(calendar:datetime() | gregorian_seconds()) -> kz_term:ne_binary().
--spec rfc1036(calendar:datetime() | gregorian_seconds(), kz_term:ne_binary()) -> kz_term:ne_binary().
 rfc1036(DateTime) ->
     rfc1036(DateTime, <<"GMT">>).
 
+-spec rfc1036(calendar:datetime() | gregorian_seconds(), kz_term:ne_binary()) -> kz_term:ne_binary().
 rfc1036({Date = {Y, Mo, D}, {H, Mi, S}}, TZ) ->
     Wday = calendar:day_of_the_week(Date),
     <<(weekday(Wday))/binary, ", ",
@@ -204,7 +204,6 @@ unitfy_seconds(Seconds) ->
     [kz_term:to_binary(D), "d", unitfy_seconds(Seconds - (D * ?SECONDS_IN_DAY))].
 
 -spec decr_timeout(timeout(), now() | gregorian_seconds()) -> timeout().
--spec decr_timeout(timeout(), now() | gregorian_seconds(), now() | gregorian_seconds()) -> timeout().
 decr_timeout('infinity', _) -> 'infinity';
 decr_timeout(Timeout, {_Mega, _S, _Micro}=Start) when is_integer(Timeout) ->
     decr_timeout(Timeout, Start, now());
@@ -213,6 +212,7 @@ decr_timeout(Timeout, StartS) when is_integer(Timeout),
                                    ?UNIX_EPOCH_IN_GREGORIAN < StartS ->
     decr_timeout(Timeout, StartS, now_s()).
 
+-spec decr_timeout(timeout(), now() | gregorian_seconds(), now() | gregorian_seconds()) -> timeout().
 decr_timeout('infinity', _Start, _Future) -> 'infinity';
 decr_timeout(Timeout, Start, {_Mega, _S, _Micro}=Now) ->
     decr_timeout_elapsed(Timeout, elapsed_s(Start, Now));
@@ -232,25 +232,24 @@ decr_timeout_elapsed(Timeout, Elapsed) ->
     end.
 
 -spec microseconds_to_seconds(float() | integer() | string() | binary()) -> non_neg_integer().
--spec milliseconds_to_seconds(float() | integer() | string() | binary()) -> non_neg_integer().
 microseconds_to_seconds(Microseconds) -> kz_term:to_integer(Microseconds) div ?MICROSECONDS_IN_SECOND.
+
+-spec milliseconds_to_seconds(float() | integer() | string() | binary()) -> non_neg_integer().
 milliseconds_to_seconds(Milliseconds) -> kz_term:to_integer(Milliseconds) div ?MILLISECONDS_IN_SECOND.
 
 -spec elapsed_s(now() | pos_integer()) -> pos_integer().
--spec elapsed_ms(now() | pos_integer()) -> pos_integer().
--spec elapsed_us(now() | pos_integer()) -> pos_integer().
 elapsed_s({_,_,_}=Start) -> elapsed_s(Start, now());
 elapsed_s(Start) when is_integer(Start) -> elapsed_s(Start, now_s()).
 
+-spec elapsed_ms(now() | pos_integer()) -> pos_integer().
 elapsed_ms({_,_,_}=Start) -> elapsed_ms(Start, now());
 elapsed_ms(Start) when is_integer(Start) -> elapsed_ms(Start, now_ms()).
 
+-spec elapsed_us(now() | pos_integer()) -> pos_integer().
 elapsed_us({_,_,_}=Start) -> elapsed_us(Start, now());
 elapsed_us(Start) when is_integer(Start) -> elapsed_us(Start, now_us()).
 
 -spec elapsed_s(now() | pos_integer(), now() | pos_integer()) -> pos_integer().
--spec elapsed_ms(now() | pos_integer(), now() | pos_integer()) -> pos_integer().
--spec elapsed_us(now() | pos_integer(), now() | pos_integer()) -> pos_integer().
 elapsed_s({_,_,_}=Start, {_,_,_}=Now) ->
     timer:now_diff(Now, Start) div ?MICROSECONDS_IN_SECOND;
 elapsed_s({_,_,_}=Start, Now) -> elapsed_s(now_s(Start), Now);
@@ -260,6 +259,7 @@ elapsed_s(Start, Now)
        is_integer(Now) ->
     Now - Start.
 
+-spec elapsed_ms(now() | pos_integer(), now() | pos_integer()) -> pos_integer().
 elapsed_ms({_,_,_}=Start, {_,_,_}=Now) ->
     timer:now_diff(Now, Start) div ?MILLISECONDS_IN_SECOND;
 elapsed_ms({_,_,_}=Start, Now) -> elapsed_ms(now_ms(Start), Now);
@@ -275,6 +275,7 @@ elapsed_ms(Start, Now)
        is_integer(Now) ->
     (Now - Start) * ?MILLISECONDS_IN_SECOND.
 
+-spec elapsed_us(now() | pos_integer(), now() | pos_integer()) -> pos_integer().
 elapsed_us({_,_,_}=Start, {_,_,_}=Now) ->
     timer:now_diff(Now, Start);
 elapsed_us({_,_,_}=Start, Now) -> elapsed_us(now_us(Start), Now);
@@ -293,50 +294,54 @@ elapsed_us(Start, Now)
 -spec now() -> now().
 now() -> os:timestamp().
 
--spec now_s() -> gregorian_seconds().
--spec now_ms() -> pos_integer().
--spec now_us() -> pos_integer().
 
+-spec now_s() -> gregorian_seconds().
 now_s() ->  erlang:system_time('seconds') + ?UNIX_EPOCH_IN_GREGORIAN.
+
+-spec now_ms() -> pos_integer().
 now_ms() -> erlang:system_time('milli_seconds') + (?UNIX_EPOCH_IN_GREGORIAN * ?MILLISECONDS_IN_SECOND).
+
+-spec now_us() -> pos_integer().
 now_us() -> erlang:system_time('micro_seconds') + (?UNIX_EPOCH_IN_GREGORIAN * ?MICROSECONDS_IN_SECOND).
 
--spec now_s(now()) -> gregorian_seconds().
--spec now_ms(now()) -> pos_integer().
 -spec now_us(now()) -> pos_integer().
 now_us({MegaSecs, Secs, MicroSecs}) ->
     unix_us_to_gregorian_us((MegaSecs*?MICROSECONDS_IN_SECOND + Secs)*?MICROSECONDS_IN_SECOND + MicroSecs).
+
+-spec now_ms(now()) -> pos_integer().
 now_ms({_,_,_}=Now) ->
     now_us(Now) div ?MILLISECONDS_IN_SECOND.
+
+-spec now_s(now()) -> gregorian_seconds().
 now_s({_,_,_}=Now) ->
     now_us(Now) div ?MICROSECONDS_IN_SECOND.
 
 unix_us_to_gregorian_us(UnixUS) ->
     UnixUS + (?UNIX_EPOCH_IN_GREGORIAN * ?MICROSECONDS_IN_SECOND).
 
--spec format_date() -> binary().
--spec format_date(gregorian_seconds()) -> binary().
--spec format_time() -> binary().
--spec format_time(gregorian_seconds()) -> binary().
--spec format_datetime() -> binary().
--spec format_datetime(gregorian_seconds()) -> binary().
 
+-spec format_date() -> binary().
 format_date() ->
     format_date(now_s()).
 
+-spec format_date(gregorian_seconds()) -> binary().
 format_date(Timestamp) when is_integer(Timestamp) ->
     {{Y,M,D}, _ } = calendar:gregorian_seconds_to_datetime(Timestamp),
     list_to_binary([kz_term:to_binary(Y), "-", kz_term:to_binary(M), "-", kz_term:to_binary(D)]).
 
+-spec format_time() -> binary().
 format_time() ->
     format_time(now_s()).
 
+-spec format_time(gregorian_seconds()) -> binary().
 format_time(Timestamp) when is_integer(Timestamp) ->
     { _, {H,I,S}} = calendar:gregorian_seconds_to_datetime(Timestamp),
     list_to_binary([kz_term:to_binary(H), ":", kz_term:to_binary(I), ":", kz_term:to_binary(S)]).
 
+-spec format_datetime() -> binary().
 format_datetime() ->
     format_datetime(now_s()).
 
+-spec format_datetime(gregorian_seconds()) -> binary().
 format_datetime(Timestamp) when is_integer(Timestamp) ->
     list_to_binary([format_date(Timestamp), " ", format_time(Timestamp)]).

--- a/core/kazoo_stdlib/src/props.erl
+++ b/core/kazoo_stdlib/src/props.erl
@@ -49,13 +49,13 @@ set_values([K|KVs], Props) ->
 
 -spec set_value(kz_term:proplist_property(), kz_term:proplist()) ->
                        kz_term:proplist().
--spec set_value(kz_term:proplist_key(), kz_term:proplist_value(), kz_term:proplist()) ->
-                       kz_term:proplist().
 set_value({K, V}, Props) ->
     set_value(K, V, Props);
 set_value(K, Props) ->
     set_value(K, 'true', Props).
 
+-spec set_value(kz_term:proplist_key(), kz_term:proplist_value(), kz_term:proplist()) ->
+                       kz_term:proplist().
 set_value([K], V, Props) ->
     [{K, V} | [KV || KV <- Props, not do_keys_match(KV, K)]];
 set_value([K|Ks], V, Props) ->
@@ -72,13 +72,13 @@ do_keys_match(_K1, _K2) -> 'false'.
 
 -spec insert_value(kz_term:proplist_property(), kz_term:proplist()) ->
                           kz_term:proplist().
--spec insert_value(kz_term:proplist_key(), kz_term:proplist_value(), kz_term:proplist()) ->
-                          kz_term:proplist().
 insert_value({K, V}, Props) ->
     insert_value(K, V, Props);
 insert_value(K, Props) ->
     insert_value(K, 'true', Props).
 
+-spec insert_value(kz_term:proplist_key(), kz_term:proplist_value(), kz_term:proplist()) ->
+                          kz_term:proplist().
 insert_value(K, V, Props) ->
     case get_value(K, Props) of
         'undefined' when V =/= 'undefined' -> [{K, V} | Props];
@@ -117,11 +117,11 @@ is_not_undefined({_, 'undefined'}) -> 'false';
 is_not_undefined(_V) -> 'true'.
 
 -spec get_value(kz_term:proplist_key() | [kz_term:proplist_key()], kz_term:proplist()) -> any().
--spec get_value(kz_term:proplist_key() | [kz_term:proplist_key()], kz_term:proplist(), Default) ->
-                       Default | any().
 get_value(Key, Props) ->
     get_value(Key, Props, 'undefined').
 
+-spec get_value(kz_term:proplist_key() | [kz_term:proplist_key()], kz_term:proplist(), Default) ->
+                       Default | any().
 get_value(_Key, [], Default) -> Default;
 get_value([Key], Props, Default) when is_binary(Key)
                                       orelse is_atom(Key) ->
@@ -144,10 +144,11 @@ get_value(Key, Props, Default) when is_list(Props) ->
     end.
 
 %% Given a list of keys, find the first one defined
+
 -spec get_first_defined([kz_term:proplist_key()], kz_term:proplist()) -> 'undefined' | any().
--spec get_first_defined([kz_term:proplist_key()], kz_term:proplist(), Default) -> Default | any().
 get_first_defined(Keys, Props) -> get_first_defined(Keys, Props, 'undefined').
 
+-spec get_first_defined([kz_term:proplist_key()], kz_term:proplist(), Default) -> Default | any().
 get_first_defined([], _Props, Default) -> Default;
 get_first_defined([H|T], Props, Default) ->
     case get_value(H, Props) of
@@ -156,14 +157,16 @@ get_first_defined([H|T], Props, Default) ->
     end.
 
 -spec get_is_true(kz_term:proplist_key(), kz_term:proplist()) -> kz_term:api_boolean().
--spec get_is_true(kz_term:proplist_key(), kz_term:proplist(), Default) -> Default | boolean().
 get_is_true(Key, Props) -> is_true(Key, Props).
+
+-spec get_is_true(kz_term:proplist_key(), kz_term:proplist(), Default) -> Default | boolean().
 get_is_true(Key, Props, Default) -> is_true(Key, Props, Default).
 
 -spec is_true(kz_term:proplist_key(), kz_term:proplist()) -> kz_term:api_boolean().
--spec is_true(kz_term:proplist_key(), kz_term:proplist(), Default) -> Default | boolean().
 is_true(Key, Props) ->
     is_true(Key, Props, 'undefined').
+
+-spec is_true(kz_term:proplist_key(), kz_term:proplist(), Default) -> Default | boolean().
 is_true(Key, Props, Default) ->
     case get_value(Key, Props) of
         'undefined' -> Default;
@@ -171,14 +174,16 @@ is_true(Key, Props, Default) ->
     end.
 
 -spec get_is_false(kz_term:proplist_key(), kz_term:proplist()) -> kz_term:api_boolean().
--spec get_is_false(kz_term:proplist_key(), kz_term:proplist(), Default) -> Default | boolean().
 get_is_false(Key, Props) -> is_false(Key, Props).
+
+-spec get_is_false(kz_term:proplist_key(), kz_term:proplist(), Default) -> Default | boolean().
 get_is_false(Key, Props, Default) -> is_false(Key, Props, Default).
 
 -spec is_false(kz_term:proplist_key(), kz_term:proplist()) -> kz_term:api_boolean().
--spec is_false(kz_term:proplist_key(), kz_term:proplist(), Default) -> boolean() | Default.
 is_false(Key, Props) ->
     is_false(Key, Props, 'undefined').
+
+-spec is_false(kz_term:proplist_key(), kz_term:proplist(), Default) -> boolean() | Default.
 is_false(Key, Props, Default) ->
     case get_value(Key, Props) of
         'undefined' -> Default;
@@ -187,10 +192,11 @@ is_false(Key, Props, Default) ->
 
 -spec get_integer_value(kz_term:proplist_key(), kz_term:proplist()) ->
                                kz_term:api_integer().
--spec get_integer_value(kz_term:proplist_key(), kz_term:proplist(), Default) ->
-                               integer() | Default.
 get_integer_value(Key, Props) ->
     get_integer_value(Key, Props, 'undefined').
+
+-spec get_integer_value(kz_term:proplist_key(), kz_term:proplist(), Default) ->
+                               integer() | Default.
 get_integer_value(Key, Props, Default) ->
     case get_value(Key, Props) of
         'undefined' -> Default;
@@ -199,10 +205,11 @@ get_integer_value(Key, Props, Default) ->
 
 -spec get_atom_value(kz_term:proplist_key(), kz_term:proplist()) ->
                             atom().
--spec get_atom_value(kz_term:proplist_key(), kz_term:proplist(), Default) ->
-                            atom() | Default.
 get_atom_value(Key, Props) ->
     get_atom_value(Key, Props, 'undefined').
+
+-spec get_atom_value(kz_term:proplist_key(), kz_term:proplist(), Default) ->
+                            atom() | Default.
 get_atom_value(Key, Props, Default) ->
     case get_value(Key, Props) of
         'undefined' -> Default;
@@ -210,10 +217,11 @@ get_atom_value(Key, Props, Default) ->
     end.
 
 -spec get_binary_value(kz_term:proplist_key() | [kz_term:proplist_key()], kz_term:proplist()) -> kz_term:api_binary().
--spec get_binary_value(kz_term:proplist_key() | [kz_term:proplist_key()], kz_term:proplist(), Default) ->
-                              kz_term:ne_binary() | Default.
 get_binary_value(Key, Props) ->
     get_binary_value(Key, Props, 'undefined').
+
+-spec get_binary_value(kz_term:proplist_key() | [kz_term:proplist_key()], kz_term:proplist(), Default) ->
+                              kz_term:ne_binary() | Default.
 get_binary_value(Keys, Props, Default) when is_list(Keys) ->
     case get_first_defined(Keys, Props) of
         'undefined' -> Default;
@@ -226,10 +234,11 @@ get_binary_value(Key, Props, Default) ->
     end.
 
 -spec get_ne_binary_value(kz_term:proplist_key(), kz_term:proplist()) -> kz_term:api_binary().
--spec get_ne_binary_value(kz_term:proplist_key(), kz_term:proplist(), Default) ->
-                                 kz_term:ne_binary() | Default.
 get_ne_binary_value(Key, Props) ->
     get_ne_binary_value(Key, Props, 'undefined').
+
+-spec get_ne_binary_value(kz_term:proplist_key(), kz_term:proplist(), Default) ->
+                                 kz_term:ne_binary() | Default.
 get_ne_binary_value(Key, Props, Default) ->
     case get_value(Key, Props) of
         'undefined' -> Default;

--- a/core/kazoo_templates/src/kz_template.erl
+++ b/core/kazoo_templates/src/kz_template.erl
@@ -45,15 +45,16 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec render(atom(), kz_term:proplist()) -> template_result().
--spec render(template(), atom(), kz_term:proplist()) -> template_result().
--spec render(template(), atom(), kz_term:proplist(), kz_term:proplist()) -> template_result().
 render(Module, TemplateData) ->
     render_template(Module, TemplateData).
 
+-spec render(template(), atom(), kz_term:proplist()) -> template_result().
 render(Template, Module, TemplateData) ->
     render(Template, Module, TemplateData, []).
 
+-spec render(template(), atom(), kz_term:proplist(), kz_term:proplist()) -> template_result().
 render(Template, Module, TemplateData, CompileOpts) ->
     case compile(Template, Module, CompileOpts) of
         {'ok', Module} -> render_template(Module, TemplateData);
@@ -62,10 +63,10 @@ render(Template, Module, TemplateData, CompileOpts) ->
 
 
 -spec compile(template(), atom()) -> template_result().
--spec compile(template(), atom(), kz_term:proplist()) -> template_result().
 compile(Template, Module) ->
     compile(Template, Module, []).
 
+-spec compile(template(), atom(), kz_term:proplist()) -> template_result().
 compile(Template, Module, CompileOpts) when is_binary(Template) ->
     try erlydtl:compile_template(Template, Module, ?COMPILE_OPTS(CompileOpts)) of
         Result ->

--- a/core/kazoo_token_buckets/src/kz_buckets.erl
+++ b/core/kazoo_token_buckets/src/kz_buckets.erl
@@ -83,23 +83,22 @@ start_link() ->
 %% StartIfMissing :: start the token bucket if it doesn't exist yet
 %% @end
 %%--------------------------------------------------------------------
--spec consume_token(kz_term:ne_binary()) -> boolean().
--spec consume_token(kz_term:ne_binary(), kz_term:ne_binary() | boolean()) -> boolean().
 
+-spec consume_token(kz_term:ne_binary()) -> boolean().
 consume_token(Name) ->
     consume_tokens(Name, 1).
 
+-spec consume_token(kz_term:ne_binary(), kz_term:ne_binary() | boolean()) -> boolean().
 consume_token(<<_/binary>> = App, <<_/binary>> = Name) ->
     consume_tokens(App, Name, 1);
 consume_token(Name, StartIfMissing) ->
     consume_tokens(?DEFAULT_APP, Name, 1, StartIfMissing).
 
 -spec consume_tokens(kz_term:ne_binary(), integer()) -> boolean().
--spec consume_tokens(kz_term:ne_binary(), kz_term:ne_binary() | integer(), integer() | boolean()) -> boolean().
--spec consume_tokens(kz_term:ne_binary(), kz_term:ne_binary(), integer(), boolean()) -> boolean().
 consume_tokens(Key, Count) ->
     consume_tokens(Key, Count, 'true').
 
+-spec consume_tokens(kz_term:ne_binary(), kz_term:ne_binary() | integer(), integer() | boolean()) -> boolean().
 consume_tokens(<<_/binary>> = App, <<_/binary>> = Key, Count) when is_integer(Count) ->
     consume_tokens(App, Key, Count, 'true');
 consume_tokens(<<_/binary>> = Key, Count, StartIfMissing) when is_integer(Count),
@@ -107,6 +106,7 @@ consume_tokens(<<_/binary>> = Key, Count, StartIfMissing) when is_integer(Count)
                                                                ->
     consume_tokens(?DEFAULT_APP, Key, Count, StartIfMissing).
 
+-spec consume_tokens(kz_term:ne_binary(), kz_term:ne_binary(), integer(), boolean()) -> boolean().
 consume_tokens(App, Key, Count, StartIfMissing) ->
     consume_tokens(App, Key, Count, StartIfMissing, fun kz_token_bucket:consume/2).
 
@@ -121,11 +121,12 @@ consume_tokens(App, Key, Count, StartIfMissing) ->
 %% remaining tokens and return false
 %% @end
 %%--------------------------------------------------------------------
+
 -spec consume_tokens_until(kz_term:ne_binary(), pos_integer()) -> boolean().
--spec consume_tokens_until(kz_term:ne_binary(), kz_term:ne_binary() | pos_integer(), pos_integer() | boolean()) -> boolean().
 consume_tokens_until(Key, Count) ->
     consume_tokens_until(?DEFAULT_APP, Key, Count, 'true').
 
+-spec consume_tokens_until(kz_term:ne_binary(), kz_term:ne_binary() | pos_integer(), pos_integer() | boolean()) -> boolean().
 consume_tokens_until(App=?NE_BINARY, Key=?NE_BINARY, Count)
   when is_integer(Count) ->
     consume_tokens_until(App, Key, Count, 'true');
@@ -163,10 +164,10 @@ maybe_start_bucket(App, Key, Count, 'true', BucketFun) ->
     end.
 
 -spec get_bucket(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_pid().
--spec get_bucket(kz_term:ne_binary(), kz_term:ne_binary(), 'record'|'server') -> kz_term:api_pid() | bucket().
 get_bucket(App, Key) ->
     get_bucket(App, Key, 'server').
 
+-spec get_bucket(kz_term:ne_binary(), kz_term:ne_binary(), 'record'|'server') -> kz_term:api_pid() | bucket().
 get_bucket(App, Key, 'record') ->
     case ets:lookup(table_id(), {App, Key}) of
         [] -> 'undefined';
@@ -182,9 +183,10 @@ get_bucket(App, Key, 'server') ->
     end.
 
 -spec exists(kz_term:ne_binary()) -> boolean().
--spec exists(kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
 exists(Key) ->
     exists(?DEFAULT_APP, Key).
+
+-spec exists(kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
 exists(App, Key) ->
     case ets:lookup(table_id(), {App, Key}) of
         [] -> 'false';
@@ -196,22 +198,26 @@ exists(App, Key) ->
 
 -spec start_bucket(kz_term:ne_binary()) ->
                           'ok' | 'error' | 'exists'.
--spec start_bucket(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                          'ok' | 'error' | 'exists'.
--spec start_bucket(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer()) ->
-                          'ok' | 'error' | 'exists'.
--spec start_bucket(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer(), pos_integer()) ->
-                          'ok' | 'error' | 'exists'.
--spec start_bucket(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer(), pos_integer(), kz_token_bucket:fill_rate_time()) ->
-                          'ok' | 'error' | 'exists'.
 start_bucket(Name) ->
     start_bucket(?DEFAULT_APP, Name).
+
+-spec start_bucket(kz_term:ne_binary(), kz_term:ne_binary()) ->
+                          'ok' | 'error' | 'exists'.
 start_bucket(App, Name) ->
     start_bucket(App, Name, ?MAX_TOKENS(App)).
+
+-spec start_bucket(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer()) ->
+                          'ok' | 'error' | 'exists'.
 start_bucket(App, Name, MaxTokens) ->
     start_bucket(App, Name, MaxTokens, ?FILL_RATE(App)).
+
+-spec start_bucket(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer(), pos_integer()) ->
+                          'ok' | 'error' | 'exists'.
 start_bucket(App, Name, MaxTokens, FillRate) ->
     start_bucket(App, Name, MaxTokens, FillRate, kz_token_bucket:default_fill_time(App)).
+
+-spec start_bucket(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer(), pos_integer(), kz_token_bucket:fill_rate_time()) ->
+                          'ok' | 'error' | 'exists'.
 start_bucket(App, Name, MaxTokens, FillRate, FillTime) ->
     case exists(App, Name) of
         'true' ->

--- a/core/kazoo_token_buckets/src/kz_token_bucket.erl
+++ b/core/kazoo_token_buckets/src/kz_token_bucket.erl
@@ -72,12 +72,15 @@
 %%--------------------------------------------------------------------
 %% @doc Starts the server
 %%--------------------------------------------------------------------
+
 -spec start_link(pos_integer(), pos_integer()) -> kz_types:startlink_ret().
--spec start_link(pos_integer(), pos_integer(), boolean()) -> kz_types:startlink_ret().
--spec start_link(pos_integer(), pos_integer(), boolean(), fill_rate_time()) -> kz_types:startlink_ret().
 start_link(Max, FillRate) -> start_link(Max, FillRate, 'true').
+
+-spec start_link(pos_integer(), pos_integer(), boolean()) -> kz_types:startlink_ret().
 start_link(Max, FillRate, FillAsBlock) ->
     start_link(Max, FillRate, FillAsBlock, default_fill_time()).
+
+-spec start_link(pos_integer(), pos_integer(), boolean(), fill_rate_time()) -> kz_types:startlink_ret().
 start_link(Max, FillRate, FillAsBlock, FillTime)
   when is_integer(FillRate), FillRate > 0,
        is_integer(Max), Max > 0,
@@ -139,9 +142,10 @@ tokens(Srv) -> gen_server:call(Srv, {'tokens'}).
 set_name(Srv, Name) -> gen_server:cast(Srv, {'name', Name}).
 
 -spec default_fill_time() -> fill_rate_time().
--spec default_fill_time(kz_term:ne_binary()) -> fill_rate_time().
 default_fill_time() ->
     default_fill_time(?DEFAULT_APP).
+
+-spec default_fill_time(kz_term:ne_binary()) -> fill_rate_time().
 default_fill_time(App) ->
     normalize_fill_time(?FILL_TIME(App)).
 

--- a/core/kazoo_transactions/src/kz_topup.erl
+++ b/core/kazoo_transactions/src/kz_topup.erl
@@ -48,14 +48,15 @@ init(Account, CurrentBalance) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec should_topup(kz_term:ne_binary()) -> boolean().
--spec should_topup(kz_term:ne_binary(), integer()) -> boolean().
 should_topup(AccountId) ->
     case wht_util:current_balance(AccountId) of
         {'ok', CurrentBalance} -> should_topup(AccountId, CurrentBalance);
         {'error', _} -> 'false'
     end.
 
+-spec should_topup(kz_term:ne_binary(), integer()) -> boolean().
 should_topup(AccountId, CurrentBalance) ->
     Balance = wht_util:units_to_dollars(CurrentBalance),
     case get_top_up(AccountId) of

--- a/core/kazoo_transactions/src/kz_transactions.erl
+++ b/core/kazoo_transactions/src/kz_transactions.erl
@@ -315,13 +315,14 @@ fetch_bookkeeper(Account, From, To) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
+
 -spec de_duplicate_transactions(kz_transactions(), kz_transactions()) -> kz_transactions().
--spec de_duplicate_transactions(kz_term:proplist(), kz_term:proplist(), kz_transactions()) -> kz_transactions().
 de_duplicate_transactions(Transactions, BookkeeperTransactions) ->
     PropsTr = transactions_to_props(Transactions),
     PropsBTr = transactions_to_props(BookkeeperTransactions),
     de_duplicate_transactions(PropsTr, PropsBTr, []).
 
+-spec de_duplicate_transactions(kz_term:proplist(), kz_term:proplist(), kz_transactions()) -> kz_transactions().
 de_duplicate_transactions([], BookkeeperTransactions, Acc) ->
     [Transaction || {_, Transaction} <- BookkeeperTransactions] ++ Acc;
 de_duplicate_transactions([{Key, Value}|Transactions], BookkeeperTransactions, Acc) ->
@@ -351,10 +352,10 @@ transaction_to_prop_fold(Transaction, Acc) ->
 -type save_acc() :: [{'ok' | 'error', kz_transaction:transaction()}].
 
 -spec save(kz_transactions()) -> save_acc().
--spec save(kz_transactions(), save_acc()) -> save_acc().
 save(L) ->
     save(L, []).
 
+-spec save(kz_transactions(), save_acc()) -> save_acc().
 save([], Acc) ->
     lists:reverse(Acc);
 save([Transaction | Transactions], Acc) ->
@@ -374,10 +375,10 @@ save([Transaction | Transactions], Acc) ->
 -type remove_acc() :: ['ok' | {'error', kz_transaction:transaction()}].
 
 -spec remove(kz_transactions()) -> remove_acc().
--spec remove(kz_transactions(), remove_acc()) -> remove_acc().
 remove(Transactions) ->
     remove(Transactions, []).
 
+-spec remove(kz_transactions(), remove_acc()) -> remove_acc().
 remove([], Acc) ->
     lists:reverse(Acc);
 remove([Transaction | Transactions], Acc) ->

--- a/core/kazoo_transactions/src/wht_util.erl
+++ b/core/kazoo_transactions/src/wht_util.erl
@@ -81,12 +81,12 @@ reasons() ->
      ,unknown() => ?CODE_UNKNOWN
      }.
 
--spec reasons(integer()) -> kz_term:ne_binaries().
--spec reasons(integer(), integer()) -> kz_term:ne_binaries().
 
+-spec reasons(integer()) -> kz_term:ne_binaries().
 reasons(Min) ->
     reasons(Min, 10000).
 
+-spec reasons(integer(), integer()) -> kz_term:ne_binaries().
 reasons(Min, Max)
   when is_integer(Min),
        is_integer(Max),
@@ -175,11 +175,11 @@ get_balance(Account, Options) ->
     end.
 
 -spec get_balance_from_previous(kz_term:ne_binary(), kazoo_modb:view_options()) -> balance_ret().
--spec get_balance_from_previous(kz_term:ne_binary(), kazoo_modb:view_options(), integer()) -> balance_ret().
 get_balance_from_previous(Account, ViewOptions) ->
     Retries = props:get_value('retry', ViewOptions, 3),
     get_balance_from_previous(Account, ViewOptions, Retries).
 
+-spec get_balance_from_previous(kz_term:ne_binary(), kazoo_modb:view_options(), integer()) -> balance_ret().
 get_balance_from_previous(Account, ViewOptions, Retries) when Retries >= 0 ->
     {DefaultYear, DefaultMonth, _} = erlang:date(),
     Y = props:get_integer_value('year', ViewOptions, DefaultYear),
@@ -412,42 +412,59 @@ calculate_call(R, RI, RM, Sur, Secs) ->
 -spec default_reason() -> kz_term:ne_binary().
 default_reason() -> unknown().
 
--spec per_minute_call() -> kz_term:ne_binary().
--spec sub_account_per_minute_call() -> kz_term:ne_binary().
--spec feature_activation() -> kz_term:ne_binary().
--spec sub_account_feature_activation() -> kz_term:ne_binary().
--spec number_activation() -> kz_term:ne_binary().
--spec sub_account_number_activation() -> kz_term:ne_binary().
--spec manual_addition() -> kz_term:ne_binary().
--spec sub_account_manual_addition() -> kz_term:ne_binary().
--spec auto_addition() -> kz_term:ne_binary().
--spec sub_account_auto_addition() -> kz_term:ne_binary().
--spec admin_discretion() -> kz_term:ne_binary().
--spec topup() -> kz_term:ne_binary().
--spec database_rollup() -> kz_term:ne_binary().
--spec recurring() -> kz_term:ne_binary().
--spec monthly_recurring() -> kz_term:ne_binary().
--spec recurring_prorate() -> kz_term:ne_binary().
--spec mobile() -> kz_term:ne_binary().
--spec unknown() -> kz_term:ne_binary().
 
+-spec per_minute_call() -> kz_term:ne_binary().
 per_minute_call() -> <<"per_minute_call">>.
+
+-spec sub_account_per_minute_call() -> kz_term:ne_binary().
 sub_account_per_minute_call() -> <<"sub_account_per_minute_call">>.
+
+-spec feature_activation() -> kz_term:ne_binary().
 feature_activation() -> <<"feature_activation">>.
+
+-spec sub_account_feature_activation() -> kz_term:ne_binary().
 sub_account_feature_activation() -> <<"sub_account_feature_activation">>.
+
+-spec number_activation() -> kz_term:ne_binary().
 number_activation() -> <<"number_activation">>.
+
+-spec sub_account_number_activation() -> kz_term:ne_binary().
 sub_account_number_activation() -> <<"sub_account_number_activation">>.
+
+-spec manual_addition() -> kz_term:ne_binary().
 manual_addition() -> <<"manual_addition">>.
+
+-spec sub_account_manual_addition() -> kz_term:ne_binary().
 sub_account_manual_addition() -> <<"sub_account_manual_addition">>.
+
+-spec auto_addition() -> kz_term:ne_binary().
 auto_addition() -> <<"auto_addition">>.
+
+-spec sub_account_auto_addition() -> kz_term:ne_binary().
 sub_account_auto_addition() -> <<"sub_account_auto_addition">>.
+
+-spec admin_discretion() -> kz_term:ne_binary().
 admin_discretion() -> <<"admin_discretion">>.
+
+-spec topup() -> kz_term:ne_binary().
 topup() -> <<"topup">>.
+
+-spec database_rollup() -> kz_term:ne_binary().
 database_rollup() -> <<"database_rollup">>.
+
+-spec recurring() -> kz_term:ne_binary().
 recurring() -> <<"recurring">>.
+
+-spec monthly_recurring() -> kz_term:ne_binary().
 monthly_recurring() -> <<"monthly_recurring">>.
+
+-spec recurring_prorate() -> kz_term:ne_binary().
 recurring_prorate() -> <<"recurring_prorate">>.
+
+-spec mobile() -> kz_term:ne_binary().
 mobile() -> <<"mobile">>.
+
+-spec unknown() -> kz_term:ne_binary().
 unknown() -> <<"unknown">>.
 
 %%--------------------------------------------------------------------
@@ -530,7 +547,6 @@ rollup_current_modb(AccountMODb, Loop) ->
     end.
 
 -spec rollup(kz_transaction:transaction()) -> 'ok'.
--spec rollup(kz_term:ne_binary(), integer()) -> 'ok'.
 rollup(Transaction) ->
     Transaction1 = kz_transaction:set_reason(<<"database_rollup">>, Transaction),
     Transaction2 = kz_transaction:set_description(<<"monthly rollup">>, Transaction1),
@@ -543,6 +559,7 @@ rollup(Transaction) ->
             lager:debug("monthly rollup transaction success")
     end.
 
+-spec rollup(kz_term:ne_binary(), integer()) -> 'ok'.
 rollup(?NE_BINARY = AccountMODb, Balance) when Balance >= 0 ->
     AccountId = kz_util:format_account_id(AccountMODb, 'raw'),
     lager:debug("creating monthly rollup for ~s as a credit for ~p", [AccountMODb, Balance]),
@@ -601,7 +618,6 @@ collapse_call_transactions([JObj|JObjs], Calls, Transactions) ->
     end.
 
 -spec collapse_call_transaction(kz_json:object(), dict:dict()) -> dict:dict().
--spec collapse_call_transaction(binary(), kz_json:object(), dict:dict()) -> dict:dict().
 collapse_call_transaction(JObj, Calls) ->
     case kz_json:get_value(<<"call_id">>, JObj) of
         'undefined' ->
@@ -610,6 +626,7 @@ collapse_call_transaction(JObj, Calls) ->
             collapse_call_transaction(CallId, JObj, Calls)
     end.
 
+-spec collapse_call_transaction(binary(), kz_json:object(), dict:dict()) -> dict:dict().
 collapse_call_transaction(CallId, JObj, Calls) ->
     case dict:find(CallId, Calls) of
         'error' ->
@@ -674,11 +691,11 @@ get_amount(Call) ->
 
 -spec clean_transactions(kz_json:objects()) ->
                                 kz_json:objects().
--spec clean_transactions(kz_json:objects(), kz_json:objects()) ->
-                                kz_json:objects().
 clean_transactions(Transactions) ->
     clean_transactions(Transactions, []).
 
+-spec clean_transactions(kz_json:objects(), kz_json:objects()) ->
+                                kz_json:objects().
 clean_transactions([], Acc) -> Acc;
 clean_transactions([{_, Transaction}|Transactions], Acc) ->
     Amount = kz_json:get_value(<<"amount">>, Transaction),

--- a/core/kazoo_translator/src/convertors/kzt_twiml_dial.erl
+++ b/core/kazoo_translator/src/convertors/kzt_twiml_dial.erl
@@ -218,11 +218,11 @@ force_outbound(Props) -> props:get_is_true('continueOnFail', Props, 'true').
 
 -spec xml_elements_to_endpoints(kapps_call:call(), kz_types:xml_els()) ->
                                        kz_json:objects().
--spec xml_elements_to_endpoints(kapps_call:call(), kz_types:xml_els(), kz_json:objects()) ->
-                                       kz_json:objects().
 xml_elements_to_endpoints(Call, EPs) ->
     xml_elements_to_endpoints(Call, EPs, []).
 
+-spec xml_elements_to_endpoints(kapps_call:call(), kz_types:xml_els(), kz_json:objects()) ->
+                                       kz_json:objects().
 xml_elements_to_endpoints(_, [], Acc) -> Acc;
 xml_elements_to_endpoints(Call, [#xmlElement{name='Device'
                                             ,content=DeviceIdTxt
@@ -313,10 +313,10 @@ sip_device(URI) ->
 request_id(N, Call) -> iolist_to_binary([N, <<"@">>, kapps_call:from_realm(Call)]).
 
 -spec media_processing(kapps_call:call()) -> kz_term:ne_binary().
--spec media_processing(boolean(), kz_term:api_binary()) -> kz_term:ne_binary().
 media_processing(Call) ->
     media_processing(kzt_util:get_record_call(Call), kzt_util:get_hangup_dtmf(Call)).
 
+-spec media_processing(boolean(), kz_term:api_binary()) -> kz_term:ne_binary().
 media_processing('false', 'undefined') -> <<"bypass">>;
 media_processing('true', _HangupDTMF) -> <<"process">>.
 

--- a/core/kazoo_translator/src/convertors/kzt_twiml_util.erl
+++ b/core/kazoo_translator/src/convertors/kzt_twiml_util.erl
@@ -65,8 +65,9 @@ get_engine(Props) ->
 loop_count(Props) -> props:get_integer_value('loop', Props, 1).
 
 -spec finish_dtmf(kz_term:proplist()) -> kz_term:ne_binary().
--spec finish_dtmf(kz_term:proplist(), kz_term:ne_binary()) -> kz_term:ne_binary().
 finish_dtmf(Props) -> finish_dtmf(Props, <<"#">>).
+
+-spec finish_dtmf(kz_term:proplist(), kz_term:ne_binary()) -> kz_term:ne_binary().
 finish_dtmf(Props, Default) when is_list(Props) ->
     case props:get_binary_value('finishOnKey', Props) of
         'undefined' -> Default;
@@ -103,8 +104,9 @@ action_url(Props) -> props:get_binary_value('action', Props).
 reject_prompt(Props) -> props:get_binary_value('prompt', Props).
 
 -spec timeout_s(kz_term:proplist()) -> pos_integer().
--spec timeout_s(kz_term:proplist(), pos_integer()) -> pos_integer().
 timeout_s(Props) -> timeout_s(Props, 30).
+
+-spec timeout_s(kz_term:proplist(), pos_integer()) -> pos_integer().
 timeout_s(Props, Default) ->
     case props:get_integer_value('timeout', Props, Default) of
         N when is_integer(N), N > 3600 -> 3600;

--- a/core/kazoo_translator/src/kzt_receiver.erl
+++ b/core/kazoo_translator/src/kzt_receiver.erl
@@ -44,15 +44,9 @@
 -spec default_on_first_fun(any()) -> 'ok'.
 default_on_first_fun(_) -> 'ok'.
 
+
 -spec collect_dtmfs(kapps_call:call(), kz_term:api_binary(), timeout(), pos_integer()) ->
                            collect_dtmfs_return().
--spec collect_dtmfs(kapps_call:call(), kz_term:api_binary(), timeout(), pos_integer(), function()) ->
-                           collect_dtmfs_return().
--spec collect_dtmfs(kapps_call:call(), kz_term:api_binary(), timeout(), pos_integer(), function(), binary()) ->
-                           collect_dtmfs_return().
--spec collect_dtmfs(kapps_call:call(), kz_term:api_binary(), timeout(), pos_integer(), function(), binary(), kz_json:object()) ->
-                           collect_dtmfs_return().
-
 collect_dtmfs(Call, FinishKey, Timeout, N) ->
     collect_dtmfs(Call
                  ,FinishKey
@@ -62,6 +56,8 @@ collect_dtmfs(Call, FinishKey, Timeout, N) ->
                  ,kzt_util:get_digits_collected(Call)
                  ).
 
+-spec collect_dtmfs(kapps_call:call(), kz_term:api_binary(), timeout(), pos_integer(), function()) ->
+                           collect_dtmfs_return().
 collect_dtmfs(Call
              ,FinishKey
              ,Timeout
@@ -76,6 +72,8 @@ collect_dtmfs(Call
                  ,kzt_util:get_digits_collected(Call)
                  ).
 
+-spec collect_dtmfs(kapps_call:call(), kz_term:api_binary(), timeout(), pos_integer(), function(), binary()) ->
+                           collect_dtmfs_return().
 collect_dtmfs(Call
              ,_FinishKey
              ,_Timeout
@@ -115,6 +113,8 @@ collect_dtmfs(Call
             collect_dtmfs(Call, FinishKey, collect_decr_timeout(Call, Timeout, Start), N, OnFirstFun, Collected)
     end.
 
+-spec collect_dtmfs(kapps_call:call(), kz_term:api_binary(), timeout(), pos_integer(), function(), binary(), kz_json:object()) ->
+                           collect_dtmfs_return().
 collect_dtmfs(Call, FinishKey, Timeout, N, OnFirstFun, Collected, JObj) ->
     case kz_util:get_event_type(JObj) of
         {<<"call_event">>, <<"CHANNEL_DESTROY">>} ->
@@ -186,12 +186,12 @@ collect_timeout(Call, Timeout) ->
 -spec say_loop(kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), timeout()) ->
                       {'ok', kapps_call:call()} |
                       {'error', _, kapps_call:call()}.
--spec say_loop(kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), list() | 'undefined', kz_term:ne_binary(), timeout()) ->
-                      {'ok', kapps_call:call()} |
-                      {'error', _, kapps_call:call()}.
 say_loop(Call, SayMe, Voice, Lang, Engine, N) ->
     say_loop(Call, SayMe, Voice, Lang, 'undefined', Engine, N).
 
+-spec say_loop(kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), list() | 'undefined', kz_term:ne_binary(), timeout()) ->
+                      {'ok', kapps_call:call()} |
+                      {'error', _, kapps_call:call()}.
 say_loop(Call, _SayMe, _Voice, _Lang, _Terminators, _Engine, N) when N =< 0 ->
     {'ok', Call};
 say_loop(Call, SayMe, Voice, Lang, Terminators, Engine, N) ->
@@ -212,12 +212,12 @@ say_loop(Call, SayMe, Voice, Lang, Terminators, Engine, N) ->
 -spec play_loop(kapps_call:call(), binary(), timeout()) ->
                        {'ok', kapps_call:call()} |
                        {'error', _, kapps_call:call()}.
--spec play_loop(kapps_call:call(), binary(), list() | 'undefined', timeout()) ->
-                       {'ok', kapps_call:call()} |
-                       {'error', _, kapps_call:call()}.
 play_loop(Call, PlayMe, N) ->
     play_loop(Call, PlayMe, 'undefined', N).
 
+-spec play_loop(kapps_call:call(), binary(), list() | 'undefined', timeout()) ->
+                       {'ok', kapps_call:call()} |
+                       {'error', _, kapps_call:call()}.
 play_loop(Call, <<>>, _Terminators, _N) ->
     {'error', 'no_media', Call};
 play_loop(Call, _, _, 0) ->
@@ -335,11 +335,11 @@ process_noop_event(Call, NoopId, JObj) ->
 
 -spec wait_for_offnet(kapps_call:call()) ->
                              {'ok', kapps_call:call()}.
--spec wait_for_offnet(kapps_call:call(), kz_term:proplist()) ->
-                             {'ok', kapps_call:call()}.
 wait_for_offnet(Call) ->
     wait_for_offnet(Call, []).
 
+-spec wait_for_offnet(kapps_call:call(), kz_term:proplist()) ->
+                             {'ok', kapps_call:call()}.
 wait_for_offnet(Call, DialProps) ->
     HangupDTMF = kzt_util:get_hangup_dtmf(Call),
     RecordCall = kzt_util:get_record_call(Call),
@@ -533,11 +533,11 @@ handle_dtmf_event(#dial_req{call=Call
 
 -spec handle_hangup(kapps_call:call(), kz_json:object()) ->
                            {'ok', kapps_call:call()}.
--spec handle_hangup(kapps_call:call(), kz_json:object(), kz_term:ne_binary()) ->
-                           {'ok', kapps_call:call()}.
 handle_hangup(Call, JObj) ->
     handle_hangup(Call, JObj, kz_call_event:hangup_cause(JObj)).
 
+-spec handle_hangup(kapps_call:call(), kz_json:object(), kz_term:ne_binary()) ->
+                           {'ok', kapps_call:call()}.
 handle_hangup(Call, _JObj, HangupCause) ->
     lager:debug("caller channel finished: ~s", [HangupCause]),
 
@@ -551,10 +551,10 @@ handle_hangup(Call, _JObj, HangupCause) ->
     {'ok', kapps_call:exec(Updates, Call)}.
 
 -spec maybe_hangup_other_leg(kapps_call:call()) -> 'ok'.
--spec maybe_hangup_other_leg(kapps_call:call(), kz_term:api_binary()) -> 'ok'.
 maybe_hangup_other_leg(Call) ->
     maybe_hangup_other_leg(Call, kapps_call:other_leg_call_id(Call)).
 
+-spec maybe_hangup_other_leg(kapps_call:call(), kz_term:api_binary()) -> 'ok'.
 maybe_hangup_other_leg(_Call, 'undefined') -> 'ok';
 maybe_hangup_other_leg(Call, OtherLeg) ->
     Req = [{<<"Application-Name">>, <<"hangup">>}

--- a/core/kazoo_translator/src/kzt_translator.erl
+++ b/core/kazoo_translator/src/kzt_translator.erl
@@ -17,10 +17,10 @@
 -include("kzt.hrl").
 
 -spec exec(kapps_call:call(), binary()) -> exec_return().
--spec exec(kapps_call:call(), binary(), kz_term:api_binary() | list()) -> exec_return().
 exec(Call, Cmds) ->
     exec(Call, Cmds, <<"text/xml">>).
 
+-spec exec(kapps_call:call(), binary(), kz_term:api_binary() | list()) -> exec_return().
 exec(Call, Cmds, 'undefined') ->
     exec(Call, Cmds, <<"text/xml">>);
 exec(Call, Cmds, CT) when not is_binary(CT) ->
@@ -43,11 +43,12 @@ just_the_type(ContentType) ->
     end.
 
 -spec get_user_vars(kapps_call:call()) -> kz_json:object().
--spec set_user_vars(kz_term:proplist(), kapps_call:call()) -> kapps_call:call().
 get_user_vars(Call) ->
     ReqVars = kzt_util:get_request_vars(Call),
     UserVars = kapps_call:kvs_fetch(?KZT_USER_VARS, kz_json:new(), Call),
     kz_json:merge_jobjs(ReqVars, UserVars).
+
+-spec set_user_vars(kz_term:proplist(), kapps_call:call()) -> kapps_call:call().
 set_user_vars(Prop, Call) ->
     UserVars = get_user_vars(Call),
     kapps_call:kvs_store(?KZT_USER_VARS, kz_json:set_values(Prop, UserVars), Call).

--- a/core/kazoo_translator/src/kzt_util.erl
+++ b/core/kazoo_translator/src/kzt_util.erl
@@ -111,9 +111,10 @@ offnet_req(Data, Call) ->
     kz_amqp_worker:cast(Req, fun kapi_offnet_resource:publish_req/1).
 
 -spec update_call_status(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_call_status(kapps_call:call()) -> kz_term:api_binary().
 update_call_status(Status, Call) ->
     kapps_call:kvs_store(<<"call_status">>, Status, Call).
+
+-spec get_call_status(kapps_call:call()) -> kz_term:api_binary().
 get_call_status(Call) ->
     kapps_call:kvs_fetch(<<"call_status">>, Call).
 
@@ -130,13 +131,15 @@ add_error(Call, K, V) ->
 get_errors(Call) -> kapps_call:kvs_fetch(<<"response_errors">>, Call).
 
 -spec set_hangup_dtmf(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_hangup_dtmf(kapps_call:call()) -> kz_term:api_binary().
 set_hangup_dtmf(DTMF, Call) -> kapps_call:kvs_store(<<"hangup_dtmf">>, DTMF, Call).
+
+-spec get_hangup_dtmf(kapps_call:call()) -> kz_term:api_binary().
 get_hangup_dtmf(Call) -> kapps_call:kvs_fetch(<<"hangup_dtmf">>, Call).
 
 -spec set_digit_pressed(kz_term:api_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_digit_pressed(kapps_call:call()) -> kz_term:api_binary() | kz_json:object().
 set_digit_pressed(DTMF, Call) -> kapps_call:kvs_store(<<"digit_pressed">>, DTMF, Call).
+
+-spec get_digit_pressed(kapps_call:call()) -> kz_term:api_binary() | kz_json:object().
 get_digit_pressed(Call) ->
     case kapps_call:kvs_fetch(<<"digit_pressed">>, Call) of
         'undefined' -> get_digits_pressed(Call);
@@ -148,37 +151,45 @@ get_digits_pressed(Call) ->
     kapps_call:kvs_fetch(<<"dtmf_collections">>, Call).
 
 -spec set_record_call(boolean(), kapps_call:call()) -> kapps_call:call().
--spec get_record_call(kapps_call:call()) -> kz_term:api_boolean().
 set_record_call(R, Call) -> kapps_call:kvs_store(<<"record_call">>, R, Call).
+
+-spec get_record_call(kapps_call:call()) -> kz_term:api_boolean().
 get_record_call(Call) -> kapps_call:kvs_fetch(<<"record_call">>, Call).
 
 -spec set_call_timeout(pos_integer(), kapps_call:call()) -> kapps_call:call().
--spec get_call_timeout(kapps_call:call()) -> kz_term:api_integer().
 set_call_timeout(T, Call) -> kapps_call:kvs_store(<<"call_timeout">>, T, Call).
+
+-spec get_call_timeout(kapps_call:call()) -> kz_term:api_integer().
 get_call_timeout(Call) -> kapps_call:kvs_fetch(<<"call_timeout">>, Call).
 
 -spec set_call_time_limit(pos_integer(), kapps_call:call()) -> kapps_call:call().
--spec get_call_time_limit(kapps_call:call()) -> kz_term:api_integer().
 set_call_time_limit(T, Call) -> kapps_call:kvs_store(<<"call_time_limit">>, T, Call).
+
+-spec get_call_time_limit(kapps_call:call()) -> kz_term:api_integer().
 get_call_time_limit(Call) -> kapps_call:kvs_fetch(<<"call_time_limit">>, Call).
 
 -spec set_voice_uri(kz_term:api_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_voice_uri(kapps_call:call()) -> kz_term:api_binary().
 set_voice_uri(Uri, Call) -> kapps_call:kvs_store(<<"voice_uri">>, Uri, Call).
+
+-spec get_voice_uri(kapps_call:call()) -> kz_term:api_binary().
 get_voice_uri(Call) -> kapps_call:kvs_fetch(<<"voice_uri">>, Call).
 
 -spec set_voice_uri_method('get' | 'post', kapps_call:call()) -> kapps_call:call().
--spec get_voice_uri_method(kapps_call:call()) -> 'get' | 'post'.
 set_voice_uri_method(M, Call) -> kapps_call:kvs_store(<<"voice_uri_method">>, M, Call).
+
+-spec get_voice_uri_method(kapps_call:call()) -> 'get' | 'post'.
 get_voice_uri_method(Call) -> kapps_call:kvs_fetch(<<"voice_uri_method">>, Call).
 
 -spec set_digits_collected(kz_term:api_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_digits_collected(kapps_call:call()) -> binary().
--spec clear_digits_collected(kapps_call:call()) -> kapps_call:call().
--spec add_digit_collected(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
 set_digits_collected(Ds, Call) -> kapps_call:kvs_store(<<"digits_collected">>, Ds, Call).
+
+-spec get_digits_collected(kapps_call:call()) -> binary().
 get_digits_collected(Call) -> kapps_call:kvs_fetch(<<"digits_collected">>, Call).
+
+-spec clear_digits_collected(kapps_call:call()) -> kapps_call:call().
 clear_digits_collected(Call) -> kapps_call:kvs_store(<<"digits_collected">>, <<>>, Call).
+
+-spec add_digit_collected(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
 add_digit_collected(D, Call) ->
     kapps_call:kvs_update(<<"digits_collected">>, fun(<<_/binary>> = Ds) -> <<Ds/binary, D/binary>>;
                                                      (_) -> D
@@ -186,133 +197,155 @@ add_digit_collected(D, Call) ->
                          ,D, Call).
 
 -spec set_recording_url(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_recording_url(kapps_call:call()) -> kz_term:api_binary().
 set_recording_url(RU, Call) -> kapps_call:kvs_store(<<"recording_url">>, RU, Call).
+
+-spec get_recording_url(kapps_call:call()) -> kz_term:api_binary().
 get_recording_url(Call) -> kapps_call:kvs_fetch(<<"recording_url">>, Call).
 
 -spec set_recording_duration(pos_integer(), kapps_call:call()) -> kapps_call:call().
--spec get_recording_duration(kapps_call:call()) -> kz_term:api_integer().
 set_recording_duration(RD, Call) -> kapps_call:kvs_store(<<"recording_duration">>, RD, Call).
+
+-spec get_recording_duration(kapps_call:call()) -> kz_term:api_integer().
 get_recording_duration(Call) -> kapps_call:kvs_fetch(<<"recording_duration">>, Call).
 
 -spec set_recording_sid(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_recording_sid(kapps_call:call()) -> kz_term:api_binary().
 set_recording_sid(SID, Call) -> kapps_call:kvs_store(<<"recording_sid">>, SID, Call).
+
+-spec get_recording_sid(kapps_call:call()) -> kz_term:api_binary().
 get_recording_sid(Call) -> kapps_call:kvs_fetch(<<"recording_sid">>, Call).
 
 -spec set_transcription_sid(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_transcription_sid(kapps_call:call()) -> kz_term:api_binary().
 set_transcription_sid(SID, Call) -> kapps_call:kvs_store(<<"transcription_sid">>, SID, Call).
+
+-spec get_transcription_sid(kapps_call:call()) -> kz_term:api_binary().
 get_transcription_sid(Call) -> kapps_call:kvs_fetch(<<"transcription_sid">>, Call).
 
 -spec set_transcription_text(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_transcription_text(kapps_call:call()) -> kz_term:api_binary().
 set_transcription_text(RD, Call) -> kapps_call:kvs_store(<<"transcription_text">>, RD, Call).
+
+-spec get_transcription_text(kapps_call:call()) -> kz_term:api_binary().
 get_transcription_text(Call) -> kapps_call:kvs_fetch(<<"transcription_text">>, Call).
 
 -spec set_transcription_status(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_transcription_status(kapps_call:call()) -> kz_term:api_binary().
 set_transcription_status(RD, Call) -> kapps_call:kvs_store(<<"transcription_status">>, RD, Call).
+
+-spec get_transcription_status(kapps_call:call()) -> kz_term:api_binary().
 get_transcription_status(Call) -> kapps_call:kvs_fetch(<<"transcription_status">>, Call).
 
 -spec set_transcription_url(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_transcription_url(kapps_call:call()) -> kz_term:api_binary().
 set_transcription_url(RD, Call) -> kapps_call:kvs_store(<<"transcription_url">>, RD, Call).
+
+-spec get_transcription_url(kapps_call:call()) -> kz_term:api_binary().
 get_transcription_url(Call) -> kapps_call:kvs_fetch(<<"transcription_url">>, Call).
 
 -spec set_dial_call_status(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_dial_call_status(kapps_call:call()) -> kz_term:api_binary().
 set_dial_call_status(DCS, Call) -> kapps_call:kvs_store(<<"dial_call_status">>, DCS, Call).
+
+-spec get_dial_call_status(kapps_call:call()) -> kz_term:api_binary().
 get_dial_call_status(Call) -> kapps_call:kvs_fetch(<<"dial_call_status">>, Call).
 
 -spec set_dial_call_sid(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_dial_call_sid(kapps_call:call()) -> kz_term:api_binary().
 set_dial_call_sid(DCS, Call) -> kapps_call:kvs_store(<<"dial_call_sid">>, DCS, Call).
+
+-spec get_dial_call_sid(kapps_call:call()) -> kz_term:api_binary().
 get_dial_call_sid(Call) -> kapps_call:kvs_fetch(<<"dial_call_sid">>, Call).
 
 -spec set_dial_call_duration(pos_integer(), kapps_call:call()) -> kapps_call:call().
--spec get_dial_call_duration(kapps_call:call()) -> kz_term:api_integer().
 set_dial_call_duration(DCS, Call) -> kapps_call:kvs_store(<<"dial_call_duration">>, DCS, Call).
+
+-spec get_dial_call_duration(kapps_call:call()) -> kz_term:api_integer().
 get_dial_call_duration(Call) -> kapps_call:kvs_fetch(<<"dial_call_duration">>, Call).
 
 -spec set_queue_sid(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_queue_sid(kapps_call:call()) -> kz_term:api_binary().
 set_queue_sid(DCS, Call) -> kapps_call:kvs_store(<<"queue_sid">>, DCS, Call).
+
+-spec get_queue_sid(kapps_call:call()) -> kz_term:api_binary().
 get_queue_sid(Call) -> kapps_call:kvs_fetch(<<"queue_sid">>, Call).
 
 -spec set_dequeue_result(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_dequeue_result(kapps_call:call()) -> kz_term:api_binary().
 set_dequeue_result(DCS, Call) -> kapps_call:kvs_store(<<"dequeue_result">>, DCS, Call).
+
+-spec get_dequeue_result(kapps_call:call()) -> kz_term:api_binary().
 get_dequeue_result(Call) -> kapps_call:kvs_fetch(<<"dequeue_result">>, Call).
 
 -spec set_dequeued_call_sid(kz_term:ne_binary(), kapps_call:call()) -> kapps_call:call().
--spec get_dequeued_call_sid(kapps_call:call()) -> kz_term:api_binary().
 set_dequeued_call_sid(DCS, Call) -> kapps_call:kvs_store(<<"dequeued_call_sid">>, DCS, Call).
+
+-spec get_dequeued_call_sid(kapps_call:call()) -> kz_term:api_binary().
 get_dequeued_call_sid(Call) -> kapps_call:kvs_fetch(<<"dequeued_call_sid">>, Call).
 
 -spec set_dequeued_call_queue_time(pos_integer(), kapps_call:call()) -> kapps_call:call().
--spec get_dequeued_call_queue_time(kapps_call:call()) -> kz_term:api_integer().
 set_dequeued_call_queue_time(DCS, Call) -> kapps_call:kvs_store(<<"dequeued_call_queue_time">>, DCS, Call).
+
+-spec get_dequeued_call_queue_time(kapps_call:call()) -> kz_term:api_integer().
 get_dequeued_call_queue_time(Call) -> kapps_call:kvs_fetch(<<"dequeued_call_queue_time">>, Call).
 
 -spec set_dequeued_call_duration(pos_integer(), kapps_call:call()) -> kapps_call:call().
--spec get_dequeued_call_duration(kapps_call:call()) -> kz_term:api_integer().
 set_dequeued_call_duration(DCS, Call) -> kapps_call:kvs_store(<<"dequeued_call_duration">>, DCS, Call).
+
+-spec get_dequeued_call_duration(kapps_call:call()) -> kz_term:api_integer().
 get_dequeued_call_duration(Call) -> kapps_call:kvs_fetch(<<"dequeued_call_duration">>, Call).
 
 -spec set_media_meta(kz_json:object(), kapps_call:call()) -> kapps_call:call().
--spec get_media_meta(kapps_call:call()) -> kz_term:api_object().
 set_media_meta(DCS, Call) -> kapps_call:kvs_store(<<"media_meta">>, DCS, Call).
+
+-spec get_media_meta(kapps_call:call()) -> kz_term:api_object().
 get_media_meta(Call) -> kapps_call:kvs_fetch(<<"media_meta">>, Call).
 
 -spec set_amqp_listener(pid(), kapps_call:call()) -> kapps_call:call().
--spec get_amqp_listener(kapps_call:call()) -> kz_term:api_pid().
 set_amqp_listener(Pid, Call) -> kapps_call:kvs_store(<<"amqp_listener">>, Pid, Call).
+
+-spec get_amqp_listener(kapps_call:call()) -> kz_term:api_pid().
 get_amqp_listener(Call) -> kapps_call:kvs_fetch(<<"amqp_listener">>, Call).
 
 -spec set_gather_pidref(kz_term:pid_ref() | 'undefined', kapps_call:call()) ->
                                kapps_call:call().
--spec get_gather_pidref(kapps_call:call()) ->
-                               kz_term:pid_ref() | 'undefined'.
 set_gather_pidref('undefined', Call) ->
     kapps_call:kvs_store(<<"gather_pidref">>, 'undefined', Call);
 set_gather_pidref({_, _}=PidRef, Call) ->
     gen_listener:cast(get_amqp_listener(Call), {'add_event_handler', PidRef}),
     kapps_call:kvs_store(<<"gather_pidref">>, PidRef, Call).
+
+-spec get_gather_pidref(kapps_call:call()) ->
+                               kz_term:pid_ref() | 'undefined'.
 get_gather_pidref(Call) -> kapps_call:kvs_fetch(<<"gather_pidref">>, Call).
 
 -spec set_conference_profile(kz_json:object(), kapps_call:call()) ->
                                     kapps_call:call().
--spec get_conference_profile(kapps_call:call()) ->
-                                    kz_json:object().
 set_conference_profile(JObj, Call) ->
     kapps_call:kvs_store(<<"conference_profile">>, JObj, Call).
+
+-spec get_conference_profile(kapps_call:call()) ->
+                                    kz_json:object().
 get_conference_profile(Call) ->
     kapps_call:kvs_fetch(<<"conference_profile">>, Call).
 
 -spec set_caller_controls(kz_json:object(), kapps_call:call()) ->
                                  kapps_call:call().
--spec get_caller_controls(kapps_call:call()) ->
-                                 kz_json:object().
 set_caller_controls(JObj, Call) ->
     kapps_call:kvs_store(<<"caller_controls">>, JObj, Call).
+
+-spec get_caller_controls(kapps_call:call()) ->
+                                 kz_json:object().
 get_caller_controls(Call) ->
     kapps_call:kvs_fetch(<<"caller_controls">>, Call).
 
 -spec set_advertise(kz_json:object(), kapps_call:call()) ->
                            kapps_call:call().
--spec get_advertise(kapps_call:call()) ->
-                           kz_json:object().
 set_advertise(JObj, Call) ->
     kapps_call:kvs_store(<<"advertise">>, JObj, Call).
+
+-spec get_advertise(kapps_call:call()) ->
+                           kz_json:object().
 get_advertise(Call) ->
     kapps_call:kvs_fetch(<<"advertise">>, Call).
 
 -spec set_chat_permissions(kz_json:object(), kapps_call:call()) ->
                                   kapps_call:call().
--spec get_chat_permissions(kapps_call:call()) -> kz_json:object().
 set_chat_permissions(JObj, Call) ->
     kapps_call:kvs_store(<<"chat_permissions">>, JObj, Call).
+
+-spec get_chat_permissions(kapps_call:call()) -> kz_json:object().
 get_chat_permissions(Call) ->
     kapps_call:kvs_fetch(<<"chat_permissions">>, Call).
 

--- a/core/kazoo_voicemail/src/kazoo_voicemail_maintenance.erl
+++ b/core/kazoo_voicemail/src/kazoo_voicemail_maintenance.erl
@@ -41,12 +41,12 @@ migrate() ->
     end.
 
 -spec migrate(kz_term:ne_binary()) -> 'ok'.
--spec migrate(kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries() | kz_json:object()) -> 'ok'.
 migrate(?NE_BINARY = AccountId) ->
     print_migration_stats(kvm_migrate_account:manual_account_migrate(AccountId));
 migrate(AccountJObj) ->
     migrate(kz_doc:id(AccountJObj)).
 
+-spec migrate(kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries() | kz_json:object()) -> 'ok'.
 migrate(AccountId, ?NE_BINARY = BoxId) ->
     migrate(AccountId, [BoxId]);
 migrate(AccountId, BoxIds) when is_list(BoxIds) ->

--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -158,11 +158,12 @@ do_fetch(AccountId, MessageId, BoxId, RetenTimestamp) ->
 %% @doc fetch message metadata
 %% @end
 %%--------------------------------------------------------------------
+
 -spec message(kz_term:ne_binary(), kz_term:ne_binary()) -> db_ret().
--spec message(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> db_ret().
 message(AccountId, MessageId) ->
     message(AccountId, MessageId, 'undefined').
 
+-spec message(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> db_ret().
 message(AccountId, MessageId, BoxId) ->
     case fetch(AccountId, MessageId, BoxId) of
         {'ok', JObj} ->
@@ -227,11 +228,12 @@ change_folder(Folder, Message, AccountId, BoxId, Funs0) ->
 %% @doc Update a single message doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update(kz_term:ne_binary(), kz_term:api_ne_binary(), message()) -> db_ret().
--spec update(kz_term:ne_binary(), kz_term:api_ne_binary(), message(), update_funs()) -> db_ret().
 update(AccountId, BoxId, Message) ->
     update(AccountId, BoxId, Message, []).
 
+-spec update(kz_term:ne_binary(), kz_term:api_ne_binary(), message(), update_funs()) -> db_ret().
 update(AccountId, BoxId, ?NE_BINARY = MsgId, Funs) ->
     RetenTimestamp = kz_time:now_s() - kvm_util:retention_seconds(AccountId),
     case do_fetch(AccountId, MsgId, BoxId, RetenTimestamp) of

--- a/core/kazoo_voicemail/src/kvm_messages.erl
+++ b/core/kazoo_voicemail/src/kvm_messages.erl
@@ -228,11 +228,12 @@ count_per_folder(AccountId, Keys, View, Folder, ResultMap) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec update(kz_term:ne_binary(), kz_term:ne_binary(), messages()) -> kz_json:object().
--spec update(kz_term:ne_binary(), kz_term:ne_binary(), messages(), update_funs()) -> kz_json:object().
 update(AccountId, BoxId, Msgs) ->
     update(AccountId, BoxId, Msgs, []).
 
+-spec update(kz_term:ne_binary(), kz_term:ne_binary(), messages(), update_funs()) -> kz_json:object().
 update(AccountId, BoxId, [?NE_BINARY = _Msg | _] = MsgIds, Funs) ->
     RetenTimestamp = kz_time:now_s() - kvm_util:retention_seconds(AccountId),
     FetchMap = fetch(AccountId, MsgIds, BoxId, RetenTimestamp),

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -32,12 +32,12 @@
 %% @doc Generate database name based on DocId
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_db(kz_term:ne_binary()) -> kz_term:ne_binary().
--spec get_db(kz_term:ne_binary(), kazoo_data:docid() | kz_json:object()) -> kz_term:ne_binary().
--spec get_db(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 get_db(AccountId) ->
     kz_util:format_account_db(AccountId).
 
+-spec get_db(kz_term:ne_binary(), kazoo_data:docid() | kz_json:object()) -> kz_term:ne_binary().
 get_db(AccountId, {_, ?MATCH_MODB_PREFIX(Year, Month, _)}) ->
     get_db(AccountId, Year, Month);
 get_db(AccountId, ?MATCH_MODB_PREFIX(Year, Month, _)) ->
@@ -47,6 +47,7 @@ get_db(AccountId, ?NE_BINARY = _DocId) ->
 get_db(AccountId, Doc) ->
     get_db(AccountId, kz_doc:id(Doc)).
 
+-spec get_db(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
 get_db(AccountId, Year, Month) ->
     kazoo_modb:get_modb(AccountId, kz_term:to_integer(Year), kz_term:to_integer(Month)).
 
@@ -55,11 +56,12 @@ get_db(AccountId, Year, Month) ->
 %% @doc Generate a range of database names
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_range_db(kz_term:ne_binary()) -> {kz_time:gregorian_seconds(), kz_time:gregorian_seconds(), kz_term:ne_binaries()}.
--spec get_range_db(kz_term:ne_binary(), pos_integer()) -> {kz_time:gregorian_seconds(), kz_time:gregorian_seconds(), kz_term:ne_binaries()}.
 get_range_db(AccountId) ->
     get_range_db(AccountId, retention_days(AccountId)).
 
+-spec get_range_db(kz_term:ne_binary(), pos_integer()) -> {kz_time:gregorian_seconds(), kz_time:gregorian_seconds(), kz_term:ne_binaries()}.
 get_range_db(AccountId, Days) ->
     To = kz_time:now_s(),
     From = To - retention_seconds(Days),
@@ -114,11 +116,12 @@ check_doc_type(_Doc, _ExpectedType, _DocType) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec check_msg_belonging(kz_term:api_ne_binary(), kz_json:object()) -> boolean().
--spec check_msg_belonging(kz_term:api_ne_binary(), kz_json:object(), kz_term:api_ne_binary()) -> boolean().
 check_msg_belonging(BoxId, JObj) ->
     check_msg_belonging(BoxId, JObj, kzd_box_message:source_id(JObj)).
 
+-spec check_msg_belonging(kz_term:api_ne_binary(), kz_json:object(), kz_term:api_ne_binary()) -> boolean().
 check_msg_belonging(_BoxId, _JObj, 'undefined') -> 'true';
 check_msg_belonging('undefined', _JObj, _SourceId) -> 'true';
 check_msg_belonging(BoxId, _JObj, BoxId) -> 'true';
@@ -318,11 +321,12 @@ publish_voicemail_saved(Length, BoxId, Call, MediaId, Timestamp) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec get_notify_completed_message(kz_json:objects()) -> kz_json:object().
--spec get_notify_completed_message(kz_json:objects(), kz_json:object()) -> kz_json:object().
 get_notify_completed_message(JObjs) ->
     get_notify_completed_message(JObjs, kz_json:new()).
 
+-spec get_notify_completed_message(kz_json:objects(), kz_json:object()) -> kz_json:object().
 get_notify_completed_message([], Acc) -> Acc;
 get_notify_completed_message([JObj|JObjs], Acc) ->
     case kz_json:get_value(<<"Status">>, JObj) of
@@ -339,8 +343,8 @@ get_notify_completed_message([JObj|JObjs], Acc) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec maybe_transcribe(kz_term:ne_binary(), kz_term:ne_binary(), boolean()) -> kz_term:api_object().
--spec maybe_transcribe(kz_term:ne_binary(), kz_json:object(), binary(), kz_term:api_binary()) -> kz_term:api_object().
 maybe_transcribe(AccountId, MediaId, 'true') ->
     Db = get_db(AccountId, MediaId),
     {'ok', MediaDoc} = kz_datamgr:open_doc(Db, MediaId),
@@ -361,6 +365,7 @@ maybe_transcribe(AccountId, MediaId, 'true') ->
     end;
 maybe_transcribe(_, _, 'false') -> 'undefined'.
 
+-spec maybe_transcribe(kz_term:ne_binary(), kz_json:object(), binary(), kz_term:api_binary()) -> kz_term:api_object().
 maybe_transcribe(_, _, _, 'undefined') -> 'undefined';
 maybe_transcribe(_, _, <<>>, _) -> 'undefined';
 maybe_transcribe(Db, MediaDoc, Bin, ContentType) ->

--- a/core/kazoo_voicemail/src/migrate/kvm_migrate_crawler.erl
+++ b/core/kazoo_voicemail/src/migrate/kvm_migrate_crawler.erl
@@ -263,8 +263,8 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
 -spec spawn_worker(state()) -> state().
--spec maybe_spawn_worker(state(), next_account_ret()) -> state().
 spawn_worker(#state{account_queue = Queue
                    ,retention_passed = IsRetPassed
                    ,workers = Workers
@@ -272,6 +272,7 @@ spawn_worker(#state{account_queue = Queue
     NextAccount = get_next_account(Queue, Workers, IsRetPassed),
     maybe_spawn_worker(State, NextAccount).
 
+-spec maybe_spawn_worker(state(), next_account_ret()) -> state().
 maybe_spawn_worker(#state{account_ids = AccountIds
                          }=State, 'retention_passed') ->
     ?SUP_LOG_WARNING(":: all voicemails in retention duration are migrated, beginning a migrating older voicemails", []),

--- a/core/kazoo_web/src/kz_http.erl
+++ b/core/kazoo_web/src/kz_http.erl
@@ -65,95 +65,116 @@
 %% @public
 %% @doc Send synchronous request
 %%--------------------------------------------------------------------
+
 -spec get(string()) -> ret().
--spec get(string(), kz_term:proplist()) -> ret().
--spec get(string(), kz_term:proplist(), kz_term:proplist()) -> ret().
 get(Url) ->
     req('get', Url, [], [], []).
+
+-spec get(string(), kz_term:proplist()) -> ret().
 get(Url, Headers) ->
     req('get', Url, Headers, [], []).
+
+-spec get(string(), kz_term:proplist(), kz_term:proplist()) -> ret().
 get(Url, Headers, Options) ->
     req('get', Url, Headers, [], Options).
 
 -spec options(string()) -> ret().
--spec options(string(), kz_term:proplist()) -> ret().
--spec options(string(), kz_term:proplist(), kz_term:proplist()) -> ret().
 options(Url) ->
     req('options', Url, [], [], []).
+
+-spec options(string(), kz_term:proplist()) -> ret().
 options(Url, Headers) ->
     req('options', Url, Headers, [], []).
+
+-spec options(string(), kz_term:proplist(), kz_term:proplist()) -> ret().
 options(Url, Headers, Options) ->
     req('options', Url, Headers, [], Options).
 
 -spec head(string()) -> ret().
--spec head(string(), kz_term:proplist()) -> ret().
--spec head(string(), kz_term:proplist(), kz_term:proplist()) -> ret().
 head(Url) ->
     req('head', Url, [], [], []).
+
+-spec head(string(), kz_term:proplist()) -> ret().
 head(Url, Headers) ->
     req('head', Url, Headers, [], []).
+
+-spec head(string(), kz_term:proplist(), kz_term:proplist()) -> ret().
 head(Url, Headers, Options) ->
     req('head', Url, Headers, [], Options).
 
 -spec trace(string()) -> ret().
--spec trace(string(), kz_term:proplist()) -> ret().
--spec trace(string(), kz_term:proplist(), kz_term:proplist()) -> ret().
 trace(Url) ->
     req('trace', Url, [], [], []).
+
+-spec trace(string(), kz_term:proplist()) -> ret().
 trace(Url, Headers) ->
     req('trace', Url, Headers, [], []).
+
+-spec trace(string(), kz_term:proplist(), kz_term:proplist()) -> ret().
 trace(Url, Headers, Options) ->
     req('trace', Url, Headers, [], Options).
 
 -spec delete(string()) -> ret().
--spec delete(string(), kz_term:proplist()) -> ret().
--spec delete(string(), kz_term:proplist(), http_body()) -> ret().
--spec delete(string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 delete(Url) ->
     req('delete', Url, [], [], []).
+
+-spec delete(string(), kz_term:proplist()) -> ret().
 delete(Url, Headers) ->
     req('delete', Url, Headers, [], []).
+
+-spec delete(string(), kz_term:proplist(), http_body()) -> ret().
 delete(Url, Headers, Body) ->
     req('delete', Url, Headers, Body, []).
+
+-spec delete(string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 delete(Url, Headers, Body, Options) ->
     req('delete', Url, Headers, Body, Options).
 
 -spec post(string()) -> ret().
--spec post(string(), kz_term:proplist()) -> ret().
--spec post(string(), kz_term:proplist(), http_body()) -> ret().
--spec post(string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 post(Url) ->
     req('post', Url, [], [], []).
+
+-spec post(string(), kz_term:proplist()) -> ret().
 post(Url, Headers) ->
     req('post', Url, Headers, [], []).
+
+-spec post(string(), kz_term:proplist(), http_body()) -> ret().
 post(Url, Headers, Body) ->
     req('post', Url, Headers, Body, []).
+
+-spec post(string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 post(Url, Headers, Body, Options) ->
     req('post', Url, Headers, Body, Options).
 
 -spec patch(string()) -> ret().
--spec patch(string(), kz_term:proplist()) -> ret().
--spec patch(string(), kz_term:proplist(), http_body()) -> ret().
--spec patch(string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 patch(Url) ->
     req('patch', Url, [], [], []).
+
+-spec patch(string(), kz_term:proplist()) -> ret().
 patch(Url, Headers) ->
     req('patch', Url, Headers, [], []).
+
+-spec patch(string(), kz_term:proplist(), http_body()) -> ret().
 patch(Url, Headers, Body) ->
     req('patch', Url, Headers, Body, []).
+
+-spec patch(string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 patch(Url, Headers, Body, Options) ->
     req('patch', Url, Headers, Body, Options).
 
 -spec put(string()) -> ret().
--spec put(string(), kz_term:proplist()) -> ret().
--spec put(string(), kz_term:proplist(), http_body()) -> ret().
--spec put(string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 put(Url) ->
     req('put', Url, [], [], []).
+
+-spec put(string(), kz_term:proplist()) -> ret().
 put(Url, Headers) ->
     req('put', Url, Headers, [], []).
+
+-spec put(string(), kz_term:proplist(), http_body()) -> ret().
 put(Url, Headers, Body) ->
     req('put', Url, Headers, Body, []).
+
+-spec put(string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 put(Url, Headers, Body, Options) ->
     req('put', Url, Headers, Body, Options).
 
@@ -161,19 +182,24 @@ put(Url, Headers, Body, Options) ->
 %% @public
 %% @doc Send a synchronous HTTP request
 %%--------------------------------------------------------------------
+
 -spec req(string()) -> ret().
--spec req(method(), string()) -> ret().
--spec req(method(), string(), kz_term:proplist()) -> ret().
--spec req(method(), string(), kz_term:proplist(), http_body()) -> ret().
--spec req(method(), string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 req(Url) ->
     req('get', Url, [], [], []).
+
+-spec req(method(), string()) -> ret().
 req(Method, Url) ->
     req(Method, Url, [], [], []).
+
+-spec req(method(), string(), kz_term:proplist()) -> ret().
 req(Method, Url, Headers) ->
     req(Method, Url, Headers, [], []).
+
+-spec req(method(), string(), kz_term:proplist(), http_body()) -> ret().
 req(Method, Url, Headers, Body) ->
     req(Method, Url, Headers, Body, []).
+
+-spec req(method(), string(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 req(Method, Url, Hdrs, Body, Opts) ->
     {Headers, Options} = maybe_basic_auth(Hdrs, Opts),
     Request = build_request(Method, Url, Headers, Body),
@@ -183,19 +209,24 @@ req(Method, Url, Hdrs, Body, Opts) ->
 %% @public
 %% @doc Send an asynchronous HTTP request
 %%--------------------------------------------------------------------
+
 -spec async_req(pid(), kz_term:text()) -> ret().
--spec async_req(pid(), method(), kz_term:text()) -> ret().
--spec async_req(pid(), method(), kz_term:text(), kz_term:proplist()) -> ret().
--spec async_req(pid(), method(), kz_term:text(), kz_term:proplist(), http_body()) -> ret().
--spec async_req(pid(), method(), kz_term:text(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 async_req(Pid, Url) ->
     async_req(Pid, 'get', Url, [], [], []).
+
+-spec async_req(pid(), method(), kz_term:text()) -> ret().
 async_req(Pid, Method, Url) ->
     async_req(Pid, Method, Url, [], [], []).
+
+-spec async_req(pid(), method(), kz_term:text(), kz_term:proplist()) -> ret().
 async_req(Pid, Method, Url, Headers) ->
     async_req(Pid, Method, Url, Headers, []).
+
+-spec async_req(pid(), method(), kz_term:text(), kz_term:proplist(), http_body()) -> ret().
 async_req(Pid, Method, Url, Headers, Body) ->
     async_req(Pid, Method, Url, Headers, Body, []).
+
+-spec async_req(pid(), method(), kz_term:text(), kz_term:proplist(), http_body(), kz_term:proplist()) -> ret().
 async_req(Pid, Method, Url, Hdrs, Body, Opts) ->
     {Headers, Options} = maybe_basic_auth(Hdrs, Opts),
     Request = build_request(Method, Url, Headers, Body),

--- a/core/kazoo_web/src/kz_http_util.erl
+++ b/core/kazoo_web/src/kz_http_util.erl
@@ -282,10 +282,10 @@ json_to_querystring(JObj, Prefix) ->
     fold_kvs(Ks, Vs, Prefix, []).
 
 -spec props_to_querystring(kz_term:proplist()) -> iolist().
--spec props_to_querystring(kz_term:proplist(), binary() | kz_term:ne_binaries()) -> iolist().
 props_to_querystring(Props) ->
     props_to_querystring(Props, <<>>).
 
+-spec props_to_querystring(kz_term:proplist(), binary() | kz_term:ne_binaries()) -> iolist().
 props_to_querystring(Props, Prefix) ->
     {Vs, Ks} = props:get_values_and_keys(Props),
     fold_kvs([kz_term:to_binary(K) || K <- Ks], Vs, Prefix, []).

--- a/core/kazoo_xml/src/kz_xml.erl
+++ b/core/kazoo_xml/src/kz_xml.erl
@@ -20,12 +20,12 @@
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
 
 -spec elements(list()) -> kz_types:xml_els().
--spec elements(list(), atom()) -> kz_types:xml_els().
 elements(Els) -> [El || #xmlElement{}=El <- Els].
+
+-spec elements(list(), atom()) -> kz_types:xml_els().
 elements(Els, Name) -> [El || #xmlElement{name=N}=El <- Els, N =:= Name].
 
 -spec texts_to_binary(kz_types:xml_texts()) -> binary().
--spec texts_to_binary(kz_types:xml_texts(), pos_integer()) -> binary().
 texts_to_binary([]) -> <<>>;
 texts_to_binary([_|_]=Vs) ->
     lists:foldl(fun(C, B) ->
@@ -35,6 +35,7 @@ texts_to_binary([_|_]=Vs) ->
                ,[$\n, $\s, $\n, $\s]
                ).
 
+-spec texts_to_binary(kz_types:xml_texts(), pos_integer()) -> binary().
 texts_to_binary(Vs, Size) when is_list(Vs), is_integer(Size), Size > 0 ->
     B = texts_to_binary(Vs),
     case byte_size(B) > Size of

--- a/core/webseq/src/webseq.erl
+++ b/core/webseq/src/webseq.erl
@@ -52,7 +52,6 @@ start(Type) ->
     end.
 
 -spec stop() -> 'ok'.
--spec stop(diagram_type()) -> 'ok'.
 stop() ->
     %% {{'n', 'l', Key}, PidToMatch, ValueToMatch}
     MatchHead = {?GPROC_KEY('$2'), '_', '$1'},
@@ -64,6 +63,7 @@ stop() ->
         Pids -> lists:foreach(fun stop_pid/1, Pids)
     end.
 
+-spec stop(diagram_type()) -> 'ok'.
 stop(Type) ->
     case get_server_ref(Type) of
         'undefined' -> 'ok';
@@ -126,8 +126,9 @@ note(Ref, Who, Dir, Note) ->
     gen_server:cast(Srv, {'write', "note ~s of ~s: ~s~n", [Dir, who(Srv, Who), what(Note)]}).
 
 -spec trunc(webseq_srv()) -> 'ok'.
--spec rotate(webseq_srv()) -> 'ok'.
 trunc(Srv) -> gen_server:cast(get_server_ref(Srv), 'trunc').
+
+-spec rotate(webseq_srv()) -> 'ok'.
 rotate(Srv) -> gen_server:cast(get_server_ref(Srv), 'rotate').
 
 -spec process_pid(kz_json:object()) -> kz_term:ne_binary().

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -268,6 +268,33 @@ Checks JSON schemas for empty "description" properties and exit(1) if any are fo
 Script for exporting `AUTH_TOKEN` and `ACCOUNT_ID` when doing Crossbar authentication. Handy when running curl commands to use `$AUTH_TOKEN` instead of the raw value (and for re-authing when auth token expires).
 
 
+## `evil_specs_remover.escript`
+
+A script to find repeated `spec` one after another (evil specs) and move them above their corresponding functions (the way which EDoc prefers). It search evil specs using `ag` (A code-searching tool similar to ack [and grep to some degrees], but faster) which has multi-line feature continued by combination of parsing AST of each file, remove the evil specs and add to above their functions.
+
+> **Note:** This script needs [`ag`](https://github.com/ggreer/the_silver_searcher) command line to run!
+
+You can pass path to directories or files. By using `--create-backup` or `-b` option, it first create a backup of the file (`{FILE_NAME}.bak`) before replacing. For searching Kazoo default directories (`applications/*`, `core/*`) use the option `--use-kazoo-dirs` or `-k`.
+
+
+
+```shell
+evil_specs_remover.escript [--create-backup|-b] [--use-kazoo-dirs|-k] <paths_to_files_or_dir>+
+```
+
+### Example
+
+In this example, the `cb_context.erl` has 115 evil specs, 119 lines were removed (some spec was multi-lines) and 200 line was added (the script will add an empty line above the `spec` line if there isn't one to make it separate from the line above since it is more easy to read).
+
+```shell
+$ scripts/evil_specs_remover.escript -k
+Searching for evil sepcspecs...
+processing 1 file(s) with evil specspec:
+  file /home/hesaam/work/2600hz/kazoo/scripts/../applications/crossbar/src/cb_context.erl (115 specs): -119 +200
+
+🍺 finished
+```
+
 ## format-json.sh
 
 Python script to format JSON files (like CouchDB views, JSON schemas) and write the formatted version back to the file. 'make apis' runs this as part of its instructions.
@@ -341,7 +368,7 @@ syntax_tools
 tools
 xmerl
 ```
-  
+
 
 ## `no_raw_json.escript`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -284,7 +284,7 @@ evil_specs_remover.escript [--create-backup|-b] [--use-kazoo-dirs|-k] <paths_to_
 
 ### Example
 
-In this example, the `cb_context.erl` has 115 evil specs, 119 lines were removed (some spec was multi-lines) and 200 line was added (the script will add an empty line above the `spec` line if there isn't one to make it separate from the line above since it is more easy to read).
+In this example, the `cb_context.erl` has 115 evil specs, 119 lines were removed (some spec was multi-lines) and 200 lines were added (the script will add an empty line above the `spec` line if there isn't one to make it separate from the line above since it is more easy to read).
 
 ```shell
 $ scripts/evil_specs_remover.escript -k

--- a/scripts/evil_specs_remover.escript
+++ b/scripts/evil_specs_remover.escript
@@ -71,8 +71,8 @@ search_for_evil_specs(Paths) ->
 parse_args([], {Opts, Paths}) ->
     Patss = [Path
              || Path <- Paths,
-                        filelib:is_file(Path)
-                            orelse filelib:is_dir(Path)
+                filelib:is_file(Path)
+                    orelse filelib:is_dir(Path)
             ],
     case Patss of
         [] ->
@@ -106,8 +106,8 @@ check_result(Result, [Path], Options) ->
             %% since this is a single file ag won't print filename
             %% adding "file_name:" to the result here
             Lines = [<<(list_to_binary(Path))/binary, ":", Line/binary>>
-                     || Line <- binary:split(Result, <<"\n">>, [global]),
-                                Line =/= <<>>
+                         || Line <- binary:split(Result, <<"\n">>, [global]),
+                            Line =/= <<>>
                     ],
             process_ag_result(Lines, Options)
     end;

--- a/scripts/evil_specs_remover.escript
+++ b/scripts/evil_specs_remover.escript
@@ -211,7 +211,7 @@ maybe_test_or_regular_function([], _, Acc) -> Acc;
 maybe_test_or_regular_function([{_, FunLine, _, _, _}|T], Map, Acc) ->
     maybe_test_or_regular_function(T, Map, [Map#{fun_pos => FunLine}|Acc]).
 
-%% this important since sometimes the order of function implementation is guarantied
+%% this important since sometimes the order of function implementation is not guarantied
 %% to be in continuance line order. Sometimes other function or other arity of the this function is implemented first
 sort_by_fun_position(#{fun_pos := Pos1}, #{fun_pos := Pos2}) ->
     Pos1 < Pos2.

--- a/scripts/evil_specs_remover.escript
+++ b/scripts/evil_specs_remover.escript
@@ -1,0 +1,282 @@
+#!/usr/bin/env escript
+%%! +A0
+%% -*- coding: utf-8 -*-
+
+-mode('compile').
+
+-export([main/1]).
+
+-define(SAMPLE_OUTPUT,
+        list_to_binary(
+          lists:flatten(["core/kazoo_apps/src/kapps_util.erl:263:-spec get_all_accounts() -> kz_term:ne_binaries().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:264:-spec get_all_accounts(kz_util:account_format()) -> kz_term:ne_binaries().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:275:-spec get_all_accounts_and_mods() -> kz_term:ne_binaries().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:276:-spec get_all_accounts_and_mods(kz_util:account_format()) -> kz_term:ne_binaries().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:301:-spec get_all_account_mods() -> kz_term:ne_binaries().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:302:-spec get_all_account_mods(kz_util:account_format()) -> kz_term:ne_binaries().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:313:-spec get_account_mods(kz_term:ne_binary()) -> kz_term:ne_binaries().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:314:-spec get_account_mods(kz_term:ne_binary(), kz_util:account_format()) -> kz_term:ne_binaries().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:608:-spec amqp_pool_request(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun()) ->\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:609:                               kz_amqp_worker:request_return().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:610:-spec amqp_pool_request(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun(), timeout()) ->\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:611:                               kz_amqp_worker:request_return().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:625:-spec amqp_pool_request_custom(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun(), gen_listener:binding()) ->\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:626:                                      kz_amqp_worker:request_return().\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:627:-spec amqp_pool_request_custom(kz_term:api_terms(), kz_amqp_worker:publish_fun(), kz_amqp_worker:validate_fun(), timeout(), gen_listener:binding()) ->\n"
+                        ,"core/kazoo_apps/src/kapps_util.erl:628:                                      kz_amqp_worker:request_return().\n"
+                        ]))
+       ).
+
+-define(SPECSPEC_REGEX, "ag --nogroup '\\-spec[^.]+\\.$(\n\\-spec[^.]+\\.$)+' ").
+
+main([_|_]=Args) ->
+    _ = io:setopts('user', [{'encoding', 'unicode'}]),
+    check_ag_available(),
+    io:format("Searching for evil sepcspecs...~n"),
+    {Options, Paths} = parse_args(Args, {[], []}),
+    check_result(list_to_binary(search_for_evil_specs(Paths)), Paths, Options);
+main(_) ->
+    usage().
+
+check_ag_available() ->
+    case os:find_executable("ag") of
+        'false' ->
+            io:format("~nPlease install 'ag' (https://github.com/ggreer/the_silver_searcher):~n~n"),
+            io:format("  apt-get install silversearcher-ag~n"),
+            io:format("  brew install the_silver_searcher~n"),
+            io:format("  yum install the_silver_searcher~n"),
+            io:format("  pacman -S the_silver_searcher~n"),
+            io:format("~n"),
+            halt(1);
+        _ ->
+            ok
+    end.
+
+usage() ->
+    io:format("no correct paths to files or directories was given.~n~n"),
+    io:format("Usage: \n\t~s [--create-backup|-b] [--use-kazoo-dirs|-k] <paths_to_files_or_dir>+\n", [filename:basename(escript:script_name())]),
+    halt(1).
+
+search_for_evil_specs([]) ->
+    usage();
+search_for_evil_specs(Paths) ->
+    Args = lists:flatten([P ++ " " || P <- Paths]),
+    try os:cmd(?SPECSPEC_REGEX ++ Args)
+    catch
+        _E:_T ->
+            io:format("ag failed: ~p:~p", [_E, _T]),
+            halt(1)
+    end.
+
+parse_args([], {Opts, Paths}) ->
+    Patss = [Path
+             || Path <- Paths,
+                        filelib:is_file(Path)
+                            orelse filelib:is_dir(Path)
+            ],
+    case Patss of
+        [] ->
+            case lists:keyfind(use_kazoo_dirs, 1, Opts) of
+                {use_kazoo_dirs, true} -> parse_args([], {Opts, filelib:wildcard(kazoo_root("core/*")) ++ filelib:wildcard(kazoo_root("applications/*"))});
+                _ -> usage()
+            end;
+        _ -> {lists:usort(Opts), lists:usort(Patss)}
+    end;
+parse_args(["--create-backup" | Rest], {Opts, Paths}) ->
+    parse_args(Rest, {[{backup, true} | Opts], Paths});
+parse_args(["-b" | Rest], {Opts, Paths}) ->
+    parse_args(Rest, {[{backup, true} | Opts], Paths});
+parse_args(["--use-kazoo-dirs" | Rest], {Opts, Paths}) ->
+    parse_args(Rest, {[{use_kazoo_dirs, true} | Opts], Paths});
+parse_args(["-k" | Rest], {Opts, Paths}) ->
+    parse_args(Rest, {[{use_kazoo_dirs, true} | Opts], Paths});
+parse_args(["." | Rest], {Opts, Paths}) ->
+    parse_args(Rest, {Opts, [kazoo_root() | Paths]});
+parse_args([Path | Rest], {Opts, Paths}) ->
+    parse_args(Rest, {Opts, [filename:absname(Path) | Paths]}).
+
+check_result(<<>>, _, _) ->
+    io:format("Hooray! no evil specsecs was found 🎉~n");
+check_result(<<"ERR:", _/binary>>=Error, _, _) ->
+    io:put_chars(Error);
+check_result(Result, [Path], Options) ->
+    case {filelib:is_dir(Path), filelib:is_file(Path)} of
+        {true, _} -> process_ag_result(Result, Options);
+        {_, true} ->
+            %% since this is a single file ag won't print filename
+            %% adding "file_name:" to the result here
+            Lines = [<<(list_to_binary(Path))/binary, ":", Line/binary>>
+                     || Line <- binary:split(Result, <<"\n">>, [global]),
+                                Line =/= <<>>
+                    ],
+            process_ag_result(Lines, Options)
+    end;
+check_result(Result, [_|_], Options) ->
+    process_ag_result(Result, Options).
+
+%% get list of files and specs from ag result
+process_ag_result(Result, Options) ->
+    FilesSpecs = parse_ag_result(Options, [Line || Line <- binary:split(Result, <<"\n">>, [global]), Line =/= <<>>], []),
+    io:format("processing ~b file(s) with evil specspec:~n", [length(FilesSpecs)]),
+    _ = lists:map(fun process_file/1, FilesSpecs),
+    io:format("~n🍺 finished~n").
+
+%% Get list of specs for each file from ag result by parse
+%% the first line, then get all specs for the file.
+%% Then extract specs info from AST.
+parse_ag_result(_, [], Acc) -> Acc;
+parse_ag_result(Options, [H|T], Acc) ->
+    FirstLine = {File, _, _, true} = parse_ag_line(H),
+    {NewTail, FileSpecs} = get_ag_file_specs(T, File, [FirstLine]),
+    FilePath = binary_to_list(File),
+    lists:keyfind(backup, 1, Options) =:= {backup, true}
+        andalso backup_file(FilePath),
+    {ok, Forms} = epp_dodger:quick_parse_file(FilePath, [{no_fail, true}]),
+    SpecMaps = get_ag_specs_info(Forms, FileSpecs, []),
+    parse_ag_result(Options, NewTail, [{FilePath, SpecMaps}|Acc]).
+
+%% get all specs for this file
+get_ag_file_specs([], _, Acc) -> {[], Acc};
+get_ag_file_specs([H|T], File, Acc) ->
+    case parse_ag_line(H) of
+        {File, _, _, _}=Line ->
+            get_ag_file_specs(T, File, Acc ++ [Line]);
+        _ ->
+            {[H|T], Acc}
+    end.
+
+%% find spec function name/arity from AST
+get_ag_specs_info(_, [], Acc) -> Acc;
+get_ag_specs_info(Forms, [{_, Pos, Line, true}|T], Acc) ->
+    %% {attribute, line, {{fun_name, arity}, func_type_ast}}
+    {_, _, _, {{FunName, Arity}, _}} = lists:keyfind(binary_to_integer(Pos), 2, Forms),
+    {NewTail, SpecLines} = get_multi_line_spec(T, [Line]),
+    SpecMap = #{spec => SpecLines
+               ,spec_pos => binary_to_integer(Pos)
+               ,spec_length => length(SpecLines)
+               ,fun_name => FunName
+               ,arity => Arity
+               },
+    get_ag_specs_info(Forms, NewTail, Acc ++ [SpecMap]).
+
+%% accumulate lines until next spec definition
+get_multi_line_spec([], Acc) -> {[], Acc};
+get_multi_line_spec([{_, _, Line, false}|T], Acc) ->
+    get_multi_line_spec(T, Acc ++ [Line]);
+get_multi_line_spec(Lines, Acc) ->
+    {Lines, Acc}.
+
+parse_ag_line(Bin) ->
+    [File, PosRest] = binary:split(Bin, <<":">>),
+    [Pos, Rest] = binary:split(PosRest, <<":">>),
+    Line = iolist_to_binary(Rest),
+    {File, Pos, Line, is_spec_line(Line)}.
+
+is_spec_line(<<"-spec", _/binary>>) -> true;
+is_spec_line(_) -> false.
+
+%% process files by first removing evil specs, then get function positions from AST
+%% and add specs to position right before their function's position
+process_file({File, SpecMaps}) ->
+    io:format("  file ~s (\e[36;1m~b\e[0m specs): ", [File, length(SpecMaps)]),
+    remove_specs(File, SpecMaps),
+    {ok, Forms} = epp_dodger:quick_parse_file(File, [{no_fail, true}]),
+    move_specs_funs(File, find_functions_position(Forms, SpecMaps, [])).
+
+%% first read files and create tuplelist of {LineNumber, String}
+%% Then loop over SpecMaps and get the position of all lines that the spec
+%% is occupied.
+remove_specs(File, SpecMaps) ->
+    Lines = read_lines(File, true),
+    Positions = lists:foldl(fun fetch_specs_pos/2, [], SpecMaps),
+    io:format("\e[31;1m-~b\e[0m", [length(Positions)]),
+    save_lines(File, [L || {LN, L} <- Lines, not lists:member(LN, Positions)]).
+
+%% Extract specs positions (if it's multi line add number of extra lines)
+fetch_specs_pos(#{spec_pos := Pos, spec_length := Length}, Acc) ->
+    Acc ++ [Pos + I - 1 || I <- lists:seq(1, Length)].
+
+%% find out the position of the function by looking fun/arity in AST (which is newly read after evil specs are removed)
+find_functions_position(_, [], Acc) ->
+    lists:sort(fun sort_by_fun_position/2, Acc);
+find_functions_position(Forms, [#{fun_name := FunName, arity := Arity}=H|T], Acc) ->
+    Functions = lists:filter(fun(Form) -> fun_filter(Form, FunName, Arity) end, Forms),
+    find_functions_position(Forms, T, Acc ++ maybe_test_or_regular_function(Functions, H, [])).
+
+%% for when there are two implementations for function, one normal and one guarded by ?TEST
+maybe_test_or_regular_function([], #{fun_name := FunName, arity := Arity}, []) ->
+    io:format("~n can't find function '~s/~b'~n", [FunName, Arity]),
+    halt(1);
+maybe_test_or_regular_function([], _, Acc) -> Acc;
+maybe_test_or_regular_function([{_, FunLine, _, _, _}|T], Map, Acc) ->
+    maybe_test_or_regular_function(T, Map, [Map#{fun_pos => FunLine}|Acc]).
+
+%% this important since sometimes the order of function implementation is guarantied
+%% to be in continuance line order. Sometimes other function or other arity of the this function is implemented first
+sort_by_fun_position(#{fun_pos := Pos1}, #{fun_pos := Pos2}) ->
+    Pos1 < Pos2.
+
+fun_filter({function, _Line, FName, Arity, _Clauses}, FName, Arity) ->
+    true;
+fun_filter(_, _, _) ->
+    false.
+
+%% read lines from the file again, and add specs to the their new position
+move_specs_funs(File, SpecMaps) ->
+    Lines = read_lines(File, false),
+    {Added, NewLines} = move_specs_funs(Lines, 0, SpecMaps),
+    io:format(" \e[32;1m+~b\e[0m~n", [Added]),
+    save_lines(File, NewLines).
+
+%% the actual hack, split the lines list at the function position
+%% in addition to number of the lines that we have added to file so far,
+%% then subtract it by one to get the function line in the right hand side list.
+%% For adding spec, first add an empty line before spec if it's necessary and adds everything together.
+%% At the end sum number of added lines so far with current spec number of the line and possible empty line.
+move_specs_funs(Lines, LinesAdded, []) -> {LinesAdded, Lines};
+move_specs_funs(Lines, LinesAdded, [#{fun_pos := Pos, spec := Spec, spec_length := Length}|T]) ->
+    {Left, [Fun|Right]} = lists:split(Pos + LinesAdded - 1, Lines),
+    EmptyLine = maybe_add_new_line(lists:last(Left)),
+    move_specs_funs(Left ++ EmptyLine ++ Spec ++ [Fun] ++ Right
+                   ,LinesAdded + Length + length(EmptyLine)
+                   ,T
+                   ).
+
+maybe_add_new_line(<<>>) -> [];
+maybe_add_new_line(_) -> [<<>>].
+
+read_lines(File, WithLineNumber) ->
+    case file:read_file(File) of
+        {ok, Bin} ->
+            case WithLineNumber of
+                true ->
+                    Fun = fun(L, {LN, Ls}) -> {LN+1, [{LN, L}|Ls]} end,
+                    Splits = binary:split(Bin, <<"\n">>, [global]),
+                    {_, Lines} = lists:foldl(Fun, {1, []}, Splits),
+                    lists:reverse(Lines);
+                false -> binary:split(Bin, <<"\n">>, [global])
+            end;
+        {error, Reason} ->
+            throw({error, File, Reason})
+    end.
+
+save_lines(File, Lines) ->
+    case file:write_file(File, lists:droplast([<<L/binary, "\n">> || L <- Lines])) of
+        ok -> ok;
+        {error, Reason} ->
+            throw({error, File, Reason})
+    end.
+
+backup_file(File) ->
+    SourceFile = File,
+    BakFile = File ++ ".bak",
+    case filelib:is_file(BakFile) of
+        true -> file:copy(BakFile, SourceFile);
+        false -> file:copy(SourceFile, BakFile)
+    end.
+
+kazoo_root() ->
+    ScriptsDir = filename:dirname(escript:script_name()),
+    filename:absname(ScriptsDir ++ "/..").
+
+kazoo_root(Dir) -> kazoo_root() ++ "/" ++ Dir.


### PR DESCRIPTION
A script to find repeated `spec` one after another (evil specs) and move them above their corresponding functions (the way which EDoc prefers).