### PR TITLE
Fix typo in doc, 'tyre' -> 'true'

### DIFF
--- a/applications/crossbar/doc/limits.md
+++ b/applications/crossbar/doc/limits.md
@@ -125,7 +125,7 @@ curl -v -X POST \
         "id": "limits",
         "allow_prepay": true,
         "outbound_trunks": 5,
-        "accept_charges": trye
+        "accept_charges": true
     }}' \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/limits
 ```


### PR DESCRIPTION
Not much of a description necessary here. Just something silly I came across in the crossbar docs.

Cheers.