### PR TITLE
handle undefined prompts

### DIFF
--- a/core/kazoo_call/src/kapps_call.erl
+++ b/core/kazoo_call/src/kapps_call.erl
@@ -1072,11 +1072,13 @@ language(#kapps_call{language='undefined', account_id=AccountId}) ->
 language(#kapps_call{language=Language}) -> Language.
 -endif.
 
--spec get_prompt(call(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
+-spec get_prompt(call(), kz_term:api_ne_binary()) -> kz_term:api_ne_binary().
+get_prompt(#kapps_call{}, 'undefined') -> 'undefined';
 get_prompt(#kapps_call{}=Call, Media) ->
     get_prompt(Call, Media, language(Call)).
 
--spec get_prompt(call(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> kz_term:api_ne_binary().
+-spec get_prompt(call(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> kz_term:api_ne_binary().
+get_prompt(_Call, 'undefined', _Lang) -> 'undefined';
 get_prompt(Call, Media, 'undefined') ->
     kz_media_util:get_prompt(Media, language(Call), account_id(Call));
 get_prompt(Call, Media, Language) ->

--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -510,7 +510,8 @@ get_prompt(PromptId, Lang, _AccountId, 'false') ->
             kz_binary:join([<<"prompt:/">>, ?KZ_MEDIA_DB, PromptId, Lang], <<"/">>)
     end.
 
--spec is_not_prompt(binary()) -> boolean().
+-spec is_not_prompt(kz_term:api_binary()) -> boolean().
+is_not_prompt('undefined') -> 'true';
 is_not_prompt(<<>>) -> 'true';
 is_not_prompt(<<"silence">>) -> 'true';
 is_not_prompt(<<"silence_stream://", _/binary>>) -> 'true';


### PR DESCRIPTION
When `Media` is not defined for a hangup cause, `kz_media_util` would crash since `is_not_prompt` didn't handle `'undefined`.