### PR TITLE
[4.2] HELP-36162: don't let crashes block config responses

### DIFF
--- a/applications/conference/src/conf_config_req.erl
+++ b/applications/conference/src/conf_config_req.erl
@@ -172,12 +172,16 @@ max_participants(Conference) ->
 
 -spec max_members_sound(kapps_conference:conference()) -> kz_term:api_binary().
 max_members_sound(Conference) ->
+    AccountId = kapps_conference:account_id(Conference),
     case kapps_conference:max_members_media(Conference) of
+        'undefined' when 'undefined' =:= AccountId ->
+            lager:debug("getting system max-members prompt"),
+            kz_media_util:get_prompt(?DEFAULT_MAX_MEMBERS_MEDIA);
         'undefined' ->
-            lager:debug("getting max members prompt from account"),
+            lager:debug("getting max members prompt from account ~s", [AccountId]),
             kz_media_util:get_account_prompt(?DEFAULT_MAX_MEMBERS_MEDIA
                                             ,'undefined'
-                                            ,kapps_conference:account_id(Conference)
+                                            ,AccountId
                                             );
         Media ->
             lager:debug("conference has max-members-sound: ~s", [Media]),

--- a/applications/ecallmgr/src/ecallmgr_fs_config.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_config.erl
@@ -492,7 +492,7 @@ maybe_fetch_conference_profile(Node, FetchId, Data, Profile) ->
               end,
     send_conference_profile_xml(Node, FetchId, XmlResp).
 
--spec conference_id(kz_term:api_ne_binary(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
+-spec conference_id(kzd_freeswitch:doc(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
 conference_id(Data, Profile) ->
     case props:get_first_defined([<<"Conf-Name">>, <<"conference_name">>], Data) of
         'undefined' -> conference_id_from_profile(Profile);

--- a/applications/ecallmgr/src/fs_event_filters.hrl
+++ b/applications/ecallmgr/src/fs_event_filters.hrl
@@ -70,6 +70,7 @@
         ,<<"X-AUTH-PORT">>
         ,<<"action">>
         ,<<"att_xfer_replaced_by">>
+        ,<<"conference_name">>
         ,<<"context">>
         ,<<"domain">>
         ,<<"expires">>

--- a/core/kazoo_call/src/kapps_conference.hrl
+++ b/core/kazoo_call/src/kapps_conference.hrl
@@ -39,8 +39,9 @@
                              ,{<<"interval">>, 20}
                              ,{<<"energy-level">>, 20}
                              ,{<<"comfort-noise">>, 1000}
-                             ,{<<"moh-sound">>, <<>>}
-                             ,{<<"enter-sound">>, <<>>}
+                             ,{<<"moh-sound">>, <<"silence_stream://1">>}
+                             ,{<<"enter-sound">>, <<"silence_stream://1">>}
+                             ,{<<"exit-sound">>, <<"silence_stream://1">>}
                              ]).
 
 -define(DEFAULT_CONTROLS, [kz_json:from_list([{<<"action">>, <<"mute">>},     {<<"digits">>, <<"*1">>}])


### PR DESCRIPTION
when a config handler crashes, no fetch response is sent until the
timeout (3s typically). This causes lots of issues on
FreeSWITCH (missed audio when joining a conference, for instance).

Catch exceptions and return the empty config XML quickly. Also removes
some lower-level defensive programming that can be handled at the
higher level try/catch

refactor page app building

get the profile name from fs data