### PR TITLE
[4.2] Help-36418: Address issues with disabling serialization by outbound number in faxing 

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -14178,6 +14178,9 @@
                 "Account-ID": {
                     "type": "string"
                 },
+                "Control-Queue": {
+                    "type": "string"
+                },
                 "Event-Category": {
                     "enum": [
                         "start"

--- a/applications/crossbar/priv/couchdb/schemas/kapi.fax.start_job.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.fax.start_job.json
@@ -6,6 +6,9 @@
         "Account-ID": {
             "type": "string"
         },
+        "Control-Queue": {
+            "type": "string"
+        },
         "Event-Category": {
             "enum": [
                 "start"

--- a/applications/fax/src/fax.hrl
+++ b/applications/fax/src/fax.hrl
@@ -4,6 +4,7 @@
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
 -include_lib("kazoo_stdlib/include/kz_log.hrl").
 -include_lib("kazoo_stdlib/include/kz_databases.hrl").
+-include_lib("kazoo/include/kz_api_literals.hrl").
 
 -define(APP_NAME, <<"fax">>).
 -define(APP_VERSION, <<"4.0.0">>).

--- a/applications/fax/src/fax_global_shared_listener.erl
+++ b/applications/fax/src/fax_global_shared_listener.erl
@@ -4,7 +4,7 @@
 %%% @author James Aimonetti
 %%% @end
 %%%-----------------------------------------------------------------------------
--module(fax_shared_listener).
+-module(fax_global_shared_listener).
 -behaviour(gen_listener).
 
 %% API
@@ -28,52 +28,20 @@
 
 -define(SERVER, ?MODULE).
 
--define(NOTIFY_RESTRICT, ['outbound_fax'
-                         ,'outbound_fax_error'
-                         ]).
-
--define(FAXBOX_RESTRICT, [{'db', <<"faxes">>}
-                         ,{'doc_type', <<"faxbox">>}
-                         ]).
-
--define(RESPONDERS, [{{'fax_cloud', 'handle_job_notify'}
-                     ,[{<<"notification">>, <<"outbound_fax">>}]
+-define(RESPONDERS, [{{'fax_jobs', 'handle_start_account'}
+                     ,[{<<"start">>, <<"account">>}]
                      }
-                    ,{{'fax_cloud', 'handle_job_notify'}
-                     ,[{<<"notification">>, <<"outbound_fax_error">>}]
-                     }
-                    ,{{'fax_cloud', 'handle_push'}
-                     ,[{<<"xmpp_event">>, <<"push">>}]
-                     }
-                    ,{{'fax_cloud', 'handle_faxbox_created'}
-                     ,[{<<"configuration">>, ?DOC_CREATED}]
-                     }
-                    ,{{'fax_cloud', 'handle_faxbox_edited'}
-                     ,[{<<"configuration">>, ?DOC_EDITED}]
-                     }
-                    ,{{'fax_cloud', 'handle_faxbox_deleted'}
-                     ,[{<<"configuration">>, ?DOC_DELETED}]
-                     }
-                    ,{{'fax_request', 'new_request'}
-                     ,[{<<"dialplan">>, <<"fax_req">>}]
-                     }
-                    ,{{'fax_xmpp', 'handle_printer_start'}
-                     ,[{<<"xmpp_event">>, <<"start">>}]
-                     }
-                    ,{{'fax_xmpp', 'handle_printer_stop'}
-                     ,[{<<"xmpp_event">>, <<"stop">>}]
+                    ,{{'fax_worker', 'handle_start_job'}
+                     ,[{<<"start">>, <<"job">>}]
                      }
                     ]).
 
--define(BINDINGS, [{'notifications', [{'restrict_to', ?NOTIFY_RESTRICT}]}
-                  ,{'xmpp',[{'restrict_to',['push']}]}
-                  ,{'xmpp', [{'restrict_to', ['start']}, 'federate']}
-                  ,{'conf',?FAXBOX_RESTRICT}
-                  ,{'fax', [{'restrict_to', ['req']}]}
-                  ,{'self', []}
+-define(BINDINGS, [{'fax', [{'restrict_to', ['start']}, 'federate']}
                   ]).
--define(QUEUE_NAME, <<"fax_shared_listener">>).
--define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(QUEUE_NAME, <<"fax_global_shared_listener">>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}
+                       ,{'federated_queue_name_is_global', 'true'}
+                       ]).
 -define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
 
 %%%=============================================================================

--- a/applications/fax/src/fax_jobs.erl
+++ b/applications/fax/src/fax_jobs.erl
@@ -121,6 +121,7 @@ handle_cast({'job_status',{JobId, <<"start">>, JObj}}, #state{jobs=#{pending := 
                                                              }=State) ->
     ServerId = kz_api:server_id(JObj),
     #{JobId := #{number := Number}} = Pending,
+    lager:debug("received fax start control status for ~s", [JobId]),
     {'noreply', State#state{jobs=Jobs#{pending => maps:remove(JobId, Pending)
                                       ,running => Running#{JobId => #{number => Number
                                                                      ,queue => ServerId
@@ -140,6 +141,7 @@ handle_cast({'job_status',{JobId, <<"end">>, JObj}}, #state{jobs=#{pending := Pe
                 ,number := Number
                 }
      } = Running,
+    lager:debug("received fax end control status for ~s", [JobId]),
     {'noreply', State#state{jobs=Jobs#{pending => maps:remove(JobId, Pending)
                                       ,running => maps:remove(JobId, Running)
                                       ,numbers => maps:remove(Number, Numbers)
@@ -268,40 +270,65 @@ invalidate_job(Job, #state{account_id=AccountId}=State) ->
     State.
 
 -spec distribute_job(kz_term:ne_binary(), kz_json:object(), state()) -> state().
-distribute_job(ToNumber, Job, #state{account_id=AccountId
-                                    ,queue=Q
-                                    ,jobs=#{pending := Pending
-                                           ,serialize := Serialize
-                                           ,numbers := Numbers
-                                           }=Map
-                                    }=State) ->
+distribute_job(ToNumber, Job, #state{jobs=#{numbers := Numbers}}=State) ->
     JobId = kz_doc:id(Job),
     case ?SERIALIZE_OUTBOUND_NUMBER
         andalso maps:is_key(ToNumber, Numbers)
     of
-        'true' -> distribute_jobs(State#state{jobs=Map#{serialize => [Job | Serialize]}});
-        'false' ->
-            Payload = [{<<"Job-ID">>, JobId}
-                      ,{<<"Account-ID">>, AccountId}
-                      ,{<<"To-Number">>, ToNumber}
-                       | kz_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
-                      ],
-            kz_amqp_worker:cast(Payload, fun kapi_fax:publish_start_job/1),
-            Start = kz_time:now_ms(),
-            distribute_jobs(State#state{jobs=Map#{pending => Pending#{JobId => #{number => ToNumber
-                                                                                ,start => Start
-                                                                                ,job => Job
-                                                                                }
-                                                                     }
-                                                 ,numbers => Numbers#{ToNumber => JobId}
-                                                 }})
+        'true' -> distribute_jobs(serialize_job(JobId, Job, State));
+        'false' -> distribute_jobs(start_job(JobId, ToNumber, Job, State))
     end.
 
+-spec start_job(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), state()) -> state().
+start_job(JobId, ToNumber, Job, #state{account_id=AccountId
+                                      ,queue=Queue
+                                      }=State) ->
+    Payload = start_job_payload(AccountId, JobId, ToNumber, Queue),
+    lager:debug("starting job: ~s for account id: ~s fax destination: ~s", [JobId, AccountId, ToNumber]),
+    case kz_amqp_worker:call(Payload, fun kapi_fax:publish_start_job/1, fun validate_job_started/1) of
+        {'error', 'timeout'} -> serialize_job(JobId, Job, State);
+        {'ok', Reply} -> set_pending_job(JobId, kz_api:node(Reply), Job, ToNumber, State)
+    end.
+
+-spec validate_job_started(kz_json:object()) -> boolean().
+validate_job_started(JObj) ->
+    lager:debug("job start reply for ~s : ~s", [kapi_fax:job_id(JObj), kapi_fax:state(JObj)]),
+    kapi_fax:state(JObj) =:= <<"start">>.
+
+-spec start_job_payload(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> list().
+start_job_payload(AccountId, JobId, ToNumber, Queue) ->
+    [{<<"Job-ID">>, JobId}
+    ,{<<"Account-ID">>, AccountId}
+    ,{<<"To-Number">>, ToNumber}
+    ,{<<"Control-Queue">>, Queue}
+     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+    ].
+
+-spec serialize_job(kz_term:ne_binary(), kz_json:object(), state()) -> state().
+serialize_job(JobId, Job, #state{jobs=#{serialize := Serialize}=Jobs}=State) ->
+    lager:debug("serializing job: ~s", [JobId]),
+    State#state{jobs=Jobs#{serialize => [Job | Serialize]}}.
+
+-spec set_pending_job(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), kz_term:ne_binary(), state()) -> state().
+set_pending_job(JobId, Node, Job, ToNumber, #state{jobs=#{pending := Pending
+                                                         ,numbers := Numbers
+                                                         }=Jobs
+                                                  }=State) ->
+    lager:debug("setting job: ~s  to pending status", [JobId]),
+    State#state{jobs=Jobs#{pending => Pending#{JobId => #{number => ToNumber
+                                                         ,start => kz_time:now_ms()
+                                                         ,job => Job
+                                                         ,node => Node
+                                                         }
+                                              }
+                          ,numbers => Numbers#{ToNumber => JobId}
+                          }}.
 
 -spec handle_start_account(kz_json:object(), kz_term:proplist()) -> 'ok'.
 handle_start_account(JObj, _Props) ->
     'true' = kapi_fax:start_account_v(JObj),
     AccountId = kapi_fax:account_id(JObj),
