### PR TITLE
Implement withholding of caller id for offnet outbound calls via property on user, device and account doc.

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -25,6 +25,7 @@
 -export([endpoint_id_by_sip_username/2]).
 -export([owner_ids_by_sip_username/2]).
 -export([apply_dialplan/2]).
+-export([ccvs_by_privacy_mode/1]).
 
 -export([sip_users_from_device_ids/2]).
 
@@ -731,6 +732,30 @@ vm_count(JObj) ->
     AccountId = kz_doc:account_id(JObj),
     BoxId = kz_doc:id(JObj),
     kvm_messages:count_non_deleted(AccountId, BoxId).
+
+-spec ccvs_by_privacy_mode(kz_term:api_ne_binary()) -> kz_term:proplist().
+ccvs_by_privacy_mode('undefined') ->
+    ccvs_by_privacy_mode(<<"full">>);
+ccvs_by_privacy_mode(<<"full">>) ->
+    [{<<"Caller-Screen-Bit">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Number">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Name">>, 'true'}
+    ];
+ccvs_by_privacy_mode(<<"yes">>) ->
+    ccvs_by_privacy_mode(<<"full">>);
+ccvs_by_privacy_mode(<<"name">>) ->
+    [{<<"Caller-Screen-Bit">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Name">>, 'true'}
+    ];
+ccvs_by_privacy_mode(<<"number">>) ->
+    [{<<"Caller-Screen-Bit">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Number">>, 'true'}
+    ];
+%% returns empty list so that callflow settings override
+ccvs_by_privacy_mode(<<"none">>) -> [];
+ccvs_by_privacy_mode(_Else) ->
+    lager:debug("unsupported privacy mode ~s, forcing full privacy", [_Else]),
+    ccvs_by_privacy_mode(<<"full">>).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/callflow/src/module/cf_privacy.erl
+++ b/applications/callflow/src/module/cf_privacy.erl
@@ -43,23 +43,5 @@ update_call(CaptureGroup, {'ok', Call}, Mode) ->
     cf_exe:set_call(kapps_call:exec(Routines, Call)).
 
 -spec ccvs_by_privacy_mode(kz_term:api_ne_binary()) -> kz_term:proplist().
-ccvs_by_privacy_mode('undefined') ->
-    ccvs_by_privacy_mode(<<"full">>);
-ccvs_by_privacy_mode(<<"full">>) ->
-    [{<<"Caller-Screen-Bit">>, 'true'}
-    ,{<<"Caller-Privacy-Hide-Number">>, 'true'}
-    ,{<<"Caller-Privacy-Hide-Name">>, 'true'}
-    ];
-ccvs_by_privacy_mode(<<"yes">>) ->
-    ccvs_by_privacy_mode(<<"full">>);
-ccvs_by_privacy_mode(<<"name">>) ->
-    [{<<"Caller-Screen-Bit">>, 'true'}
-    ,{<<"Caller-Privacy-Hide-Name">>, 'true'}
-    ];
-ccvs_by_privacy_mode(<<"number">>) ->
-    [{<<"Caller-Screen-Bit">>, 'true'}
-    ,{<<"Caller-Privacy-Hide-Number">>, 'true'}
-    ];
-ccvs_by_privacy_mode(_Else) ->
-    lager:debug("unsupported privacy mode ~s, forcing full privacy", [_Else]),
-    ccvs_by_privacy_mode(<<"full">>).
+ccvs_by_privacy_mode(Mode) ->
+    cf_util:ccvs_by_privacy_mode(Mode).

--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -357,7 +357,7 @@ get_privacy_prefs(Call) ->
 get_privacy_prefs_from_endpoint(Call) ->
     lager:debug("Call is outbound, checking caller_id_outbound_privacy value"),
     {'ok', Endpoint} = kz_endpoint:get(Call),
-    case kz_json:get_value(<<"caller_id_outbound_privacy">>, Endpoint) of
+    case kz_json:get_value([<<"caller_id_options">>, <<"outbound_privacy">>], Endpoint) of
         'undefined' ->
             [];
         %% can't call kapps_call_command:privacy/2 with Mode = <<"none">>

--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -21,6 +21,9 @@
 %%% @end
 %%% @contributors
 %%%   Karl Anderson
+%%%
+%%%   Account, user, device level privacy - Sponsored by Raffel Internet B.V.
+%%%       implemented by Voyager Internet Ltd.
 %%%-------------------------------------------------------------------
 -module(cf_resources).
 -behaviour(gen_cf_action).
@@ -127,7 +130,7 @@ get_channel_vars(Call) ->
 -spec add_privacy_flags(kapps_call:call(), kz_term:proplist()) -> kz_term:proplist().
 add_privacy_flags(Call, Acc) ->
     CCVs = kapps_call:custom_channel_vars(Call),
-    kz_privacy:flags(CCVs) ++ Acc.
+    props:set_values(get_privacy_prefs(Call), kz_privacy:flags(CCVs)) ++ Acc.
 
 -spec maybe_require_ignore_early_media(kapps_call:call(), kz_term:proplist()) -> kz_term:proplist().
 maybe_require_ignore_early_media(Call, Acc) ->
@@ -341,3 +344,26 @@ handle_channel_destroy(<<"loopback", _/binary>>, _JObj) ->
     {<<"TRANSFER">>, 'ok'};
 handle_channel_destroy(_, JObj) ->
     {kz_call_event:hangup_cause(JObj), kz_call_event:hangup_code(JObj)}.
+
+-spec get_privacy_prefs(kapps_call:call()) -> kz_term:proplist().
+get_privacy_prefs(Call) ->
+    lager:debug("Checking inception of call"),
+    case kapps_call:inception(Call) of
+        'undefined' -> get_privacy_prefs_from_endpoint(Call);
+        _Else -> []
+    end.
+
+-spec get_privacy_prefs_from_endpoint(kapps_call:call()) -> kz_term:proplist().
+get_privacy_prefs_from_endpoint(Call) ->
+    lager:debug("Call is outbound, checking caller_id_outbound_privacy value"),
+    {'ok', Endpoint} = kz_endpoint:get(Call),
+    case kz_json:get_value(<<"caller_id_outbound_privacy">>, Endpoint) of
+        'undefined' ->
+            [];
+        %% can't call kapps_call_command:privacy/2 with Mode = <<"none">>
+        <<"none">>=NoneMode ->
+            cf_util:ccvs_by_privacy_mode(NoneMode);
+        Mode ->
+            kapps_call_command:privacy(Mode, Call),
+            cf_util:ccvs_by_privacy_mode(Mode)
+    end.

--- a/applications/crossbar/doc/accounts.md
+++ b/applications/crossbar/doc/accounts.md
@@ -24,6 +24,7 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The account default caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
 `dial_plan` | A list of default rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  
 `do_not_disturb.enabled` | The default value for do-not-disturb | `boolean()` |   | `false` |  
 `do_not_disturb` |   | `object()` |   | `false` |  

--- a/applications/crossbar/doc/accounts.md
+++ b/applications/crossbar/doc/accounts.md
@@ -24,7 +24,8 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The account default caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `dial_plan` | A list of default rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  
 `do_not_disturb.enabled` | The default value for do-not-disturb | `boolean()` |   | `false` |  
 `do_not_disturb` |   | `object()` |   | `false` |  

--- a/applications/crossbar/doc/devices.md
+++ b/applications/crossbar/doc/devices.md
@@ -26,6 +26,7 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` |  
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false` |  
 `device_type` | Arbitrary device type used by the UI and billing system | `string()` |   | `false` |  

--- a/applications/crossbar/doc/devices.md
+++ b/applications/crossbar/doc/devices.md
@@ -26,7 +26,8 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` |  
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false` |  
 `device_type` | Arbitrary device type used by the UI and billing system | `string()` |   | `false` |  

--- a/applications/crossbar/doc/ref/accounts.md
+++ b/applications/crossbar/doc/ref/accounts.md
@@ -16,6 +16,7 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The account default caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
 `dial_plan` | A list of default rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  
 `do_not_disturb.enabled` | The default value for do-not-disturb | `boolean()` |   | `false` |  
 `do_not_disturb` |   | `object()` |   | `false` |  

--- a/applications/crossbar/doc/ref/accounts.md
+++ b/applications/crossbar/doc/ref/accounts.md
@@ -16,7 +16,8 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The account default caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `dial_plan` | A list of default rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  
 `do_not_disturb.enabled` | The default value for do-not-disturb | `boolean()` |   | `false` |  
 `do_not_disturb` |   | `object()` |   | `false` |  

--- a/applications/crossbar/doc/ref/devices.md
+++ b/applications/crossbar/doc/ref/devices.md
@@ -23,6 +23,7 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` |  
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false` |  
 `device_type` | Arbitrary device type used by the UI and billing system | `string()` |   | `false` |  

--- a/applications/crossbar/doc/ref/devices.md
+++ b/applications/crossbar/doc/ref/devices.md
@@ -23,7 +23,8 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` |  
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false` |  
 `device_type` | Arbitrary device type used by the UI and billing system | `string()` |   | `false` |  

--- a/applications/crossbar/doc/ref/users.md
+++ b/applications/crossbar/doc/ref/users.md
@@ -23,7 +23,8 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` |  
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false` |  
 `dial_plan` | A list of rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  

--- a/applications/crossbar/doc/ref/users.md
+++ b/applications/crossbar/doc/ref/users.md
@@ -23,6 +23,7 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` |  
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false` |  
 `dial_plan` | A list of rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  

--- a/applications/crossbar/doc/users.md
+++ b/applications/crossbar/doc/users.md
@@ -25,6 +25,7 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` |  
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false` |  
 `dial_plan` | A list of rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  

--- a/applications/crossbar/doc/users.md
+++ b/applications/crossbar/doc/users.md
@@ -25,7 +25,8 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` |  
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false` |  
 `dial_plan` | A list of rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -402,6 +402,16 @@
                     "$ref": "#/definitions/caller_id",
                     "description": "The account default caller ID parameters"
                 },
+                "caller_id_outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "type": "string"
+                },
                 "dial_plan": {
                     "$ref": "#/definitions/dialplans",
                     "description": "A list of default rules used to modify dialed numbers"
@@ -4413,6 +4423,16 @@
                 "caller_id": {
                     "$ref": "#/definitions/caller_id",
                     "description": "The device caller ID parameters"
+                },
+                "caller_id_outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "type": "string"
                 },
                 "contact_list": {
                     "default": {},
@@ -32080,6 +32100,16 @@
                 "caller_id": {
                     "$ref": "#/definitions/caller_id",
                     "description": "The device caller ID parameters"
+                },
+                "caller_id_outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "type": "string"
                 },
                 "contact_list": {
                     "default": {},

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -402,15 +402,21 @@
                     "$ref": "#/definitions/caller_id",
                     "description": "The account default caller ID parameters"
                 },
