### PR TITLE
KAZOO-5853: put circleci 2.0 configs in each app dir

### DIFF
--- a/applications/acdc/.circleci/config.yml
+++ b/applications/acdc/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/acdc/.circleci/config.yml
+++ b/applications/acdc/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/ananke/.circleci/config.yml
+++ b/applications/ananke/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/ananke/.circleci/config.yml
+++ b/applications/ananke/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/blackhole/.circleci/config.yml
+++ b/applications/blackhole/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/blackhole/.circleci/config.yml
+++ b/applications/blackhole/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/call_inspector/.circleci/config.yml
+++ b/applications/call_inspector/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/call_inspector/.circleci/config.yml
+++ b/applications/call_inspector/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/callflow/.circleci/config.yml
+++ b/applications/callflow/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/callflow/.circleci/config.yml
+++ b/applications/callflow/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/camper/.circleci/config.yml
+++ b/applications/camper/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/camper/.circleci/config.yml
+++ b/applications/camper/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/cccp/.circleci/config.yml
+++ b/applications/cccp/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/cccp/.circleci/config.yml
+++ b/applications/cccp/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/cdr/.circleci/config.yml
+++ b/applications/cdr/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/cdr/.circleci/config.yml
+++ b/applications/cdr/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/conference/.circleci/config.yml
+++ b/applications/conference/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/conference/.circleci/config.yml
+++ b/applications/conference/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/crossbar/.circleci/config.yml
+++ b/applications/crossbar/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/crossbar/.circleci/config.yml
+++ b/applications/crossbar/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/doodle/.circleci/config.yml
+++ b/applications/doodle/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/doodle/.circleci/config.yml
+++ b/applications/doodle/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/dth/.circleci/config.yml
+++ b/applications/dth/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/dth/.circleci/config.yml
+++ b/applications/dth/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/ecallmgr/.circleci/config.yml
+++ b/applications/ecallmgr/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/ecallmgr/.circleci/config.yml
+++ b/applications/ecallmgr/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/edr/.circleci/config.yml
+++ b/applications/edr/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/edr/.circleci/config.yml
+++ b/applications/edr/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/fax/.circleci/config.yml
+++ b/applications/fax/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/fax/.circleci/config.yml
+++ b/applications/fax/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/frontier/.circleci/config.yml
+++ b/applications/frontier/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/frontier/.circleci/config.yml
+++ b/applications/frontier/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/hangups/.circleci/config.yml
+++ b/applications/hangups/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/hangups/.circleci/config.yml
+++ b/applications/hangups/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/hotornot/.circleci/config.yml
+++ b/applications/hotornot/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/hotornot/.circleci/config.yml
+++ b/applications/hotornot/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/jonny5/.circleci/config.yml
+++ b/applications/jonny5/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/jonny5/.circleci/config.yml
+++ b/applications/jonny5/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/konami/.circleci/config.yml
+++ b/applications/konami/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/konami/.circleci/config.yml
+++ b/applications/konami/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/media_mgr/.circleci/config.yml
+++ b/applications/media_mgr/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/media_mgr/.circleci/config.yml
+++ b/applications/media_mgr/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/milliwatt/.circleci/config.yml
+++ b/applications/milliwatt/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/milliwatt/.circleci/config.yml
+++ b/applications/milliwatt/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/notify/.circleci/config.yml
+++ b/applications/notify/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/notify/.circleci/config.yml
+++ b/applications/notify/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/omnipresence/.circleci/config.yml
+++ b/applications/omnipresence/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/omnipresence/.circleci/config.yml
+++ b/applications/omnipresence/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/pivot/.circleci/config.yml
+++ b/applications/pivot/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/pivot/.circleci/config.yml
+++ b/applications/pivot/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/pusher/.circleci/config.yml
+++ b/applications/pusher/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/pusher/.circleci/config.yml
+++ b/applications/pusher/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/registrar/.circleci/config.yml
+++ b/applications/registrar/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/registrar/.circleci/config.yml
+++ b/applications/registrar/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/reorder/.circleci/config.yml
+++ b/applications/reorder/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/reorder/.circleci/config.yml
+++ b/applications/reorder/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/skel/.circleci/config.yml
+++ b/applications/skel/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/skel/.circleci/config.yml
+++ b/applications/skel/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/spyvsspy/.circleci/config.yml
+++ b/applications/spyvsspy/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/spyvsspy/.circleci/config.yml
+++ b/applications/spyvsspy/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/stats/.circleci/config.yml
+++ b/applications/stats/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/stats/.circleci/config.yml
+++ b/applications/stats/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/stepswitch/.circleci/config.yml
+++ b/applications/stepswitch/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/stepswitch/.circleci/config.yml
+++ b/applications/stepswitch/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/sysconf/.circleci/config.yml
+++ b/applications/sysconf/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/sysconf/.circleci/config.yml
+++ b/applications/sysconf/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/tasks/.circleci/config.yml
+++ b/applications/tasks/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/tasks/.circleci/config.yml
+++ b/applications/tasks/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/teletype/.circleci/config.yml
+++ b/applications/teletype/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/teletype/.circleci/config.yml
+++ b/applications/teletype/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/trunkstore/.circleci/config.yml
+++ b/applications/trunkstore/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/trunkstore/.circleci/config.yml
+++ b/applications/trunkstore/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/applications/webhooks/.circleci/config.yml
+++ b/applications/webhooks/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     - checkout
-    - run: ${PWD}/scripts/circleci.bash
+    - run: ${KAZOO_ROOT}/scripts/circleci.bash
     - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
     - run:
         command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh

