### PR TITLE
Fix teletype deregister test

### DIFF
--- a/applications/teletype/test/rendered-templates/deregister.html
+++ b/applications/teletype/test/rendered-templates/deregister.html
@@ -61,7 +61,7 @@
                             <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Account ID:</b>&nbsp;&nbsp;<span style="font-family:monospace;">account0000000000000000000000003</span></li>
                             <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Account Realm:</b>&nbsp;&nbsp;<span style="font-family:monospace;">paustu8.sip.2600hz.local</span></li>
                             <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>User Agent:</b>&nbsp;&nbsp;<span style="font-family:monospace;">OBIHAI/OBi1020-5.0.0.3201</span></li>
-                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Contact:</b>&nbsp;&nbsp;<span style="font-family:monospace;">sip:device-3@101.3.2.55:5060;expires=60;+sip.instance="urn:uuid:00000000-0000-0000-0000-9cadefc002b5"</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Contact:</b>&nbsp;&nbsp;<span style="font-family:monospace;">sip:device-3@101.3.2.55:5060;expires=60;+sip.instance=&quot;urn:uuid:00000000-0000-0000-0000-9cadefc002b5&quot;</span></li>
                         </ul>
                     </td>
                 </tr>


### PR DESCRIPTION
kz_template:render will render the quotes in the placeholder replacement as `&quot;`, not `\"`