### PR TITLE
HELP-35856: use conference name as ID if ID is missing

### DIFF
--- a/applications/conference/src/conf_discovery_req.erl
+++ b/applications/conference/src/conf_discovery_req.erl
@@ -30,6 +30,7 @@ create_conference(DiscoveryReq, Call) ->
 
 -spec create_conference(kapi_conference:discovery_req(), kapps_call:call(), kz_term:api_ne_binary()) -> kapps_conference:conference().
 create_conference(DiscoveryReq, Call, 'undefined') ->
+    lager:debug("using discovery to build conference"),
     kapps_conference:set_call(Call, kapps_conference:from_json(DiscoveryReq));
 create_conference(DiscoveryReq, Call, ConferenceId) ->
     case kz_datamgr:open_cache_doc(kapps_call:account_db(Call), ConferenceId) of
@@ -44,6 +45,12 @@ create_conference(DiscoveryReq, Call, ConferenceId) ->
 
 -spec maybe_welcome_to_conference(pid(), kapps_conference:conference()) -> 'ok'.
 maybe_welcome_to_conference(Srv, Conference) ->
+    lager:debug("starting discovery process for conference ~s(~s)"
+               ,[kapps_conference:name(Conference)
+                ,kapps_conference:id(Conference)
+                ]
+               ),
+
     case kapps_conference:play_welcome(Conference) of
         'false' ->
             lager:debug("not playing welcome prompt"),

--- a/applications/ecallmgr/src/ecallmgr_fs_conferences.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_conferences.erl
@@ -330,11 +330,12 @@ handle_call({'participant_create', Props, Node}, _, State) ->
     UUID = kzd_freeswitch:conference_uuid(Props),
     _ = case ets:lookup(?CONFERENCES_TBL, UUID) of
             [#conference{account_id='undefined'}] ->
-                lager:info("failed to find account_id in conference ~s, adding", [UUID]),
+                lager:info("failed to find account_id in conference ~s, adding from participant"
+                          ,[UUID]
+                          ),
                 Conference = conference_from_props(Props, Node),
                 _ = ets:insert(?CONFERENCES_TBL, Conference);
-            [#conference{}] ->
-                'ok';
+            [#conference{}] -> 'ok';
             _Else ->
                 lager:info("failed to find participants conference ~s, adding", [UUID]),
                 Conference = conference_from_props(Props, Node),
@@ -441,7 +442,7 @@ conference_from_props(Props, Node) ->
 
 -spec conference_from_props(kz_term:proplist(), atom(), conference()) -> conference().
 conference_from_props(Props, Node, Conference) ->
-    CtrlNode = kz_term:to_atom(props:get_value(?GET_CCV(<<"Ecallmgr-Node">>), Props), 'true'),
+    CtrlNode = kz_term:to_atom(kzd_freeswitch:ccv(Props, <<"Ecallmgr-Node">>), 'true'),
     AccountId = find_account_id(Props),
 
     Conference#conference{node = Node


### PR DESCRIPTION
Prior to the dynamic conference profile work, conference names were
used when interacting with FreeSWITCH. The field used was shifted to
the 'id' in the kapps_conference record but the 'name' was not used as
a backup if id was missing when building the kapps_conference record.

What would happen is, a callflow with a dynamic conference doc in the
action (defining "name" but not "id") would get "id" set to
rand_hex(8) instead of the value of "name". Conference dial API would
put another caller in the "name" conference and an API command to put
the original caller in would fail as the rand_hex was used instead.

If "id" isn't defined, we now default to using the "name".