### PR TITLE
KAZOO-5808: add loop count param to tts/play

### DIFF
--- a/applications/Makefile
+++ b/applications/Makefile
@@ -25,4 +25,4 @@ test: ACTION = test
 test: $(MAKEDIRS)
 
 $(MAKEDIRS):
-	@$(MAKE) -C $(@D) $(ACTION)
+	@$(MAKE) -j1 -C $(@D) $(ACTION)

--- a/applications/callflow/doc/audio_macro.md
+++ b/applications/callflow/doc/audio_macro.md
@@ -75,6 +75,7 @@ Key | Description | Type | Default | Required | Support Level
 `answer` | Whether to answer an unanswered call | `boolean()` |   | `false` |  
 `endless_playback` | Loop the media continuously | `boolean()` | `false` | `false` |  
 `id` | Media ID or URL of the media to play | `string()` |   | `false` |  
+`loop_count` | How many times to loop the media | `integer()` |   | `false` |  
 `terminators.[]` |   | `string()` |   | `false` |  
 `terminators` | What DTMF can terminate playback of the audio | `array(string())` | `["1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "0", "#"]` | `false` |  
 

--- a/applications/callflow/doc/play.md
+++ b/applications/callflow/doc/play.md
@@ -15,8 +15,21 @@ Key | Description | Type | Default | Required | Support Level
 `answer` | Whether to answer an unanswered call | `boolean()` |   | `false` |  
 `endless_playback` | Loop the media continuously | `boolean()` | `false` | `false` |  
 `id` | Media ID or URL of the media to play | `string()` |   | `false` |  
+`loop_count` | How many times to loop the media | `integer()` |   | `false` |  
 `terminators.[]` |   | `string()` |   | `false` |  
 `terminators` | What DTMF can terminate playback of the audio | `array(string())` | `["1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "0", "#"]` | `false` |  
 
 
 
+
+
+
+#### Loop Count
+
+If you want to play the media a number of times, include `loop_count` to do so.
+
+#### Endless Playback
+
+Endless playback is exactly that - playback of the media will not stop on the channel until the channel is hung up. The media is not interruptible.
+
+`endless_playback=true` takes precedence over `loop_count>0` if both are included.

--- a/applications/callflow/doc/ref/audio_macro.md
+++ b/applications/callflow/doc/ref/audio_macro.md
@@ -66,6 +66,7 @@ Key | Description | Type | Default | Required | Support Level
 `answer` | Whether to answer an unanswered call | `boolean()` |   | `false` |  
 `endless_playback` | Loop the media continuously | `boolean()` | `false` | `false` |  
 `id` | Media ID or URL of the media to play | `string()` |   | `false` |  
+`loop_count` | How many times to loop the media | `integer()` |   | `false` |  
 `terminators.[]` |   | `string()` |   | `false` |  
 `terminators` | What DTMF can terminate playback of the audio | `array(string())` | `["1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "0", "#"]` | `false` |  
 

--- a/applications/callflow/doc/ref/play.md
+++ b/applications/callflow/doc/ref/play.md
@@ -13,6 +13,7 @@ Key | Description | Type | Default | Required | Support Level
 `answer` | Whether to answer an unanswered call | `boolean()` |   | `false` |  
 `endless_playback` | Loop the media continuously | `boolean()` | `false` | `false` |  
 `id` | Media ID or URL of the media to play | `string()` |   | `false` |  
+`loop_count` | How many times to loop the media | `integer()` |   | `false` |  
 `terminators.[]` |   | `string()` |   | `false` |  
 `terminators` | What DTMF can terminate playback of the audio | `array(string())` | `["1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "0", "#"]` | `false` |  
 

--- a/applications/callflow/src/module/cf_play.erl
+++ b/applications/callflow/src/module/cf_play.erl
@@ -55,9 +55,26 @@ play(Data, Call, Media) ->
     end,
     lager:info("playing media ~s", [Media]),
 
