### PR TITLE
AMQP updates

### DIFF
--- a/core/kazoo_amqp/include/kz_amqp.hrl
+++ b/core/kazoo_amqp/include/kz_amqp.hrl
@@ -148,7 +148,6 @@
 -define(EXCHANGE_TASKS, <<"tasks">>).
 -define(TYPE_TASKS, <<"topic">>).
 
-
 -type kz_amqp_command() :: #'queue.declare'{} | #'queue.delete'{} |
                            #'queue.bind'{} | #'queue.unbind'{} |
                            #'basic.consume'{} | #'basic.cancel'{} |

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -995,13 +995,10 @@ remove_binding(Binding, Props, Q) ->
 create_binding(Binding, Props, Q) when not is_binary(Binding) ->
     create_binding(kz_term:to_binary(Binding), Props, Q);
 create_binding(Binding, Props, Q) ->
-    Wapi = list_to_binary([<<"kapi_">>, kz_term:to_binary(Binding)]),
+    Wapi = kz_term:to_atom(list_to_binary([<<"kapi_">>, kz_term:to_binary(Binding)]), 'true'),
     declare_binding_exchanges(Wapi),
-    try (kz_term:to_atom(Wapi, 'true')):bind_q(Q, Props)
-    catch
-        'error':'undef' ->
-            erlang:error({'api_module_undefined', Wapi})
-    end.
+    'true' = kz_module:is_exported(Wapi, 'bind_q', 2),
+    Wapi:bind_q(Q, Props).
 
 -spec declare_binding_exchanges(module()) -> 'ok'.
 declare_binding_exchanges(Wapi) ->

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -996,10 +996,18 @@ create_binding(Binding, Props, Q) when not is_binary(Binding) ->
     create_binding(kz_term:to_binary(Binding), Props, Q);
 create_binding(Binding, Props, Q) ->
     Wapi = list_to_binary([<<"kapi_">>, kz_term:to_binary(Binding)]),
+    declare_binding_exchanges(Wapi),
     try (kz_term:to_atom(Wapi, 'true')):bind_q(Q, Props)
     catch
         'error':'undef' ->
             erlang:error({'api_module_undefined', Wapi})
+    end.
+
+-spec declare_binding_exchanges(module()) -> 'ok'.
+declare_binding_exchanges(Wapi) ->
+    case kz_module:is_exported(Wapi, 'declare_exchanges', 0) of
+        'true' -> Wapi:declare_exchanges();
+        'false' -> 'ok'
     end.
 
 -spec stop_timer(kz_term:api_reference()) -> non_neg_integer() | 'false'.

--- a/core/kazoo_amqp/src/kazoo_amqp_maintenance.erl
+++ b/core/kazoo_amqp/src/kazoo_amqp_maintenance.erl
@@ -558,7 +558,9 @@ print_gc_summary(Results) ->
                              ]
                             ,<<" < ">>
                             ),
-    io:format("  Min/Avg/Max of ~p workers: ~s~n", [Count, Summary]).
+    io:format("  Min/Avg/Max of ~p workers: ~s (total: ~s)~n"
+             ,[Count, Summary, kz_util:pretty_print_bytes(kz_term:words_to_bytes(Sum), 'truncated')]
+             ).
 
 -spec gc_summary([{pid(), integer(), integer(), integer()}]) ->
                         {integer(), integer(), integer(), integer()}.

--- a/core/kazoo_amqp/src/kz_amqp_channel.erl
+++ b/core/kazoo_amqp/src/kz_amqp_channel.erl
@@ -395,8 +395,9 @@ handle_command_result(#'queue.unbind_ok'{}
                                      }=Command
                      ,#kz_amqp_assignment{channel=Channel}=Assignment) ->
     lager:debug("unbound ~s from ~s exchange (routing key ~s) via channel ~p"
-               ,[Queue, Exchange, RoutingKey, Channel]),
-    _ = kz_amqp_history:add_command(Assignment, Command, 'sync'),
+               ,[Queue, Exchange, RoutingKey, Channel]
+               ),
+    _ = kz_amqp_history:add_command(Assignment, Command),
     'ok';
 handle_command_result(#'queue.bind_ok'{}
                      ,#'queue.bind'{exchange=_Exchange

--- a/core/kazoo_amqp/src/kz_amqp_connections.erl
+++ b/core/kazoo_amqp/src/kz_amqp_connections.erl
@@ -194,7 +194,7 @@ broker_available_connections(Broker) ->
                 ],
     ets:select_count(?TAB, MatchSpec).
 
--spec primary_broker() -> kz_term:api_binary().
+-spec primary_broker() -> kz_term:api_ne_binary().
 primary_broker() ->
     Pattern = #kz_amqp_connections{available='true'
                                   ,zone='local'

--- a/core/kazoo_amqp/src/kz_amqp_history.erl
+++ b/core/kazoo_amqp/src/kz_amqp_history.erl
@@ -7,7 +7,7 @@
 -behaviour(gen_server).
 
 -export([start_link/0]).
