### PR TITLE
[master] HELP-34270: using list entries for both list/lists dynamic_cid actions

### DIFF
--- a/applications/callflow/doc/dynamic_cid.md
+++ b/applications/callflow/doc/dynamic_cid.md
@@ -5,7 +5,7 @@
 The Dynamic CID callflow enables you to dynamically change the Caller ID (CID). There are different methods for doing that:
 
 * **manual:** dial the new Caller ID on the keypad when prompted, this way you can set the Caller ID number only. This works with and without a capture group
-* **list:** setting Caller ID name and number based on the configurtion on the specified document in the database. This requires a capture group
+* **list:** setting Caller ID name and number based on the configuration on the specified document in the database. This requires a capture group
 * **lists:** almost the same as list mode but you can use account's lists feature to configure entries
 * **static** set the caller id to a value in a `caller_id.name` and `caller_id.number` property in the data object. This works with and without a capture group
 
@@ -18,17 +18,17 @@ Key | Description | Type | Default | Required
 `caller_id.name` | caller id name for `static` action | `string` | | `false`
 `caller_id.number` | caller id number for `static` action | `string` | | `false`
 `enforce_call_restriction` | in `list`  and `lists` action mode, should call be restricted by number classification | `boolean` | `true` | `false`
-`id` | The id of document in database that holds the new Caller ID when action is set to `list` | `string` | | `false`
+`id` | The id of document in database that holds the new Caller ID when action is set to `list` or `lists` | `string` | | `false`
 `interdigit_timeout` | The amount of time (in milliseconds) to wait for the caller to press the next digit after pressing a digit | `integer` | 2000 | `false`
-`max_digits` | maximum digits length to ollect for `manual` action | `integer` | 10 | `false`
+`max_digits` | maximum digits length to collect for `manual` action | `integer` | 10 | `false`
 `media_id` | The id of the media prompt to play when collecting Caller ID from user if action is set to `manual` | `string` | `"dynamic-cid-enter_cid"` | `false`
-`min_digits` | minumum digits length to collect for `manual` action | `integer` | 10 | `false`
+`min_digits` | minimum digits length to collect for `manual` action | `integer` | 10 | `false`
 `whitelist_regex` | the regex that will run over collected digits for number verification | `string` | `"\\d+"` | `false`
 
 #### Manual action mode
 
-In this method user is prompted to dial a new Caller ID number. The lenght of the dialed new Caller ID is checked to be
-in the default(or configured) boundry and it is also matched against the default(or configured) regex, if these checks are passed the call will proceed.
+In this method user is prompted to dial a new Caller ID number. The length of the dialed new Caller ID is checked to be
+in the default(or configured) boundary and it is also matched against the default(or configured) regex, if these checks are passed the call will proceed.
 
 > **Notes** You can only set the Caller ID number with this method.
 
@@ -46,26 +46,29 @@ Key | Description | Type | Default | Required
 `accept_prompt` | The media that would be played when the new caller id is accepted | `string` | `"tone_stream://%(250,50,440)"` | `false`
 `reject_prompt` | The media that would be played when the new caller id is rejected | `string` | `"dynamic-cid-invalid_using_default"` | `false`
 `default_prompt` | The media that would be played to user to dial the new caller id | `string` | `dynamic-cid-enter_cid` | `false`
-`max_digits` | Maximum lenght of the new caller id number | `integer` | 10 | `false`
-`min_digits` | Minimum lenght of the new caller id number | `integer` | 10 | `false`
+`max_digits` | Maximum length of the new caller id number | `integer` | 10 | `false`
+`min_digits` | Minimum length of the new caller id number | `integer` | 10 | `false`
 `whitelist_regex` | The regex to use for number to be matched against | `string` | `"\\d+"` | `false`
 
 #### List action mode
 
-In this method you have flexibility to define multiple Caller ID, each assgin to a specific number. You can set both the Caller ID name and
-number in a document in database. This callflow's module use that information to set new Caller ID.
+In this method you have flexibility to define multiple Caller ID, each assign to a specific number using account's list. You can set both the Caller ID name and
+number in a document in database. This callflow's module use that information to set new Caller ID. You can create your list and list's entries using [List Crossbar API](../../crossbar/doc/lists.md).
+
+This done by first getting group capture which populate by callflow automatically (feature code is removed from the beginning) then get a specific length of numbers starting from the beginning of the dialed number (by default 2 numbers). This number is it the key (or index) in a list of Caller ID entry list. For and example how this works, see the example section.
+
+This behavior is exactly same as `lists` action, the only difference is that you can define the index of the matching number (entry index) in the callflow data in `idx_name`.
 
 > **Notes** You can set  both the Caller ID number and name with this method.
 
