### PR TITLE
Ignore non-filter keys when checking if filters are defined

### DIFF
--- a/applications/crossbar/src/crossbar_filter.erl
+++ b/applications/crossbar/src/crossbar_filter.erl
@@ -75,16 +75,25 @@ is_only_time_filter(Context, FilterKey) ->
     case kz_term:is_empty(QueryString) of
         'true' -> 'false';
         'false' ->
-            Fun = fun({<<"created_from">>, _}) -> 'true';
-                     ({<<"created_to">>, _}) -> 'true';
-                     ({<<"modified_from">>, _}) -> 'true';
-                     ({<<"modified_to">>, _}) -> 'true';
-                     ({Key, _}) ->
+            does_query_string_have_time_filters(QueryString, FilterKey)
+    end.
+
+-spec does_query_string_have_time_filters(kz_json:object(), kz_term:ne_binary()) -> boolean().
+does_query_string_have_time_filters(QueryString, FilterKey) ->
+    Fun = fun({<<"created_from">>, _}) -> 'true';
+             ({<<"created_to">>, _}) -> 'true';
+             ({<<"modified_from">>, _}) -> 'true';
+             ({<<"modified_to">>, _}) -> 'true';
+             ({Key, _}) ->
+                  case is_filter_key(Key) of
+                      'false' -> 'true'; % handles non-filter query string params
+                      'true' ->
+                          lager:debug("checking qs key ~s against filter key ~s", [Key, FilterKey]),
                           Key =:= <<FilterKey/binary, "_from">>
                               orelse Key =:= <<FilterKey/binary, "_to">>
-                  end,
-            kz_json:all(Fun, cb_context:query_string(Context))
-    end.
+                  end
+          end,
+    kz_json:all(Fun, QueryString).
 
 %% @equiv by_doc(Doc, Context, is_defined(Context))
 
@@ -98,12 +107,8 @@ by_doc(Doc, Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec by_doc(kz_term:api_object(), cb_context:context(), boolean()) -> boolean().
-by_doc(_, _, 'false') ->
-    lager:debug("no filters defined"),
-    'true';
-by_doc('undefined', _, 'true') ->
-    lager:debug("no doc was returned (no include_docs?)"),
-    'true';
+by_doc(_, _, 'false') -> 'true';
+by_doc('undefined', _, 'true') -> 'true';
 by_doc(Doc, Context, 'true') ->
     filter_doc_by_querystring(Doc, cb_context:query_string(Context)).
 
@@ -131,7 +136,7 @@ build(Context, 'true') ->
 -spec build_filter_map_fun(cb_context:context(), filter_fun(), crossbar_view:user_mapper_fun()) -> crossbar_view:mapper_fun().
 build_filter_map_fun(_, FilterFun, 'undefined') ->
     fun(JObj, Acc) ->
-            case FilterFun(kz_json:get_value(<<"doc">>, JObj)) of
+            case FilterFun(kz_json:get_json_value(<<"doc">>, JObj)) of
                 'true' -> [JObj|Acc];
                 'false' -> Acc
             end
@@ -140,20 +145,20 @@ build_filter_map_fun(_, FilterFun, UserMapper) when is_function(UserMapper, 1) -
     fun(JObjs) ->
             Filtered0 = [JObj
                          || JObj <- JObjs,
-                            FilterFun(kz_json:get_value(<<"doc">>, JObj))
+                            FilterFun(kz_json:get_json_value(<<"doc">>, JObj))
                         ],
             UserMapper(Filtered0)
     end;
 build_filter_map_fun(_, FilterFun, UserMapper) when is_function(UserMapper, 2) ->
     fun(JObj, Acc) ->
-            case FilterFun(kz_json:get_value(<<"doc">>, JObj)) of
+            case FilterFun(kz_json:get_json_value(<<"doc">>, JObj)) of
                 'true' -> UserMapper(JObj, Acc);
                 'false' -> Acc
             end
     end;
 build_filter_map_fun(Context, FilterFun, UserMapper) when is_function(UserMapper, 3) ->
     fun(JObj, Acc) ->
-            case FilterFun(kz_json:get_value(<<"doc">>, JObj)) of
+            case FilterFun(kz_json:get_json_value(<<"doc">>, JObj)) of
                 'true' -> UserMapper(Context, JObj, Acc);
                 'false' -> Acc
             end
@@ -181,15 +186,8 @@ filter_doc_by_querystring(Doc, QueryString) ->
 -spec should_filter_doc(kz_json:object(), kz_term:ne_binary(), kz_json:json_term()) -> boolean().
 should_filter_doc(Doc, K, V) ->
     try filter_prop(Doc, K, V) of
-        'undefined' ->
-            lager:debug("should include doc based on key: ~s value: ~p", [K, V]),
-            'true';
-        'true' ->
-            lager:debug("should include doc based on key: ~s value: ~p", [K, V]),
-            'true';
-        'false' ->
-            lager:debug("should not include doc based on key: ~s value: ~p", [K, V]),
-            'false'
+        'undefined' -> 'true';
+        Bool -> Bool
     catch
         _E:_R ->
             lager:debug("failed to process filter ~s: ~s:~p", [K, _E, _R]),

--- a/applications/crossbar/src/crossbar_filter.erl
+++ b/applications/crossbar/src/crossbar_filter.erl
@@ -84,8 +84,8 @@ does_query_string_have_time_filters(QueryString, FilterKey) ->
              ({<<"created_to">>, _}) -> 'true';
              ({<<"modified_from">>, _}) -> 'true';
              ({<<"modified_to">>, _}) -> 'true';
-             ({Key, _}) ->
-                  case is_filter_key(Key) of
+             ({Key, _}=KV) ->
+                  case is_filter_key(KV) of
                       'false' -> 'true'; % handles non-filter query string params
                       'true' ->
                           lager:debug("checking qs key ~s against filter key ~s", [Key, FilterKey]),

--- a/applications/crossbar/src/crossbar_view.erl
+++ b/applications/crossbar/src/crossbar_view.erl
@@ -224,6 +224,7 @@ build_load_range_params(Context, View, Options) ->
 
             HasQSFilter = crossbar_filter:is_defined(Context)
                 andalso not crossbar_filter:is_only_time_filter(Context, TimeFilterKey),
+            lager:debug("has qs filter: ~s", [HasQSFilter]),
 
             case time_range(Context, Options, TimeFilterKey) of
                 {StartTime, EndTime} ->

--- a/applications/crossbar/src/crossbar_view.erl
+++ b/applications/crossbar/src/crossbar_view.erl
@@ -599,7 +599,7 @@ next_chunk(#{options := #{page_size := PageSize}
             }=ChunkMap)
   when is_integer(PageSize)
        andalso PageSize > 0
