### PR TITLE
PISTON-535: allow agents/status queries with no limit

### DIFF
--- a/applications/acdc/src/acdc_stats.erl
+++ b/applications/acdc/src/acdc_stats.erl
@@ -545,7 +545,7 @@ is_valid_call_status(S) ->
         'false' -> 'false'
     end.
 
--spec query_calls(kz_term:ne_binary(), kz_term:ne_binary(), ets:match_spec(), pos_integer()) -> 'ok'.
+-spec query_calls(kz_term:ne_binary(), kz_term:ne_binary(), ets:match_spec(), pos_integer() | 'no_limit') -> 'ok'.
 query_calls(RespQ, MsgId, Match, _Limit) ->
     case ets:select(call_table_id(), Match) of
         [] ->

--- a/applications/acdc/src/acdc_stats.hrl
+++ b/applications/acdc/src/acdc_stats.hrl
@@ -5,6 +5,7 @@
 
 -define(VALID_STATUSES, [<<"waiting">>, <<"handled">>, <<"abandoned">>, <<"processed">>]).
 
+-define(STATS_QUERY_LIMITS_ENABLED, kapps_config:get_is_true(?CONFIG_CAT, <<"stats_query_limits_enabled">>, 'true')).
 -define(MAX_RESULT_SET, kapps_config:get_integer(?CONFIG_CAT, <<"max_result_set">>, 25)).
 
 -record(agent_miss, {agent_id :: kz_term:api_binary()

--- a/applications/acdc/src/acdc_stats_util.erl
+++ b/applications/acdc/src/acdc_stats_util.erl
@@ -45,12 +45,22 @@ caller_id_number(_, JObj) ->
 queue_id(_, JObj) ->
     kz_json:get_value(<<"Queue-ID">>, JObj).
 
--spec get_query_limit(kz_json:object()) -> pos_integer().
+-spec get_query_limit(kz_json:object()) -> pos_integer() | 'no_limit'.
 get_query_limit(JObj) ->
+    get_query_limit(JObj, ?STATS_QUERY_LIMITS_ENABLED).
+
+-spec get_query_limit(kz_json:object(), boolean()) -> pos_integer() | 'no_limit'.
+get_query_limit(JObj, 'true') ->
     Max = ?MAX_RESULT_SET,
     case kz_json:get_integer_value(<<"Limit">>, JObj) of
         'undefined' -> Max;
         N when N > Max -> Max;
+        N when N < 1 -> 1;
+        N -> N
+    end;
+get_query_limit(JObj, 'false') ->
+    case kz_json:get_integer_value(<<"Limit">>, JObj) of
+        'undefined' -> 'no_limit';
         N when N < 1 -> 1;
         N -> N
     end.

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -26417,6 +26417,11 @@
                     "default": 5,
                     "description": "acdc queue worker count",
                     "type": "integer"
+                },
+                "stats_query_limits_enabled": {
+                    "default": true,
+                    "description": "When enabled, prevent stats queries with limits greater than max_result_set",
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.acdc.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.acdc.json
@@ -60,6 +60,11 @@
             "default": 5,
             "description": "acdc queue worker count",
             "type": "integer"
+        },
+        "stats_query_limits_enabled": {
+            "default": true,
+            "description": "When enabled, prevent stats queries with limits greater than max_result_set",
+            "type": "boolean"
         }
     },
     "type": "object"


### PR DESCRIPTION
Conflicts:
	applications/acdc/src/acdc_agent_stats.erl
	applications/acdc/src/acdc_stats.erl
	applications/acdc/src/acdc_stats_util.erl