### PR TITLE
KAZOO-5693: Remove attachment content from stored error

### DIFF
--- a/applications/crossbar/src/modules/cb_storage.erl
+++ b/applications/crossbar/src/modules/cb_storage.erl
@@ -440,8 +440,10 @@ validate_attachment_settings_fold(AttId, Att, ContextAcc) ->
     AttSettings = kz_maps:keys_to_atoms(kz_json:to_map(Settings)),
     Opts = [{'plan_override', #{'att_handler' => {AttHandler, AttSettings}
                                ,'att_post_handler' => 'external'
+                               ,'att_handler_id' => AttId
                                }}
            ,{'error_verbosity', 'verbose'}
+           ,{'save_error', 'false'}
            ],
     %% Check the storage settings have permissions to create files
     case kz_datamgr:put_attachment(DbName, DocId, AName, Content, Opts) of

--- a/core/kazoo_attachments/src/kz_att_error.erl
+++ b/core/kazoo_attachments/src/kz_att_error.erl
@@ -17,7 +17,6 @@
 -export([resp_body/1, set_resp_body/2]).
 -export([resp_code/1, set_resp_code/2]).
 -export([resp_headers/1, set_resp_headers/2]).
--export([attachment_content/1, set_attachment_content/2]).
 -export([options/1, set_options/2]).
 
 -export([to_json/1]).
@@ -32,7 +31,6 @@
 -type extended_error() :: #{'db_name' => gen_attachment:db_name()
                            ,'document_id' => gen_attachment:doc_id()
                            ,'attachment_name' => gen_attachment:att_name()
-                           ,'attachment_content' => gen_attachment:contents() | 'undefined'
                            ,'handler_props' => gen_attachment:handler_props()
                            ,'req_url' => req_url()
                            ,'resp_code' => resp_code()
@@ -81,12 +79,11 @@ fetch_routines(HandlerProps, DbName, DocumentId, AttachmentName) ->
                   ,gen_attachment:contents()
                   ,gen_attachment:options()
                   ) -> update_routines().
-put_routines(Settings, DbName, DocumentId, AttachmentName, Contents, Options) ->
+put_routines(Settings, DbName, DocumentId, AttachmentName, _Contents, Options) ->
     [{fun set_handler_props/2, Settings}
     ,{fun set_db_name/2, DbName}
     ,{fun set_document_id/2, DocumentId}
     ,{fun set_attachment_name/2, AttachmentName}
-    ,{fun set_attachment_content/2, Contents}
     ,{fun set_options/2, Options}
     ].
 
@@ -153,14 +150,6 @@ resp_headers(#{'resp_headers' := Headers}) ->
 -spec set_resp_headers(extended_error(), resp_headers()) -> extended_error().
 set_resp_headers(ExtendedError, Headers) ->
     ExtendedError#{'resp_headers' => Headers}.
-
--spec attachment_content(extended_error()) -> gen_attachment:contents().
-attachment_content(#{'attachment_content' := Contents}) ->
-    Contents.
-
--spec set_attachment_content(extended_error(), gen_attachment:contents()) -> extended_error().
-set_attachment_content(ExtendedError, Contents) ->
-    ExtendedError#{'attachment_content' => Contents}.
 
 -spec options(extended_error()) -> gen_attachment:options().
 options(#{'options' := Options}) ->

--- a/core/kazoo_attachments/test/kz_att_error_test.erl
+++ b/core/kazoo_attachments/test/kz_att_error_test.erl
@@ -22,10 +22,7 @@ error_response_test_() ->
                           ,resp_code => 500
                           ,resp_body => <<>>
                           },
-    PutExtendedError = FetchExtendedError#{attachment_content => att_content()
-                                          ,handler_props => #{}
-                                          ,options => options()
-                                          },
+    PutExtendedError = FetchExtendedError#{handler_props => #{}, options => options()},
 
     %% Attachment handlers must always return extended errors (3 elements tuple),
     %% e.g: `{error, Reason, ExtendedError}'.

--- a/core/kazoo_data/src/kzs_plan.erl
+++ b/core/kazoo_data/src/kzs_plan.erl
@@ -192,6 +192,7 @@ dataplan_match(Classification, Plan, AccountId) ->
              ,att_proxy => 'true'
              ,att_post_handler => att_post_handler(CAtt)
              ,att_handler => {AttHandler, kz_maps:keys_to_atoms(Params)}
+             ,att_handler_id => AttConnection
              ,classification => Classification
              ,account_id => AccountId
              }
@@ -238,6 +239,7 @@ dataplan_type_match(Classification, DocType, Plan, AccountId) ->
              ,att_proxy => 'true'
              ,att_post_handler => att_post_handler(TypeAttMap)
              ,att_handler => {AttHandler, kz_maps:keys_to_atoms(Params)}
+             ,att_handler_id => AttConnection
              ,classification => Classification
              ,doc_type => DocType
              ,account_id => AccountId


### PR DESCRIPTION
Also:
-  Include the att handler id within the stored error