### PR TITLE
Update knm_vitelity_util.erl

### DIFF
--- a/core/kazoo_number_manager/src/knm_vitelity_util.erl
+++ b/core/kazoo_number_manager/src/knm_vitelity_util.erl
@@ -33,7 +33,7 @@
 -define(API_URL
        ,kapps_config:get_ne_binary(?KNM_VITELITY_CONFIG_CAT
                                   ,<<"api_uri">>
-                                  ,<<"http://api.vitelity.net/api.php">>
+                                  ,<<"https://api.vitelity.net/api.php">>
                                   )
        ).
 


### PR DESCRIPTION
Due to Vitelity API gone accessible only via HTTPS default URL should be changed in sources.

Vitelity message: "Please be advised, there are upcoming changes to the Vitelity API. HTTP requests have been shut off as of Monday Oct 15 at 10 AM MDT and all API requests are being redirected to HTTPS. As of Wednesday, Nov 14 at 10 AM MST, there will no longer be support for the redirects and all API requests must be done using HTTPS."