### PR TITLE
HELP-39208: allow the call if the number is in the account

### DIFF
--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1719,8 +1719,9 @@ encryption_method_map(CCVs, Endpoint) ->
 
 -spec set_sip_invite_domain(ccv_acc()) -> ccv_acc().
 set_sip_invite_domain({Endpoint, Call, CallFwd, CCVs}) ->
+    SipRealm = get_sip_realm(Endpoint, Call, kapps_call:request_realm(Call)),
     {Endpoint, Call, CallFwd
-    ,kz_json:set_value(<<"SIP-Invite-Domain">>, kapps_call:request_realm(Call), CCVs)
+    ,kz_json:set_value(<<"SIP-Invite-Domain">>, SipRealm, CCVs)
     }.
 
 -spec maybe_set_call_waiting(ccv_acc()) -> ccv_acc().

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1366,6 +1366,7 @@ create_mobile_audio_endpoint(Endpoint, Properties, Call) ->
               [{<<"Invite-Format">>, <<"route">>}
               ,{<<"Ignore-Early-Media">>, <<"true">>}
               ,{<<"Route">>, Route}
+              ,{<<"To-Realm">>, get_sip_realm(Endpoint, kapps_call:account_id(Call))}
               ,{<<"Ignore-Early-Media">>, <<"true">>}
               ,{<<"Endpoint-Timeout">>, get_timeout(Properties)}
               ,{<<"Endpoint-Delay">>, get_delay(Properties)}
@@ -1912,7 +1913,7 @@ get_sip_realm(SIPJObj, AccountId, Default) ->
     case kzd_devices:sip_realm(SIPJObj) of
         'undefined' ->
             case kzd_accounts:fetch_realm(AccountId) of
-                undefined -> Default;
+                'undefined' -> Default;
                 Realm -> Realm
             end;
         Realm -> Realm


### PR DESCRIPTION
If the referred-by is a number assigned to the account (such as when
the device making the call is a 2600Hz mobile device), allow the
route_req to use the no_match if necessary.