### PR TITLE
Master pr added utc time offset to cdr request

### DIFF
--- a/applications/crossbar/doc/cdrs.md
+++ b/applications/crossbar/doc/cdrs.md
@@ -87,6 +87,14 @@ curl -v -X GET \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/cdrs?created_from={FROM_TIMESTAMP}&created_to={TO_TIMESTAMP}
 ```
 
+Get CDRs and update datetime field to local time zone (using seconds for timeoffset from UTC time):
+
+```shell
+curl -v -X GET \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/cdrs?created_from={FROM_TIMESTAMP}&created_to={TO_TIMESTAMP}&utc_offset={SECONDS_OFFSET}
+```
+
 Get CDRs as CSV:
 
 ```shell

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -23,6 +23,10 @@
         ]).
 
 -export([load_chunked_cdr_ids/3]).
+-ifdef(TEST).
+    -export([handle_utc_time_offset/2]).
+-endif.
+
 
 -include("crossbar.hrl").
 
@@ -42,47 +46,48 @@
 -define(PATH_LEGS, <<"legs">>).
 -define(PATH_SUMMARY, <<"summary">>).
 
+-define(KEY_UO, <<"utc_offset">>).
 -define(KEY_CCV, <<"custom_channel_vars">>).
 
 -define(COLUMNS
-       ,[{<<"id">>, fun col_id/2}
-        ,{<<"call_id">>, fun col_call_id/2}
-        ,{<<"caller_id_number">>, fun col_caller_id_number/2}
-        ,{<<"caller_id_name">>, fun col_caller_id_name/2}
-        ,{<<"callee_id_number">>, fun col_callee_id_number/2}
-        ,{<<"callee_id_name">>, fun col_callee_id_name/2}
-        ,{<<"duration_seconds">>, fun col_duration_seconds/2}
-        ,{<<"billing_seconds">>, fun col_billing_seconds/2}
-        ,{<<"timestamp">>, fun col_timestamp/2}
-        ,{<<"hangup_cause">>, fun col_hangup_cause/2}
-        ,{<<"other_leg_call_id">>, fun col_other_leg_call_id/2}
-        ,{<<"owner_id">>, fun col_owner_id/2}
-        ,{<<"to">>, fun col_to/2}
-        ,{<<"from">>, fun col_from/2}
-        ,{<<"direction">>, fun col_call_direction/2}
-        ,{<<"request">>, fun col_request/2}
-        ,{<<"authorizing_id">>, fun col_authorizing_id/2}
-        ,{<<"cost">>, fun col_customer_cost/2}
+       ,[{<<"id">>, fun col_id/3}
+        ,{<<"call_id">>, fun col_call_id/3}
+        ,{<<"caller_id_number">>, fun col_caller_id_number/3}
+        ,{<<"caller_id_name">>, fun col_caller_id_name/3}
+        ,{<<"callee_id_number">>, fun col_callee_id_number/3}
+        ,{<<"callee_id_name">>, fun col_callee_id_name/3}
+        ,{<<"duration_seconds">>, fun col_duration_seconds/3}
+        ,{<<"billing_seconds">>, fun col_billing_seconds/3}
+        ,{<<"timestamp">>, fun col_timestamp/3}
+        ,{<<"hangup_cause">>, fun col_hangup_cause/3}
+        ,{<<"other_leg_call_id">>, fun col_other_leg_call_id/3}
+        ,{<<"owner_id">>, fun col_owner_id/3}
+        ,{<<"to">>, fun col_to/3}
+        ,{<<"from">>, fun col_from/3}
+        ,{<<"direction">>, fun col_call_direction/3}
+        ,{<<"request">>, fun col_request/3}
+        ,{<<"authorizing_id">>, fun col_authorizing_id/3}
+        ,{<<"cost">>, fun col_customer_cost/3}
          %% New fields
-        ,{<<"dialed_number">>, fun col_dialed_number/2}
-        ,{<<"calling_from">>, fun col_calling_from/2}
-        ,{<<"datetime">>, fun col_pretty_print/2}
-        ,{<<"unix_timestamp">>, fun col_unix_timestamp/2}
-        ,{<<"rfc_1036">>, fun col_rfc1036/2}
-        ,{<<"iso_8601">>, fun col_iso8601/2}
-        ,{<<"call_type">>, fun col_account_call_type/2}
-        ,{<<"rate">>, fun col_rate/2}
-        ,{<<"rate_name">>, fun col_rate_name/2}
-        ,{<<"bridge_id">>, fun col_bridge_id/2}
-        ,{<<"recording_url">>, fun col_recording_url/2}
-        ,{<<"media_recordings">>, fun col_media_recordings/2}
-        ,{<<"media_server">>, fun col_media_server/2}
-        ,{<<"call_priority">>, fun col_call_priority/2}
+        ,{<<"dialed_number">>, fun col_dialed_number/3}
+        ,{<<"calling_from">>, fun col_calling_from/3}
+        ,{<<"datetime">>, fun col_pretty_print/3}
+        ,{<<"unix_timestamp">>, fun col_unix_timestamp/3}
+        ,{<<"rfc_1036">>, fun col_rfc1036/3}
+        ,{<<"iso_8601">>, fun col_iso8601/3}
+        ,{<<"call_type">>, fun col_account_call_type/3}
+        ,{<<"rate">>, fun col_rate/3}
+        ,{<<"rate_name">>, fun col_rate_name/3}
+        ,{<<"bridge_id">>, fun col_bridge_id/3}
+        ,{<<"recording_url">>, fun col_recording_url/3}
+        ,{<<"media_recordings">>, fun col_media_recordings/3}
+        ,{<<"media_server">>, fun col_media_server/3}
+        ,{<<"call_priority">>, fun col_call_priority/3}
         ]).
 
 -define(COLUMNS_RESELLER
-       ,[{<<"reseller_cost">>, fun col_reseller_cost/2}
-        ,{<<"reseller_call_type">>, fun col_reseller_call_type/2}
+       ,[{<<"reseller_cost">>, fun col_reseller_cost/3}
+        ,{<<"reseller_call_type">>, fun col_reseller_call_type/3}
         ]).
 
 -type csv_column_fun() :: fun((kz_json:object(), kz_time:gregorian_seconds()) -> kz_term:ne_binary()).
@@ -376,7 +381,7 @@ normalize_cdrs(Context, <<"csv">>, JObjs) ->
 normalize_cdr_to_jobj(JObj, Context) ->
     Duration = kz_json:get_integer_value(<<"duration_seconds">>, JObj, 0),
     Timestamp = kz_json:get_integer_value(<<"timestamp">>, JObj, 0) - Duration,
-    kz_json:from_list([{K, F(JObj, Timestamp)} || {K, F} <- csv_rows(Context)]).
+    kz_json:from_list( [{K, F(JObj, Timestamp, Context)} || {K, F} <- csv_rows(Context)]).
 
 %%------------------------------------------------------------------------------
 %% @doc Normalize CDR in CSV
@@ -385,7 +390,7 @@ normalize_cdr_to_jobj(JObj, Context) ->
 -spec normalize_cdr_to_csv(kz_json:object(), cb_context:context()) -> binary().
 normalize_cdr_to_csv(JObj, Context) ->
     Timestamp = kz_json:get_integer_value(<<"timestamp">>, JObj, 0),
-    CSV = kz_binary:join([F(JObj, Timestamp) || {_, F} <- csv_rows(Context)], <<",">>),
+    CSV = kz_binary:join([F(JObj, Timestamp, Context) || {_, F} <- csv_rows(Context)], <<",">>),
     case cb_context:fetch(Context, 'chunking_started') of
         'true' -> <<CSV/binary, "\r\n">>;
         'false' ->
@@ -403,23 +408,23 @@ csv_rows(Context) ->
     end.
 
 %% see csv_column_fun() for specs for each function here
-col_id(JObj, _Timestamp) -> kz_doc:id(JObj, <<>>).
-col_call_id(JObj, _Timestamp) -> kz_json:get_value(<<"call_id">>, JObj, <<>>).
-col_caller_id_number(JObj, _Timestamp) -> kz_json:get_value(<<"caller_id_number">>, JObj, <<>>).
-col_caller_id_name(JObj, _Timestamp) -> kz_json:get_value(<<"caller_id_name">>, JObj, <<>>).
-col_callee_id_number(JObj, _Timestamp) -> kz_json:get_value(<<"callee_id_number">>, JObj, <<>>).
-col_callee_id_name(JObj, _Timestamp) -> kz_json:get_value(<<"callee_id_name">>, JObj, <<>>).
-col_duration_seconds(JObj, _Timestamp) -> kz_json:get_value(<<"duration_seconds">>, JObj, <<>>).
-col_billing_seconds(JObj, _Timestamp) -> kz_json:get_value(<<"billing_seconds">>, JObj, <<>>).
-col_timestamp(_JObj, Timestamp) -> kz_term:to_binary(Timestamp).
-col_hangup_cause(JObj, _Timestamp) -> kz_json:get_value(<<"hangup_cause">>, JObj, <<>>).
-col_other_leg_call_id(JObj, _Timestamp) -> kz_json:get_value(<<"other_leg_call_id">>, JObj, <<>>).
-col_owner_id(JObj, _Timestamp) -> kz_json:get_value([?KEY_CCV, <<"owner_id">>], JObj, <<>>).
-col_to(JObj, _Timestamp) -> kz_json:get_value(<<"to">>, JObj, <<>>).
-col_from(JObj, _Timestamp) -> kz_json:get_value(<<"from">>, JObj, <<>>).
-col_call_direction(JObj, _Timestamp) -> kz_json:get_value(<<"call_direction">>, JObj, <<>>).
-col_request(JObj, _Timestamp) -> kz_json:get_value(<<"request">>, JObj, <<>>).
-col_authorizing_id(JObj, _Timestamp) ->
+col_id(JObj, _Timestamp, _Context) -> kz_doc:id(JObj, <<>>).
+col_call_id(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"call_id">>, JObj, <<>>).
+col_caller_id_number(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"caller_id_number">>, JObj, <<>>).
+col_caller_id_name(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"caller_id_name">>, JObj, <<>>).
+col_callee_id_number(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"callee_id_number">>, JObj, <<>>).
+col_callee_id_name(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"callee_id_name">>, JObj, <<>>).
+col_duration_seconds(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"duration_seconds">>, JObj, <<>>).
+col_billing_seconds(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"billing_seconds">>, JObj, <<>>).
+col_timestamp(_JObj, Timestamp, _Context) -> kz_term:to_binary(Timestamp).
+col_hangup_cause(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"hangup_cause">>, JObj, <<>>).
+col_other_leg_call_id(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"other_leg_call_id">>, JObj, <<>>).
+col_owner_id(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"owner_id">>], JObj, <<>>).
+col_to(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"to">>, JObj, <<>>).
+col_from(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"from">>, JObj, <<>>).
+col_call_direction(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"call_direction">>, JObj, <<>>).
+col_request(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"request">>, JObj, <<>>).
+col_authorizing_id(JObj, _Timestamp, _Context) ->
     case {kz_json:get_value([?KEY_CCV, <<"account_id">>], JObj, <<>>)
          ,kz_json:get_value([?KEY_CCV, <<"authorizing_id">>], JObj, <<>>)
          }
@@ -427,25 +432,42 @@ col_authorizing_id(JObj, _Timestamp) ->
         {A, A} -> <<>>;
         {_A, B} -> B
     end.
-col_customer_cost(JObj, _Timestamp) -> kz_term:to_binary(customer_cost(JObj)).
+col_customer_cost(JObj, _Timestamp, _Context) -> kz_term:to_binary(customer_cost(JObj)).
 
-col_dialed_number(JObj, _Timestamp) -> dialed_number(JObj).
-col_calling_from(JObj, _Timestamp) -> calling_from(JObj).
-col_pretty_print(_JObj, Timestamp) -> pretty_print_datetime(Timestamp).
-col_unix_timestamp(_JObj, Timestamp) -> kz_term:to_binary(kz_time:gregorian_seconds_to_unix_seconds(Timestamp)).
-col_rfc1036(_JObj, Timestamp) -> list_to_binary([$", kz_time:rfc1036(Timestamp), $"]).
-col_iso8601(_JObj, Timestamp) -> list_to_binary([$", kz_date:to_iso8601_extended(Timestamp), $"]).
-col_account_call_type(JObj, _Timestamp) -> kz_json:get_value([?KEY_CCV, <<"account_billing">>], JObj, <<>>).
-col_rate(JObj, _Timestamp) -> kz_term:to_binary(wht_util:units_to_dollars(kz_json:get_value([?KEY_CCV, <<"rate">>], JObj, 0))).
-col_rate_name(JObj, _Timestamp) -> kz_json:get_value([?KEY_CCV, <<"rate_name">>], JObj, <<>>).
-col_bridge_id(JObj, _Timestamp) -> kz_json:get_value([?KEY_CCV, <<"bridge_id">>], JObj, <<>>).
-col_recording_url(JObj, _Timestamp) -> kz_json:get_value([<<"recording_url">>], JObj, <<>>).
-col_media_recordings(JObj, _Timestamp) -> format_recordings(JObj).
-col_media_server(JObj, _Timestamp) -> kz_json:get_value(<<"media_server">>, JObj, <<>>).
-col_call_priority(JObj, _Timestamp) -> kz_json:get_value([?KEY_CCV, <<"call_priority">>], JObj, <<>>).
+col_dialed_number(JObj, _Timestamp, _Context) -> dialed_number(JObj).
+col_calling_from(JObj, _Timestamp, _Context) -> calling_from(JObj).
+col_pretty_print(_JObj, Timestamp, Context) ->
+    UTCSecondsOffset = cb_context:req_value(Context, ?KEY_UO),
+    pretty_print_datetime(handle_utc_time_offset(Timestamp, UTCSecondsOffset)).
+col_unix_timestamp(_JObj, Timestamp, _Context) -> kz_term:to_binary(kz_time:gregorian_seconds_to_unix_seconds(Timestamp)).
+col_rfc1036(_JObj, Timestamp, _Context) -> list_to_binary([$", kz_time:rfc1036(Timestamp), $"]).
+col_iso8601(_JObj, Timestamp, _Context) -> list_to_binary([$", kz_date:to_iso8601_extended(Timestamp), $"]).
+col_account_call_type(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"account_billing">>], JObj, <<>>).
+col_rate(JObj, _Timestamp, _Context) -> kz_term:to_binary(wht_util:units_to_dollars(kz_json:get_value([?KEY_CCV, <<"rate">>], JObj, 0))).
+col_rate_name(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"rate_name">>], JObj, <<>>).
+col_bridge_id(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"bridge_id">>], JObj, <<>>).
+col_recording_url(JObj, _Timestamp, _Context) -> kz_json:get_value([<<"recording_url">>], JObj, <<>>).
+col_media_recordings(JObj, _Timestamp, _Context) -> format_recordings(JObj).
+col_media_server(JObj, _Timestamp, _Context) -> kz_json:get_value(<<"media_server">>, JObj, <<>>).
+col_call_priority(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"call_priority">>], JObj, <<>>).
 
