### PR TITLE
4two: correctly cast bindings on inital add so that they can be remov…

### DIFF
--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -1334,7 +1334,7 @@ declare_exchange(Channel, Exchange, Exchanges) ->
 -spec start_initial_bindings(state(), kz_term:proplist()) -> state().
 start_initial_bindings(State, Params) ->
     lists:foldl(fun({Binding, Props}, StateAcc) ->
-                        handle_add_binding(Binding, Props, StateAcc)
+                        handle_add_binding(kz_term:to_binary(Binding), Props, StateAcc)
                 end
                ,State
                ,props:get_value('bindings', Params, [])


### PR DESCRIPTION
…ed with rm_binding later