--- a/applications/webhooks/.circleci/config.yml
+++ b/applications/webhooks/.circleci/config.yml
@@ -1,0 +1,130 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      TZ: "/usr/share/zoneinfo/UTC"
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    - image: couchdb:2.1.1
+    - image: rabbitmq:3.7
+    - image: circleci/python:3.6.1
+
+    steps:
+    - run: |
+        APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
+        APP=${APP_DASH/-/_}
+        echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
+    - run: echo -e "export KAZOO_ROOT=${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo\nexport APP_PATH=applications/${KAZOO_APP}\n\n" >> $BASH_ENV
+          # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    - checkout
+    - run: ${PWD}/scripts/circleci.bash
+    - run: echo -e "export OTP_VERSION=$(<${HOME}/${CIRCLE_PROJECT_USERNAME}/kazoo/make/erlang_version)\nexport PATH=${HOME}/.kerl/${OTP_VERSION:-19.3}/bin:${PATH}\n" >> $BASH_ENV
+    - run:
+        command: bash ${KAZOO_ROOT}/scripts/circleci-build-erlang.sh
+        no_output_timeout: 1800s
+    - run: which ag >/dev/null 2>&1 || sudo apt-get update; sudo apt-get install silversearcher-ag
+    - run: sudo pip install --upgrade pip
+    - run: sudo pip install PyYAML mkdocs pyembed-markdown jsonschema
+
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo -e "\n. ~/.kerl/${OTP_VERSION:-19.3}/activate\n" >> $BASH_ENV
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # These cache paths were specified in the 1.0 config
+        - ~/.kerl
+        - ~/.local/
+        - ~/2600hz/kazoo
+    - run: echo -e "\nexport CHANGED=${KAZOO_ROOT}/applications/${KAZOO_APP}/src/*.erl" >> $BASH_ENV
+    - run: echo $CHANGED
+    - run: pwd
+    - run: env
+    - run: ${KAZOO_ROOT}/scripts/state-of-docs.sh || true
+    - run: ${KAZOO_ROOT}/scripts/code_checks.bash ${CHANGED}
+    - run: TO_FMT="${CHANGED}" make -C ${KAZOO_ROOT} fmt
+    - run: JOBS="2" make -C ${KAZOO_ROOT}
+    - run: make -C ${KAZOO_ROOT} code_checks
+    - run: make -C ${KAZOO_ROOT} app_applications
+    - run: ${KAZOO_ROOT}/scripts/validate-js.sh ${CHANGED}
+    - run: make -C ${KAZOO_ROOT} apis
+    - run: make -C ${KAZOO_ROOT} docs || true
+    - run: make -C ${KAZOO_ROOT} validate-schemas
+    - run: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
+    - run: make -C ${KAZOO_ROOT} xref
+    - run: make -C ${KAZOO_ROOT} sup_completion
+    - run: |
+        if [[ ! -z "${CHANGED}" ]]; then
+          TO_DIALYZE="${CHANGED}" make -C ${KAZOO_ROOT} dialyze
+        fi
+    - run: make -C ${KAZOO_ROOT} elvis
+    - run: make -C ${KAZOO_ROOT} build-ci-release
+    - run: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+    - run: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
+    - run: |
+        if [[ $(grep -c -v -F 'exit with reason shutdown' ${KAZOO_ROOT}/_rel/kazoo/log/error.log) -gt 0 ]]; then
+          cat ${KAZOO_ROOT}/_rel/kazoo/log/error.log
+          exit 1
+        fi
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mkdir $CIRCLE_ARTIFACTS/logs
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: mv ${KAZOO_ROOT}/_rel/kazoo/log/* $CIRCLE_ARTIFACTS/logs/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: cp ${KAZOO_ROOT}/rel/ci.relx.config $CIRCLE_ARTIFACTS/
+    - run:
+        working_directory: $KAZOO_ROOT
+        command: find ${KAZOO_ROOT}/_rel/kazoo/releases -name kazoo.rel -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -103,6 +103,10 @@ If there are any calls to nonexistent modules, or non-exported functions, you wi
 
 Removes trailing whitespaces from files
 
+## circleci.bash
+
+When building applications that don't live in the kazoo src tree, this script will configure CircleCI to run the necessary tests against Kazoo with the application added in.
+
 ## circleci-build-erlang.sh
 
 Fetches kerl and installs configured Erlang version (used in CircleCI)

--- a/scripts/circleci.bash
+++ b/scripts/circleci.bash
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if [ ! -d $KAZOO_ROOT ]; then
+    echo Cloning kazoo into $KAZOO_ROOT
+    git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+fi
+
+cd $KAZOO_ROOT
+
+echo resetting kazoo to origin/master
+git fetch --prune
+git rebase origin/master
+
+if [ ! -d $APP_PATH ]; then
+    echo adding submodule to $KAZOO_ROOT
+    git submodule add ${CIRCLE_REPOSITORY_URL} $APP_PATH
+fi
+
+cd $APP_PATH
+
+echo checking out our commit $CIRCLE_BRANCH
+git fetch --prune
+git checkout -B $CIRCLE_BRANCH
+git reset --hard $CIRCLE_SHA1
+
+cd $KAZOO_ROOT
+
+# wanted when committing
+echo setup git config
+git config user.email 'circleci@dev.null'
+git config user.name 'CircleCI'
+
+echo committing kazoo changes to avoid false positives later
+git add .gitmodules $APP_PATH
+git commit -m "add submodule"
+
+echo cleaning up kazoo
+make -k clean


### PR DESCRIPTION
Preparing for the breakening, add the script for running apps from outside the kazoo source tree through a circleci pass