-    kapps_call_command:play(Media
-                           ,kz_json:get_list_value(<<"terminators">>, Data)
-                           ,'undefined'
-                           ,kz_json:is_true(<<"endless_playback">>, Data, 'false')
-                           ,Call
-                           ).
+    NoopId = kapps_call_command:noop_id(),
+    Commands = [kz_json:from_list([{<<"Application-Name">>, <<"noop">>}
+                                  ,{<<"Call-ID">>, kapps_call:call_id(Call)}
+                                  ,{<<"Msg-ID">>, NoopId}
+                                  ])
+               ,play_command(Data, kapps_call:call_id_direct(Call), Media)
+               ],
+    Command = [{<<"Application-Name">>, <<"queue">>}
+              ,{<<"Commands">>, Commands}
+              ],
+    kapps_call_command:send_command(Command, Call),
+    cf_util:wait_for_noop(Call, NoopId).
+
+-spec play_command(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_json:object().
+play_command(Data, CallId, Media) ->
+    kz_json:from_list(
+      [{<<"Application-Name">>, <<"play">>}
+      ,{<<"Media-Name">>, Media}
+      ,{<<"Terminators">>, kapps_call_command:play_terminators(kz_json:get_list_value(<<"terminators">>, Data))}
+      ,{<<"Call-ID">>, CallId}
+      ,{<<"Endless-Playback">>, kz_json:is_true(<<"endless_playback">>, Data)}
+      ,{<<"Loop-Count">>, kz_json:get_integer_value(<<"loop_count">>, Data)}
+      ]).

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -2760,6 +2760,11 @@
                     "description": "Media ID or URL of the media to play",
                     "type": "string"
                 },
