### PR TITLE
Calculate ringing seconds properly based on total call duration minus…

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -1089,9 +1089,9 @@ get_billing_seconds(Props) ->
 -spec get_ringing_seconds(kz_term:proplist()) -> kz_term:ne_binary().
 get_ringing_seconds(Props) ->
     RingingSeconds =
-      props:get_integer_value(<<"variable_duration">>, Props) -
-      get_billing_seconds(Props) -
-      props:get_integer_value(<<"variable_progresssec">>, Props),
+        props:get_integer_value(<<"variable_duration">>, Props)
+        - get_billing_seconds(Props)
+        - props:get_integer_value(<<"variable_progresssec">>, Props),
     kz_term:to_binary(RingingSeconds).
 
 -spec swap_call_legs(kz_term:proplist() | kz_json:object()) -> kz_term:proplist().

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -760,7 +760,7 @@ specific_call_event_props(<<"CHANNEL_DESTROY">>, _, Props) ->
     ,{<<"Local-SDP">>, props:get_value(<<"variable_rtp_local_sdp_str">>, Props)}
     ,{<<"Duration-Seconds">>, props:get_value(<<"variable_duration">>, Props)}
     ,{<<"Billing-Seconds">>, get_billing_seconds(Props)}
-    ,{<<"Ringing-Seconds">>, props:get_value(<<"variable_progresssec">>, Props)}
+    ,{<<"Ringing-Seconds">>, get_ringing_seconds(Props)}
     ,{<<"User-Agent">>, props:get_value(<<"variable_sip_user_agent">>, Props)}
     ,{<<"Fax-Info">>, maybe_fax_specific(Props)}
      | debug_channel_props(Props)
@@ -1086,6 +1086,12 @@ get_billing_seconds(Props) ->
         Billmsec -> kz_term:to_binary(kz_term:ceiling(Billmsec / 1000))
     end.
 
+-spec get_billing_seconds(kz_term:proplist()) -> kz_term:api_binary().
+get_ringing_seconds(Props) ->
+    RingingSeconds = props:get_integer_value(<<"variable_duration">>, Props)
+      - get_billing_seconds(Props)
+      - props:get_integer_value(<<"variable_progresssec">>, Props),
+    kz_term:to_binary(RingingSeconds).
 
 -spec swap_call_legs(kz_term:proplist() | kz_json:object()) -> kz_term:proplist().
 swap_call_legs(Props) when is_list(Props) -> swap_call_legs(Props, []);

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -1088,7 +1088,7 @@ get_billing_seconds(Props) ->
 
 -spec get_ringing_seconds(kz_term:proplist()) -> kz_term:ne_binary().
 get_ringing_seconds(Props) ->
-    RingingSeconds = 
+    RingingSeconds =
       props:get_integer_value(<<"variable_duration">>, Props) -
       get_billing_seconds(Props) -
       props:get_integer_value(<<"variable_progresssec">>, Props),

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -1086,7 +1086,7 @@ get_billing_seconds(Props) ->
         Billmsec -> kz_term:to_binary(kz_term:ceiling(Billmsec / 1000))
     end.
 
--spec get_billing_seconds(kz_term:proplist()) -> kz_term:api_binary().
+-spec get_ringing_seconds(kz_term:proplist()) -> kz_term:api_binary().
 get_ringing_seconds(Props) ->
     RingingSeconds = props:get_integer_value(<<"variable_duration">>, Props)
       - get_billing_seconds(Props)

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -1088,9 +1088,10 @@ get_billing_seconds(Props) ->
 
 -spec get_ringing_seconds(kz_term:proplist()) -> kz_term:ne_binary().
 get_ringing_seconds(Props) ->
-    RingingSeconds = props:get_integer_value(<<"variable_duration">>, Props)
-      - get_billing_seconds(Props)
-      - props:get_integer_value(<<"variable_progresssec">>, Props),
+    RingingSeconds = 
+      props:get_integer_value(<<"variable_duration">>, Props) -
+      get_billing_seconds(Props) -
+      props:get_integer_value(<<"variable_progresssec">>, Props),
     kz_term:to_binary(RingingSeconds).
 
 -spec swap_call_legs(kz_term:proplist() | kz_json:object()) -> kz_term:proplist().

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -1086,7 +1086,7 @@ get_billing_seconds(Props) ->
         Billmsec -> kz_term:to_binary(kz_term:ceiling(Billmsec / 1000))
     end.
 
--spec get_ringing_seconds(kz_term:proplist()) -> kz_term:api_binary().
+-spec get_ringing_seconds(kz_term:proplist()) -> kz_term:ne_binary().
 get_ringing_seconds(Props) ->
     RingingSeconds = props:get_integer_value(<<"variable_duration">>, Props)
       - get_billing_seconds(Props)


### PR DESCRIPTION
… the billable minus the time it takes to start ringing

taking progressmsec is wrong because it is the time from INVITE to 180 as speced here https://freeswitch.org/confluence/display/FREESWITCH/mod_xml_cdr

and ringing secs are already documented to be the actual ring duration

    "ringing_seconds": {
      "type": "string",
      "required": false,
      "name": "Ringing (seconds)",
      "description": "How many seconds the leg was ringing (pre-answer)"
    },