### PR TITLE
HELP-40129: restrict group_confirm from being lifted to global props

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_bridge.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_bridge.erl
@@ -263,6 +263,14 @@ create_command(DP, _Node, _UUID, #channel{profile=ChannelProfile}, JObj) ->
                                                                ,<<"To-Realm">>
                                                                ,<<"To-User">>
                                                                ,<<"To-Username">>
+
+                                                                    %% Per FS-3792, group confirm must be
+                                                                    %% set per-channel, not globally
+                                                                    %% otherwise double prompting
+                                                               ,<<"Confirm-Cancel-Timeout">>
+                                                               ,<<"Confirm-File">>
+                                                               ,<<"Confirm-Key">>
+                                                               ,<<"Confirm-Read-Timeout">>
                                                                ]),
     UpdatedJObj = kz_json:set_value(<<"Endpoints">>, UniqueEndpoints, kz_json:merge(JObj, Common)),
 


### PR DESCRIPTION
As per Tony in https://freeswitch.org/jira/browse/FS-3792:

"if you are using group_confirm, the variables will be parsed twice
once for the top originate and one for the one inside the loopback set
the group_confirm options inside [] for each leg instead of globally
in {}
"

See note in
https://freeswitch.org/confluence/display/FREESWITCH/XML+User+Directory
in section "Group Call with Answer Confirmation" as well

Since it seems only loopback endpoints are affected, future work could
be done to detect if the endpoints are loopback or not but for now
let's just patch and address it later if necessary.