### PR TITLE
HELP-37054-4.2: address ownership of conference dial channels

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_call_control.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_control.erl
@@ -54,6 +54,7 @@
 -export([other_legs/1
         ,update_node/2
         ,control_procs/1
+        ,publish_usurp/3
         ]).
 -export([fs_nodeup/2]).
 -export([fs_nodedown/2]).
@@ -79,17 +80,17 @@
 -record(state, {node :: atom()
                ,call_id :: kz_term:ne_binary()
                ,command_q = queue:new() :: queue:queue()
-               ,current_app :: kz_term:api_binary()
+               ,current_app :: kz_term:api_ne_binary()
                ,current_cmd :: kz_term:api_object()
                ,start_time = os:timestamp() :: kz_time:now()
                ,is_call_up = 'true' :: boolean()
                ,is_node_up = 'true' :: boolean()
                ,keep_alive_ref :: kz_term:api_reference()
                ,other_legs = [] :: kz_term:ne_binaries()
-               ,last_removed_leg :: kz_term:api_binary()
+               ,last_removed_leg :: kz_term:api_ne_binary()
                ,sanity_check_tref :: kz_term:api_reference()
-               ,msg_id :: kz_term:api_binary()
-               ,fetch_id :: kz_term:api_binary()
+               ,msg_id :: kz_term:api_ne_binary()
+               ,fetch_id :: kz_term:api_ne_binary()
                ,controller_q :: kz_term:api_ne_binary()
                ,control_q :: kz_term:api_ne_binary()
                ,initial_ccvs :: kz_json:object()
@@ -360,9 +361,9 @@ handle_call_events(JObj, FetchId) ->
     kz_util:put_callid(kz_json:get_value(<<"Call-ID">>, JObj)),
     case kz_api:event_name(JObj) of
         <<"usurp_control">> ->
-            case kz_json:get_ne_binary_value(<<"Fetch-ID">>, JObj) =:= FetchId of
-                'false' -> gen_listener:cast(self(), {'usurp_control', JObj});
-                'true' -> 'ok'
+            case kz_json:get_ne_binary_value(<<"Fetch-ID">>, JObj) =/= FetchId of
+                'true' -> gen_listener:cast(self(), {'usurp_control', JObj});
+                'false' -> 'ok'
             end;
         _Else -> 'ok'
     end.
@@ -423,13 +424,17 @@ publish_usurp(#state{call_id=CallId
                     ,fetch_id=FetchId
                     ,node=Node
                     }) ->
+    publish_usurp(CallId, FetchId, Node).
+
+-spec publish_usurp(kz_term:ne_binary(), kz_term:ne_binary(), atom()) -> 'ok'.
+publish_usurp(CallId, FetchId, Node) ->
     Usurp = [{<<"Call-ID">>, CallId}
             ,{<<"Fetch-ID">>, FetchId}
             ,{<<"Reason">>, <<"Route-Win">>}
             ,{<<"Media-Node">>, kz_term:to_binary(Node)}
              | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
             ],
-    lager:debug("sending control usurp for ~s(~s)", [FetchId, CallId]),
+    lager:debug("sending control usurp for fetch-id ~s(~s)", [FetchId, CallId]),
     kapi_call:publish_usurp_control(CallId, Usurp).
 
 -spec publish_route_win(state()) -> 'ok'.

--- a/applications/ecallmgr/src/ecallmgr_fs_channel.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channel.erl
@@ -602,6 +602,7 @@ process_specific_event(<<"CHANNEL_CREATE">>, UUID, Props, Node) ->
         =:= kz_term:to_binary(node())
     of
         'true' ->
+            lager:debug("we are the controlling ecallmgr, trying to authorize"),
             case ecallmgr_fs_authz:authorize(Props, UUID, Node) of
                 {'true', CCVs} ->
                     ecallmgr_fs_command:set(Node, UUID, kz_json:to_proplist(CCVs));
@@ -638,8 +639,7 @@ process_specific_event(<<"CHANNEL_UNBRIDGE">>, UUID, Props, _) ->
     OtherLeg = get_other_leg(UUID, Props),
     ecallmgr_fs_channels:update(UUID, #channel.other_leg, 'undefined'),
     ecallmgr_fs_channels:update(OtherLeg, #channel.other_leg, 'undefined');
-process_specific_event(_EventName, _UUID, _Props, _Node) ->
-    'ok'.
+process_specific_event(_EventName, _UUID, _Props, _Node) -> 'ok'.
 
 -spec maybe_publish_channel_state(kz_term:proplist(), atom()) -> 'ok'.
 maybe_publish_channel_state(Props, Node) ->
@@ -726,13 +726,17 @@ other_leg_handling_locally(OtherLeg) ->
 -spec handling_locally(kz_term:proplist(), kz_term:api_binary()) -> boolean().
 handling_locally(Props, 'undefined') ->
     ChannelEcallmgr = props:get_value(?GET_CCV(<<"Ecallmgr-Node">>), Props),
-    lager:debug("channel has ecallmgr ~s", [ChannelEcallmgr]),
+    lager:debug("channel has ecallmgr ~s (we are ~s)", [ChannelEcallmgr, node()]),
     ChannelEcallmgr =:= kz_term:to_binary(node());
 handling_locally(Props, OtherLeg) ->
     Node = kz_term:to_binary(node()),
     case props:get_value(?GET_CCV(<<"Ecallmgr-Node">>), Props) of
         Node -> 'true';
-        _ -> other_leg_handling_locally(OtherLeg)
+        _OtherNode ->
+            lager:debug("ccv has ecallmgr ~s (we are ~s), checking other leg ~s"
+                       ,[_OtherNode, node(), OtherLeg]
+                       ),
+            other_leg_handling_locally(OtherLeg)
     end.
 
 -spec get_username(kz_term:proplist()) -> kz_term:api_binary().
@@ -766,37 +770,37 @@ props_to_update(Props) ->
     CAVs = ecallmgr_util:custom_application_vars(Props),
 
     props:filter_undefined(
-      [{#channel.destination, props:get_value(<<"Caller-Destination-Number">>, Props)}
-      ,{#channel.direction, kzd_freeswitch:call_direction(Props)}
+      [{#channel.account_billing, props:get_value(<<"Account-Billing">>, CCVs)}
       ,{#channel.account_id, props:get_value(<<"Account-ID">>, CCVs)}
-      ,{#channel.account_billing, props:get_value(<<"Account-Billing">>, CCVs)}
+      ,{#channel.answered, props:get_value(<<"Answer-State">>, Props) =:= <<"answered">>}
       ,{#channel.authorizing_id, props:get_value(<<"Authorizing-ID">>, CCVs)}
       ,{#channel.authorizing_type, props:get_value(<<"Authorizing-Type">>, CCVs)}
-      ,{#channel.is_authorized, props:get_value(?GET_CCV(<<"Channel-Authorized">>), Props)}
-      ,{#channel.owner_id, props:get_value(<<"Owner-ID">>, CCVs)}
-      ,{#channel.resource_id, props:get_value(<<"Resource-ID">>, CCVs)}
-      ,{#channel.presence_id, props:get_value(<<"Channel-Presence-ID">>, CCVs
-                                             ,props:get_value(<<"variable_presence_id">>, Props))}
-      ,{#channel.fetch_id, props:get_value(<<"Fetch-ID">>, CCVs)}
       ,{#channel.bridge_id, props:get_value(<<"Bridge-ID">>, CCVs, UUID)}
-      ,{#channel.reseller_id, props:get_value(<<"Reseller-ID">>, CCVs)}
-      ,{#channel.reseller_billing, props:get_value(<<"Reseller-Billing">>, CCVs)}
-      ,{#channel.precedence, kz_term:to_integer(props:get_value(<<"Precedence">>, CCVs, 5))}
-      ,{#channel.realm, props:get_value(<<"Realm">>, CCVs, get_realm(Props))}
-      ,{#channel.username, props:get_value(<<"Username">>, CCVs, get_username(Props))}
-      ,{#channel.import_moh, props:get_value(<<"variable_hold_music">>, Props) =:= 'undefined'}
-      ,{#channel.answered, props:get_value(<<"Answer-State">>, Props) =:= <<"answered">>}
-      ,{#channel.profile, props:get_value(<<"variable_sofia_profile_name">>, Props)}
+      ,{#channel.callflow_id, props:get_value(<<"CallFlow-ID">>, CCVs)}
+      ,{#channel.cavs, CAVs}
       ,{#channel.context, props:get_value(<<"Caller-Context">>, Props)}
+      ,{#channel.destination, props:get_value(<<"Caller-Destination-Number">>, Props)}
       ,{#channel.dialplan, props:get_value(<<"Caller-Dialplan">>, Props)}
-      ,{#channel.to_tag, props:get_value(<<"variable_sip_to_tag">>, Props)}
+      ,{#channel.direction, kzd_freeswitch:call_direction(Props)}
+      ,{#channel.fetch_id, props:get_value(<<"Fetch-ID">>, CCVs)}
       ,{#channel.from_tag, props:get_value(<<"variable_sip_from_tag">>, Props)}
+      ,{#channel.handling_locally, handling_locally(Props, 'undefined')}
+      ,{#channel.import_moh, props:get_value(<<"variable_hold_music">>, Props) =:= 'undefined'}
       ,{#channel.interaction_id, props:get_value(<<?CALL_INTERACTION_ID>>, CCVs)}
+      ,{#channel.is_authorized, props:get_value(?GET_CCV(<<"Channel-Authorized">>), Props)}
       ,{#channel.is_loopback, kzd_freeswitch:is_loopback(Props)}
       ,{#channel.loopback_leg_name, kzd_freeswitch:loopback_leg_name(Props)}
       ,{#channel.loopback_other_leg, kzd_freeswitch:loopback_other_leg(Props)}
-      ,{#channel.callflow_id, props:get_value(<<"CallFlow-ID">>, CCVs)}
-      ,{#channel.cavs, CAVs}
+      ,{#channel.owner_id, props:get_value(<<"Owner-ID">>, CCVs)}
+      ,{#channel.precedence, kz_term:to_integer(props:get_value(<<"Precedence">>, CCVs, 5))}
+      ,{#channel.presence_id, props:get_value(<<"Channel-Presence-ID">>, CCVs, props:get_value(<<"variable_presence_id">>, Props))}
+      ,{#channel.profile, props:get_value(<<"variable_sofia_profile_name">>, Props)}
+      ,{#channel.realm, props:get_value(<<"Realm">>, CCVs, get_realm(Props))}
+      ,{#channel.reseller_billing, props:get_value(<<"Reseller-Billing">>, CCVs)}
+      ,{#channel.reseller_id, props:get_value(<<"Reseller-ID">>, CCVs)}
+      ,{#channel.resource_id, props:get_value(<<"Resource-ID">>, CCVs)}
+      ,{#channel.to_tag, props:get_value(<<"variable_sip_to_tag">>, Props)}
+      ,{#channel.username, props:get_value(<<"Username">>, CCVs, get_username(Props))}
        | update_callee(UUID, Props)
       ]).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_conferences_shared.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_conferences_shared.erl
@@ -236,7 +236,6 @@ exec_loopback(Loopback, {ConferenceNode, ConferenceId, JObj, Resps}) ->
         end,
     Endpoint = kz_json:set_values([{<<"Outbound-Call-ID">>, LoopbackId}
                                   ,{[<<"Custom-Channel-Vars">>, <<"Outbound-Call-ID">>], OutboundId}
-                                  ,{[<<"Custom-Channel-Vars">>, <<"Fetch-ID">>], kz_api:msg_id(JObj)}
                                   ]
                                  ,Loopback
                                  ),
@@ -275,17 +274,33 @@ handle_response(ConferenceNode, JObj, {LoopbackCallId, {'ok', Resp}}) ->
     BuiltResp = handle_call_startup(ConferenceNode, JObj, LoopbackCallId, Resp),
     props:insert_value(<<"Call-ID">>, LoopbackCallId, BuiltResp).
 
+-record(outbound_dial, {loopback_a :: kz_term:ne_binary()
+                       ,loopback_b :: kz_term:api_ne_binary()
+                       ,b_leg :: kz_term:api_ne_binary()
+                       ,dial_resp :: kz_term:api_ne_binary()
+                       ,channel_props = [] :: kz_term:proplist()
+                       }
+       ).
+-type outbound_dial() :: #outbound_dial{}.
+
 -spec handle_call_startup(atom(), kapi_conference:doc(), kz_term:ne_binary(), kz_term:proplist()) ->
                                  kz_term:proplist().
 handle_call_startup(ConferenceNode, JObj, LoopbackCallId, Resp) ->
-    case wait_for_bowout(LoopbackCallId
-                        ,'undefined'
+    case wait_for_bowout(#outbound_dial{loopback_a=LoopbackCallId}
                         ,kz_json:get_integer_value(<<"Timeout">>, JObj) * ?MILLISECONDS_IN_SECOND
                         )
     of
-        {'ok', CallId, DialResp, ChannelProps} ->
+        {'ok', #outbound_dial{b_leg=CallId
+                             ,dial_resp=DialResp
+                             ,channel_props=ChannelProps
+                             }=OutboundDial
+        }->
             lager:debug("finished waiting for ~s, now ~s", [LoopbackCallId, CallId]),
-            add_participant(JObj, CallId, start_call_handlers(ConferenceNode, JObj, CallId), ChannelProps),
+            add_participant(JObj
+                           ,CallId
+                           ,start_call_handlers(ConferenceNode, JObj, OutboundDial)
+                           ,ChannelProps
+                           ),
             props:set_values([{<<"Message">>, DialResp}
                              ,{<<"Call-ID">>, CallId}
                              ]
@@ -303,86 +318,125 @@ handle_call_startup(ConferenceNode, JObj, LoopbackCallId, Resp) ->
                             )
     end.
 
--spec wait_for_bowout(kz_term:ne_binary(), kz_term:api_ne_binary(), pos_integer()) ->
-                             {'ok', kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()} |
-                             {'error', 'timeout'} |
-                             {'error', kz_term:ne_binary(), kz_term:ne_binary()}.
-wait_for_bowout(LoopbackALeg, LoopbackBLeg, Timeout) ->
-    wait_for_bowout(LoopbackALeg, LoopbackBLeg, Timeout, []).
+-type bowout_return() :: {'ok', outbound_dial()} |
+                         {'error', 'timeout'} |
+                         {'error', kz_term:ne_binary(), kz_term:ne_binary()}.
 
--spec wait_for_bowout(kz_term:ne_binary(), kz_term:api_ne_binary(), pos_integer(), kz_term:proplist()) ->
-                             {'ok', kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()} |
-                             {'error', 'timeout'} |
-                             {'error', kz_term:ne_binary(), kz_term:ne_binary()}.
-wait_for_bowout(LoopbackALeg, LoopbackBLeg, Timeout, ChannelProps) ->
+-spec wait_for_bowout(outbound_dial(), pos_integer()) -> bowout_return().
+wait_for_bowout(#outbound_dial{loopback_a=LoopbackALeg
+                              ,loopback_b=LoopbackBLeg
+                              }=OutboundDial
+               ,Timeout) ->
     Start = kz_time:now_s(),
     receive
         {'event', [LoopbackALeg | Props]} ->
-            handle_event(LoopbackALeg, LoopbackBLeg, Timeout, ChannelProps, Start, Props);
+            handle_call_event(OutboundDial, Timeout, Start, Props);
         {'event', [LoopbackBLeg | Props]} ->
-            handle_event(LoopbackALeg, LoopbackBLeg, Timeout, ChannelProps, Start, Props);
+            handle_call_event(OutboundDial, Timeout, Start, Props);
         ?LOOPBACK_BOWOUT_MSG(_Node, Props) when is_list(Props) ->
-            handle_bowout(LoopbackALeg, LoopbackBLeg, Timeout, ChannelProps, Start, Props)
+            handle_bowout(OutboundDial, Timeout, Start, Props)
     after Timeout ->
             lager:info("timed out waiting for ~s", [LoopbackALeg]),
             {'error', 'timeout'}
     end.
 
-handle_event(LoopbackALeg, LoopbackBLeg, Timeout, ChannelProps, Start, Props) ->
+-spec handle_call_event(outbound_dial(), pos_integer(), pos_integer(), kz_term:proplist()) ->
+                               bowout_return().
+handle_call_event(#outbound_dial{loopback_a=LoopbackALeg
+                                ,loopback_b=LoopbackBLeg
+                                }=OutboundDial
+                 ,Timeout, Start, Props
+                 ) ->
     case {kzd_freeswitch:call_id(Props)
          ,kzd_freeswitch:event_name(Props)
          }
     of
         {LoopbackALeg, <<"CHANNEL_DESTROY">>} ->
-            handle_loopback_destroy(LoopbackALeg, kzd_freeswitch:hangup_cause(Props));
+            handle_loopback_destroy(OutboundDial, kzd_freeswitch:hangup_cause(Props));
         {LoopbackBLeg, <<"CHANNEL_DESTROY">>} ->
-            handle_loopback_destroy(LoopbackBLeg, kzd_freeswitch:hangup_cause(Props));
+            handle_loopback_destroy(OutboundDial, kzd_freeswitch:hangup_cause(Props));
         {LoopbackALeg, <<"CHANNEL_CREATE">>} ->
-            handle_create(LoopbackALeg, Timeout, ChannelProps, Start, Props);
+            handle_create(OutboundDial, Timeout, Start, Props);
         {_CallId, _Evt} ->
-            wait_for_bowout(LoopbackALeg, LoopbackBLeg, kz_time:decr_timeout(Timeout, Start), ChannelProps)
+            wait_for_bowout(OutboundDial, kz_time:decr_timeout(Timeout, Start))
     end.
 
-handle_create(<<?LB_ALEG_PREFIX, _/binary>>=LoopbackALeg, Timeout, ChannelProps, Start, Props) ->
+-spec handle_create(outbound_dial(), pos_integer(), pos_integer(), kz_term:proplist()) ->
+                           bowout_return().
+handle_create(#outbound_dial{loopback_a = <<?LB_ALEG_PREFIX, _/binary>>
+                            ,channel_props=ChannelProps
+                            }=OutboundDial
+             ,Timeout, Start, Props
+             ) ->
     case {kzd_freeswitch:other_leg_call_id(Props)
          ,kzd_freeswitch:loopback_other_leg(Props)
          }
     of
         {'undefined', 'undefined'} ->
-            wait_for_bowout(LoopbackALeg, 'undefined', kz_time:decr_timeout(Timeout, Start), props:insert_values(Props, ChannelProps));
+            wait_for_bowout(OutboundDial#outbound_dial{channel_props=props:insert_values(Props, ChannelProps)}
+                           ,kz_time:decr_timeout(Timeout, Start)
+                           );
         {'undefined', LoopbackBLeg} ->
             lager:debug("loopback bleg ~s started", [LoopbackBLeg]),
             register_for_events(kzd_freeswitch:switch_nodename(Props), LoopbackBLeg),
-            wait_for_bowout(LoopbackALeg, LoopbackBLeg, kz_time:decr_timeout(Timeout, Start), props:insert_values(Props, ChannelProps));
+            maybe_update_ecallmgr_node([LoopbackBLeg]),
+            wait_for_bowout(OutboundDial#outbound_dial{loopback_b=LoopbackBLeg
+                                                      ,channel_props=props:insert_values(Props, ChannelProps)
+                                                      }
+                           ,kz_time:decr_timeout(Timeout, Start)
+                           );
         {LoopbackBLeg, _} ->
             lager:debug("loopback bleg ~s started", [LoopbackBLeg]),
             register_for_events(kzd_freeswitch:switch_nodename(Props), LoopbackBLeg),
-            wait_for_bowout(LoopbackALeg, LoopbackBLeg, kz_time:decr_timeout(Timeout, Start), props:insert_values(Props, ChannelProps))
+            wait_for_bowout(OutboundDial#outbound_dial{channel_props=props:insert_values(Props, ChannelProps)}
+                           ,kz_time:decr_timeout(Timeout, Start)
+                           )
     end;
-handle_create(ALeg, _Timeout, ChannelProps, _Start, Props) ->
+handle_create(#outbound_dial{loopback_a=ALeg
+                            ,channel_props=ChannelProps
+                            }=OutboundDial, _Timeout, _Start, Props) ->
     lager:debug("dial started to ~s", [ALeg]),
-    {'ok', ALeg, <<"dial resulted in call id ", ALeg/binary>>, props:insert_values(Props, ChannelProps)}.
+    {'ok'
+    ,OutboundDial#outbound_dial{b_leg=ALeg
+                               ,channel_props=props:insert_values(Props, ChannelProps)
+                               ,dial_resp = <<"dial resulted in call id ", ALeg/binary>>
+                               }
+    }.
 
-handle_loopback_destroy(_LoopbackALeg, <<"NORMAL_UNSPECIFIED">>) ->
-    lager:debug("~s went down", [_LoopbackALeg]);
-handle_loopback_destroy(_LoopbackALeg, HangupCause) ->
+handle_loopback_destroy(#outbound_dial{loopback_a=_LoopbackALeg}, <<"NORMAL_UNSPECIFIED">>) ->
+    lager:debug("loopback a-leg ~s went down", [_LoopbackALeg]);
+handle_loopback_destroy(#outbound_dial{loopback_a=_LoopbackALeg}, HangupCause) ->
     lager:info("~s went down with ~s", [_LoopbackALeg, HangupCause]),
     {'error', HangupCause, <<"failed to start call: ", HangupCause/binary>>}.
 
-handle_bowout(LoopbackALeg, LoopbackBLeg, Timeout, ChannelProps, Start, Props) ->
+handle_bowout(#outbound_dial{loopback_a=LoopbackALeg
+                            ,channel_props=ChannelProps
+                            }=OutboundDial
+             ,Timeout, Start, Props
+             ) ->
     case {props:get_value(?RESIGNING_UUID, Props)
          ,props:get_value(?ACQUIRED_UUID, Props)
          }
     of
         {LoopbackALeg, LoopbackALeg} ->
             lager:debug("call id after bowout remains the same"),
-            {'ok', LoopbackALeg, <<"dial resulted in call id ", LoopbackALeg/binary>>, props:insert_values(Props, ChannelProps)};
+            {'ok'
+            ,OutboundDial#outbound_dial{b_leg=LoopbackALeg
+                                       ,channel_props=props:insert_values(Props, ChannelProps)
+                                       ,dial_resp = <<"dial resulted in call id ", LoopbackALeg/binary>>
+                                       }
+            };
         {LoopbackALeg, AcquiringUUID} when AcquiringUUID =/= 'undefined' ->
             lager:debug("~s acquired as ~s", [LoopbackALeg, AcquiringUUID]),
-            {'ok', AcquiringUUID, <<"dial resulted in call id ", AcquiringUUID/binary>>, props:insert_values(Props, ChannelProps)};
+            {'ok'
+            ,OutboundDial#outbound_dial{b_leg=AcquiringUUID
+                                       ,channel_props=props:insert_values(Props, ChannelProps)
+                                       ,dial_resp = <<"dial resulted in call id ", LoopbackALeg/binary>>
+                                       }
+            };
         {_UUID, _AcquiringUUID} ->
             lager:debug("failed to update after bowout, r: ~s a: ~s", [_UUID, _AcquiringUUID]),
-            wait_for_bowout(LoopbackALeg, LoopbackBLeg, kz_time:decr_timeout(Timeout, Start), ChannelProps)
+            wait_for_bowout(OutboundDial, kz_time:decr_timeout(Timeout, Start))
     end.
 
 -spec register_for_events(atom(), kz_term:ne_binary()) -> 'ok'.
@@ -393,15 +447,30 @@ register_for_events(ConferenceNode, EndpointCallId) ->
         ],
     'ok'.
 
--spec start_call_handlers(atom(), kapi_conference:doc(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
-start_call_handlers(Node, JObj, CallId) ->
-    FetchId = kz_api:msg_id(JObj),
+-spec start_call_handlers(atom(), kapi_conference:doc(), outbound_dial()) -> kz_term:api_ne_binary().
+start_call_handlers(Node, JObj, #outbound_dial{loopback_b=LoopbackB, b_leg=CallId}) ->
     CCVs = kz_json:new(),
+    FetchId = kz_api:msg_id(JObj),
+
+    ecallmgr_call_control:publish_usurp(LoopbackB, FetchId, node()),
+    maybe_update_ecallmgr_node([LoopbackB, CallId]),
 
     _ = kz_util:spawn(fun ecallmgr_call_sup:start_event_process/2, [Node, CallId]),
     {'ok', CtlPid} = ecallmgr_call_sup:start_control_process(Node, CallId, FetchId, 'undefined', CCVs, []),
 
     get_control_queue(CtlPid).
+
+maybe_update_ecallmgr_node([]) -> 'ok';
+maybe_update_ecallmgr_node(['undefined' | Legs]) -> maybe_update_ecallmgr_node(Legs);
+maybe_update_ecallmgr_node([Leg | Legs]) ->
+    case ecallmgr_fs_channel:fetch(Leg, 'record') of
+        {'ok', #channel{node=Node}} ->
+            ecallmgr_fs_command:export(Node, Leg, [{<<"Ecallmgr-Node">>, node()}]),
+            lager:debug("exported ecallmgr node to ~s (~s)", [Node, Leg]);
+        {'error', 'not_found'} ->
+            lager:debug("leg ~s not found, skipping", [Leg])
+    end,
+    maybe_update_ecallmgr_node(Legs).
 
 -spec get_control_queue(pid()) -> kz_term:api_ne_binary().
 get_control_queue(CtlPid) ->

--- a/core/kazoo_amqp/src/api/kapi_call.erl
+++ b/core/kazoo_amqp/src/api/kapi_call.erl
@@ -334,7 +334,12 @@ publish_event(Event) -> publish_event(Event, ?DEFAULT_CONTENT_TYPE).
 publish_event(Event, ContentType) when is_list(Event) ->
     CallId = props:get_first_defined([<<"Origination-Call-ID">>, <<"Call-ID">>, <<"Unique-ID">>], Event),
     EventName = props:get_value(<<"Event-Name">>, Event),
-    {'ok', Payload} = kz_api:prepare_api_payload(Event, ?CALL_EVENT_VALUES, fun event/1),
+    {'ok', Payload} = kz_api:prepare_api_payload(Event
+                                                ,?CALL_EVENT_VALUES
+                                                ,[{'formatter', fun event/1}
+                                                 ,{'remove_recursive', 'false'}
+                                                 ]
+                                                ),
     amqp_util:callevt_publish(?CALL_EVENT_ROUTING_KEY(EventName, CallId), Payload, ContentType);
 publish_event(Event, ContentType) ->
     publish_event(kz_json:to_proplist(Event), ContentType).

--- a/core/kazoo_amqp/src/api/kapi_metaflow.erl
+++ b/core/kazoo_amqp/src/api/kapi_metaflow.erl
@@ -236,7 +236,12 @@ publish_flow(JObj) ->
 
 -spec publish_flow(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_flow(Req, ContentType) ->
-    {'ok', Payload} = kz_api:prepare_api_payload(Req, ?METAFLOW_FLOW_VALUES, fun flow/1),
+    {'ok', Payload} = kz_api:prepare_api_payload(Req
+                                                ,?METAFLOW_FLOW_VALUES
+                                                ,[{'formatter', fun flow/1}
+                                                 ,{'remove_recursive', 'false'}
+                                                 ]
+                                                ),
     RK = ?METAFLOW_FLOW_ROUTING_KEY(rk_call_id(Req)),
     amqp_util:basic_publish(?METAFLOW_EXCHANGE, RK, Payload, ContentType).
 

--- a/core/kazoo_amqp/src/api/kapi_route.erl
+++ b/core/kazoo_amqp/src/api/kapi_route.erl
@@ -238,7 +238,12 @@ publish_req(JObj) ->
 
 -spec publish_req(kz_term:api_terms(), binary()) -> 'ok'.
 publish_req(Req, ContentType) ->
-    {'ok', Payload} = kz_api:prepare_api_payload(Req, ?ROUTE_REQ_VALUES, fun req/1),
+    {'ok', Payload} = kz_api:prepare_api_payload(Req
+                                                ,?ROUTE_REQ_VALUES
+                                                ,[{'formatter', fun req/1}
+                                                 ,{'remove_recursive', 'false'}
+                                                 ]
+                                                ),
     amqp_util:callmgr_publish(Payload, ContentType, get_route_req_routing(Req)).
 
 -spec publish_resp(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.


### PR DESCRIPTION
When there are multiple ecallmgrs connected to a FreeSWITCH server, it
is possible that the conference dial occurs on ecallmgr1 and the fetch
request for the loopback-b channel comes in on ecallmgr2. This results
in the legs associated with the loopback (a and b) and the final
b-leg, are all considered "local" to ecallmgr2.

However, the conference dial needs to start a call control process on
ecallmgr1 to get a control queue for the add_participant API (used to
start a conf_participant process to manage the now-dialed
participant).

This means both ecallmgr1 and ecallmgr2 consider the b-leg to be
"local". Metaflows checks the local ecallmgr's channel cache to
determine if it should repond to channel API actions - since both
ecallmgrs consider the channel local, both metaflow listeners publish
the payloads for konami to execute.

In this particular case, two CHANNEL_PIVOTs are picked up by the
cf_exe process and cause the conference action to be skipped (since
both "set_variables" actions call cf_exe:continue/1), the callflow is
exhausted, and cf_exe tears down the channel.