### PR TITLE
QF: fixed a few bugs in teletype_fax_util and kzd_fax

### DIFF
--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -215,7 +215,7 @@ maybe_fetch_attachments(DataJObj, FaxJObj, Macros, 'false') ->
     lager:debug("accessing fax attachment ~s at ~s", [Db, FaxId]),
     teletype_util:send_update(DataJObj, <<"pending">>),
     Format = kapps_config:get_ne_binary(?CONVERT_CONFIG_CAT, [<<"fax">>, <<"attachment_format">>], <<"pdf">>),
-    Filename = get_file_name(Macros, <<".", Format/binary>>),
+    Filename = get_file_name(Macros, Format),
     case kzd_fax:fetch_attachment_format(Format, Db, FaxJObj) of
         {'ok', Content, ContentType, _Doc} ->
             [{ContentType, Filename, Content}];

--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -215,14 +215,18 @@ maybe_fetch_attachments(DataJObj, FaxJObj, Macros, 'false') ->
     lager:debug("accessing fax attachment ~s at ~s", [Db, FaxId]),
     teletype_util:send_update(DataJObj, <<"pending">>),
     Format = kapps_config:get_ne_binary(?CONVERT_CONFIG_CAT, [<<"fax">>, <<"attachment_format">>], <<"pdf">>),
-    Filename = get_file_name(Macros, Format),
     case kzd_fax:fetch_attachment_format(Format, Db, FaxJObj) of
         {'ok', Content, ContentType, _Doc} ->
+            Filename = get_file_name(Macros, get_extension(Format, ContentType)),
             [{ContentType, Filename, Content}];
         {'error', _E} ->
             lager:debug("failed to fetch attachment: ~p", [_E]),
             []
     end.
+
+-spec get_extension(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:ne_binary().
+get_extension(<<"original">>, ContentType) -> kz_mime:to_extension(ContentType);
+get_extension(Format, _) -> Format.
 
 -spec get_file_name(kz_term:proplist(), kz_term:ne_binary()) -> kz_term:ne_binary().
 get_file_name(Macros, Ext) ->


### PR DESCRIPTION
- Teletype was adding an extra . in the extension. 
- Teletype was not handling the case where the extension was using the original fax_file_format in kazoo_convert config. 
- fetch_original_attachment had an invalid pattern match, should have been a binary not a tuple. 
- Updated search for legacy attachment to exclude the reserved file types. 
- maybe_store_url_attachment should have been using save_fax_doc not save_outbound_fax. 
- Added some debug log lines to the chained cases so the logic is apparent in the logs 
- Switch the cases in save_outbound_fax for the url fax case to avoid unnecessary lookup of document in cases where store_url_document is false on receipt of api call. 