### PR TITLE
HELP-37054: always publish usurp; conditionally publish route_win

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_channel.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channel.erl
@@ -725,8 +725,9 @@ other_leg_handling_locally(OtherLeg) ->
 
 -spec handling_locally(kz_term:proplist(), kz_term:api_binary()) -> boolean().
 handling_locally(Props, 'undefined') ->
-    props:get_value(?GET_CCV(<<"Ecallmgr-Node">>), Props)
-        =:= kz_term:to_binary(node());
+    ChannelEcallmgr = props:get_value(?GET_CCV(<<"Ecallmgr-Node">>), Props),
+    lager:debug("channel has ecallmgr ~s", [ChannelEcallmgr]),
+    ChannelEcallmgr =:= kz_term:to_binary(node());
 handling_locally(Props, OtherLeg) ->
     Node = kz_term:to_binary(node()),
     case props:get_value(?GET_CCV(<<"Ecallmgr-Node">>), Props) of

--- a/applications/ecallmgr/src/ecallmgr_fs_conferences_shared.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_conferences_shared.erl
@@ -236,6 +236,7 @@ exec_loopback(Loopback, {ConferenceNode, ConferenceId, JObj, Resps}) ->
         end,
     Endpoint = kz_json:set_values([{<<"Outbound-Call-ID">>, LoopbackId}
                                   ,{[<<"Custom-Channel-Vars">>, <<"Outbound-Call-ID">>], OutboundId}
+                                  ,{[<<"Custom-Channel-Vars">>, <<"Fetch-ID">>], kz_api:msg_id(JObj)}
                                   ]
                                  ,Loopback
                                  ),


### PR DESCRIPTION
When using conference dial and DIDs, the loopback will cause a
dialplan fetch request to come back around into Kazoo. With multiple
ecallmgrs connected, it is possible that the control process will be
on a separate VM from the conference dial process.

The conference dial code must start a control process on the
initiating node to supply the conference participant process with an
AMQP control queue. Since there's no route_win to publish as well (no
controller queue), this commit conditionally publishes the route_win
if the controller queue is defined but opts to always publish the
usurp (which should teardown the control process started by the
loopback).

log the ecallmgr node

use kz_api

try to set fetch-id on the originate