### PR TITLE
OpenTelecom: Fix blackhole amqp creds

### DIFF
--- a/applications/blackhole/src/blackhole_data_emitter.erl
+++ b/applications/blackhole/src/blackhole_data_emitter.erl
@@ -24,7 +24,7 @@ event(Binding, RK, Name, Data) ->
           ,{<<"data">>, kz_json:delete_key(<<"amqp_broker">>, Data)}
           ],
     SessionPid ! {'send_data', kz_json:from_list(Msg)},
-   'ok'.
+    'ok'.
 
 -spec reply(pid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 reply(SessionPid, RequestId, Status, Data) ->

--- a/applications/blackhole/src/blackhole_data_emitter.erl
+++ b/applications/blackhole/src/blackhole_data_emitter.erl
@@ -21,10 +21,10 @@ event(Binding, RK, Name, Data) ->
           ,{<<"subscription_key">>, SubscriptionKey}
           ,{<<"name">>, Name}
           ,{<<"routing_key">>, RK}
-          ,{<<"data">>, Data}
+          ,{<<"data">>, kz_json:delete_key(<<"amqp_broker">>, Data)}
           ],
     SessionPid ! {'send_data', kz_json:from_list(Msg)},
-    'ok'.
+   'ok'.
 
 -spec reply(pid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 reply(SessionPid, RequestId, Status, Data) ->


### PR DESCRIPTION
This is a very small fix to avoid emitting AMQP credentials in blackhole events. It simply deletes the amqp_broker key from the event payload.