+                "loop_count": {
+                    "description": "How many times to loop the media",
+                    "minimum": 1,
+                    "type": "integer"
+                },
                 "terminators": {
                     "default": [
                         "1",
@@ -9895,6 +9900,10 @@
                 "Leg": {
                     "type": "string"
                 },
+                "Loop-Count": {
+                    "minimum": 1,
+                    "type": "integer"
+                },
                 "Terminators": {
                     "items": {
                         "enum": [
@@ -11857,6 +11866,10 @@
                     ],
                     "type": "string"
                 },
+                "Loop-Count": {
+                    "minimum": 1,
+                    "type": "integer"
+                },
                 "Media-Name": {
                     "type": "string"
                 },
@@ -13577,6 +13590,10 @@
                 },
                 "Leg": {
                     "type": "string"
+                },
+                "Loop-Count": {
+                    "minimum": 1,
+                    "type": "integer"
                 },
                 "Terminators": {
                     "items": {

--- a/applications/crossbar/priv/couchdb/schemas/callflows.play.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.play.json
@@ -16,6 +16,11 @@
             "description": "Media ID or URL of the media to play",
             "type": "string"
         },
+        "loop_count": {
+            "description": "How many times to loop the media",
+            "minimum": 1,
+            "type": "integer"
+        },
         "terminators": {
             "default": [
                 "1",

--- a/applications/crossbar/priv/couchdb/schemas/kapi.conference.say.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.conference.say.json
@@ -52,6 +52,10 @@
         "Leg": {
             "type": "string"
         },
+        "Loop-Count": {
+            "minimum": 1,
+            "type": "integer"
+        },
         "Terminators": {
             "items": {
                 "enum": [

--- a/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.play.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.play.json
@@ -53,6 +53,10 @@
             ],
             "type": "string"
         },
+        "Loop-Count": {
+            "minimum": 1,
+            "type": "integer"
+        },
         "Media-Name": {
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.tts.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.dialplan.tts.json
@@ -51,6 +51,10 @@
         "Leg": {
             "type": "string"
         },
+        "Loop-Count": {
+            "minimum": 1,
+            "type": "integer"
+        },
         "Terminators": {
             "items": {
                 "enum": [

--- a/applications/ecallmgr/src/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_command.erl
@@ -1425,9 +1425,13 @@ play_app(UUID, JObj) ->
 
 -spec playback_app(kz_json:object()) -> kz_term:ne_binary().
 playback_app(JObj) ->
-    case kz_json:is_true(<<"Endless-Playback">>, JObj, 'false') of
+    case kz_json:is_true(<<"Endless-Playback">>, JObj, 'false')
+        orelse kz_json:get_integer_value(<<"Loop-Count">>, JObj)
+    of
         'true' -> <<"endless_playback">>;
-        'false' -> <<"playback">>
+        Count when is_integer(Count), Count > 0 ->
+            <<"loop_playback +", (kz_term:to_binary(Count))/binary>>;
+        _ -> <<"playback">>
     end.
 
 -spec play_bridged(kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary()) -> fs_app().

--- a/core/Makefile
+++ b/core/Makefile
@@ -25,9 +25,9 @@ test: ACTION = test
 test: $(MAKEDIRS)
 
 first:
-	@$(MAKE) -C kazoo_stdlib/ $(ACTION)
-	@$(MAKE) -C kazoo_amqp/ $(ACTION)
-	@$(MAKE) -C kazoo_data/ $(ACTION)
+	@$(MAKE) -j1 -C kazoo_stdlib/ $(ACTION)
+	@$(MAKE) -j1 -C kazoo_amqp/ $(ACTION)
+	@$(MAKE) -j1 -C kazoo_data/ $(ACTION)
 
 $(MAKEDIRS): first
-	@$(MAKE) -C $(@D) $(ACTION)
+	@$(MAKE) -j1 -C $(@D) $(ACTION)

--- a/core/kazoo_amqp/src/api/kapi_dialplan.hrl
+++ b/core/kazoo_amqp/src/api/kapi_dialplan.hrl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @yright (C) 2011-2015 2600Hz INC
+%%% @yright (C) 2011-2018 2600Hz INC
 %%% @doc
 %%% Dialplan API definitions
 %%% @end
@@ -541,6 +541,7 @@
                           ,<<"Media-Name">>
                           ]).
 -define(OPTIONAL_PLAY_REQ_HEADERS, [<<"Endless-Playback">>
+                                   ,<<"Loop-Count">>
                                    ,<<"Format">>
                                    ,<<"Group-ID">> % group media together (one DTMF cancels all in group)
                                    ,<<"Insert-At">>
@@ -557,6 +558,7 @@
                          ]).
 -define(PLAY_REQ_TYPES, [{<<"Terminators">>, ?IS_TERMINATOR}
                         ,{<<"Endless-Playback">>, fun kz_term:is_boolean/1}
+                        ,{<<"Loop-Count">>, fun kz_term:is_pos_integer/1}
                         ]).
 
 %% Break Request
@@ -667,6 +669,7 @@
 -define(TTS_REQ_HEADERS, [<<"Application-Name">>, <<"Call-ID">>, <<"Text">>]).
 -define(OPTIONAL_TTS_REQ_HEADERS, [<<"Conference-ID">>
                                   ,<<"Endless-Playback">>
+                                  ,<<"Loop-Count">>
                                   ,<<"Engine">>
                                   ,<<"Group-ID">> % group media together (one DTMF cancels all in group)
                                   ,<<"Insert-At">>
@@ -683,6 +686,7 @@
                         ]).
 -define(TTS_REQ_TYPES, [{<<"Terminators">>, ?IS_TERMINATOR}
                        ,{<<"Endless-Playback">>, fun kz_term:is_boolean/1}
+                       ,{<<"Loop-Count">>, fun kz_term:is_pos_integer/1}
                        ]).
 
 %% Respond

--- a/core/kazoo_ast/src/kapi_schemas.erl
+++ b/core/kazoo_ast/src/kapi_schemas.erl
@@ -392,6 +392,10 @@ validator_properties([<<_/binary>>|_]=Values) ->
     kz_json:from_list([{<<"type">>, <<"string">>}
                       ,{<<"enum">>, Values}
                       ]);
+validator_properties({_, 'is_pos_integer', 1}) ->
+    kz_json:from_list([{<<"type">>, <<"integer">>}
+                      ,{<<"minimum">>, 1}
+                      ]);
 validator_properties({_, 'is_integer', 1}) ->
     kz_json:from_list([{<<"type">>, <<"integer">>}]);
 validator_properties({_, 'is_binary', 1}) ->

--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -72,6 +72,8 @@
 -export([play/2, play/3, play/4, play/5
         ,play_command/2, play_command/3, play_command/4, play_command/5
         ,b_play/2, b_play/3, b_play/4, b_play/5
+        ,play_terminators/1
+        ,play_leg/1
         ]).
 -export([prompt/2, prompt/3]).
 
@@ -115,7 +117,7 @@
         ,b_conference/6, b_conference/7
         ]).
 
--export([noop/1]).
+-export([noop/1, noop_id/0]).
 -export([flush/1, flush_dtmf/1
         ,send_dtmf/2, send_dtmf/3
         ,recv_dtmf/2
@@ -462,7 +464,7 @@ audio_macro(Prompts, Call) -> audio_macro(Prompts, Call, []).
 -spec audio_macro(audio_macro_prompts(), kapps_call:call(), kz_json:objects()) ->
                          binary().
 audio_macro([], Call, Queue) ->
-    NoopId = kz_datamgr:get_uuid(),
+    NoopId = noop_id(),
     Prompts = [kz_json:from_list(
                  [{<<"Application-Name">>, <<"noop">>}
                  ,{<<"Msg-ID">>, NoopId}
@@ -1492,7 +1494,7 @@ play(Media, Terminators, Leg, Call) ->
 -spec play(kz_term:ne_binary(), kz_term:api_binaries(), kz_term:api_binary(), kz_term:api_boolean(), kapps_call:call()) ->
                   kz_term:ne_binary().
 play(Media, Terminators, Leg, Endless, Call) ->
-    NoopId = kz_datamgr:get_uuid(),
+    NoopId = noop_id(),
     Commands = [kz_json:from_list([{<<"Application-Name">>, <<"noop">>}
                                   ,{<<"Call-ID">>, kapps_call:call_id(Call)}
                                   ,{<<"Msg-ID">>, NoopId}
@@ -1549,7 +1551,7 @@ tts(SayMe, Voice, Lang, Terminators, Call) ->
 
 -spec tts(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binaries(), kz_term:api_binary(), kapps_call:call()) -> kz_term:ne_binary().
 tts(SayMe, Voice, Lang, Terminators, Engine, Call) ->
-    NoopId = kz_datamgr:get_uuid(),
+    NoopId = noop_id(),
 
     Commands = [kz_json:from_list([{<<"Application-Name">>, <<"noop">>}
                                   ,{<<"Call-ID">>, kapps_call:call_id(Call)}
@@ -2308,10 +2310,12 @@ b_conference(ConfId, Mute, Deaf, Moderator, Profile, Reinvite, Call) ->
 %% Produces the low level kz_api request to preform a noop
 %% @end
 %%--------------------------------------------------------------------
+-spec noop_id() -> kz_term:ne_binary().
+noop_id() -> kz_datamgr:get_uuid().
 
 -spec noop(kapps_call:call()) -> kz_term:ne_binary().
 noop(Call) ->
-    NoopId = kz_datamgr:get_uuid(),
+    NoopId = noop_id(),
     Command = [{<<"Application-Name">>, <<"noop">>}
               ,{<<"Msg-ID">>, NoopId}
               ],
@@ -2331,7 +2335,7 @@ b_noop(Call) -> wait_for_noop(Call, noop(Call)).
 
 -spec flush(kapps_call:call()) -> binary().
 flush(Call) ->
-    NoopId = kz_datamgr:get_uuid(),
+    NoopId = noop_id(),
     Command = [{<<"Application-Name">>, <<"noop">>}
               ,{<<"Msg-ID">>, NoopId}
               ,{<<"Insert-At">>, <<"flush">>}
@@ -3436,7 +3440,7 @@ b_play_macro(Media, Call) ->
 
 -spec play_macro(kz_term:ne_binaries(), kapps_call:call()) -> kz_term:ne_binary().
 play_macro(Media, Call) ->
-    NoopId = kz_datamgr:get_uuid(),
+    NoopId = noop_id(),
     Commands = [kz_json:from_list([{<<"Application-Name">>, <<"noop">>}
                                   ,{<<"Call-ID">>, kapps_call:call_id(Call)}
                                   ,{<<"Msg-ID">>, NoopId}

--- a/core/kazoo_number_manager/Makefile
+++ b/core/kazoo_number_manager/Makefile
@@ -22,13 +22,14 @@ ITU_URL = https://raw.githubusercontent.com/mledoze/countries/c212082894e48e8be1
 # https://countrycode.org/
 # https://en.wikipedia.org/wiki/List_of_country_calling_codes
 
-SOURCES = $(wildcard src/*.erl) $(wildcard src/*/*.erl) $(ITU)
+COMPILE_MOAR = $(ITU)
+SOURCES = $(ITU) $(wildcard src/*.erl) $(wildcard src/*/*.erl)
 
 CLEAN_MOAR = clean-generated
 
 all: compile
 
-compile: $(ITU)
+compile:
 
 compile-test: compile-also
 
@@ -38,12 +39,14 @@ compile-also:
 include $(ROOT)/make/kz.mk
 
 clean-generated:
-	$(if $(wildcard $(ITU)), rm $(ITU))
+	$(if $(wildcard $(ITU)), @rm $(ITU))
 
 $(ITU_FILE):
 	wget -qO $@ $(ITU_URL)
 
-$(ITU): $(ITU_FILE) $(ITU_SRC)
+$(ITU_SRC): $(ITU_FILE)
+
+$(ITU): $(ITU_SRC)
 	@cat $(ITU_SRC) >$(ITU)
 	@python -c 'from __future__ import print_function; import json; [print("to_itu(<<\"", l["cca2"], "\">>) -> <<\"+", l["callingCode"][0], "\">>;", sep="") for l in sorted(json.load(open("dialcodes.json")), key=lambda l: l["cca2"]) if len(l["callingCode"]) > 0]' >>$(ITU)
 	@echo 'to_itu(_) -> <<>>.' >>$(ITU)

--- a/core/kazoo_stdlib/src/kz_term.erl
+++ b/core/kazoo_stdlib/src/kz_term.erl
@@ -40,6 +40,7 @@
         ,is_ne_binaries/1
         ,is_empty/1, is_not_empty/1
         ,is_proplist/1, is_ne_list/1
+        ,is_pos_integer/1
         ,identity/1
         ,always_true/1, always_false/1
         ]).
@@ -319,7 +320,6 @@ is_true("true") -> 'true';
 is_true('true') -> 'true';
 is_true(_) -> 'false'.
 
-
 -type caster() :: fun((any()) -> any()).
 -spec safe_cast(any(), any(), caster()) -> any().
 safe_cast(Value, Default, CastFun) ->
@@ -403,6 +403,11 @@ is_proplist(_) -> 'false'.
 is_ne_list([_|_]) -> 'true';
 is_ne_list(_) -> 'false'.
 
+-spec is_pos_integer(any()) -> boolean().
+is_pos_integer(X) ->
+    is_integer(X)
+        andalso X > 0.
+
 -spec identity(X) -> X.
 identity(X) -> X.
 
@@ -417,7 +422,6 @@ to_lower_string(L) when is_list(L) ->
     [to_lower_char(C) || C <- L];
 to_lower_string(Else) ->
     to_lower_string(to_list(Else)).
-
 
 -spec to_upper_binary(any()) -> api_binary().
 to_upper_binary('undefined') -> 'undefined';

--- a/make/kz.mk
+++ b/make/kz.mk
@@ -60,6 +60,7 @@ space := $(empty) $(empty)
 SOURCES     ?= $(wildcard src/*.erl) $(wildcard src/*/*.erl)
 MODULE_NAMES := $(sort $(foreach module,$(SOURCES),$(shell basename $(module) .erl)))
 MODULES := $(shell echo $(MODULE_NAMES) | sed 's/ /,/g')
+BEAMS := $(sort $(foreach module,$(SOURCES),ebin/$(shell basename $(module) .erl).beam))
 
 TEST_SOURCES := $(SOURCES) $(wildcard test/*.erl)
 TEST_MODULE_NAMES := $(sort $(foreach module,$(TEST_SOURCES),$(shell basename $(module) .erl)))
@@ -70,11 +71,11 @@ include $(DEPS_RULES)
 endif
 
 ## COMPILE_MOAR can contain Makefile-specific targets (see CLEAN_MOAR, compile-test)
-compile: $(COMPILE_MOAR) ebin/$(PROJECT).app json depend
+compile: $(COMPILE_MOAR) ebin/$(PROJECT).app json depend $(BEAMS)
 
-ebin/$(PROJECT).app: $(SOURCES)
+ebin/$(PROJECT).app:
 	@mkdir -p ebin/
-	ERL_LIBS=$(ELIBS) erlc -v $(ERLC_OPTS) $(PA) -o ebin/ $?
+	ERL_LIBS=$(ELIBS) erlc -v $(ERLC_OPTS) $(PA) -o ebin/ $(SOURCES)
 	@sed "s/{modules,\s*\[\]}/{modules, \[$(MODULES)\]}/" src/$(PROJECT).app.src > $@
 
 ebin/%.beam: src/%.erl


### PR DESCRIPTION
Since endless_playback is not easily interruptible (going into a conference appears to work), allow setting a loop counter on the media to be played.