### PR TITLE
add publisher confirms to amqp_worker

### DIFF
--- a/core/kazoo_amqp/src/kz_amqp_sup.erl
+++ b/core/kazoo_amqp/src/kz_amqp_sup.erl
@@ -28,6 +28,7 @@
 -define(DEFAULT_POOL_SIZE, 150).
 -define(DEFAULT_POOL_OVERFLOW, 100).
 -define(DEFAULT_POOL_THRESHOLD, 5).
+-define(DEFAULT_POOL_SERVER_CONFIRMS, true).
 
 %%% Move the section to kazoo_apps or ecallmgr for per-vm control
 
@@ -41,6 +42,7 @@
                   ]).
 
 -define(POOL_THRESHOLD, kz_config:get_integer(?CONFIG_SECTION, 'pool_threshold', ?DEFAULT_POOL_THRESHOLD)).
+-define(POOL_SERVER_CONFIRMS, kz_config:get_boolean(?CONFIG_SECTION, 'pool_server_confirms', ?DEFAULT_POOL_SERVER_CONFIRMS)).
 
 -define(ADD_POOL_ARGS(Pool, Broker, Size, Overflow, Bindings, Exchanges, ServerAck),
         [[{'worker_module', 'kz_amqp_worker'}
@@ -169,6 +171,7 @@ init([]) ->
             [] -> ?POOL_THRESHOLD;
             [Threshold|_] -> Threshold
         end,
+    PoolServerConfirms = kz_config:get_boolean(?CONFIG_SECTION, 'pool_server_confirms', ?DEFAULT_POOL_SERVER_CONFIRMS),
 
     PoolArgs = [{'worker_module', 'kz_amqp_worker'}
                ,{'name', {'local', ?POOL_NAME}}
@@ -176,6 +179,7 @@ init([]) ->
                ,{'max_overflow', PoolOverflow}
                ,{'strategy', 'fifo'}
                ,{'neg_resp_threshold', PoolThreshold}
+               ,{'amqp_server_confirms', PoolServerConfirms}
                ],
 
     Children = ?CHILDREN ++ [?POOL_NAME_ARGS(?POOL_NAME, [PoolArgs])],


### PR DESCRIPTION
also handles event without spawning process as it was noticed that this may lead to out of order message handling.

the spawned process only does a cast and the erlang scheduler may run the process out of order of received message.

the use case is presence detail queries where proxy servers send 1+ messages with details and a final message to indicate completion. the completion message may be processed before one of the intermediary detail messages and the result will be the absence of details in `monster-ui-debug`
