### PR TITLE
Dialyzing hard of callflows (#5182) - 4.3

### DIFF
--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -815,7 +815,7 @@ handle_cast('call_status_req', #state{call=Call, my_q=Q}=State) ->
                | kz_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
               ],
 
-    kapi_call:publish_channel_status_req(Command, CallId),
+    _ = kapi_call:publish_channel_status_req(Command),
     {'noreply', State};
 
 handle_cast({'call_status_req', CallId}, #state{my_q=Q}=State) when is_binary(CallId) ->
@@ -823,7 +823,7 @@ handle_cast({'call_status_req', CallId}, #state{my_q=Q}=State) when is_binary(Ca
               ,{<<"Server-ID">>, Q}
                | kz_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
               ],
-    kapi_call:publish_channel_status_req(CallId, Command),
+    _ = kapi_call:publish_channel_status_req(Command),
     {'noreply', State};
 handle_cast({'call_status_req', Call}, State) ->
     handle_cast({'call_status_req', kapps_call:call_id(Call)}, State);

--- a/applications/callflow/doc/dynamic_cid.md
+++ b/applications/callflow/doc/dynamic_cid.md
@@ -1,6 +1,6 @@
-### Callflow Dynamic CID
+# Callflow Dynamic CID
 
-#### About Dynamic CID
+## About Dynamic CID
 
 The Dynamic CID callflow enables you to dynamically change the Caller ID (CID). There are different methods for doing that:
 
@@ -9,7 +9,7 @@ The Dynamic CID callflow enables you to dynamically change the Caller ID (CID). 
 * **lists:** almost the same as list mode but you can use account's lists feature to configure entries
 * **static** set the caller id to a value in a `caller_id.name` and `caller_id.number` property in the data object. This works with and without a capture group
 
-##### Callflow fields
+## Callflow fields
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
@@ -25,19 +25,18 @@ Key | Description | Type | Default | Required
 `min_digits` | minimum digits length to collect for `manual` action | `integer` | 10 | `false`
 `whitelist_regex` | the regex that will run over collected digits for number verification | `string` | `"\\d+"` | `false`
 
-#### Manual action mode
+## Manual action mode
 
-In this method user is prompted to dial a new Caller ID number. The length of the dialed new Caller ID is checked to be
-in the default(or configured) boundary and it is also matched against the default(or configured) regex, if these checks are passed the call will proceed.
+In this method user is prompted to dial a new Caller ID number. The length of the dialed new Caller ID is checked to be in the default(or configured) boundary and it is also matched against the default(or configured) regex, if these checks are passed the call will proceed.
 
 > **Notes** You can only set the Caller ID number with this method.
 
-###### Example Scenario
+### Example Scenario
 
 User dial `*212223332222` (assuming you set the feature code to `*2` by setting callflow patterns to `"^\\*2([0-9]{2,})$"`) and
 prompted to dial the new Caller ID number, then the call will send onto real destination which in this case is `12223332222`.
 
-##### Manual callflow settings
+### Manual callflow settings
 
 You may want to customize `manual` behavior in `system_configs/callflow.dynamic_cid`.
 
@@ -50,7 +49,7 @@ Key | Description | Type | Default | Required
 `min_digits` | Minimum length of the new caller id number | `integer` | 10 | `false`
 `whitelist_regex` | The regex to use for number to be matched against | `string` | `"\\d+"` | `false`
 
-#### List action mode
+## List action mode
 
 In this method you have flexibility to define multiple Caller ID, each assign to a specific number using account's list. You can set both the Caller ID name and
 number in a document in database. This callflow's module use that information to set new Caller ID. You can create your list and list's entries using [List Crossbar API](../../crossbar/doc/lists.md).
@@ -61,7 +60,7 @@ This behavior is exactly same as `lists` action, the only difference is that you
 
 > **Notes** You can set  both the Caller ID number and name with this method.
 
-##### List Entry document fields
+### List Entry document fields
 
 Key | Description | Type | Default | Required
 --- | ----------- | ---- | ------- | --------
@@ -70,7 +69,7 @@ Key | Description | Type | Default | Required
 `number` | Caller ID number | `string` | | `true`
 `name` | Caller ID name | `string` | | `true`
 
-###### Example 1: Two digits as CID selector
+### Example 1: Two digits as CID selector
 
 Consider that the user wants to call number `5149072508` using the caller id `16139999999`. We assume that callflow patterns set as follow:
 
@@ -98,7 +97,7 @@ These are the steps will happen if a user dial `*2015149072508` in handset:
 3. Selected CID will be set for the call
 3. `5149072508` becomes `+15149072508` and gets dialed as such
 
-###### Example 1: One digits as CID selector
+### Example 2: One digits as CID selector
 
 Another example which uses number with length of 1 to select the Caller ID:
 
@@ -113,15 +112,15 @@ Another example which uses number with length of 1 to select the Caller ID:
 
 Dialing number `*205149072508` will cause number "5149072508" gets dialed with CID number set to "16139999999" CID name to "Awesome Co.".
 
-#### Lists action mode
+## Lists action mode
 
 Almost the same as [list mode](#list-action-mode) using account's lists feature to configure entries.
 
-#### Static action mode
+## Static action mode
 
 In this method the new Caller ID number and name would be set to `caller_id` value sets in the callflow Data object.
 
-###### Example Callflow Data
+### Example Callflow Data
 
 ```json
 {

--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -440,10 +440,9 @@ send_default_response(Cause, Call) ->
 -spec apply_dialplan(kz_term:ne_binary(), kz_term:api_object()) -> kz_term:ne_binary().
 apply_dialplan(N, 'undefined') -> N;
 apply_dialplan(Number, DialPlan) ->
-    Regexs = kz_json:get_keys(DialPlan),
-    case Regexs of
+    case kz_json:get_keys(DialPlan) of
         [] -> Number;
-        _ -> maybe_apply_dialplan(Regexs, DialPlan, Number)
+        Regexps -> maybe_apply_dialplan(Regexps, DialPlan, Number)
     end.
 
 -spec maybe_apply_dialplan(kz_json:path(), kz_json:object(), kz_term:ne_binary()) -> kz_term:ne_binary().

--- a/applications/callflow/src/module/cf_call_forward.erl
+++ b/applications/callflow/src/module/cf_call_forward.erl
@@ -58,7 +58,7 @@ handle(Data, Call) ->
             catch({'ok', _} = kapps_call_command:b_prompt(<<"cf-not_available">>, Call)),
             cf_exe:stop(Call);
         CF ->
-            kapps_call_command:b_answer(Call),
+            {'ok', _} = kapps_call_command:b_answer(Call),
             CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
 
             CF1 = case kz_json:get_ne_binary_value(<<"action">>, Data) of

--- a/applications/callflow/src/module/cf_park.erl
+++ b/applications/callflow/src/module/cf_park.erl
@@ -93,7 +93,7 @@ handle_nomatch_with_empty_referred_to(Data, Call, PresenceType, ParkedCalls, Slo
             direct_park(SlotNumber, Slot, ParkedCalls, Data, Call);
         <<"park">> ->
             lager:info("action is to park the call"),
-            Slot = create_slot(<<>>, PresenceType, SlotNumber, Data, 'true', Call),
+            Slot = create_slot('undefined', PresenceType, SlotNumber, Data, 'true', Call),
             park_call(SlotNumber, Slot, ParkedCalls, 'undefined', Data, Call);
         <<"retrieve">> ->
             lager:info("action is to retrieve a parked call"),
@@ -276,32 +276,32 @@ wait_for_hangup(Call) ->
 %% @doc Builds the json object representing the call in the parking slot
 %% @end
 %%------------------------------------------------------------------------------
--spec create_slot(kz_term:api_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), boolean(), kapps_call:call()) -> kz_json:object().
+-spec create_slot(kz_term:api_ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), boolean(), kapps_call:call()) -> kz_json:object().
 create_slot(ParkerCallId, PresenceType, SlotNumber, Data, Attended, Call) ->
     CallId = cf_exe:callid(Call),
     RingbackId = maybe_get_ringback_id(Call),
     SlotCallId = kz_binary:rand_hex(16),
     User = slot_presence_id(SlotNumber, Data, Call),
     Realm = kapps_call:account_realm(Call),
-    kz_json:from_list(
-      [{<<"Call-ID">>, CallId}
-      ,{<<"Attended">>, Attended}
-      ,{<<"Slot-Call-ID">>, SlotCallId}
-      ,{<<"Switch-URI">>, kapps_call:switch_uri(Call)}
-      ,{<<"From-Tag">>, kapps_call:from_tag(Call)}
-      ,{<<"To-Tag">>, kapps_call:to_tag(Call)}
-      ,{<<"Parker-Call-ID">>, ParkerCallId}
-      ,{<<"Ringback-ID">>, RingbackId}
-      ,{<<"Presence-User">>, User}
-      ,{<<"Presence-Realm">>, Realm}
-      ,{<<"Presence-ID">>, <<User/binary, "@", Realm/binary>>}
-      ,{<<"Node">>, kapps_call:switch_nodename(Call)}
-      ,{<<"CID-Number">>, kapps_call:caller_id_number(Call)}
-      ,{<<"CID-Name">>, kapps_call:caller_id_name(Call)}
-      ,{<<"CID-URI">>, kapps_call:from(Call)}
-      ,{<<"Hold-Media">>, kz_attributes:moh_attributes(RingbackId, <<"media_id">>, Call)}
-      ,{?PRESENCE_TYPE_KEY, PresenceType}
-      ]).
+    kz_json:from_list([{<<"Call-ID">>, CallId}
+                      ,{<<"Attended">>, Attended}
+                      ,{<<"Slot-Call-ID">>, SlotCallId}
+                      ,{<<"Switch-URI">>, kapps_call:switch_uri(Call)}
+                      ,{<<"From-Tag">>, kapps_call:from_tag(Call)}
+                      ,{<<"To-Tag">>, kapps_call:to_tag(Call)}
+                      ,{<<"Parker-Call-ID">>, ParkerCallId}
+                      ,{<<"Ringback-ID">>, RingbackId}
+                      ,{<<"Presence-User">>, User}
+                      ,{<<"Presence-Realm">>, Realm}
+                      ,{<<"Presence-ID">>, <<User/binary, "@", Realm/binary>>}
+                      ,{<<"Node">>, kapps_call:switch_nodename(Call)}
+                      ,{<<"CID-Number">>, kapps_call:caller_id_number(Call)}
+                      ,{<<"CID-Name">>, kapps_call:caller_id_name(Call)}
+                      ,{<<"CID-URI">>, kapps_call:from(Call)}
+                      ,{<<"Hold-Media">>, kz_attributes:moh_attributes(RingbackId, <<"media_id">>, Call)}
+                      ,{?PRESENCE_TYPE_KEY, PresenceType}
+                      ]
+                     ).
 
 -spec slot_presence_id(kz_term:ne_binary(), kz_json:object(), kapps_call:call()) -> kz_term:ne_binary().
 slot_presence_id(SlotNumber, Data, Call) ->

--- a/applications/ecallmgr/src/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_command.erl
@@ -706,7 +706,7 @@ get_channel_status(TargetCallId) ->
     kz_amqp_worker:call_collect([{<<"Call-ID">>, TargetCallId}
                                  | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                                 ]
-                               ,fun(API) -> kapi_call:publish_channel_status_req(API, TargetCallId) end
+                               ,fun kapi_call:publish_channel_status_req/1
                                ,{'ecallmgr', 'true'}
                                ).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_channel.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channel.erl
@@ -576,7 +576,7 @@ get_active_channel_status(UUID) ->
                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
               ],
     kz_amqp_worker:call(Command
-                       ,fun(API) -> kapi_call:publish_channel_status_req(API, UUID) end
+                       ,fun kapi_call:publish_channel_status_req/1
                        ,fun kapi_call:channel_status_resp_v/1
                        ).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_channels.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channels.erl
@@ -324,7 +324,7 @@ handle_query_channels(JObj, _Props) ->
 handle_channel_status(JObj, _Props) ->
     'true' = kapi_call:channel_status_req_v(JObj),
     _ = kz_util:put_callid(JObj),
-    CallId = kz_json:get_value(<<"Call-ID">>, JObj),
+    CallId = kz_api:call_id(JObj),
     lager:debug("channel status request received"),
     case ecallmgr_fs_channel:fetch(CallId) of
         {'error', 'not_found'} ->
@@ -349,7 +349,7 @@ handle_channel_status(JObj, _Props) ->
                    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                   ]
                  ),
-            kapi_call:publish_channel_status_resp(kz_json:get_value(<<"Server-ID">>, JObj), Resp)
+            kapi_call:publish_channel_status_resp(kz_api:server_id(JObj), Resp)
     end.
 
 -spec maybe_send_empty_channel_resp(kz_term:ne_binary(), kz_json:object()) -> 'ok'.
@@ -367,7 +367,7 @@ send_empty_channel_resp(CallId, JObj) ->
            ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
-    kapi_call:publish_channel_status_resp(kz_json:get_value(<<"Server-ID">>, JObj), Resp).
+    kapi_call:publish_channel_status_resp(kz_api:server_id(JObj), Resp).
 
 %%%=============================================================================
 %%% gen_server callbacks

--- a/applications/konami/src/module/konami_intercept.erl
+++ b/applications/konami/src/module/konami_intercept.erl
@@ -91,7 +91,7 @@ get_originate_req(Data, Call) ->
     TargetId = kz_json:get_value(<<"target_id">>, Data),
     UnbridgedOnly = kz_json:is_true(<<"unbridged_only">>, Data, 'true'),
 
-    Params = kz_json:set_values([{<<"source">>, ?MODULE}
+    Params = kz_json:set_values([{<<"source">>, <<?MODULE_STRING>>}
                                 ,{<<"can_call_self">>, 'true'}
                                 ]
                                ,Data

--- a/applications/konami/src/module/konami_move.erl
+++ b/applications/konami/src/module/konami_move.erl
@@ -84,7 +84,7 @@ source_leg_of_dtmf(Data, Call) ->
 get_originate_req(Data, Call) ->
     SourceOfDTMF = kz_json:get_value(<<"dtmf_leg">>, Data),
 
-    Params = kz_json:set_values([{<<"source">>, ?MODULE}
+    Params = kz_json:set_values([{<<"source">>, <<?MODULE_STRING>>}
                                 ,{<<"can_call_self">>, 'true'}
                                 ]
                                ,Data

--- a/core/kazoo/src/kz_doc.erl
+++ b/core/kazoo/src/kz_doc.erl
@@ -507,11 +507,11 @@ attachment(JObj) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec attachment(doc(), kz_json:path()) -> kz_term:api_object().
+-spec attachment(doc(), kz_json:key()) -> kz_term:api_object().
 attachment(JObj, AName) ->
     attachment(JObj, AName, 'undefined').
 
--spec attachment(doc(), kz_json:path(), Default) -> doc() | Default.
+-spec attachment(doc(), kz_json:key(), Default) -> doc() | Default.
 attachment(JObj, AName, Default) ->
     kz_json:get_json_value(AName, attachments(JObj, kz_json:new()), Default).
 
@@ -560,17 +560,17 @@ attachment_content_type(JObj, AName, Default) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec attachment_property(doc(), kz_term:ne_binary(), kz_json:path()) ->
+-spec attachment_property(doc(), kz_term:ne_binary(), kz_json:get_key()) ->
                                  kz_json:api_json_term().
 attachment_property(JObj, AName, Key) ->
     attachment_property(JObj, AName, Key, 'undefined').
 
--spec attachment_property(doc(), kz_term:ne_binary(), kz_json:path(), Default) ->
+-spec attachment_property(doc(), kz_term:ne_binary(), kz_json:get_key(), Default) ->
                                  Default | kz_json:json_term().
 attachment_property(JObj, AName, Key, Default) ->
     attachment_property(JObj, AName, Key, Default, fun kz_json:get_value/3).
 
--spec attachment_property(doc(), kz_term:ne_binary(), kz_json:path(), Default, fun((kz_json:path(), doc(), Default) -> Default | kz_json:json_term())) ->
+-spec attachment_property(doc(), kz_term:ne_binary(), kz_json:get_key(), Default, fun((kz_json:get_key(), doc(), Default) -> Default | kz_json:json_term())) ->
                                  Default | kz_json:json_term().
 attachment_property(JObj, AName, Key, Default, Get) when is_function(Get, 3) ->
     Get(Key, attachment(JObj, AName, kz_json:new()), Default).

--- a/core/kazoo_amqp/src/api/kapi_switch.erl
+++ b/core/kazoo_amqp/src/api/kapi_switch.erl
@@ -305,21 +305,13 @@ publish_notify(Req, ContentType) ->
                               ,ContentType
                               ).
 
--spec notify_realm(kz_term:api_terms()) -> kz_term:api_binary().
-notify_realm(Props) when is_list(Props) ->
-    notify_value(Props, <<"Realm">>, fun props:get_value/2);
-notify_realm(JObj) ->
-    notify_value(JObj, <<"Realm">>, fun kz_json:get_value/2).
+-spec notify_realm(kz_term:api_terms()) -> kz_term:api_ne_binary().
+notify_realm(API) ->
+    get_value(API, <<"Realm">>, 'undefined').
 
--spec notify_username(kz_term:api_terms()) -> kz_term:api_binary().
-notify_username(Props) when is_list(Props) ->
-    notify_value(Props, <<"Username">>, fun props:get_value/2);
-notify_username(JObj) ->
-    notify_value(JObj, <<"Username">>, fun kz_json:get_value/2).
-
--spec notify_value(kz_term:api_terms(), kz_term:ne_binary(), fun()) -> kz_term:api_binary().
-notify_value(API, Key, Get) ->
-    Get(Key, API).
+-spec notify_username(kz_term:api_terms()) -> kz_term:api_ne_binary().
+notify_username(API) ->
+    get_value(API, <<"Username">>, 'undefined').
 
 -spec publish_command(kz_term:api_terms()) -> 'ok'.
 publish_command(JObj) ->
@@ -336,16 +328,16 @@ publish_reply(Queue, Req) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?FSREPLY_COMMAND_VALUES, fun fs_reply/1),
     kz_amqp_util:targeted_publish(Queue, Payload).
 
--spec check_fs_node(kz_term:api_terms()) -> kz_term:api_binary().
-check_fs_node(Props) ->
-    get_value(Props, <<"FreeSWITCH-Node">>, <<"*">>).
+-spec check_fs_node(kz_term:api_terms()) -> kz_term:api_ne_binary().
+check_fs_node(API) ->
+    get_value(API, <<"FreeSWITCH-Node">>, <<"*">>).
 
--spec get_value(kz_term:api_terms(), kz_json:path(), kz_term:ne_binary()) -> kz_term:api_binary().
+-spec get_value(kz_term:api_terms(), kz_json:key(), Default) -> kz_term:ne_binary() | Default.
 get_value(Props, Key, Default) when is_list(Props) ->
-    get_value(Props, Key, fun props:get_value/3, Default);
+    get_value(Props, Key, Default, fun props:get_value/3);
 get_value(JObj, Key, Default) ->
-    get_value(JObj, Key, fun kz_json:get_value/3, Default).
+    get_value(JObj, Key, Default, fun kz_json:get_value/3).
 
--spec get_value(kz_term:api_terms(), kz_term:ne_binary(), fun(), kz_term:ne_binary()) -> kz_term:api_binary().
-get_value(API, Key, Get, Default) ->
+-spec get_value(kz_term:api_terms(), kz_json:key(), Default, fun()) -> kz_term:ne_binary() | Default.
+get_value(API, Key, Default, Get) ->
     Get(Key, API, Default).

--- a/core/kazoo_amqp/src/kz_amqp_worker.erl
+++ b/core/kazoo_amqp/src/kz_amqp_worker.erl
@@ -906,7 +906,7 @@ handle_info(_Info, State) ->
 %% @doc Allows listener to pass options to handlers.
 %% @end
 %%------------------------------------------------------------------------------
--spec handle_event(kz_json:object(), kz_term:proplist()) -> gen_listener:handle_event_return().
+-spec handle_event(kz_json:object(), state()) -> gen_listener:handle_event_return().
 handle_event(JObj, #state{client_from='relay'
                          ,client_pid=Pid
                          }) ->

--- a/core/kazoo_apps/src/kapps_account_config.erl
+++ b/core/kazoo_apps/src/kapps_account_config.erl
@@ -29,10 +29,11 @@
 
 -type api_account() :: kz_term:api_ne_binary() | kz_json:object().
 -type account_or_not() :: kz_term:ne_binary() | 'no_account_id'.
+-type config_key() :: kz_json:path() | kz_json:key().
 
 %% @equiv get_ne_binary(Account, Category, Path, undefined)
 
--spec get_ne_binary(api_account(), kz_term:ne_binary(), kz_json:path()) -> kz_term:api_ne_binary().
+-spec get_ne_binary(api_account(), kz_term:ne_binary(), config_key()) -> kz_term:api_ne_binary().
 get_ne_binary(Account, Category, Path) ->
     get_ne_binary(Account, Category, Path, 'undefined').
 
@@ -42,19 +43,19 @@ get_ne_binary(Account, Category, Path) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_ne_binary(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> kz_term:ne_binary() | Default.
+-spec get_ne_binary(api_account(), kz_term:ne_binary(), config_key(), Default) -> kz_term:ne_binary() | Default.
 get_ne_binary(Account, Category, Path, Default) ->
     Value = get(Account, Category, Path, Default),
     case kz_term:is_empty(Value) of
-        true -> Default;
-        false -> kz_term:to_binary(Value)
+        'true' -> Default;
+        'false' -> kz_term:to_binary(Value)
     end.
 
 %% @equiv get_ne_binaries(Account, Category, Path, undefined)
 
--spec get_ne_binaries(api_account(), kz_term:ne_binary(), kz_json:path()) -> kz_term:ne_binaries().
+-spec get_ne_binaries(api_account(), kz_term:ne_binary(), config_key()) -> kz_term:ne_binaries().
 get_ne_binaries(Account, Category, Path) ->
-    get_ne_binaries(Account, Category, Path, undefined).
+    get_ne_binaries(Account, Category, Path, 'undefined').
 
 %%------------------------------------------------------------------------------
 %% @doc Get a non-empty configuration key for a given category and cast it as
@@ -62,17 +63,17 @@ get_ne_binaries(Account, Category, Path) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_ne_binaries(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> kz_term:ne_binaries() | Default.
+-spec get_ne_binaries(api_account(), kz_term:ne_binary(), config_key(), Default) -> kz_term:ne_binaries() | Default.
 get_ne_binaries(Account, Category, Path, Default) ->
     Values = get(Account, Category, Path, Default),
     case kz_term:is_ne_binaries(Values) of
-        false -> Default;
-        true -> Values
+        'false' -> Default;
+        'true' -> Values
     end.
 
 %% @equiv get_pos_integer(Account, Category, Path, 'undefined')
 
--spec get_pos_integer(api_account(), kz_term:ne_binary(), kz_json:path()) -> 'undefined' | pos_integer().
+-spec get_pos_integer(api_account(), kz_term:ne_binary(), config_key()) -> 'undefined' | pos_integer().
 get_pos_integer(Account, Category, Path) ->
     get_pos_integer(Account, Category, Path, 'undefined').
 
@@ -82,7 +83,7 @@ get_pos_integer(Account, Category, Path) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_pos_integer(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> pos_integer() | Default.
+-spec get_pos_integer(api_account(), kz_term:ne_binary(), config_key(), Default) -> pos_integer() | Default.
 get_pos_integer(Account, Category, Path, Default) ->
     to_pos_integer(get(Account, Category, Path, Default), Default).
 
@@ -98,10 +99,10 @@ to_pos_integer(Value, Default) ->
 
 %% @equiv get_global(Account, Category, Key, undefined)
 
--spec get_global(api_account(), kz_term:ne_binary(), kz_json:path()) ->
-                        kz_json:json_term().
+-spec get_global(api_account(), kz_term:ne_binary(), config_key()) ->
+                        kz_json:api_json_term().
 get_global(Account, Category, Key) ->
-    get_global(Account, Category, Key, undefined).
+    get_global(Account, Category, Key, 'undefined').
 
 %%------------------------------------------------------------------------------
 %% @doc Searches for configuration in `Category' and `Key' by first trying
@@ -109,13 +110,13 @@ get_global(Account, Category, Key) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_global(api_account(), kz_term:ne_binary(), kz_json:path(), kz_json:api_json_term()) ->
-                        kz_json:json_term().
+-spec get_global(api_account(), kz_term:ne_binary(), config_key(), Default) ->
+                        kz_json:json_term() | Default.
 get_global(Account, Category, Key, Default) ->
     case load_config_from_account(account_id(Account), Category) of
-        {ok, JObj} ->
+        {'ok', JObj} ->
             get_global_from_doc(Category, Key, Default, JObj);
-        {error, _} ->
+        {'error', _} ->
             get_from_reseller(Account, Category, Key, Default)
     end.
 
@@ -129,22 +130,22 @@ get_global(Account, Category, Key, Default) ->
 -spec get_global(api_account(), kz_term:ne_binary()) -> kz_json:object().
 get_global(Account, Category) ->
     case load_config_from_account(account_id(Account), Category) of
-        {ok, JObj} -> JObj;
-        {error, no_account_id} ->
+        {'ok', JObj} -> JObj;
+        {'error', no_account_id} ->
             maybe_new_doc(load_config_from_system(Account, Category), Category);
-        {error, _} ->
+        {'error', _} ->
             case load_config_from_reseller(Account, Category) of
-                {ok, JObj} -> JObj;
-                {error, _} ->
+                {'ok', JObj} -> JObj;
+                {'error', _} ->
                     maybe_new_doc(load_config_from_system(Account, Category), Category)
             end
     end.
 
 %% @equiv get_from_reseller(Account, Category, Key, undefined)
 
--spec get_from_reseller(api_account(), kz_term:ne_binary(), kz_json:path()) -> kz_json:api_json_term().
+-spec get_from_reseller(api_account(), kz_term:ne_binary(), config_key()) -> kz_json:api_json_term().
 get_from_reseller(Account, Category, Key) ->
-    get_from_reseller(Account, Category, Key, undefined).
+    get_from_reseller(Account, Category, Key, 'undefined').
 
 %%------------------------------------------------------------------------------
 %% @doc Get configuration from reseller (if any) or global config.
@@ -152,12 +153,12 @@ get_from_reseller(Account, Category, Key) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_from_reseller(api_account(), kz_term:ne_binary(), kz_json:path(), kz_json:api_json_term()) -> kz_json:api_json_term().
+-spec get_from_reseller(api_account(), kz_term:ne_binary(), config_key(), kz_json:api_json_term()) -> kz_json:api_json_term().
 get_from_reseller(Account, Category, Key, Default) ->
     case maybe_load_config_from_reseller(Account, Category) of
-        {ok, JObj} ->
+        {'ok', JObj} ->
             get_global_from_doc(Category, Key, Default, JObj);
-        {error, _} ->
+        {'error', _} ->
             kapps_config:get(Category, Key, Default)
     end.
 
@@ -167,7 +168,7 @@ maybe_load_config_from_reseller(Account, _) when Account =:= <<"master_account_6
                                                  Account =:= <<"reseller_account_b113394f16cb76d">>;
                                                  Account =:= <<"child_account_670a04df0014d0b27a">>;
                                                  Account =:= <<"unrelated_account_b113394f16cb71">> ->
-    {error, not_found};
+    {'error', 'not_found'};
 maybe_load_config_from_reseller(Account, Category) ->
     load_config_from_reseller(Account, Category).
 -else.
@@ -177,22 +178,22 @@ maybe_load_config_from_reseller(Account, Category) ->
 
 %% @equiv get_hierarchy(Account, Category, Key, undefined)
 
--spec get_hierarchy(api_account(), kz_term:ne_binary(), kz_json:path()) -> kz_json:json_term().
+-spec get_hierarchy(api_account(), kz_term:ne_binary(), config_key()) -> kz_json:json_term().
 get_hierarchy(Account, Category, Key) ->
-    get_hierarchy(Account, Category, Key, undefined).
+    get_hierarchy(Account, Category, Key, 'undefined').
 
 %% @equiv get_with_strategy(<<"hierarchy_merge">>, Account, Category, Key, Default)
 
--spec get_hierarchy(api_account(), kz_term:ne_binary(), kz_json:path(), kz_json:api_json_term()) -> kz_json:json_term().
+-spec get_hierarchy(api_account(), kz_term:ne_binary(), config_key(), kz_json:api_json_term()) -> kz_json:json_term().
 get_hierarchy(Account, Category, Key, Default) ->
     get_with_strategy(<<"hierarchy_merge">>, Account, Category, Key, Default).
 
 %% @equiv get_with_strategy(Strategy, Account, Category, Key, undefined)
 
--spec get_with_strategy(kz_term:ne_binary(), api_account(), kz_term:ne_binary(), kz_json:path()) ->
+-spec get_with_strategy(kz_term:ne_binary(), api_account(), kz_term:ne_binary(), config_key()) ->
                                kz_json:json_term().
 get_with_strategy(Strategy, Account, Category, Key) ->
-    get_with_strategy(Strategy, Account, Category, Key, undefined).
+    get_with_strategy(Strategy, Account, Category, Key, 'undefined').
 
 %%------------------------------------------------------------------------------
 %% @doc Get configuration `Key' for a given `Category' using a given strategy.
@@ -224,38 +225,38 @@ get_with_strategy(Strategy, Account, Category, Key) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_with_strategy(kz_term:ne_binary(), api_account(), kz_term:ne_binary(), kz_json:path(), kz_json:api_json_term()) ->
+-spec get_with_strategy(kz_term:ne_binary(), api_account(), kz_term:ne_binary(), config_key(), kz_json:api_json_term()) ->
                                kz_json:json_term().
 get_with_strategy(Strategy, Account, Category, Key, Default) ->
     ShouldMerge = is_merge_strategy(Strategy),
     case get_from_strategy_cache(Strategy, account_id(Account), Category, Key, ShouldMerge) of
-        {ok, JObj} ->
+        {'ok', JObj} ->
             case kz_json:get_value(Key, JObj) of
-                undefined -> Default;
+                'undefined' -> Default;
                 Value -> Value
             end;
-        {error, no_account_id} ->
+        {'error', 'no_account_id'} ->
             kapps_config:get(Category, Key, Default);
-        {error, _} ->
+        {'error', _} ->
             _ = kapps_config:set(Category, Key, Default),
             Default
     end.
 
--spec get_from_strategy_cache(kz_term:ne_binary(), account_or_not(), kz_json:path(), kz_term:ne_binary(), boolean()) ->
-                                     {ok, kz_json:object()} |
-                                     {error, any()}.
-get_from_strategy_cache(_, no_account_id, _, _, _) ->
-    {error, no_account_id};
-get_from_strategy_cache(Strategy, AccountId, Category, Key, true) ->
+-spec get_from_strategy_cache(kz_term:ne_binary(), account_or_not(), config_key(), kz_term:ne_binary(), boolean()) ->
+                                     {'ok', kz_json:object()} |
+                                     {'error', any()}.
+get_from_strategy_cache(_, 'no_account_id', _, _, _) ->
+    {'error', 'no_account_id'};
+get_from_strategy_cache(Strategy, AccountId, Category, Key, 'true') ->
     %% Only read from cache if it is merge strategy
     case kz_cache:fetch_local(?KAPPS_CONFIG_CACHE, strategy_cache_key(AccountId, Category, Strategy)) of
-        {ok, _}=OK ->
+        {'ok', _}=OK ->
             OK;
-        {error, _} ->
-            walk_the_walk(strategy_options(Strategy, AccountId, Category, true, Key))
+        {'error', _} ->
+            walk_the_walk(strategy_options(Strategy, AccountId, Category, 'true', Key))
     end;
-get_from_strategy_cache(Strategy, AccountId, Category, Key, false) ->
-    walk_the_walk(strategy_options(Strategy, AccountId, Category, false, Key)).
+get_from_strategy_cache(Strategy, AccountId, Category, Key, 'false') ->
+    walk_the_walk(strategy_options(Strategy, AccountId, Category, 'false', Key)).
 
 %%------------------------------------------------------------------------------
 %% @doc Get Key's value from account db document if defined, otherwise get
@@ -263,10 +264,10 @@ get_from_strategy_cache(Strategy, AccountId, Category, Key, false) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_global_from_doc(kz_term:ne_binary(), kz_json:path(), kz_json:api_json_term(), kz_json:object()) -> kz_json:object().
+-spec get_global_from_doc(kz_term:ne_binary(), config_key(), kz_json:api_json_term(), kz_json:object()) -> kz_json:object().
 get_global_from_doc(Category, Key, Default, JObj) ->
     case kz_json:get_value(Key, JObj) of
-        undefined ->
+        'undefined' ->
             kapps_config:get(Category, Key, Default);
         Value ->
             Value
@@ -274,16 +275,16 @@ get_global_from_doc(Category, Key, Default, JObj) ->
 
 %% @equiv get(Account, Category, Key, undefined)
 
--spec get(api_account(), kz_term:ne_binary(), kz_json:path()) -> kz_json:api_json_term().
+-spec get(api_account(), kz_term:ne_binary(), config_key()) -> kz_json:api_json_term().
 get(Account, Category, Key) ->
-    get(Account, Category, Key, undefined).
+    get(Account, Category, Key, 'undefined').
 
 %%------------------------------------------------------------------------------
 %% @doc Get `Key' value at `Category' from account db document if defined.
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get(api_account(), kz_term:ne_binary(), kz_json:path(), Default) -> kz_json:json_term() | Default.
+-spec get(api_account(), kz_term:ne_binary(), config_key(), Default) -> kz_json:json_term() | Default.
 get(Account, Category, Key, Default) ->
     kz_json:get_value(Key, get(Account, Category), Default).
 
@@ -295,37 +296,37 @@ get(Account, Category, Key, Default) ->
 -spec get(api_account(), kz_term:ne_binary()) -> kz_json:object().
 get(Account, Category) ->
     case load_config_from_account(account_id(Account), Category) of
-        {ok, JObj} -> JObj;
-        {error, _} -> kz_doc:set_id(kz_json:new(), kapps_config_util:account_doc_id(Category))
+        {'ok', JObj} -> JObj;
+        {'error', _} -> kz_doc:set_id(kz_json:new(), kapps_config_util:account_doc_id(Category))
     end.
 
 -spec load_config_from_system(kz_term:api_binary(), kz_term:ne_binary()) -> kazoo_data:get_results_return().
 load_config_from_system(_Account, Category) ->
     case kapps_config:get_category(Category) of
-        {ok, JObj} ->
-            Doc = kz_json:get_value(<<"default">>, JObj, kz_json:new()),
-            {ok, Doc};
-        {error, _}=Error -> Error
+        {'ok', JObj} ->
+            Doc = kz_json:get_json_value(<<"default">>, JObj, kz_json:new()),
+            {'ok', Doc};
+        {'error', _}=Error -> Error
     end.
 
 -spec load_config_from_reseller(api_account(), kz_term:ne_binary()) -> kazoo_data:get_results_return().
 load_config_from_reseller(Account, Category) ->
     AccountId = account_id(Account),
-    case AccountId =/= no_account_id
+    case AccountId =/= 'no_account_id'
         andalso find_reseller_account(AccountId)
     of
-        false -> {error, not_found};
-        [] -> {error, not_found};
+        'false' -> {'error', 'not_found'};
+        [] -> {'error', 'not_found'};
         [ResellerId] -> load_config_from_account(ResellerId, Category)
     end.
 
 -spec load_config_from_account(account_or_not(), kz_term:ne_binary()) -> kazoo_data:get_results_return().
-load_config_from_account(no_account_id, _Category) ->
-    {error, no_account_id};
+load_config_from_account('no_account_id', _Category) ->
+    {'error', 'no_account_id'};
 load_config_from_account(AccountId, Category) ->
     DocId = kapps_config_util:account_doc_id(Category),
     AccountDb = kz_util:format_account_db(AccountId),
-    kz_datamgr:open_cache_doc(AccountDb, DocId, [{cache_failures, [not_found]}]).
+    kz_datamgr:open_cache_doc(AccountDb, DocId, [{'cache_failures', ['not_found']}]).
 
 %%------------------------------------------------------------------------------
 %% @doc Get Accounts parent configuration for the Category.
@@ -344,11 +345,11 @@ load_config_from_ancestors(AccountId, Category) ->
     load_config_from_ancestors(AccountId, Category, kz_services_reseller:is_reseller(AccountId)).
 
 -spec load_config_from_ancestors(kz_term:ne_binary(), kz_term:ne_binary(), boolean()) -> kazoo_data:get_results_return().
-load_config_from_ancestors(_, _, true) ->
+load_config_from_ancestors(_, _, 'true') ->
     %% account is reseller, no need to read from its parents
     %% Note: load_config_from_account is already read the config from this AccountId
-    {error, <<"account_is_reseller">>};
-load_config_from_ancestors(AccountId, Category, false) ->
+    {'error', <<"account_is_reseller">>};
+load_config_from_ancestors(AccountId, Category, 'false') ->
     %% not reseller, get its ancestors and walk
     Tree = get_account_ancestors_or_reseller(AccountId),
     load_config_from_ancestors_fold(Tree, Category, []).
@@ -368,23 +369,23 @@ get_account_ancestors_or_reseller(AccountId) ->
 -spec load_config_from_ancestors_fold(kz_term:ne_binaries(), kz_term:ne_binary(), kz_json:objects()) ->
                                              kazoo_data:get_results_return().
 load_config_from_ancestors_fold([], _Category, JObjs) ->
-    {ok, JObjs};
+    {'ok', JObjs};
 load_config_from_ancestors_fold([ParentId|AncestorIds], Category, JObjs) ->
     case {load_config_from_account(ParentId, Category)
          ,kz_services_reseller:is_reseller(ParentId)
          }
     of
-        {{ok, JObj}, true} ->
+        {{'ok', JObj}, 'true'} ->
             lager:debug("reached to the reseller account ~s (for category ~s)", [ParentId, Category]),
-            {ok, [JObj|JObjs]};
-        {{ok, JObj}, _} ->
+            {'ok', [JObj|JObjs]};
+        {{'ok', JObj}, _} ->
             load_config_from_ancestors_fold(AncestorIds, Category, [JObj|JObjs]);
-        {{error, _Reason}, true} ->
+        {{'error', _Reason}, 'true'} ->
             lager:debug("reached to the reseller account ~s (failed to get category ~s: ~p)"
                        ,[ParentId, Category, _Reason]
                        ),
-            {ok, JObjs};
-        {{error, _Reason}, _} ->
+            {'ok', JObjs};
+        {{'error', _Reason}, _} ->
             lager:debug("failed to get category ~s for account ~s: ~p", [Category, ParentId, _Reason]),
             load_config_from_ancestors_fold(AncestorIds, Category, JObjs)
     end.
@@ -392,7 +393,7 @@ load_config_from_ancestors_fold([ParentId|AncestorIds], Category, JObjs) ->
 -spec find_reseller_account(kz_term:ne_binary()) -> kz_term:ne_binaries().
 find_reseller_account(AccountId) ->
     case kz_services_reseller:get_id(AccountId) of
-        undefined ->
+        'undefined' ->
             lager:debug("failed to find account ~s parents and reseller"),
             [];
         AccountId -> []; %% should get from direct reseller only
@@ -402,8 +403,8 @@ find_reseller_account(AccountId) ->
 -spec get_account_tree(kz_term:ne_binary()) -> kz_term:ne_binaries().
 get_account_tree(AccountId) ->
     case kzd_accounts:fetch(AccountId) of
-        {ok , JObj} -> kzd_accounts:tree(JObj);
-        {error, _Reason} ->
+        {'ok' , JObj} -> kzd_accounts:tree(JObj);
+        {'error', _Reason} ->
             lager:debug("failed to find account ~p parents: ~p", [AccountId, _Reason]),
             []
     end.
@@ -413,18 +414,18 @@ get_account_tree(AccountId) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec set(api_account(), kz_term:ne_binary(), kz_json:path(), kz_json:json_term()) -> kz_json:object().
+-spec set(api_account(), kz_term:ne_binary(), config_key(), kz_json:json_term()) -> kz_json:object().
 set(Account, Category, Key, Value) ->
     maybe_set_account(account_id(Account), Category, Key, Value).
 
--spec maybe_set_account(account_or_not(), kz_term:ne_binary(), kz_json:path(), kz_json:json_term()) -> kz_json:object().
+-spec maybe_set_account(account_or_not(), kz_term:ne_binary(), config_key(), kz_json:json_term()) -> kz_json:object().
 maybe_set_account(no_account_id, _, Key, Value) ->
     kz_json:set_value(Key, Value, kz_json:new());
 maybe_set_account(AccountId, Category, Key, Value) ->
     JObj = kz_json:set_value(Key, Value, get(AccountId, Category)),
     JObj1 = update_config_for_saving(AccountId, JObj),
     AccountDb = kz_util:format_account_db(AccountId),
-    {ok, JObj2} = kz_datamgr:ensure_saved(AccountDb, JObj1),
+    {'ok', JObj2} = kz_datamgr:ensure_saved(AccountDb, JObj1),
     JObj2.
 
 %%------------------------------------------------------------------------------
@@ -434,11 +435,11 @@ maybe_set_account(AccountId, Category, Key, Value) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec set_global(api_account(), kz_term:ne_binary(), kz_json:path(), kz_json:json_term()) -> kz_json:object().
+-spec set_global(api_account(), kz_term:ne_binary(), config_key(), kz_json:json_term()) -> kz_json:object().
 set_global(Account, Category, Key, Value) ->
     set_account_or_merge_global(account_id(Account), Category, Key, Value).
 
--spec set_account_or_merge_global(account_or_not(), kz_term:ne_binary(), kz_json:path(), kz_json:json_term()) ->
+-spec set_account_or_merge_global(account_or_not(), kz_term:ne_binary(), config_key(), kz_json:json_term()) ->
                                          kz_json:object().
 set_account_or_merge_global(no_account_id, _, Key, Value) ->
     kz_json:set_value(Key, Value, kz_json:new());
@@ -447,7 +448,7 @@ set_account_or_merge_global(AccountId, Category, Key, Value) ->
     Doc1 = kz_json:set_value(Key, Value, update_config_for_saving(AccountId, Doc)),
 
     AccountDb = kz_util:format_account_db(AccountId),
-    {ok, JObj1} = kz_datamgr:ensure_saved(AccountDb, Doc1),
+    {'ok', JObj1} = kz_datamgr:ensure_saved(AccountDb, Doc1),
     JObj1.
 
 -spec update_config_for_saving(kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
@@ -507,11 +508,11 @@ flush(Account, Category, Strategy) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec walk_the_walk(map()) -> {ok, kz_json:object()} | {error, not_found}.
+-spec walk_the_walk(map()) -> {'ok', kz_json:object()} | {'error', not_found}.
 walk_the_walk(#{strategy_funs := []
                ,results := []
                }) ->
-    {error, not_found};
+    {'error', not_found};
 walk_the_walk(#{strategy_funs := []
                ,merge := ShouldMerge
                }=Map) ->
@@ -524,33 +525,33 @@ walk_the_walk(#{account_id := AccountId
                ,results := Results
                }=Map) ->
     case Fun(AccountId, Category) of
-        {ok, JObj} when not ShouldMerge ->
+        {'ok', JObj} when not ShouldMerge ->
             %% requester does not want merge result from ancestors and system
             %% returning the result of the first function if defined
             case kz_json:get_value(Key, JObj) of
-                undefined ->
+                'undefined' ->
                     %% key is not defined, continuing the walk
                     walk_the_walk(Map#{results := [JObj|Results], strategy_funs := Funs});
                 _Value ->
                     walk_the_walk(Map#{results := [JObj], strategy_funs := []})
             end;
-        {ok, JObjs} when is_list(JObjs) ->
+        {'ok', JObjs} when is_list(JObjs) ->
             %% the function returns list (load from ancestor), forcing merge
-            walk_the_walk(Map#{results := lists:flatten([JObjs|Results]), strategy_funs := Funs, merge := true});
-        {ok, JObj} ->
+            walk_the_walk(Map#{results := lists:flatten([JObjs|Results]), strategy_funs := Funs, merge := 'true'});
+        {'ok', JObj} ->
             %% requester wants merge result from ancestors and system
             walk_the_walk(Map#{results := [JObj|Results], strategy_funs := Funs});
-        {error, _} ->
+        {'error', _} ->
             walk_the_walk(Map#{strategy_funs := Funs})
     end.
 
--spec maybe_merge_results(map(), boolean()) -> {ok, kz_json:object()}.
-maybe_merge_results(#{results := JObjs}=Map, true) ->
-    store_in_strategy_cache(Map, kz_json:merge_recursive([kz_doc:public_fields(J, false) || J <- JObjs]));
-maybe_merge_results(#{results := JObjs}, false) ->
-    {ok, lists:last(JObjs)}.
+-spec maybe_merge_results(map(), boolean()) -> {'ok', kz_json:object()}.
+maybe_merge_results(#{results := JObjs}=Map, 'true') ->
+    store_in_strategy_cache(Map, kz_json:merge_recursive([kz_doc:public_fields(J, 'false') || J <- JObjs]));
+maybe_merge_results(#{results := JObjs}, 'false') ->
+    {'ok', lists:last(JObjs)}.
 
--spec store_in_strategy_cache(map(), kz_json:object()) -> {ok, kz_json:object()}.
+-spec store_in_strategy_cache(map(), kz_json:object()) -> {'ok', kz_json:object()}.
 store_in_strategy_cache(#{account_id := AccountId
                          ,strategy := Strategy
                          ,category := Category
@@ -558,17 +559,17 @@ store_in_strategy_cache(#{account_id := AccountId
                          }, Result) ->
     CacheKey = strategy_cache_key(AccountId, Category, Strategy),
     Origins = lists:foldl(fun config_origins/2, [], JObjs),
-    kz_cache:store_local(?KAPPS_CONFIG_CACHE, CacheKey, Result, [{origin, Origins}]),
-    {ok, Result}.
+    kz_cache:store_local(?KAPPS_CONFIG_CACHE, CacheKey, Result, [{'origin', Origins}]),
+    {'ok', Result}.
 
 -spec config_origins(kz_json:object(), list()) -> list().
 config_origins(Doc, Acc) ->
     case {kz_doc:account_db(Doc), kz_doc:account_id(Doc)} of
-        {undefined, undefined} -> Acc;
-        {undefined, DocAccountId} ->
+        {'undefined', 'undefined'} -> Acc;
+        {'undefined', DocAccountId} ->
             Db = kz_util:format_account_db(DocAccountId),
-            [{db, Db, kz_doc:id(Doc)}|Acc];
-        {Db, _} -> [{db, Db, kz_doc:id(Doc)}|Acc]
+            [{'db', Db, kz_doc:id(Doc)}|Acc];
+        {Db, _} -> [{'db', Db, kz_doc:id(Doc)}|Acc]
     end.
 
 -spec strategy_cache_key(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
@@ -576,7 +577,7 @@ config_origins(Doc, Acc) ->
 strategy_cache_key(AccountId, Category, Strategy) ->
     {?MODULE, AccountId, Category, Strategy}.
 
--spec strategy_options(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), boolean(), kz_json:path()) -> map().
+-spec strategy_options(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), boolean(), config_key()) -> map().
 strategy_options(Strategy, AccountId, Category, ShouldMerge, Key) ->
     #{account_id => AccountId
      ,strategy => Strategy
@@ -590,8 +591,8 @@ strategy_options(Strategy, AccountId, Category, ShouldMerge, Key) ->
 -spec is_merge_strategy(kz_term:ne_binary()) -> boolean().
 is_merge_strategy(Strategy) ->
     case kz_binary:reverse(Strategy) of
-        <<"egrem", _/binary>> -> true;
-        _ -> false
+        <<"egrem", _/binary>> -> 'true';
+        _ -> 'false'
     end.
 
 -spec strategy_funs(kz_term:ne_binary()) -> [function()].
@@ -644,8 +645,8 @@ maybe_new_doc({'error', _}, Category) -> kz_doc:set_id(kz_json:new(), Category).
 %% Migrates config settings
 %%==============================================================================
 
--type migrate_setting() :: {kz_term:ne_binary(), kz_json:path()}.
--type migrate_value() :: {kz_term:ne_binary(), kz_term:ne_binary(), kz_json:path(), _}.
+-type migrate_setting() :: {kz_term:ne_binary(), config_key()}.
+-type migrate_value() :: {kz_term:ne_binary(), kz_term:ne_binary(), config_key(), _}.
 -type migrate_values() :: [migrate_value()].
 
 -define(ACCOUNT_CONFIG_MIGRATIONS
@@ -669,60 +670,60 @@ maybe_new_doc({'error', _}, Category) -> kz_doc:set_id(kz_json:new(), Category).
 %% @end
 %%------------------------------------------------------------------------------
 
--spec migrate(kz_term:ne_binary()) -> ok.
+-spec migrate(kz_term:ne_binary()) -> 'ok'.
 migrate(Account) ->
     AccountDb = kz_util:format_account_db(Account),
     _ = [migrate_config_setting(AccountDb, From, To)
          || {From, To} <- ?ACCOUNT_CONFIG_MIGRATIONS
         ],
-    ok.
+    'ok'.
 
 -spec migrate_config_setting(kz_term:ne_binary(), migrate_setting(), migrate_setting()) ->
-                                    ok | {error, any()}.
+                                    'ok' | {'error', any()}.
 migrate_config_setting(AccountDb, From, To) ->
     case remove_config_setting(AccountDb, From) of
-        {ok, _, []} -> ok;
-        {ok, JObj, Removed} ->
+        {'ok', _, []} -> 'ok';
+        {'ok', JObj, Removed} ->
             migrate_config_setting(AccountDb, JObj, Removed, To);
-        {error, not_found} -> ok;
-        {error, Reason} -> {error, {remove, Reason}}
+        {'error', 'not_found'} -> 'ok';
+        {'error', Reason} -> {'error', {'remove', Reason}}
     end.
 
 -spec migrate_config_setting(kz_term:ne_binary(), kz_json:object(), migrate_values(), migrate_setting()) ->
-                                    ok | {error, any()}.
+                                    'ok' | {'error', any()}.
 migrate_config_setting(AccountDb, UpdatedFrom, Removed, To) ->
     case add_config_setting(AccountDb, To, Removed) of
-        {ok, UpdatedTo} ->
-            {ok, _} = kz_datamgr:save_doc(AccountDb, UpdatedTo),
-            {ok, _} = kz_datamgr:save_doc(AccountDb, UpdatedFrom),
-            ok;
-        {error, Reason} -> {error, {add, Reason}}
+        {'ok', UpdatedTo} ->
+            {'ok', _} = kz_datamgr:save_doc(AccountDb, UpdatedTo),
+            {'ok', _} = kz_datamgr:save_doc(AccountDb, UpdatedFrom),
+            'ok';
+        {'error', Reason} -> {'error', {'add', Reason}}
     end.
 
 -spec add_config_setting(kz_term:ne_binary(), migrate_setting(), migrate_values()) ->
-                                ok | {error, any()}.
+                                'ok' | {'error', any()}.
 add_config_setting(AccountDb, {Id, Setting}, Values) ->
     add_config_setting(AccountDb, Id, Setting, Values).
 
--spec add_config_setting(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:path(), migrate_values()) ->
-                                ok | {error, any()}.
+-spec add_config_setting(kz_term:ne_binary(), kz_term:ne_binary(), config_key(), migrate_values()) ->
+                                'ok' | {'error', any()}.
 add_config_setting(AccountDb, Id, Setting, Values) when is_binary(Id) ->
     case kz_datamgr:open_doc(AccountDb, Id) of
-        {ok, JObj} -> add_config_setting(JObj, Setting, Values);
-        {error, not_found} ->
+        {'ok', JObj} -> add_config_setting(JObj, Setting, Values);
+        {'error', 'not_found'} ->
             add_config_setting(AccountDb
                               ,update_config_for_saving(AccountDb, kz_doc:set_id(kz_json:new(), Id))
                               ,Setting
                               ,Values
                               );
-        {error, _}=Error -> Error
+        {'error', _}=Error -> Error
     end;
-add_config_setting(_AccountDb, JObj, _, []) -> {ok, JObj};
+add_config_setting(_AccountDb, JObj, _, []) -> {'ok', JObj};
 add_config_setting(AccountDb, JObj, ToSetting, [{FromId, Node, FromSetting, Value} | Values]) ->
     ToId  = kz_doc:id(JObj),
     Key = config_setting_key(Node, ToSetting),
     case kz_json:get_value(Key, JObj) of
-        undefined ->
+        'undefined' ->
             io:format("migrating setting in ~s from ~s ~s.~s to ~s ~s.~s value ~p~n"
                      ,[AccountDb
                       ,FromId, Node, FromSetting
@@ -739,27 +740,30 @@ add_config_setting(AccountDb, JObj, ToSetting, [{FromId, Node, FromSetting, Valu
         _Else ->
             io:format("the system tried to move the parameter listed below"
                       " but found a different setting already there,"
-                      " you need to correct this disparity manually!~n"),
+                      " you need to correct this disparity manually!~n"
+                     ),
             io:format("  Source~n    db: ~s~n    id: ~s~n    key: ~s ~s~n    value: ~p~n"
-                     ,[AccountDb, FromId, Node, FromSetting, Value]),
+                     ,[AccountDb, FromId, Node, FromSetting, Value]
+                     ),
             io:format("  Destination~n    db: ~s~n    id: ~s~n    key: ~s ~s~n    value: ~p~n"
-                     ,[AccountDb, ToId, Node, ToSetting, _Else]),
-            {error, disparity}
+                     ,[AccountDb, ToId, Node, ToSetting, _Else]
+                     ),
+            {'error', 'disparity'}
     end.
 
 -spec remove_config_setting(kz_term:ne_binary(), migrate_setting()) ->
-                                   {ok, kz_json:object(), migrate_values()} |
-                                   {error, any()}.
+                                   {'ok', kz_json:object(), migrate_values()} |
+                                   {'error', any()}.
 remove_config_setting(AccountDb, {Id, Setting}) ->
     remove_config_setting(AccountDb, Id, Setting).
 
--spec remove_config_setting(kz_term:ne_binary(), kz_term:ne_binary() | kz_json:object(), kz_json:path()) ->
-                                   {ok, kz_json:object(), migrate_values()} |
-                                   {error, any()}.
+-spec remove_config_setting(kz_term:ne_binary(), kz_term:ne_binary() | kz_json:object(), config_key()) ->
+                                   {'ok', kz_json:object(), migrate_values()} |
+                                   {'error', any()}.
 remove_config_setting(AccountDb, Id, Setting) when is_binary(Id) ->
     case kz_datamgr:open_doc(AccountDb, Id) of
-        {ok, JObj} -> remove_config_setting(AccountDb, JObj, Setting);
-        {error, _}=Error -> Error
+        {'ok', JObj} -> remove_config_setting(AccountDb, JObj, Setting);
+        {'error', _}=Error -> Error
     end;
 remove_config_setting(AccountDb, JObj, Setting) ->
     Id = kz_doc:id(JObj),
@@ -769,14 +773,14 @@ remove_config_setting(AccountDb, JObj, Setting) ->
         ],
     remove_config_setting(AccountDb, Keys, JObj, []).
 
--spec remove_config_setting(kz_term:ne_binary(), [{kz_term:ne_binary(), kz_term:ne_binary(), kz_json:path()}], kz_json:object(), migrate_values()) ->
-                                   {ok, kz_json:object(), migrate_values()}.
+-spec remove_config_setting(kz_term:ne_binary(), [{kz_term:ne_binary(), kz_term:ne_binary(), config_key()}], kz_json:object(), migrate_values()) ->
+                                   {'ok', kz_json:object(), migrate_values()}.
 remove_config_setting(_AccountDb, [], JObj, Removed) ->
-    {ok, JObj, Removed};
+    {'ok', JObj, Removed};
 remove_config_setting(AccountDb, [{Id, Node, Setting} | Keys], JObj, Removed) ->
     Key = config_setting_key(Node, Setting),
     case kz_json:get_value(Key, JObj) of
-        undefined -> remove_config_setting(AccountDb, Keys, JObj, Removed);
+        'undefined' -> remove_config_setting(AccountDb, Keys, JObj, Removed);
         Value ->
             remove_config_setting(AccountDb
                                  ,Keys
@@ -785,7 +789,7 @@ remove_config_setting(AccountDb, [{Id, Node, Setting} | Keys], JObj, Removed) ->
                                  )
     end.
 
--spec config_setting_key(kz_term:ne_binary(), kz_json:path()) -> kz_term:ne_binaries().
+-spec config_setting_key(kz_term:ne_binary(), config_key()) -> kz_term:ne_binaries().
 %% NOTE: to support nested keys, update this merge function
 config_setting_key(Node, Setting) ->
     [Node, Setting].

--- a/core/kazoo_apps/src/kapps_config.erl
+++ b/core/kazoo_apps/src/kapps_config.erl
@@ -59,7 +59,7 @@
 -include_lib("kazoo_stdlib/include/kazoo_json.hrl").
 
 -type config_category() :: kz_json:key() | nonempty_string().
--type config_key() :: kz_json:path() | nonempty_string().
+-type config_key() :: kz_json:path() | kz_json:key() | nonempty_string().
 -type config_node() :: atom() | kz_term:ne_binary().
 
 -type update_option() :: {'node_specific', boolean()} |

--- a/core/kazoo_apps/src/kapps_util.erl
+++ b/core/kazoo_apps/src/kapps_util.erl
@@ -134,7 +134,7 @@ replicate_from_account(AccountDb, TargetDb, FilterDoc) ->
 -spec get_master_account_id() -> {'ok', kz_term:ne_binary()} |
                                  {'error', atom()}.
 get_master_account_id() ->
-    case kapps_config:get_ne_binary(?KZ_SYSTEM_CONFIG_ACCOUNT, <<"master_account_id">>) of
+    case kapps_config:get_ne_binary(?KZ_ACCOUNTS_DB, <<"master_account_id">>) of
         'undefined' ->
             R = kz_datamgr:get_results(?KZ_ACCOUNTS_DB, <<"accounts/listing_by_id">>, ['include_docs']),
             find_master_account_id(R);
@@ -148,8 +148,8 @@ find_master_account_id({'ok', Accounts}) ->
         find_oldest_doc([kz_json:get_value(<<"doc">>, Account)
                          || Account <- Accounts
                         ]),
-    lager:debug("setting ~s.master_account_id to ~s", [?KZ_SYSTEM_CONFIG_ACCOUNT, OldestAccountId]),
-    {'ok', _} = kapps_config:set(?KZ_SYSTEM_CONFIG_ACCOUNT, <<"master_account_id">>, OldestAccountId),
+    lager:debug("setting ~s.master_account_id to ~s", [?KZ_ACCOUNTS_DB, OldestAccountId]),
+    {'ok', _} = kapps_config:set(?KZ_ACCOUNTS_DB, <<"master_account_id">>, OldestAccountId),
     Ok.
 
 %%------------------------------------------------------------------------------

--- a/core/kazoo_call/src/kapps_call.erl
+++ b/core/kazoo_call/src/kapps_call.erl
@@ -1120,24 +1120,26 @@ message_left(#kapps_call{message_left=MessageLeft}) ->
 set_message_left(MessageLeft, #kapps_call{}=Call) when is_boolean(MessageLeft) ->
     Call#kapps_call{message_left=MessageLeft}.
 
--spec remove_custom_channel_vars(kz_json:path(), call()) -> call().
+-spec remove_custom_channel_vars(kz_json:keys(), call()) -> call().
 remove_custom_channel_vars(Keys, #kapps_call{}=Call) ->
     kapps_call_command:set(kz_json:from_list([{Key, <<>>} || Key <- Keys]), 'undefined', Call),
     handle_ccvs_remove(Keys, Call).
 
--spec handle_ccvs_remove(kz_json:path(), call()) -> call().
+-spec handle_ccvs_remove(kz_json:keys(), call()) -> call().
 handle_ccvs_remove(Keys, #kapps_call{ccvs=CCVs}=Call) ->
-    lists:foldl(fun(Key, C) ->
-                        case props:get_value(Key, ?SPECIAL_VARS) of
-                            'undefined' -> C;
-                            Index -> setelement(Index, C, 'undefined')
-                        end
-                end
+    lists:foldl(fun ccv_remove_fold/2
                ,Call#kapps_call{ccvs=kz_json:delete_keys(Keys, CCVs)}
                ,Keys
                ).
 
--spec set_custom_channel_var(kz_json:path(), kz_json:json_term(), call()) -> call().
+-spec ccv_remove_fold(kz_json:key(), call()) -> call().
+ccv_remove_fold(Key, Call) ->
+    case props:get_value(Key, ?SPECIAL_VARS) of
+        'undefined' -> Call;
+        Index -> setelement(Index, Call, 'undefined')
+    end.
+
+-spec set_custom_channel_var(kz_json:key(), kz_json:json_term(), call()) -> call().
 -ifdef(TEST).
 set_custom_channel_var(Key, Value, Call) ->
     insert_custom_channel_var(Key, Value, Call).
@@ -1147,7 +1149,7 @@ set_custom_channel_var(Key, Value, Call) ->
     insert_custom_channel_var(Key, Value, Call).
 -endif.
 
--spec insert_custom_channel_var(kz_json:path(), kz_json:json_term(), call()) -> call().
+-spec insert_custom_channel_var(kz_json:key(), kz_json:json_term(), call()) -> call().
 insert_custom_channel_var(Key, Value, #kapps_call{ccvs=CCVs}=Call) ->
     handle_ccvs_update(kz_json:set_value(Key, Value, CCVs), Call).
 
@@ -1217,11 +1219,11 @@ custom_application_vars(#kapps_call{cavs=CAVs}) ->
 set_custom_sip_header(Key, Value, #kapps_call{sip_headers=SHs}=Call) ->
     Call#kapps_call{sip_headers=kz_json:set_value(Key, Value, SHs)}.
 
--spec custom_sip_header(kz_json:path(), call()) -> kz_json:api_json_term().
+-spec custom_sip_header(kz_json:get_key(), call()) -> kz_json:api_json_term().
 custom_sip_header(Key, #kapps_call{}=Call) ->
     custom_sip_header(Key, 'undefined', Call).
 
--spec custom_sip_header(kz_json:path(), Default, call()) -> kz_json:json_term() | Default.
+-spec custom_sip_header(kz_json:get_key(), Default, call()) -> kz_json:json_term() | Default.
 custom_sip_header(Key, Default, #kapps_call{sip_headers=SHs}) ->
     kz_json:get_value(Key, SHs, Default).
 

--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -372,7 +372,7 @@ channel_status('undefined', _) -> {'error', 'no_channel_id'};
 channel_status(CallId, SrvQueue) when is_binary(CallId), is_binary(SrvQueue) ->
     Command = channel_status_command(CallId)
         ++ kz_api:default_headers(SrvQueue, ?APP_NAME, ?APP_VERSION),
-    kapi_call:publish_channel_status_req(CallId, Command);
+    kapi_call:publish_channel_status_req(Command);
 channel_status(Call, SrvQueue) ->
     channel_status(kapps_call:call_id(Call), SrvQueue).
 
@@ -403,7 +403,7 @@ b_channel_status(ChannelId) when is_binary(ChannelId) ->
                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
               ],
     Resp = kz_amqp_worker:call_collect(Command
-                                      ,fun(C) -> kapi_call:publish_channel_status_req(ChannelId, C) end
+                                      ,fun kapi_call:publish_channel_status_req/1
                                       ,{'ecallmgr', 'true'}
                                       ),
     case Resp of
@@ -3292,7 +3292,7 @@ maybe_add_debug_data(JObj, Call) ->
 attended_transfer(To, Call) ->
     attended_transfer(To, 'undefined', Call).
 
--spec attended_transfer(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
+-spec attended_transfer(kz_term:ne_binary(), kz_term:api_ne_binary(), kapps_call:call()) -> 'ok'.
 attended_transfer(To, TransferLeg, Call) ->
     Command = transfer_command(<<"attended">>, To, TransferLeg, Call),
     send_command(Command, Call).
@@ -3319,28 +3319,28 @@ transfer(TransferType, To, TransferLeg, Call) ->
 transfer_command(TransferType, TransferTo, Call) ->
     transfer_command(TransferType, TransferTo, 'undefined', Call).
 
--spec transfer_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> kz_term:api_terms().
+-spec transfer_command(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_ne_binary(), kapps_call:call()) -> kz_term:api_terms().
 transfer_command(TransferType, TransferTo, TransferLeg, Call) ->
-    kz_json:from_list(
-      [{<<"Application-Name">>, <<"transfer">>}
-      ,{<<"Transfer-Type">>, TransferType}
-      ,{<<"Transfer-To">>, TransferTo}
-      ,{<<"Transfer-Leg">>, TransferLeg}
-      ,{<<"Caller-ID-Number">>, kapps_call:callee_id_number(Call)}
-      ,{<<"Caller-ID-Name">>, kapps_call:callee_id_name(Call)}
-      ,{<<"Insert-At">>, <<"now">>}
-      ,{<<"Call-ID">>, kapps_call:call_id(Call)}
-      ,{<<"Custom-Channel-Vars">>, kapps_call:custom_channel_vars(Call)}
-      ]).
+    kz_json:from_list([{<<"Application-Name">>, <<"transfer">>}
+                      ,{<<"Transfer-Type">>, TransferType}
+                      ,{<<"Transfer-To">>, TransferTo}
+                      ,{<<"Transfer-Leg">>, TransferLeg}
+                      ,{<<"Caller-ID-Number">>, kapps_call:callee_id_number(Call)}
+                      ,{<<"Caller-ID-Name">>, kapps_call:callee_id_name(Call)}
+                      ,{<<"Insert-At">>, <<"now">>}
+                      ,{<<"Call-ID">>, kapps_call:call_id(Call)}
+                      ,{<<"Custom-Channel-Vars">>, kapps_call:custom_channel_vars(Call)}
+                      ]
+                     ).
 
 -spec play_macro_command(kz_term:ne_binaries(), kapps_call:call()) -> kz_term:api_terms().
 play_macro_command(Media, Call) ->
-    kz_json:from_list(
-      [{<<"Application-Name">>, <<"play_macro">>}
-      ,{<<"Media-Macro">>, Media}
-      ,{<<"Insert-At">>, <<"now">>}
-      ,{<<"Call-ID">>, kapps_call:call_id(Call)}
-      ]).
+    kz_json:from_list([{<<"Application-Name">>, <<"play_macro">>}
+                      ,{<<"Media-Macro">>, Media}
+                      ,{<<"Insert-At">>, <<"now">>}
+                      ,{<<"Call-ID">>, kapps_call:call_id(Call)}
+                      ]
+                     ).
 
 -spec b_play_macro(kz_term:ne_binaries(), kapps_call:call()) -> kapps_api_std_return().
 b_play_macro(Media, Call) ->

--- a/core/kazoo_documents/src/kz_call_event.erl
+++ b/core/kazoo_documents/src/kz_call_event.erl
@@ -96,12 +96,12 @@ custom_channel_vars(JObj) ->
 custom_channel_vars(JObj, Default) ->
     kz_json:get_json_value(<<"Custom-Channel-Vars">>, JObj, Default).
 
--spec custom_channel_var(doc(), kz_json:path()) ->
+-spec custom_channel_var(doc(), kz_json:key()) ->
                                 kz_term:api_ne_binary().
 custom_channel_var(JObj, Key) ->
     custom_channel_var(JObj, Key, 'undefined').
 
--spec custom_channel_var(doc(), kz_json:path(), Default) ->
+-spec custom_channel_var(doc(), kz_json:key(), Default) ->
                                 kz_term:ne_binary() | Default.
 custom_channel_var(JObj, Key, Default) ->
     kz_json:get_ne_binary_value([<<"Custom-Channel-Vars">>, Key], JObj, Default).
@@ -114,12 +114,12 @@ custom_application_vars(JObj) ->
 custom_application_vars(JObj, Default) ->
     kz_json:get_json_value(<<"Custom-Application-Vars">>, JObj, Default).
 
--spec custom_application_var(doc(), kz_json:path()) ->
+-spec custom_application_var(doc(), kz_json:key()) ->
                                     kz_term:api_ne_binary().
 custom_application_var(JObj, Key) ->
     custom_application_var(JObj, Key, 'undefined').
 
--spec custom_application_var(doc(), kz_json:path(), Default) ->
+-spec custom_application_var(doc(), kz_json:key(), Default) ->
                                     kz_term:ne_binary() | Default.
 custom_application_var(JObj, Key, Default) ->
     kz_json:get_ne_binary_value([<<"Custom-Application-Vars">>, Key], JObj, Default).

--- a/core/kazoo_number_manager/src/converters/knm_converters.erl
+++ b/core/kazoo_number_manager/src/converters/knm_converters.erl
@@ -106,11 +106,11 @@ normalize(Nums)
 
 -spec normalize(kz_term:ne_binary(), kz_term:api_ne_binary()) -> kz_term:ne_binary();
                (kz_term:ne_binaries(), kz_term:api_ne_binary()) -> kz_term:ne_binaries().
-normalize(Num=?NE_BINARY, undefined) ->
+normalize(Num=?NE_BINARY, 'undefined') ->
     normalize(Num);
 normalize(Num=?NE_BINARY, AccountId) ->
     (?CONVERTER_MOD):normalize(Num, AccountId);
-normalize(Nums, undefined)
+normalize(Nums, 'undefined')
   when is_list(Nums) ->
     normalize(Nums);
 normalize(Nums, AccountId)
@@ -271,7 +271,7 @@ get_classifier_regex(JObj) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec correct_depreciated_classifiers(kz_json:path(), kz_json:json_term(), kz_json:object()) ->
+-spec correct_depreciated_classifiers(kz_json:key(), kz_json:json_term(), kz_json:object()) ->
                                                  kz_json:object().
 correct_depreciated_classifiers(Classifier, ?NE_BINARY=Regex, JObj) ->
     J = kz_json:from_list([{<<"regex">>, Regex}

--- a/core/kazoo_stdlib/include/kazoo_json.hrl
+++ b/core/kazoo_stdlib/include/kazoo_json.hrl
@@ -48,7 +48,7 @@
 -type json_array() :: json_terms() | [].
 
 -else.
--type json_string() :: kz_term:ne_binary() | atom().
+-type json_string() :: kz_term:ne_binary().
 
 -type json_term() :: non_null_json_term() | 'null'.
 

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -115,9 +115,12 @@
              ,flat_object/0, flat_objects/0
              ,path/0, paths/0
              ,key/0, keys/0
+             ,get_key/0
              ,json_term/0, api_json_term/0, json_terms/0
              ,encode_options/0
              ]).
+
+-type get_key() :: key() | path().
 
 -spec new() -> object().
 new() -> ?JSON_WRAPPER([]).
@@ -182,7 +185,7 @@ try_converting(JSON) ->
             JSON
     end.
 
--spec is_defined(path(), object()) -> boolean().
+-spec is_defined(get_key(), object()) -> boolean().
 is_defined(Path, JObj) ->
     'undefined' =/= get_value(Path, JObj).
 
@@ -194,7 +197,7 @@ is_empty(MaybeJObj) ->
 is_json_object(?JSON_WRAPPER(P)) when is_list(P) -> 'true';
 is_json_object(_) -> 'false'.
 
--spec is_json_object(path(), any()) -> boolean().
+-spec is_json_object(get_key(), any()) -> boolean().
 is_json_object(Key, JObj) ->
     is_json_object(get_value(Key, JObj)).
 
@@ -251,7 +254,7 @@ are_equal(JObj1, JObj2) ->
 %% The sub-proplist `[{d,e}]' needs converting before being passed to the next level.
 %% @end
 %%------------------------------------------------------------------------------
--spec from_list(json_proplist() | flat_proplist()) -> object() | flat_object().
+-spec from_list([set_value_kv()] | flat_proplist()) -> object() | flat_object().
 from_list(L) when is_list(L) ->
     ?JSON_WRAPPER(props:filter_undefined(L)).
 
@@ -486,7 +489,7 @@ sum_jobjs([FirstJObj|JObjs], Sumer)
 %% Both lists MUST be of same size.
 %% @end
 %%------------------------------------------------------------------------------
--spec order_by(path(), kz_term:ne_binaries(), [objects()]) -> objects().
+-spec order_by(get_key(), kz_term:ne_binaries(), [objects()]) -> objects().
 order_by(Path, Ids, ListOfJObjs)
   when is_list(Ids), is_list(ListOfJObjs) ->
     _ = [[put(get_value(Path, JObj), JObj) || JObj <- JObjs]
@@ -536,7 +539,7 @@ jobj_properties(JObj, Unliftable) ->
     Properties = jobj_properties(JObj, []),
     lists:foldl(fun remove_unliftable/2, Properties, Unliftable).
 
--spec remove_unliftable(path(), flat_proplist()) -> flat_proplist().
+-spec remove_unliftable(get_key(), flat_proplist()) -> flat_proplist().
 remove_unliftable([_|_]=Path, Properties) ->
     lists:filter(fun(Property) -> should_remove_unliftable(Property, Path) end
                 ,Properties
@@ -552,7 +555,7 @@ should_remove_unliftable({Path, _}, Unliftable) ->
 remove_common_properties(JObjs, CommonProperties) ->
     foldl(fun remove_common_property/3, JObjs, CommonProperties).
 
--spec remove_common_property(path(), any(), objects()) -> objects().
+-spec remove_common_property(get_key(), any(), objects()) -> objects().
 remove_common_property(Path, _Value, JObjs) ->
     lists:map(fun(JObj) -> delete_key(Path, JObj, 'prune') end, JObjs).
 
@@ -565,7 +568,7 @@ to_proplist(?JSON_WRAPPER(Prop)) -> Prop.
 
 %% convert everything starting at a specific key
 
--spec to_proplist(path(), object() | objects()) ->
+-spec to_proplist(get_key(), object() | objects()) ->
                          json_proplist() | json_proplists() | flat_proplist().
 to_proplist(Key, JObj) -> to_proplist(get_json_value(Key, JObj, new())).
 
@@ -589,7 +592,7 @@ to_map(JObj) ->
 
 %% convert everything starting at a specific key
 
--spec to_map(path(), object() | objects()) -> map().
+-spec to_map(get_key(), object() | objects()) -> map().
 to_map(Key, JObj) ->
     recursive_to_map(get_json_value(Key, JObj, new())).
 
@@ -638,10 +641,10 @@ maybe_tuple_to_json({K, V}) ->
     from_list([{kz_term:to_binary(K), V}]);
 maybe_tuple_to_json(V) -> V.
 
--spec get_json_value(path(), object()) -> kz_term:api_object().
+-spec get_json_value(get_key(), object()) -> kz_term:api_object().
 get_json_value(Key, JObj) -> get_json_value(Key, JObj, 'undefined').
 
--spec get_json_value(path(), object(), Default) -> Default | object().
+-spec get_json_value(get_key(), object(), Default) -> Default | object().
 get_json_value(Key, ?JSON_WRAPPER(_)=JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
@@ -649,11 +652,11 @@ get_json_value(Key, ?JSON_WRAPPER(_)=JObj, Default) ->
         _ -> Default
     end.
 
--spec get_ne_json_value(path(), object()) -> kz_term:api_object().
+-spec get_ne_json_value(get_key(), object()) -> kz_term:api_object().
 get_ne_json_value(Key, JObj) ->
     get_ne_json_value(Key, JObj, 'undefined').
 
--spec get_ne_json_value(path(), object(), Default) -> Default | object().
+-spec get_ne_json_value(get_key(), object(), Default) -> Default | object().
 get_ne_json_value(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
@@ -716,22 +719,22 @@ foldr(F, Acc0, ?JSON_WRAPPER([])) when is_function(F, 3) -> Acc0;
 foldr(F, Acc0, ?JSON_WRAPPER(Prop)) when is_function(F, 3) ->
     lists:foldr(fun({Key, Value}, Acc1) -> F(Key, Value, Acc1) end, Acc0, Prop).
 
--spec get_string_value(path(), object() | objects()) -> kz_term:api_list().
+-spec get_string_value(get_key(), object() | objects()) -> kz_term:api_list().
 get_string_value(Key, JObj) ->
     get_string_value(Key, JObj, 'undefined').
 
--spec get_string_value(path(), object(), Default) -> list() | Default.
+-spec get_string_value(get_key(), object(), Default) -> list() | Default.
 get_string_value(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
         Value -> kz_term:safe_cast(Value, Default, fun kz_term:to_list/1)
     end.
 
--spec get_list_value(path(), object() | objects()) -> kz_term:api_list().
+-spec get_list_value(get_key(), object() | objects()) -> kz_term:api_list().
 get_list_value(Key, JObj) ->
     get_list_value(Key, JObj, 'undefined').
 
--spec get_list_value(path(), object() | objects(), Default) -> Default | list().
+-spec get_list_value(get_key(), object() | objects(), Default) -> Default | list().
 get_list_value(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
@@ -739,22 +742,22 @@ get_list_value(Key, JObj, Default) ->
         _Else -> Default
     end.
 
--spec get_binary_value(path(), object() | objects()) -> kz_term:api_binary().
+-spec get_binary_value(get_key(), object() | objects()) -> kz_term:api_binary().
 get_binary_value(Key, JObj) ->
     get_binary_value(Key, JObj, 'undefined').
 
--spec get_binary_value(path(), object() | objects(), Default) -> binary() | Default.
+-spec get_binary_value(get_key(), object() | objects(), Default) -> binary() | Default.
 get_binary_value(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
         Value -> kz_term:safe_cast(Value, Default, fun kz_term:to_binary/1)
     end.
 
--spec get_ne_binary_value(path(), object() | objects()) -> kz_term:api_ne_binary().
+-spec get_ne_binary_value(get_key(), object() | objects()) -> kz_term:api_ne_binary().
 get_ne_binary_value(Key, JObj) ->
     get_ne_binary_value(Key, JObj, 'undefined').
 
--spec get_ne_binary_value(path(), object() | objects(), Default) -> kz_term:ne_binary() | Default.
+-spec get_ne_binary_value(get_key(), object() | objects(), Default) -> kz_term:ne_binary() | Default.
 get_ne_binary_value(Key, JObj, Default) ->
     case get_binary_value(Key, JObj, Default) of
         Default -> Default;
@@ -762,11 +765,11 @@ get_ne_binary_value(Key, JObj, Default) ->
         Value -> Value
     end.
 
--spec get_lower_binary(path(), object() | objects()) -> kz_term:api_binary().
+-spec get_lower_binary(get_key(), object() | objects()) -> kz_term:api_binary().
 get_lower_binary(Key, JObj) ->
     get_lower_binary(Key, JObj, 'undefined').
 
--spec get_lower_binary(path(), object() | objects(), Default) -> binary() | Default.
+-spec get_lower_binary(get_key(), object() | objects(), Default) -> binary() | Default.
 get_lower_binary(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
@@ -775,88 +778,88 @@ get_lower_binary(Key, JObj, Default) ->
 
 %% must be an existing atom
 
--spec get_atom_value(path(), object() | objects()) -> kz_term:api_atom().
+-spec get_atom_value(get_key(), object() | objects()) -> kz_term:api_atom().
 get_atom_value(Key, JObj) ->
     get_atom_value(Key, JObj, 'undefined').
 
--spec get_atom_value(path(), object() | objects(), Default) -> atom() | Default.
+-spec get_atom_value(get_key(), object() | objects(), Default) -> atom() | Default.
 get_atom_value(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
         Value -> kz_term:safe_cast(Value, Default, fun kz_term:to_atom/1)
     end.
 
--spec get_boolean_value(path(), object() | objects()) -> kz_term:api_atom().
+-spec get_boolean_value(get_key(), object() | objects()) -> kz_term:api_atom().
 get_boolean_value(Key, JObj) ->
     get_boolean_value(Key, JObj, 'undefined').
 
--spec get_boolean_value(path(), object() | objects(), Default) -> atom() | Default.
+-spec get_boolean_value(get_key(), object() | objects(), Default) -> atom() | Default.
 get_boolean_value(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
         Value -> kz_term:safe_cast(Value, Default, fun kz_term:to_boolean/1)
     end.
 
--spec get_integer_value(path(), object() | objects()) -> kz_term:api_integer().
+-spec get_integer_value(get_key(), object() | objects()) -> kz_term:api_integer().
 get_integer_value(Key, JObj) ->
     get_integer_value(Key, JObj, 'undefined').
 
--spec get_integer_value(path(), object() | objects(), Default) -> integer() | Default.
+-spec get_integer_value(get_key(), object() | objects(), Default) -> integer() | Default.
 get_integer_value(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
         Value -> kz_term:safe_cast(Value, Default, fun kz_term:to_integer/1)
     end.
 
--spec get_number_value(path(), object() | objects()) -> kz_term:api_number().
+-spec get_number_value(get_key(), object() | objects()) -> kz_term:api_number().
 get_number_value(Key, JObj) ->
     get_number_value(Key, JObj, 'undefined').
 
--spec get_number_value(path(), object() | objects(), Default) -> number() | Default.
+-spec get_number_value(get_key(), object() | objects(), Default) -> number() | Default.
 get_number_value(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
         Value -> kz_term:safe_cast(Value, Default, fun kz_term:to_number/1)
     end.
 
--spec get_float_value(path(), object() | objects()) -> kz_term:api_float().
+-spec get_float_value(get_key(), object() | objects()) -> kz_term:api_float().
 get_float_value(Key, JObj) ->
     get_float_value(Key, JObj, 'undefined').
 
--spec get_float_value(path(), object() | objects(), Default) -> float() | Default.
+-spec get_float_value(get_key(), object() | objects(), Default) -> float() | Default.
 get_float_value(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
         Value -> kz_term:safe_cast(Value, Default, fun kz_term:to_float/1)
     end.
 
--spec is_false(path(), object() | objects()) -> boolean().
+-spec is_false(get_key(), object() | objects()) -> boolean().
 is_false(Key, JObj) ->
     kz_term:is_false(get_value(Key, JObj)).
 
--spec is_false(path(), object() | objects(), Default) -> boolean() | Default.
+-spec is_false(get_key(), object() | objects(), Default) -> boolean() | Default.
 is_false(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
         V -> kz_term:is_false(V)
     end.
 
--spec is_true(path(), object() | objects()) -> boolean().
+-spec is_true(get_key(), object() | objects()) -> boolean().
 is_true(Key, JObj) ->
     is_true(Key, JObj, 'false').
 
--spec is_true(path(), object() | objects(), Default) -> boolean() | Default.
+-spec is_true(get_key(), object() | objects(), Default) -> boolean() | Default.
 is_true(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
         V -> kz_term:is_true(V)
     end.
 
--spec get_binary_boolean(path(), object() | objects()) -> kz_term:api_ne_binary().
+-spec get_binary_boolean(get_key(), object() | objects()) -> kz_term:api_ne_binary().
 get_binary_boolean(Key, JObj) ->
     get_binary_boolean(Key, JObj, 'undefined').
 
--spec get_binary_boolean(path(), object() | objects(), Default) -> Default | kz_term:ne_binary().
+-spec get_binary_boolean(get_key(), object() | objects(), Default) -> Default | kz_term:ne_binary().
 get_binary_boolean(Key, JObj, Default) ->
     case get_value(Key, JObj) of
         'undefined' -> Default;
@@ -866,7 +869,7 @@ get_binary_boolean(Key, JObj, Default) ->
 -spec get_keys(object() | flat_object()) -> keys() | [keys(),...].
 get_keys(JObj) -> get_keys1(JObj).
 
--spec get_keys(path(), object() | flat_object()) -> keys() | [keys(),...].
+-spec get_keys(get_key(), object() | flat_object()) -> keys() | [keys(),...].
 get_keys([], JObj) -> get_keys1(JObj);
 get_keys(Keys, JObj) -> get_keys1(get_json_value(Keys, JObj, new())).
 
@@ -874,11 +877,11 @@ get_keys(Keys, JObj) -> get_keys1(get_json_value(Keys, JObj, new())).
 get_keys1(KVs) when is_list(KVs) -> lists:seq(1, length(KVs));
 get_keys1(JObj) -> props:get_keys(to_proplist(JObj)).
 
--spec get_ne_value(path(), object() | objects()) -> api_json_term().
+-spec get_ne_value(get_key(), object() | objects()) -> api_json_term().
 get_ne_value(Key, JObj) ->
     get_ne_value(Key, JObj, 'undefined').
 
--spec get_ne_value(path(), object() | objects(), Default) -> json_term() | Default.
+-spec get_ne_value(get_key(), object() | objects(), Default) -> json_term() | Default.
 get_ne_value(Key, JObj, Default) ->
     Value = get_value(Key, JObj),
     case kz_term:is_empty(Value) of
@@ -892,11 +895,11 @@ get_ne_value(Key, JObj, Default) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec find(path(), objects()) -> api_json_term().
+-spec find(get_key(), objects()) -> api_json_term().
 find(Key, JObjs) ->
     find(Key, JObjs, 'undefined').
 
--spec find(path(), objects(), Default) -> json_term() | Default.
+-spec find(get_key(), objects(), Default) -> json_term() | Default.
 find(_, [], Default) -> Default;
 find(Key, [JObj|JObjs], Default) when is_list(JObjs) ->
     try get_value(Key, JObj) of
@@ -906,11 +909,11 @@ find(Key, [JObj|JObjs], Default) when is_list(JObjs) ->
         'error':'badarg' -> find(Key, JObjs, Default)
     end.
 
--spec find_first_defined(paths(), objects()) -> api_json_term().
+-spec find_first_defined(keys() | paths(), objects()) -> api_json_term().
 find_first_defined(Keys, JObjs) ->
     find_first_defined(Keys, JObjs, 'undefined').
 
--spec find_first_defined(paths(), objects(), Default) -> json_term() | Default.
+-spec find_first_defined(keys() | paths(), objects(), Default) -> json_term() | Default.
 find_first_defined([], _JObjs, Default) -> Default;
 find_first_defined([Key|Keys], JObjs, Default) ->
     try find(Key, JObjs) of
@@ -926,11 +929,11 @@ find_first_defined([Key|Keys], JObjs, Default) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec find_value(path(), json_term(), objects()) -> kz_term:api_object().
+-spec find_value(get_key(), json_term(), objects()) -> kz_term:api_object().
 find_value(Key, Value, JObjs) ->
     find_value(Key, Value, JObjs, 'undefined').
 
--spec find_value(path(), json_term(), objects(), Default) -> object() | Default.
+-spec find_value(get_key(), json_term(), objects(), Default) -> object() | Default.
 find_value(_Key, _Value, [], Default) -> Default;
 find_value(Key, Value, [JObj|JObjs], Default) ->
     try get_value(Key, JObj) of
@@ -940,11 +943,11 @@ find_value(Key, Value, [JObj|JObjs], Default) ->
         'error':'badarg' -> find_value(Key, Value, JObjs, Default)
     end.
 
--spec get_first_defined(paths(), object()) -> json_term() | 'undefined'.
+-spec get_first_defined(keys() | paths(), object()) -> json_term() | 'undefined'.
 get_first_defined(Keys, JObj) ->
     get_first_defined(Keys, JObj, 'undefined').
 
--spec get_first_defined(paths(), object(), Default) -> json_term() | Default.
+-spec get_first_defined(keys() | paths(), object(), Default) -> json_term() | Default.
 get_first_defined([], _JObj, Default) -> Default;
 get_first_defined([H|T], JObj, Default) ->
     try get_value(H, JObj) of
@@ -954,11 +957,11 @@ get_first_defined([H|T], JObj, Default) ->
         'error':'badarg' -> get_first_defined(T, JObj, Default)
     end.
 
--spec get_value(path(), object() | objects()) -> json_term() | 'undefined'.
+-spec get_value(get_key(), object() | objects()) -> json_term() | 'undefined'.
 get_value(Key, JObj) ->
     get_value(Key, JObj, 'undefined').
 
--spec get_value(path(), object() | objects(), Default) -> json_term() | Default.
+-spec get_value(get_key(), object() | objects(), Default) -> json_term() | Default.
 get_value([Key|Ks], L, Default) when is_list(L) ->
     try
         get_value1(Ks, lists:nth(kz_term:to_integer(Key), L), Default)
@@ -970,7 +973,7 @@ get_value([Key|Ks], L, Default) when is_list(L) ->
 get_value(K, Doc, Default) ->
     get_value1(K, Doc, Default).
 
--spec get_value1(path(), kz_term:api_object() | objects(), Default) ->
+-spec get_value1(get_key(), kz_term:api_object() | objects(), Default) ->
                         json_term() | Default.
 get_value1([], 'undefined', Default) -> Default;
 get_value1([], JObj, _Default) -> JObj;
@@ -985,12 +988,12 @@ get_value1([K|Ks], JObjs, Default) when is_list(JObjs) ->
     end;
 get_value1([K|Ks], ?JSON_WRAPPER(Props), Default) ->
     get_value1(Ks, props:get_value(K, Props), Default);
-get_value1(_, undefined, Default) ->
+get_value1(_, 'undefined', Default) ->
     Default;
 get_value1(_, ?JSON_WRAPPER(_), Default) ->
     Default;
 get_value1(_K, _V, _D) ->
-    erlang:error(badarg).
+    erlang:error('badarg').
 
 -spec values(object()) -> json_terms().
 values(JObj) ->
@@ -998,7 +1001,7 @@ values(JObj) ->
      || Key <- ?MODULE:get_keys(JObj)
     ].
 
--spec values(path(), object()) -> json_terms().
+-spec values(get_key(), object()) -> json_terms().
 values(Key, JObj) ->
     values(get_value(Key, JObj, new())).
 
@@ -1015,7 +1018,7 @@ get_values(JObj) ->
                ,?MODULE:get_keys(JObj)
                ).
 
--spec get_values(path(), object()) -> {json_terms(), keys()}.
+-spec get_values(get_key(), object()) -> {json_terms(), keys()}.
 get_values(Key, JObj) ->
     get_values(get_value(Key, JObj, new())).
 
@@ -1024,12 +1027,14 @@ get_values(Key, JObj) ->
 -type set_value_fun() :: {fun((object(), json_term()) -> object()), json_term()} |
                          fun((object()) -> object()).
 -type set_value_funs() :: [set_value_fun(),...].
+-type set_value_kv() :: {get_key(), api_json_term() | 'null'}.
+-type set_value_kvs() :: [set_value_kv()].
 
--spec set_values([{path(), json_term()}] | set_value_funs(), object()) -> object().
+-spec set_values(set_value_kvs() | set_value_funs(), object()) -> object().
 set_values(KVs, JObj) when is_list(KVs) ->
     lists:foldr(fun set_value_fold/2, JObj, KVs).
 
--spec set_value_fold(set_value_fun() | {path(), json_term()}, object()) -> object().
+-spec set_value_fold(set_value_fun() | set_value_kv(), object()) -> object().
 set_value_fold({F, V}, JObj) when is_function(F, 2) ->
     F(JObj, V);
 set_value_fold(F, JObj) when is_function(F, 1) ->
@@ -1037,7 +1042,7 @@ set_value_fold(F, JObj) when is_function(F, 1) ->
 set_value_fold({K, V}, JObj) ->
     set_value(K, V, JObj).
 
--spec insert_value(path(), json_term(), object()) -> object().
+-spec insert_value(get_key(), json_term(), object()) -> object().
 insert_value(Key, Value, JObj) ->
     case get_value(Key, JObj) of
         'undefined' -> set_value(Key, Value, JObj);
@@ -1048,11 +1053,11 @@ insert_value(Key, Value, JObj) ->
 insert_values(KVs, JObj) ->
     lists:foldl(fun insert_value_fold/2, JObj, KVs).
 
--spec insert_value_fold({path(), json_term()}, object()) -> object().
+-spec insert_value_fold({get_key(), json_term()}, object()) -> object().
 insert_value_fold({Key, Value}, JObj) ->
     insert_value(Key, Value, JObj).
 
--spec set_value(path(), api_json_term() | 'null', object() | objects()) -> object() | objects().
+-spec set_value(get_key(), api_json_term() | 'null', object() | objects()) -> object() | objects().
 set_value(_Keys, 'undefined', JObj) -> JObj;
 set_value(Keys, Value, JObj) when is_list(Keys) -> set_value1(Keys, Value, JObj);
 set_value(Key, Value, JObj) -> set_value1([Key], Value, JObj).
@@ -1121,7 +1126,7 @@ set_value1([], Value, _JObj) -> Value.
 %% @end
 %%------------------------------------------------------------------------------
 
--spec delete_key(path(), object() | objects()) -> object() | objects().
+-spec delete_key(get_key(), object() | objects()) -> object() | objects().
 delete_key(Keys, JObj) when is_list(Keys) ->
     delete_key(Keys, JObj, 'no_prune');
 delete_key(Key, JObj) ->
@@ -1139,7 +1144,7 @@ delete_key(Key, JObj) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec delete_key(path(), object() | objects(), 'prune' | 'no_prune') -> object() | objects().
+-spec delete_key(get_key(), object() | objects(), 'prune' | 'no_prune') -> object() | objects().
 delete_key(Key, JObj, 'prune') when not is_list(Key) ->
     prune([Key], JObj);
 delete_key(Key, JObj, 'no_prune') when not is_list(Key) ->
@@ -1153,7 +1158,7 @@ delete_key(Keys, JObj, 'no_prune') ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec delete_keys(paths(), object()) -> object().
+-spec delete_keys(paths() | keys(), object()) -> object().
 delete_keys(Keys, JObj) when is_list(Keys) ->
     %% Figure out how to set the current key among a list of objects
     lists:foldr(fun(K, JObj0) -> delete_key(K, JObj0) end, JObj, Keys).
@@ -1162,7 +1167,7 @@ delete_keys(Keys, JObj) when is_list(Keys) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec prune_keys(paths(), object()) -> object().
+-spec prune_keys(keys() | paths(), object()) -> object().
 prune_keys(Keys, JObj) when is_list(Keys) ->
     lists:foldr(fun(K, JObj0) -> delete_key(K, JObj0, 'prune') end
                ,JObj
@@ -1279,16 +1284,16 @@ load_fixture_from_file(App, Dir, File) ->
             {'error', Reason}
     end.
 
--spec fixture(file:filename_all()) -> {ok, object()} | {error, not_found}.
+-spec fixture(file:filename_all()) -> {'ok', object()} | {'error', 'not_found'}.
 fixture(Path) ->
     case file:read_file(Path) of
-        {ok, Bin} -> {ok, decode(Bin)};
-        {error, _} -> {error, not_found}
+        {'ok', Bin} -> {'ok', decode(Bin)};
+        {'error', _} -> {'error', 'not_found'}
     end.
 
--spec fixture(atom(), file:filename_all()) -> {ok, object()} | {error, not_found}.
+-spec fixture(atom(), file:filename_all()) -> {'ok', object()} | {'error', 'not_found'}.
 fixture(App, Path) when is_atom(App) ->
-    fixture(filename:join(code:lib_dir(App, test), Path)).
+    fixture(filename:join(code:lib_dir(App, 'test'), Path)).
 
 %%------------------------------------------------------------------------------
 %% @doc Normalize a JSON object for storage as a Document.

--- a/core/kazoo_stdlib/src/kz_time.erl
+++ b/core/kazoo_stdlib/src/kz_time.erl
@@ -222,7 +222,7 @@ format_iso8601(Timestamp, TimeOffset) ->
 %% @throws {error, invalid_time}
 %% @end
 %%------------------------------------------------------------------------------
--spec from_iso8601_time(binary()) -> time().
+-spec from_iso8601_time(binary()) -> {time(), integer()}.
 %% HH:MM:SS
 from_iso8601_time(<<Hour:2/binary, ":", Minute:2/binary, ":", Second:2/binary>>) ->
     iso8601_offset(from_binary_to_time(Hour, Minute, Second), <<>>);
@@ -404,7 +404,7 @@ adjust_utc_datetime(DateTime, Adjustment) ->
 %% @throws {error, any()}
 %% @end
 %%------------------------------------------------------------------------------
--spec cast_integer(integer(), atom()) -> integer().
+-spec cast_integer(any(), atom()) -> integer().
 cast_integer(Value, Exception) ->
     try kz_term:to_integer(Value)
     catch

--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -683,15 +683,14 @@ try_save_document(Call, MsgJObj, Loop) ->
 %%------------------------------------------------------------------------------
 -spec fake_vmbox_jobj(kapps_call:call(), kz_term:proplist()) -> kz_json:object().
 fake_vmbox_jobj(Call, Props) ->
-    kz_json:from_list(
-      [{<<"_id">>, props:get_value(<<"Box-Id">>, Props)}
-      ,{<<"mailbox">>, props:get_value(<<"Box-Num">>, Props)}
-      ,{<<"timezone">>, props:get_value(<<"Timezone">>, Props)}
-      ,{<<"owner_id">>, props:get_value(<<"Owner-Id">>, Props)}
-      ,{<<"pvt_account_id">>, kapps_call:account_id(Call)}
-      ,{<<"pvt_account_db">>, kapps_call:account_db(Call)}
-      ]
-     ).
+    kz_json:from_list([{<<"_id">>, props:get_value(<<"Box-Id">>, Props)}
+                      ,{<<"mailbox">>, props:get_value(<<"Box-Num">>, Props)}
+                      ,{<<"timezone">>, props:get_value(<<"Timezone">>, Props)}
+                      ,{<<"owner_id">>, props:get_value(<<"Owner-Id">>, Props)}
+                      ,{<<"pvt_account_id">>, kapps_call:account_id(Call)}
+                      ,{<<"pvt_account_db">>, kapps_call:account_db(Call)}
+                      ]
+                     ).
 
 -spec store_recording(kz_term:ne_binary(), kz_term:ne_binary() | sotre_media_url(), kapps_call:call(), kz_term:ne_binary()) ->
                              'ok' |


### PR DESCRIPTION
* update kazoo json type usages

* don't bind unless necessary

* will filter undefined while setting

* fix some more json specs/types, use kz_datamgr:update_doc/3

* fix type for config_key()

* more type updates

* a few more dialyzer-related updates

* refactor out the try/catch

* more refactoring to appease the dialyzer

* cleanup docs for dynamic CID

* more dialyzer updates

* clean up spec for kz_json:from_list

* update specs

* revert to from_list/1

Conflicts:
	core/kazoo_amqp/src/kz_amqp_worker.erl