### PR TITLE
HELP-37171: check if media is convertible to prompt://

### DIFF
--- a/core/kazoo_media/Makefile
+++ b/core/kazoo_media/Makefile
@@ -4,3 +4,8 @@ PROJECT = kazoo_media
 all: compile
 
 include $(ROOT)/make/kz.mk
+
+compile-test: compile-also
+
+compile-also:
+	$(MAKE) compile-test -C $(ROOT)/core/kazoo_config/

--- a/core/kazoo_media/test/kz_media_util_tests.erl
+++ b/core/kazoo_media/test/kz_media_util_tests.erl
@@ -1,0 +1,30 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2011-2018, 2600Hz
+%%% @doc Tests for kz_media_util
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kz_media_util_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+get_prompt_test_() ->
+    Tests = [{"untouched tone_stream", [<<"tone_stream://%(250,250,480,620);loops=25">>], <<"tone_stream://%(250,250,480,620);loops=25">>}
+            ,{"untouched tone_stream with lang", [<<"tone_stream://%(250,250,480,620);loops=25">>, <<"en-us">>], <<"tone_stream://%(250,250,480,620);loops=25">>}
+            ,{"untouched tone_stream with lang and account", [<<"tone_stream://%(250,250,480,620);loops=25">>, <<"en-us">>, kz_binary:rand_hex(16)], <<"tone_stream://%(250,250,480,620);loops=25">>}
+
+            ,{"untouched prompt", [<<"prompt://system_media/vm-full/en-us">>], <<"prompt://system_media/vm-full/en-us">>}
+            ,{"full prompt path", [<<"vm-full">>], <<"prompt://system_media/vm-full/en-us">>}
+            ,{"full prompt path with lang", [<<"vm-full">>, <<"mk-bs">>], <<"prompt://system_media/vm-full/mk-bs">>}
+            ],
+
+    [{Description, ?_assertEqual(Expected, apply_get_prompt(Args))}
+     || {Description, Args, Expected} <- Tests
+    ].
+
+apply_get_prompt([Name]) ->
+    kz_media_util:get_prompt(Name);
+apply_get_prompt([Name, Lang]) ->
+    kz_media_util:get_prompt(Name, Lang);
+apply_get_prompt([Name, Lang, AccountId]) ->
+    kz_media_util:get_prompt(Name, Lang, AccountId).


### PR DESCRIPTION
When overriding prompts with other forms of media, like tone_stream or
HTTP URLs, normalization still occurs as it would for prompts like
"/{ACCOUNT_ID}/{PROMPT}" or "/system_media/{PROMPT}" or
"{PROMPT}". This results in invalid "prompt://" URLs and FreeSWITCH
being unable to play the appropriate media back to the call leg.

Introduce a function that looks for media that isn't
prompt-normalizable and returns a boolean indicating such.