### PR TITLE
[4.2] ignore non-bridge channel_execute_complete events

### DIFF
--- a/core/kazoo_documents/src/kz_call_event.erl
+++ b/core/kazoo_documents/src/kz_call_event.erl
@@ -161,11 +161,11 @@ hangup_code(JObj) ->
 disposition(JObj) ->
     kz_json:get_ne_binary_value(<<"Disposition">>, JObj).
 
--spec application_name(doc()) -> kz_term:api_binary().
+-spec application_name(doc()) -> kz_term:api_ne_binary().
 application_name(JObj) ->
     kz_json:get_ne_binary_value(<<"Application-Name">>, JObj).
 
--spec application_event(doc()) -> kz_term:api_binary().
+-spec application_event(doc()) -> kz_term:api_ne_binary().
 application_event(JObj) ->
     kz_json:get_ne_binary_value(<<"Application-Event">>, JObj).
 


### PR DESCRIPTION
```
Aug 22 13:30:40 apps001 2600hz[28410]: |CALL_ID|gen_listener:929 (<0.23921.80>) CRASH in handle_event {{badmatch,<<"ring">>},[{stepswitch_bridge,handle_event,2,[{file,"src/stepswitch_bridge.erl"},{line,196}]},{gen_listener,callback_handle_event,4,[{file,"src/gen_listener.erl"},{line,943}]},{gen_listener,callback_handle_event,3,[{file,"src/gen_listener.erl"},{line,907}]},{gen_listener,distribute_event,3,[{file,"src/gen_listener.erl"},{line,825}]},{gen_listener,handle_info,2,[{file,"src/gen_listener.erl"},{line,645}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,601}]},{gen_server,handle_msg,5,[{file,"gen_server.erl"},{line,667}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
```