--export([add_command/2, add_command/3]).
+-export([add_command/2]).
 -export([update_consumer_tag/3]).
 -export([remove/1]).
 -export([get/1]).
@@ -51,11 +51,7 @@ start_link() ->
     gen_server:start_link({'local', ?SERVER}, ?MODULE, [], []).
 
 -spec add_command(kz_amqp_assignment(), kz_amqp_command()) -> 'ok'.
-add_command(Assignment, Command) ->
-    add_command(Assignment, Command, 'async').
-
--spec add_command(kz_amqp_assignment(), kz_amqp_command(), 'sync' | 'async') -> 'ok'.
-add_command(#kz_amqp_assignment{consumer=Consumer}, Command, _Method) ->
+add_command(#kz_amqp_assignment{consumer=Consumer}, Command) ->
     case kz_amqp_history_ets:is_existing_command(Consumer, Command) of
         'false' -> handle_command(Consumer, Command);
         'true' ->

--- a/core/kazoo_amqp/src/kz_amqp_history.erl
+++ b/core/kazoo_amqp/src/kz_amqp_history.erl
@@ -202,12 +202,6 @@ handle_info({'DOWN', _, 'process', Pid, _Reason}
             lager:debug("connection ~p went down: ~p", [Pid, _Reason]),
             {'noreply', State#state{connections=sets:del_element(Pid, Connections)}};
         'false' ->
-            %% Allow kz_amqp_assignments time to get the history so it
-            %% can cleanly remove queues/consumers/etc
-            lager:debug("removing AMQP history for consumer ~p in 2.5s: ~p"
-                       ,[Pid, _Reason]
-                       ),
-            erlang:send_after(2500, self(), {'remove_history', Pid}),
             {'noreply', State}
     end;
 handle_info(_Info, State) ->

--- a/core/kazoo_amqp/src/kz_amqp_history_ets.erl
+++ b/core/kazoo_amqp/src/kz_amqp_history_ets.erl
@@ -1,0 +1,170 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2011-2018, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kz_amqp_history_ets).
+
+-export([create/0
+
+        ,is_existing_command/2
+        ,is_consumer_queue_consuming/2
+        ,is_consumer_queue_bound_to_exchange/4
+
+        ,get_consumer_history/1
+        ,get_consumer_basic_consumes/1
+        ,get_consumer_commands_by_tag/2
+
+        ,add_consumer_command/2
+
+        ,update_command_tag/2
+
+        ,delete_consumer_queue/2
+        ,delete_consumer_consume/2
+        ,delete_consumer/1
+
+        ,unbind_queue/2
+        ]).
+
+-export_type([history/0]).
+
+-include("kz_amqp_util.hrl").
+
+-define(TAB, 'kz_amqp_history').
+
+-record(kz_amqp_history, {timestamp = os:timestamp() :: kz_time:now() | '_'
+                         ,consumer :: kz_term:api_pid() | '_'
+                         ,command :: kz_amqp_command() | '_'
+                         }).
+-type history() :: #kz_amqp_history{}.
+
+-spec create() -> ets:tid() | atom().
+create() ->
+    ets:new(?TAB, ['named_table'
+                  ,{'keypos', #kz_amqp_history.timestamp}
+                  ,'public'
+                  ,'ordered_set'
+                  ]).
+
+-spec is_existing_command(pid(), kz_amqp_command()) -> boolean().
+is_existing_command(Consumer, Command) ->
+    MatchSpec = [{#kz_amqp_history{consumer=Consumer
+                                  ,command=Command
+                                  ,_='_'
+                                  }
+                 ,[]
+                 ,['true']
+                 }],
+    ets:select_count(?TAB, MatchSpec) > 0.
+
+-spec is_consumer_queue_consuming(pid(), kz_term:ne_binary()) -> boolean().
+is_consumer_queue_consuming(Consumer, Queue) ->
+    MatchSpec = [{#kz_amqp_history{consumer=Consumer
+                                  ,command=#'basic.consume'{queue=Queue
+                                                           ,_='_'
+                                                           }
+                                  ,_='_'
+                                  }
+                 ,[]
+                 ,['true']
+                 }],
+    ets:select_count(?TAB, MatchSpec) =/= 0.
+
+-spec is_consumer_queue_bound_to_exchange(pid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
+is_consumer_queue_bound_to_exchange(Consumer, Queue, Exchange, RoutingKey) ->
+    MatchSpec = [{#kz_amqp_history{consumer=Consumer
+                                  ,command=#'queue.bind'{queue=Queue
+                                                        ,exchange=Exchange
+                                                        ,routing_key=RoutingKey
+                                                        ,_='_'
+                                                        }
+                                  ,_='_'
+                                  }
+                 ,[]
+                 ,['true']
+                 }],
+    ets:select_count(?TAB, MatchSpec) =/= 0.
+
+-spec get_consumer_history(pid()) -> [kz_amqp_command()].
+get_consumer_history(Consumer) ->
+    Pattern = #kz_amqp_history{consumer=Consumer
+                              ,_='_'
+                              },
+    [Command
+     || #kz_amqp_history{command=Command}
+            <- ets:match_object(?TAB, Pattern)
+    ].
+
+-spec get_consumer_basic_consumes(pid()) -> [#'basic.consume'{}].
+get_consumer_basic_consumes(Consumer) ->
+    Pattern = #kz_amqp_history{consumer=Consumer
+                              ,command=#'basic.consume'{_='_'}
+                              ,_='_'
+                              },
+    [Command
+     || #kz_amqp_history{command=Command} <- ets:match_object(?TAB, Pattern)
+    ].
+
+-spec get_consumer_commands_by_tag(pid(), kz_term:ne_binary()) -> [history()].
+get_consumer_commands_by_tag(Consumer, OldTag) ->
+    Pattern = #kz_amqp_history{consumer=Consumer
+                              ,command=#'basic.consume'{consumer_tag=OldTag
+                                                       ,_='_'
+                                                       }
+                              ,_='_'
+                              },
+    ets:match_object(?TAB, Pattern).
+
+-spec add_consumer_command(pid(), kz_amqp_command()) -> 'true'.
+add_consumer_command(Consumer, Command) ->
+    'true' = ets:insert(?TAB, #kz_amqp_history{consumer=Consumer
+                                              ,command=Command
+                                              }).
+
+-spec update_command_tag(history(), kz_term:ne_binary()) -> boolean().
+update_command_tag(#kz_amqp_history{timestamp=Timestamp
+                                   ,command=Command
+                                   }
+                  ,NewTag
+                  ) ->
+    Props = [{#kz_amqp_history.command, Command#'basic.consume'{consumer_tag=NewTag}}],
+    _ = ets:update_element(?TAB, Timestamp, Props).
+
+-spec delete_consumer_queue(pid(), kz_term:ne_binary()) -> 'true'.
+delete_consumer_queue(Consumer, Queue) ->
+    Pattern = #kz_amqp_history{consumer=Consumer
+                              ,command=#'queue.declare'{queue=Queue
+                                                       ,_='_'
+                                                       }
+                              ,_='_'
+                              },
+    'true' = ets:match_delete(?TAB, Pattern).
+
+-spec delete_consumer_consume(pid(), kz_term:ne_binary()) -> 'true'.
+delete_consumer_consume(Consumer, Tag) ->
+    Pattern = #kz_amqp_history{consumer=Consumer
+                              ,command=#'basic.consume'{consumer_tag=Tag
+                                                       ,_='_'
+                                                       }
+                              ,_='_'},
+    'true' = ets:match_delete(?TAB, Pattern).
+
+-spec delete_consumer(pid()) -> 'true'.
+delete_consumer(Consumer) ->
+    Pattern = #kz_amqp_history{consumer=Consumer, _='_'},
+    'true' = ets:match_delete(?TAB, Pattern).
+
+-spec unbind_queue(pid(), #'queue.unbind'{}) -> 'true'.
+unbind_queue(Consumer, #'queue.unbind'{queue=Queue
+                                      ,exchange=Exchange
+                                      ,routing_key=RoutingKey
+                                      }) ->
+    Pattern = #kz_amqp_history{consumer=Consumer
+                              ,command=#'queue.bind'{queue=Queue
+                                                    ,exchange=Exchange
+                                                    ,routing_key=RoutingKey
+                                                    ,_='_'
+                                                    }
+                              ,_='_'
+                              },
+    'true' = ets:match_delete(?TAB, Pattern).

