### PR TITLE
Fix rate import race condition

### DIFF
--- a/applications/tasks/src/kz_task_worker.erl
+++ b/applications/tasks/src/kz_task_worker.erl
@@ -140,6 +140,7 @@ teardown(API, IterValue, #state{task_id = TaskId
                                ,total_failed = TotalFailed
                                ,columns = Columns
                                }) ->
+    _ = kz_tasks_scheduler:finish_task(API, IterValue),
     _ = kz_tasks_scheduler:worker_finished(TaskId
                                           ,TotalSucceeded
                                           ,TotalFailed

--- a/applications/tasks/src/modules/kt_rates.erl
+++ b/applications/tasks/src/modules/kt_rates.erl
@@ -11,7 +11,7 @@
 -export([init/0
         ,help/1, help/2, help/3
         ,output_header/1
-        ,cleanup/2
+        ,finish/2
         ]).
 
 %% Verifiers
@@ -50,7 +50,7 @@ init() ->
     _ = tasks_bindings:bind(<<"tasks.help">>, ?MODULE, 'help'),
     _ = tasks_bindings:bind(<<"tasks."?CATEGORY".output_header">>, ?MODULE, 'output_header'),
     _ = tasks_bindings:bind(<<"tasks."?CATEGORY".direction">>, ?MODULE, 'direction'),
-    _ = tasks_bindings:bind(<<"tasks."?CATEGORY".cleanup">>, ?MODULE, 'cleanup'),
+    _ = tasks_bindings:bind(<<"tasks."?CATEGORY".finish">>, ?MODULE, 'finish'),
     tasks_bindings:bind_actions(<<"tasks."?CATEGORY>>, ?MODULE, ?ACTIONS).
 
 -spec output_header(kz_term:ne_binary()) -> kz_tasks:output_header().
@@ -231,12 +231,12 @@ delete(_ExtraArgs, State, Args) ->
             }
     end.
 
--spec cleanup(kz_term:ne_binary(), any()) -> any().
-cleanup(<<"import">>, Dict) ->
+-spec finish(kz_term:ne_binary(), any()) -> any().
+finish(<<"import">>, Dict) ->
     _Size = dict:size(Dict),
-    lager:debug("importing ~p ratedeck~s", [_Size, maybe_plural(_Size)]),
+    lager:info("importing ~p ratedeck~s", [_Size, maybe_plural(_Size)]),
     _ = dict:map(fun import_rates_into_ratedeck/2, Dict);
-cleanup(<<"delete">>, State) ->
+finish(<<"delete">>, State) ->
     Db = props:get_value('db', State),
     Keys = props:get_value('keys', State),
     Dict = props:get_value('dict', State),


### PR DESCRIPTION
Prior to this PR, tasks would execute each row in the CSV using the provided task module, mark the task as complete, and then run the task's `cleanup` if provided.

The `kt_rates` used `cleanup` to do the actual uploading of rates into the ratedecks. Due to the tight testing in `pqc_cb_rates:seq/0`, the test would query for the rate before the task's cleanup function had finished uploading, resulting in a failed test (subject to race conditions).

This PR introduces a `finish` callback for tasks to run after all CSV rows are processed but before the task is marked as complete.