### PR TITLE
Improve JSON object generation for testing

### DIFF
--- a/core/kazoo_stdlib/include/kazoo_json.hrl
+++ b/core/kazoo_stdlib/include/kazoo_json.hrl
@@ -13,41 +13,66 @@
 
 -define(EMPTY_JSON_OBJECT, ?JSON_WRAPPER([])).
 
--type non_null_json_term() :: boolean()
-                            | json_string() | <<>>
-                            | json_number()
-                            | object()
-                            | json_array().
-%% Denotes term definitions for JSON.
+-type non_object_json_term() :: boolean()
+                              | json_string() | <<>>
+                              | json_number()
+                              | json_array().
 
--type json_term() :: non_null_json_term() | 'null'.
-%% Denotes term definitions or null object for JSON.
+-type non_null_json_term() :: non_object_json_term()
+                            | object().
+
+%% Denotes term definitions for JSON.
 
 -type flat_json_term() :: boolean()
                         | json_string() | <<>>
                         | json_number()
-                        | json_array().
+                        | flat_json_array().
 %% Denotes all valid term definitions for JSON for a flatten JSON.
 
 -type api_json_term() :: json_term() | 'undefined'.
 %% Denotes all valid term definitions or `undefined' for JSON.
 
--type json_terms() :: [json_term()].
-%% Denotes all valid term definitions for JSON.
-
--type json_array()  :: json_terms().
-%% Denotes array in JSON.
-
 -ifdef(PROPER).
 %% PropEr will blow up the atom table if running this in an interactive shell
 -type json_string() :: kz_term:ne_binary().
+
+-type json_term() :: non_null_json_term() | <<>>.
+
+%% We want non-empty keys when generating objects
+-type keys() :: [key(),...].
+
+%% Denotes a flatten version of JSON proplist, `[{full_path, value}]'.
+-type flat_proplist() :: [{keys(), flat_json_term()},...].
+
+%% Denotes array in JSON.
+-type json_array() :: json_terms() | [].
+
 -else.
 -type json_string() :: kz_term:ne_binary() | atom().
+
+-type json_term() :: non_null_json_term() | 'null'.
+
+%% Denotes a list of JSON keys.
+-type keys() :: [key()].
+
+%% Denotes a flatten version of JSON proplist, `[{full_path, value}]'.
+-type flat_proplist() :: [{keys(), flat_json_term()}].
+
+%% Denotes array in JSON.
+-type json_array() :: json_terms().
+
 -endif.
-%% Denotes string in JSON.
+
+%% Denotes all valid term definitions for JSON.
+-type json_terms() :: [json_term()].
+
+-type flat_json_array() :: [flat_json_term()].
 
 -type json_number() :: integer() | float().
 %% Denotes number in JSON.
+
+-type json_proplist() :: [{key(), json_term()}].
+%% Denotes proplist of JSON object Erlang representation.
 
 -type object() :: ?JSON_WRAPPER(json_proplist()) | ?EMPTY_JSON_OBJECT.
 %% Denotes JSON object Erlang representation, {@link json_proplist} wrapped in `{}'.
@@ -55,29 +80,21 @@
 -type objects() :: [object()].
 %% Denotes a list of {@link object()}.
 
--type flat_proplist() :: [{path(), flat_json_term()}].
-%% Denotes a flatten version of JSON proplist, `[{full_path, value}]'.
-
--type flat_object() :: ?JSON_WRAPPER(flat_proplist()).
 %% Denotes a JSON of flatten version of JSON proplist, same as {@link flat_proplist()} but wrapped in `{}'.
+-type flat_object() :: ?JSON_WRAPPER(flat_proplist()).
 
--type flat_objects() :: [flat_object()].
 %% A list of flatten JSON objects.
+-type flat_objects() :: [flat_object()].
 
--type key() :: json_string().
 %% Denotes a JSON key.
+-type key() :: json_string().
 
--type keys() :: [key()].
-%% Denotes a list of JSON keys.
-
--type path() :: keys() | key() | pos_integer() | [pos_integer()].
+-type path() :: keys() | [pos_integer()].
 %% Denotes a path to (or n-th element of) a value in a JSON.
 
 -type paths() :: [path()].
 %% Denotes a list of paths (or n-th element of) a value in a JSON.
 
--type json_proplist() :: [{key(), json_term()}].
-%% Denotes proplist of JSON object Erlang representation.
 -type json_proplists() :: [json_proplist()].
 
 -type encode_option() :: 'uescape'

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -213,17 +213,13 @@ are_json_objects(JObjs) when is_list(JObjs) ->
     lists:all(fun is_json_object/1, JObjs).
 
 -spec is_valid_json_object(any()) -> boolean().
