### PR TITLE
[4.2] Avoid asking for cached value when possible

### DIFF
--- a/applications/ecallmgr/src/ecallmgr.hrl
+++ b/applications/ecallmgr/src/ecallmgr.hrl
@@ -151,8 +151,9 @@
 -define(MAX_TIMEOUT_FOR_NODE_RESTART, ecallmgr_config:get_integer(<<"max_timeout_for_node_restart">>, 10 * ?MILLISECONDS_IN_SECOND)).
 -define(MAX_NODE_RESTART_FAILURES, 3).
 
--define(EXPIRES_DEVIATION_TIME,
-        ecallmgr_config:get_integer(<<"expires_deviation_time">>, 180)).
+-define(EXPIRES_DEVIATION_TIME
+       ,ecallmgr_config:get_integer(<<"expires_deviation_time">>, 180)
+       ).
 
 %% list of dialplan Application-Names that can execute after a call has hung up
 -define(POST_HANGUP_COMMANDS, [<<"store">>, <<"set">>, <<"presence">>

--- a/applications/ecallmgr/src/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_command.erl
@@ -1674,9 +1674,13 @@ transfer_leg(JObj) ->
 
 -spec transfer_context(kz_json:object()) -> binary().
 transfer_context(JObj) ->
-    kz_json:get_binary_value(<<"Transfer-Context">>, JObj, ?DEFAULT_FREESWITCH_CONTEXT).
+    case kz_json:get_binary_value(<<"Transfer-Context">>, JObj) of
+        'undefined' -> ?DEFAULT_FREESWITCH_CONTEXT;
+        Context -> Context
+    end.
 
--spec sound_touch(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> {kz_term:ne_binary(), kz_term:ne_binary()}.
+-spec sound_touch(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
+                         {kz_term:ne_binary(), kz_term:ne_binary()}.
 sound_touch(UUID, <<"start">>, JObj) ->
     {<<"soundtouch">>, list_to_binary([UUID, " start ", sound_touch_options(JObj)])};
 sound_touch(UUID, <<"stop">>, _JObj) ->

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -582,7 +582,7 @@ create_event(EventName, Props) ->
 create_event(EventName, ApplicationName, Props) ->
     props:filter_undefined(
       [{<<"Event-Name">>, EventName}
-       |specific_call_event_props(EventName, ApplicationName, Props)
+       | specific_call_event_props(EventName, ApplicationName, Props)
        ++ generic_call_event_props(Props)
        ++ specific_call_channel_vars_props(EventName, Props)
       ]).

--- a/applications/ecallmgr/src/ecallmgr_config.erl
+++ b/applications/ecallmgr/src/ecallmgr_config.erl
@@ -301,7 +301,7 @@ fetch(Key, Default, Node, RequestTimeout) ->
                                  ),
     case ReqResp of
         {'error', _R} ->
-            lager:debug("unable to get config for key '~s' failed: ~p", [Key, _R]),
+            lager:warning("unable to get config for key '~s' failed: ~p", [Key, _R]),
             Default;
         {'ok', JObj} ->
             Value = get_response_value(JObj, Default),
@@ -314,11 +314,11 @@ maybe_cache_resp(_, _ , 'null') -> 'ok';
 maybe_cache_resp(_, _ , <<"null">>) -> 'ok';
 maybe_cache_resp(Key, Node, Value) ->
     CacheProps = [{'origin', {'db', ?KZ_CONFIG_DB, <<"ecallmgr">>}}],
-    kz_cache:store_local(?ECALLMGR_UTIL_CACHE
-                        ,cache_key(Key, Node)
-                        ,Value
-                        ,CacheProps
-                        ).
+    kz_cache:store_local_async(?ECALLMGR_UTIL_CACHE
+                              ,cache_key(Key, Node)
+                              ,Value
+                              ,CacheProps
+                              ).
 
 -spec set(kz_json:path(), kz_json:json_term()) -> 'ok'.
 set(Key, Value) ->

--- a/applications/ecallmgr/src/ecallmgr_registrar.erl
+++ b/applications/ecallmgr/src/ecallmgr_registrar.erl
@@ -78,9 +78,9 @@
                       ,realm :: kz_term:api_ne_binary() | '_' | '$1'
                       ,network_port :: kz_term:api_ne_binary() | '_'
                       ,network_ip :: kz_term:api_ne_binary() | '_'
-                      ,to_host = ?DEFAULT_REALM :: kz_term:ne_binary() | '_'
+                      ,to_host :: kz_term:api_ne_binary() | '_'
                       ,to_user = <<"nouser">> :: kz_term:ne_binary() | '_'
-                      ,from_host = ?DEFAULT_REALM :: kz_term:ne_binary() | '_'
+                      ,from_host :: kz_term:api_ne_binary() | '_'
                       ,from_user = <<"nouser">> :: kz_term:ne_binary() | '_'
                       ,call_id :: kz_term:api_ne_binary() | '_'
                       ,user_agent :: kz_term:api_ne_binary() | '_'
@@ -824,9 +824,9 @@ create_registration(JObj) ->
                                          ,initial_registration=kz_json:get_integer_value(<<"Initial-Registration">>, JObj, Reg#registration.initial_registration)
                                          ,network_port=kz_json:get_value(<<"Network-Port">>, JObj, Reg#registration.network_port)
                                          ,network_ip=kz_json:get_value(<<"Network-IP">>, JObj, Reg#registration.network_ip)
-                                         ,to_host=kz_json:get_value(<<"To-Host">>, JObj, Reg#registration.to_host)
+                                         ,to_host=get_realm(<<"To-Host">>, JObj)
                                          ,to_user=kz_json:get_value(<<"To-User">>, JObj, Reg#registration.to_user)
-                                         ,from_host=kz_json:get_value(<<"From-Host">>, JObj, Reg#registration.from_host)
+                                         ,from_host=get_realm(<<"From-Host">>, JObj)
                                          ,from_user=kz_json:get_value(<<"From-User">>, JObj, Reg#registration.from_user)
                                          ,call_id=kz_json:get_value(<<"Call-ID">>, JObj, Reg#registration.call_id)
                                          ,user_agent=kz_json:get_value(<<"User-Agent">>, JObj, Reg#registration.user_agent)
@@ -836,6 +836,13 @@ create_registration(JObj) ->
                                          }
                         ,JObj
                         ).
+
+-spec get_realm(kz_json:key(), kz_json:object()) -> kz_json:ne_binary().
+get_realm(Key, JObj) ->
+    case kz_json:get_ne_binary_value(Key, JObj) of
+        'undefined' -> ?DEFAULT_REALM;
+        Realm -> Realm
+    end.
 
 -spec augment_registration(registration(), kz_json:object()) -> registration().
 augment_registration(Reg, JObj) ->

--- a/core/kazoo_documents/src/kzd_freeswitch.erl
+++ b/core/kazoo_documents/src/kzd_freeswitch.erl
@@ -23,6 +23,7 @@
         ,disposition/1
         ,event_name/1
         ,from_network_ip/1, from_network_port/1
+        ,from_user/1, from_realm/1
         ,from_tag/1, to_tag/1
         ,hangup_code/1, hangup_cause/1
         ,hostname/1, hostname/2
@@ -36,10 +37,11 @@
         ,other_leg_call_id/1
         ,outbound_flags/1
         ,presence_id/1, presence_direction/1
+        ,request_realm/1
         ,reseller_id/1, reseller_billing/1, reseller_trunk_usage/1
         ,resource_id/1
         ,resource_type/1, resource_type/2
-        ,to_did/1
+        ,to_did/1, to_realm/1
         ,transfer_history/1
         ,transfer_source/1
         ,user_agent/1
@@ -233,6 +235,26 @@ to_did(Props) ->
                            ,Props
                            ).
 
+-spec to_realm(data()) -> kz_term:api_ne_binary().
+to_realm(Props) ->
+    case ccv(Props, <<"Realm">>) of
+        'undefined' -> props:get_value(<<"variable_sip_to_host">>, Props);
+        Realm -> Realm
+    end.
+
+-spec request_realm(data()) -> kz_term:api_ne_binary().
+request_realm(Props) ->
+    case ccv(Props, <<"Realm">>) of
+        'undefined' ->
+            props:get_first_defined([<<"variable_sip_auth_realm">>
+                                    ,<<"variable_sip_to_host">>
+                                    ,<<"variable_sip_req_host">>
+                                    ]
+                                   ,Props
+                                   );
+        Realm -> Realm
+    end.
+
 -spec ccv(data(), kz_term:ne_binary()) -> kz_term:api_binary() | kz_term:ne_binaries().
 ccv(Props, Key) ->
     ccv(Props, Key, 'undefined').
@@ -408,6 +430,23 @@ update_referred_to_ccv(ReferredTo, CCVs) ->
                    ,kz_http_util:urldecode(ReferredTo)
                    ,CCVs
                    ).
+
+-spec from_user(data()) -> kz_term:ne_binary().
+from_user(Props) ->
+    props:get_value(<<"sip_from_user">>, Props, <<"nouser">>).
+
+-spec from_realm(data()) -> kz_term:api_ne_binary().
+from_realm(Props) ->
+    case ccv(Props, <<"Realm">>) of
+        'undefined' ->
+            props:get_first_defined([<<"variable_sip_auth_realm">>
+                                    ,<<"variable_sip_from_host">>
+                                    ,<<"sip_from_host">>
+                                    ]
+                                   ,Props
+                                   );
+        Realm -> Realm
+    end.
 
 -spec from_tag(data()) -> kz_term:api_binary().
 from_tag(Props) ->


### PR DESCRIPTION
The default realm config is accessed on nearly every call event
processed in ecallmgr before publishing to the wider kazoo
ecosystem. When the cache is cold, several things happen:

1. Each event for any active calls will request the default realm
2. Since the cache is cold, a kz_amqp_worker will be checked out to
fetch the value from sysconf
3. Each worker will return at about the same time and attempt to cache
the value.

Under load, this causes:
1. If enough call events happen before the value can be retrieved from
sysconf, the worker pool will be exhausted, crashing the event
process.
2. When the amqp workers that did get used to fetch the value return,
they will inundate the cache process' mailbox, causing timeouts
waiting for the cache to respond.

This patch does two things to help:

1. Only ask the ecallmgr_config cache for the default realm if the
realm isn't found in the FreeSWITCH props (vs asking for it before
looking).
2. Add store_async to the kz_cache to use gen_server:cast/2 to not
block the ecallmgr process trying to get on with its work.

What this doesn't address is a potential stampede on the
ecallmgr_config cache that results in many multiples of amqp workers
being used to fetch the same key.

As 4.3+ remove ecallmgr_config entirely, it didn't seem worth the time
to add stampede mitigation here. However, kapps_config should be
looked at for possible stampede mitigation in 4.3+

During loaded issue period, ecallmgr_config asked for these most often:
     19 ecallmgr:debug_channel
     47 ecallmgr:default_realm
     64 ecallmgr:freeswitch_context
    161 ecallmgr:expires_deviation_time