-col_reseller_cost(JObj, _Timestamp) -> kz_term:to_binary(reseller_cost(JObj)).
-col_reseller_call_type(JObj, _Timestamp) -> kz_json:get_value([?KEY_CCV, <<"reseller_billing">>], JObj, <<>>).
+col_reseller_cost(JObj, _Timestamp, _Context) -> kz_term:to_binary(reseller_cost(JObj)).
+col_reseller_call_type(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"reseller_billing">>], JObj, <<>>).
+
+-spec handle_utc_time_offset(pos_integer(), integer() | 'undefined') -> pos_integer().
+handle_utc_time_offset(Timestamp, Atom) when is_atom(Atom) -> Timestamp;
+handle_utc_time_offset(Timestamp, UTCSecondsOffset) ->
+    try offset_timestamp_from_UTC(Timestamp, kz_term:to_number(UTCSecondsOffset))
+    catch error:badarg -> Timestamp
+    end.
+
+-spec offset_timestamp_from_UTC(pos_integer(), integer()) -> pos_integer().
+offset_timestamp_from_UTC(Timestamp, UTCSecondsOffset) ->
+    lager:debug("Adjusting CDR timestamp with UTC Time Offset: ~p", [UTCSecondsOffset]),
+    LocalDateTime = calendar:gregorian_seconds_to_datetime(Timestamp),
+    UTCDateTimeList = calendar:local_time_to_universal_time_dst(LocalDateTime),
+    UTCTimestamp = calendar:datetime_to_gregorian_seconds(lists:last(UTCDateTimeList)),
+    UTCTimestamp+UTCSecondsOffset.
 
 -spec pretty_print_datetime(kz_time:datetime() | integer()) -> kz_term:ne_binary().
 pretty_print_datetime(Timestamp) when is_integer(Timestamp) ->

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -24,7 +24,7 @@
 
 -export([load_chunked_cdr_ids/3]).
 -ifdef(TEST).