+    lager:debug("starting account jobs worker for account id: ~s", [AccountId]),
     case is_running(AccountId) of
         'true' -> 'ok';
         'false' ->
@@ -412,10 +439,7 @@ cleanup_jobs(AccountId) ->
     end.
 
 -spec handle_error(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), map()) -> map().
-handle_error(JobId, AccountId, JObj, #{pending := Pending
-                                      ,numbers := Numbers
-                                      ,serialize := Serialize
-                                      } = Jobs) ->
+handle_error(JobId, AccountId, JObj, #{pending := Pending} = Jobs) ->
     Status = kz_json:get_ne_binary_value(<<"Status">>, JObj),
     Stage = kz_json:get_ne_binary_value(<<"Stage">>, JObj),
     case kz_maps:get([JobId, job], Pending, 'undefined') of
@@ -425,16 +449,27 @@ handle_error(JobId, AccountId, JObj, #{pending := Pending
         Job ->
             Number = knm_converters:normalize(number(Job), AccountId),
             lager:warning("received error for fax job ~s/~s/~s on stage ~p: ~p", [AccountId, JobId, Number, Stage, Status]),
-            Jobs#{pending => maps:remove(JobId, Pending)
-                 ,numbers => maps:remove(Number, Numbers)
-                 ,serialize => Serialize ++ maybe_serialize(Status, Stage, JobId, AccountId, Job)
-                 }
+            maybe_serialize(Status, Stage, JobId, AccountId, Number, Job, Jobs)
     end.
 
--spec maybe_serialize(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> kz_json:objects().
-maybe_serialize(<<"not_found">> = Status, <<"acquire">> = Stage, JobId, AccountId, _Job) ->
+-spec maybe_serialize(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), map()) -> kz_json:objects().
+maybe_serialize(<<"not_found">> = Status, <<"acquire">> = Stage, JobId, AccountId, Number, _Job, Jobs) ->
     lager:debug("dropping job ~s/~s from cache in stage ~s : ~s", [AccountId, JobId, Stage, Status]),
-    [];
-maybe_serialize(Status, Stage, JobId, AccountId, Job) ->
+    #{pending := Pending
+     ,numbers := Numbers
+     ,serialize := Serialize
+     } = Jobs,
+    Jobs#{pending => maps:remove(JobId, Pending)
+         ,numbers => maps:remove(Number, Numbers)
+         ,serialize => Serialize
+         };
+maybe_serialize(Status, Stage, JobId, AccountId, Number, Job, Jobs) ->
     lager:debug("serializing job ~s/~s into cache in stage ~s : ~s", [AccountId, JobId, Stage, Status]),
