### PR TITLE
kz_nodes proxy display alignment to left with size

### DIFF
--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -442,20 +442,28 @@ print_proxy({<<"Listeners">>, Data}) ->
     case maps:to_list(Listeners) of
         [] -> 'ok';
         Addrs ->
+            S = lists:max([byte_size(A) || {A, _} <- Addrs]),
+            Fmt = print_address_format(S),
             [{Address, Info} | Addresses] = lists:keysort(1, Addrs),
             io:format(?HEADER_COL ++ ": ", [<<"Listening on">>]),
-            print_address_info(Address, Info),
-            _ = lists:foreach(fun print_address/1, Addresses),
+            print_address_info(Address, Info, Fmt),
+            _ = lists:foreach(fun(A) -> print_address(A, Fmt) end, Addresses),
             'ok'
     end.
 
--spec print_address({kz_term:ne_binary(), map()}) -> 'ok'.
-print_address({Address, Info}) ->
+-spec print_address_format(pos_integer()) -> kz_term:ne_binary().
+print_address_format(S) ->
+    Size = 15 - (15 - S),
+    list_to_binary(["~-",io_lib:format("~B", [Size]),"s "]).
+    
+-spec print_address({kz_term:ne_binary(), map()}, kz_term:ne_binary()) -> 'ok'.
+print_address({Address, Info}, Fmt) ->
     io:format(?HEADER_COL ++ "  ", [""]),
-    print_address_info(Address, Info).
+    print_address_info(Address, Info, Fmt).
 
-print_address_info(Address, Info) ->
-    io:format("~15s ", [Address]),
+-spec print_address_info(kz_term:ne_binary(), map(), kz_term:ne_binary()) -> 'ok'.
+print_address_info(Address, Info, Fmt) ->
+    io:format(Fmt, [Address]),
     _ = lists:foreach(fun print_proto/1, lists:keysort(1, maps:to_list(Info))),
     io:format("~n").
 

--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -455,7 +455,7 @@ print_proxy({<<"Listeners">>, Data}) ->
 print_address_format(S) ->
     Size = 15 - (15 - S),
     list_to_binary(["~-",io_lib:format("~B", [Size]),"s "]).
-    
+
 -spec print_address({kz_term:ne_binary(), map()}, kz_term:ne_binary()) -> 'ok'.
 print_address({Address, Info}, Fmt) ->
     io:format(?HEADER_COL ++ "  ", [""]),


### PR DESCRIPTION
new format will adjusat to max size of address

``` 
Node          : kamailio@dev-01.lx.labs.2600hz.com
Version       : 5.2.0-dev6
Memory Usage  : 26.72MB
Zone          : lx1 (local)
Broker        : amqp://rabbitmq:5676/lx1
WhApps        : kamailio(3h54m38s)       
Roles         : Dispatcher Presence Proxy Registrar 
Dispatcher 1  : sip:192.168.16.125:11000 (AX)   
Dispatcher 51 : sip:192.168.16.125:12000 (AX)   
Subscribers   : message-summary (4)  dialog (4)  
Subscriptions : message-summary (5)  dialog (30)  
Presentities  : presence (0)  dialog (2)  message-summary (2)  
Listening on  : 192.168.16.125 tcp (5060 7000 7070) tls (5061 7001) udp (5060 7000) ws (5064) wss (5065) 
                192.168.25.125 udp (7000) 
                XX.XXX.XX.XX   tcp (7005) udp (7005) 
Registrations : 6

Node          : kamailio@5f0f9d5be0d3.lx.labs.2600hz.com
Version       : 5.0.4
Memory Usage  : 17.33MB
Zone          : lx3
Broker        : amqp://rabbitmq:5676/lx3
WhApps        : kamailio(2d22h1m54s)     
Roles         : Dispatcher Presence Proxy Registrar 
Dispatcher 1  : sip:172.18.0.5:11000 (AX)   sip:192.168.16.125:11000 (AX)   
Dispatcher 2  : sip:192.168.16.145:11000 (AX)   sip:192.168.16.144:11000 (AX)   sip:192.168.16.74:12000 (AX)   sip:192.168.16.74:11000 (AX)   sip:192.168.16.73:11000 (AX)   
                sip:10.0.0.4:11000 (AX)   
Dispatcher 51 : sip:192.168.16.125:12000 (AX)   
Subscribers   : dialog (1)  
Subscriptions : dialog (6)  
Presentities  : presence (0)  dialog (0)  message-summary (0)  
Listening on  : 10.21.0.5 tcp (5060 7000) udp (5060 7000) 
Registrations : 1
```