### PR TITLE
Fixed creation of storage document with empty data

### DIFF
--- a/applications/crossbar/src/modules/cb_storage.erl
+++ b/applications/crossbar/src/modules/cb_storage.erl
@@ -410,6 +410,8 @@ maybe_check_storage_settings(Context, _ReqVerb) ->
 -spec validate_attachments_settings(kz_json:object()
                                    ,cb_context:context()
                                    ) -> cb_context:context().
+validate_attachments_settings('undefined', Context) ->
+    kz_json:foldl(fun validate_attachment_settings_fold/3, Context, kz_json:new());
 validate_attachments_settings(Attachments, Context) ->
     kz_json:foldl(fun validate_attachment_settings_fold/3, Context, Attachments).
 


### PR DESCRIPTION
When executed command like `curl -X PUT --data-binary '{"data":{}}'  'https://api.rcsnet.ru/v2/accounts/{accountid}/storage'` I get exception like 
```
20:59:27.967 debug crossbar_bindings.90 folding v2_resource.validate_resource.storage
20:59:27.967 debug crossbar_bindings.90 folding v2_resource.validate.storage
20:59:27.970 debug kz_cache.837 storing {kzs_cache,<<"system_schemas">>,<<"storage">>} for 900s
20:59:27.970 debug cb_context.853 validation passed
20:59:27.970 debug cb_storage.401 validating storage settings
20:59:27.971 error kazoo_bindings.682 unable to find function clause for kz_json:foldl(#Fun<cb_storage.13.7913819>, {cb_context,[{to_json,[{<<"application">>,<<"json">>},
                       {<<"application">>,<<"x-json">>}]}],
            [],
            [<<"GET">>,<<"POST">>,<<"PUT">>,<<"DELETE">>,<<"HEAD">>,
             <<"PATCH">>,<<"OPTIONS">>],
            [<<"PATCH">>,<<"POST">>,<<"PUT">>,<<"GET">>,<<"DELETE">>],
            [<<"en">>,<<"en-us">>,<<"en-gb">>],
            [<<"iso-8859-1">>],
            [<<"gzip;q=1.0">>,<<"identity;q=0.5">>],
            <<"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImFkODBiY2U4YmQ5OGJkN2JmMGEyMmY0NWRlNjkyZTc4In0.eyJpc3MiOiJrYXpvbyIsImlkZW50aXR5X3NpZyI6IlhiR282N0p0YVA2S3hVYmhxR1dKYlUzNFBvUXRzblhnUkF3T1pneUl5NzQiLCJhY2NvdW50X2lkIjoiNjNmODE0Nzk1ZmQ1YjhjNzRhYTA0ZWU4NjVjNTJmNzMiLCJvd25lcl9pZCI6IjRhN2JhZDdjODBlOGQ4OTAzMjE0OTJlMWJhMmQwMjA0IiwibWV0aG9kIjoiY2JfdXNlcl9hdXRoIiwiZXhwIjoxNTMyNjQwNjc0fQ.ssWvCDAW2_-00GilZrJTB71-4J03QzeMdo6qOZiD4GbThufaoZg-Cc6b84S8H7ahA3EsQF-DB2B9eW0QQIcaZCCc6mfqBl_4cgjq9E79NPDHz0hPve_vyOWjYBoddpZdgWYjtzHBgsHqnoeTrvY9B1-TZ9SaUSMDWEX7IPYkpykFhsTsgautoOLAIQEgK_jYnyCvAhkRkr68A1UuGMtwFeQYZCNkdnkZufL-i1kwKVwPHnghnX3tWe-_TXm6ujVtLNEL7RJMDZ-ZAAZV26bRQ6YDlt47DNlZtFi5ejSf64r8q7QxZA1cOxvQTDReUSxyouFbpHoRWDIiOX1xbjM4dw">>,
            'x-auth-token',<<"63f814795fd5b8c74aa04ee865c52f73">>,
            {[{<<"account_id">>,<<"63f814795fd5b8c7...) in src/kz_json.erl:652
20:59:27.971 error kazoo_bindings.688 as part of cb_storage:validate/1
20:59:27.971 error kazoo_bindings.689 st: {kazoo_bindings,fold_bind_results,5,[{file,"src/kazoo_bindings.erl"},{line,624}]}
20:59:27.971 error kazoo_bindings.689 st: {lists,foldl,3,[{file,"lists.erl"},{line,1263}]}
20:59:27.971 error kazoo_bindings.689 st: {kazoo_bindings,fold_processor,3,[{file,"src/kazoo_bindings.erl"},{line,846}]}
20:59:27.971 error kazoo_bindings.689 st: {api_util,validate_data,2,[{file,"src/api_util.erl"},{line,1065}]}
20:59:27.971 error kazoo_bindings.689 st: {api_util,validate,2,[{file,"src/api_util.erl"},{line,1049}]}
20:59:27.972 error kazoo_bindings.689 st: {api_resource,does_request_validate,2,[{file,"src/api_resource.erl"},{line,667}]}
20:59:27.972 error kazoo_bindings.689 st: {cowboy_rest,call,3,[{file,"src/cowboy_rest.erl"},{line,1182}]}
20:59:27.972 debug api_util.1053 validating data failed
```
This PR is fix
Optionally this this may moved to `kz_json:foldl` and `kz_json:foldr` definition