### PR TITLE
HELP-39529: ensure comparisons of FROM to permissions list is ensuring lower case 

### DIFF
--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -516,7 +516,8 @@ check_empty_permissions(#state{errors=Errors
 
 -spec match(binary(), binary()) -> boolean().
 match(Address, Element) ->
-    re:run(Address, Element) =/= 'nomatch'.
+    Address =:= kz_term:to_lower_binary(Element)
+        orelse re:run(Address, Element) =/= 'nomatch'.
 
 -spec maybe_faxbox(state()) -> state().
 maybe_faxbox(#state{faxbox_email=Domain}=State) ->

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -517,7 +517,8 @@ check_empty_permissions(#state{errors=Errors
 -spec match(binary(), binary()) -> boolean().
 match(Address, Element) ->
     Address =:= kz_term:to_lower_binary(Element)
-        orelse re:run(Address, Element) =/= 'nomatch'.
+        orelse re:run(Address, kz_term:to_lower_binary(Element)) =/= 'nomatch'
+            orelse re:run(Address, Element) =/= 'nomatch'.
 
 -spec maybe_faxbox(state()) -> state().
 maybe_faxbox(#state{faxbox_email=Domain}=State) ->

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -517,7 +517,6 @@ check_empty_permissions(#state{errors=Errors
 -spec match(binary(), binary()) -> boolean().
 match(Address, Element) ->
     Address =:= kz_term:to_lower_binary(Element)
-        orelse re:run(Address, kz_term:to_lower_binary(Element)) =/= 'nomatch'
         orelse re:run(Address, Element) =/= 'nomatch'.
 
 -spec maybe_faxbox(state()) -> state().

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -518,7 +518,7 @@ check_empty_permissions(#state{errors=Errors
 match(Address, Element) ->
     Address =:= kz_term:to_lower_binary(Element)
         orelse re:run(Address, kz_term:to_lower_binary(Element)) =/= 'nomatch'
-            orelse re:run(Address, Element) =/= 'nomatch'.
+        orelse re:run(Address, Element) =/= 'nomatch'.
 
 -spec maybe_faxbox(state()) -> state().
 maybe_faxbox(#state{faxbox_email=Domain}=State) ->


### PR DESCRIPTION
…sions list and from email

from email is always lowercase on receipt of a message, but the permissions list could have upper case characters making the comparison fail. 
https://github.com/2600hz/kazoo/blob/master/applications/fax/src/fax_smtp.erl#L111