### PR TITLE
[4.2] Fixed UK ringback and made configurable multivar separator

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -28695,7 +28695,7 @@
                     "type": "integer"
                 },
                 "multivar_separator": {
-                    "default": ";",
+                    "default": "~",
                     "description": "ecallmgr multivar_separator",
                     "type": "string"
                 },

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -28694,6 +28694,11 @@
                     "description": "ecallmgr maximum timeout for node restart",
                     "type": "integer"
                 },
+                "multivar_separator": {
+                    "default": ";",
+                    "description": "ecallmgr multivar_separator",
+                    "type": "string"
+                },
                 "network_map": {
                     "default": {},
                     "description": "ecallmgr network map",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
@@ -258,6 +258,11 @@
             "description": "ecallmgr maximum timeout for node restart",
             "type": "integer"
         },
+        "multivar_separator": {
+            "default": ";",
+            "description": "ecallmgr multivar_separator",
+            "type": "string"
+        },
         "network_map": {
             "default": {},
             "description": "ecallmgr network map",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
@@ -259,7 +259,7 @@
             "type": "integer"
         },
         "multivar_separator": {
-            "default": ";",
+            "default": "~",
             "description": "ecallmgr multivar_separator",
             "type": "string"
         },

--- a/applications/ecallmgr/src/ecallmgr_config.erl
+++ b/applications/ecallmgr/src/ecallmgr_config.erl
@@ -78,7 +78,7 @@ flush_default(Key) ->
 -ifdef(TEST).
 
 -spec get(kz_json:path()) -> kz_json:api_json_term().
-get(_) -> undefined.
+get(_) -> 'undefined'.
 
 -spec get(kz_json:path(), Default) ->
                  kz_json:json_term() | Default.
@@ -260,7 +260,6 @@ get_ne_binaries(Key, Default, Node) ->
             ];
         _ -> Default
     end.
-
 
 -spec fetch(kz_json:path()) -> kz_json:api_json_term().
 fetch(Key) ->

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -59,7 +59,7 @@
 
 -define(HTTP_GET_PREFIX, "http_cache://").
 
--define(FS_MULTI_VAR_SEP, ";").
+-define(FS_MULTI_VAR_SEP, ecallmgr_config:get_ne_binary(<<"multivar_separator">>, <<";">>)).
 -define(FS_MULTI_VAR_SEP_PREFIX, "^^").
 
 -type send_cmd_ret() :: fs_sendmsg_ret() | fs_api_ret().
@@ -505,7 +505,7 @@ is_node_up(Node, UUID) ->
 %%------------------------------------------------------------------------------
 -spec multi_set_args(atom(), kz_term:ne_binary(), kz_term:proplist()) -> binary().
 multi_set_args(Node, UUID, KVs) ->
-    multi_set_args(Node, UUID, KVs, <<?FS_MULTI_VAR_SEP>>).
+    multi_set_args(Node, UUID, KVs, ?FS_MULTI_VAR_SEP).
 
 -spec multi_set_args(atom(), kz_term:ne_binary(), kz_term:proplist(), kz_term:ne_binary()) -> binary().
 multi_set_args(Node, UUID, KVs, Separator) ->
@@ -517,7 +517,7 @@ multi_set_args(Node, UUID, KVs, Separator, Prefix) ->
 
 -spec multi_unset_args(atom(), kz_term:ne_binary(), kz_term:proplist()) -> binary().
 multi_unset_args(Node, UUID, KVs) ->
-    multi_unset_args(Node, UUID, KVs, <<?FS_MULTI_VAR_SEP>>).
+    multi_unset_args(Node, UUID, KVs, ?FS_MULTI_VAR_SEP).
 
 -spec multi_unset_args(atom(), kz_term:ne_binary(), kz_term:proplist(), kz_term:ne_binary()) -> binary().
 multi_unset_args(Node, UUID, KVs, Separator) ->
@@ -531,7 +531,7 @@ multi_unset_args(Node, UUID, KVs, Separator, Prefix) ->
 fs_args_to_binary([_]=Args) ->
     list_to_binary(Args);
 fs_args_to_binary(Args) ->
-    fs_args_to_binary(Args, <<?FS_MULTI_VAR_SEP>>).
+    fs_args_to_binary(Args, ?FS_MULTI_VAR_SEP).
 
 -spec fs_args_to_binary(list(), kz_term:ne_binary()) -> binary().
 fs_args_to_binary(Args, Sep) ->

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -59,7 +59,7 @@
 
 -define(HTTP_GET_PREFIX, "http_cache://").
 
--define(FS_MULTI_VAR_SEP, ecallmgr_config:get_ne_binary(<<"multivar_separator">>, <<";">>)).
+-define(FS_MULTI_VAR_SEP, ecallmgr_config:get_ne_binary(<<"multivar_separator">>, <<"~">>)).
 -define(FS_MULTI_VAR_SEP_PREFIX, "^^").
 
 -type send_cmd_ret() :: fs_sendmsg_ret() | fs_api_ret().


### PR DESCRIPTION
Also  default default multivar separator set to `"~"`