### PR TITLE
[WIP] PISTON-549: cb_collections

### DIFF
--- a/applications/crossbar/src/api_flow.erl
+++ b/applications/crossbar/src/api_flow.erl
@@ -1,0 +1,306 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2018, Voxter Communications Inc
+%%% @doc API operation Context flow
+%%% Perform validation of API resources separately from request state
+%%%
+%%% @author Daniel Finke
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(api_flow).
+
+-export([allowed_methods/2
+        ,malformed_request/1
+        ,is_authorized/1
+        ,forbidden/1
+        ,content_types_provided/1
+        ,languages_provided/2
+        ,resource_exists/1
+        ]).
+
+-include("crossbar.hrl").
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec allowed_methods(cb_context:context(), boolean()) ->
+                             {http_methods() | 'stop', cb_context:context()}.
+allowed_methods(Context, IsCORSRequest) ->
+    lager:debug("run: allowed_methods"),
+
+    case api_util:is_early_authentic(Context) of
+        {'true', Context1} ->
+            authed_allowed_methods(Context1, IsCORSRequest);
+        {'stop', Context1} ->
+            lager:error("request is not authorized, stopping"),
+            {'stop', Context1}
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec authed_allowed_methods(cb_context:context(), boolean()) ->
+                                    {http_methods() | 'stop', cb_context:context()}.
+authed_allowed_methods(Context, IsCORSRequest) ->
+    lager:debug("run: authed_allowed_methods"),
+
+    Methods = cb_context:allowed_methods(Context),
+    Tokens = api_util:path_tokens(Context),
+
+    case api_util:parse_path_tokens(Context, Tokens) of
+        [_|_] = Nouns ->
+            find_allowed_methods(cb_context:set_req_nouns(Context, Nouns), IsCORSRequest);
+        [] ->
+            {Methods, cb_context:set_allow_methods(Context, Methods)};
+        Result -> Result
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec find_allowed_methods(cb_context:context(), boolean()) ->
+                                  {http_methods() | 'stop', cb_context:context()}.
+find_allowed_methods(Context, IsCORSRequest) ->
+    [{Mod, Params}|_] = cb_context:req_nouns(Context),
+
+    Event = api_util:create_event_name(Context, <<"allowed_methods">>),
+    Responses = crossbar_bindings:map(<<Event/binary, ".", Mod/binary>>, Params),
+
+    Method = cb_context:method(Context),
+    AllowMethods = api_util:allow_methods(Responses
+                                         ,cb_context:req_verb(Context)
+                                         ,kz_term:to_binary(Method)
+                                         ),
+    maybe_allow_preflight(cb_context:set_allow_methods(Context, AllowMethods), IsCORSRequest).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec maybe_allow_preflight(cb_context:context(), boolean()) ->
+                                   {http_methods() | 'stop', cb_context:context()}.
+maybe_allow_preflight(Context, IsCORSRequest) ->
+    case IsCORSRequest of
+        'true' ->
+            check_preflight(Context);
+        'false' ->
+            maybe_allow_method(Context)
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec check_preflight(cb_context:context()) ->
+                             {http_methods() | 'stop', cb_context:context()}.
+check_preflight(Context) ->
+    check_preflight(Context, cb_context:req_verb(Context)).
+
+check_preflight(Context, ?HTTP_OPTIONS) ->
+    lager:debug("allowing OPTIONS request for CORS preflight"),
+    {[?HTTP_OPTIONS], Context};
+check_preflight(Context, _Verb) ->
+    maybe_allow_method(Context).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec maybe_allow_method(cb_context:context()) ->
+                                {http_methods() | 'stop', cb_context:context()}.
+maybe_allow_method(Context) ->
+    maybe_allow_method(Context, cb_context:allow_methods(Context), cb_context:req_verb(Context)).
+
+maybe_allow_method(Context, [], _Verb) ->
+    lager:debug("no allow methods"),
+    {'stop', cb_context:add_system_error('not_found', Context)};
+maybe_allow_method(Context, [Verb]=Methods, Verb) ->
+    {Methods, Context};
+maybe_allow_method(Context, Methods, Verb) ->
+    case lists:member(Verb, Methods) of
+        'true' -> {Methods, Context};
+        'false' -> {'stop', cb_context:add_system_error('invalid_method', Context)}
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec malformed_request(cb_context:context()) ->
+                               {boolean() | 'stop', cb_context:context()}.
+malformed_request(Context) ->
+    malformed_request(Context, cb_context:req_verb(Context)).
+
+-spec malformed_request(cb_context:context(), http_method()) ->
+                               {boolean() | 'stop', cb_context:context()}.
+malformed_request(Context, ?HTTP_OPTIONS) ->
+    {'false', Context};
+malformed_request(Context, _ReqVerb) ->
+    case props:get_value(<<"accounts">>, cb_context:req_nouns(Context)) of
+        'undefined' ->
+            {'false', Context};
+        [] ->
+            {'false', Context};
+        [?MATCH_ACCOUNT_RAW(_) | _] = AccountArgs ->
+            Context1 = cb_accounts:validate_resource(Context, AccountArgs),
+            case cb_context:resp_status(Context1) of
+                'success' -> {'false', Context1};
+                _RespStatus -> {'stop', Context1}
+                    % api_util:stop(Req, Context1)
+            end;
+        [<<>> | _] ->
+            Error = kz_json:from_list([{<<"message">>, <<"missing account_id">>}]),
+            {'stop', cb_context:add_system_error(404, <<"bad identifier">>, Error, Context)};
+            % api_util:stop(Req, cb_context:add_system_error(404, <<"bad identifier">>, Error, Context));
+        [_Other | _] ->
+            Msg = kz_term:to_binary(io_lib:format("invalid account_id '~s'", [_Other])),
+            Error = kz_json:from_list([{<<"message">>, Msg}]),
+            {'stop', cb_context:add_system_error(404, <<"bad identifier">>, Error, Context)}
+            % api_util:stop(Req, cb_context:add_system_error(404, <<"bad identifier">>, Error, Context))
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec is_authorized(cb_context:context()) ->
+                           {boolean() | 'stop', cb_context:context()}.
+is_authorized(Context) ->
+    api_util:is_authentic(Context).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec forbidden(cb_context:context()) ->
+                       {'false' | 'stop', cb_context:context()}.
+forbidden(Context0) ->
+    case api_util:is_permitted(Context0) of
+        {'stop', Context1} -> {'stop', Context1};
+        {IsPermitted, Context1} ->
+            {not IsPermitted, Context1}
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec content_types_provided(cb_context:context()) ->
+                                    {content_type_callbacks(), cb_context:context()}.
+content_types_provided(Context0) ->
+    lager:debug("run: content_types_provided"),
+
+    [{Mod, Params}|_] = cb_context:req_nouns(Context0),
+    Event = api_util:create_event_name(Context0, <<"content_types_provided.", Mod/binary>>),
+    Payload = [Context0 | Params],
+
+    Context1 = crossbar_bindings:fold(Event, Payload),
+
+    content_types_provided(Context1, cb_context:content_types_provided(Context1)).
+
+content_types_provided(Context, []) ->
+    Def = ?CONTENT_PROVIDED,
+    content_types_provided(cb_context:set_content_types_provided(Context, Def), Def);
+content_types_provided(Context, CTPs) ->
+    CTP =
+        lists:foldr(fun({Fun, L}, Acc) ->
+                            lists:foldr(fun({Type, SubType}, Acc1) ->
+                                                [{{Type, SubType, []}, Fun} | Acc1];
+                                           ({_,_,_}=EncType, Acc1) ->
+                                                [ {EncType, Fun} | Acc1 ];
+                                           (CT, Acc1) when is_binary(CT) ->
+                                                [{CT, Fun} | Acc1]
+                                        end, Acc, L)
+                    end
+                   ,[]
+                   ,CTPs
+                   ),
+    lager:debug("ctp: ~p", [CTP]),
+    {CTP, Context}.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec languages_provided(cb_context:context(), kz_term:api_binary()) ->
+                                {kz_term:ne_binaries(), cb_context:context()}.
+languages_provided(Context0, ExtraAcceptLanguage) ->
+    lager:debug("run: languages_provided"),
+
+    [{Mod, Params} | _] = cb_context:req_nouns(Context0),
+    Event = api_util:create_event_name(Context0, <<"languages_provided.", Mod/binary>>),
+    Payload = [Context0 | Params],
+    Context1 = crossbar_bindings:fold(Event, Payload),
+
+    case ExtraAcceptLanguage of
+        'undefined' ->
+            {cb_context:languages_provided(Context1), Context1};
+        _ ->
+            {cb_context:languages_provided(Context1) ++ [ExtraAcceptLanguage]
+            ,Context1
+            }
+    end.
+
+    % case cowboy_req:parse_header(<<"accept-language">>, Req0) of
+    %     'undefined' ->
+    %         {cb_context:languages_provided(Context1), Req0, Context1};
+    %     [{A,_}|_]=_Accepted ->
+    %         lager:debug("adding first accept-lang header language: ~s", [A]),
+    %         {cb_context:languages_provided(Context1) ++ [A], Req0, Context1}
+    % end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec resource_exists(cb_context:context()) ->
+                             {boolean() | 'stop', cb_context:context()}.
+resource_exists(Context) ->
+    resource_exists(Context, cb_context:req_nouns(Context)).
+
+resource_exists(Context, [{<<"404">>,_}|_]) ->
+    lager:debug("failed to tokenize request, returning 404"),
+    {'false', Context};
+resource_exists(Context, _Nouns) ->
+    lager:debug("run: resource_exists"),
+    case api_util:does_resource_exist(Context) of
+        'true' ->
+            does_request_validate(Context);
+        'false' ->
+            lager:debug("requested resource does not exist"),
+            {'false', Context}
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec does_request_validate(cb_context:context()) ->
+                                   {boolean() | 'stop', cb_context:context()}.
+does_request_validate(Context0) ->
+    lager:debug("requested resource exists, validating it"),
+    Context1 = api_util:validate(Context0),
+    Verb = cb_context:req_verb(Context1),
+    case api_util:succeeded(Context1) of
+        'true' when Verb =/= ?HTTP_PUT ->
+            lager:debug("requested resource update validated"),
+            {'true', Context1};
+        'true' ->
+            lager:debug("requested resource creation validated"),
+            {'false', Context1};
+        'false' ->
+            lager:debug("failed to validate resource"),
+            Msg = case {cb_context:resp_error_msg(Context1)
+                       ,cb_context:resp_data(Context1)
+                       }
+                  of
+                      {'undefined', 'undefined'} ->
+                          <<"validation failed">>;
+                      {'undefined', Data} ->
+                          kz_json:get_value(<<"message">>, Data, <<"validation failed">>);
+                      {Message, _} -> Message
+                  end,
+            {'stop', cb_context:set_resp_error_msg(Context1, Msg)}
+    end.

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -95,7 +95,7 @@
         ,host_url/1, set_host_url/2
         ,set_pretty_print/2
         ,set_port/2