-       andalso TotalQueried + PrevLength == PageSize
+       andalso TotalQueried + PrevLength =:= PageSize
        andalso LastKey =/= 'undefined' ->
     lager:debug("(chunked) page size exhausted: ~b", [PageSize]),
     ChunkMap#{total_queried => TotalQueried + PrevLength

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -114,7 +114,7 @@ to_csv({Req, Context}) ->
     {Req, to_response(Context, <<"csv">>, cb_context:req_nouns(Context))}.
 
 -spec to_response(cb_context:context(), kz_term:ne_binary(), req_nouns()) ->
-                         {cb_cowboy_payload(), cb_context:context()}.
+                         cb_context:context().
 to_response(Context, RespType, [{<<"cdrs">>, []}, {?KZ_ACCOUNTS_DB, _}|_]) ->
     load_chunked_cdrs(Context, RespType);
 to_response(Context, RespType, [{<<"cdrs">>, []}, {<<"users">>, _}|_]) ->

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -113,6 +113,8 @@ to_json({Req, Context}) ->
 to_csv({Req, Context}) ->
     {Req, to_response(Context, <<"csv">>, cb_context:req_nouns(Context))}.
 
+-spec to_response(cb_context:context(), kz_term:ne_binary(), req_nouns()) ->
+                         {cb_cowboy_payload(), cb_context:context()}.
 to_response(Context, RespType, [{<<"cdrs">>, []}, {?KZ_ACCOUNTS_DB, _}|_]) ->
     load_chunked_cdrs(Context, RespType);
 to_response(Context, RespType, [{<<"cdrs">>, []}, {<<"users">>, _}|_]) ->


### PR DESCRIPTION
The 'time-only' filter check wasn't differentiating between filter keys and non-filter keys on the query string. So you'd get `paginate` being compared with `created_to` and `created_from`, not matching, and returning `false` when `true` was the appropriate return (as seen when omitting `paginate=false` from the query string).