### PR TITLE
[master] HELP-37319: handle huge load view better

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -29463,6 +29463,67 @@
             },
             "type": "object"
         },
+        "system_config.kazoo_convert": {
+            "description": "Schema for kazoo_convert system_config",
+            "properties": {
+                "convert_command_timeout": {
+                    "default": 120000,
+                    "description": "kazoo_convert convert_command_timeout",
+                    "type": "integer"
+                },
+                "convert_image_command": {
+                    "default": "convert $FROM -resample 204x98 -units PixelsPerInch -compress group4 -size 1728x1078 $TO",
+                    "description": "kazoo_convert convert_image_command",
+                    "type": "string"
+                },
+                "convert_openoffice_command": {
+                    "default": "libreoffice --headless --convert-to pdf $FROM --outdir $WORKDIR  2>&1 |egrep 'parser error|Error' && exit 1 || exit 0",
+                    "description": "kazoo_convert convert_openoffice_command",
+                    "type": "string"
+                },
+                "convert_pdf_command": {
+                    "default": "/usr/bin/gs -q -r204x98 -g1728x1078 -dNOPAUSE -dBATCH -dSAFER -sDEVICE=tiffg4 -sOutputFile=$TO -- $FROM",
+                    "description": "kazoo_convert convert_pdf_command",
+                    "type": "string"
+                },
+                "convert_tiff_command": {
+                    "default": "tiff2pdf -o $TO $FROM",
+                    "description": "kazoo_convert convert_tiff_command",
+                    "type": "string"
+                },
+                "enable_openoffice": {
+                    "default": true,
+                    "description": "kazoo_convert enable_openoffice",
+                    "type": "boolean"
+                },
+                "fax_converter": {
+                    "default": "fax_converter",
+                    "description": "kazoo_convert fax_converter",
+                    "type": "string"
+                },
+                "file_cache_path": {
+                    "default": "/tmp/",
+                    "description": "kazoo_convert file_cache_path",
+                    "type": "string"
+                },
+                "serialize_openoffice": {
+                    "default": true,
+                    "description": "kazoo_convert serialize_openoffice",
+                    "type": "boolean"
+                },
+                "validate_pdf_command": {
+                    "default": "gs -dNOPAUSE -dBATCH -sDEVICE=nullpage $FROM",
+                    "description": "kazoo_convert validate_pdf_command",
+                    "type": "string"
+                },
+                "validate_tiff_command": {
+                    "default": "tiff2pdf -o $TO $FROM",
+                    "description": "kazoo_convert validate_tiff_command",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "system_config.kazoo_couch": {
             "description": "Schema for kazoo_couch system_config",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.kazoo_convert.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.kazoo_convert.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.kazoo_convert",
+    "description": "Schema for kazoo_convert system_config",
+    "properties": {
+        "convert_command_timeout": {
+            "default": 120000,
+            "description": "kazoo_convert convert_command_timeout",
+            "type": "integer"
+        },
+        "convert_image_command": {
+            "default": "convert $FROM -resample 204x98 -units PixelsPerInch -compress group4 -size 1728x1078 $TO",
+            "description": "kazoo_convert convert_image_command",
+            "type": "string"
+        },
+        "convert_openoffice_command": {
+            "default": "libreoffice --headless --convert-to pdf $FROM --outdir $WORKDIR  2>&1 |egrep 'parser error|Error' && exit 1 || exit 0",
+            "description": "kazoo_convert convert_openoffice_command",
+            "type": "string"
+        },
+        "convert_pdf_command": {
+            "default": "/usr/bin/gs -q -r204x98 -g1728x1078 -dNOPAUSE -dBATCH -dSAFER -sDEVICE=tiffg4 -sOutputFile=$TO -- $FROM",
+            "description": "kazoo_convert convert_pdf_command",
+            "type": "string"
+        },
+        "convert_tiff_command": {
+            "default": "tiff2pdf -o $TO $FROM",
+            "description": "kazoo_convert convert_tiff_command",
+            "type": "string"
+        },
+        "enable_openoffice": {
+            "default": true,
+            "description": "kazoo_convert enable_openoffice",
+            "type": "boolean"
+        },
+        "fax_converter": {
+            "default": "fax_converter",
+            "description": "kazoo_convert fax_converter",
+            "type": "string"
+        },
+        "file_cache_path": {
+            "default": "/tmp/",
+            "description": "kazoo_convert file_cache_path",
+            "type": "string"
+        },
+        "serialize_openoffice": {
+            "default": true,
+            "description": "kazoo_convert serialize_openoffice",
+            "type": "boolean"
+        },
+        "validate_pdf_command": {
+            "default": "gs -dNOPAUSE -dBATCH -sDEVICE=nullpage $FROM",
+            "description": "kazoo_convert validate_pdf_command",
+            "type": "string"
+        },
+        "validate_tiff_command": {
+            "default": "tiff2pdf -o $TO $FROM",
+            "description": "kazoo_convert validate_tiff_command",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/core/kazoo_couch/src/kz_couch.hrl
+++ b/core/kazoo_couch/src/kz_couch.hrl
@@ -32,7 +32,7 @@
                             integer() |
                             {'EXIT', _} |
                             {'url_parsing_failed', _} |
-                            {'conn_failed', _} |
+                            {'conn_failed', _} | 'tcp_closed' |
                             {'ok', string(), _, _}.
 -type couchbeam_error() :: {'error', couchbeam_errors()}.
 

--- a/core/kazoo_couch/src/kz_couch_util.erl
+++ b/core/kazoo_couch/src/kz_couch_util.erl
@@ -290,6 +290,12 @@ format_error('not_found') -> 'not_found';
 format_error('db_not_found') -> 'db_not_found';
 format_error({'error', 'connect_timeout'}) -> 'connect_timeout';
 format_error({'http_error', _, Msg}) -> Msg;
+format_error({'error', {'closed', _Buffer}}) ->
+    lager:warning("socket closed unexpectedly"),
+    'tcp_closed';
+format_error({'error', 'closed'}) ->
+    lager:warning("socket closed unexpectedly"),
+    'tcp_closed';
 format_error({'error', Error}) -> Error;
 format_error(<<"400: illegal_database_name">>) -> 'illegal_database_name';
 format_error('forbidden') -> 'forbidden';

--- a/core/kazoo_couch/src/kz_couch_view.erl
+++ b/core/kazoo_couch/src/kz_couch_view.erl
@@ -18,7 +18,9 @@
 
 -include("kz_couch.hrl").
 
--type ddoc() :: 'all_docs' | kz_term:ne_binary() | {kz_term:ne_binary(), kz_term:ne_binary()}.
+-type ddoc() :: 'all_docs' |
+                kz_term:ne_binary() |
+                {kz_term:ne_binary(), kz_term:ne_binary()}.
 
 %%% View-related functions -----------------------------------------------------
 -spec design_compact(server(), kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
@@ -100,11 +102,11 @@ do_fetch_results(Db, DesignDoc, Options) ->
     ?RETRY_504(
        case couchbeam_view:fetch(Db, DesignDoc, Options) of
            {'ok', JObj} -> {'ok', kz_json:get_value(<<"rows">>, JObj, JObj)};
-           {'error', Error, []} -> {'error', kz_couch_util:format_error(Error)};
+           {'error', Error, []} -> {'error', Error};
            {'error', Error, Rows} ->
                lager:error("error ~p with results, ~p", [Error, Rows]),
-               {'error', kz_couch_util:format_error(Error)};
-           {'error', E} -> {'error', kz_couch_util:format_error(E)}
+               {'error', Error};
+           {'error', _}=Error -> Error
        end
       ).
 

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -9,6 +9,7 @@
 -include("kzl.hrl").
 
 -export([get/1, get/3
+        ,get_ranged/1
         ,available_ledgers/1
         ]).
 
@@ -28,43 +29,57 @@
 -spec get(kz_term:ne_binary()) -> {'ok', kz_json:object()} |
                                   {'error', atom()}.
 get(Account) ->
-    get(Account, undefined, undefined).
+    get(Account, 'undefined', 'undefined').
 
--spec get(kz_term:ne_binary(), kz_time:api_seconds(), kz_time:api_seconds()) -> {'ok', kz_json:object()} |
-                                                                                {'error', atom()}.
-get(Account, undefined, undefined) ->
-    case kazoo_modb:get_results(Account, ?TOTAL_BY_SERVICE_LEGACY, [group]) of
+-spec get(kz_term:ne_binary(), kz_time:api_seconds(), kz_time:api_seconds()) ->
+                 {'ok', kz_json:object()} |
+                 {'error', atom()}.
+get(Account, 'undefined', 'undefined') ->
+    case kazoo_modb:get_results(Account, ?TOTAL_BY_SERVICE_LEGACY, ['group']) of
         {'error', _R}=Error -> Error;
         {'ok', JObjs}->
             LedgersJObj = kz_json:from_list(
                             [{kz_json:get_value(<<"key">>, JObj), kz_json:get_value(<<"value">>, JObj)}
                              || JObj <- JObjs
                             ]),
-            {ok, LedgersJObj}
+            {'ok', LedgersJObj}
     end;
 
 get(Account, CreatedFrom, CreatedTo)
   when is_integer(CreatedFrom), CreatedFrom > 0,
        is_integer(CreatedTo), CreatedTo > 0 ->
-    MoDBs = kazoo_modb:get_range(Account, CreatedFrom, CreatedTo),
-    lager:debug("from:~p to:~p -> ~p", [CreatedFrom, CreatedTo, MoDBs]),
-    try
-        Sum = kz_json:sum_jobjs(
-                [case kazoo_modb:get_results(MoDB, ?LIST_BY_SERVICE_LEGACY, []) of
-                     {error, Reason} -> throw(Reason);
-                     {ok, JObjs} ->
-                         kz_json:sum_jobjs([kz_json:get_value(<<"value">>, JObj)
-                                            || JObj <- JObjs,
-                                               [_Type, TimeStamp] <- [kz_json:get_value(<<"key">>, JObj)],
-                                               CreatedFrom =< TimeStamp,
-                                               TimeStamp =< CreatedTo
-                                           ])
-                 end
-                 || MoDB <- MoDBs
+    MODBs = kazoo_modb:get_range(Account, CreatedFrom, CreatedTo),
+    Options = [{'databases', MODBs}
+              ,{'startkey', CreatedFrom}
+              ,{'endkey', CreatedTo}
+              ],
+    get_ranged(Options).
+
+-spec get_ranged(kz_term:proplist()) -> {'ok', kz_json:object()} | {'error', any()}.
+get_ranged(Options) ->
+    MODBs = props:get_value('databases', Options, []),
+    ViewOptions = props:filter_undefined(props:delete('databases', Options)),
+
+    lager:debug("from: ~p to: ~p in direction ~p -> ~p"
+               ,[props:get_value('startkey', ViewOptions)
+                ,props:get_value('endkey', ViewOptions)
+                ,props:get_value('direction', ViewOptions, 'ascending')
+                ,MODBs
                 ]),
-        {ok, Sum}
+
+    try
+        MODBs =:= []
+            andalso throw('no_account_db'),
+        Sum = kz_json:sum_jobjs(
+                [case kazoo_modb:get_results(MODB, <<"ledgers/list_by_timestamp_legacy">>, Options) of
+                     {'error', Reason} -> throw(Reason);
+                     {'ok', JObjs} -> kz_json:sum_jobjs([kz_json:get_value(<<"value">>, JObj) || JObj <- JObjs])
+                 end
+                 || MODB <- MODBs
+                ]),
+        {'ok', Sum}
     catch
-        throw:_R -> {error, _R}
+        'throw':_R -> {'error', _R}
     end.
 
 -spec available_ledgers(kz_term:api_binary()) -> kz_json:objects().

--- a/core/kazoo_modb/priv/couchdb/views/ledgers.json
+++ b/core/kazoo_modb/priv/couchdb/views/ledgers.json
@@ -2,6 +2,22 @@
     "_id": "_design/ledgers",
     "language": "javascript",
     "views": {
+        "list_by_timestamp_legacy": {
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_deleted || (doc.pvt_type !== 'ledger' && !( (doc.pvt_type === 'credit' || doc.pvt_type === 'debit') && (doc.pvt_code === 1001 || doc.pvt_code === 1002 )) ))",
+                "    return;",
+                "  var amount = doc.pvt_amount || doc.amount || 0;",
+                "  var usage = doc.pvt_usage || doc.usage || {};",
+                "  var service = doc.pvt_type === 'ledger' ? doc.source.service : 'per-minute-voip';",
+                "  if (doc.pvt_ledger_type === 'debit' || doc.pvt_type === 'debit')",
+                "    amount *= -1;",
+                "  var o = {};",
+                "  o[service] = {amount:amount, usage:usage};",
+                "  emit(doc.pvt_created, o);",
+                "}"
+            ]
+        },
         "listing_by_service": {
             "map": [
                 "function(doc) {",

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -67,7 +67,7 @@ dep_erlcloud = git https://github.com/lazedo/erlcloud 54fe6b96eb0bc591b80161fc55
 
 dep_erlazure = git https://github.com/lazedo/erlazure.git add-start-link
 
-dep_couchbeam = git https://github.com/2600hz/couchbeam 1.4.1b
+dep_couchbeam = git https://github.com/2600hz/couchbeam 2600hz 
 ###dep_couchbeam = git https://github.com/benoitc/couchbeam 1.4.1
 ### waiting for pull requests
 ### https://github.com/benoitc/couchbeam/pull/158


### PR DESCRIPTION
Ledgers summary was not honoring page size, and timestamp correctly, so it was loading all ledgers in a MODB database causing slowness and pressure on CouchDb and kazoo.

This PR changes ledgers API (`/ledger`) to use use crossbar_view for handling multi database load and time range query (default to 50). Currently I'm not sure how set the page size and next start key in response. This is the summary API, meaning it is returning all categories sums, so if you have 2 service category it returns two object. Since behind scene it limits the db result to 50, and we returning two object there is ambiguity between request page size (default to 50) and response  page size (in this example 2).

Also fixing KAZOO-5191 . There are times that view result is big, and couchdb dropping the connection during parsing buffer in couchbeam, and couchbeam should return proper error. [this fix depends on https://github.com/2600hz/couchbeam/commit/3fcd4679da7d6301304ad715d76e15bf2ae74c84]

4.2: https://github.com/2600hz/kazoo/pull/4911

### How to test

From UI:

Select and account which has a huge amount of the call (ledger: per-minute for example):

1. From UI go to account settings and Usage Charges
2. Use date range and next page, previous page crawl all ledgers.
3. It should returning without any error
4. It should returning all matched result
5. It should be relatively faster than before
6. It should *not* be as slow as and as time consuming as before.

For testing with API:

1, Make request to `/v2/account/{account_id}/ldegers` on an account which has more than 50 ledgers for this month, the API should only returns sum for the 50 ledgers (starting from latest one to older one), check with UI, (manually sum 50 ledgers).
2. make request to same URL and setting `?page_size=2`, it should return sum of the last 2 ledgers.
3. make request to same URL add `?paginate=false`, it should dump the whole ledgers for 1 month, causing slowness and takes a lot of time and probably results in and error or timeout.