-##### List document fields
+##### List Entry document fields
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
-`length` | Lenght of the numbers in the list entries for which it used to select desire Caller ID | `integer` | | `true`
-`entries` | Collection of maps of numbers to Caller ID | `object` | | `true`
-`entries.{NUMBER}` | Object that contains the desire Caller ID, it's key (number) is used to select this entry | `object` | | `true`
-`entries.{NUMBER}.number` | Caller ID number | `string` | | `true`
-`entries.{NUMBER}.name` | Caller ID name | `string` | | `true`
+`capture_group_length` | Length of the numbers in the list entries for which it used to select desire Caller ID | `integer` | 2 | `false`
+`capture_group_key` | The number which is used to select this entry, length should be same as `capture_group_length` | `string` | | `true`
+`number` | Caller ID number | `string` | | `true`
+`name` | Caller ID name | `string` | | `true`
 
 ###### Example 1: Two digits as CID selector
 
@@ -81,48 +84,30 @@ and the content list document is:
 
 ```json
 {
-    "_id": "cidlist",
-    "_rev": "5-FyFaandfumIsmellthebloudofanEnglishman",
-    "length" : 2,
-    "entries": {
-        "00": {
-            "number": "16139999999",
-            "name": "Awesome Co."
-        },
-        "01": {
-            "number": "19058888888",
-            "name": "Awesome Inc."
-        }
-    }
+    "capture_group_length" : 2,
+    "capture_group_key": "01",
+    "number": "19058888888",
+    "name": "Awesome Inc."
 }
 ```
 
 These are the steps will happen if a user dial `*2015149072508` in handset:
 
-1. This pattern above means that `*2` is the "feature code" for this feature. callflow will use this module to handle the call
-2. `01` will use to select the Caller ID with number "19058888888" and name "Awesome Inc.". Consider that it's **length** is 2 digits as specified in `lenght` field
+1. This pattern above means that `*2` is the "feature code". Callflow will use this module to handle the call
+2. `01` will be used to select the Caller ID with number "19058888888" and name "Awesome Inc.". Consider that it's **length** is 2 digits as specified in `capture_group_length` field
 3. Selected CID will be set for the call
 3. `5149072508` becomes `+15149072508` and gets dialed as such
 
 ###### Example 1: One digits as CID selector
 
-Another example which uses number with lenght of 1 to select the Caller ID:
+Another example which uses number with length of 1 to select the Caller ID:
 
 ```json
 {
-    "_id": "cidlist",
-    "_rev": "5-FyFaandfumIsmellthebloudofanEnglishman",
-    "length" : 1,
-    "entries": {
-        "0": {
-            "number": "16139999999",
-            "name": "Awesome Co."
-        },
-        "1": {
-            "number": "19058888888",
-            "name": "Awesome Inc."
-        }
-    }
+    "capture_group_length" : 1,
+    "capture_group_key": "0",
+    "number": "16139999999",
+    "name": "Awesome Co."
 }
 ```
 
@@ -130,38 +115,7 @@ Dialing number `*205149072508` will cause number "5149072508" gets dialed with C
 
 #### Lists action mode
 
