### PR TITLE
[master] give more time for fix/sync account numbers

### DIFF
--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -267,8 +267,10 @@ fix_account_numbers(AccountDb = ?MATCH_ACCOUNT_ENCODED(A,B,Rest)) ->
                    ),
 
     ToRm0 = case Leftovers =:= [] of
-                'true' -> []; %% Only if there is no number_dbs, plists would return empty list
-                              %% regardless of initAcc value. See `plists:fuse/2'.
+                'true' ->
+                    %% Only if there is no number_dbs, plists would return empty list
+                    %% regardless of initAcc value. See `plists:fuse/2'.
+                    [];
                 'false' -> gb_sets:to_list(Leftovers)
             end,
     lists:foreach(fun (_DID) -> log_alien(AccountDb, _DID) end, ToRm0),

--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -243,14 +243,12 @@ fix_account_numbers(AccountDb = ?MATCH_ACCOUNT_ENCODED(A,B,Rest)) ->
     put(trunkstore_DIDs, get_DIDs_trunkstore(AccountDb)),
     AccountId = ?MATCH_ACCOUNT_RAW(A, B, Rest),
 
-    ?DEV_LOG("~nHESAAM: ~p self ~p~n", [erlang:system_info(schedulers), self()]),
     Malt = [1
-           ,{processes, schedulers}
+           ,{processes, ?PARALLEL_JOBS_COUNT}
            ],
     Leftovers =
         plists:fold(fun (NumberDb, Leftovers) ->
                             Fixer = fun (DID) -> fix_docs(AccountDb, NumberDb, DID) end,
-                            ?DEV_LOG("~nHESAAM: Leftovers pid ~p~n", [self()]),
                             ?SUP_LOG_DEBUG("[~s] getting numbers from ~s", [AccountDb, NumberDb]),
                             AuthoritativePNs = get_DIDs_assigned_to(NumberDb, AccountId),
                             ?SUP_LOG_DEBUG("[~s] start fixing ~s", [AccountDb, NumberDb]),

--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -243,12 +243,14 @@ fix_account_numbers(AccountDb = ?MATCH_ACCOUNT_ENCODED(A,B,Rest)) ->
     put(trunkstore_DIDs, get_DIDs_trunkstore(AccountDb)),
     AccountId = ?MATCH_ACCOUNT_RAW(A, B, Rest),
 
+    ?DEV_LOG("~nHESAAM: ~p self ~p~n", [erlang:system_info(schedulers), self()]),
     Malt = [1
            ,{processes, schedulers}
            ],
     Leftovers =
         plists:fold(fun (NumberDb, Leftovers) ->
                             Fixer = fun (DID) -> fix_docs(AccountDb, NumberDb, DID) end,
+                            ?DEV_LOG("~nHESAAM: Leftovers pid ~p~n", [self()]),
                             ?SUP_LOG_DEBUG("[~s] getting numbers from ~s", [AccountDb, NumberDb]),
                             AuthoritativePNs = get_DIDs_assigned_to(NumberDb, AccountId),
                             ?SUP_LOG_DEBUG("[~s] start fixing ~s", [AccountDb, NumberDb]),

--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -244,7 +244,7 @@ fix_account_numbers(AccountDb = ?MATCH_ACCOUNT_ENCODED(A,B,Rest)) ->
     AccountId = ?MATCH_ACCOUNT_RAW(A, B, Rest),
 
     Malt = [1
-           ,{processes, ?PARALLEL_JOBS_COUNT}
+           ,{processes, schedulers}
            ],
     Leftovers =
         plists:fold(fun (NumberDb, Leftovers) ->
@@ -266,7 +266,11 @@ fix_account_numbers(AccountDb = ?MATCH_ACCOUNT_ENCODED(A,B,Rest)) ->
                    ,Malt
                    ),
 
-    ToRm0 = gb_sets:to_list(Leftovers),
+    ToRm0 = case Leftovers =:= [] of
+                'true' -> []; %% Only if there is no number_dbs, plists would return empty list
+                              %% regardless of initAcc value. See `plists:fuse/2'.
+                'false' -> gb_sets:to_list(Leftovers)
+            end,
     lists:foreach(fun (_DID) -> log_alien(AccountDb, _DID) end, ToRm0),
     ToRm = [DID
             || DID <- ToRm0,

--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -242,8 +242,12 @@ fix_account_numbers(AccountDb = ?MATCH_ACCOUNT_ENCODED(A,B,Rest)) ->
     put(callflow_DIDs, get_DIDs_callflow(AccountDb)),
     put(trunkstore_DIDs, get_DIDs_trunkstore(AccountDb)),
     AccountId = ?MATCH_ACCOUNT_RAW(A, B, Rest),
+
+    Malt = [1
+           ,{processes, schedulers}
+           ],
     Leftovers =
-        lists:foldl(fun (NumberDb, Leftovers) ->
+        plists:fold(fun (NumberDb, Leftovers) ->
                             Fixer = fun (DID) -> fix_docs(AccountDb, NumberDb, DID) end,
                             ?SUP_LOG_DEBUG("[~s] getting numbers from ~s", [AccountDb, NumberDb]),
                             AuthoritativePNs = get_DIDs_assigned_to(NumberDb, AccountId),
@@ -253,12 +257,15 @@ fix_account_numbers(AccountDb = ?MATCH_ACCOUNT_ENCODED(A,B,Rest)) ->
                                                     ,gb_sets:to_list(AuthoritativePNs)
                                                     ),
                             ?SUP_LOG_DEBUG("[~s] done fixing ~s", [AccountDb, NumberDb]),
-                            timer:sleep(?TIME_BETWEEN_ACCOUNTS_MS),
+                            %% timer:sleep(?TIME_BETWEEN_ACCOUNTS_MS),
                             gb_sets:subtract(Leftovers, AuthoritativePNs)
                     end
+                   ,fun (Set1, Set2) -> gb_sets:union(Set1, Set2) end
                    ,DisplayPNs
                    ,knm_util:get_all_number_dbs()
+                   ,Malt
                    ),
+
     ToRm0 = gb_sets:to_list(Leftovers),
     lists:foreach(fun (_DID) -> log_alien(AccountDb, _DID) end, ToRm0),
     ToRm = [DID

--- a/scripts/dev/kazoo.sh
+++ b/scripts/dev/kazoo.sh
@@ -36,7 +36,8 @@ else
 fi
 echo "Kazoo config file path: $KAZOO_CONFIG"
 
-NODE_NAME=${NODE_NAME:-"kazoo_apps"}
+KAZOO_NODE=${KAZOO_NODE:-"kazoo_apps"}
+NODE_NAME=${NODE_NAME:-"$KAZOO_NODE"}
 echo "Node name: $NODE_NAME"
 
 COOKIE=${COOKIE:-"change_me"}


### PR DESCRIPTION
Also removes the timer between accounts, since most of the time the account doesn't have any numbers in the current processing number db., it's just wasting too much time.


~DO NOT MERGE THIS YET!~

4.2: #4801 