### PR TITLE
add defaults to billing & ringing seconds

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -1082,15 +1082,15 @@ get_hangup_code(Props) ->
 -spec get_billing_seconds(kz_term:proplist()) -> integer().
 get_billing_seconds(Props) ->
     case props:get_integer_value(<<"variable_billmsec">>, Props) of
-        'undefined' -> props:get_integer_value(<<"variable_billsec">>, Props);
+        'undefined' -> props:get_integer_value(<<"variable_billsec">>, Props, 0);
         Billmsec -> kz_term:ceiling(Billmsec / 1000)
     end.
 
 -spec get_ringing_seconds(kz_term:proplist()) -> integer().
 get_ringing_seconds(Props) ->
-    DurationS = props:get_integer_value(<<"variable_duration">>, Props),
+    DurationS = props:get_integer_value(<<"variable_duration">>, Props, 0),
     BillingS = get_billing_seconds(Props),
-    ProgressS = props:get_integer_value(<<"variable_progresssec">>, Props),
+    ProgressS = props:get_integer_value(<<"variable_progresssec">>, Props, 0),
 
     DurationS - BillingS - ProgressS.
 


### PR DESCRIPTION
i still feel that this ringing seconds should be
```
if ( answered_time == 0 ) then
 length_of_phone_ringing = hangup_time - created_time
else   
 length_of_phone_ringing = answered_time - created_time
end
```