### PR TITLE
Fix kazoo_number_manager_maintenance fix_account_numbers

### DIFF
--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -260,7 +260,7 @@ fix_account_numbers(AccountDb = ?MATCH_ACCOUNT_ENCODED(A,B,Rest)) ->
                             %% timer:sleep(?TIME_BETWEEN_ACCOUNTS_MS),
                             gb_sets:subtract(Leftovers, AuthoritativePNs)
                     end
-                   ,fun (Set1, Set2) -> gb_sets:union(Set1, Set2) end
+                   ,fun (Set1, Set2) -> gb_sets:intersection(Set1, Set2) end
                    ,DisplayPNs
                    ,knm_util:get_all_number_dbs()
                    ,Malt


### PR DESCRIPTION
Currently the sync button in Monster UI will actually remove valid numbers from the list of available numbers, but clicking it again will result in them coming back. This corrects that.