### PR TITLE
reference 2600hz fork of syslog driver

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -69,7 +69,7 @@ dep_erlcloud = git https://github.com/lazedo/erlcloud 54fe6b96eb0bc591b80161fc55
 
 dep_erlazure = git https://github.com/lazedo/erlazure.git add-start-link
 
-dep_couchbeam = git https://github.com/2600hz/couchbeam 2600hz 
+dep_couchbeam = git https://github.com/2600hz/couchbeam 2600hz
 ###dep_couchbeam = git https://github.com/benoitc/couchbeam 1.4.1
 ### waiting for pull requests
 ### https://github.com/benoitc/couchbeam/pull/158
@@ -102,3 +102,5 @@ dep_parse_trans = git https://github.com/lazedo/parse_trans
 dep_horse = git https://github.com/ninenines/horse
 
 dep_proper = git https://github.com/manopapad/proper v1.2
+
+dep_syslog = git https://github.com/2600hz/erlang-syslog bbad537a1cb5e4f37e672d2e2665659e850662d0


### PR DESCRIPTION
Patched syslog to properly encode unicode characters before sending via `port_command`.