### PR TITLE
decouple cb_api_endpoints from crossbar

### DIFF
--- a/applications/crossbar/src/crossbar_types.hrl
+++ b/applications/crossbar/src/crossbar_types.hrl
@@ -1,5 +1,6 @@
 -ifndef(CROSSBAR_TYPES_INCLUDED).
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
+-include_lib("kazoo_web/include/kazoo_web.hrl").
 
 -define(CATCH_ALL, <<"_">>).
 -define(HARD_DELETE, 'false').
@@ -60,14 +61,6 @@
 -type couch_schema() :: [{couch_doc_path(), validator_rules()}].
 
 -type cb_cowboy_payload() :: {cowboy_req:req(), cb_context:context()}.
-
--define(HTTP_GET, <<"GET">>).
--define(HTTP_POST, <<"POST">>).
--define(HTTP_PUT, <<"PUT">>).
--define(HTTP_DELETE, <<"DELETE">>).
--define(HTTP_OPTIONS, <<"OPTIONS">>).
--define(HTTP_HEAD, <<"HEAD">>).
--define(HTTP_PATCH, <<"PATCH">>).
 
 -define(CSV_CONTENT_TYPES, [{<<"application">>, <<"octet-stream">>}
                            ,{<<"text">>, <<"csv">>}

--- a/core/kazoo_ast/src/cb_api_endpoints.erl
+++ b/core/kazoo_ast/src/cb_api_endpoints.erl
@@ -19,7 +19,10 @@
 -endif.
 
 -include_lib("kazoo_ast/include/kz_ast.hrl").
--include_lib("crossbar/src/crossbar.hrl").
+-include_lib("kazoo_stdlib/include/kz_types.hrl").
+-include_lib("kazoo_web/include/kazoo_web.hrl").
+-include_lib("kazoo_documents/include/kazoo_documents.hrl").
+
 -include_lib("kazoo_ast/src/kz_ast.hrl").
 
 -define(REF_PATH
@@ -600,6 +603,7 @@ process_api_ast(Module, {'raw_abstract_v1', Attributes}) ->
                    ],
     process_api_ast_functions(Module, APIFunctions).
 
+-type http_methods() :: kz_term:ne_binaries().
 -type path_with_methods() :: {iodata(), http_methods()}.
 -type paths_with_methods() :: [path_with_methods()].
 -type allowed_methods() :: {'allowed_methods', paths_with_methods()}.

--- a/core/kazoo_web/include/kazoo_web.hrl
+++ b/core/kazoo_web/include/kazoo_web.hrl
@@ -1,0 +1,12 @@
+-ifndef(KAZOO_WEB_HRL).
+
+-define(HTTP_GET, <<"GET">>).
+-define(HTTP_POST, <<"POST">>).
+-define(HTTP_PUT, <<"PUT">>).
+-define(HTTP_DELETE, <<"DELETE">>).
+-define(HTTP_OPTIONS, <<"OPTIONS">>).
+-define(HTTP_HEAD, <<"HEAD">>).
+-define(HTTP_PATCH, <<"PATCH">>).
+
+-define(KAZOO_WEB_HRL, 'true').
+-endif.


### PR DESCRIPTION
Some includes were picked up from `crossbar.hrl`. With the breakening, `crossbar` won't necessarily exist; this decouples kazoo_ast from crossbar to build properly.