### PR TITLE
KAZOO-5938

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -30940,6 +30940,10 @@
                 },
                 "routesip": {
                     "description": "number_manager.vitelity routesip"
+                },
+                "use_stepswitch_cnam": {
+                    "description": "number_manager.vitelity use_stepswitch_cnam",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
@@ -10,6 +10,9 @@
         },
         "routesip": {
             "description": "number_manager.vitelity routesip"
+        },
+        "use_stepswitch_cnam": {
+            "description": "number_manager.vitelity stepswitch_cnam"
         }
     },
     "type": "object"

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -96,11 +96,16 @@ disconnect_number(Number) ->
     query_vitelity(Number, release_did_options(DID)).
 
 %%------------------------------------------------------------------------------
-%% @doc
+%% @doc Check to see if use_stepswitch_cnam is defined in the couchdoc. If it is
+%% set to true, then incoming calls will use stepswitch for cnam
 %% @end
 %%------------------------------------------------------------------------------
 -spec should_lookup_cnam() -> boolean().
-should_lookup_cnam() -> 'false'.
+should_lookup_cnam() ->
+  case kapps_config:get_ne_binary(?KNM_VITELITY_CONFIG_CAT, <<"use_stepswitch_cnam">>) of
+    <<"true">> -> 'true';
+    _          -> 'false'
+  end.
 
 %%------------------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
should_lookup_cnam() does a check to see if use_stepswitch_cnam() is set to true in the couchdoc. If so, then incoming cnam requests are done against the stepswitch cnam service.