### PR TITLE
[master] HELP-36162: don't let crashes block config responses

### DIFF
--- a/applications/conference/src/conf_config_req.erl
+++ b/applications/conference/src/conf_config_req.erl
@@ -173,12 +173,16 @@ max_participants(Conference) ->
 
 -spec max_members_sound(kapps_conference:conference()) -> kz_term:api_binary().
 max_members_sound(Conference) ->
+    AccountId = kapps_conference:account_id(Conference),
     case kapps_conference:max_members_media(Conference) of
+        'undefined' when 'undefined' =:= AccountId ->
+            lager:debug("getting system max-members prompt"),
+            kz_media_util:get_prompt(?DEFAULT_MAX_MEMBERS_MEDIA);
         'undefined' ->
-            lager:debug("getting max members prompt from account"),
+            lager:debug("getting max members prompt from account ~s", [AccountId]),
             kz_media_util:get_account_prompt(?DEFAULT_MAX_MEMBERS_MEDIA
                                             ,'undefined'
-                                            ,kapps_conference:account_id(Conference)
+                                            ,AccountId
                                             );
         Media ->
             lager:debug("conference has max-members-sound: ~s", [Media]),

--- a/applications/ecallmgr/src/ecallmgr_fs_config.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_config.erl
@@ -148,12 +148,22 @@ code_change(_OldVsn, State, _Extra) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_config_req(atom(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist() | 'undefined') -> fs_sendmsg_ret().
-handle_config_req(Node, FetchId, <<"acl.conf">>, _Props) ->
+handle_config_req(Node, FetchId, ConfFile, FSData) ->
     kz_util:put_callid(FetchId),
+    try process_config_req(Node, FetchId, ConfFile, FSData)
+    catch
+        _E:_R ->
+            ST = erlang:get_stacktrace(),
+            lager:info("failed to process config request for ~s: ~s: ~p", [ConfFile, _E, _R]),
+            kz_util:log_stacktrace(ST),
+            config_req_not_handled(Node, FetchId, ConfFile)
+    end.
 
+-spec process_config_req(atom(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist() | 'undefined') -> fs_sendmsg_ret().
+process_config_req(Node, FetchId, <<"acl.conf">>, _Props) ->
     SysconfResp = ecallmgr_config:fetch(<<"acls">>, kz_json:new(), ecallmgr_fs_node:fetch_timeout(Node)),
 
-    try generate_acl_xml(SysconfResp) of
+    case generate_acl_xml(SysconfResp) of
         'undefined' ->
             lager:warning("failed to query for ACLs; is sysconf running?"),
             {'ok', Resp} = ecallmgr_fs_xml:not_found(),
@@ -161,46 +171,22 @@ handle_config_req(Node, FetchId, <<"acl.conf">>, _Props) ->
         ConfigXml ->
             lager:debug("sending acl XML to ~s: ~s", [Node, ConfigXml]),
             freeswitch:fetch_reply(Node, FetchId, 'configuration', ConfigXml)
-    catch
-        _E:_R ->
-            lager:info("acl resp failed to convert to XML (~s): ~p", [_E, _R]),
-            {'ok', Resp} = ecallmgr_fs_xml:not_found(),
-            freeswitch:fetch_reply(Node, FetchId, 'configuration', iolist_to_binary(Resp))
     end;
-
-handle_config_req(Node, FetchId, <<"sofia.conf">>, _Props) ->
-    kz_util:put_callid(FetchId),
-    case ecallmgr_config:is_true(<<"sofia_conf">>) of
-        'false' ->
-            lager:info("sofia conf disabled"),
-            {'ok', Resp} = ecallmgr_fs_xml:not_found(),
-            freeswitch:fetch_reply(Node, FetchId, 'configuration', iolist_to_binary(Resp));
-        'true' ->
-            Profiles = ecallmgr_config:fetch(<<"fs_profiles">>, kz_json:new()),
-            DefaultProfiles = default_sip_profiles(Node),
-            try ecallmgr_fs_xml:sip_profiles_xml(kz_json:merge(DefaultProfiles, Profiles)) of
-                {'ok', ConfigXml} ->
-                    lager:debug("sending sofia XML to ~s: ~s", [Node, ConfigXml]),
-                    freeswitch:fetch_reply(Node, FetchId, 'configuration', erlang:iolist_to_binary(ConfigXml))
-            catch
-                _E:_R ->
-                    lager:info("sofia profile resp failed to convert to XML (~s): ~p", [_E, _R]),
-                    {'ok', Resp} = ecallmgr_fs_xml:not_found(),
-                    freeswitch:fetch_reply(Node, FetchId, 'configuration', iolist_to_binary(Resp))
-            end
-    end;
-
-handle_config_req(Node, FetchId, <<"conference.conf">>, Data) ->
-    kz_util:put_callid(FetchId),
-    fetch_conference_config(Node, FetchId, kzd_freeswitch:event_name(Data), Data);
-handle_config_req(Node, FetchId, <<"kazoo.conf">>, Data) ->
-    kz_util:put_callid(FetchId),
-    lager:debug("received configuration request for kazoo configuration ~p , ~p", [Node, FetchId]),
-    fetch_mod_kazoo_config(Node, FetchId, kzd_freeswitch:event_name(Data), Data);
-handle_config_req(Node, FetchId, Conf, Data) ->
-    kz_util:put_callid(FetchId),
-    case kazoo_bindings:map(<<"freeswitch.config.", Conf/binary>>, [Node, FetchId, Conf, Data]) of
-        [] -> config_req_not_handled(Node, FetchId, Conf);
+process_config_req(Node, Id, <<"sofia.conf">>, _Props) ->
+    'true' = ecallmgr_config:is_true(<<"sofia_conf">>),
+    Profiles = ecallmgr_config:fetch(<<"fs_profiles">>, kz_json:new()),
+    DefaultProfiles = default_sip_profiles(Node),
+    {'ok', ConfigXml} = ecallmgr_fs_xml:sip_profiles_xml(kz_json:merge(DefaultProfiles, Profiles)),
+    lager:debug("sending sofia XML to ~s: ~s", [Node, ConfigXml]),
+    freeswitch:fetch_reply(Node, Id, 'configuration', erlang:iolist_to_binary(ConfigXml));
+process_config_req(Node, Id, <<"conference.conf">>, Data) ->
+    fetch_conference_config(Node, Id, kzd_freeswitch:event_name(Data), Data);
+process_config_req(Node, Id, <<"kazoo.conf">>, Data) ->
+    lager:debug("received configuration request for kazoo configuration ~p , ~p", [Node, Id]),
+    fetch_mod_kazoo_config(Node, Id, kzd_freeswitch:event_name(Data), Data);
+process_config_req(Node, Id, Conf, Data) ->
+    case kazoo_bindings:map(<<"freeswitch.config.", Conf/binary>>, [Node, Id, Conf, Data]) of
+        [] -> config_req_not_handled(Node, Id, Conf);
         _  -> 'ok'
     end.
 
@@ -210,7 +196,7 @@ config_req_not_handled(Node, FetchId, Conf) ->
     lager:debug("ignoring conf ~s: ~s", [Conf, FetchId]),
     freeswitch:fetch_reply(Node, FetchId, 'configuration', iolist_to_binary(NotHandled)).
 
--spec generate_acl_xml(kz_term:api_object()) -> kz_term:api_binary().
+-spec generate_acl_xml(kz_term:api_object()) -> kz_term:api_ne_binary().
 generate_acl_xml('undefined') ->
     'undefined';
 generate_acl_xml(SysconfResp) ->
@@ -422,7 +408,12 @@ fetch_conference_config(Node, FetchId, <<"REQUEST_PARAMS">>, Data) ->
 
 fetch_conference_params(Node, FetchId, <<"request-controls">>, _ConfName, Data) ->
     FSName = props:get_value(<<"Controls">>, Data),
-    [KZName, Profile] = binary:split(FSName, <<"?profile=">>),
+    lager:debug("request controls for ~s", [FSName]),
+
+    {KZName, Profile} = case binary:split(FSName, <<"?profile=">>) of
+                            [N, P] -> {N, P};
+                            [N] -> {N, props:get_value(<<"profile_name">>, Data)}
+                        end,
     lager:debug("request controls:~s for profile: ~s", [KZName, Profile]),
 
     Cmd = [{<<"Request">>, <<"Controls">>}

--- a/applications/ecallmgr/src/ecallmgr_fs_config.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_config.erl
@@ -494,7 +494,7 @@ maybe_fetch_conference_profile(Node, FetchId, Data, Profile) ->
               end,
     send_conference_profile_xml(Node, FetchId, XmlResp).
 
--spec conference_id(kz_term:api_ne_binary(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
+-spec conference_id(kzd_freeswitch:doc(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
 conference_id(Data, Profile) ->
     case props:get_first_defined([<<"Conf-Name">>, <<"conference_name">>], Data) of
         'undefined' -> conference_id_from_profile(Profile);

--- a/applications/ecallmgr/src/ecallmgr_fs_config.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_config.erl
@@ -408,7 +408,6 @@ fetch_conference_config(Node, FetchId, <<"REQUEST_PARAMS">>, Data) ->
 
 fetch_conference_params(Node, FetchId, <<"request-controls">>, _ConfName, Data) ->
     FSName = props:get_value(<<"Controls">>, Data),
-    lager:debug("request controls for ~s", [FSName]),
 
     {KZName, Profile} = case binary:split(FSName, <<"?profile=">>) of
                             [N, P] -> {N, P};
@@ -419,6 +418,7 @@ fetch_conference_params(Node, FetchId, <<"request-controls">>, _ConfName, Data) 
     Cmd = [{<<"Request">>, <<"Controls">>}
           ,{<<"Profile">>, Profile}
           ,{<<"Controls">>, KZName}
+          ,{<<"Conference-ID">>, conference_id(Data, Profile)}
           ,{<<"Call-ID">>, kzd_freeswitch:call_id(Data)}
            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
           ],
@@ -467,10 +467,11 @@ maybe_fetch_conference_profile(Node, FetchId, _Data, 'undefined') ->
 maybe_fetch_conference_profile(Node, FetchId, Data, Profile) ->
     Cmd = [{<<"Request">>, <<"Conference">>}
           ,{<<"Profile">>, Profile}
-          ,{<<"Conference-ID">>, conference_id(props:get_value(<<"Conf-Name">>, Data), Profile)}
+          ,{<<"Conference-ID">>, conference_id(Data, Profile)}
            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
           ],
     lager:debug("fetching profile '~s'", [Profile]),
+
     XmlResp = case kz_amqp_worker:call(Cmd
                                       ,fun kapi_conference:publish_config_req/1
                                       ,fun kapi_conference:config_resp_v/1
@@ -494,12 +495,17 @@ maybe_fetch_conference_profile(Node, FetchId, Data, Profile) ->
     send_conference_profile_xml(Node, FetchId, XmlResp).
 
 -spec conference_id(kz_term:api_ne_binary(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
-conference_id('undefined', Profile) ->
+conference_id(Data, Profile) ->
+    case props:get_first_defined([<<"Conf-Name">>, <<"conference_name">>], Data) of
+        'undefined' -> conference_id_from_profile(Profile);
+        Id -> Id
+    end.
+
+conference_id_from_profile(Profile) ->
     case binary:split(Profile, <<"_">>) of
         [ConferenceId, _AccountId] -> ConferenceId;
         _ -> 'undefined'
-    end;
-conference_id(ConferenceId, _Profile) -> ConferenceId.
+    end.
 
 -spec send_conference_profile_xml(atom(), kz_term:ne_binary(), iolist()) -> fs_sendmsg_ret().
 send_conference_profile_xml(Node, FetchId, XmlResp) ->

--- a/applications/ecallmgr/src/fs_event_filters.hrl
+++ b/applications/ecallmgr/src/fs_event_filters.hrl
@@ -70,6 +70,7 @@
         ,<<"X-AUTH-PORT">>
         ,<<"action">>
         ,<<"att_xfer_replaced_by">>
+        ,<<"conference_name">>
         ,<<"context">>
         ,<<"domain">>
         ,<<"expires">>

--- a/core/kazoo_call/src/kapps_conference.erl
+++ b/core/kazoo_call/src/kapps_conference.erl
@@ -438,10 +438,7 @@ build_conference_profile(#kapps_conference{profile_name=?PAGE_PROFILE_NAME
                                           ,account_id='undefined'
                                           }=Conference) ->
     lager:debug("no account id for page profile ~s, using system", [?PAGE_PROFILE_NAME]),
-
-    Language = language(Conference),
-    Profile = kapps_config:get_json(?CONFERENCE_CONFIG_CAT, [<<"profiles">>, Language, ?PAGE_PROFILE_NAME], default_page_profile(Language, 'undefined')),
-    {?PAGE_PROFILE_NAME, Profile};
+    build_system_page_profile(Conference);
 build_conference_profile(#kapps_conference{profile_name=?PAGE_PROFILE_NAME
                                           ,account_id=AccountId
                                           }=Conference) ->
@@ -512,6 +509,21 @@ build_system_profile(Conference) ->
         Profile -> {ProfileName, kz_json:merge(LanguageProfile, Profile)}
     end.
 
+-spec build_system_page_profile(conference()) -> {kz_term:ne_binary(), kz_json:object()}.
+build_system_page_profile(Conference) ->
+    Language = language(Conference),
+    LanguageProfile = kapps_config:get_json(?CONFERENCE_CONFIG_CAT
+                                           ,[<<"profiles">>, Language, ?PAGE_PROFILE_NAME]
+                                           ,default_page_profile(Language, 'undefined')
+                                           ),
+    case kapps_config:get_json(?CONFERENCE_CONFIG_CAT
+                              ,[<<"profiles">>, ?PAGE_PROFILE_NAME]
+                              )
+    of
+        'undefined' -> {?PAGE_PROFILE_NAME, LanguageProfile};
+        Profile -> {?PAGE_PROFILE_NAME, kz_json:merge(LanguageProfile, Profile)}
+    end.
+
 -spec raw_profile(conference()) -> kz_term:api_object().
 raw_profile(#kapps_conference{profile=Profile}) -> Profile.
 
@@ -540,6 +552,8 @@ update_profile_language(Language, AccountId, Profile) ->
 update_prompt_language(_Yek, Key, <<>> = Value, _Language, _AccountId) ->
     {Key, Value};
 update_prompt_language(_Yek, Key, <<"tone_stream://", _/binary>> = Value, _Language, _AccountId) ->
+    {Key, Value};
+update_prompt_language(_Yek, Key, <<"silence_stream://", _/binary>> = Value, _Language, _AccountId) ->
     {Key, Value};
 update_prompt_language(_Yek, Key, <<"$${", _/binary>> = Value, _Language, _AccountId) ->
     {Key, Value};
@@ -894,7 +908,6 @@ exit_tone(#kapps_conference{account_id=AccountId}) -> ?EXIT_TONE(AccountId).
 -spec moderator_exit_tone(conference()) -> kz_term:ne_binary().
 moderator_exit_tone(#kapps_conference{account_id='undefined'}) -> ?DEFAULT_EXIT_TONE;
 moderator_exit_tone(#kapps_conference{account_id=AccountId}) -> ?MOD_EXIT_TONE(AccountId).
-
 
 -spec get_tone(any()) -> tone().
 get_tone(Thing) ->

--- a/core/kazoo_call/src/kapps_conference.hrl
+++ b/core/kazoo_call/src/kapps_conference.hrl
@@ -39,8 +39,9 @@
                              ,{<<"interval">>, 20}
                              ,{<<"energy-level">>, 20}
                              ,{<<"comfort-noise">>, 1000}
-                             ,{<<"moh-sound">>, <<>>}
-                             ,{<<"enter-sound">>, <<>>}
+                             ,{<<"moh-sound">>, <<"silence_stream://1">>}
+                             ,{<<"enter-sound">>, <<"silence_stream://1">>}
+                             ,{<<"exit-sound">>, <<"silence_stream://1">>}
                              ]).
 
 -define(DEFAULT_CONTROLS, [kz_json:from_list([{<<"action">>, <<"mute">>},     {<<"digits">>, <<"*1">>}])


### PR DESCRIPTION
when a config handler crashes, no fetch response is sent until the
timeout (3s typically). This causes lots of issues on
FreeSWITCH (missed audio when joining a conference, for instance).

Catch exceptions and return the empty config XML quickly. Also removes
some lower-level defensive programming that can be handled at the
higher level try/catch

refactor page app building

get the profile name from fs data