-    -export([handle_utc_time_offset/2]).
+-export([handle_utc_time_offset/2]).
 -endif.
 
 

--- a/applications/crossbar/test/cb_cdrs_test.erl
+++ b/applications/crossbar/test/cb_cdrs_test.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2010-2018, Voxter Comunications Inc
+%%% @copyright (C) 2010-2018, Voxter Communications Inc
 %%% @doc
 %%%
 %%% @end
@@ -9,11 +9,11 @@
 -module(cb_cdrs_test).
 -include_lib("eunit/include/eunit.hrl").
 
-%% Test handle_utc_time_offset function with diferent server
+%% Test handle_utc_time_offset function with different server
 %% time zones and offsets
 handle_utc_time_offset_test_() ->
     %% Simulate a time stamp from a CDR
-    %% (generated in freeswitch depoending on system TZ)
+    %% (generated in freeswitch depending on system TZ)
     LocalTimestamp = 63687252084,
 
     %% Depending on the systems timezone, Calculate the UTC time from the LocalTimestamp

--- a/applications/crossbar/test/cb_cdrs_test.erl
+++ b/applications/crossbar/test/cb_cdrs_test.erl
@@ -1,0 +1,44 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2010-2018, Voxter Comunications Inc
+%%% @doc
+%%%
+%%% @end
+%%% @contributors
+%%%   Ben Bradford
+%%%-------------------------------------------------------------------
+-module(cb_cdrs_test).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Test handle_utc_time_offset function with diferent server
+%% time zones and offsets
+handle_utc_time_offset_test_() ->
+    %% Simulate a time stamp from a CDR
+    %% (generated in freeswitch depoending on system TZ)
+    LocalTimestamp = 63687252084,
+
+    %% Depending on the systems timezone, Calculate the UTC time from the LocalTimestamp
+    LocalDateTime = calendar:gregorian_seconds_to_datetime(LocalTimestamp),
+    UTCDateTimeList = calendar:local_time_to_universal_time_dst(LocalDateTime),
+    UTCTimestamp = calendar:datetime_to_gregorian_seconds(lists:last(UTCDateTimeList)),
+
+    [{"Verify the Atom 'undefined' returns unaltered timestamp"
+     ,?_assertEqual(LocalTimestamp, cb_cdrs:handle_utc_time_offset(LocalTimestamp, 'undefined'))
+     }
+    ,{"Verify the Atom 'true' returns unaltered timestamp"
+     ,?_assertEqual(LocalTimestamp, cb_cdrs:handle_utc_time_offset(LocalTimestamp, 'true'))
+     }
+    ,{"Verify the binary <<\"abc\">> returns unaltered timestamp as its NAN"
+     ,?_assertEqual(LocalTimestamp, cb_cdrs:handle_utc_time_offset(LocalTimestamp, <<"bla">>))
+     }
+    ,{"Verify with offset binary <<\"0\">> returns UTC timestamp"
+     ,?_assertEqual(UTCTimestamp, cb_cdrs:handle_utc_time_offset(LocalTimestamp, <<"0">>))
+     }
+    ,{"Verify with offset binary <<\"-14400\">> returns the UTC -4H"
+     ,?_assertEqual((UTCTimestamp - 14400), cb_cdrs:handle_utc_time_offset(LocalTimestamp, <<"-14400">>))
+     }
+    ,{"Verify with offset binary <<\"14400\">> returns the UTC +4H"
+     ,?_assertEqual((UTCTimestamp + 14400), cb_cdrs:handle_utc_time_offset(LocalTimestamp, <<"14400">>))
+     }
+    ].
+
+


### PR DESCRIPTION
Added the ability to request the 'datetime' field to be returned in local time zone. 

This is useful when requesting CDR's as a CSV. At the moment in kazoo ui the time zone conversion is done in kazoo ui to display a list of the cdrs in the browser as local time, but when you request the CSV the times retuned do not match the browsers list as they are returned in the server time zone. With this change the 'seconds from utc' can be provided and the datetime returned will be set accordingly.