### PR TITLE
Add more Erlang versions and note issues with 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ notifications:
       - "irc.freenode.org#2600hz-dev"
 
 otp_release:
-  - 19.3
+  - 19.3.6.5
+  - 20.3.8
+  - 21.0.3
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
       - "irc.freenode.org#2600hz-dev"
 
 otp_release:
-  - 19.3.6.5
+  - 19.3
   - 20.3.8
   - 21.0.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ notifications:
 otp_release:
   - 19.3
   - 20.3.8
-  - 21.0.3
+#  - 21.0.3
+# Lots of issues with erlang:get_stacktrace/0-related deprecations - going to take a while to unravel all this jazz
 
 sudo: required
 

--- a/doc/engineering/ci.md
+++ b/doc/engineering/ci.md
@@ -1,0 +1,11 @@
+# Continuous Integration
+
+Kazoo makes use of [TravisCI](https://travis-ci.org/2600hz/kazoo/) and [CircleCI](https://circleci.com/gh/2600hz/kazoo/).
+
+## TravisCI
+
+Travis is tasked with building Kazoo against various versions of Erlang and running the test suites (core/ and applications/).
+
+## CircleCI
+
+Circle handles doing checks against the code base, documentation, Dialyzer, and building and testing a release using the currently supported Erlang version.

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -446,6 +446,7 @@ pages:
 - 'Engineering':
   - 'Announcements': 'doc/announcements.md'
   - 'Install/Build Kazoo': 'doc/installation.md'
+  - 'Continuous Integration (CI)': 'doc/engineering/ci.md'
   - 'Call Recording': 'doc/engineering/call_recording.md'
   - 'Caller ID Formatting': 'doc/reference/caller_id_formatting.md'
   - 'Documentation':


### PR DESCRIPTION
We want to make sure Kazoo tracks newer Erlang versions even if we're not ready to build packages using those versions.

Deprecation in 21 of `erlang:get_stacktrace/0` (primarily) will require a lot of work in Kazoo and its deps to get working builds and isn't currently prioritized. We'll probably need to vendor all our deps and patch for 21 when we move to it as the official version.