### PR TITLE
[4.2] filter same name test modules

### DIFF
--- a/make/kz.mk
+++ b/make/kz.mk
@@ -126,19 +126,19 @@ TEST_CONFIG=$(ROOT)/rel/config-test.ini
 
 ## Use this one when debugging
 test: compile-test
-	KAZOO_CONFIG=$(TEST_CONFIG) ERL_LIBS=$(ELIBS) erl -noshell $(TEST_PA) -eval "case eunit:test([$(TEST_MODULES)], [verbose]) of ok -> init:stop(); _ -> init:stop(1) end."
+	KAZOO_CONFIG=$(TEST_CONFIG) ERL_LIBS=$(ELIBS) $(ROOT)/scripts/eunit_run.escript $(TEST_MODULE_NAMES)
 test.%: compile-test
-	KAZOO_CONFIG=$(TEST_CONFIG) ERL_LIBS=$(ELIBS) erl -noshell $(TEST_PA) -eval "case eunit:test([$*], [verbose]) of ok -> init:stop(); _ -> init:stop(1) end."
+	KAZOO_CONFIG=$(TEST_CONFIG) ERL_LIBS=$(ELIBS) $(ROOT)/scripts/eunit_run.escript $*
 
-COVERDATA=$(PROJECT).coverdata
 COVER_REPORT_DIR=cover
 
 ## Use this one when CI
 eunit: compile-test eunit-run
 
 eunit-run:
-	@mkdir -p $(COVER_REPORT_DIR)
-	KAZOO_CONFIG=$(TEST_CONFIG) ERL_LIBS=$(ELIBS) erl -noshell $(TEST_PA) -eval "_ = cover:start(), cover:compile_beam_directory(\"ebin\"), case eunit:test([$(TEST_MODULES)], [verbose]) of ok -> cover:export(\"$(COVERDATA)\"), cover:analyse_to_file([html, {outdir, \"$(COVER_REPORT_DIR)\"}]), init:stop(); _ -> init:stop(1) end."
+	KAZOO_CONFIG=$(TEST_CONFIG) ERL_LIBS=$(ELIBS) $(ROOT)/scripts/eunit_run.escript --with-cover \
+		--cover-project-name $(PROJECT) --cover-report-dir $(COVER_REPORT_DIR) \
+		$(TEST_MODULE_NAMES)
 
 cover: $(ROOT)/make/cover.mk
 	COVER=1 $(MAKE) eunit

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -296,6 +296,29 @@ Already EDocified! 🎉
 Checks JSON schemas for empty "description" properties and exit(1) if any are found
 
 
+## `eunit_run.escript`
+
+Run EUnit tests on specified module names, filtering test modules which has same as their normal module name like `fobar` and `fobar_tests` to avoid running the `fobar_tests` twice.
+
+Usage:
+
+```bash
+cd core/kazoo_stdlib ## or your desire application or on the root kazoo project dir
+KAZOO_CONFIG=../../rel/config-test.ini ERL_LIBS=../../deps:../../core:../../applications ../../scripts/eunit_run.escript --with-cover \
+    --cover-project-name kazoo_stdlib --cover-report-dir cover \
+    kz_binary kz_binary_tests kz_date kz_date_tests kz_json kz_json_tests kz_maps kz_maps_tests kz_mochinum kz_module kz_module_tests
+    kz_term kz_term_tests kz_time kz_time_tests kz_types props props_tests
+
+```
+
+or simply:
+
+```bash
+cd core/kazoo_stdlib ## or your desire application or on the root kazoo project dir
+make eunit # or make test
+```
+
+
 ## `export_auth_token.bash`
 
 Script for exporting `AUTH_TOKEN` and `ACCOUNT_ID` when doing Crossbar authentication. Handy when running curl commands to use `$AUTH_TOKEN` instead of the raw value (and for re-authing when auth token expires).

--- a/scripts/eunit_run.escript
+++ b/scripts/eunit_run.escript
@@ -1,0 +1,77 @@
+#!/usr/bin/env escript
+%%! +A0
+%% -*- coding: utf-8 -*-
+
+-mode(compile).
+
+-export([main/1]).
+
+main(Args) ->
+    _ = io:setopts(user, [{encoding, unicode}]),
+    run_eunit(parse_args(Args, #{modules => []})).
+
+parse_args([], Opts) ->
+    Opts;
+parse_args(["--with-cover" | Rest], Opts) ->
+    parse_args(Rest, Opts#{cover => true});
+parse_args(["--cover-project-name", ProjectName | Rest], Opts) ->
+    parse_args(Rest, Opts#{coverdata => ProjectName ++ ".coverdata"});
+parse_args(["--cover-report-dir", Dir | Rest], Opts) ->
+    parse_args(Rest, Opts#{report_dir => Dir});
+parse_args([Mod | Rest], #{modules := Modules}=Opts) ->
+    parse_args(Rest, Opts#{modules => [Mod | Modules]}).
+
+run_eunit(#{modules := []}) ->
+    io:format(user, "No modules are specified.\n", []),
+    usage();
+run_eunit(#{modules := Modules}=Opts) ->
+    maybe_start_cover(Opts),
+
+    TestMods = filter_same_name_test_modules(Modules),
+    case eunit:test([TestMods], [verbose]) of
+        ok ->
+            maybe_stop_cover(Opts),
+            init:stop();
+        _ ->
+            init:stop(1)
+    end.
+
+filter_same_name_test_modules(Modules) ->
+    Fun = fun(Mod, Acc) ->
+                  Module = filename:rootname(filename:basename(Mod)),
+                  case lists:reverse(Module) of
+                      "stset_"++M ->
+                          case not lists:member(lists:reverse(M), Modules) of
+                              true -> [list_to_atom(Module) | Acc];
+                              false -> Acc
+                          end;
+                      _ ->
+                          [list_to_atom(Module) | Acc]
+                  end
+          end,
+    lists:usort(lists:foldl(Fun, [], Modules)).
+
+maybe_start_cover(#{cover := true
+                   ,coverdata := _
+                   }=Opts) ->
+    ok = filelib:ensure_dir(maps:get(report_dir, Opts, "cover")),
+    _ = cover:start(),
+    cover:compile_beam_directory("ebin");
+maybe_start_cover(#{cover := true}) ->
+    io:format(user, "No project name is specified.\n", []),
+    usage();
+maybe_start_cover(_) ->
+    ok.
+
+maybe_stop_cover(#{cover := true
+                  ,coverdata := Coverdata
+                  }=Opts) ->
+    cover:export(Coverdata),
+    cover:analyse_to_file([html, {outdir, maps:get(report_dir, Opts, "cover")}]);
+maybe_stop_cover(_) ->
+    ok.
+
+usage() ->
+    Arg0 = escript:script_name(),
+    io:format(user, "Usage: ~s [--with-cover] [--cover-project-name <project name>] [--cover-report-dir <cover report dir>] <erlang module name/>+\n", [filename:basename(Arg0)]),
+    halt(1).


### PR DESCRIPTION
Filter test modules which has the same name as their normal module (e.g. `kz_date` and `kz_date_tests`) to avoid running tests in `kz_date_tests` twice.

When running EUnit to test the module `kz_date`, it will also look for the module `kz_date_tests` and run those tests as well.