### PR TITLE
PISTON-523: handle Lang when using account db, not just system_media

### DIFF
--- a/core/kazoo_media/src/kz_media_file.erl
+++ b/core/kazoo_media/src/kz_media_file.erl
@@ -24,7 +24,7 @@ get_uri(#media_store_path{}=Store, JObj) ->
     maybe_proxy(JObj, Store);
 get_uri(Media, JObj) when is_binary(Media) ->
     kz_util:put_callid(JObj),
-    Paths = [Path
+    Paths = [kz_http_util:urldecode(Path)
              || Path <- binary:split(Media, <<"/">>, ['global', 'trim']),
                 not kz_term:is_empty(Path)
             ],

--- a/core/kazoo_media/src/kz_media_map.erl
+++ b/core/kazoo_media/src/kz_media_map.erl
@@ -392,7 +392,7 @@ maybe_add_prompt(AccountId, JObj, PromptId) ->
     lager:debug("adding language ~s for prompt ~s to map for ~s", [Lang, PromptId, AccountId]),
     Languages = kz_json:set_value(Lang
                                  ,kz_media_util:prompt_path(kz_doc:account_id(JObj, ?KZ_MEDIA_DB)
-                                                           ,kz_doc:id(JObj)
+                                                           ,kz_http_util:urlencode(kz_doc:id(JObj))
                                                            )
                                  ,Langs
                                  ),


### PR DESCRIPTION
Prompts overridden by cb_media right now cannot be found by kz_media_file (kz_media_file:get_uri/2 returns <<>>).
Fixed by this PR. Tested various other calls to get_uri and they all still work.