### PR TITLE
KAZOO-5952: do not default settings in conference callflow

### DIFF
--- a/applications/callflow/doc/conference.md
+++ b/applications/callflow/doc/conference.md
@@ -16,9 +16,9 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `config` | Build an ad-hoc conference using the conferences JSON schema | `object()` |   | `false` |  
 `id` | Kazoo ID of the conference | `string(32)` |   | `false` |  
-`moderator` | Is the caller entering the conference as a moderator | `boolean()` | `false` | `false` |  
-`play_entry_tone` | Should the Entry Tone be played | `boolean() | string()` | `true` | `false` |  
-`play_exit_tone` | Should the Exit Tone be played | `boolean() | string()` | `true` | `false` |  
+`moderator` | Is the caller entering the conference as a moderator | `boolean()` |   | `false` |  
+`play_entry_tone` | Should the Entry Tone be played | `boolean() | string()` |   | `false` |  
+`play_exit_tone` | Should the Exit Tone be played | `boolean() | string()` |   | `false` |  
 `welcome_prompt.media_id` | Media to play, either Kazoo media ID or URL | `string()` |   | `false` |  
 `welcome_prompt.play` | Should the Welcome Prompt be played | `boolean()` | `true` | `false` |  
 `welcome_prompt` | Describes how the caller is greeted on entering a conference | `object()` |   | `false` |  

--- a/applications/callflow/doc/ref/conference.md
+++ b/applications/callflow/doc/ref/conference.md
@@ -12,9 +12,9 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `config` | Build an ad-hoc conference using the conferences JSON schema | `object()` |   | `false` |  
 `id` | Kazoo ID of the conference | `string(32)` |   | `false` |  
-`moderator` | Is the caller entering the conference as a moderator | `boolean()` | `false` | `false` |  
-`play_entry_tone` | Should the Entry Tone be played | `boolean() | string()` | `true` | `false` |  
-`play_exit_tone` | Should the Exit Tone be played | `boolean() | string()` | `true` | `false` |  
+`moderator` | Is the caller entering the conference as a moderator | `boolean()` |   | `false` |  
+`play_entry_tone` | Should the Entry Tone be played | `boolean() | string()` |   | `false` |  
+`play_exit_tone` | Should the Exit Tone be played | `boolean() | string()` |   | `false` |  
 `welcome_prompt.media_id` | Media to play, either Kazoo media ID or URL | `string()` |   | `false` |  
 `welcome_prompt.play` | Should the Welcome Prompt be played | `boolean()` | `true` | `false` |  
 `welcome_prompt` | Describes how the caller is greeted on entering a conference | `object()` |   | `false` |  

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1939,12 +1939,10 @@
                     "type": "string"
                 },
                 "moderator": {
-                    "default": false,
                     "description": "Is the caller entering the conference as a moderator",
                     "type": "boolean"
                 },
                 "play_entry_tone": {
-                    "default": true,
                     "description": "Should the Entry Tone be played",
                     "type": [
                         "boolean",
@@ -1952,7 +1950,6 @@
                     ]
                 },
                 "play_exit_tone": {
-                    "default": true,
                     "description": "Should the Exit Tone be played",
                     "type": [
                         "boolean",

--- a/applications/crossbar/priv/couchdb/schemas/callflows.conference.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.conference.json
@@ -15,12 +15,10 @@
             "type": "string"
         },
         "moderator": {
-            "default": false,
             "description": "Is the caller entering the conference as a moderator",
             "type": "boolean"
         },
         "play_entry_tone": {
-            "default": true,
             "description": "Should the Entry Tone be played",
             "type": [
                 "boolean",
@@ -28,7 +26,6 @@
             ]
         },
         "play_exit_tone": {
-            "default": true,
             "description": "Should the Exit Tone be played",
             "type": [
                 "boolean",


### PR DESCRIPTION
Since callflow always wins over conference config when merging settings, remove the default values which would supersede the values in the conference so new conference callflows that are created will use the conference settings, not the callflow settings.