### PR TITLE
basic_auth.md updated with correct param options

### DIFF
--- a/applications/crossbar/doc/basic_auth.md
+++ b/applications/crossbar/doc/basic_auth.md
@@ -18,7 +18,7 @@ PASSWORD=`echo -n username:password | md5sum | awk '{print $1}'`
 
 ```shell
 curl -v \
-    -basic -user {AUTH_ACCOUNT_ID}:$PASSWORD \
+    --basic --user {AUTH_ACCOUNT_ID}:$PASSWORD \
     http://server.com:8000/v2/accounts/{ACCOUNT_ID}/devices
 ```
 


### PR DESCRIPTION
A missing '-' in the parameters options broke this example. The following commit works on curl 7.19.7 and above