--- a/core/kazoo_caches/src/kz_cache_listener.erl
+++ b/core/kazoo_caches/src/kz_cache_listener.erl
@@ -164,6 +164,8 @@ handle_event(JObj, #state{name=Name}) ->
     'ignore'.
 
 -spec terminate(any(), state()) -> 'ok'.
+terminate('shutdown', _State) -> 'ok';
+terminate('normal', _State) -> 'ok';
 terminate(_Reason, _State) ->
     lager:info("terminating: ~p", [_Reason]).
 

--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -839,7 +839,8 @@ create_node(Heartbeat, #state{zone=Zone
                            ,node_info=node_info()
                            }).
 
--spec normalize_amqp_uri(kz_term:ne_binary()) -> kz_term:ne_binary().
+-spec normalize_amqp_uri(kz_term:api_ne_binary()) -> kz_term:ne_binary().
+normalize_amqp_uri('undefined') -> <<"disconnected">>;
 normalize_amqp_uri(URI) ->
     kz_term:to_binary(amqp_uri:remove_credentials(kz_term:to_list(URI))).
 


### PR DESCRIPTION
Moved ETS operations to a new module to separate concerns a bit. Also moved the execution of those operations out of the gen_server; now the gen_server is used to track and connections and exchanges (removed tracking of consumers - cleanup is triggered by kz_amqp_assignments).

Hopefully this is a first step to addressing history backups causing issues on bigger Kazoo installs. Would need to find out how to trigger the issue reliably.