### PR TITLE
HELP-37054-4.2: always publish usurp; conditionally publish route_win

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_call_control.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_control.erl
@@ -253,11 +253,6 @@ handle_cast({'event_execute_complete', _, _, _}, State) ->
     {'noreply', State};
 handle_cast({'gen_listener', {'created_queue', Q}}, State) ->
     {'noreply', State#state{control_q=Q}};
-handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}
-           ,#state{controller_q='undefined'}=State
-           ) ->
-    lager:debug("call control got is_consuming but controller is undefined"),
-    {'noreply', State};
 handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
     call_control_ready(State),
     {'noreply', State};
@@ -363,9 +358,9 @@ handle_conference_command(JObj) ->
 -spec handle_call_events(kz_json:object(), kz_term:ne_binary()) -> 'ok'.
 handle_call_events(JObj, FetchId) ->
     kz_util:put_callid(kz_json:get_value(<<"Call-ID">>, JObj)),
-    case kz_json:get_value(<<"Event-Name">>, JObj) of
+    case kz_api:event_name(JObj) of
         <<"usurp_control">> ->
-            case kz_json:get_value(<<"Fetch-ID">>, JObj) =:= FetchId of
+            case kz_json:get_ne_binary_value(<<"Fetch-ID">>, JObj) =:= FetchId of
                 'false' -> gen_listener:cast(self(), {'usurp_control', JObj});
                 'true' -> 'ok'
             end;
@@ -415,13 +410,34 @@ call_control_ready(#state{call_id=CallId
     call_control_ready(IsAlive, State).
 
 -spec call_control_ready(boolean(), state()) -> 'ok'.
-call_control_ready('true', #state{call_id=CallId
-                                 ,controller_q=ControllerQ
-                                 ,control_q=Q
-                                 ,initial_ccvs=CCVs
-                                 ,fetch_id=FetchId
-                                 ,node=Node
-                                 }) ->
+call_control_ready('true', #state{controller_q=ControllerQ}=State) ->
+    'undefined' =/= ControllerQ
+        andalso publish_route_win(State),
+    publish_usurp(State);
+call_control_ready('false', _) ->
+    lager:info("call is not in the channels cache, short lived call?"),
+    gen_listener:cast(self(), 'stop').
+
+-spec publish_usurp(state()) -> 'ok'.
+publish_usurp(#state{call_id=CallId
+                    ,fetch_id=FetchId
+                    ,node=Node
+                    }) ->
+    Usurp = [{<<"Call-ID">>, CallId}
+            ,{<<"Fetch-ID">>, FetchId}
+            ,{<<"Reason">>, <<"Route-Win">>}
+            ,{<<"Media-Node">>, kz_term:to_binary(Node)}
+             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+            ],
+    lager:debug("sending control usurp for ~s(~s)", [FetchId, CallId]),
+    kapi_call:publish_usurp_control(CallId, Usurp).
+
+-spec publish_route_win(state()) -> 'ok'.
+publish_route_win(#state{call_id=CallId
+                        ,controller_q=ControllerQ
+                        ,control_q=Q
+                        ,initial_ccvs=CCVs
+                        }) ->
     Win = [{<<"Msg-ID">>, CallId}
           ,{<<"Call-ID">>, CallId}
           ,{<<"Control-Queue">>, Q}
@@ -429,18 +445,7 @@ call_control_ready('true', #state{call_id=CallId
            | kz_api:default_headers(Q, <<"dialplan">>, <<"route_win">>, ?APP_NAME, ?APP_VERSION)
           ],
     lager:debug("sending route_win to ~s", [ControllerQ]),
-    kapi_route:publish_win(ControllerQ, Win),
-    Usurp = [{<<"Call-ID">>, CallId}
-            ,{<<"Fetch-ID">>, FetchId}
-            ,{<<"Reason">>, <<"Route-Win">>}
-            ,{<<"Media-Node">>, kz_term:to_binary(Node)}
-             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
-            ],
-    lager:debug("sending control usurp for ~s", [FetchId]),
-    kapi_call:publish_usurp_control(CallId, Usurp);
-call_control_ready('false', _) ->
-    lager:info("call is not in the channels cache, short lived call?"),
-    gen_listener:cast(self(), 'stop').
+    kapi_route:publish_win(ControllerQ, Win).
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/applications/ecallmgr/src/ecallmgr_fs_channel.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channel.erl
@@ -725,8 +725,9 @@ other_leg_handling_locally(OtherLeg) ->
 
 -spec handling_locally(kz_term:proplist(), kz_term:api_binary()) -> boolean().
 handling_locally(Props, 'undefined') ->
-    props:get_value(?GET_CCV(<<"Ecallmgr-Node">>), Props)
-        =:= kz_term:to_binary(node());
+    ChannelEcallmgr = props:get_value(?GET_CCV(<<"Ecallmgr-Node">>), Props),
+    lager:debug("channel has ecallmgr ~s", [ChannelEcallmgr]),
+    ChannelEcallmgr =:= kz_term:to_binary(node());
 handling_locally(Props, OtherLeg) ->
     Node = kz_term:to_binary(node()),
     case props:get_value(?GET_CCV(<<"Ecallmgr-Node">>), Props) of

--- a/applications/ecallmgr/src/ecallmgr_fs_conferences_shared.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_conferences_shared.erl
@@ -236,6 +236,7 @@ exec_loopback(Loopback, {ConferenceNode, ConferenceId, JObj, Resps}) ->
         end,
     Endpoint = kz_json:set_values([{<<"Outbound-Call-ID">>, LoopbackId}
                                   ,{[<<"Custom-Channel-Vars">>, <<"Outbound-Call-ID">>], OutboundId}
+                                  ,{[<<"Custom-Channel-Vars">>, <<"Fetch-ID">>], kz_api:msg_id(JObj)}
                                   ]
                                  ,Loopback
                                  ),


### PR DESCRIPTION
When using conference dial and DIDs, the loopback will cause a
dialplan fetch request to come back around into Kazoo. With multiple
ecallmgrs connected, it is possible that the control process will be
on a separate VM from the conference dial process.

The conference dial code must start a control process on the
initiating node to supply the conference participant process with an
AMQP control queue. Since there's no route_win to publish as well (no
controller queue), this commit conditionally publishes the route_win
if the controller queue is defined but opts to always publish the
usurp (which should teardown the control process started by the
loopback).

log the ecallmgr node

use kz_api

try to set fetch-id on the originate