### PR TITLE
KAZOO-5938 - 4.2

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -30940,6 +30940,10 @@
                 },
                 "routesip": {
                     "description": "number_manager.vitelity routesip"
+                },
+                "use_stepswitch_cnam": {
+                    "description": "number_manager.vitelity use_stepswitch_cnam",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -30942,8 +30942,9 @@
                     "description": "number_manager.vitelity routesip"
                 },
                 "use_stepswitch_cnam": {
+                    "default": false,
                     "description": "number_manager.vitelity use_stepswitch_cnam",
-                    "type": "string"
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
@@ -12,7 +12,8 @@
             "description": "number_manager.vitelity routesip"
         },
         "use_stepswitch_cnam": {
-            "description": "number_manager.vitelity use_stepswitch_cnam"
+            "description": "number_manager.vitelity use_stepswitch_cnam",
+            "type": "string"
         }
     },
     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
@@ -10,6 +10,9 @@
         },
         "routesip": {
             "description": "number_manager.vitelity routesip"
+        },
+        "use_stepswitch_cnam": {
+            "description": "number_manager.vitelity use_stepswitch_cnam"
         }
     },
     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
@@ -12,8 +12,9 @@
             "description": "number_manager.vitelity routesip"
         },
         "use_stepswitch_cnam": {
+            "default": false,
             "description": "number_manager.vitelity use_stepswitch_cnam",
-            "type": "string"
+            "type": "boolean"
         }
     },
     "type": "object"

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -102,10 +102,7 @@ disconnect_number(Number) ->
 %%------------------------------------------------------------------------------
 -spec should_lookup_cnam() -> boolean().
 should_lookup_cnam() ->
-    case kapps_config:get_ne_binary(?KNM_VITELITY_CONFIG_CAT, <<"use_stepswitch_cnam">>) of
-        <<"true">> -> 'true';
-        _          -> 'false'
-    end.
+    kapps_config:get_is_true(?KNM_VITELITY_CONFIG_CAT, <<"use_stepswitch_cnam">>, false).
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -96,11 +96,16 @@ disconnect_number(Number) ->
     query_vitelity(Number, release_did_options(DID)).
 
 %%------------------------------------------------------------------------------
-%% @doc
+%% @doc Check to see if use_stepswitch_cnam is defined in the couchdoc. If it is
+%% set to true, then incoming calls will use stepswitch for cnam
 %% @end
 %%------------------------------------------------------------------------------
 -spec should_lookup_cnam() -> boolean().
-should_lookup_cnam() -> 'false'.
+should_lookup_cnam() ->
+  case kapps_config:get_ne_binary(?KNM_VITELITY_CONFIG_CAT, <<"use_stepswitch_cnam">>) of
+    <<"true">> -> 'true';
+    _          -> 'false'
+  end.
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -103,8 +103,8 @@ disconnect_number(Number) ->
 -spec should_lookup_cnam() -> boolean().
 should_lookup_cnam() ->
     case kapps_config:get_ne_binary(?KNM_VITELITY_CONFIG_CAT, <<"use_stepswitch_cnam">>) of
-    <<"true">> -> 'true';
-    _          -> 'false'
+        <<"true">> -> 'true';
+        _          -> 'false'
     end.
 
 %%------------------------------------------------------------------------------

--- a/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_vitelity.erl
@@ -102,10 +102,10 @@ disconnect_number(Number) ->
 %%------------------------------------------------------------------------------
 -spec should_lookup_cnam() -> boolean().
 should_lookup_cnam() ->
-  case kapps_config:get_ne_binary(?KNM_VITELITY_CONFIG_CAT, <<"use_stepswitch_cnam">>) of
+    case kapps_config:get_ne_binary(?KNM_VITELITY_CONFIG_CAT, <<"use_stepswitch_cnam">>) of
     <<"true">> -> 'true';
     _          -> 'false'
-  end.
+    end.
 
 %%------------------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
should_lookup_cnam() does a check to see if use_stepswitch_cnam() is set to true in the couchdoc. If so, then incoming cnam requests are done against the stepswitch cnam service.