### PR TITLE
[4.2] - rest terminate fix-up #4827

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -9,7 +9,7 @@
 -module(api_resource).
 
 -export([init/2, rest_init/2
-        ,terminate/2, rest_terminate/2
+        ,terminate/3
         ,known_methods/2
         ,allowed_methods/2
         ,malformed_request/2
@@ -241,17 +241,16 @@ find_path(Req, Opts) ->
             Magic
     end.
 
--spec terminate(cowboy_req:req(), cb_context:context()) -> 'ok'.
-terminate(_Req, _Context) ->
-    lager:debug("session finished").
-
--spec rest_terminate(cowboy_req:req(), cb_context:context()) -> 'ok'.
-rest_terminate(Req, Context) ->
+-spec terminate(any(), cowboy_req:req(), cb_context:context()) -> 'ok'.
+terminate(_Reason, Req, Context) ->
+    lager:debug("session finished: ~p", [_Reason]),
     rest_terminate(Req, Context, cb_context:method(Context)).
 
+-spec rest_terminate(cowboy_req:req(), cb_context:context(), http_method()) -> 'ok'.
 rest_terminate(Req, Context, ?HTTP_OPTIONS) ->
     lager:info("OPTIONS request fulfilled in ~p ms"
-              ,[kz_time:elapsed_ms(cb_context:start(Context))]),
+              ,[kz_time:elapsed_ms(cb_context:start(Context))]
+              ),
     _ = api_util:finish_request(Req, Context),
     'ok';
 rest_terminate(Req, Context, Verb) ->


### PR DESCRIPTION
Revert "Update terminate/2 and rest_terminate/3 callbacks to terminate/3 after cowboy 2.2 update"

This reverts commit 3fa5bd5d8d9654fb629969d97c6138f17ea8ca0c.

Remove legacy cowboy terminate/2 callback and add expected terminate/3 for updated cowboy dep.

add specs

(cherry picked from commit 39413fef82e2dd805ab2fce584de4214f2a61710)