-is_valid_json_object(MaybeJObj) ->
-    try
-        lists:all(fun(K) ->
-                          is_json_term(get_value([K], MaybeJObj))
-                  end
-                 ,?MODULE:get_keys(MaybeJObj)
-                 )
-    catch
-        'throw':_ -> 'false';
-        'error':_ -> 'false'
-    end.
+is_valid_json_object(?JSON_WRAPPER(_)=JObj) ->
+    lists:all(fun(K) ->
+                      is_json_term(get_value([K], JObj))
+              end
+             ,get_keys(JObj)
+             );
+is_valid_json_object(_) -> 'false'.
 
 -spec is_json_term(json_term()) -> boolean().
 is_json_term('undefined') -> throw({'error', 'no_atom_undefined_in_jobj_please'});
@@ -235,8 +231,7 @@ is_json_term(V) when is_float(V) -> 'true';
 is_json_term(Vs) when is_list(Vs) ->
     lists:all(fun is_json_term/1, Vs);
 is_json_term({'json', IOList}) when is_list(IOList) -> 'true';
-is_json_term(MaybeJObj) ->
-    is_json_object(MaybeJObj).
+is_json_term(MaybeJObj) -> is_valid_json_object(MaybeJObj).
 
 %%------------------------------------------------------------------------------
 %% @doc Finds out whether 2 JSON objects are recursively identical.

--- a/core/kazoo_stdlib/test/kz_json_generators.erl
+++ b/core/kazoo_stdlib/test/kz_json_generators.erl
@@ -60,5 +60,4 @@ max_depth(JObj) ->
                          ,0
                          ,kz_json:flatten(JObj)
                          ),
-    Depth > 44 andalso io:format('user', "maxdepth ~p~n", [JObj]),
     Depth.

--- a/core/kazoo_stdlib/test/kz_json_generators.erl
+++ b/core/kazoo_stdlib/test/kz_json_generators.erl
@@ -1,20 +1,64 @@
 -module(kz_json_generators).
 
--export([test_object/0]).
+-export([test_object/0
+        ,non_empty_object/0
+        ,deep_object/0, deep_object/1
 
--include_lib("proper/include/proper.hrl").
+        ,max_depth/1
+        ]).
+
 -include_lib("kazoo_stdlib/include/kazoo_json.hrl").
+-include_lib("proper/include/proper.hrl").
+
+non_empty_object() ->
+    ?SUCHTHAT(JObj, test_object(), not kz_json:is_empty(JObj)).
 
 test_object() ->
     ?LET(JObj, object(), remove_duplicate_keys(JObj)).
 
-remove_duplicate_keys(?EMPTY_JSON_OBJECT) -> ?EMPTY_JSON_OBJECT;
 remove_duplicate_keys(?JSON_WRAPPER(_)=JObj) ->
-    kz_json:foldl(fun no_dups/3, kz_json:new(), JObj);
-remove_duplicate_keys(V) -> V.
+    kz_json:expand(kz_json:from_map(kz_json:to_map(kz_json:flatten(JObj)))).
 
-no_dups(Key, ?JSON_WRAPPER(_)=JObj, Acc) ->
-    DeDuped = remove_duplicate_keys(JObj),
-    kz_json:set_value(Key, DeDuped, Acc);
-no_dups(Key, Value, Acc) ->
-    kz_json:set_value(Key, Value, Acc).
+deep_object() ->
+    ?SIZED(Nesting, deep_object(Nesting)).
+
+deep_object(Nesting) ->
+    ?LET(DeepObject
+        ,deep_object(Nesting, {'$call', 'kz_json', 'new', []})
+        ,DeepObject
+        ).
+
+deep_object(0, JObj) ->
+    JObj;
+deep_object(Depth, JObj) ->
+    deep_object(Depth-1
+               ,{'$call', 'kz_json', 'set_value', [path(Depth), freq_value(Depth), JObj]}
+               ).
+
+path(0) ->
+    ?LET(Key, json_string(), Key);
+path(Depth) ->
+    ?LET(Path
+        ,resize(Depth, non_empty(json_string()))
+        ,Path
+        ).
+
+freq_value(0) ->
+    ?LET(Value, non_object_json_term(), Value);
+freq_value(Depth) ->
+    frequency([{90, ?LET(Value, non_object_json_term(), Value)}
+              ,{10, ?LET(JObj, deep_object(Depth-1), JObj)}
+              ]).
+
+max_depth(JObj) ->
+    Depth = kz_json:foldl(fun(Path, _, Max) ->
+                                  case length(Path) of
+                                      NewMax when NewMax > Max -> NewMax;
+                                      _Len -> Max
+                                  end
+                          end
+                         ,0
+                         ,kz_json:flatten(JObj)
+                         ),
+    Depth > 44 andalso io:format('user', "maxdepth ~p~n", [JObj]),
+    Depth.


### PR DESCRIPTION
Add a property check that reports the object depth generation

Use symbolic calls to kz_json:set_value/3 to construct the object

Use resize/2 to control the max depth of the object

Update tests to use the new deep_object/0 generator