### PR TITLE
HELP-37225: don't consider [] as empty

### DIFF
--- a/core/kazoo_amqp/src/api/kapi_callflow.erl
+++ b/core/kazoo_amqp/src/api/kapi_callflow.erl
@@ -64,5 +64,10 @@ declare_exchanges() ->
 %%------------------------------------------------------------------------------
 -spec publish_resume(kz_term:api_terms()) -> 'ok'.
 publish_resume(JObj) ->
-    {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?RESUME_VALUES, fun resume/1),
+    {'ok', Payload} = kz_api:prepare_api_payload(JObj
+                                                ,?RESUME_VALUES
+                                                ,[{'formatter', fun resume/1}
+                                                 ,{'remove_recursive', 'false'}
+                                                 ]
+                                                ),
     kz_amqp_util:kapps_publish(?RESUME_ROUTING_KEY, Payload).

--- a/core/kazoo_amqp/src/api/kz_api.erl
+++ b/core/kazoo_amqp/src/api/kz_api.erl
@@ -237,7 +237,7 @@ set_missing_values(Prop, HeaderValues) when is_list(Prop) ->
     lists:foldl(fun({_, V}, PropAcc) when is_list(V) ->
                         PropAcc;
                    ({K, _}=KV, PropAcc) ->
-                        case is_empty(props:get_value(K, Prop)) of
+                        case should_strip_from_payload(props:get_value(K, Prop)) of
                             'true' -> [ KV | PropAcc ];
                             'false' -> PropAcc
                         end
@@ -267,7 +267,7 @@ do_empty_value_removal([{?KEY_SERVER_ID,_}=KV|T], Recursive, Acc) ->
 do_empty_value_removal([{?KEY_MSG_ID,_}=KV|T], Recursive, Acc) ->
     do_empty_value_removal(T, Recursive, [KV|Acc]);
 do_empty_value_removal([{K,V}=KV|T], Recursive, Acc) ->
-    case is_empty(V) of
+    case should_strip_from_payload(V) of
         'true' -> do_empty_value_removal(T, Recursive, Acc);
         'false' ->
             case (kz_json:is_json_object(V)
@@ -283,10 +283,10 @@ do_empty_value_removal([{K,V}=KV|T], Recursive, Acc) ->
             end
     end.
 
--spec is_empty(any()) -> boolean().
-is_empty('undefined') -> 'true';
-is_empty(<<>>) -> 'true';
-is_empty(_) -> 'false'.
+-spec should_strip_from_payload(any()) -> boolean().
+should_strip_from_payload('undefined') -> 'true';
+should_strip_from_payload(<<>>) -> 'true';
+should_strip_from_payload(_) -> 'false'.
 
 %%------------------------------------------------------------------------------
 %% @doc Extract just the default headers from a message

--- a/core/kazoo_amqp/src/api/kz_api.erl
+++ b/core/kazoo_amqp/src/api/kz_api.erl
@@ -285,7 +285,6 @@ do_empty_value_removal([{K,V}=KV|T], Recursive, Acc) ->
 
 -spec is_empty(any()) -> boolean().
 is_empty('undefined') -> 'true';
-is_empty([]) -> 'true';
 is_empty(<<>>) -> 'true';
 is_empty(_) -> 'false'.
 


### PR DESCRIPTION
Especially since tts/play commands consider [] different from
'undefined' for terminators. It is getting hard to know which API
commands might have a callflow payload (or a terminators attribute in
general); easier to permit a key with [] when it make no difference
than stripping keys with [] when there is a difference.