### PR TITLE
[master] HELP-34519: don't do after-notify action if notify was not successful

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -15609,7 +15609,7 @@
                 },
                 "Event-Name": {
                     "enum": [
-                        "update"
+                        "notify_update"
                     ],
                     "type": "string"
                 },
@@ -15626,7 +15626,7 @@
                     "type": "string"
                 },
                 "Preview": {
-                    "type": "string"
+                    "type": "boolean"
                 },
                 "Reply-To": {
                     "type": "string"
@@ -15634,7 +15634,9 @@
                 "Status": {
                     "enum": [
                         "completed",
+                        "disabled",
                         "failed",
+                        "ignored",
                         "pending"
                     ],
                     "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.notify_update.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.notify_update.json
@@ -26,7 +26,7 @@
         },
         "Event-Name": {
             "enum": [
-                "update"
+                "notify_update"
             ],
             "type": "string"
         },
@@ -43,7 +43,7 @@
             "type": "string"
         },
         "Preview": {
-            "type": "string"
+            "type": "boolean"
         },
         "Reply-To": {
             "type": "string"
@@ -51,7 +51,9 @@
         "Status": {
             "enum": [
                 "completed",
+                "disabled",
                 "failed",
+                "ignored",
                 "pending"
             ],
             "type": "string"

--- a/applications/teletype/src/teletype_bindings.erl
+++ b/applications/teletype/src/teletype_bindings.erl
@@ -78,6 +78,16 @@ maybe_send_update(JObj, RoutingKey, #{'failed' := [{_, Reason}|_]}=Map) ->
     print_result(RoutingKey, Map),
     Metadata = kz_json:from_list_recursive(maps:to_list(Map)),
     teletype_util:send_update(JObj, <<"failed">>, Reason, Metadata);
+maybe_send_update(JObj, RoutingKey, #{'disabled' := _Completed}=Map) ->
+    %% for now just send the first disabled as failure message
+    print_result(RoutingKey, Map),
+    Metadata = kz_json:from_list_recursive(maps:to_list(Map)),
+    teletype_util:send_update(JObj, <<"disabled">>, 'undefined', Metadata);
+maybe_send_update(JObj, RoutingKey, #{'ignored' := _Completed}=Map) ->
+    %% for now just send the first ignored as failure message
+    print_result(RoutingKey, Map),
+    Metadata = kz_json:from_list_recursive(maps:to_list(Map)),
+    teletype_util:send_update(JObj, <<"ignored">>, 'undefined', Metadata);
 maybe_send_update(JObj, RoutingKey, Map) ->
     print_result(RoutingKey, Map),
     Metadata = kz_json:from_list_recursive(maps:to_list(Map)),

--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -141,7 +141,7 @@ maybe_process_req(DataJObj) ->
 
 -spec maybe_process_req(kz_json:object(), boolean()) -> template_response().
 maybe_process_req(DataJObj, false) ->
-    Msg = io_lib:format("request or box ~s has no emails or owner doesn't want emails"
+    Msg = io_lib:format("requestor or box ~s has no emails or owner doesn't want emails"
                        ,[kz_json:get_value(<<"voicemail_box">>, DataJObj)]
                        ),
     lager:debug(Msg),

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -172,7 +172,9 @@ notify_update_definition() ->
                                              | ?DEFAULT_OPTIONAL_HEADERS
                                         ]
                     ,values = [{<<"Status">>, [<<"completed">>
+                                              ,<<"disabled">>
                                               ,<<"failed">>
+                                              ,<<"ignored">>
                                               ,<<"pending">>
                                               ]}
                                | ?NOTIFY_VALUES(<<"notify_update">>)

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -21,7 +21,6 @@
         ,enforce_retention/1, enforce_retention/2, is_prior_to_retention/2
 
         ,publish_saved_notify/5, publish_voicemail_saved/5
-        ,get_notify_completed_message/1
         ,get_caller_id_name/1, get_caller_id_number/1
         ]).
 
@@ -315,24 +314,6 @@ publish_voicemail_saved(Length, BoxId, Call, MediaId, Timestamp) ->
            ],
     kapps_notify_publisher:cast(Prop, fun kapi_notifications:publish_voicemail_saved/1),
     lager:debug("published voicemail_saved for ~s", [BoxId]).
-
-%%--------------------------------------------------------------------
-%% @public
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
-
--spec get_notify_completed_message(kz_json:objects()) -> kz_json:object().
-get_notify_completed_message(JObjs) ->
-    get_notify_completed_message(JObjs, kz_json:new()).
-
--spec get_notify_completed_message(kz_json:objects(), kz_json:object()) -> kz_json:object().
-get_notify_completed_message([], Acc) -> Acc;
-get_notify_completed_message([JObj|JObjs], Acc) ->
-    case kz_json:get_value(<<"Status">>, JObj) of
-        <<"completed">> -> get_notify_completed_message([], JObj);
-        _ -> get_notify_completed_message(JObjs, Acc)
-    end.
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
Check for any completed in the notification response and if it wasn't successful don't do nothing.

This for the case when the user don't have any email address set or doesn't want to receive notification or the template is disabled in account but `delete_after_notify` or `save_after_notify` is set on voicemail box, so kazoo_voicemail would do that action regardless of the reality that it wasn't successful.

4.1: https://github.com/2600hz/kazoo/pull/4519