-Almost the same as list mode but you can use account's lists feature to configure entries:
-
-> **Notes** CID key length is always 2 in this mode.
-
-- Create a list
-
-```shell
-curl -v -X POST \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -d '{"data":{"name":"Dynamic CID","description":"List of new callerid name and number entries ","list_type":"dynamic_cid"}}' \
-    http://{SERVER}/v2/accounts/{ACCOUNT_ID}/lists
-```
-
-> `list_type` field is optional here and used just for easier filtering `dynamic_cid` list among the others
-
-- Create entries
-
-```shell
-curl -v -X POST \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -d '{"data":{"cid_key":"01","cid_name":"My Office CID","cid_number":"+78124906700"}}' \
-    http://{SERVER}/v2/accounts/{ACCOUNT_ID}/lists/{LIST_ID}/entries
-```
-
-- Create callflow dynamic_cid feature code
-
-```shell
-curl -v -X POST \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -d '{"data":{"flow":{"children":{},"data":{"action":"lists","id":"{LIST_ID}"},"module":"dynamic_cid"},"numbers":[],"patterns":["^\\*69([0-9]{2,})$"],"featurecode":{"number":"69","name":"dynamic_cid"}}}'
-    http://{SERVER}/v2/accounts/{ACCOUNT_ID}/callflows
-```
+Almost the same as [list mode](#list-action-mode) using account's lists feature to configure entries.
 
 #### Static action mode
 

--- a/applications/callflow/src/module/cf_cidlistmatch.erl
+++ b/applications/callflow/src/module/cf_cidlistmatch.erl
@@ -55,7 +55,10 @@ is_matching_prefix(AccountDb, ListId, Number) ->
 is_matching_regexp(AccountDb, ListId, Number) ->
     case kz_datamgr:get_results(AccountDb, <<"lists/regexps_in_list">>, [{'key', ListId}]) of
         {'ok', Regexps} ->
-            Patterns = [kz_json:get_value(<<"value">>, X) || X <- Regexps],
+            Patterns = [kz_json:get_value(<<"value">>, X)
+                        || X <- Regexps,
+                           X =/= null
+                       ],
             match_regexps(Patterns, Number);
         _ ->
             'false'

--- a/applications/callflow/src/module/cf_dynamic_cid.erl
+++ b/applications/callflow/src/module/cf_dynamic_cid.erl
@@ -384,11 +384,11 @@ get_new_caller_id(Call, [], ListId, 'undefined') ->
     LengthDigits = get_cid_length_from_list_document(Call, ListId),
     CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
     try <<_:LengthDigits/binary, Destination/binary>> = CaptureGroup,
-        {CidName, CidNumber} = maybe_set_default_cid('undefined', 'undefined', Call),
-        {CidName, CidNumber, Destination}
+         {CidName, CidNumber} = maybe_set_default_cid('undefined', 'undefined', Call),
+         {CidName, CidNumber, Destination}
     catch _E:_T ->
-        lager:warning("failed to get cid_key (with length ~b) and destination number: ~p:~p", [LengthDigits, _E, _T]),
-        {'error', 'not_found'}
+            lager:warning("failed to get cid_key (with length ~b) and destination number: ~p:~p", [LengthDigits, _E, _T]),
+            {'error', 'not_found'}
     end;
 get_new_caller_id(Call, [JObj | Entries], ListId, KeyDest) ->
     Entry = kz_json:get_value(<<"value">>, JObj),
@@ -420,10 +420,10 @@ get_key_and_dest(Call, Entry, 'undefined') ->
     CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
 
     try <<CIDKey:LengthDigits/binary, Destination/binary>> = CaptureGroup,
-        {CIDKey, Destination}
+         {CIDKey, Destination}
     catch _E:_T ->
-        lager:warning("failed to get cid_key (with length ~b) and destination number: ~p:~p", [LengthDigits, _E, _T]),
-        {'error', <<"entry_failed">>}
+            lager:warning("failed to get cid_key (with length ~b) and destination number: ~p:~p", [LengthDigits, _E, _T]),
+            {'error', <<"entry_failed">>}
     end.
 
 -spec get_cid_length_from_list_document(kapps_call:call(), kz_term:ne_binary()) -> non_neg_integer().

--- a/applications/callflow/src/module/cf_dynamic_cid.erl
+++ b/applications/callflow/src/module/cf_dynamic_cid.erl
@@ -66,7 +66,7 @@ handle(Data, Call) ->
 
 -spec handle(kz_json:object(), kapps_call:call(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> 'ok'.
 handle(Data, Call, <<"list">>, ?NE_BINARY = _CaptureGroup) ->
-    lager:info("user is choosing a caller id for this call from couchdb doc"),
+    lager:info("using account's lists/entries view to get new cid info"),
     handle_list(Data, Call);
 handle(Data, Call, <<"lists">>, ?NE_BINARY = _CaptureGroup) ->
     lager:info("using account's lists/entries view to get new cid info"),
@@ -120,7 +120,8 @@ handle_list(Data, Call) ->
 
 -spec handle_lists(kz_json:object(), kapps_call:call()) -> 'ok'.
 handle_lists(Data, Call) ->
-    maybe_proceed_with_call(get_lists_entry(Data, Call), Data, Call).
+    ListId = kz_json:get_ne_binary_value(<<"id">>, Data),
+    maybe_proceed_with_call(get_caller_id_from_entries(Call, ListId, 'undefined'), Data, Call).
 
 -spec maybe_proceed_with_call(list_cid_entry(), kz_json:object(), kapps_call:call()) -> 'ok'.
 maybe_proceed_with_call({NewCallerIdName, NewCallerIdNumber, Dest}, Data, Call) ->
@@ -334,28 +335,21 @@ get_static_cid_entry(Data, Call) ->
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
-%% Pull in document from database with the callerid switching information inside
+%% Pull in document from database with the caller id switching information inside
 %% @end
 %%--------------------------------------------------------------------
+
+-type key_dest() :: 'undefined' | {kz_term:ne_binary(), kz_term:ne_binary()}.
+
 -spec get_list_entry(kz_json:object(), kapps_call:call()) -> list_cid_entry().
 get_list_entry(Data, Call) ->
     ListId = kz_json:get_ne_binary_value(<<"id">>, Data),
-    AccountDb = kapps_call:account_db(Call),
+    get_caller_id_from_entries(Call, ListId, maybe_key_and_dest_using_data(Data, Call)).
 
-    case kz_datamgr:open_cache_doc(AccountDb, ListId) of
-        {'ok', ListJObj} ->
-            {CIDKey, DestNumber} = find_key_and_dest(ListJObj, Data, Call),
-            {NewCallerIdName, NewCallerIdNumber} = get_new_caller_id(CIDKey, ListJObj, Call),
-            {NewCallerIdName, NewCallerIdNumber, DestNumber};
-        {'error', _Reason}=E ->
-            lager:info("failed to load match list document ~s: ~p", [ListId, _Reason]),
-            E
-    end.
-
--spec find_key_and_dest(kz_json:object(), kz_json:object(), kapps_call:call()) -> {kz_term:ne_binary(), kz_term:ne_binary()}.
-find_key_and_dest(ListJObj, Data, Call) ->
+-spec maybe_key_and_dest_using_data(kz_json:object(), kapps_call:call()) -> key_dest().
+maybe_key_and_dest_using_data(Data, Call) ->
     case kz_json:get_ne_binary_value(<<"idx_name">>, Data) of
-        'undefined' -> find_key_and_dest(ListJObj, Call);
+        'undefined' -> 'undefined';
         Idx ->
             Groups = kapps_call:kvs_fetch('cf_capture_groups', Call),
             CIDKey = kz_json:get_ne_binary_value(Idx, Groups),
@@ -363,57 +357,87 @@ find_key_and_dest(ListJObj, Data, Call) ->
             {CIDKey, Dest}
     end.
 
--spec find_key_and_dest(kz_json:object(), kapps_call:call()) -> {kz_term:ne_binary(), kz_term:ne_binary()}.
-find_key_and_dest(ListJObj, Call) ->
-    LengthDigits = kz_json:get_integer_value(<<"length">>, ListJObj, 2),
+-spec get_caller_id_from_entries(kapps_call:call(), kz_term:api_ne_binary(), key_dest()) -> list_cid_entry().
+get_caller_id_from_entries(_, 'undefined', _) ->
+    lager:warning("list id is missing"),
+    {'error', 'not_found'};
+get_caller_id_from_entries(Call, ListId, KeyDest) ->
+    case kz_datamgr:get_results(kapps_call:account_db(Call), <<"lists/entries">>, [{'key', ListId}]) of
+        {'ok', Entries} ->
+            get_new_caller_id(Call, Entries, ListId, KeyDest);
+        {'error', _Reason}=Error ->
+            lager:info("failed to load entry documents ~s: ~p", [ListId, _Reason]),
+            Error
+    end.
+
+-spec get_new_caller_id(kapps_call:call(), kz_json:objects(), kz_term:ne_binary(), key_dest()) -> list_cid_entry().
+get_new_caller_id(Call, [], _ListId, {_, Dest}) ->
+    lager:warning("no entries were found in list ~p", [_ListId]),
+    {CidName, CidNumber} = maybe_set_default_cid('undefined', 'undefined', Call),
+    {CidName, CidNumber, Dest};
+get_new_caller_id(Call, [], ListId, 'undefined') ->
+    lager:warning("no entries were found, maybe finding destination number using specified index"),
+    LengthDigits = get_cid_length_from_list_document(Call, ListId),
+    CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
+    try <<_:LengthDigits/binary, Dest/binary>> = CaptureGroup,
+        {CidName, CidNumber} = maybe_set_default_cid('undefined', 'undefined', Call),
+        {CidName, CidNumber, Dest}
+    catch _E:_T ->
+        lager:warning("failed to get cid_key (with length ~b) and destination number: ~p:~p", [LengthDigits, _E, _T]),
+        {'error', 'not_found'}
+    end;
+get_new_caller_id(Call, [JObj | Entries], ListId, KeyDest) ->
+    Entry = kz_json:ge_value(<<"value">>, JObj),
+
+    case get_key_and_dest(Call, Entry, KeyDest) of
+        {'error', _}=Error ->
+            Error;
+        {CIDKey, Dest} ->
+            case kz_json:get_ne_binary_value(<<"capture_group_key">>, Entry) of
+                CIDKey ->
+                    Name = kz_json:get_ne_binary_value(<<"name">>, Entry),
+                    Number = kz_json:get_ne_binary_value(<<"number">>, Entry),
+                    {CidName, CidNumber} = maybe_set_default_cid(Name, Number, Call),
+                    {CidName, CidNumber, Dest};
+                _ ->
+                    get_new_caller_id(Call, Entries, ListId, KeyDest)
+            end
+    end.
+
+-spec get_key_and_dest(kapps_call:call(), kz_json:objects(), key_dest()) -> key_dest() | {'error', any()}.
+get_key_and_dest(_, _, {CIDKey, Dest}=KeyDest) ->
+    case not kz_term:is_ne_binary(CIDKey)
+        andalso kz_term:is_ne_binary(Dest)
+    of
+        'true' -> KeyDest;
+        'false' ->
+            {'error', <<"key_dest_failed">>}
+    end;
+get_key_and_dest(Call, Entry, 'undefined') ->
+    LengthDigits = kz_json:get_integer_value(<<"capture_group_length">>, Entry, 2),
     lager:debug("digit length to limit lookup key in number: ~p", [LengthDigits]),
     CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
-    <<CIDKey:LengthDigits/binary, Dest/binary>> = CaptureGroup,
-    {CIDKey, Dest}.
 
--spec get_new_caller_id(kz_json:key(), kz_json:object(), kapps_call:call()) -> cid().
-get_new_caller_id(CIDKey, ListJObj, Call) ->
-    JObj = kz_json:get_json_value(<<"entries">>, ListJObj, kz_json:new()),
-    case kz_json:get_json_value(CIDKey, JObj) of
-        'undefined' ->
-            maybe_set_default_cid('undefined', 'undefined', Call);
-        NewCallerId ->
-            Name = kz_json:get_ne_binary_value(<<"name">>, NewCallerId),
-            Number = kz_json:get_ne_binary_value(<<"number">>, NewCallerId),
-            maybe_set_default_cid(Name, Number, Call)
+    try <<CIDKey:LengthDigits/binary, Dest/binary>> = CaptureGroup,
+        {CIDKey, Dest}
+    catch _E:_T ->
+        lager:warning("failed to get cid_key (with length ~b) and destination number: ~p:~p", [LengthDigits, _E, _T]),
+        {'error', <<"entry_failed">>}
     end.
 
--spec get_lists_entry(kz_json:object(), kapps_call:call()) -> list_cid_entry().
-get_lists_entry(Data, Call) ->
-    ListId = kz_json:get_ne_binary_value(<<"id">>, Data),
-    AccountDb = kapps_call:account_db(Call),
-    case kz_datamgr:get_results(AccountDb, <<"lists/entries">>, [{'key', ListId}]) of
-        {'ok', Entries} ->
-            CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
-            <<CIDKey:2/binary, Dest/binary>> = CaptureGroup,
-            {NewCallerIdName, NewCallerIdNumber} = cid_key_lookup(CIDKey, Entries, Call),
-            {NewCallerIdName, NewCallerIdNumber, Dest};
-        {'error', Reason} = E ->
-            lager:info("failed to load match list document ~s: ~p", [ListId, Reason]),
-            E
-    end.
-
--spec cid_key_lookup(binary(), kz_json:objects(), kapps_call:call()) -> cid().
-cid_key_lookup(CIDKey, Entries, Call) ->
-    case lists:foldl(fun(Entry, Acc) -> cidkey_wanted(CIDKey, Entry, Acc) end, [], Entries) of
-        [{NewCallerIdName, NewCallerIdNumber}|_] ->
-            maybe_set_default_cid(NewCallerIdName, NewCallerIdNumber, Call);
-        _ ->
-            maybe_set_default_cid('undefined', 'undefined', Call)
-    end.
-
--spec cidkey_wanted(binary(), kz_json:object(), kz_term:proplist()) -> kz_term:proplist().
-cidkey_wanted(CIDKey, Entry, Acc) ->
-    case kz_json:get_binary_value([<<"value">>, <<"cid_key">>], Entry) == CIDKey of
-        'true' -> Acc ++ [{kz_json:get_ne_binary_value([<<"value">>, <<"cid_name">>], Entry)
-                          ,kz_json:get_ne_binary_value([<<"value">>, <<"cid_number">>], Entry)
-                          }];
-        'false' -> Acc
+-spec get_cid_length_from_list_document(kapps_call:call(), kz_term:ne_binary()) -> non_neg_integer().
+get_cid_length_from_list_document(Call, ListId) ->
+    case kz_datamgr:open_cache_doc(kapps_call:account_db(Call), ListId) of
+        {'ok', ListJObj} ->
+            case kz_json:get_integer_value(<<"length">>, ListJObj, 2) of
+                I when is_integer(I), I > 0 -> I;
+                _ ->
+                    lager:info("cid length from ~s is least than '1', using default '2'", [ListId]),
+                    2
+            end;
+        {'error', _Reason} ->
+            lager:info("failed to load list document ~s using default length '2': ~p", [ListId, _Reason]),
+            2
     end.
 
 %%--------------------------------------------------------------------

--- a/applications/callflow/src/module/cf_lookupcidname.erl
+++ b/applications/callflow/src/module/cf_lookupcidname.erl
@@ -20,6 +20,8 @@
 
 -include("callflow.hrl").
 
+-type match_number_result() :: {'stop', kz_term:api_binary()} | 'continue'.
+
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
     CallerNumber = kapps_call:caller_id_number(Call),
@@ -41,7 +43,7 @@ handle_caller_name(Call, CallerName) ->
     lager:info("setting caller name to ~p", [CallerName]),
     cf_exe:continue(kapps_call:set_caller_id_name(CallerName, Call)).
 
--type match_number_result() :: {'stop', kz_term:api_binary()} | 'continue'.
+
 -spec match_number_in_lists(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binaries()) ->
                                    match_number_result().
 match_number_in_lists(AccountDb, Number, Lists) ->
@@ -63,21 +65,22 @@ match_prefixes_in_lists(_AccountDb, _Number, []) ->
                                     match_number_result().
 match_prefixes_in_list(AccountDb, Prefixes, ListId) ->
     Keys = [[ListId, Prefix] || Prefix <- Prefixes],
-    case kz_datamgr:get_results(AccountDb
-                               ,<<"lists/match_prefix_in_list">>
-                               ,[{'keys', Keys}
-                                ,'include_docs'
-                                ]
-                               )
-    of
-        {'ok', [_ | _] = Matched} ->
-            lager:debug("matched ~p prefixes, getting longest", [length(Matched)]),
-            [ListEntry|_] = lists:sort(fun compare_prefixes/2, Matched),
-            Name = kz_json:get_value([<<"doc">>, <<"displayname">>], ListEntry),
-            lager:debug("matched prefix ~p", [get_prefix(ListEntry)]),
-            {'stop', Name};
+    ViewOptions = [{'keys', Keys}
+                  ,'include_docs'
+                  ],
+    case kz_datamgr:get_results(AccountDb , <<"lists/match_prefix_in_list">>, ViewOptions) of
         {'ok', []} ->
             'continue';
+        {'ok', Entries} ->
+            lager:debug("matched ~p prefixes, getting longest", [length(Entries)]),
+
+            [Entry|_] = lists:sort(fun compare_prefixes/2, Entries),
+            Doc = kz_json:get_value(<<"doc">>, Entry),
+            Name = kz_json:get_value([<<"displayname">>, <<"name">>, <<"cid_name">>], Doc),
+
+            lager:debug("matched prefix ~p", [get_prefix(Entry)]),
+
+            {'stop', Name};
         {'error', Error} ->
             lager:warning("error while matching prefixes in list ~p: ~p", [ListId, Error]),
             'continue'
@@ -87,7 +90,7 @@ match_prefixes_in_list(AccountDb, Prefixes, ListId) ->
 compare_prefixes(JObj1, JObj2) ->
     byte_size(get_prefix(JObj1)) >= byte_size(get_prefix(JObj2)).
 
--spec get_prefix(kz_json:object()) -> binary().
+-spec get_prefix(kz_json:object()) -> kz_term:ne_binary().
 get_prefix(JObj) ->
     Doc = kz_json:get_value(<<"doc">>, JObj),
     kz_json:get_ne_binary_value(<<"number">>, Doc, kz_json:get_ne_binary_value(<<"prefix">>, Doc)).
@@ -107,24 +110,16 @@ build_keys(<<>>, _, Acc) -> Acc.
 -spec match_regexp_in_list(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
                                   'continue' | {'stop', kz_term:api_binary()}.
 match_regexp_in_list(AccountDb, Number, ListId) when is_binary(ListId) ->
-    case fetch_regexes(AccountDb, ListId) of
-        {'ok', Regexps} ->
-            match_regexp(Regexps, Number);
+    ViewOptions = [{'keys', [ListId]}
+                  ,'include_docs'
+                  ],
+    case kz_datamgr:get_results(AccountDb, <<"lists/regexps_in_list">>, ViewOptions) of
+        {'ok', Entries} ->
+            match_regexp(Entries, Number);
         Error ->
             lager:warning("getting regexps error: ~p", [Error]),
             'continue'
     end.
-
--spec fetch_regexes(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                           {'ok', kz_json:objects()} |
-                           {'error', any()}.
-fetch_regexes(AccountDb, ListId) ->
-    kz_datamgr:get_results(AccountDb
-                          ,<<"lists/regexps_in_list">>
-                          ,[{'keys', [ListId]}
-                           ,'include_docs'
-                           ]
-                          ).
 
 -spec match_regexp_in_lists(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries()) ->
                                    kz_term:api_ne_binary().
@@ -139,12 +134,17 @@ match_regexp_in_lists(_, _, []) ->
 -spec match_regexp(kz_json:objects(), kz_term:ne_binary()) ->
                           'continue' |
                           {'stop', kz_term:api_binary()}.
-match_regexp([Re | Rest], Number) ->
-    case re:run(Number, kz_json:get_value(<<"value">>, Re)) of
-        'nomatch' -> match_regexp(Rest, Number);
+match_regexp([Entry | Entries], Number) ->
+    Regex = kz_json:get_ne_binary_value(<<"value">>, Entry),
+    Doc = kz_json:get_value(<<"doc">>, Entry),
+    case Regex =/= 'undefined'
+      andalso re:run(Number, Regex)
+    of
+        'false' -> match_regexp(Entries, Number);
+        'nomatch' -> match_regexp(Entries, Number);
         {'match', _} ->
-            lager:debug("matched regexp ~p", [Re]),
-            {'stop', kz_json:get_value([<<"doc">>, <<"displayname">>], Re)}
+            lager:debug("matched regexp ~p", [kz_doc:id(Doc)]),
+            {'stop', kz_json:get_first_defined([<<"displayname">>, <<"name">>, <<"cid_name">>], Entry)}
     end;
 match_regexp([], _Number) ->
     'continue'.

--- a/applications/callflow/src/module/cf_lookupcidname.erl
+++ b/applications/callflow/src/module/cf_lookupcidname.erl
@@ -138,7 +138,7 @@ match_regexp([Entry | Entries], Number) ->
     Regex = kz_json:get_ne_binary_value(<<"value">>, Entry),
     Doc = kz_json:get_value(<<"doc">>, Entry),
     case Regex =/= 'undefined'
-      andalso re:run(Number, Regex)
+        andalso re:run(Number, Regex)
     of
         'false' -> match_regexp(Entries, Number);
         'nomatch' -> match_regexp(Entries, Number);

--- a/applications/crossbar/priv/couchdb/account/lists.json
+++ b/applications/crossbar/priv/couchdb/account/lists.json
@@ -6,19 +6,82 @@
     "language": "javascript",
     "views": {
         "crossbar_listing": {
-            "map": "function(doc) {if ((doc.pvt_type != 'list') || doc.pvt_deleted) return; emit(doc._id, {'id': doc._id, 'name': doc.name, 'description': doc.description, 'list_type': doc.list_type});}"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'list' || doc.pvt_deleted)",
+                "    return;",
+                "  emit(doc._id, {",
+                "    'id': doc._id,",
+                "    'name': doc.name,",
+                "    'description': doc.description,",
+                "    'list_type': doc.list_type",
+                "  });",
+                "}"
+            ]
         },
         "entries": {
-            "map": "function(doc) {if ((doc.pvt_type != 'list_entry') || doc.pvt_deleted) return; emit(doc.list_id, doc);}"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_deleted)",
+                "    return;",
+                "  if (doc.pvt_type === 'list_entry') {",
+                "    emit(doc.list_id, {",
+                "      capture_group_key: doc.capture_group_key,",
+                "      capture_group_length: doc.capture_group_length,",
+                "      name: doc.name,",
+                "      number: doc.number,",
+                "      pattern: doc.pattern,",
+                "      prefix: doc.prefix,",
+                "      regexp: doc.regexp,",
+                "      type: doc.type",
+                "    })",
+                "  } else if (doc.pvt_type === 'list' && doc.entries) {",
+                "    for (var key in doc.entries) {",
+                "      if (!doc.entries.hasOwnProperty(key))",
+                "        continue;",
+                "      emit(doc._id, {",
+                "        capture_group_key: doc.cid_key,",
+                "        capture_group_length: doc.length,",
+                "        name: doc.entries[key].cid_name || doc.entries[key].name,",
+                "        number: doc.entries[key].cid_number || doc.entries[key].number,",
+                "        pattern: doc.entries[key].pattern,",
+                "        prefix: doc.entries[key].prefix,",
+                "        regexp: doc.entries[key].regexp,",
+                "        type: doc.entries[key].type",
+                "      })",
+                "    }",
+                "  } else {",
+                "    return",
+                "  }",
+                "}"
+            ]
         },
         "match_prefix": {
-            "map": "function(doc) {if ((doc.pvt_type != 'list_entry') || doc.pvt_deleted || (doc.number == null && doc.prefix == null)) return; emit(doc.number ? doc.number : doc.prefix, null);}"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'list_entry' || doc.pvt_deleted || !(doc.number || doc.prefix))",
+                "    return;",
+                "  emit(doc.number ? doc.number : doc.prefix, null);",
+                "}"
+            ]
         },
         "match_prefix_in_list": {
-            "map": "function(doc) {if ((doc.pvt_type != 'list_entry') || doc.pvt_deleted || (doc.number == null && doc.prefix == null)) return; emit([doc.list_id, doc.number ? doc.number : doc.prefix], null);}"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'list_entry' || doc.pvt_deleted || !(doc.number || doc.prefix))",
+                "    return;",
+                "  emit([doc.list_id, doc.number ? doc.number : doc.prefix], null);",
+                "}"
+            ]
         },
         "regexps_in_list": {
-            "map": "function(doc) {if ((doc.pvt_type != 'list_entry') || doc.pvt_deleted || !(doc.regexp || doc.pattern)) return; emit(doc.list_id, doc.regexp ? doc.regexp : doc.pattern);}"
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'list_entry' || doc.pvt_deleted || !(doc.regexp || doc.pattern))",
+                "    return;",
+                "  emit(doc.list_id, doc.regexp ? doc.regexp : doc.pattern);",
+                "}"
+            ]
         }
     }
 }

