### PR TITLE
[4.2] Kazoo-5901: Fixed faxbox email address comparison failing due to upp…

### DIFF
--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -474,7 +474,7 @@ check_permissions(#state{from=From
                         ,errors=Errors
                         }=State, Permissions) ->
     case lists:any(fun(A) -> match(From, A) end, Permissions)
-        orelse From =:= OwnerEmail
+        orelse From =:= kz_term:to_lower_binary(OwnerEmail)
     of
         'true' -> add_fax_document(State);
         'false' ->


### PR DESCRIPTION
…ercase chars in user email address