### PR TITLE
[4.1] HELP-34519: don't do after-notify action if notify was not successful

### DIFF
--- a/applications/tasks/src/kz_notify_resend.erl
+++ b/applications/tasks/src/kz_notify_resend.erl
@@ -33,7 +33,7 @@
 -define(MOD_CONFIG_CAT, <<(?CONFIG_CAT)/binary, ".notify_resend">>).
 -define(DEFAULT_TIMEOUT, 10 * ?MILLISECONDS_IN_SECOND).
 
-%% notify resned crawler settungs
+%% notify resend crawler settings
 -define(NOTIFY_RESEND_ENABLED,
         kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"notify_resend_enabled">>, 'true')).
 -define(TIME_BETWEEN_CYCLE,
@@ -183,7 +183,7 @@ handle_call(_Request, _From, State) ->
 handle_cast('next_cycle', State) ->
     {'noreply', State#state{running=[]}, ?TIME_BETWEEN_CYCLE};
 handle_cast(stop, State) ->
-    lager:debug("notify resender has been stopped"),
+    lager:debug("notify re sender has been stopped"),
     {stop, normal, State};
 handle_cast(_Msg, State) ->
     lager:debug("unhandled cast: ~p", [_Msg]),
@@ -297,7 +297,7 @@ call_collect(undefined, _) -> 'ok';
 call_collect(API, PublishFun) ->
     kz_amqp_worker:call_collect(kz_json:recursive_to_proplist(API)
                                ,fun kapi_notifications:PublishFun/1
-                               ,fun collecting/1
+                               ,fun kapps_notify_publisher:collecting/1
                                ,?PUBLISH_TIMEOUT
                                ).
 
@@ -337,15 +337,15 @@ db_bulk_result(JObj) ->
 
 -spec handle_result(kz_amqp_worker:request_return()) -> boolean().
 handle_result('ok') -> 'true';
-handle_result({'ok', Resp}) -> is_completed(Resp);
+handle_result({'ok', Resp}) -> kapps_notify_publisher:is_completed(Resp);
 handle_result({'error', [Error|_]=List}) ->
     case kz_json:is_json_object(Error) of
-        'true' -> is_completed(List);
+        'true' -> kapps_notify_publisher:is_completed(List);
         _ -> 'false'
     end;
 handle_result({'error', _Reason}) -> 'false';
-handle_result({'returned', _, Resp}) -> is_completed(Resp);
-handle_result({'timeout', Resp}) -> is_completed(Resp).
+handle_result({'returned', _, Resp}) -> kapps_notify_publisher:is_completed(Resp);
+handle_result({'timeout', Resp}) -> kapps_notify_publisher:is_completed(Resp).
 
 -spec maybe_reschedule(ne_binary(), kz_json:object(), map()) -> map().
 maybe_reschedule(NotifyType, JObj, #{ko := KO}=Map) ->
@@ -429,25 +429,3 @@ new_results_map() ->
     #{ok => []
      ,ko => []
      }.
-
--spec collecting(kz_json:objects()) -> boolean().
-collecting([JObj|_]) ->
-    case kapi_notifications:notify_update_v(JObj)
-        andalso kz_json:get_value(<<"Status">>, JObj)
-    of
-        <<"completed">> -> 'true';
-        <<"failed">> -> 'true';
-        _ -> 'false'
-    end.
-
--spec is_completed(kz_json:objects()) -> boolean().
-is_completed([]) -> 'false';
-is_completed([JObj|_]) ->
-    case kapi_notifications:notify_update_v(JObj)
-        andalso kz_json:get_value(<<"Status">>, JObj)
-    of
-        <<"completed">> -> 'true';
-        %% FIXME: Is pending enough to consider publish was successful? at least teletype recieved the notification!
-        %% <<"pending">> -> 'true';
-        _ -> 'false'
-    end.

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -935,7 +935,7 @@ public_proplist(Key, JObj) ->
 notification_disabled(DataJObj, TemplateId) ->
     AccountId = kapi_notifications:account_id(DataJObj),
     lager:debug("notification ~s handling not configured for account ~s", [TemplateId, AccountId]),
-    send_update(DataJObj, <<"completed">>).
+    send_update(DataJObj, <<"disabled">>, <<""notification is disabled>>).
 
 -spec maybe_get_attachments(kz_json:object() | api_binary()) -> attachments().
 maybe_get_attachments('undefined') -> [];

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -935,7 +935,7 @@ public_proplist(Key, JObj) ->
 notification_disabled(DataJObj, TemplateId) ->
     AccountId = kapi_notifications:account_id(DataJObj),
     lager:debug("notification ~s handling not configured for account ~s", [TemplateId, AccountId]),
-    send_update(DataJObj, <<"disabled">>, <<""notification is disabled>>).
+    send_update(DataJObj, <<"disabled">>, <<"notification is disabled">>).
 
 -spec maybe_get_attachments(kz_json:object() | api_binary()) -> attachments().
 maybe_get_attachments('undefined') -> [];

--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -142,11 +142,11 @@ maybe_process_req(DataJObj) ->
 
 -spec maybe_process_req(kz_json:object(), boolean()) -> 'ok'.
 maybe_process_req(DataJObj, false) ->
-    Msg = io_lib:format("request or box ~s has no emails or owner doesn't want emails"
+    Msg = io_lib:format("requestor or box ~s has no emails or owner doesn't want emails"
                        ,[kz_json:get_value(<<"voicemail_box">>, DataJObj)]
                        ),
     lager:debug(Msg),
-    teletype_util:send_update(DataJObj, <<"completed">>, kz_term:to_binary(Msg));
+    teletype_util:send_update(DataJObj, <<"ignored">>, kz_term:to_binary(Msg));
 maybe_process_req(DataJObj, true) ->
     do_process_req(DataJObj).
 

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -531,7 +531,13 @@
                                         ]).
 -define(NOTIFY_UPDATE_VALUES, [{<<"Event-Category">>, <<"notification">>}
                               ,{<<"Event-Name">>, <<"update">>}
-                              ,{<<"Status">>, [<<"completed">>, <<"failed">>, <<"pending">>]}
+                              ,{<<"Status">>, [<<"completed">>
+                                              ,<<"disabled">>
+                                              ,<<"failed">>
+                                              ,<<"ignored">>
+                                              ,<<"pending">>
+                                              ]
+                               }
                               ]).
 -define(NOTIFY_UPDATE_TYPES, []).
 

--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -742,17 +742,15 @@ remove_malform_vm(Call, ForwardId) ->
 -spec notify_and_update_meta(kapps_call:call(), ne_binary(), integer(), kz_proplist()) -> {'ok', kapps_call:call()}.
 notify_and_update_meta(Call, MediaId, Length, Props) ->
     BoxId = props:get_value(<<"Box-Id">>, Props),
-    NotifyAction = props:get_atom_value(<<"After-Notify-Action">>, Props),
+    NotifyAction = props:get_atom_value(<<"After-Notify-Action">>, Props, 'nothing'),
 
     case kvm_util:publish_saved_notify(MediaId, BoxId, Call, Length, Props) of
         {'ok', JObjs} ->
-            JObj = kvm_util:get_notify_completed_message(JObjs),
-            log_notification_response(NotifyAction, MediaId, JObj, Call),
-            maybe_update_meta(Length, NotifyAction, Call, MediaId, BoxId);
+            NewAction = is_notified_successfully(Call, MediaId, JObjs, NotifyAction),
+            maybe_update_meta(Length, NewAction, Call, MediaId, BoxId);
         {'timeout', JObjs} ->
-            JObj = kvm_util:get_notify_completed_message(JObjs),
-            log_notification_response(NotifyAction, MediaId, JObj, Call),
-            maybe_update_meta(Length, 'nothing', Call, MediaId, BoxId);
+            NewAction = is_notified_successfully(Call, MediaId, JObjs, NotifyAction),
+            maybe_update_meta(Length, NewAction, Call, MediaId, BoxId);
         {'error', _R} ->
             AccountId = kapps_call:account_id(Call),
             lager:debug("failed to send new voicemail notification for message ~s in account ~s: ~p"
@@ -760,26 +758,29 @@ notify_and_update_meta(Call, MediaId, Length, Props) ->
             maybe_update_meta(Length, 'nothing', Call, MediaId, BoxId)
     end.
 
--spec log_notification_response(notify_action(), ne_binary(), kz_json:object(), kapps_call:call()) -> 'ok'.
-log_notification_response('nothing', _MediaId, _UpdateJObj, Call) ->
-    AccountId = kapps_call:account_id(Call),
-    lager:debug("successfully sent new voicemail notification for message ~s in account ~s: ~s"
-               ,[_MediaId, AccountId, kz_json:encode(_UpdateJObj)]);
-log_notification_response(_Action, MediaId, UpdateJObj, Call) ->
-    AccountId = kapps_call:account_id(Call),
-    case kz_json:get_value(<<"Status">>, UpdateJObj) of
+%%--------------------------------------------------------------------
+%% @private
+%% @doc If notification was successfully processed return the NotifyAction.
+%% Otherwise return action 'nothing' to store the message as new voicemail.
+%% @end
+%%--------------------------------------------------------------------
+-spec is_notified_successfully(kapps_call:call(), ne_binary(), kz_json:object(), notify_action() | ne_binary()) -> notify_action().
+is_notified_successfully(Call, _MediaId, [], Thing) ->
+    ErrorMsg = case is_atom(Thing) of
+                   'true' -> <<"timeout">>;
+                   'false' -> Thing
+               end,
+    lager:debug("failed to send new voicemail notification for message ~s in account ~s: ~s", [_MediaId, kapps_call:account_id(Call), ErrorMsg]),
+    'nothing';
+is_notified_successfully(Call, MediaId, [JObj|JObjs], NotifyAction) ->
+    case kz_json:get_value(<<"Status">>, JObj) of
         <<"completed">> ->
-            lager:debug("successfully sent new voicemail notification for message ~s in account ~s: ~s"
-                       ,[MediaId, AccountId, kz_json:encode(UpdateJObj)]);
+            lager:debug("successfully sent new voicemail notification for message ~s in account ~s", [MediaId, kapps_call:account_id(Call)]),
+            NotifyAction;
         <<"failed">> ->
-            lager:debug("failed to send new voicemail notification for message ~s in account ~s: ~s"
-                       ,[MediaId
-                        ,AccountId
-                        ,kz_json:get_value(<<"Failure-Message">>, UpdateJObj)
-                        ]);
+            is_notified_successfully(Call, MediaId, [], kz_json:get_value(<<"Failure-Message">>, JObj));
         _ ->
-            lager:info("failed to send new voicemail notification for message ~s in account ~s: timeout"
-                      ,[MediaId, AccountId])
+            is_notified_successfully(Call, MediaId, JObjs, NotifyAction)
     end.
 
 -spec maybe_update_meta(pos_integer(), notify_action(), kapps_call:call(), ne_binary(), ne_binary()) -> {'ok', kapps_call:call()}.

--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -27,7 +27,7 @@
 
 %%--------------------------------------------------------------------
 %% @public
-%% @doc recieve and store a new voicemail message
+%% @doc receive and store a new voicemail message
 %% expected options:
 %% [{<<"Attachment-Name">>, AttachmentName}
 %% ,{<<"Box-Id">>, BoxId}
@@ -317,7 +317,7 @@ do_move(AccountId, FromId, OldBoxId, NewBoxId, NBoxJ, Funs) ->
         {'error', 'timeout'} ->
             move_copy_final_check(AccountId, FromId, ToId);
         {'error', 'conflict'} ->
-            Msg = io_lib:format("conflict occured during moving voicemail ~s / ~s to ~s / ~s"
+            Msg = io_lib:format("conflict occurred during moving voicemail ~s / ~s to ~s / ~s"
                                ,[FromDb, FromId, ToDb, ToId]
                                ),
             Subject = <<"Conflict during forward voicemail message">>,
@@ -421,7 +421,7 @@ do_copy(AccountId, ?NE_BINARY = FromId, ToId, Funs) ->
         {'error', 'timeout'} ->
             move_copy_final_check(AccountId, FromId, ToId);
         {'error', 'conflict'} ->
-            Msg = io_lib:format("conflict occured during forwarding voicemail ~s / ~s to ~s / ~s"
+            Msg = io_lib:format("conflict occurred during forwarding voicemail ~s / ~s to ~s / ~s"
                                ,[FromDb, FromId, ToDb, ToId]
                                ),
             Subject = <<"Conflict during forward voicemail message">>,
@@ -764,23 +764,17 @@ notify_and_update_meta(Call, MediaId, Length, Props) ->
 %% Otherwise return action 'nothing' to store the message as new voicemail.
 %% @end
 %%--------------------------------------------------------------------
--spec is_notified_successfully(kapps_call:call(), ne_binary(), kz_json:object(), notify_action() | ne_binary()) -> notify_action().
-is_notified_successfully(Call, _MediaId, [], Thing) ->
-    ErrorMsg = case is_atom(Thing) of
-                   'true' -> <<"timeout">>;
-                   'false' -> Thing
-               end,
-    lager:debug("failed to send new voicemail notification for message ~s in account ~s: ~s", [_MediaId, kapps_call:account_id(Call), ErrorMsg]),
+-spec is_notified_successfully(kapps_call:call(), ne_binary(), kz_json:object(), notify_action()) -> notify_action().
+is_notified_successfully(Call, _MediaId, [], _) ->
+    lager:debug("failed to send new voicemail notification for message ~s in account ~s: timeout", [_MediaId, kapps_call:account_id(Call)]),
     'nothing';
 is_notified_successfully(Call, MediaId, [JObj|JObjs], NotifyAction) ->
     case kz_json:get_value(<<"Status">>, JObj) of
-        <<"completed">> ->
-            lager:debug("successfully sent new voicemail notification for message ~s in account ~s", [MediaId, kapps_call:account_id(Call)]),
-            NotifyAction;
-        <<"failed">> ->
-            is_notified_successfully(Call, MediaId, [], kz_json:get_value(<<"Failure-Message">>, JObj));
-        _ ->
-            is_notified_successfully(Call, MediaId, JObjs, NotifyAction)
+        <<"completed">> -> NotifyAction;
+        <<"disabled">> -> 'nothing';
+        <<"ignored">> -> 'nothing';
+        <<"failed">> -> 'nothing';
+        _ -> is_notified_successfully(Call, MediaId, JObjs, NotifyAction)
     end.
 
 -spec maybe_update_meta(pos_integer(), notify_action(), kapps_call:call(), ne_binary(), ne_binary()) -> {'ok', kapps_call:call()}.

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -21,7 +21,6 @@
         ,enforce_retention/1, enforce_retention/2, is_prior_to_retention/2
 
         ,publish_saved_notify/5, publish_voicemail_saved/5
-        ,get_notify_completed_message/1
         ,get_caller_id_name/1, get_caller_id_number/1
         ]).
 
@@ -312,23 +311,6 @@ publish_voicemail_saved(Length, BoxId, Call, MediaId, Timestamp) ->
            ],
     kapps_notify_publisher:cast(Prop, fun kapi_notifications:publish_voicemail_saved/1),
     lager:debug("published voicemail_saved for ~s", [BoxId]).
-
-%%--------------------------------------------------------------------
-%% @public
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
--spec get_notify_completed_message(kz_json:objects()) -> kz_json:object().
--spec get_notify_completed_message(kz_json:objects(), kz_json:object()) -> kz_json:object().
-get_notify_completed_message(JObjs) ->
-    get_notify_completed_message(JObjs, kz_json:new()).
-
-get_notify_completed_message([], Acc) -> Acc;
-get_notify_completed_message([JObj|JObjs], Acc) ->
-    case kz_json:get_value(<<"Status">>, JObj) of
-        <<"completed">> -> get_notify_completed_message([], JObj);
-        _ -> get_notify_completed_message(JObjs, Acc)
-    end.
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
Check for any completed in the notification response and if it wasn't successful don't do nothing.

This for the case when the user don't have any email address set or doesn't want to receive notification or the template is disabled in account but `delete_after_notify` or `save_after_notify` is set on voicemail box, so kazoo_voicemail would do that action regardless of the reality that it wasn't successful.

master: https://github.com/2600hz/kazoo/pull/4520