### PR TITLE
HELP-37255 - add Require-Fail-On-Single-Reject - 4.2

### DIFF
--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -144,6 +144,7 @@ build_offnet_request(Data, Call) ->
 get_channel_vars(Call) ->
     GetterFuns = [fun add_privacy_flags/2
                  ,fun maybe_require_ignore_early_media/2
+                 ,fun maybe_require_single_fail/2
                  ,fun maybe_set_bridge_generate_comfort_noise/2
                  ],
     CCVs = lists:foldl(fun(F, Acc) -> F(Call, Acc) end
@@ -160,6 +161,10 @@ add_privacy_flags(Call, Acc) ->
 -spec maybe_require_ignore_early_media(kapps_call:call(), kz_term:proplist()) -> kz_term:proplist().
 maybe_require_ignore_early_media(Call, Acc) ->
     [{<<"Require-Ignore-Early-Media">>, kapps_call:custom_channel_var(<<"Require-Ignore-Early-Media">>, Call)} | Acc].
+
+-spec maybe_require_single_fail(kapps_call:call(), kz_term:proplist()) -> kz_term:proplist().
+maybe_require_single_fail(Call, Acc) ->
+    [{<<"Require-Fail-On-Single-Reject">>, kapps_call:custom_channel_var(<<"Require-Fail-On-Single-Reject">>, Call)} | Acc].
 
 -spec get_bypass_e164(kz_json:object()) -> boolean().
 get_bypass_e164(Data) ->

--- a/applications/stepswitch/src/stepswitch_bridge.erl
+++ b/applications/stepswitch/src/stepswitch_bridge.erl
@@ -325,19 +325,27 @@ build_bridge(#state{endpoints=Endpoints
             ) ->
     lager:debug("set outbound caller id to ~s '~s'", [Number, Name]),
     AccountId = kapi_offnet_resource:account_id(OffnetReq),
-    CCVs =
-        kz_json:set_values(props:filter_undefined([{<<"Ignore-Display-Updates">>, <<"true">>}
-                                                  ,{<<"Account-ID">>, AccountId}
-                                                  ,{<<"From-URI">>, bridge_from_uri(Number, OffnetReq)}
-                                                  ,{<<"Realm">>, stepswitch_util:default_realm(OffnetReq)}
-                                                  ,{<<"Reseller-ID">>, kz_services:find_reseller_id(AccountId)}
-                                                  ,{<<"Outbound-Flags">>, outbound_flags(OffnetReq)}
-                                                  ])
-                          ,kapi_offnet_resource:custom_channel_vars(OffnetReq, kz_json:new())
-                          ),
-    FmtEndpoints = stepswitch_util:format_endpoints(Endpoints, Name, Number, OffnetReq),
-    IgnoreEarlyMedia = kz_json:is_true(<<"Require-Ignore-Early-Media">>, CCVs, 'false')
+
+    ReqCCVs = kapi_offnet_resource:custom_channel_vars(OffnetReq, kz_json:new()),
+
+    IgnoreEarlyMedia = kz_json:is_true(<<"Require-Ignore-Early-Media">>, ReqCCVs, 'false')
         orelse kapi_offnet_resource:ignore_early_media(OffnetReq, 'false'),
+
+    FailOnSingleReject = kz_json:get_value(<<"Require-Fail-On-Single-Reject">>, ReqCCVs),
+
+    AddCCVs = props:filter_undefined([{<<"Ignore-Display-Updates">>, <<"true">>}
+                                     ,{<<"Account-ID">>, AccountId}
+                                     ,{<<"From-URI">>, bridge_from_uri(Number, OffnetReq)}
+                                     ,{<<"Realm">>, stepswitch_util:default_realm(OffnetReq)}
+                                     ,{<<"Reseller-ID">>, kz_services:find_reseller_id(AccountId)}
+                                     ,{<<"Outbound-Flags">>, outbound_flags(OffnetReq)}
+                                     ]),
+    RemoveCCVs = [{<<"Require-Ignore-Early-Media">>, null}
+                 ,{<<"Require-Fail-On-Single-Reject">>, null}
+                 ],
+
+    CCVs = kz_json:set_values(AddCCVs ++ RemoveCCVs, ReqCCVs),
+    FmtEndpoints = stepswitch_util:format_endpoints(Endpoints, Name, Number, OffnetReq),
 
     props:filter_undefined(
       [{<<"Application-Name">>, <<"bridge">>}
@@ -350,6 +358,7 @@ build_bridge(#state{endpoints=Endpoints
       ,{<<"Custom-Application-Vars">>, kapi_offnet_resource:custom_application_vars(OffnetReq)}
       ,{<<"Timeout">>, kapi_offnet_resource:timeout(OffnetReq)}
       ,{<<"Ignore-Early-Media">>, IgnoreEarlyMedia}
+      ,{<<"Fail-On-Single-Reject">>, FailOnSingleReject}
       ,{<<"Media">>, kapi_offnet_resource:media(OffnetReq)}
       ,{<<"Hold-Media">>, kapi_offnet_resource:hold_media(OffnetReq)}
       ,{<<"Presence-ID">>, kapi_offnet_resource:presence_id(OffnetReq)}

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1641,6 +1641,7 @@ maybe_set_confirm_properties({Endpoint, Call, CallFwd, CCVs}=Acc) ->
                       ,{<<"Confirm-Read-Timeout">>, kz_term:to_binary(7 * ?MILLISECONDS_IN_SECOND)}
                       ,{<<"Confirm-File">>, ?CONFIRM_FILE(Call)}
                       ,{<<"Require-Ignore-Early-Media">>, <<"true">>}
+                      ,{<<"Require-Fail-On-Single-Reject">>, <<"USER_BUSY,CALL_REJECTED,NORMAL_CLEARING">>}
                       ],
             {Endpoint, Call, CallFwd
             ,kz_json:merge_jobjs(kz_json:from_list(Confirm), CCVs)

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1641,7 +1641,7 @@ maybe_set_confirm_properties({Endpoint, Call, CallFwd, CCVs}=Acc) ->
                       ,{<<"Confirm-Read-Timeout">>, kz_term:to_binary(7 * ?MILLISECONDS_IN_SECOND)}
                       ,{<<"Confirm-File">>, ?CONFIRM_FILE(Call)}
                       ,{<<"Require-Ignore-Early-Media">>, <<"true">>}
-                      ,{<<"Require-Fail-On-Single-Reject">>, <<"USER_BUSY,CALL_REJECTED,NORMAL_CLEARING">>}
+                      ,{<<"Require-Fail-On-Single-Reject">>, <<"USER_BUSY,CALL_REJECTED,NO_ANSWER,NORMAL_CLEARING">>}
                       ],
             {Endpoint, Call, CallFwd
             ,kz_json:merge_jobjs(kz_json:from_list(Confirm), CCVs)


### PR DESCRIPTION
call forwarding configured to require key press needs to exit
from the originate loop if the user rejects the call

using Fail-On-Single-Reject is not enough because it will add
the variable to the a-leg of the loopback channel, and we want to
add it as part of the bridge dial string of the b-leg