### PR TITLE
[4.3] when using update_doc/3, don't include {_rev, null}

### DIFF
--- a/applications/crossbar/src/modules/cb_faxboxes.erl
+++ b/applications/crossbar/src/modules/cb_faxboxes.erl
@@ -541,14 +541,16 @@ oauth_req(Doc, OAuthRefresh, Context) ->
 faxbox_doc_save(Context) ->
     Ctx2 = crossbar_doc:save(Context),
 
-    Updates = [{kz_doc:path_account_db(), ?KZ_FAXES_DB}
-              ,{kz_doc:path_revision(), 'null'}
-              ],
+    ToSave = kz_json:set_values([{kz_doc:path_account_db(), ?KZ_FAXES_DB}
+                                ,{kz_doc:path_revision(), 'null'}
+                                ]
+                               ,cb_context:doc(Ctx2)
+                               ),
 
-    DocId = kz_doc:id(cb_context:doc(Ctx2)),
+    DocId = kz_doc:id(ToSave),
     Ctx3 = crossbar_doc:update(cb_context:set_account_db(Ctx2, ?KZ_FAXES_DB)
                               ,DocId
-                              ,Updates
+                              ,kz_json:to_proplist(kz_json:flatten(ToSave))
                               ),
 
     case cb_context:resp_status(Ctx3) of

--- a/applications/crossbar/src/modules_v2/cb_devices_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_devices_v2.erl
@@ -723,28 +723,34 @@ is_creds_global_unique(Realm, Username, DeviceId) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec maybe_aggregate_device(kz_term:api_binary(), cb_context:context()) -> boolean().
+-spec maybe_aggregate_device(kz_term:api_ne_binary(), cb_context:context()) -> boolean().
 maybe_aggregate_device(DeviceId, Context) ->
     maybe_aggregate_device(DeviceId, Context, cb_context:resp_status(Context)).
 
--spec maybe_aggregate_device(kz_term:api_binary(), cb_context:context(), crossbar_status()) -> boolean().
+-spec maybe_aggregate_device(kz_term:api_ne_binary(), cb_context:context(), crossbar_status()) -> boolean().
 maybe_aggregate_device(DeviceId, Context, 'success') ->
     case kz_term:is_true(cb_context:fetch(Context, 'aggregate_device'))
         andalso ?DEVICES_ALLOW_AGGREGATES
     of
         'false' -> maybe_remove_aggregate(DeviceId, Context);
         'true' ->
-            lager:debug("adding device to the sip auth aggregate"),
-            Update = [{kz_doc:path_revision(), 'null'}],
-            UpdateOptions = [{'update', Update}
-                            ,{'create', kz_json:to_proplist(cb_context:doc(Context))}
-                            ,{'ensure_saved', 'true'}
-                            ],
-            {'ok', _} = kz_datamgr:update_doc(?KZ_SIP_DB, DeviceId, UpdateOptions),
+            aggregate_device(cb_context:doc(Context)),
             _ = kz_amqp_worker:cast([], fun(_) -> kapi_switch:publish_reload_acls() end),
             'true'
     end;
 maybe_aggregate_device(_, _, _) -> 'false'.
+
+-spec aggregate_device(kz_json:object()) -> 'ok'.
+aggregate_device(Device) ->
+    lager:debug("adding device to the sip auth aggregate"),
+    Doc = kz_doc:delete_revision(Device),
+    Update = kz_json:to_proplist(kz_json:flatten(Doc)),
+    UpdateOptions = [{'update', Update}
+                    ,{'create', []}
+                    ,{'ensure_saved', 'true'}
+                    ],
+    {'ok', _} = kz_datamgr:update_doc(?KZ_SIP_DB, kz_doc:id(Device), UpdateOptions),
+    'ok'.
 
 %%------------------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
Previous versions used kz_doc:delete_revision/1 before calling
kz_datamgr:ensure_saved/2 to clear the _rev from the doc. In
deprecating kz_datgmgr:ensure_saved/2 the initial refactor chose to
refactor this to using {_rev, null} in the {update, [...]} list passed
to kz_datamgr:update_doc/3.

However, as these calls were being made to replicate a doc from an
account database to an aggregate database (like sip_auth or accounts),
the effect was that the save would fail with conflict (because the
original doc's _rev didn't match the aggregate doc's _rev), the
aggregate doc would be fetched and updates applied (nulling _rev
again). Saving would then conflict again as no _rev was supplied but
the doc exists...and you got yourself a loop.