-        ,set_raw_path/2
+        ,raw_path/1, set_raw_path/2
         ,raw_qs/1, set_raw_qs/2
         ,profile_id/1 ,set_profile_id/2
 
@@ -667,6 +667,9 @@ host_url(#cb_context{host_url = Value}) -> Value.
 -spec set_pretty_print(context(), boolean()) -> context().
 set_pretty_print(#cb_context{}=Context, Value) ->
     Context#cb_context{pretty_print = Value}.
+
+-spec raw_path(context()) -> binary().
+raw_path(#cb_context{raw_path = Value}) -> Value.
 
 -spec set_raw_path(context(), binary()) -> context().
 set_raw_path(#cb_context{}=Context, Value) ->

--- a/applications/crossbar/src/crossbar_types.hrl
+++ b/applications/crossbar/src/crossbar_types.hrl
@@ -29,6 +29,9 @@
 
 -type content_type() :: {kz_term:ne_binary(), kz_term:ne_binary(), '*' | kz_term:proplist()} | kz_term:ne_binary().
 %% `{Type, SubType, Options}'
+-type content_type_callbacks() :: [{{kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()}, atom()} |
+                                   {kz_term:ne_binary(), atom()}
+                                  ].
 
 -type media_value() :: {content_type(), non_neg_integer(), list()}.
 -type media_values() :: [media_value()].

--- a/applications/crossbar/src/modules/cb_collections.erl
+++ b/applications/crossbar/src/modules/cb_collections.erl
@@ -1,0 +1,305 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2018, Voxter Communications Inc
+%%% @doc Multiple operations module
+%%% Handle requests to perform crossbar operations on multiple IDs at once or on
+%%% the results of a view
+%%%
+%%% @author Daniel Finke
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(cb_collections).
+
+-export([init/0
+        ,allowed_methods/0
+        ,resource_exists/0
+        ,validate/1
+        % ,post/1
+        ]).
+
+-include("crossbar.hrl").
+
+-spec init() -> 'ok'.
+init() ->
+    Bindings = [{<<"*.allowed_methods.collections">>, 'allowed_methods'}
+               ,{<<"*.resource_exists.collections">>, 'resource_exists'}
+               ,{<<"*.validate.collections">>, 'validate'}
+               % ,{<<"*.execute.put.accounts">>, 'put'}
+               % ,{<<"*.execute.post.accounts">>, 'post'}
+               % ,{<<"*.execute.patch.accounts">>, 'patch'}
+               % ,{<<"*.execute.delete.accounts">>, 'delete'}
+               ],
+    cb_modules_util:bind(?MODULE, Bindings).
+
+%%------------------------------------------------------------------------------
+%% @doc This function determines the verbs that are appropriate for the
+%% given Nouns.
+%%
+%% Failure here returns `405 Method Not Allowed'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec allowed_methods() -> http_methods().
+allowed_methods() ->
+    % [?HTTP_GET, ?HTTP_PUT, ?HTTP_POST].
+    [?HTTP_GET].
+
+%%------------------------------------------------------------------------------
+%% @doc This function determines if the provided list of Nouns are valid.
+%% Failure here returns `404 Not Found'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec resource_exists() -> 'true'.
+resource_exists() -> 'true'.
+
+%%------------------------------------------------------------------------------
+%% @doc This function determines if the parameters and content are correct
+%% for this request
+%%
+%% Failure here returns 400.
+%% @end
+%%------------------------------------------------------------------------------
+-spec validate(cb_context:context()) -> cb_context:context().
+validate(Context) ->
+    Context1 = cb_context:set_resp_data(Context, #{}),
+    case create_collection_context(Context1) of
+        {'error', Context2} -> Context2;
+        CollectionContext -> validate_paths(Context1, CollectionContext)
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+% -spec post(cb_context:context()) -> cb_context:context().
+% post(Context) ->
+%     CollectionContexts = maps:to_list(cb_context:fetch(Context, 'collection_contexts')),
+%     post_paths(Context, CollectionContexts).
+
+% -spec post_paths(cb_context:context(), [{binary(), cb_context:context()}]) -> cb_context:context().
+% post_paths(Context, []) -> Context;
+% post_paths(Context, [{Path, CollectionContext}|CollectionContexts]) ->
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec validate_paths(cb_context:context(), cb_context:context()) -> cb_context:context().
+validate_paths(Context, CollectionContext) ->
+    Paths = sets:to_list(cb_context:fetch(CollectionContext, 'paths')),
+    validate_paths(Context, CollectionContext, Paths).
+
+-spec validate_paths(cb_context:context(), cb_context:context(), kz_term:ne_binaries()) ->
+                            cb_context:context().
+validate_paths(Context, _, []) ->
+    cb_context:set_resp_status(Context, 'success');
+validate_paths(Context, CollectionContext, [Path|Paths]) ->
+    CollectionContext1 = cb_context:set_raw_path(CollectionContext, Path),
+    case api_flow:allowed_methods(CollectionContext1, 'false') of
+        {'stop', CollectionContext2} ->
+            %% TODO handle better?
+            CollectionContext2;
+        {Methods, CollectionContext2} ->
+            CollectionContext3 = validate_method(CollectionContext2, Methods),
+            Context1 = include_collection_result(Context, CollectionContext3),
+            %% Re-use unmodified CollectionContext
+            validate_paths(Context1, CollectionContext, Paths)
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec validate_method(cb_context:context(), http_methods()) -> cb_context:context().
+validate_method(CollectionContext, Methods) ->
+    case lists:member(cb_context:method(CollectionContext), Methods) of
+        'true' -> validate_request_format(CollectionContext);
+        'false' -> crossbar_util:response('error', <<"method not allowed">>, 405, CollectionContext)
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec validate_request_format(cb_context:context()) -> cb_context:context().
+validate_request_format(CollectionContext) ->
+    case api_flow:malformed_request(CollectionContext) of
+        {'stop', CollectionContext1} -> CollectionContext1;
+        {_, CollectionContext1} -> validate_authorization(CollectionContext1)
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+%% TODO test failing here
+-spec validate_authorization(cb_context:context()) -> cb_context:context().
+validate_authorization(CollectionContext) ->
+    case api_flow:is_authorized(CollectionContext) of
+        {'stop', CollectionContext1} -> CollectionContext1;
+        {'false', CollectionContext1} -> crossbar_util:response_401(CollectionContext1);
+        {'true', CollectionContext1} -> validate_resource_exists(CollectionContext1)
+    end.
+
+% -spec validate_content_type_provided(cb_context:context()) -> cb_context:context().
+% validate_content_type_provided(CollectionContext) ->
+
+% -spec validate_language_provided(cb_context:context()) -> cb_context().
+% validate_language_provided(CollectionContext) ->
+
+%% TODO test failing here w/ something like users or devices
+-spec validate_resource_exists(cb_context:context()) -> cb_context:context().
+validate_resource_exists(CollectionContext) ->
+    case api_flow:resource_exists(CollectionContext) of
+        {'stop', CollectionContext1} -> CollectionContext1;
+        {_, CollectionContext1} -> CollectionContext1
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec include_collection_result(cb_context:context(), cb_context:context()) -> cb_context:context().
+include_collection_result(Context, CollectionContext) ->
+    RespData = cb_context:resp_data(Context),
+    CollectionPathKey = cb_context:raw_path(CollectionContext),
+    Result = collection_result(CollectionContext),
+    CollectionContexts = cb_context:fetch(Context, 'collection_contexts', #{}),
+    cb_context:setters(Context
+                      ,[{fun cb_context:set_resp_data/2, RespData#{CollectionPathKey => Result}}
+                       ,{fun cb_context:store/3
+                         ,'collection_contexts'
+                         ,CollectionContexts#{CollectionPathKey => CollectionContext}
+                        }
+                       ]).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec collection_result(cb_context:context()) -> kz_json:object().
+collection_result(CollectionContext) ->
+    case cb_context:response(CollectionContext) of
+        {'ok', RespData} ->
+            kz_json:from_list([{<<"data">>, RespData}
+                              ,{<<"revision">>, kz_term:to_api_binary(cb_context:resp_etag(CollectionContext))}
+                              ,{<<"status">>, <<"success">>}
+                              ]);
+        {'error', {ErrorCode, ErrorMsg, RespData}} ->
+            kz_json:from_list([{<<"data">>, RespData}
+                              ,{<<"error">>, kz_term:to_binary(ErrorCode)}
+                              ,{<<"message">>, ErrorMsg}
+                              ,{<<"status">>, <<"error">>}
+                              ])
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Create a cb_context:context() that will be used for requests of the
+%% specified path.
+%% @end
+%%------------------------------------------------------------------------------
+-spec create_collection_context(cb_context:context()) -> cb_context:context() | {'error', cb_context:context()}.
+create_collection_context(Context) ->
+    %% TODO validate using JSONschema
+    validate_request_path(Context, cb_context:req_value(Context, <<"path">>)).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec validate_request_path(cb_context:context(), kz_json:api_json_term()) ->
+                                   cb_context:context() | {'error', cb_context:context()}.
+validate_request_path(Context, <<_,_/binary>> = Path) ->
+    validate_request_arguments(Context, Path, cb_context:req_verb(Context), cb_context:req_value(Context, <<"arguments">>));
+validate_request_path(Context, 'undefined') ->
+    {'error', cb_context:add_validation_error(<<"path">>, <<"required">>, <<"Field is required but missing">>, Context)};
+validate_request_path(Context, _) ->
+    {'error', cb_context:add_validation_error(<<"path">>
+                                             ,<<"type">>
+                                             ,kz_json:from_list([{<<"message">>, <<"Value did not match type(s): string">>}
+                                                                ,{<<"target">>, <<"string">>}
+                                                                ])
+                                             ,Context
+                                             )}.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec validate_request_arguments(cb_context:context(), kz_term:ne_binary(), http_method(), kz_json:api_json_term()) ->
+                                        cb_context:context() | {'error', cb_context:context()}.
+validate_request_arguments(Context, Path, ?HTTP_GET, Arguments) when is_binary(Arguments) ->
+    try kz_json:unsafe_decode(Arguments) of
+        JObj -> validate_request_arguments_type(Context, Path, JObj)
+    catch
+        'throw':{'invalid_json', _, _} ->
+            {'error', cb_context:add_validation_error(<<"arguments">>
+                                                     ,<<"invalid">>
+                                                     ,<<"Field must be valid URL-encoded JSON">>
+                                                     ,Context
+                                                     )}
+    end;
+validate_request_arguments(Context, _, ?HTTP_GET, _) ->
+    {'error', crossbar_util:response_400(<<"invalid arguments JSON">>, kz_json:new(), Context)};
+validate_request_arguments(Context, Path, _, Arguments) ->
+    %% TODO more validation
+    validate_request_arguments_type(Context, Path, Arguments).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec validate_request_arguments_type(cb_context:context(), kz_term:ne_binary(), kz_json:json_term()) ->
+                                             cb_context:context() | {'error', cb_context:context()}.
+validate_request_arguments_type(Context, Path, Arguments) ->
+    %% TODO validate types of each argument
+    case kz_json:is_json_object(Arguments) of
+        'true' -> do_create_collection_context(Context, Path, Arguments);
+        'false' ->
+            {'error', crossbar_util:response_400(<<"invalid arguments JSON">>, kz_json:new(), Context)}
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec do_create_collection_context(cb_context:context(), binary(), kz_json:object()) -> cb_context:context().
+do_create_collection_context(Context, Path, Arguments) ->
+    Paths = generate_distinct_paths(Path, Arguments),
+
+    Setters = [{fun cb_context:set_method/2, cb_context:method(Context)}
+              ,{fun cb_context:set_auth_token/2, cb_context:auth_token(Context)}
+              ,{fun cb_context:set_auth_token_type/2, cb_context:auth_token_type(Context)}
+              ,{fun cb_context:store/3, 'paths', Paths}
+              ],
+    cb_context:setters(cb_context:new(), Setters).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec generate_distinct_paths(kz_term:ne_binary(), kz_json:object()) -> sets:set(kz_term:ne_binary()).
+generate_distinct_paths(Path, Arguments) ->
+    generate_distinct_paths(Path, Arguments, kz_json:get_keys(Arguments), sets:new()).
+
+-spec generate_distinct_paths(kz_term:ne_binary(), kz_json:object(), kz_json:keys(), sets:set(kz_term:ne_binary())) ->
+                                     sets:set(kz_term:ne_binary()).
+generate_distinct_paths(_, _, [], Acc) -> Acc;
+generate_distinct_paths(Path, Arguments, [Key|Keys], Acc) ->
+    Value = kz_json:get_value(Key, Arguments),
+    Acc1 = apply_path_arguments(Path, Key, Value, Acc),
+    generate_distinct_paths(Path, Arguments, Keys, Acc1).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec apply_path_arguments(kz_term:ne_binary(), kz_json:path(), kz_json:json_term(), sets:set(kz_term:ne_binary())) ->
+                                  sets:set(kz_term:ne_binary()).
+apply_path_arguments(Path, Key, Values, Acc) when is_list(Values) ->
+    %% TODO test for multiple arguments. Cross product?
+    lists:foldl(fun(Value, Acc1) ->
+                        Path1 = re:replace(Path, <<"{", Key/binary, "}">>, Value, ['global', {'return', 'binary'}]),
+                        sets:add_element(Path1, Acc1)
+                end
+               ,Acc
+               ,Values
+               ).


### PR DESCRIPTION
Access multiple entities within a single GET request. Later adding PUT/POST/PATCH/DELETE

Sample request URL for GET: `{host}:8000/v1/accounts/{account_id}/collections?path=%2Fv1%2Faccounts%2F%7Bid%7D&arguments=%7B%22id%22%3A%5B%22id1%22%2C%22id2%22%5D%7D`
For GET (future: DELETE) requests, the params for the collection operation are equivalent to the contents of the data object of the (future) body of PUT/POST/PATCH requests, except URL-encoded.

Payload:
```
{
    "data": {
        "path": "/v1/accounts/{id}",
        "arguments": {
            "id":["id1","id2"]
        }
    }
}
```
Properties of "arguments" replace placeholders (e.g. {id}) from the path. They will also replace placeholders in the PUT/POST/PATCH body in the future.