### PR TITLE
Filter rates by caller_id number

### DIFF
--- a/applications/hotornot/doc/README.md
+++ b/applications/hotornot/doc/README.md
@@ -46,7 +46,7 @@ Key | Description | Type | Default
 `default_rate_nocharge_time` | No charge time when `rate_nocharge_time`  is not defined in rate | `integer` | `0`
 `default_rate_surcharge` | Surcharge used when `rate_surcharge` is not defined in rate | `float` | `0.0`
 `filter_list.[]` |  | `string` |
-`filter_list` | List additional filters (after prefix match) | `array(string)` | `["direction", "route_options", "routes"]`
+`filter_list` | List additional filters (after prefix match) | `array(string)` | `["direction", "route_options", "routes", "caller_id_numbers"]`
 `sort_by_weight` | Sort matched filters by `weight`(`true`) or by `rate_cost` (`false`) | `boolean` | `true`
 `use_trie` | Use in-memory prefix dictionary for search rates | `boolean` | `false`
 
@@ -81,6 +81,10 @@ If `route_options` filter defined in `filter_list` then "Options", "Outbound-Fla
 ### routes
 
 If `routes` filter defined in `filter_list` then "To-DID" from rate request compared with list of regexes in `routes` value of rates. Rate matched if any of regexes matched. Empty regexes list or undefined value in rate means "match nobody" and this rate will never be used.
+
+### caller_id_numbers
+
+If `caller_id_numbers` filter defined in `filter_list` then "From-DID" from rate request compared with list of regexes in `caller_id_numbers` value of rates. Rate matched if any of regexes matched. Undefined regexes list value in rate means "match all".
 
 ### ratedeck_name
 

--- a/applications/hotornot/src/hon_util.erl
+++ b/applications/hotornot/src/hon_util.erl
@@ -225,6 +225,12 @@ matching_rate(Rate, <<"routes">>, RateReq) ->
              ,kzd_rate:routes(Rate, [])
              );
 
+matching_rate(Rate, <<"caller_id_numbers">>, RateReq) ->
+    E164 = knm_converters:normalize(kz_json:get_value(<<"From-DID">>, RateReq)),
+    lists:any(fun(Regex) -> re:run(E164, Regex) =/= 'nomatch' end
+             ,kzd_rate:caller_id_numbers(Rate, [<<".">>])
+             );
+
 matching_rate(Rate, <<"ratedeck_id">>, RateReq) ->
     AccountId = kz_json:get_value(<<"Account-ID">>, RateReq),
     AccountRatedeck = kz_service_ratedeck_name:get_ratedeck_name(AccountId),

--- a/core/kazoo_documents/src/kzd_rate.erl
+++ b/core/kazoo_documents/src/kzd_rate.erl
@@ -22,6 +22,7 @@
         ,rate_cost/1, rate_cost/2, set_rate_cost/2
         ,ratedeck/1, ratedeck/2, set_ratedeck/2
         ,routes/1, routes/2, set_routes/2
+        ,caller_id_numbers/1, caller_id_numbers/2
         ,surcharge/1, surcharge/2, set_surcharge/2
         ,type/0, type/1, set_type/1
         ,version/1, version/2
@@ -267,6 +268,14 @@ options(Rate, Default) ->
 -spec set_options(doc(), kz_term:ne_binaries()) -> doc().
 set_options(Rate, Options) when is_list(Options) ->
     kz_json:set_value(<<"options">>, Options, Rate).
+
+-spec caller_id_numbers(doc()) -> kz_term:ne_binaries().
+caller_id_numbers(Rate) ->
+    caller_id_numbers(Rate, []).
+
+-spec caller_id_numbers(doc(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
+caller_id_numbers(Rate, Default) ->
+    kz_json:get_list_value(<<"caller_id_numbers">>, Rate, Default).
 
 -spec routes(doc()) -> kz_term:ne_binaries().
 routes(Rate) ->


### PR DESCRIPTION
Use case example:
Could be useful when inbound toll_free rating should be done CID based. 
Like calls from landline and cell phone to local toll_free number should have different rates