### PR TITLE
Call control updates

### DIFF
--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -73,10 +73,15 @@ token_check(Call, Flow) ->
             'true';
         'true' ->
             {Name, Cost} = bucket_info(Call, Flow),
+            DryRun = kapps_config:get_is_true(?CF_CONFIG_CAT, <<"should_dry_run_token_restrictions">>, 'false'),
+
             case kz_buckets:consume_tokens(?APP_NAME, Name, Cost) of
                 'true' -> 'true';
+                'false' when DryRun ->
+                    lager:info("dry-run: bucket ~s does not have enough tokens(~b needed) for this call", [Name, Cost]),
+                    'true';
                 'false' ->
-                    lager:warning("bucket ~s doesn't have enough tokens(~b needed) for this call", [Name, Cost]),
+                    lager:warning("bucket ~s does not have enough tokens(~b needed) for this call", [Name, Cost]),
                     'false'
             end
     end.
@@ -106,7 +111,6 @@ bucket_cost(Flow) ->
         N when N < Min -> Min;
         N -> N
     end.
-
 
 -spec presence_probe(kz_json:object(), kz_term:proplist()) -> any().
 presence_probe(JObj, _Props) ->

--- a/applications/callflow/src/module/cf_park.erl
+++ b/applications/callflow/src/module/cf_park.erl
@@ -955,14 +955,14 @@ maybe_empty_slot(JObj) ->
 error_occupied_slot(Call) ->
     lager:info("selected slot is occupied"),
     %% Update screen with error that the slot is occupied
-    case kapps_call_command:b_answer(Call) of
-        {'error', 'timeout'} ->
-            lager:info("timed out waiting for the answer to complete");
-        {'error', 'channel_hungup'} ->
-            lager:info("channel hungup while answering");
-        _ ->
-            lager:debug("channel answered, prompting of the slot being in use"),
-            %% playback message that caller will have to try a different slot
-            kapps_call_command:b_prompt(<<"park-already_in_use">>, Call)
-    end,
+    _ = case kapps_call_command:b_answer(Call) of
+            {'error', 'timeout'} ->
+                lager:info("timed out waiting for the answer to complete");
+            {'error', 'channel_hungup'} ->
+                lager:info("channel hungup while answering");
+            _ ->
+                lager:debug("channel answered, prompting of the slot being in use"),
+                %% playback message that caller will have to try a different slot
+                kapps_call_command:b_prompt(<<"park-already_in_use">>, Call)
+        end,
     cf_exe:stop(Call).

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -27306,6 +27306,11 @@
                     "description": "callflow route win timeout",
                     "type": "integer"
                 },
+                "should_dry_run_token_restrictions": {
+                    "default": false,
+                    "description": "callflow should_dry_run_token_restrictions",
+                    "type": "boolean"
+                },
                 "singular_call_hook_url": {
                     "default": "",
                     "description": "callflow singular call hook url",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
@@ -77,6 +77,11 @@
             "description": "callflow route win timeout",
             "type": "integer"
         },
+        "should_dry_run_token_restrictions": {
+            "default": false,
+            "description": "callflow should_dry_run_token_restrictions",
+            "type": "boolean"
+        },
         "singular_call_hook_url": {
             "default": "",
             "description": "callflow singular call hook url",

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -124,7 +124,6 @@ bucket_name('undefined', AccountId) ->
 bucket_name(IP, AccountId) ->
     <<IP/binary, "/", AccountId/binary>>.
 
-
 -spec token_cost(cb_context:context()) -> non_neg_integer().
 token_cost(Context) ->
     token_cost(Context, 1).

--- a/applications/ecallmgr/src/ecallmgr_call_control.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_control.erl
@@ -342,7 +342,8 @@ handle_event(JObj, #state{fetch_id=FetchId}) ->
     _ = case kz_util:get_event_type(JObj) of
             {<<"call">>, <<"command">>} -> handle_call_command(JObj);
             {<<"conference">>, <<"command">>} -> handle_conference_command(JObj);
-            {<<"call_event">>, _} -> handle_call_events(JObj, FetchId)
+            {<<"call_event">>, _} -> handle_call_events(JObj, FetchId);
+            {<<"error">>, _EvtName} -> lager:debug("ignoring error event for ~s", [_EvtName])
         end,
     'ignore'.
 

--- a/applications/ecallmgr/src/ecallmgr_fs_channel.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channel.erl
@@ -480,7 +480,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%------------------------------------------------------------------------------
 -spec handle_channel_req_legacy(kz_term:ne_binary(), kz_term:ne_binary(), atom(), pid()) -> 'ok'.
 handle_channel_req_legacy(UUID, FetchId, Node, Pid) ->
-    kz_amqp_channel:consumer_pid(Pid),
+    _ = kz_amqp_channel:consumer_pid(Pid),
     case fetch_channel(UUID) of
         'undefined' -> channel_not_found(Node, FetchId);
         Channel ->
@@ -492,7 +492,7 @@ handle_channel_req_legacy(UUID, FetchId, Node, Pid) ->
 
 -spec handle_channel_req(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), atom(), pid()) -> 'ok'.
 handle_channel_req(UUID, FetchId, Props, Node, Pid) ->
-    kz_amqp_channel:consumer_pid(Pid),
+    _ = kz_amqp_channel:consumer_pid(Pid),
     ForUUID = props:get_value(<<"refer-for-channel-id">>, Props),
     {'ok', ForChannel} = fetch(ForUUID, 'proplist'),
     case fetch_channel(UUID) of
@@ -589,7 +589,7 @@ process_event(UUID, Props, Node) ->
 -spec process_event(kz_term:api_binary(), kz_term:proplist(), atom(), pid()) -> any().
 process_event(UUID, Props, Node, Pid) ->
     kz_util:put_callid(UUID),
-    kz_amqp_channel:consumer_pid(Pid),
+    _ = kz_amqp_channel:consumer_pid(Pid),
     EventName = props:get_value(<<"Event-Subclass">>, Props, props:get_value(<<"Event-Name">>, Props)),
 
     process_specific_event(EventName, UUID, Props, Node).


### PR DESCRIPTION
* ignore error events

* add dry-run to token restrictions on callflows

* update log lines to match

* made apis

unmatched returns