-                "caller_id_outbound_privacy": {
-                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
-                    "enum": [
-                        "full",
-                        "name",
-                        "number",
-                        "none"
-                    ],
-                    "type": "string"
+                "caller_id_options": {
+                    "description": "custom properties for configuring caller_id",
+                    "properties": {
+                        "outbound_privacy": {
+                            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                            "enum": [
+                                "full",
+                                "name",
+                                "number",
+                                "none"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "dial_plan": {
                     "$ref": "#/definitions/dialplans",
@@ -4424,15 +4430,21 @@
                     "$ref": "#/definitions/caller_id",
                     "description": "The device caller ID parameters"
                 },
-                "caller_id_outbound_privacy": {
-                    "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
-                    "enum": [
-                        "full",
-                        "name",
-                        "number",
-                        "none"
-                    ],
-                    "type": "string"
+                "caller_id_options": {
+                    "description": "custom properties for configuring caller_id",
+                    "properties": {
+                        "outbound_privacy": {
+                            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                            "enum": [
+                                "full",
+                                "name",
+                                "number",
+                                "none"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "contact_list": {
                     "default": {},
@@ -32101,15 +32113,21 @@
                     "$ref": "#/definitions/caller_id",
                     "description": "The device caller ID parameters"
                 },
-                "caller_id_outbound_privacy": {
-                    "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
-                    "enum": [
-                        "full",
-                        "name",
-                        "number",
-                        "none"
-                    ],
-                    "type": "string"
+                "caller_id_options": {
+                    "description": "custom properties for configuring caller_id",
+                    "properties": {
+                        "outbound_privacy": {
+                            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                            "enum": [
+                                "full",
+                                "name",
+                                "number",
+                                "none"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "contact_list": {
                     "default": {},

--- a/applications/crossbar/priv/couchdb/schemas/accounts.json
+++ b/applications/crossbar/priv/couchdb/schemas/accounts.json
@@ -41,6 +41,16 @@
             "$ref": "caller_id",
             "description": "The account default caller ID parameters"
         },
+        "caller_id_outbound_privacy": {
+            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+            "enum": [
+                "full",
+                "name",
+                "number",
+                "none"
+            ],
+            "type": "string"
+        },
         "dial_plan": {
             "$ref": "dialplans",
             "description": "A list of default rules used to modify dialed numbers"

--- a/applications/crossbar/priv/couchdb/schemas/accounts.json
+++ b/applications/crossbar/priv/couchdb/schemas/accounts.json
@@ -41,15 +41,21 @@
             "$ref": "caller_id",
             "description": "The account default caller ID parameters"
         },
-        "caller_id_outbound_privacy": {
-            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
-            "enum": [
-                "full",
-                "name",
-                "number",
-                "none"
-            ],
-            "type": "string"
+        "caller_id_options": {
+            "description": "custom properties for configuring caller_id",
+            "properties": {
+                "outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
         },
         "dial_plan": {
             "$ref": "dialplans",

--- a/applications/crossbar/priv/couchdb/schemas/devices.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.json
@@ -77,6 +77,16 @@
             "$ref": "caller_id",
             "description": "The device caller ID parameters"
         },
+        "caller_id_outbound_privacy": {
+            "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
+            "enum": [
+                "full",
+                "name",
+                "number",
+                "none"
+            ],
+            "type": "string"
+        },
         "contact_list": {
             "default": {},
             "description": "Contect List Parameters",

--- a/applications/crossbar/priv/couchdb/schemas/devices.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.json
@@ -77,15 +77,21 @@
             "$ref": "caller_id",
             "description": "The device caller ID parameters"
         },
-        "caller_id_outbound_privacy": {
-            "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
-            "enum": [
-                "full",
-                "name",
-                "number",
-                "none"
-            ],
-            "type": "string"
+        "caller_id_options": {
+            "description": "custom properties for configuring caller_id",
+            "properties": {
+                "outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
         },
         "contact_list": {
             "default": {},

--- a/applications/crossbar/priv/couchdb/schemas/users.json
+++ b/applications/crossbar/priv/couchdb/schemas/users.json
@@ -77,6 +77,16 @@
             "$ref": "caller_id",
             "description": "The device caller ID parameters"
         },
+        "caller_id_outbound_privacy": {
+            "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
+            "enum": [
+                "full",
+                "name",
+                "number",
+                "none"
+            ],
+            "type": "string"
+        },
         "contact_list": {
             "default": {},
             "description": "Contect List Parameters",

--- a/applications/crossbar/priv/couchdb/schemas/users.json
+++ b/applications/crossbar/priv/couchdb/schemas/users.json
@@ -77,15 +77,21 @@
             "$ref": "caller_id",
             "description": "The device caller ID parameters"
         },
-        "caller_id_outbound_privacy": {
-            "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
-            "enum": [
-                "full",
-                "name",
-                "number",
-                "none"
-            ],
-            "type": "string"
+        "caller_id_options": {
+            "description": "custom properties for configuring caller_id",
+            "properties": {
+                "outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
         },
         "contact_list": {
             "default": {},

--- a/core/kazoo_documents/src/kzd_accounts.erl.src
+++ b/core/kazoo_documents/src/kzd_accounts.erl.src
@@ -7,6 +7,7 @@
 -export([call_restriction/1, call_restriction/2, set_call_restriction/2]).
 -export([call_waiting/1, call_waiting/2, set_call_waiting/2]).
 -export([caller_id/1, caller_id/2, set_caller_id/2]).
+-export([caller_id_outbound_privacy/1, caller_id_outbound_privacy/2, set_caller_id_outbound_privacy/2]).
 -export([dial_plan/1, dial_plan/2, set_dial_plan/2]).
 -export([do_not_disturb/1, do_not_disturb/2, set_do_not_disturb/2]).
 -export([do_not_disturb_enabled/1, do_not_disturb_enabled/2, set_do_not_disturb_enabled/2]).
@@ -125,6 +126,18 @@ caller_id(Doc, Default) ->
 -spec set_caller_id(doc(), kz_json:object()) -> doc().
 set_caller_id(Doc, CallerId) ->
     kz_json:set_value([<<"caller_id">>], CallerId, Doc).
+
+-spec caller_id_outbound_privacy(doc()) -> kz_term:api_binary().
+caller_id_outbound_privacy(Doc) ->
+    caller_id_outbound_privacy(Doc, 'undefined').
+
+-spec caller_id_outbound_privacy(doc(), Default) -> binary() | Default.
+caller_id_outbound_privacy(Doc, Default) ->
+    kz_json:get_binary_value([<<"caller_id_outbound_privacy">>], Doc, Default).
+
+-spec set_caller_id_outbound_privacy(doc(), binary()) -> doc().
+set_caller_id_outbound_privacy(Doc, CallerIdOutboundPrivacy) ->
+    kz_json:set_value([<<"caller_id_outbound_privacy">>], CallerIdOutboundPrivacy, Doc).
 
 -spec dial_plan(doc()) -> kz_term:api_object().
 dial_plan(Doc) ->

--- a/core/kazoo_documents/src/kzd_accounts.erl.src
+++ b/core/kazoo_documents/src/kzd_accounts.erl.src
@@ -7,7 +7,8 @@
 -export([call_restriction/1, call_restriction/2, set_call_restriction/2]).
 -export([call_waiting/1, call_waiting/2, set_call_waiting/2]).
 -export([caller_id/1, caller_id/2, set_caller_id/2]).
--export([caller_id_outbound_privacy/1, caller_id_outbound_privacy/2, set_caller_id_outbound_privacy/2]).
+-export([caller_id_options/1, caller_id_options/2, set_caller_id_options/2]).
+-export([caller_id_options_outbound_privacy/1, caller_id_options_outbound_privacy/2, set_caller_id_options_outbound_privacy/2]).
 -export([dial_plan/1, dial_plan/2, set_dial_plan/2]).
 -export([do_not_disturb/1, do_not_disturb/2, set_do_not_disturb/2]).
 -export([do_not_disturb_enabled/1, do_not_disturb_enabled/2, set_do_not_disturb_enabled/2]).
@@ -127,17 +128,29 @@ caller_id(Doc, Default) ->
 set_caller_id(Doc, CallerId) ->
     kz_json:set_value([<<"caller_id">>], CallerId, Doc).
 
--spec caller_id_outbound_privacy(doc()) -> kz_term:api_binary().
-caller_id_outbound_privacy(Doc) ->
-    caller_id_outbound_privacy(Doc, 'undefined').
+-spec caller_id_options(doc()) -> kz_term:api_object().
+caller_id_options(Doc) ->
+    caller_id_options(Doc, 'undefined').
 
--spec caller_id_outbound_privacy(doc(), Default) -> binary() | Default.
-caller_id_outbound_privacy(Doc, Default) ->
-    kz_json:get_binary_value([<<"caller_id_outbound_privacy">>], Doc, Default).
+-spec caller_id_options(doc(), Default) -> kz_json:object() | Default.
+caller_id_options(Doc, Default) ->
+    kz_json:get_json_value([<<"caller_id_options">>], Doc, Default).
 
--spec set_caller_id_outbound_privacy(doc(), binary()) -> doc().
-set_caller_id_outbound_privacy(Doc, CallerIdOutboundPrivacy) ->
-    kz_json:set_value([<<"caller_id_outbound_privacy">>], CallerIdOutboundPrivacy, Doc).
+-spec set_caller_id_options(doc(), kz_json:object()) -> doc().
+set_caller_id_options(Doc, CallerIdOptions) ->
+    kz_json:set_value([<<"caller_id_options">>], CallerIdOptions, Doc).
+
+-spec caller_id_options_outbound_privacy(doc()) -> kz_term:api_binary().
+caller_id_options_outbound_privacy(Doc) ->
+    caller_id_options_outbound_privacy(Doc, 'undefined').
+
+-spec caller_id_options_outbound_privacy(doc(), Default) -> binary() | Default.
+caller_id_options_outbound_privacy(Doc, Default) ->
+    kz_json:get_binary_value([<<"caller_id_options">>, <<"outbound_privacy">>], Doc, Default).
+
+-spec set_caller_id_options_outbound_privacy(doc(), binary()) -> doc().
+set_caller_id_options_outbound_privacy(Doc, CallerIdOptionsOutboundPrivacy) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"outbound_privacy">>], CallerIdOptionsOutboundPrivacy, Doc).
 
 -spec dial_plan(doc()) -> kz_term:api_object().
 dial_plan(Doc) ->

--- a/core/kazoo_documents/src/kzd_devices.erl.src
+++ b/core/kazoo_documents/src/kzd_devices.erl.src
@@ -14,7 +14,8 @@
 -export([call_restriction/1, call_restriction/2, set_call_restriction/2]).
 -export([call_waiting/1, call_waiting/2, set_call_waiting/2]).
 -export([caller_id/1, caller_id/2, set_caller_id/2]).
--export([caller_id_outbound_privacy/1, caller_id_outbound_privacy/2, set_caller_id_outbound_privacy/2]).
+-export([caller_id_options/1, caller_id_options/2, set_caller_id_options/2]).
+-export([caller_id_options_outbound_privacy/1, caller_id_options_outbound_privacy/2, set_caller_id_options_outbound_privacy/2]).
 -export([contact_list/1, contact_list/2, set_contact_list/2]).
 -export([contact_list_exclude/1, contact_list_exclude/2, set_contact_list_exclude/2]).
 -export([device_type/1, device_type/2, set_device_type/2]).
@@ -231,17 +232,29 @@ caller_id(Doc, Default) ->
 set_caller_id(Doc, CallerId) ->
     kz_json:set_value([<<"caller_id">>], CallerId, Doc).
 
--spec caller_id_outbound_privacy(doc()) -> kz_term:api_binary().
-caller_id_outbound_privacy(Doc) ->
-    caller_id_outbound_privacy(Doc, 'undefined').
+-spec caller_id_options(doc()) -> kz_term:api_object().
+caller_id_options(Doc) ->
+    caller_id_options(Doc, 'undefined').
 
--spec caller_id_outbound_privacy(doc(), Default) -> binary() | Default.
-caller_id_outbound_privacy(Doc, Default) ->
-    kz_json:get_binary_value([<<"caller_id_outbound_privacy">>], Doc, Default).
+-spec caller_id_options(doc(), Default) -> kz_json:object() | Default.
+caller_id_options(Doc, Default) ->
+    kz_json:get_json_value([<<"caller_id_options">>], Doc, Default).
 
--spec set_caller_id_outbound_privacy(doc(), binary()) -> doc().
-set_caller_id_outbound_privacy(Doc, CallerIdOutboundPrivacy) ->
-    kz_json:set_value([<<"caller_id_outbound_privacy">>], CallerIdOutboundPrivacy, Doc).
+-spec set_caller_id_options(doc(), kz_json:object()) -> doc().
+set_caller_id_options(Doc, CallerIdOptions) ->
+    kz_json:set_value([<<"caller_id_options">>], CallerIdOptions, Doc).
+
+-spec caller_id_options_outbound_privacy(doc()) -> kz_term:api_binary().
+caller_id_options_outbound_privacy(Doc) ->
+    caller_id_options_outbound_privacy(Doc, 'undefined').
+
+-spec caller_id_options_outbound_privacy(doc(), Default) -> binary() | Default.
+caller_id_options_outbound_privacy(Doc, Default) ->
+    kz_json:get_binary_value([<<"caller_id_options">>, <<"outbound_privacy">>], Doc, Default).
+
+-spec set_caller_id_options_outbound_privacy(doc(), binary()) -> doc().
+set_caller_id_options_outbound_privacy(Doc, CallerIdOptionsOutboundPrivacy) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"outbound_privacy">>], CallerIdOptionsOutboundPrivacy, Doc).
 
 -spec contact_list(doc()) -> kz_json:object().
 contact_list(Doc) ->

--- a/core/kazoo_documents/src/kzd_devices.erl.src
+++ b/core/kazoo_documents/src/kzd_devices.erl.src
@@ -14,6 +14,7 @@
 -export([call_restriction/1, call_restriction/2, set_call_restriction/2]).
 -export([call_waiting/1, call_waiting/2, set_call_waiting/2]).
 -export([caller_id/1, caller_id/2, set_caller_id/2]).
+-export([caller_id_outbound_privacy/1, caller_id_outbound_privacy/2, set_caller_id_outbound_privacy/2]).
 -export([contact_list/1, contact_list/2, set_contact_list/2]).
 -export([contact_list_exclude/1, contact_list_exclude/2, set_contact_list_exclude/2]).
 -export([device_type/1, device_type/2, set_device_type/2]).
@@ -229,6 +230,18 @@ caller_id(Doc, Default) ->
 -spec set_caller_id(doc(), kz_json:object()) -> doc().
 set_caller_id(Doc, CallerId) ->
     kz_json:set_value([<<"caller_id">>], CallerId, Doc).
+
+-spec caller_id_outbound_privacy(doc()) -> kz_term:api_binary().
+caller_id_outbound_privacy(Doc) ->
+    caller_id_outbound_privacy(Doc, 'undefined').
+
+-spec caller_id_outbound_privacy(doc(), Default) -> binary() | Default.
+caller_id_outbound_privacy(Doc, Default) ->
+    kz_json:get_binary_value([<<"caller_id_outbound_privacy">>], Doc, Default).
+
+-spec set_caller_id_outbound_privacy(doc(), binary()) -> doc().
+set_caller_id_outbound_privacy(Doc, CallerIdOutboundPrivacy) ->
+    kz_json:set_value([<<"caller_id_outbound_privacy">>], CallerIdOutboundPrivacy, Doc).
 
 -spec contact_list(doc()) -> kz_json:object().
 contact_list(Doc) ->

--- a/core/kazoo_documents/src/kzd_users.erl.src
+++ b/core/kazoo_documents/src/kzd_users.erl.src
@@ -14,6 +14,7 @@
 -export([call_restriction/1, call_restriction/2, set_call_restriction/2]).
 -export([call_waiting/1, call_waiting/2, set_call_waiting/2]).
 -export([caller_id/1, caller_id/2, set_caller_id/2]).
+-export([caller_id_outbound_privacy/1, caller_id_outbound_privacy/2, set_caller_id_outbound_privacy/2]).
 -export([contact_list/1, contact_list/2, set_contact_list/2]).
 -export([contact_list_exclude/1, contact_list_exclude/2, set_contact_list_exclude/2]).
 -export([dial_plan/1, dial_plan/2, set_dial_plan/2]).
@@ -222,6 +223,18 @@ caller_id(Doc, Default) ->
 -spec set_caller_id(doc(), kz_json:object()) -> doc().
 set_caller_id(Doc, CallerId) ->
     kz_json:set_value([<<"caller_id">>], CallerId, Doc).
+
+-spec caller_id_outbound_privacy(doc()) -> kz_term:api_binary().
+caller_id_outbound_privacy(Doc) ->
+    caller_id_outbound_privacy(Doc, 'undefined').
+
+-spec caller_id_outbound_privacy(doc(), Default) -> binary() | Default.
+caller_id_outbound_privacy(Doc, Default) ->
+    kz_json:get_binary_value([<<"caller_id_outbound_privacy">>], Doc, Default).
+
+-spec set_caller_id_outbound_privacy(doc(), binary()) -> doc().
+set_caller_id_outbound_privacy(Doc, CallerIdOutboundPrivacy) ->
+    kz_json:set_value([<<"caller_id_outbound_privacy">>], CallerIdOutboundPrivacy, Doc).
 
 -spec contact_list(doc()) -> kz_json:object().
 contact_list(Doc) ->

--- a/core/kazoo_documents/src/kzd_users.erl.src
+++ b/core/kazoo_documents/src/kzd_users.erl.src
@@ -14,7 +14,8 @@
 -export([call_restriction/1, call_restriction/2, set_call_restriction/2]).
 -export([call_waiting/1, call_waiting/2, set_call_waiting/2]).
 -export([caller_id/1, caller_id/2, set_caller_id/2]).
--export([caller_id_outbound_privacy/1, caller_id_outbound_privacy/2, set_caller_id_outbound_privacy/2]).
+-export([caller_id_options/1, caller_id_options/2, set_caller_id_options/2]).
+-export([caller_id_options_outbound_privacy/1, caller_id_options_outbound_privacy/2, set_caller_id_options_outbound_privacy/2]).
 -export([contact_list/1, contact_list/2, set_contact_list/2]).
 -export([contact_list_exclude/1, contact_list_exclude/2, set_contact_list_exclude/2]).
 -export([dial_plan/1, dial_plan/2, set_dial_plan/2]).
@@ -224,17 +225,29 @@ caller_id(Doc, Default) ->
 set_caller_id(Doc, CallerId) ->
     kz_json:set_value([<<"caller_id">>], CallerId, Doc).
 
--spec caller_id_outbound_privacy(doc()) -> kz_term:api_binary().
-caller_id_outbound_privacy(Doc) ->
-    caller_id_outbound_privacy(Doc, 'undefined').
+-spec caller_id_options(doc()) -> kz_term:api_object().
+caller_id_options(Doc) ->
+    caller_id_options(Doc, 'undefined').
 
--spec caller_id_outbound_privacy(doc(), Default) -> binary() | Default.
-caller_id_outbound_privacy(Doc, Default) ->
-    kz_json:get_binary_value([<<"caller_id_outbound_privacy">>], Doc, Default).
+-spec caller_id_options(doc(), Default) -> kz_json:object() | Default.
+caller_id_options(Doc, Default) ->
+    kz_json:get_json_value([<<"caller_id_options">>], Doc, Default).
 
--spec set_caller_id_outbound_privacy(doc(), binary()) -> doc().
-set_caller_id_outbound_privacy(Doc, CallerIdOutboundPrivacy) ->
-    kz_json:set_value([<<"caller_id_outbound_privacy">>], CallerIdOutboundPrivacy, Doc).
+-spec set_caller_id_options(doc(), kz_json:object()) -> doc().
+set_caller_id_options(Doc, CallerIdOptions) ->
+    kz_json:set_value([<<"caller_id_options">>], CallerIdOptions, Doc).
+
+-spec caller_id_options_outbound_privacy(doc()) -> kz_term:api_binary().
+caller_id_options_outbound_privacy(Doc) ->
+    caller_id_options_outbound_privacy(Doc, 'undefined').
+
+-spec caller_id_options_outbound_privacy(doc(), Default) -> binary() | Default.
+caller_id_options_outbound_privacy(Doc, Default) ->
+    kz_json:get_binary_value([<<"caller_id_options">>, <<"outbound_privacy">>], Doc, Default).
+
+-spec set_caller_id_options_outbound_privacy(doc(), binary()) -> doc().
+set_caller_id_options_outbound_privacy(Doc, CallerIdOptionsOutboundPrivacy) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"outbound_privacy">>], CallerIdOptionsOutboundPrivacy, Doc).
 
 -spec contact_list(doc()) -> kz_json:object().
 contact_list(Doc) ->

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -236,7 +236,6 @@ attributes_keys() ->
     ,<<"ringtones">>
     ,<<"caller_id">>
     ,<<"caller_id_options">>
-    ,<<"caller_id_outbound_privacy">>
     ,<<"do_not_disturb">>
     ,<<"call_forward">>
     ,<<"dial_plan">>
@@ -332,8 +331,6 @@ merge_attribute(<<"caller_id">> = Key, Account, Endpoint, Owner) ->
             CallerId = kz_json:set_value(L, Number, Merged),
             kz_json:set_value(Key, CallerId, Endpoint)
     end;
-merge_attribute(<<"caller_id_outbound_privacy">> = Key, Account, Endpoint, Owner) ->
-    merge_value(Key, Account, Endpoint, Owner);
 merge_attribute(<<"do_not_disturb">> = Key, Account, Endpoint, Owner) ->
     L = [Key, <<"enabled">>],
     AccountAttr = kz_json:is_true(L, Account, 'false'),

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -236,6 +236,7 @@ attributes_keys() ->
     ,<<"ringtones">>
     ,<<"caller_id">>
     ,<<"caller_id_options">>
+    ,<<"caller_id_outbound_privacy">>
     ,<<"do_not_disturb">>
     ,<<"call_forward">>
     ,<<"dial_plan">>
@@ -331,6 +332,8 @@ merge_attribute(<<"caller_id">> = Key, Account, Endpoint, Owner) ->
             CallerId = kz_json:set_value(L, Number, Merged),
             kz_json:set_value(Key, CallerId, Endpoint)
     end;
+merge_attribute(<<"caller_id_outbound_privacy">> = Key, Account, Endpoint, Owner) ->
+    merge_value(Key, Account, Endpoint, Owner);
 merge_attribute(<<"do_not_disturb">> = Key, Account, Endpoint, Owner) ->
     L = [Key, <<"enabled">>],
     AccountAttr = kz_json:is_true(L, Account, 'false'),


### PR DESCRIPTION
Caller id privacy settings can be controlled through the User, Device and Account docs. Configuration works similarly to how it does in cf_privacy; common code has been refactored into cf_util.