### PR TITLE
[master] set reason to empty json when previewing port notifications

### DIFF
--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -509,6 +509,8 @@ maybe_add_extra_data(<<"transaction">>, API) ->
     props:set_value(<<"Success">>, 'true', API);
 maybe_add_extra_data(<<"transaction_failed">>, API) ->
     props:set_value(<<"Success">>, 'false', API);
+maybe_add_extra_data(<<"port_", _/binary>>, API) ->
+    props:set_value(<<"Reason">>, kz_json:new(), API);
 maybe_add_extra_data(_Id, API) -> API.
 
 -spec publish_fun(kz_term:ne_binary()) -> fun((kz_term:api_terms()) -> 'ok').


### PR DESCRIPTION
4.2: #4757 