-    [Job].
+    #{pending := Pending
+     ,numbers := Numbers
+     ,serialize := Serialize
+     } = Jobs,
+    Jobs#{pending => maps:remove(JobId, Pending)
+         ,numbers => maps:remove(Number, Numbers)
+         ,serialize => Serialize ++ [Job]
+         }.

--- a/applications/fax/src/fax_sup.erl
+++ b/applications/fax/src/fax_sup.erl
@@ -35,6 +35,7 @@
                   ,?SUPER('fax_xmpp_sup')
                   ,?SUPER('fax_jobs_sup')
                   ,?SUPER('fax_worker_sup')
+                  ,?WORKER('fax_global_shared_listener')
                   ,?WORKER('fax_shared_listener')
                   ,?WORKER('fax_monitor')
                   ,?WORKER_ARGS('gen_smtp_server', ?SMTP_ARGS)

--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -154,7 +154,7 @@ handle_job_status_query(JObj, Props) ->
 %%------------------------------------------------------------------------------
 -spec init([kz_json:object() | kz_term:ne_binary()]) -> {'ok', state()}.
 init([FaxJob, CallId]) ->
-    CtrlQ = kz_api:server_id(FaxJob),
+    CtrlQ = kapi_fax:control_queue(FaxJob),
     JobId = kapi_fax:job_id(FaxJob),
     kz_util:put_callid(JobId),
     {'ok', #state{callid = CallId
@@ -1100,12 +1100,24 @@ send_control_status(CtrlQ, Q, JobId, FaxState, Stage) ->
 handle_start_job(JObj, _Props) ->
     'true' = kapi_fax:start_job_v(JObj),
     case fax_worker_sup:start_fax_job(JObj) of
-        {'error', _Reason} ->
-            JobId = kapi_fax:job_id(JObj),
-            CtrlQ = kz_api:server_id(JObj),
-            send_control_error(JobId, CtrlQ, <<"start">>, <<"already running">>);
-        _ -> 'ok'
+        {'ok', _Pid} -> send_start_reply(JObj, <<"start">>, 'undefined');
+        {'error', _Reason} -> send_start_reply(JObj, <<"error">>, <<"already running">>)
     end.
+
+-spec send_start_reply(kz_json:object(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> 'ok'.
+send_start_reply(JObj, Status, Reason) ->
+    JobId = kapi_fax:job_id(JObj),
+    CtrlQ = kz_api:server_id(JObj),
+    MsgId = kz_api:msg_id(JObj),
+    Payload = [{<<"Job-ID">>, JobId}
+              ,{<<"Fax-State">>, Status}
+              ,{<<"Stage">>, <<"start">>}
+              ,{<<"Status">>, Reason}
+              ,{?KEY_MSG_ID, MsgId}
+               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+              ],
+    Publisher = fun(P) -> kapi_fax:publish_targeted_status(CtrlQ, P) end,
+    kz_amqp_worker:cast(Payload, Publisher).
 
 -spec send_control_error(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 send_control_error(JobId, CtrlQ, Stage, Reason) ->

--- a/core/kazoo_amqp/src/amqp_util.erl
+++ b/core/kazoo_amqp/src/amqp_util.erl
@@ -144,6 +144,7 @@
 
 -export([is_json/1, is_host_available/0]).
 -export([encode/1]).
+-export([split_routing_key/1]).
 
 -ifdef(TEST).
 -export([trim/3]).
@@ -1320,3 +1321,13 @@ encode_char(C) ->
 
 hexint(C) when C < 10 -> ($0 + C);
 hexint(C) when C < 16 -> ($A + (C - 10)).
+
+-spec split_routing_key(binary()) -> {kz_term:api_pid(), binary()}.
+split_routing_key(<<"consumer://", _/binary>> = RoutingKey) ->
+    Size = byte_size(RoutingKey),
+    {Start, _} = lists:last(binary:matches(RoutingKey, <<"/">>)),
+    {list_to_pid(kz_term:to_list(binary:part(RoutingKey, 11, Start - 11)))
+    ,binary:part(RoutingKey, Start + 1, Size - Start - 1)
+    };
+split_routing_key(RoutingKey) ->
+    {'undefined', RoutingKey}.

--- a/core/kazoo_amqp/src/api/kapi_fax.erl
+++ b/core/kazoo_amqp/src/api/kapi_fax.erl
@@ -305,7 +305,7 @@ account_id(JObj) ->
 
 -spec control_queue(kz_json:object()) -> kz_term:ne_binary().
 control_queue(JObj) ->
-    case kz_amqp_util:split_routing_key(kz_api:server_id(JObj)) of
+    case amqp_util:split_routing_key(kz_api:server_id(JObj)) of
         {'undefined', _} -> kz_json:get_ne_binary_value(<<"Control-Queue">>, JObj);
         {Pid, _} -> list_to_binary(["consumer://"
                                    ,kz_term:to_binary(Pid)

--- a/core/kazoo_amqp/src/api/kapi_fax.erl
+++ b/core/kazoo_amqp/src/api/kapi_fax.erl
@@ -9,6 +9,7 @@
 -export([account_id/1
         ,job_id/1
         ,to_number/1
+        ,control_queue/1
         ,state/1
         ]).
 
@@ -44,7 +45,7 @@
 -define(FAX_OUTGOING, <<"outgoing">>).
 -define(FAX_INCOMING, <<"incoming">>).
 
--define(FAX_EXCHANGE, <<"fax">>).
+-define(FAX_EXCHANGE, <<"faxes">>).
 
 -define(FAX_REQ_HEADERS, [<<"Call">>, <<"Action">>]).
 -define(OPTIONAL_FAX_REQ_HEADERS, [<<"Owner-ID">>, <<"FaxBox-ID">>, <<"Fax-T38-Option">>]).
@@ -84,7 +85,7 @@
                                   ]).
 -define(FAX_START_ACCOUNT_TYPES, []).
 
--define(FAX_START_JOB_HEADERS, [<<"Job-ID">>, <<"Account-ID">>, <<"To-Number">>]).
+-define(FAX_START_JOB_HEADERS, [<<"Job-ID">>, <<"Account-ID">>, <<"To-Number">>, <<"Control-Queue">>]).
 -define(OPTIONAL_FAX_START_JOB_HEADERS, []).
 -define(FAX_START_JOB_VALUES, [{<<"Event-Category">>,<<"start">>}
                               ,{<<"Event-Name">>, <<"job">>}
@@ -224,7 +225,7 @@ unbind_q(_, _, _, _, []) -> 'ok'.
 %%------------------------------------------------------------------------------
 -spec declare_exchanges() -> 'ok'.
 declare_exchanges() ->
-    amqp_util:new_exchange(?FAX_EXCHANGE, <<"fanout">>),
+    amqp_util:new_exchange(?FAX_EXCHANGE, <<"topic">>),
     amqp_util:targeted_exchange(),
     amqp_util:callmgr_exchange().
 
@@ -302,6 +303,17 @@ status_routing_key(AccountId, FaxId) ->
 account_id(JObj) ->
     kz_json:get_ne_binary_value(<<"Account-ID">>, JObj).
 
+-spec control_queue(kz_json:object()) -> kz_term:ne_binary().
+control_queue(JObj) ->
+    case kz_amqp_util:split_routing_key(kz_api:server_id(JObj)) of
+        {'undefined', _} -> kz_json:get_ne_binary_value(<<"Control-Queue">>, JObj);
+        {Pid, _} -> list_to_binary(["consumer://"
+                                   ,kz_term:to_binary(Pid)
+                                   ,"/"
+                                   ,kz_json:get_ne_binary_value(<<"Control-Queue">>, JObj)
+                                   ])
+    end.
+
 -spec job_id(kz_json:object()) -> kz_term:ne_binary().
 job_id(JObj) ->
     kz_json:get_ne_binary_value(<<"Job-ID">>, JObj).
@@ -313,3 +325,4 @@ to_number(JObj) ->
 -spec state(kz_json:object()) -> kz_term:ne_binary().
 state(JObj) ->
     kz_json:get_ne_binary_value(<<"Fax-State">>, JObj).
+

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -1228,18 +1228,21 @@ update_existing_listener_bindings({_Broker, Pid}, Binding, Props) ->
 -spec create_federated_params({binding_module(), kz_term:proplist()}, kz_term:proplist()) ->
                                      kz_term:proplist().
 create_federated_params(FederateBindings, Params) ->
+    QueueOptions = props:get_value('queue_options', Params, []),
     [{'responders', []}
     ,{'bindings', [FederateBindings]}
-    ,{'queue_name', federated_queue_name(Params)}
-    ,{'queue_options', props:get_value('queue_options', Params, [])}
+    ,{'queue_name', federated_queue_name(Params, QueueOptions)}
+    ,{'queue_options', QueueOptions}
     ,{'consume_options', props:get_value('consume_options', Params, [])}
     ].
 
--spec federated_queue_name(kz_term:proplist()) -> kz_term:api_binary().
-federated_queue_name(Params) ->
+-spec federated_queue_name(kz_term:proplist(), kz_term:proplist()) -> kz_term:api_binary().
+federated_queue_name(Params, Options) ->
     QueueName = props:get_value('queue_name', Params, <<>>),
+    IsGlobalQueue = props:is_true('federated_queue_name_is_global', Options, 'false'),
     case kz_term:is_empty(QueueName) of
         'true' -> QueueName;
+        'false' when IsGlobalQueue -> QueueName;
         'false' ->
             Zone = kz_config:zone('binary'),
             <<QueueName/binary, "-", Zone/binary>>


### PR DESCRIPTION
   when using federation on shared queues
   we create queuename-zone by default on the federated connection
   this adds the option to listen on original queue name
   this allows for round-robin distribution of events across zones

add split_routing_key to amqp utils

add control queue to fax status

handle fax start with global queue name

rename fax exchange name to faxes so restarts don't break

Renamed exchange to faxes to change from fanout to topic

moved some loglines around