### PR TITLE
Prepend after privacy

### DIFF
--- a/core/kazoo_endpoint/src/kz_attributes.erl
+++ b/core/kazoo_endpoint/src/kz_attributes.erl
@@ -21,6 +21,7 @@
 -export([get_account_external_cid/1]).
 -export([maybe_get_assigned_number/3]).
 -export([maybe_get_account_default_number/4]).
+-export([maybe_prefix_cid/5]).
 -export([get_flags/2]).
 -export([process_dynamic_flags/2
         ,process_dynamic_flags/3
@@ -176,10 +177,10 @@ maybe_normalize_cid(Number, 'undefined', Validate, Attribute, Call) ->
     lager:debug("replacing empty caller id name with SIP caller id name ~s", [Name]),
     maybe_normalize_cid(Number, Name, Validate, Attribute, Call);
 maybe_normalize_cid(Number, Name, Validate, Attribute, Call) ->
-    maybe_prefix_cid_number(kz_term:to_binary(Number), Name, Validate, Attribute, Call).
+    maybe_prefix_cid(kz_term:to_binary(Number), Name, Validate, Attribute, Call).
 
--spec maybe_prefix_cid_number(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kz_term:ne_binary(), kapps_call:call()) -> cid().
-maybe_prefix_cid_number(Number, Name, Validate, Attribute, Call) ->
+-spec maybe_prefix_cid(kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kz_term:ne_binary(), kapps_call:call()) -> cid().
+maybe_prefix_cid(Number, Name, Validate, Attribute, Call) ->
     OrigNumber = kapps_call:kvs_fetch('original_cid_number', Number, Call),
     case kapps_call:kvs_fetch('prepend_cid_number', Call) of
         'undefined' -> maybe_prefix_cid_name(Number, Name, Validate, Attribute, Call);

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1098,7 +1098,11 @@ maybe_privacy_cid(#clid{caller_name=CallerName
     case kz_privacy:maybe_cid_privacy(kapps_call:custom_channel_vars(Call), {CallerName, CallerNumber}) of
         {CallerName, CallerNumber} -> Clid;
         %% Ensure prepend is applied after privacy
-        {Name, Number} -> kz_attributes:maybe_prefix_cid(Name, Number, 'false', Type, Call)
+        {Name, Number} ->
+            {NewName, NewNumber} = kz_attributes:maybe_prefix_cid(Name, Number, 'false', Type, Call),
+            Clid#clid{caller_number=NewNumber
+                     ,caller_name=NewName
+                     }
     end.
 
 -spec create_sip_endpoint(kz_json:object(), kz_json:object(), kapps_call:call()) ->

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1069,9 +1069,10 @@ guess_endpoint_type(Endpoint, []) ->
 get_clid(Endpoint, Properties, Call) ->
     get_clid(Endpoint, Properties, Call, <<"internal">>).
 
+-spec get_clid(kz_json:object(), kz_json:object(), kapps_call:call(), kz_term:ne_binary()) -> clid().
 get_clid(Endpoint, Properties, Call, Type) ->
     case kz_json:is_true(<<"suppress_clid">>, Properties) of
-        'true' -> maybe_privacy_cid(#clid{}, Call);
+        'true' -> maybe_privacy_cid(#clid{}, Call, Type);
         'false' ->
             {Number, Name} = kz_attributes:caller_id(Type, Call),
             CallerNumber = case kapps_call:caller_id_number(Call) of
@@ -1087,17 +1088,18 @@ get_clid(Endpoint, Properties, Call, Type) ->
                                    ,caller_name=CallerName
                                    ,callee_number=CalleeNumber
                                    ,callee_name=CalleeName
-                                   }, Call)
+                                   }, Call, Type)
     end.
 
--spec maybe_privacy_cid(clid(), kapps_call:call()) -> clid().
+-spec maybe_privacy_cid(clid(), kapps_call:call(), kz_term:ne_binary()) -> clid().
 maybe_privacy_cid(#clid{caller_name=CallerName
                        ,caller_number=CallerNumber
-                       }=Clid, Call) ->
-    {Name, Number} = kz_privacy:maybe_cid_privacy(kapps_call:custom_channel_vars(Call), {CallerName, CallerNumber}),
-    Clid#clid{caller_name=Name
-             ,caller_number=Number
-             }.
+                       }=Clid, Call, Type) ->
+    case kz_privacy:maybe_cid_privacy(kapps_call:custom_channel_vars(Call), {CallerName, CallerNumber}) of
+        {CallerName, CallerNumber} -> Clid;
+        %% Ensure prepend is applied after privacy
+        {Name, Number} -> kz_attributes:maybe_prefix_cid(Name, Number, 'false', Type, Call)
+    end.
 
 -spec create_sip_endpoint(kz_json:object(), kz_json:object(), kapps_call:call()) ->
                                  kz_json:object().


### PR DESCRIPTION
When privacy is enabled the prepend gets overwritten after anonymization. This fixes it by applying the prepend again afterwards.