### PR TITLE
[4.2] Call control updates

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -78,10 +78,10 @@ token_check(Call, Flow) ->
             case kz_buckets:consume_tokens(?APP_NAME, Name, Cost) of
                 'true' -> 'true';
                 'false' when DryRun ->
-                    lager:info("dry-run: bucket ~s doesn't have enough tokens(~b needed) for this call", [Name, Cost]),
+                    lager:info("dry-run: bucket ~s does not have enough tokens(~b needed) for this call", [Name, Cost]),
                     'true';
                 'false' ->
-                    lager:warning("bucket ~s doesn't have enough tokens(~b needed) for this call", [Name, Cost]),
+                    lager:warning("bucket ~s does not have enough tokens(~b needed) for this call", [Name, Cost]),
                     'false'
             end
     end.

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -27202,6 +27202,11 @@
                     "description": "callflow route win timeout",
                     "type": "integer"
                 },
+                "should_dry_run_token_restrictions": {
+                    "default": false,
+                    "description": "callflow should_dry_run_token_restrictions",
+                    "type": "boolean"
+                },
                 "singular_call_hook_url": {
                     "default": "",
                     "description": "callflow singular call hook url",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
@@ -76,6 +76,11 @@
             "description": "callflow route win timeout",
             "type": "integer"
         },
+        "should_dry_run_token_restrictions": {
+            "default": false,
+            "description": "callflow should_dry_run_token_restrictions",
+            "type": "boolean"
+        },
         "singular_call_hook_url": {
             "default": "",
             "description": "callflow singular call hook url",

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -129,7 +129,6 @@ bucket_name('undefined', AccountId) ->
 bucket_name(IP, AccountId) ->
     <<IP/binary, "/", AccountId/binary>>.
 
-
 -spec token_cost(cb_context:context()) -> non_neg_integer().
 token_cost(Context) ->
     token_cost(Context, 1).

--- a/applications/ecallmgr/src/ecallmgr_call_control.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_control.erl
@@ -344,7 +344,8 @@ handle_event(JObj, #state{fetch_id=FetchId}) ->
     _ = case kz_util:get_event_type(JObj) of
             {<<"call">>, <<"command">>} -> handle_call_command(JObj);
             {<<"conference">>, <<"command">>} -> handle_conference_command(JObj);
-            {<<"call_event">>, _} -> handle_call_events(JObj, FetchId)
+            {<<"call_event">>, _} -> handle_call_events(JObj, FetchId);
+            {<<"error">>, _EvtName} -> lager:debug("ignoring error event for ~s", [_EvtName])
         end,
     'ignore'.
 


### PR DESCRIPTION
- don't crash ecallmgr_call_control on dialplan errors
- allow callflows to dry-run blocking calls via token bucket