### PR TITLE
use defaults from jesse (#4561) - 4.1

### DIFF
--- a/core/kazoo_documents/test/kzd_callflow_test.erl
+++ b/core/kazoo_documents/test/kzd_callflow_test.erl
@@ -109,13 +109,8 @@ action_failure_test_() ->
     Doc = kz_json:from_list([{?FLOW, kz_json:new()}]),
     {'error', Errors} = kzd_callflow:validate_flow(Doc),
 
-    [?_assertEqual(2, length(Errors))
+    [?_assertEqual(1, length(Errors))
     ,?_assertMatch([{'data_invalid', _SchemaJObj
-                    ,'missing_required_property'
-                    ,<<"data">>
-                    ,[]
-                    }
-                   ,{'data_invalid', _SchemaJObj
                     ,'missing_required_property'
                     ,<<"module">>
                     ,[]
@@ -135,13 +130,8 @@ child_action_failure_test_() ->
 
     Doc = kz_json:from_list([{?FLOW, Child}]),
     {'error', Errors} = kzd_callflow:validate_flow(Doc),
-    [?_assertEqual(4, length(Errors))
+    [?_assertEqual(3, length(Errors))
     ,?_assertMatch([{'data_invalid', _
-                    ,'missing_required_property'
-                    ,<<"data">>
-                    ,[<<"children">>, <<"ca1">>]
-                    }
-                   ,{'data_invalid', _
                     ,'missing_required_property'
                     ,<<"module">>
                     ,[<<"children">>, <<"ca1">>]
@@ -172,13 +162,13 @@ child_action_failure_data_test_() ->
     Doc = kz_json:from_list([{?FLOW, Child}]),
     {'error', Errors} = kzd_callflow:validate_flow(Doc),
 
-    [?_assertEqual(5, length(Errors))
+    [?_assertEqual(4, length(Errors))
     ,?_assertMatch([_, _, {'data_invalid', _SchemaJObj
                           ,'missing_required_property'
-                          ,<<"data">>
-                          ,[<<"children">>, <<"ca2">>]
+                          ,<<"key1">>
+                          ,[<<"data">>]
                           }
-                   , _, _]
+                   , _]
                   ,Errors
                   )
     ].
@@ -200,21 +190,11 @@ multiple_child_action_failures_test_() ->
     Doc = kz_json:from_list([{?FLOW, Child}]),
     {'error', Errors} = kzd_callflow:validate_flow(Doc),
 
-    [?_assertEqual(4, length(Errors))
+    [?_assertEqual(2, length(Errors))
     ,?_assertMatch([{'data_invalid', _SchemaJObj
-                    ,'missing_required_property'
-                    ,<<"data">>
-                    ,[<<"children">>, <<"mp1">>]
-                    }
-                   ,{'data_invalid', _SchemaJObj
                     ,'missing_required_property'
                     ,<<"module">>
                     ,[<<"children">>, <<"mp1">>]
-                    }
-                   ,{'data_invalid', _SchemaJObj
-                    ,'missing_required_property'
-                    ,<<"data">>
-                    ,[<<"children">>, <<"mp2">>]
                     }
                    ,{'data_invalid', _SchemaJObj
                     ,'missing_required_property'
@@ -225,3 +205,4 @@ multiple_child_action_failures_test_() ->
                   ,Errors
                   )
     ].
+

--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -134,6 +134,12 @@ add_defaults(JObj, SchemaJObj) ->
 validate(SchemaJObj, DataJObj) ->
     validate(SchemaJObj, DataJObj, ?DEFAULT_OPTIONS).
 
+-ifdef(TEST).
+-define(DEFAULT_LOADER, fun fload/1).
+-else.
+-define(DEFAULT_LOADER, fun load/1).
+-endif.
+
 validate(<<_/binary>> = Schema, DataJObj, Options) ->
     Fun = props:get_value('schema_loader_fun', Options, fun load/1),
     {'ok', SchemaJObj} = Fun(Schema),

--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -792,16 +792,23 @@ flatten(?EMPTY_JSON_OBJECT=Empty) -> Empty;
 flatten(?JSON_WRAPPER(L) = Schema) when is_list(L) ->
     kz_json:from_list(
       lists:flatten(
-        flatten_props(kz_json:get_value(<<"properties">>, Schema)
+        flatten_props(kz_json:get_json_value(<<"properties">>, Schema)
                      ,[]
                      ,Schema
                      )
        )
      ).
 
-flatten_props(undefined, Path, Obj) -> flatten_prop(Path, Obj);
-flatten_props(?JSON_WRAPPER(L), Path, _) when is_list(L) ->
-    [ flatten_props(kz_json:get_value(<<"properties">>, V), Path ++ [K], V) || {K, V} <- L ].
+flatten_props('undefined', Path, Obj) -> flatten_prop(Path, Obj);
+flatten_props(?JSON_WRAPPER(L), Path, Obj) when is_list(L) ->
+    [maybe_flatten_props(K, V, Path, Obj)
+     || {K, V} <- L
+    ].
+
+maybe_flatten_props(K, ?JSON_WRAPPER(_)=V, Path, _Obj) ->
+    flatten_props(kz_json:get_json_value(<<"properties">>, V), Path ++ [K], V);
+maybe_flatten_props(K, _V, Path, Obj) ->
+    flatten_prop(Path ++ [K], Obj).
 
 flatten_prop(Path, ?JSON_WRAPPER(L) = Value) when is_list(L) ->
     case lists:last(Path) of

--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -99,62 +99,15 @@ add_defaults(JObj, <<_/binary>> = Schema) ->
     {'ok', SchemaJObj} = load(Schema),
     add_defaults(JObj, SchemaJObj);
 add_defaults(JObj, SchemaJObj) ->
-    kz_json:foldl(fun defaults_foldl/3
-                 ,JObj
-                 ,kz_json:get_value(<<"properties">>, SchemaJObj, kz_json:new())
-                 ).
-
--spec defaults_foldl(kz_json:path(), kz_json:object(), api_object()) -> api_object().
-defaults_foldl(SchemaKey, SchemaValue, JObj) ->
-    case kz_json:get_value(<<"default">>, SchemaValue) of
-        'undefined' ->
-            maybe_sub_properties(SchemaKey, SchemaValue, JObj);
-        Default ->
-            maybe_sub_properties(SchemaKey
-                                ,SchemaValue
-                                ,maybe_default(SchemaKey, Default, JObj)
-                                )
-    end.
-
--spec maybe_sub_properties(kz_json:path(), kz_json:object(), api_object()) -> api_object().
-maybe_sub_properties(SchemaKey, SchemaValue, JObj) ->
-    case kz_json:get_value(<<"type">>, SchemaValue) of
-        <<"object">> ->
-            maybe_update_data_with_sub(SchemaKey, SchemaValue, JObj);
-        <<"array">> ->
-            {_, JObj1} = lists:foldl(fun(SubJObj, Acc) ->
-                                             maybe_sub_properties_foldl(SchemaKey, SchemaValue, SubJObj, Acc)
-                                     end
-                                    ,{1, JObj}
-                                    ,kz_json:get_value(SchemaKey, JObj, [])
-                                    ),
-            JObj1;
-        _Type -> JObj
-    end.
-
--spec maybe_sub_properties_foldl(kz_json:path(), kz_json:object(), kz_json:json_term(), {pos_integer(), kz_json:object()}) ->
-                                        {pos_integer(), kz_json:object()}.
-maybe_sub_properties_foldl(SchemaKey, SchemaValue, SubJObj, {Idx, JObj}) ->
-    case add_defaults(SubJObj, kz_json:get_value(<<"items">>, SchemaValue, kz_json:new())) of
-        'undefined' -> {Idx+1, JObj};
-        NewSubJObj -> {Idx+1, kz_json:set_value([SchemaKey, Idx], NewSubJObj, JObj)}
-    end.
-
--spec maybe_update_data_with_sub(kz_json:path(), kz_json:object(), kz_json:object()) -> kz_json:object().
-maybe_update_data_with_sub(SchemaKey, SchemaValue, JObj) ->
-    case add_defaults(kz_json:get_value(SchemaKey, JObj), SchemaValue) of
-        'undefined' -> JObj;
-        SubJObj ->  kz_json:set_value(SchemaKey, SubJObj, JObj)
-    end.
-
--spec maybe_default(kz_json:path(), kz_json:json_term(), api_object()) -> api_object().
-maybe_default(Key, Default, JObj) ->
-    case kz_json:is_json_object(JObj)
-        andalso kz_json:get_value(Key, JObj)
-    of
-        'undefined' when JObj =/= 'undefined' -> kz_json:set_value(Key, Default, JObj);
-        'undefined' ->  kz_json:set_value(Key, Default, kz_json:new());
-        _Value -> JObj
+    try validate(SchemaJObj, JObj) of
+        {'ok', WithDefaultsJObj} -> WithDefaultsJObj;
+        {'error', Err} ->
+            lager:debug("schema has errors : ~p ", [Err]),
+            JObj
+    catch
+        _Ex:_Err ->
+            lager:debug("exception getting schema default ~p : ~p", [_Ex, _Err]),
+            JObj
     end.
 
 -type extra_validator() :: fun((jesse:json_term(), jesse_state:state()) -> jesse_state:state()).
@@ -184,9 +137,10 @@ validate(SchemaJObj, DataJObj) ->
 validate(<<_/binary>> = Schema, DataJObj, Options) ->
     Fun = props:get_value('schema_loader_fun', Options, fun load/1),
     {'ok', SchemaJObj} = Fun(Schema),
-    validate(SchemaJObj, DataJObj, Options);
-validate(SchemaJObj, DataJObj, Options0) ->
-    jesse:validate_with_schema(SchemaJObj, DataJObj, Options0 ++ ?DEFAULT_OPTIONS).
+    validate(SchemaJObj, DataJObj, props:insert_values([{'schema_loader_fun', ?DEFAULT_LOADER}], Options));
+validate(SchemaJObj, DataJObj, Options0) when is_list(Options0) ->
+    Options = props:insert_values(?DEFAULT_OPTIONS, Options0),
+    jesse:validate_with_schema(SchemaJObj, DataJObj, Options).
 
 -type option() :: {'version', ne_binary()} |
                   {'error_code', integer()} |
@@ -847,24 +801,20 @@ flatten_prop(Path, ?JSON_WRAPPER(L) = Value) when is_list(L) ->
     case lists:last(Path) of
         <<"default">> -> [{Path, Value}];
         _ -> [{Path ++ [K], V} || {K,V} <- L]
-    end;
-flatten_prop(Path, V) -> [{Path, V}].
+    end.
 
 -spec default_object(kz_json:object()) -> kz_json:object().
 default_object(Schema) ->
-    Flat = flatten(Schema),
-
-    FlatDefault = default_properties(Flat),
-    kz_json:expand(FlatDefault).
-
--spec default_properties(kz_json:flat_object()) -> kz_json:flat_object().
-default_properties(Flat) ->
-    kz_json:filtermap(fun(Keys, Value) ->
-                              <<"default">> =:= lists:last(Keys)
-                                  andalso {'true', {lists:droplast(Keys), Value}}
-                      end
-                      ,Flat
-                     ).
+    try validate(Schema, kz_json:new()) of
+        {'ok', JObj} -> JObj;
+        {'error', Err} ->
+            lager:debug("schema has errors : ~p ", [Err]),
+            kz_json:new()
+    catch
+        _Ex:_Err ->
+            lager:debug("exception getting schema default ~p : ~p", [_Ex, _Err]),
+            kz_json:new()
+    end.
 
 -spec filtering_list(kz_json:object()) -> list(kz_json:keys() | []).
 filtering_list(Schema) ->

--- a/core/kazoo_schemas/test/fixtures/schemav3_sub_defaults_array.json
+++ b/core/kazoo_schemas/test/fixtures/schemav3_sub_defaults_array.json
@@ -1,0 +1,438 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "properties": {
+        "emergency": {
+            "default": false,
+            "description": "Determines if the resource represents emergency services",
+            "type": "boolean"
+        },
+        "enabled": {
+            "default": true,
+            "description": "Determines if the resource is currently enabled",
+            "type": "boolean"
+        },
+        "flags": {
+            "default": [],
+            "description": "A list of flags that can be provided on the request and must match for the resource to be eligible",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "flat_rate_blacklist": {
+            "description": "Regex for determining if a number should not be eligible for flat-rate trunking",
+            "type": "string"
+        },
+        "flat_rate_whitelist": {
+            "description": "Regex for determining if the number is eligible for flat-rate trunking",
+            "type": "string"
+        },
+        "format_from_uri": {
+            "description": "When set to true requests to this resource will have a reformatted SIP From Header",
+            "type": "boolean"
+        },
+        "formatters": {
+            "$ref": "formatters",
+            "type": "object"
+        },
+        "from_uri_realm": {
+            "description": "When formating SIP From on outbound requests this can be used to override the realm",
+            "type": "string"
+        },
+        "gateways": {
+            "description": "A list of gateways avaliable for this resource",
+            "items": {
+                "properties": {
+                    "bypass_media": {
+                        "default": "auto",
+                        "description": "The device bypass media mode",
+                        "enum": [
+                            "true",
+                            "false",
+                            "auto"
+                        ],
+                        "name": "Bypass Media (gateways)",
+                        "type": "string"
+                    },
+                    "caller_id_type": {
+                        "description": "The type of caller id to use",
+                        "enum": [
+                            "internal",
+                            "external",
+                            "emergency"
+                        ],
+                        "type": "string"
+                    },
+                    "channel_selection": {
+                        "default": "ascending",
+                        "description": "Automatic selection of the channel within the span: ascending starts at 1 and moves up; descending is the opposite",
+                        "enum": [
+                            "ascending",
+                            "descending"
+                        ],
+                        "type": "string"
+                    },
+                    "codecs": {
+                        "default": [
+                            "PCMU",
+                            "PCMA"
+                        ],
+                        "description": "A list of single list codecs supported by this gateway (to support backward compatibilty)",
+                        "items": {
+                            "enum": [
+                                "G729",
+                                "PCMU",
+                                "PCMA",
+                                "G722_16",
+                                "G722_32",
+                                "CELT_48",
+                                "CELT_64",
+                                "Speex",
+                                "GSM",
+                                "OPUS",
+                                "H261",
+                                "H263",
+                                "H264",
+                                "VP8"
+                            ],
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": true
+                    },
+                    "custom_sip_headers": {
+                        "anyOf": [
+                            {
+                                "$ref": "custom_sip_headers"
+                            },
+                            {
+                                "properties": {
+                                    "in": {
+                                        "$ref": "custom_sip_headers",
+                                        "description": "Custom SIP Headers to be applied to calls inbound to Kazoo from the endpoint"
+                                    },
+                                    "out": {
+                                        "$ref": "custom_sip_headers",
+                                        "description": "Custom SIP Headers to be applied to calls outbound from Kazoo to the endpoint"
+                                    }
+                                }
+                            }
+                        ],
+                        "default": {},
+                        "description": "A property list of SIP headers",
+                        "type": "object"
+                    },
+                    "custom_sip_interface": {
+                        "description": "The name of a custom SIP interface",
+                        "type": "string"
+                    },
+                    "enabled": {
+                        "default": true,
+                        "description": "Determines if the resource gateway is currently enabled",
+                        "type": "boolean"
+                    },
+                    "endpoint_type": {
+                        "default": "sip",
+                        "description": "What type of endpoint is this gateway",
+                        "enum": [
+                            "sip",
+                            "freetdm",
+                            "skype",
+                            "amqp"
+                        ],
+                        "type": "string"
+                    },
+                    "force_port": {
+                        "default": false,
+                        "description": "Allow request only from this port",
+                        "type": "boolean"
+                    },
+                    "format_from_uri": {
+                        "description": "When set to true requests to this resource gateway will have a reformatted SIP From Header",
+                        "type": "boolean"
+                    },
+                    "from_uri_realm": {
+                        "description": "When formating SIP From on outbound requests this can be used to override the realm",
+                        "type": "string"
+                    },
+                    "invite_format": {
+                        "default": "route",
+                        "description": "The format of the DID needed by the underlying hardware/gateway",
+                        "enum": [
+                            "route",
+                            "username",
+                            "e164",
+                            "npan",
+                            "1npan"
+                        ],
+                        "type": "string"
+                    },
+                    "invite_parameters": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "dynamic": {
+                                "description": "A list of properties that, if found on the inbound call, should be added as an INVITE parameter",
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "pattern": "custom_channel_vars\\..*",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "pattern": "custom_sip_headers\\..*",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "enum": [
+                                                "zone"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "key": {
+                                                    "oneOf": [
+                                                        {
+                                                            "pattern": "custom_channel_vars\\..*",
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "pattern": "custom_sip_headers\\..*",
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "enum": [
+                                                                "zone"
+                                                            ],
+                                                            "type": "string"
+                                                        }
+                                                    ]
+                                                },
+                                                "seperator": {
+                                                    "type": "string"
+                                                },
+                                                "tag": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "tag"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            "static": {
+                                "description": "A list of static values that should be added as INVITE parameters",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "media": {
+                        "description": "The media parameters for the resource gateway",
+                        "properties": {
+                            "codecs": {
+                                "default": [
+                                    "PCMU",
+                                    "PCMA"
+                                ],
+                                "description": "A list of audio codecs supported by this gateway",
+                                "items": {
+                                    "properties": {
+                                        "enum": [
+                                            "G729",
+                                            "PCMU",
+                                            "PCMA",
+                                            "G722_16",
+                                            "G722_32",
+                                            "CELT_48",
+                                            "CELT_64",
+                                            "Speex",
+                                            "GSM",
+                                            "OPUS",
+                                            "H261",
+                                            "H263",
+                                            "H264",
+                                            "VP8"
+                                        ],
+                                        "type": "string"
+                                    }
+                                },
+                                "name": "Codecs (gateways)",
+                                "type": "array"
+                            },
+                            "fax_option": {
+                                "default": "auto",
+                                "description": "Is T.38 Supported?",
+                                "enum": [
+                                    "true",
+                                    "false",
+                                    "auto"
+                                ],
+                                "type": "string"
+                            },
+                            "rtcp_mux": {
+                                "description": "RTCP protocol messages mixed with RTP data",
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "password": {
+                        "description": "SIP authentication password",
+                        "maxLength": 32,
+                        "type": "string"
+                    },
+                    "port": {
+                        "default": 5060,
+                        "description": "This resource gateway port",
+                        "type": "integer"
+                    },
+                    "prefix": {
+                        "default": "+1",
+                        "description": "A string to prepend to the dialed number or capture group of the matching rule",
+                        "maxLength": 64,
+                        "type": "string"
+                    },
+                    "progress_timeout": {
+                        "description": "The progress timeout to apply to the resource gateway",
+                        "type": "integer"
+                    },
+                    "realm": {
+                        "description": "This resource gateway authentication realm",
+                        "maxLength": 64,
+                        "type": "string"
+                    },
+                    "route": {
+                        "description": "A staticly configured SIP URI to route all call to",
+                        "type": "string"
+                    },
+                    "server": {
+                        "description": "This resource gateway server",
+                        "maxLength": 128,
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "skype_interface": {
+                        "description": "The name of the Skype interface to route the call over",
+                        "type": "string"
+                    },
+                    "skype_rr": {
+                        "description": "Determines whether to round-robin calls amongst all interfaces (overrides \"skype_interface\" setting)",
+                        "type": "boolean"
+                    },
+                    "span": {
+                        "description": "The identity of the hardware on the media server",
+                        "type": "string"
+                    },
+                    "suffix": {
+                        "description": "A string to append to the dialed number or capture group of the matching rule",
+                        "maxLength": 64,
+                        "type": "string"
+                    },
+                    "username": {
+                        "description": "SIP authentication username",
+                        "maxLength": 32,
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "server"
+                ],
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "grace_period": {
+            "default": 5,
+            "description": "The amount of time, in seconds, to wait before starting another resource",
+            "maximum": 20,
+            "minimum": 1,
+            "type": "integer"
+        },
+        "media": {
+            "description": "The media parameters for the device",
+            "properties": {
+                "codecs": {
+                    "default": [
+                        "PCMU",
+                        "PCMA"
+                    ],
+                    "description": "A list of audio codecs supported by this gateway",
+                    "items": {
+                        "properties": {
+                            "enum": [
+                                "G729",
+                                "PCMU",
+                                "PCMA",
+                                "G722_16",
+                                "G722_32",
+                                "CELT_48",
+                                "CELT_64",
+                                "Speex",
+                                "GSM",
+                                "OPUS",
+                                "H261",
+                                "H263",
+                                "H264",
+                                "VP8"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "name": "Codecs (gateways)",
+                    "type": "array"
+                },
+                "fax_option": {
+                    "default": "auto",
+                    "description": "The fax mode to option",
+                    "enum": [
+                        "true",
+                        "false",
+                        "auto"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "name": {
+            "description": "A friendly name for the resource",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+        },
+        "require_flags": {
+            "description": "When set to true this resource is ignored if the request does not specify outbound flags",
+            "type": "boolean"
+        },
+        "rules": {
+            "default": [],
+            "description": "A list of regular expressions of which one must match for the rule to be eligible, they can optionally contain capture groups",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "weight_cost": {
+            "default": 50,
+            "description": "A value between 0 and 100 that determines the order of resources when multiple can be used",
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+        }
+    },
+    "required": [
+        "gateways",
+        "name"
+    ],
+    "type": "object"
+}

--- a/core/kazoo_schemas/test/kz_json_schema_test.erl
+++ b/core/kazoo_schemas/test/kz_json_schema_test.erl
@@ -51,7 +51,7 @@ add_defaults_array_test_() ->
     ].
 
 add_sub_defaults_array_test_() ->
-    SchemaJObj = kz_json:decode(<<"{\"properties\":{\"enabled\":{\"name\":\"Enabled\",\"description\":\"Determines if the resource is currently enabled\",\"type\":\"boolean\",\"default\":true},\"emergency\":{\"name\":\"Emergency\",\"description\":\"Determines if the resource represents emergency services\",\"type\":\"boolean\",\"default\":false},\"grace_period\":{\"name\":\"Grace Period\",\"description\":\"The amount of time, in seconds, to wait before starting another resource\",\"type\":\"integer\",\"default\":5,\"minimum\":3,\"maximum\":20},\"weight_cost\":{\"name\":\"Weight Cost\",\"description\":\"A value between 0 and 100 that determines the order of resources when multiple can be used\",\"type\":\"integer\",\"default\":50,\"minimum\":0,\"maximum\":100},\"flags\":{\"name\":\"Flags\",\"description\":\"A list of flags that can be provided on the request and must match for the resource to be eligible\",\"type\":\"array\",\"default\":[]},\"gateways\":{\"description\":\"A list of gateways avaliable for this resource\",\"type\":\"array\",\"items\":{\"properties\":{\"enabled\":{\"name\":\"Enabled (gateways)\",\"description\":\"Determines if the resource gateway is currently enabled\",\"type\":\"boolean\",\"default\":true},\"prefix\":{\"name\":\"Prefix (gateways)\",\"description\":\"A string to prepend to the dialed number or capture group of the matching rule\",\"type\":\"string\",\"default\":\"+1\",\"minLength\":1,\"maxLength\":64},\"suffix\":{\"name\":\"Suffix (gateways)\",\"description\":\"A string to append to the dialed number or capture group of the matching rule\",\"type\":\"string\",\"minLength\":1,\"maxLength\":64},\"codecs\":{\"name\":\"Codecs (gateways)\",\"description\":\"A list of audio codecs supported by this gateway\",\"type\":\"array\",\"enum\":[\"G729\",\"PCMU\",\"PCMA\",\"G722_16\",\"G722_32\",\"CELT_48\",\"CELT_64\",\"Speex\",\"GSM\",\"OPUS\",\"H261\",\"H263\",\"H264\"],\"default\":[\"PCMU\",\"PCMA\" ]},\"media\":{\"description\":\"The media parameters for the device\",\"type\":\"object\",\"properties\":{\"fax_option\":{\"description\":\"The fax mode to option\",\"type\":\"string\",\"enum\":[\"true\",\"false\",\"auto\"],\"default\":\"auto\"},\"codecs\":{\"name\":\"Codecs (gateways)\",\"description\":\"A list of audio codecs supported by this gateway\",\"type\":\"array\",\"enum\":[\"G729\",\"PCMU\",\"PCMA\",\"G722_16\",\"G722_32\",\"CELT_48\",\"CELT_64\",\"Speex\",\"GSM\",\"OPUS\",\"H261\",\"H263\",\"H264\",\"VP8\"],\"default\":[\"PCMU\",\"PCMA\" ]}}},\"custom_sip_headers\":{\"name\":\"Custom SIP Header (gateways)\",\"type\":\"object\",\"default\":{}},\"bypass_media\":{\"name\":\"Bypass Media (gateways)\",\"description\":\"The device bypass media mode\",\"type\":\"string\",\"enum\":[\"true\",\"false\",\"auto\"],\"default\":\"auto\"},\"progress_timeout\":{\"name\":\"Progress Timeout (gateways)\",\"description\":\"The progress timeout to apply to the device\",\"type\":\"integer\"},\"endpoint_type\":{\"name\":\"Endpoint Type (gateways)\",\"description\":\"What type of endpoint is this gateway.\",\"type\":\"string\",\"enum\":[\"sip\",\"freetdm\",\"skype\"],\"default\":\"sip\"},\"invite_format\":{\"name\":\"Invite Format (gateways)\",\"description\":\"The format of the DID needed by the underlying hardware/gateway\",\"type\":\"string\",\"enum\":[\"route\",\"username\",\"e164\",\"npan\",\"1npan\"],\"default\":\"route\"}}}}}}">>),
+    {ok, SchemaJObj} = from_file("schemav3_sub_defaults_array.json"),
 
     JObj = kz_json:decode(<<"{\"gateways\":[{\"name\":\"gateway1\",\"media\":{}}]}">>),
 
@@ -75,6 +75,19 @@ add_sub_defaults_array_test_() ->
     ,?_assertEqual(kz_json:new(), kz_json:get_value(<<"custom_sip_headers">>, Gateway))
     ,?_assertEqual(<<"auto">>, kz_json:get_value(<<"bypass_media">>, Gateway))
     ,?_assertEqual(<<"sip">>, kz_json:get_value(<<"endpoint_type">>, Gateway))
+    ].
+
+validate_sub_array_test_() ->
+    {ok, SchemaJObj} = from_file("schemav3_sub_defaults_array.json"),
+
+    JObj = kz_json:decode(<<"{\"gateways\":[{\"name\":\"gateway1\",\"media\":{}, \"codecs\": [\"G999\"]}, {\"name\":\"gateway2\", \"codecs\": [\"G999\"]}, {\"name\":\"gateway3\", \"codecs\": [\"PCMU\", \"G999\"]}]}">>),
+
+    [?_assertMatch({error,[{data_invalid,_, not_in_enum,<<"G999">>,[<<"gateways">>,0,<<"codecs">>,0]}
+                          ,{data_invalid,_, not_in_enum,<<"G999">>,[<<"gateways">>,1,<<"codecs">>,0]}
+                          ,{data_invalid,_, not_in_enum,<<"G999">>,[<<"gateways">>,2,<<"codecs">>,1]}
+                          ]}
+                  ,kz_json_schema:validate(SchemaJObj, JObj)
+                  )
     ].
 
 -spec from_file(nonempty_string()) -> kz_json:object().

--- a/core/kazoo_schemas/test/kz_json_schema_test.erl
+++ b/core/kazoo_schemas/test/kz_json_schema_test.erl
@@ -51,7 +51,7 @@ add_defaults_array_test_() ->
     ].
 
 add_sub_defaults_array_test_() ->
-    {ok, SchemaJObj} = from_file("schemav3_sub_defaults_array.json"),
+    {'ok', SchemaJObj} = fixture('kazoo_schemas', "fixtures/schemav3_sub_defaults_array.json"),
 
     JObj = kz_json:decode(<<"{\"gateways\":[{\"name\":\"gateway1\",\"media\":{}}]}">>),
 
@@ -78,7 +78,7 @@ add_sub_defaults_array_test_() ->
     ].
 
 validate_sub_array_test_() ->
-    {ok, SchemaJObj} = from_file("schemav3_sub_defaults_array.json"),
+    {'ok', SchemaJObj} = fixture('kazoo_schemas', "fixtures/schemav3_sub_defaults_array.json"),
 
     JObj = kz_json:decode(<<"{\"gateways\":[{\"name\":\"gateway1\",\"media\":{}, \"codecs\": [\"G999\"]}, {\"name\":\"gateway2\", \"codecs\": [\"G999\"]}, {\"name\":\"gateway3\", \"codecs\": [\"PCMU\", \"G999\"]}]}">>),
 
@@ -89,6 +89,18 @@ validate_sub_array_test_() ->
                   ,kz_json_schema:validate(SchemaJObj, JObj)
                   )
     ].
+
+-spec fixture(file:filename_all()) -> {ok, kz_json:object()} | {error, not_found}.
+fixture(Path) ->
+    case file:read_file(Path) of
+        {ok, Bin} -> {ok, kz_json:decode(Bin)};
+        {error, _} -> {error, not_found}
+    end.
+
+-spec fixture(atom(), file:filename_all()) -> {ok, kz_json:object()} | {error, not_found}.
+fixture(App, Path) when is_atom(App) ->
+    fixture(filename:join(code:lib_dir(App, test), Path)).
+
 
 -spec from_file(nonempty_string()) -> kz_json:object().
 from_file(File) ->

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -72,7 +72,7 @@ dep_couchbeam = git https://github.com/2600hz/couchbeam 1.4.1b
 ### https://github.com/benoitc/couchbeam/pull/166
 ### https://github.com/benoitc/couchbeam/pull/174
 
-dep_jesse = git https://github.com/2600hz/jesse 1.5-rc6
+dep_jesse = git https://github.com/2600hz/jesse 1.5-rc7
 ##dep_jesse = git https://github.com/for-GET/jesse 1.5.0-rc2
 
 dep_lager = git https://github.com/erlang-lager/lager 3.2.1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -87,6 +87,10 @@ Done
 If there are any calls to non-existant modules, or non-exported functions, you will get errors listed here.
 
 
+## check-whitespace.sh
+
+Removes trailing whitespaces from files
+
 ## circleci-build-erlang.sh
 
 Fetches kerl and installs configured Erlang version (used in CircleCI)

--- a/scripts/check-whitespace.sh
+++ b/scripts/check-whitespace.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Files with trailing whitespace:"
+# From /
+
+ws="$(echo -ne ' \t\v')"
+
+count=0
+for file in $(git grep -IE "[$ws]$" -- $* | cut -d: -f1 | sort -u); do
+    echo "$file"
+    sed -i 's/\s*$//g' "$file"
+    ((count++))
+done
+
+exit $count
+


### PR DESCRIPTION
fix callflow tests

data object has a default

add check-whitespace description to README