### PR TITLE
HELP-39798: find conference username from sip_req_uri

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_channel.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channel.erl
@@ -756,7 +756,7 @@ get_username(Props) ->
 get_realm(Props, CCVs) ->
     case props:get_value(<<"Realm">>, CCVs) of
         'undefined' ->
-            lager:info("no realm in CCVs, checking FS props: ~p", [CCVs]),
+            lager:info("no 'Realm' in CCVs, checking FS props"),
             get_realm_from_props(Props);
         Realm -> Realm
     end.
@@ -766,7 +766,7 @@ get_realm(Props, CCVs) ->
 get_realm_from_props(Props) ->
     case props:get_value(<<"variable_domain_name">>, Props) of
         'undefined' ->
-            lager:info("no realm found in props ~p", [Props]),
+            lager:info("no realm found in 'variable_domain_name' in FS props"),
             'undefined';
         Realm -> kz_term:to_lower_binary(Realm)
     end.

--- a/core/kazoo_documents/src/kzd_freeswitch.erl
+++ b/core/kazoo_documents/src/kzd_freeswitch.erl
@@ -170,9 +170,23 @@ channel_authorized(Props) ->
 outbound_flags(Props) ->
     ccv(Props, <<"Outbound-Flags">>).
 
--spec hunt_destination_number(data()) -> kz_term:api_binary().
+-spec hunt_destination_number(data()) -> kz_term:api_ne_binary().
 hunt_destination_number(Props) ->
-    props:get_value(<<"Hunt-Destination-Number">>, Props).
+    case props:get_value(<<"Hunt-Destination-Number">>, Props) of
+        'undefined' -> sip_req_user(Props);
+        HuntDestinationNumber -> HuntDestinationNumber
+    end.
+
+-spec sip_req_user(data()) -> kz_term:api_ne_binary().
+sip_req_user(Props) ->
+    case props:get_value(<<"variable_sip_req_uri">>, Props) of
+        'undefined' -> 'undefined';
+        ReqURI ->
+            case binary:split(ReqURI, <<"@">>) of
+                [Number, _Realm] -> Number;
+                _Split -> 'undefined'
+            end
+    end.
 
 -spec is_channel_recovering(data()) -> boolean().
 is_channel_recovering(Props) ->


### PR DESCRIPTION
When bridging a remote conference participant, the 'conference' username is not always being found via the `Hunt-Destination-Number` FreeSWITCH variable:

```
|{CALL_ID}|ecallmgr_fs_authz:91(<0.29383.2451>) is destination number 'conference': undefined
```

If missing, check the `variable_sip_req_uri` which has the `conference@FS:11000` (when it is a bridged conference participant).
