### PR TITLE
KAZOO-5938

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -31074,6 +31074,10 @@
                 },
                 "routesip": {
                     "description": "number_manager.vitelity routesip"
+                },
+                "use_stepswitch_cnam": {
+                    "description": "number_manager.vitelity use_stepswitch_cnam",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
@@ -10,6 +10,10 @@
         },
         "routesip": {
             "description": "number_manager.vitelity routesip"
+        },
+        "use_stepswitch_cnam": {
+            "description": "number_manager.vitelity use_stepswitch_cnam",
+            "type": "string"
         }
     },
     "type": "object"

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -96,7 +96,7 @@ disconnect_number(Number) ->
     query_vitelity(Number, release_did_options(DID)).
 
 %%------------------------------------------------------------------------------
-%% @doc Check to see if use_stepswich_cnam is defined in the couchdoc and is set 
+%% @doc Check to see if use_stepswich_cnam is defined in the couchdoc and is set
 %% to true. When set to true, incoming calls will use stepswitch to lookup cnam.
 %% @end
 %%------------------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -96,11 +96,16 @@ disconnect_number(Number) ->
     query_vitelity(Number, release_did_options(DID)).
 
 %%------------------------------------------------------------------------------
-%% @doc
+%% @doc Check to see if use_stepswich_cnam is defined in the couchdoc and is set 
+%% to true. When set to true, incoming calls will use stepswitch to lookup cnam.
 %% @end
 %%------------------------------------------------------------------------------
 -spec should_lookup_cnam() -> boolean().
-should_lookup_cnam() -> 'false'.
+should_lookup_cnam() ->
+  case kapps_config:get_ne_binary(?KNM_VITELITY_CONFIG_CAT, <<"use_stepswitch_cnam">>) of
+    <<"true">> -> 'true';
+    _          -> 'false'
+  end.
 
 %%------------------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
- Adds a lookup for use_stepswitch_cnam for
  knm_vitelity:should_lookup_cnam(). If set to true, knm_vitelity
  will use stepswitch cnam.