--- a/applications/crossbar/priv/couchdb/account/lists.json
+++ b/applications/crossbar/priv/couchdb/account/lists.json
@@ -40,7 +40,7 @@
                 "      if (!doc.entries.hasOwnProperty(key))",
                 "        continue;",
                 "      emit(doc._id, {",
-                "        capture_group_key: doc.cid_key,",
+                "        capture_group_key: key,",
                 "        capture_group_length: doc.length,",
                 "        name: doc.entries[key].cid_name || doc.entries[key].name,",
                 "        number: doc.entries[key].cid_number || doc.entries[key].number,",

--- a/scripts/misspellings.txt
+++ b/scripts/misspellings.txt
@@ -100,6 +100,7 @@ jewelry|jewelery
 judgment|judgement
 kernel|kernal
 leisure|liesure
+length|lenght
 liaison|liason
 library|libary liberry
 license|lisence


### PR DESCRIPTION
Updating Callflow Dynamic CID module to use `list/entries` for both `list` and `lists` action.

For doing this, `lists/entries` view has been updated to emit both monolithic `list` entries and `lists_entry` documents. The migration command in `cb_list_v2` has been updated too rename and set some especial property like `name/cid_name`, `number/cid_number`  and `length/capture_group_length`.

Be aware that these changes expect that at least the view has been updated. Otherwise dynamic cid will not work properly.