### PR TITLE
Account user device privacy 4.1

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -25,6 +25,7 @@
 -export([endpoint_id_by_sip_username/2]).
 -export([owner_ids_by_sip_username/2]).
 -export([apply_dialplan/2]).
+-export([ccvs_by_privacy_mode/1]).
 
 -export([sip_users_from_device_ids/2]).
 
@@ -852,6 +853,30 @@ vm_count(JObj) ->
     AccountId = kz_doc:account_id(JObj),
     BoxId = kz_doc:id(JObj),
     kvm_messages:count_non_deleted(AccountId, BoxId).
+
+-spec ccvs_by_privacy_mode(api_ne_binary()) -> kz_proplist().
+ccvs_by_privacy_mode('undefined') ->
+    ccvs_by_privacy_mode(<<"full">>);
+ccvs_by_privacy_mode(<<"full">>) ->
+    [{<<"Caller-Screen-Bit">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Number">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Name">>, 'true'}
+    ];
+ccvs_by_privacy_mode(<<"yes">>) ->
+    ccvs_by_privacy_mode(<<"full">>);
+ccvs_by_privacy_mode(<<"name">>) ->
+    [{<<"Caller-Screen-Bit">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Name">>, 'true'}
+    ];
+ccvs_by_privacy_mode(<<"number">>) ->
+    [{<<"Caller-Screen-Bit">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Number">>, 'true'}
+    ];
+%% returns empty list so that callflow settings override
+ccvs_by_privacy_mode(<<"none">>) -> [];
+ccvs_by_privacy_mode(_Else) ->
+    lager:debug("unsupported privacy mode ~s, forcing full privacy", [_Else]),
+    ccvs_by_privacy_mode(<<"full">>).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -867,10 +867,12 @@ ccvs_by_privacy_mode(<<"yes">>) ->
 ccvs_by_privacy_mode(<<"name">>) ->
     [{<<"Caller-Screen-Bit">>, 'true'}
     ,{<<"Caller-Privacy-Hide-Name">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Number">>, 'false'}
     ];
 ccvs_by_privacy_mode(<<"number">>) ->
     [{<<"Caller-Screen-Bit">>, 'true'}
     ,{<<"Caller-Privacy-Hide-Number">>, 'true'}
+    ,{<<"Caller-Privacy-Hide-Name">>, 'false'}
     ];
 %% returns empty list so that callflow settings override
 ccvs_by_privacy_mode(<<"none">>) -> [];

--- a/applications/callflow/src/module/cf_privacy.erl
+++ b/applications/callflow/src/module/cf_privacy.erl
@@ -43,23 +43,5 @@ update_call(CaptureGroup, {'ok', Call}, Mode) ->
     cf_exe:set_call(kapps_call:exec(Routines, Call)).
 
 -spec ccvs_by_privacy_mode(api_ne_binary()) -> kz_proplist().
-ccvs_by_privacy_mode('undefined') ->
-    ccvs_by_privacy_mode(<<"full">>);
-ccvs_by_privacy_mode(<<"full">>) ->
-    [{<<"Caller-Screen-Bit">>, 'true'}
-    ,{<<"Caller-Privacy-Hide-Number">>, 'true'}
-    ,{<<"Caller-Privacy-Hide-Name">>, 'true'}
-    ];
-ccvs_by_privacy_mode(<<"yes">>) ->
-    ccvs_by_privacy_mode(<<"full">>);
-ccvs_by_privacy_mode(<<"name">>) ->
-    [{<<"Caller-Screen-Bit">>, 'true'}
-    ,{<<"Caller-Privacy-Hide-Name">>, 'true'}
-    ];
-ccvs_by_privacy_mode(<<"number">>) ->
-    [{<<"Caller-Screen-Bit">>, 'true'}
-    ,{<<"Caller-Privacy-Hide-Number">>, 'true'}
-    ];
-ccvs_by_privacy_mode(_Else) ->
-    lager:debug("unsupported privacy mode ~s, forcing full privacy", [_Else]),
-    ccvs_by_privacy_mode(<<"full">>).
+ccvs_by_privacy_mode(Mode) ->
+    cf_util:ccvs_by_privacy_mode(Mode).

--- a/applications/callflow/src/module/cf_privacy.erl
+++ b/applications/callflow/src/module/cf_privacy.erl
@@ -23,14 +23,15 @@ handle(Data, Call) ->
             update_call(CaptureGroup
                        ,cf_exe:get_call(Call)
                        ,Mode
+                       ,should_use_endpoint_privacy(Data)
                        ),
             cf_exe:branch(kz_json:get_value(<<"flow">>, CallFlow), Call);
         {'error', _} ->
             cf_exe:stop(Call)
     end.
 
--spec update_call(ne_binary(), {'ok', kapps_call:call()}, ne_binary()) -> 'ok'.
-update_call(CaptureGroup, {'ok', Call}, Mode) ->
+-spec update_call(ne_binary(), {'ok', kapps_call:call()}, ne_binary(), boolean()) -> 'ok'.
+update_call(CaptureGroup, {'ok', Call}, Mode, Overwrite) ->
     Normalize = knm_converters:normalize(CaptureGroup),
     CCVs = ccvs_by_privacy_mode(Mode),
     Routines = [{fun kapps_call:set_request/2
@@ -39,9 +40,17 @@ update_call(CaptureGroup, {'ok', Call}, Mode) ->
                  >>
                 }
                ,{fun kapps_call:set_custom_channel_vars/2, CCVs}
+               ,{fun kapps_call:kvs_store/3, <<"use_endpoint_privacy">>, Overwrite}
                ],
     cf_exe:set_call(kapps_call:exec(Routines, Call)).
 
 -spec ccvs_by_privacy_mode(api_ne_binary()) -> kz_proplist().
 ccvs_by_privacy_mode(Mode) ->
     cf_util:ccvs_by_privacy_mode(Mode).
+
+-spec should_use_endpoint_privacy(kz_json:object()) -> boolean().
+should_use_endpoint_privacy(Data) ->
+    case kz_json:get_ne_binary_value(<<"endpoint_strategy">>, Data, <<"overwrite">>) of
+        <<"overwrite">> -> 'false';
+        <<"merge">> -> 'true'
+    end.

--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -439,6 +439,19 @@ handle_channel_destroy(_, JObj) ->
 
 -spec get_privacy_prefs(kapps_call:call()) -> kz_proplist().
 get_privacy_prefs(Call) ->
+    case use_endpoint_prefs(Call) of
+        'true' -> check_inception(Call);
+        'false'  -> []
+    end.
+
+-spec use_endpoint_prefs(kapps_call:call()) -> boolean().
+use_endpoint_prefs(Call) ->
+    %% only overwrite the ccvs if privacy has not been set by cf_privacy
+    %% or if the call has been configured to overwrite cf_privacy settings
+    not kz_privacy:has_flags(kapps_call:custom_channel_vars(Call)) orelse kapps_call:kvs_fetch(<<"use_endpoint_privacy">>, Call).
+
+-spec check_inception(kapps_call:call()) -> kz_proplist().
+check_inception(Call) ->
     lager:debug("Checking inception of call"),
     case kapps_call:inception(Call) of
         'undefined' -> get_privacy_prefs_from_endpoint(Call);

--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -448,7 +448,8 @@ get_privacy_prefs(Call) ->
 use_endpoint_prefs(Call) ->
     %% only overwrite the ccvs if privacy has not been set by cf_privacy
     %% or if the call has been configured to overwrite cf_privacy settings
-    not kz_privacy:has_flags(kapps_call:custom_channel_vars(Call)) orelse kapps_call:kvs_fetch(<<"use_endpoint_privacy">>, Call).
+    not kz_privacy:has_flags(kapps_call:custom_channel_vars(Call))
+        orelse kapps_call:kvs_fetch(<<"use_endpoint_privacy">>, Call).
 
 -spec check_inception(kapps_call:call()) -> kz_proplist().
 check_inception(Call) ->

--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -21,6 +21,10 @@
 %%% @end
 %%% @contributors
 %%%   Karl Anderson
+%%%
+%%%
+%%%   Account, user, device level privacy - Sponsored by Raffel Internet B.V
+%%%       implemented by Voyager Internet Ltd.
 %%%-------------------------------------------------------------------
 -module(cf_resources).
 -behaviour(gen_cf_action).
@@ -443,9 +447,9 @@ get_privacy_prefs(Call) ->
 
 -spec get_privacy_prefs_from_endpoint(kapps_call:call()) -> kz_proplist().
 get_privacy_prefs_from_endpoint(Call) ->
-    lager:debug("Call is outbound, checking caller_id_outbound_privacy value"),
+    lager:debug("Call is outbound, checking outbound_privacy value"),
     {'ok', Endpoint} = kz_endpoint:get(Call),
-    case kz_json:get_value(<<"caller_id_outbound_privacy">>, Endpoint) of
+    case kz_json:get_value([<<"caller_id_options">>, <<"outbound_privacy">>], Endpoint) of
         'undefined' ->
             [];
         %% can't call kapps_call_command:privacy/2 with Mode = <<"none">>

--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -124,7 +124,7 @@ get_channel_vars(Call) ->
 -spec add_privacy_flags(kapps_call:call(), kz_proplist()) -> kz_proplist().
 add_privacy_flags(Call, Acc) ->
     CCVs = kapps_call:custom_channel_vars(Call),
-    kz_privacy:flags(CCVs) ++ Acc.
+    props:set_values(get_privacy_prefs(Call), kz_privacy:flags(CCVs)) ++ Acc.
 
 -spec maybe_require_ignore_early_media(kapps_call:call(), kz_proplist()) -> kz_proplist().
 maybe_require_ignore_early_media(Call, Acc) ->
@@ -432,3 +432,26 @@ handle_channel_destroy(<<"loopback", _/binary>>, _JObj) ->
     {<<"TRANSFER">>, 'ok'};
 handle_channel_destroy(_, JObj) ->
     {kz_call_event:hangup_cause(JObj), kz_call_event:hangup_code(JObj)}.
+
+-spec get_privacy_prefs(kapps_call:call()) -> kz_proplist().
+get_privacy_prefs(Call) ->
+    lager:debug("Checking inception of call"),
+    case kapps_call:inception(Call) of
+        'undefined' -> get_privacy_prefs_from_endpoint(Call);
+        _Else -> []
+    end.
+
+-spec get_privacy_prefs_from_endpoint(kapps_call:call()) -> kz_proplist().
+get_privacy_prefs_from_endpoint(Call) ->
+    lager:debug("Call is outbound, checking caller_id_outbound_privacy value"),
+    {'ok', Endpoint} = kz_endpoint:get(Call),
+    case kz_json:get_value(<<"caller_id_outbound_privacy">>, Endpoint) of
+        'undefined' ->
+            [];
+        %% can't call kapps_call_command:privacy/2 with Mode = <<"none">>
+        <<"none">>=NoneMode ->
+            cf_util:ccvs_by_privacy_mode(NoneMode);
+        Mode ->
+            kapps_call_command:privacy(Mode, Call),
+            cf_util:ccvs_by_privacy_mode(Mode)
+    end.

--- a/applications/crossbar/doc/accounts.md
+++ b/applications/crossbar/doc/accounts.md
@@ -24,7 +24,8 @@ Key | Description | Type | Default | Required
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The account default caller ID parameters | `object()` | `{}` | `false`
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false`
 `dial_plan` | A list of default rules used to modify dialed numbers | `object()` | `{}` | `false`
 `do_not_disturb.enabled` | The default value for do-not-disturb | `boolean()` |   | `false`
 `do_not_disturb` |   | `object()` |   | `false`

--- a/applications/crossbar/doc/accounts.md
+++ b/applications/crossbar/doc/accounts.md
@@ -24,6 +24,7 @@ Key | Description | Type | Default | Required
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The account default caller ID parameters | `object()` | `{}` | `false`
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
 `dial_plan` | A list of default rules used to modify dialed numbers | `object()` | `{}` | `false`
 `do_not_disturb.enabled` | The default value for do-not-disturb | `boolean()` |   | `false`
 `do_not_disturb` |   | `object()` |   | `false`

--- a/applications/crossbar/doc/devices.md
+++ b/applications/crossbar/doc/devices.md
@@ -26,7 +26,8 @@ Key | Description | Type | Default | Required
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The device caller ID parameters | `object()` | `{}` | `false`
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false`
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false`
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false`
 `device_type` | Arbitrary device type used by the UI and billing system | `string()` |   | `false`

--- a/applications/crossbar/doc/devices.md
+++ b/applications/crossbar/doc/devices.md
@@ -26,6 +26,7 @@ Key | Description | Type | Default | Required
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The device caller ID parameters | `object()` | `{}` | `false`
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false`
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false`
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false`
 `device_type` | Arbitrary device type used by the UI and billing system | `string()` |   | `false`

--- a/applications/crossbar/doc/ref/accounts.md
+++ b/applications/crossbar/doc/ref/accounts.md
@@ -16,6 +16,7 @@ Key | Description | Type | Default | Required
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The account default caller ID parameters | `object()` | `{}` | `false`
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
 `dial_plan` | A list of default rules used to modify dialed numbers | `object()` | `{}` | `false`
 `do_not_disturb.enabled` | The default value for do-not-disturb | `boolean()` |   | `false`
 `do_not_disturb` |   | `object()` |   | `false`

--- a/applications/crossbar/doc/ref/accounts.md
+++ b/applications/crossbar/doc/ref/accounts.md
@@ -16,7 +16,8 @@ Key | Description | Type | Default | Required
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The account default caller ID parameters | `object()` | `{}` | `false`
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false`
 `dial_plan` | A list of default rules used to modify dialed numbers | `object()` | `{}` | `false`
 `do_not_disturb.enabled` | The default value for do-not-disturb | `boolean()` |   | `false`
 `do_not_disturb` |   | `object()` |   | `false`

--- a/applications/crossbar/doc/ref/devices.md
+++ b/applications/crossbar/doc/ref/devices.md
@@ -23,7 +23,8 @@ Key | Description | Type | Default | Required
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The device caller ID parameters | `object()` | `{}` | `false`
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false`
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false`
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false`
 `device_type` | Arbitrary device type used by the UI and billing system | `string()` |   | `false`

--- a/applications/crossbar/doc/ref/devices.md
+++ b/applications/crossbar/doc/ref/devices.md
@@ -23,6 +23,7 @@ Key | Description | Type | Default | Required
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The device caller ID parameters | `object()` | `{}` | `false`
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false`
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false`
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false`
 `device_type` | Arbitrary device type used by the UI and billing system | `string()` |   | `false`

--- a/applications/crossbar/doc/ref/users.md
+++ b/applications/crossbar/doc/ref/users.md
@@ -23,7 +23,8 @@ Key | Description | Type | Default | Required
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The device caller ID parameters | `object()` | `{}` | `false`
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false`
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false`
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false`
 `dial_plan` | A list of rules used to modify dialed numbers | `object()` | `{}` | `false`

--- a/applications/crossbar/doc/ref/users.md
+++ b/applications/crossbar/doc/ref/users.md
@@ -23,6 +23,7 @@ Key | Description | Type | Default | Required
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The device caller ID parameters | `object()` | `{}` | `false`
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false`
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false`
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false`
 `dial_plan` | A list of rules used to modify dialed numbers | `object()` | `{}` | `false`

--- a/applications/crossbar/doc/users.md
+++ b/applications/crossbar/doc/users.md
@@ -25,6 +25,7 @@ Key | Description | Type | Default | Required
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The device caller ID parameters | `object()` | `{}` | `false`
+`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false`
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false`
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false`
 `dial_plan` | A list of rules used to modify dialed numbers | `object()` | `{}` | `false`

--- a/applications/crossbar/doc/users.md
+++ b/applications/crossbar/doc/users.md
@@ -25,7 +25,8 @@ Key | Description | Type | Default | Required
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false`
 `call_waiting` |   | [#/definitions/call_waiting](#call_waiting) |   | `false`
 `caller_id` | The device caller ID parameters | `object()` | `{}` | `false`
-`caller_id_outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings) | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false`
+`caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false`
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false`
 `contact_list` | Contect List Parameters | `object()` | `{}` | `false`
 `dial_plan` | A list of rules used to modify dialed numbers | `object()` | `{}` | `false`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -2286,6 +2286,15 @@
         "callflows.privacy": {
             "description": "Validator for the privacy callflow's data object",
             "properties": {
+                "endpoint_strategy": {
+                    "default": "overwrite",
+                    "description": "whether cf_privacy should overwrite or merge with the caller_id_options of the endpoint.",
+                    "enum": [
+                        "overwrite",
+                        "merge"
+                    ],
+                    "type": "string"
+                },
                 "mode": {
                     "default": "full",
                     "description": "set caller privacy on calls, restricting the presentation some or full parts of Caller ID",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -379,6 +379,17 @@
                     "description": "The account default caller ID parameters",
                     "type": "object"
                 },
+                "caller_id_outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "required": false,
+                    "type": "string"
+                },
                 "dial_plan": {
                     "$ref": "#/definitions/dialplans",
                     "default": {},
@@ -3742,6 +3753,17 @@
                     "default": {},
                     "description": "The device caller ID parameters",
                     "type": "object"
+                },
+                "caller_id_outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "required": false,
+                    "type": "string"
                 },
                 "contact_list": {
                     "default": {},
@@ -29936,6 +29958,17 @@
                     "default": {},
                     "description": "The device caller ID parameters",
                     "type": "object"
+                },
+                "caller_id_outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "required": false,
+                    "type": "string"
                 },
                 "contact_list": {
                     "default": {},

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -379,16 +379,21 @@
                     "description": "The account default caller ID parameters",
                     "type": "object"
                 },
-                "caller_id_outbound_privacy": {
-                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
-                    "enum": [
-                        "full",
-                        "name",
-                        "number",
-                        "none"
-                    ],
-                    "required": false,
-                    "type": "string"
+                "caller_id_options": {
+                    "description": "custom properties for configuring caller_id",
+                    "properties": {
+                        "outbound_privacy": {
+                            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                            "enum": [
+                                "full",
+                                "name",
+                                "number",
+                                "none"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "dial_plan": {
                     "$ref": "#/definitions/dialplans",
@@ -3754,16 +3759,21 @@
                     "description": "The device caller ID parameters",
                     "type": "object"
                 },
-                "caller_id_outbound_privacy": {
-                    "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
-                    "enum": [
-                        "full",
-                        "name",
-                        "number",
-                        "none"
-                    ],
-                    "required": false,
-                    "type": "string"
+                "caller_id_options": {
+                    "description": "custom properties for configuring caller_id",
+                    "properties": {
+                        "outbound_privacy": {
+                            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                            "enum": [
+                                "full",
+                                "name",
+                                "number",
+                                "none"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "contact_list": {
                     "default": {},
@@ -29959,16 +29969,21 @@
                     "description": "The device caller ID parameters",
                     "type": "object"
                 },
-                "caller_id_outbound_privacy": {
-                    "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
-                    "enum": [
-                        "full",
-                        "name",
-                        "number",
-                        "none"
-                    ],
-                    "required": false,
-                    "type": "string"
+                "caller_id_options": {
+                    "description": "custom properties for configuring caller_id",
+                    "properties": {
+                        "outbound_privacy": {
+                            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                            "enum": [
+                                "full",
+                                "name",
+                                "number",
+                                "none"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "contact_list": {
                     "default": {},

--- a/applications/crossbar/priv/couchdb/schemas/accounts.json
+++ b/applications/crossbar/priv/couchdb/schemas/accounts.json
@@ -45,6 +45,16 @@
             "description": "The account default caller ID parameters",
             "type": "object"
         },
+        "caller_id_outbound_privacy": {
+            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+            "enum": [
+                "full",
+                "name",
+                "number",
+                "none"
+            ],
+            "type": "string"
+        },
         "dial_plan": {
             "$ref": "dialplans",
             "default": {},

--- a/applications/crossbar/priv/couchdb/schemas/accounts.json
+++ b/applications/crossbar/priv/couchdb/schemas/accounts.json
@@ -45,15 +45,21 @@
             "description": "The account default caller ID parameters",
             "type": "object"
         },
-        "caller_id_outbound_privacy": {
-            "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
-            "enum": [
-                "full",
-                "name",
-                "number",
-                "none"
-            ],
-            "type": "string"
+        "caller_id_options": {
+            "description": "custom properties for configuring caller_id",
+            "properties": {
+                "outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
         },
         "dial_plan": {
             "$ref": "dialplans",

--- a/applications/crossbar/priv/couchdb/schemas/callflows.privacy.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.privacy.json
@@ -3,6 +3,15 @@
     "_id": "callflows.privacy",
     "description": "Validator for the privacy callflow's data object",
     "properties": {
+        "endpoint_strategy": {
+            "default": "overwrite",
+            "description": "whether cf_privacy should overwrite or merge with the caller_id_options of the endpoint.",
+            "enum": [
+                "overwrite",
+                "merge"
+            ],
+            "type": "string"
+        },
         "mode": {
             "default": "full",
             "description": "set caller privacy on calls, restricting the presentation some or full parts of Caller ID",

--- a/applications/crossbar/priv/couchdb/schemas/devices.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.json
@@ -80,6 +80,16 @@
             "description": "The device caller ID parameters",
             "type": "object"
         },
+        "caller_id_outbound_privacy": {
+            "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
+            "enum": [
+                "full",
+                "name",
+                "number",
+                "none"
+            ],
+            "type": "string"
+        },
         "contact_list": {
             "default": {},
             "description": "Contect List Parameters",

--- a/applications/crossbar/priv/couchdb/schemas/devices.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.json
@@ -80,15 +80,21 @@
             "description": "The device caller ID parameters",
             "type": "object"
         },
-        "caller_id_outbound_privacy": {
-            "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
-            "enum": [
-                "full",
-                "name",
-                "number",
-                "none"
-            ],
-            "type": "string"
+        "caller_id_options": {
+            "description": "custom properties for configuring caller_id",
+            "properties": {
+                "outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
         },
         "contact_list": {
             "default": {},

--- a/applications/crossbar/priv/couchdb/schemas/users.json
+++ b/applications/crossbar/priv/couchdb/schemas/users.json
@@ -80,6 +80,16 @@
             "description": "The device caller ID parameters",
             "type": "object"
         },
+        "caller_id_outbound_privacy": {
+            "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
+            "enum": [
+                "full",
+                "name",
+                "number",
+                "none"
+            ],
+            "type": "string"
+        },
         "contact_list": {
             "default": {},
             "description": "Contect List Parameters",

--- a/applications/crossbar/priv/couchdb/schemas/users.json
+++ b/applications/crossbar/priv/couchdb/schemas/users.json
@@ -80,15 +80,21 @@
             "description": "The device caller ID parameters",
             "type": "object"
         },
-        "caller_id_outbound_privacy": {
-            "description": "Determines what appears as caller id for offnet outbound calls. Takes precedence over the same property on device and account doc. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing (useful for overriding default settings)",
-            "enum": [
-                "full",
-                "name",
-                "number",
-                "none"
-            ],
-            "type": "string"
+        "caller_id_options": {
+            "description": "custom properties for configuring caller_id",
+            "properties": {
+                "outbound_privacy": {
+                    "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
+                    "enum": [
+                        "full",
+                        "name",
+                        "number",
+                        "none"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
         },
         "contact_list": {
             "default": {},

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -222,7 +222,6 @@ merge_attributes(Endpoint, Type) ->
            ,<<"ringtones">>
            ,<<"caller_id">>
            ,<<"caller_id_options">>
-           ,<<"caller_id_outbound_privacy">>
            ,<<"do_not_disturb">>
            ,<<"call_forward">>
            ,<<"dial_plan">>
@@ -317,8 +316,6 @@ merge_attribute(<<"caller_id">> = Key, Account, Endpoint, Owner) ->
             CallerId = kz_json:set_value(L, Number, Merged),
             kz_json:set_value(Key, CallerId, Endpoint)
     end;
-merge_attribute(<<"caller_id_outbound_privacy">> = Key, Account, Endpoint, Owner) ->
-    merge_value(Key, Account, Endpoint, Owner);
 merge_attribute(<<"do_not_disturb">> = Key, Account, Endpoint, Owner) ->
     L = [Key, <<"enabled">>],
     AccountAttr = kz_json:is_true(L, Account, 'false'),

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -222,6 +222,7 @@ merge_attributes(Endpoint, Type) ->
            ,<<"ringtones">>
            ,<<"caller_id">>
            ,<<"caller_id_options">>
+           ,<<"caller_id_outbound_privacy">>
            ,<<"do_not_disturb">>
            ,<<"call_forward">>
            ,<<"dial_plan">>
@@ -316,6 +317,8 @@ merge_attribute(<<"caller_id">> = Key, Account, Endpoint, Owner) ->
             CallerId = kz_json:set_value(L, Number, Merged),
             kz_json:set_value(Key, CallerId, Endpoint)
     end;
+merge_attribute(<<"caller_id_outbound_privacy">> = Key, Account, Endpoint, Owner) ->
+    merge_value(Key, Account, Endpoint, Owner);
 merge_attribute(<<"do_not_disturb">> = Key, Account, Endpoint, Owner) ->
     L = [Key, <<"enabled">>],
     AccountAttr = kz_json:is_true(L, Account, 'false'),


### PR DESCRIPTION
This is a 4.1 port of #4585, allowing caller_id privacy to be set on the device, user or account document