### PR TITLE
[4.3] Updates to Pivot and ClickToCall

### DIFF
--- a/applications/callflow/src/cf_route_req.erl
+++ b/applications/callflow/src/cf_route_req.erl
@@ -18,22 +18,22 @@
 -define(ROUTE_WIN_TIMEOUT_KEY, <<"route_win_timeout">>).
 -define(ROUTE_WIN_TIMEOUT, kapps_config:get_integer(?CF_CONFIG_CAT, ?ROUTE_WIN_TIMEOUT_KEY, ?DEFAULT_ROUTE_WIN_TIMEOUT)).
 
--spec handle_req(kz_json:object(), kz_term:proplist()) -> 'ok'.
-handle_req(JObj, Props) ->
-    CallId = kapi_route:call_id(JObj),
+-spec handle_req(kapi_route:req(), kz_term:proplist()) -> 'ok'.
+handle_req(RouteReq, Props) ->
+    CallId = kapi_route:call_id(RouteReq),
     kz_util:put_callid(CallId),
-    'true' = kapi_route:req_v(JObj),
+    'true' = kapi_route:req_v(RouteReq),
     gproc:reg({'p', 'l', {'route_req', CallId}}),
     Routines = [fun maybe_referred_call/1
                ,fun maybe_device_redirected/1
                ],
-    Call = kapps_call:exec(Routines, kapps_call:from_route_req(JObj)),
+    Call = kapps_call:exec(Routines, kapps_call:from_route_req(RouteReq)),
     case is_binary(kapps_call:account_id(Call))
         andalso callflow_should_respond(Call)
     of
         'true' ->
             lager:info("received request ~s asking if callflows can route the call to ~s"
-                      ,[kapi_route:fetch_id(JObj), kapps_call:request_user(Call)]
+                      ,[kapi_route:fetch_id(RouteReq), kapps_call:request_user(Call)]
                       ),
             AllowNoMatch = allow_no_match(Call),
             case cf_flow:lookup(Call) of
@@ -41,40 +41,40 @@ handle_req(JObj, Props) ->
                 %% to use it for this call
                 {'ok', Flow, NoMatch} when (not NoMatch)
                                            orelse AllowNoMatch ->
-                    maybe_prepend_preflow(JObj, Props, Call, Flow, NoMatch);
+                    maybe_prepend_preflow(RouteReq, Props, Call, Flow, NoMatch);
                 {'ok', _, 'true'} ->
                     lager:info("only available callflow is a nomatch for a unauthorized call", []);
                 {'error', R} ->
                     lager:info("unable to find callflow ~p", [R])
             end;
         'false' ->
-            lager:debug("callflow not handling fetch-id ~s", [kapi_route:fetch_id(JObj)])
+            lager:debug("callflow not handling fetch-id ~s", [kapi_route:fetch_id(RouteReq)])
     end.
 
--spec maybe_prepend_preflow(kz_json:object(), kz_term:proplist()
+-spec maybe_prepend_preflow(kapi_route:req(), kz_term:proplist()
                            ,kapps_call:call(), kzd_callflow:doc()
                            ,boolean()
                            ) -> 'ok'.
-maybe_prepend_preflow(JObj, Props, Call, Callflow, NoMatch) ->
+maybe_prepend_preflow(RouteReq, Props, Call, Callflow, NoMatch) ->
     AccountId = kapps_call:account_id(Call),
     case kzd_accounts:fetch(AccountId) of
         {'error', _E} ->
             lager:warning("could not open account doc ~s : ~p", [AccountId, _E]),
-            maybe_reply_to_req(JObj, Props, Call, Callflow, NoMatch);
+            maybe_reply_to_req(RouteReq, Props, Call, Callflow, NoMatch);
         {'ok', AccountDoc} ->
             case kzd_accounts:preflow_id(AccountDoc) of
                 'undefined' ->
                     lager:debug("ignore preflow, not set"),
-                    maybe_reply_to_req(JObj, Props, Call, Callflow, NoMatch);
+                    maybe_reply_to_req(RouteReq, Props, Call, Callflow, NoMatch);
                 PreflowId ->
                     NewCallflow = kzd_callflow:prepend_preflow(Callflow, PreflowId),
-                    maybe_reply_to_req(JObj, Props, Call, NewCallflow, NoMatch)
+                    maybe_reply_to_req(RouteReq, Props, Call, NewCallflow, NoMatch)
             end
     end.
 
--spec maybe_reply_to_req(kz_json:object(), kz_term:proplist()
+-spec maybe_reply_to_req(kapi_route:req(), kz_term:proplist()
                         ,kapps_call:call(), kz_json:object(), boolean()) -> 'ok'.
-maybe_reply_to_req(JObj, Props, Call, Flow, NoMatch) ->
+maybe_reply_to_req(RouteReq, Props, Call, Flow, NoMatch) ->
     lager:info("callflow ~s in ~s satisfies request for ~s", [kz_doc:id(Flow)
                                                              ,kapps_call:account_id(Call)
                                                              ,kapps_call:request_user(Call)
@@ -84,7 +84,7 @@ maybe_reply_to_req(JObj, Props, Call, Flow, NoMatch) ->
         'true' ->
             ControllerQ = props:get_value('queue', Props),
             NewCall = update_call(Flow, NoMatch, ControllerQ, Call),
-            send_route_response(Flow, JObj, NewCall)
+            send_route_response(Flow, RouteReq, NewCall)
     end.
 
 %%------------------------------------------------------------------------------
@@ -139,24 +139,24 @@ callflow_should_respond(Call) ->
 %% process.
 %% @end
 %%------------------------------------------------------------------------------
--spec send_route_response(kz_json:object(), kz_json:object(), kapps_call:call()) -> 'ok'.
-send_route_response(Flow, JObj, Call) ->
+-spec send_route_response(kz_json:object(), kapi_route:req(), kapps_call:call()) -> 'ok'.
+send_route_response(Flow, RouteReq, Call) ->
     lager:info("callflows knows how to route the call! sending park response"),
     AccountId = kapps_call:account_id(Call),
     Resp = props:filter_undefined(
-             [{?KEY_MSG_ID, kz_api:msg_id(JObj)}
+             [{?KEY_MSG_ID, kz_api:msg_id(RouteReq)}
              ,{?KEY_MSG_REPLY_ID, kapps_call:call_id_direct(Call)}
              ,{<<"Routes">>, []}
              ,{<<"Method">>, <<"park">>}
-             ,{<<"Transfer-Media">>, get_transfer_media(Flow, JObj)}
-             ,{<<"Ringback-Media">>, get_ringback_media(Flow, JObj)}
+             ,{<<"Transfer-Media">>, get_transfer_media(Flow, RouteReq)}
+             ,{<<"Ringback-Media">>, get_ringback_media(Flow, RouteReq)}
              ,{<<"Pre-Park">>, pre_park_action(Call)}
              ,{<<"From-Realm">>, kzd_accounts:fetch_realm(AccountId)}
              ,{<<"Custom-Channel-Vars">>, kapps_call:custom_channel_vars(Call)}
              ,{<<"Custom-Application-Vars">>, kapps_call:custom_application_vars(Call)}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
-    ServerId = kz_api:server_id(JObj),
+    ServerId = kz_api:server_id(RouteReq),
     Publisher = fun(P) -> kapi_route:publish_resp(ServerId, P) end,
     case kz_amqp_worker:call(Resp
                             ,Publisher
@@ -189,19 +189,19 @@ wait_for_running(Call, N) ->
             end
     end.
 
--spec get_transfer_media(kz_json:object(), kz_json:object()) -> kz_term:api_binary().
-get_transfer_media(Flow, JObj) ->
+-spec get_transfer_media(kz_json:object(), kapi_route:req()) -> kz_term:api_binary().
+get_transfer_media(Flow, RouteReq) ->
     case kz_json:get_value([<<"ringback">>, <<"transfer">>], Flow) of
         'undefined' ->
-            kz_json:get_value(<<"Transfer-Media">>, JObj);
+            kz_json:get_ne_binary_value(<<"Transfer-Media">>, RouteReq);
         MediaId -> MediaId
     end.
 
--spec get_ringback_media(kz_json:object(), kz_json:object()) -> kz_term:api_binary().
-get_ringback_media(Flow, JObj) ->
+-spec get_ringback_media(kz_json:object(), kapi_route:req()) -> kz_term:api_binary().
+get_ringback_media(Flow, RouteReq) ->
     case kz_json:get_value([<<"ringback">>, <<"early">>], Flow) of
         'undefined' ->
-            kz_json:get_value(<<"Ringback-Media">>, JObj);
+            kz_json:get_ne_binary_value(<<"Ringback-Media">>, RouteReq);
         MediaId -> MediaId
     end.
 

--- a/applications/callflow/src/module/cf_pivot.erl
+++ b/applications/callflow/src/module/cf_pivot.erl
@@ -77,6 +77,9 @@ wait_for_pivot(Data, Call) ->
                 {<<"pivot">>,<<"failed">>} ->
                     lager:warning("pivot failed failing back to next callflow action"),
                     cf_exe:continue(Call);
+                {<<"pivot">>,<<"processing">>} ->
+                    lager:info("pivot is processing the response"),
+                    cf_exe:stop_on_destroy(Call);
                 _Other ->
                     wait_for_pivot(Data, Call)
             end;

--- a/applications/crossbar/doc/clicktocall.md
+++ b/applications/crossbar/doc/clicktocall.md
@@ -9,19 +9,42 @@ Click-to-call allows you to create URLs that can be POSTed to with a phone numbe
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `auth_required` | Determines if this click to call requires valid auth-tokens when invoked | `boolean()` | `true` | `false` |
+`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('true' | 'false' | 'auto')` |   | `false` |
 `caller_id_number` | Explicitly set caller id number | `string()` |   | `false` |
+`custom_application_vars./[a-zA-Z0-9\-_]+/` |   | `string()` |   | `false` |
+`custom_application_vars` | Key-value pairs to set as custom_application_vars on the channel | `object()` | `{}` | `false` |
+`custom_sip_headers.in` | Custom SIP Headers to be applied to calls inbound to Kazoo from the endpoint | [#/definitions/custom_sip_headers](#custom_sip_headers) |   | `false` |
+`custom_sip_headers.out` | Custom SIP Headers to be applied to calls outbound from Kazoo to the endpoint | [#/definitions/custom_sip_headers](#custom_sip_headers) |   | `false` |
+`custom_sip_headers.^[a-zA-z0-9_\-]+$` | The SIP header to add | `string()` |   | `false` |
+`custom_sip_headers` | A property list of SIP headers | `object()` |   | `false` |
 `dial_first` | Determines what will be dialed first: extension or contact | `string('extension' | 'contact')` |   | `false` |
 `extension` | The extension to connect to when the click to call is invoked | `string()` |   | `true` |
+`media.ignore_early_media` | The option to determine if early media from the endpoint should always be ignored | `boolean()` |   | `false` |
+`media` |   | `object()` |   | `false` |
+`music_on_hold.media_id` | The ID of a media object that should be used as the music on hold | `string(0..2048)` |   | `false` |
+`music_on_hold` | The music on hold parameters used if not a property of the device owner | `object()` |   | `false` |
 `name` | A friendly name for the click to call | `string(1..128)` |   | `true` |
 `outbound_callee_id_name` | Callee ID Name of the device calling out to the contact number | `string()` |   | `false` |
 `outbound_callee_id_number` | Callee ID Number of the device calling out to the contact number | `string()` |   | `false` |
+`presence_id` | Static presence ID (used instead of SIP username) | `string()` |   | `false` | `supported`
+`ringback` | Ringback to use | `string()` |   | `false` |
 `throttle` | The rate that this click to call can be invoked | `integer()` |   | `false` |
+`timeout` | How long, in seconds, to wait for the call to progress | `integer()` |   | `false` |
 `whitelist.[]` |   | `string(1..)` |   | `false` |
 `whitelist` | A list of regular expressions that the click to call can dial to | `array(string(1..))` |   | `false` |
 
+### custom_sip_headers
+
+Custom SIP headers applied to an INVITE
 
 
-## Fetch
+Key | Description | Type | Default | Required | Support Level
+--- | ----------- | ---- | ------- | -------- | -------------
+`^[a-zA-z0-9_\-]+$` | The SIP header to add | `string()` |   | `false` |
+
+
+
+## List all clicktocall endpoints
 
 > GET /v2/accounts/{ACCOUNT_ID}/clicktocall
 
@@ -31,14 +54,54 @@ curl -v -X GET \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/clicktocall
 ```
 
-## Create
+```json
+{
+    "auth_token":"{AUTH_TOKEN}",
+    "data": [
+        {
+            "extension": "{EXTENSION}",
+            "id": "{C2C_ID}",
+            "name": "{NAME}"
+        }
+    ],
+    "node": "{NODE_HASH}",
+    "page_size": 1,
+    "request_id": "{REQUEST_ID}",
+    "revision": "{REVISION}",
+    "status": "success",
+    "timestamp": "{TIMESTAMP}",
+    "version": "4.3.1"
+}
+```
+
+## Create a clicktocall endpoint
 
 > PUT /v2/accounts/{ACCOUNT_ID}/clicktocall
 
 ```shell
 curl -v -X PUT \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -d '{"data":{"name":"{NAME}, "auth_required":false, "extension":"{EXTENSION}"}}'
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/clicktocall
+```
+
+```json
+{
+    "auth_token":"{AUTH_TOKEN}",
+    "data": {
+        "auth_required": false,
+        "custom_application_vars": {},
+        "extension": "{EXTENSION}",
+        "id": "{C2C_ID}",
+        "name": "{NAME}"
+    },
+    "node": "{NODE_HASH}",
+    "request_id": "{REQUEST_ID}",
+    "revision": "{REVISION}",
+    "status": "success",
+    "timestamp": "{TIMESTAMP}",
+    "version": "4.3.1"
+}
 ```
 
 ## Fetch
@@ -49,6 +112,26 @@ curl -v -X PUT \
 curl -v -X GET \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/clicktocall/{C2C_ID}
+```
+
+```json
+{
+    "auth_token":"{AUTH_TOKEN}",
+    "data": {
+        "auth_required": false,
+        "custom_application_vars": {},
+        "extension": "{EXTENSION}",
+        "id": "{C2C_ID}",
+        "name": "{NAME}"
+    },
+    "node": "{NODE_HASH}",
+    "request_id": "{REQUEST_ID}",
+    "revision": "{REVISION}",
+    "status": "success",
+    "timestamp": "{TIMESTAMP}",
+    "version": "4.3.1"
+}
+
 ```
 
 ## Change
@@ -91,14 +174,77 @@ curl -v -X GET \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/clicktocall/{C2C_ID}/history
 ```
 
-## Fetch
+## Execute the clicktocall with a supplied number
 
-> GET /v2/accounts/{ACCOUNT_ID}/clicktocall/{C2C_ID}/connect
+> GET/POST /v2/accounts/{ACCOUNT_ID}/clicktocall/{C2C_ID}/connect
+
+### Non-blocking version
 
 ```shell
 curl -v -X GET \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/clicktocall/{C2C_ID}/connect
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/clicktocall/{C2C_ID}/connect?contact={CONTACT}
+```
+
+Will return immediately with a 202
+
+```json
+    "data": {
+        "application_data": {
+            "route": "{CONTACT}"
+        },
+        "application_name": "transfer",
+        "continue_on_fail": true,
+        "custom_application_vars": {
+            "contact": "{CONTACT}"
+        },
+        "custom_channel_vars": {
+            "account_id": "{ACCOUNT_ID}",
+            "authorizing_id": "{C2C_ID}",
+            "authorizing_type": "clicktocall",
+            "auto_answer_loopback": true,
+            "from_uri": "{EXTENSION}@{ACCOUNT_REALM}",
+            "inherit_codec": false,
+            "loopback_request_uri": "{CONTACT}@{ACCOUNT_REALM}",
+            "request_uri": "{CONTACT}@{ACCOUNT_REALM}",
+            "retain_cid": true
+        },
+        "dial_endpoint_method": "single",
+        "endpoints": [
+            {
+                "invite_format": "loopback",
+                "route": "{EXTENSION}",
+                "to_did": "{EXTENSION}",
+                "to_realm": "{ACCOUNT_REALM}"
+            }
+        ],
+        "export_custom_channel_vars": [
+            "Account-ID",
+            "Authorizing-ID",
+            "Authorizing-Type",
+            "Loopback-Request-URI",
+            "From-URI",
+            "Request-URI"
+        ],
+        "ignore_early_media": true,
+        "loopback_bowout": "false",
+        "outbound_call_id": "c2c-{C2C_ID}-{RANDOM}",
+        "outbound_callee_id_name": "{EXTENSION}",
+        "outbound_callee_id_number": "{EXTENSION}",
+        "outbound_caller_id_name": "{C2C NAME}",
+        "outbound_caller_id_number": "{CONTACT}",
+        "simplify_loopback": "false",
+        "start_control_process": "false",
+        "timeout": 30
+    },
+    "node": "{NODE_HASH}",
+    "request_id": "{REQUEST_ID}",
+    "revision": "{REVISION}",
+    "status": "success",
+    "timestamp": "{TIMESTAMP}",
+    "version": "4.3.1"
+}
+
 ```
 
 ## Change
@@ -110,4 +256,3 @@ curl -v -X POST \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/clicktocall/{C2C_ID}/connect
 ```
-

--- a/applications/crossbar/doc/ref/clicktocall.md
+++ b/applications/crossbar/doc/ref/clicktocall.md
@@ -11,15 +11,38 @@ Click-to-call allows you to create URLs that can be POSTed to with a phone numbe
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `auth_required` | Determines if this click to call requires valid auth-tokens when invoked | `boolean()` | `true` | `false` |  
+`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('true' | 'false' | 'auto')` |   | `false` |  
 `caller_id_number` | Explicitly set caller id number | `string()` |   | `false` |  
+`custom_application_vars./[a-zA-Z0-9\-_]+/` |   | `string()` |   | `false` |  
+`custom_application_vars` | Key-value pairs to set as custom_application_vars on the channel | `object()` | `{}` | `false` |  
+`custom_sip_headers.in` | Custom SIP Headers to be applied to calls inbound to Kazoo from the endpoint | [#/definitions/custom_sip_headers](#custom_sip_headers) |   | `false` |  
+`custom_sip_headers.out` | Custom SIP Headers to be applied to calls outbound from Kazoo to the endpoint | [#/definitions/custom_sip_headers](#custom_sip_headers) |   | `false` |  
+`custom_sip_headers.^[a-zA-z0-9_\-]+$` | The SIP header to add | `string()` |   | `false` |  
+`custom_sip_headers` | A property list of SIP headers | `object()` |   | `false` |  
 `dial_first` | Determines what will be dialed first: extension or contact | `string('extension' | 'contact')` |   | `false` |  
 `extension` | The extension to connect to when the click to call is invoked | `string()` |   | `true` |  
+`media.ignore_early_media` | The option to determine if early media from the endpoint should always be ignored | `boolean()` |   | `false` |  
+`media` |   | `object()` |   | `false` |  
+`music_on_hold.media_id` | The ID of a media object that should be used as the music on hold | `string(0..2048)` |   | `false` |  
+`music_on_hold` | The music on hold parameters used if not a property of the device owner | `object()` |   | `false` |  
 `name` | A friendly name for the click to call | `string(1..128)` |   | `true` |  
 `outbound_callee_id_name` | Callee ID Name of the device calling out to the contact number | `string()` |   | `false` |  
 `outbound_callee_id_number` | Callee ID Number of the device calling out to the contact number | `string()` |   | `false` |  
+`presence_id` | Static presence ID (used instead of SIP username) | `string()` |   | `false` | `supported`
+`ringback` | Ringback to use | `string()` |   | `false` |  
 `throttle` | The rate that this click to call can be invoked | `integer()` |   | `false` |  
+`timeout` | How long, in seconds, to wait for the call to progress | `integer()` |   | `false` |  
 `whitelist.[]` |   | `string(1..)` |   | `false` |  
 `whitelist` | A list of regular expressions that the click to call can dial to | `array(string(1..))` |   | `false` |  
+
+### custom_sip_headers
+
+Custom SIP headers applied to an INVITE
+
+
+Key | Description | Type | Default | Required | Support Level
+--- | ----------- | ---- | ------- | -------- | -------------
+`^[a-zA-z0-9_\-]+$` | The SIP header to add | `string()` |   | `false` |  
 
 
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -3973,9 +3973,47 @@
                     "description": "Determines if this click to call requires valid auth-tokens when invoked",
                     "type": "boolean"
                 },
+                "bypass_media": {
+                    "description": "Default bypass media mode (The string type is deprecated, please use this as a boolean)",
+                    "enum": [
+                        true,
+                        false,
+                        "auto"
+                    ],
+                    "type": [
+                        "boolean",
+                        "string"
+                    ]
+                },
                 "caller_id_number": {
                     "description": "Explicitly set caller id number",
                     "type": "string"
+                },
+                "custom_application_vars": {
+                    "default": {},
+                    "description": "Key-value pairs to set as custom_application_vars on the channel",
+                    "type": "object"
+                },
+                "custom_sip_headers": {
+                    "anyOf": [
+                        {
+                            "$ref": "custom_sip_headers"
+                        },
+                        {
+                            "properties": {
+                                "in": {
+                                    "$ref": "custom_sip_headers",
+                                    "description": "Custom SIP Headers to be applied to calls inbound to Kazoo from the endpoint"
+                                },
+                                "out": {
+                                    "$ref": "custom_sip_headers",
+                                    "description": "Custom SIP Headers to be applied to calls outbound from Kazoo to the endpoint"
+                                }
+                            }
+                        }
+                    ],
+                    "description": "A property list of SIP headers",
+                    "type": "object"
                 },
                 "dial_first": {
                     "description": "Determines what will be dialed first: extension or contact",
@@ -3988,6 +4026,26 @@
                 "extension": {
                     "description": "The extension to connect to when the click to call is invoked",
                     "type": "string"
+                },
+                "media": {
+                    "properties": {
+                        "ignore_early_media": {
+                            "description": "The option to determine if early media from the endpoint should always be ignored",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "music_on_hold": {
+                    "description": "The music on hold parameters used if not a property of the device owner",
+                    "properties": {
+                        "media_id": {
+                            "description": "The ID of a media object that should be used as the music on hold",
+                            "maxLength": 2048,
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "name": {
                     "description": "A friendly name for the click to call",
@@ -4003,8 +4061,20 @@
                     "description": "Callee ID Number of the device calling out to the contact number",
                     "type": "string"
                 },
+                "presence_id": {
+                    "description": "Static presence ID (used instead of SIP username)",
+                    "type": "string"
+                },
+                "ringback": {
+                    "description": "Ringback to use",
+                    "type": "string"
+                },
                 "throttle": {
                     "description": "The rate that this click to call can be invoked",
+                    "type": "integer"
+                },
+                "timeout": {
+                    "description": "How long, in seconds, to wait for the call to progress",
                     "type": "integer"
                 },
                 "whitelist": {
@@ -19258,6 +19328,30 @@
             ],
             "type": "object"
         },
+        "kapi.pivot.processing": {
+            "description": "AMQP API for pivot.processing",
+            "properties": {
+                "Call-ID": {
+                    "type": "string"
+                },
+                "Event-Category": {
+                    "enum": [
+                        "pivot"
+                    ],
+                    "type": "string"
+                },
+                "Event-Name": {
+                    "enum": [
+                        "processing"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Call-ID"
+            ],
+            "type": "object"
+        },
         "kapi.pivot.req": {
             "description": "AMQP API for pivot.req",
             "properties": {
@@ -21746,6 +21840,9 @@
                     "type": "string"
                 },
                 "Orig-Port": {
+                    "type": "string"
+                },
+                "Origination-Call-ID": {
                     "type": "string"
                 },
                 "Prepend-CID-Name": {
@@ -31814,6 +31911,17 @@
                     "default": 4000,
                     "description": "pivot tts texts size",
                     "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.pivot.twiml": {
+            "description": "Schema for pivot.twiml system_config",
+            "properties": {
+                "conference_moh": {
+                    "default": "$${hold_music}",
+                    "description": "Default MOH for conferences dialed via TwiML",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/clicktocall.json
+++ b/applications/crossbar/priv/couchdb/schemas/clicktocall.json
@@ -8,9 +8,52 @@
             "description": "Determines if this click to call requires valid auth-tokens when invoked",
             "type": "boolean"
         },
+        "bypass_media": {
+            "description": "Default bypass media mode (The string type is deprecated, please use this as a boolean)",
+            "enum": [
+                true,
+                false,
+                "auto"
+            ],
+            "type": [
+                "boolean",
+                "string"
+            ]
+        },
         "caller_id_number": {
             "description": "Explicitly set caller id number",
             "type": "string"
+        },
+        "custom_application_vars": {
+            "default": {},
+            "description": "Key-value pairs to set as custom_application_vars on the channel",
+            "patternProperties": {
+                "[a-zA-Z0-9\\-_]+": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "custom_sip_headers": {
+            "anyOf": [
+                {
+                    "$ref": "custom_sip_headers"
+                },
+                {
+                    "properties": {
+                        "in": {
+                            "$ref": "custom_sip_headers",
+                            "description": "Custom SIP Headers to be applied to calls inbound to Kazoo from the endpoint"
+                        },
+                        "out": {
+                            "$ref": "custom_sip_headers",
+                            "description": "Custom SIP Headers to be applied to calls outbound from Kazoo to the endpoint"
+                        }
+                    }
+                }
+            ],
+            "description": "A property list of SIP headers",
+            "type": "object"
         },
         "dial_first": {
             "description": "Determines what will be dialed first: extension or contact",
@@ -23,6 +66,26 @@
         "extension": {
             "description": "The extension to connect to when the click to call is invoked",
             "type": "string"
+        },
+        "media": {
+            "properties": {
+                "ignore_early_media": {
+                    "description": "The option to determine if early media from the endpoint should always be ignored",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "music_on_hold": {
+            "description": "The music on hold parameters used if not a property of the device owner",
+            "properties": {
+                "media_id": {
+                    "description": "The ID of a media object that should be used as the music on hold",
+                    "maxLength": 2048,
+                    "type": "string"
+                }
+            },
+            "type": "object"
         },
         "name": {
             "description": "A friendly name for the click to call",
@@ -38,8 +101,21 @@
             "description": "Callee ID Number of the device calling out to the contact number",
             "type": "string"
         },
+        "presence_id": {
+            "description": "Static presence ID (used instead of SIP username)",
+            "support_level": "supported",
+            "type": "string"
+        },
+        "ringback": {
+            "description": "Ringback to use",
+            "type": "string"
+        },
         "throttle": {
             "description": "The rate that this click to call can be invoked",
+            "type": "integer"
+        },
+        "timeout": {
+            "description": "How long, in seconds, to wait for the call to progress",
             "type": "integer"
         },
         "whitelist": {

--- a/applications/crossbar/priv/couchdb/schemas/kapi.pivot.processing.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.pivot.processing.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.pivot.processing",
+    "description": "AMQP API for pivot.processing",
+    "properties": {
+        "Call-ID": {
+            "type": "string"
+        },
+        "Event-Category": {
+            "enum": [
+                "pivot"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "processing"
+            ],
+            "type": "string"
+        }
+    },
+    "required": [
+        "Call-ID"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/kapi.route.req.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.route.req.json
@@ -100,6 +100,9 @@
         "Orig-Port": {
             "type": "string"
         },
+        "Origination-Call-ID": {
+            "type": "string"
+        },
         "Prepend-CID-Name": {
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.pivot.twiml.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.pivot.twiml.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.pivot.twiml",
+    "description": "Schema for pivot.twiml system_config",
+    "properties": {
+        "conference_moh": {
+            "default": "$${hold_music}",
+            "description": "Default MOH for conferences dialed via TwiML",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/src/modules_v2/cb_devices_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_devices_v2.erl
@@ -71,20 +71,17 @@ init() ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec allowed_methods() ->
-                             http_methods().
+-spec allowed_methods() -> http_methods().
 allowed_methods() ->
     [?HTTP_GET, ?HTTP_PUT].
 
--spec allowed_methods(path_token()) ->
-                             http_methods().
+-spec allowed_methods(path_token()) -> http_methods().
 allowed_methods(?STATUS_PATH_TOKEN) ->
     [?HTTP_GET];
 allowed_methods(_DeviceId) ->
     [?HTTP_GET, ?HTTP_PATCH, ?HTTP_POST, ?HTTP_PUT, ?HTTP_DELETE].
 
--spec allowed_methods(path_token(), path_token()) ->
-                             http_methods().
+-spec allowed_methods(path_token(), path_token()) -> http_methods().
 allowed_methods(_DeviceId, ?CHECK_SYNC_PATH_TOKEN) ->
     [?HTTP_POST].
 

--- a/applications/ecallmgr/src/ecallmgr_call_control.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_control.erl
@@ -453,7 +453,9 @@ handle_loopback_destroyed(JObj, State) ->
             lager:debug("our loopback has ended but we may not have recv the bowout"),
             State;
         {_Cause, _Bowout} ->
-            lager:debug("our loopback has ended with ~s(bowout ~s); treating as done"),
+            lager:debug("our loopback has ended with ~s(bowout ~s); treating as done"
+                       ,[_Cause, _Bowout]
+                       ),
             handle_channel_destroyed(State)
     end.
 

--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -435,7 +435,9 @@ handle_bowout(Node, Props, ResigningUUID) ->
             lager:debug("call id after bowout remains the same"),
             ResigningUUID;
         {ResigningUUID, AcquiringUUID} when AcquiringUUID =/= 'undefined' ->
-            lager:debug("loopback bowout detected, replacing ~s with ~s", [ResigningUUID, AcquiringUUID]),
+            lager:debug("loopback bowout detected, replacing ~s with ~s"
+                       ,[ResigningUUID, AcquiringUUID]
+                       ),
             _ = register_event_process(Node, AcquiringUUID),
             register_for_events(Node, AcquiringUUID),
             unregister_for_events(Node, ResigningUUID),
@@ -507,7 +509,7 @@ maybe_manual_bowout(Node, <<"att_xfer">>, <<"originator">>, UUID) ->
         {'ok', #channel{loopback_other_leg=OtherLeg, is_loopback='true'}} ->
             _ = freeswitch:api(Node, 'uuid_setvar', <<UUID/binary, " ", "loopback_bowout true">>),
             _ = freeswitch:api(Node, 'uuid_setvar', <<OtherLeg/binary, " ", "loopback_bowout true">>),
-            'ok';
+            lager:info("performed manual loopback bowout on ~s and ~s", [UUID, OtherLeg]);
         _ -> 'ok'
     end;
 maybe_manual_bowout(_Node, _App, _Role, _UUID) -> 'ok'.

--- a/applications/ecallmgr/src/ecallmgr_fs_router_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_router_util.erl
@@ -134,8 +134,9 @@ route_resp_xml(_, Section, JObj, Props) ->
 -spec route_req(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist(), atom()) -> kz_term:proplist().
 route_req(CallId, FetchId, Props, Node) ->
     AccountId = kzd_freeswitch:account_id(Props),
+    lager:debug("route req for ~s (~s)", [CallId, kzd_freeswitch:origination_call_id(Props)]),
     props:filter_empty(
-      [{<<"Body">>, get_body(Props) }
+      [{<<"Body">>, get_body(Props)}
       ,{<<"Call-Direction">>, kzd_freeswitch:call_direction(Props)}
       ,{<<"Call-ID">>, CallId}
       ,{<<"Caller-ID-Name">>
@@ -154,6 +155,7 @@ route_req(CallId, FetchId, Props, Node) ->
       ,{<<"From-Tag">>, props:get_value(<<"variable_sip_from_tag">>, Props)}
       ,{<<"Message-ID">>, props:get_value(<<"Message-ID">>, Props)}
       ,{<<"Msg-ID">>, FetchId}
+      ,{<<"Origination-Call-ID">>, kzd_freeswitch:origination_call_id(Props)}
       ,{<<"Request">>, ecallmgr_util:get_sip_request(Props)}
       ,{<<"Resource-Type">>, kzd_freeswitch:resource_type(Props, <<"audio">>)}
       ,{<<"SIP-Request-Host">>, props:get_value(<<"variable_sip_req_host">>, Props)}

--- a/core/kazoo_amqp/src/api/kapi_pivot.erl
+++ b/core/kazoo_amqp/src/api/kapi_pivot.erl
@@ -17,7 +17,10 @@
 
 
 -export([failed/1, failed_v/1
+        ,processing/1, processing_v/1
+
         ,publish_failed/2
+        ,publish_processing/2
         ]).
 
 -define(KEY_PIVOT_REQ, <<"pivot.req">>).
@@ -42,6 +45,13 @@
                              ,{<<"Event-Name">>, <<"failed">>}
                              ]).
 -define(PIVOT_FAILED_TYPES, []).
+
+-define(PIVOT_PROCESSING_HEADERS, [<<"Call-ID">>]).
+-define(OPTIONAL_PIVOT_PROCESSING_HEADERS, []).
+-define(PIVOT_PROCESSING_VALUES, [{<<"Event-Category">>,<<"pivot">>}
+                                 ,{<<"Event-Name">>, <<"processing">>}
+                                 ]).
+-define(PIVOT_PROCESSING_TYPES, []).
 
 -spec req(kz_term:api_terms()) -> {'ok', iolist()} |
                                   {'error', string()}.
@@ -75,6 +85,22 @@ failed_v(Prop) when is_list(Prop) ->
 failed_v(JObj) ->
     failed_v(kz_json:to_proplist(JObj)).
 
+-spec processing(kz_term:api_terms()) -> {'ok', iolist()} |
+                                         {'error', string()}.
+processing(Prop) when is_list(Prop) ->
+    case processing_v(Prop) of
+        'false' -> {'error', "Proplist processing validation for pivot_processing"};
+        'true' -> kz_api:build_message(Prop, ?PIVOT_PROCESSING_HEADERS, ?OPTIONAL_PIVOT_PROCESSING_HEADERS)
+    end;
+processing(JObj) ->
+    processing(kz_json:to_proplist(JObj)).
+
+-spec processing_v(kz_term:api_terms()) -> boolean().
+processing_v(Prop) when is_list(Prop) ->
+    kz_api:validate(Prop, ?PIVOT_PROCESSING_HEADERS, ?PIVOT_PROCESSING_VALUES, ?PIVOT_PROCESSING_TYPES);
+processing_v(JObj) ->
+    processing_v(kz_json:to_proplist(JObj)).
+
 -spec bind_q(kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 bind_q(Queue, Props) ->
     Realm = props:get_value('realm', Props, <<"*">>),
@@ -107,10 +133,14 @@ publish_req(Req, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(Req, ?PIVOT_REQ_VALUES, fun req/1),
     kz_amqp_util:callmgr_publish(Payload, ContentType, get_pivot_req_routing(Req)).
 
-
 -spec publish_failed(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
 publish_failed(Target, JObj) ->
     {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?PIVOT_FAILED_VALUES, fun failed/1),
+    kz_amqp_util:targeted_publish(Target, Payload).
+
+-spec publish_processing(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
+publish_processing(Target, JObj) ->
+    {'ok', Payload} = kz_api:prepare_api_payload(JObj, ?PIVOT_PROCESSING_VALUES, fun processing/1),
     kz_amqp_util:targeted_publish(Target, Payload).
 
 -spec get_from_realm(kz_term:api_terms()) -> kz_term:ne_binary().

--- a/core/kazoo_amqp/src/api/kapi_resource.erl
+++ b/core/kazoo_amqp/src/api/kapi_resource.erl
@@ -72,19 +72,20 @@
                                         ,<<"Existing-Call-ID">> % If set, use this node, otherwise ignore
                                         ,<<"Export-Custom-Channel-Vars">>
                                         ,<<"Originate-Immediate">>
-                                        ,<<"Outbound-Call-ID">>
                                         ,<<"Origination-Call-ID">>
+                                        ,<<"Outbound-Call-ID">>
 
                                              %% Eavesdrop
                                         ,<<"Eavesdrop-Call-ID">>
-                                        ,<<"Eavesdrop-Mode">>
                                         ,<<"Eavesdrop-Group-ID">>
+                                        ,<<"Eavesdrop-Mode">>
+
                                         ,<<"Fax-Identity-Name">>
                                         ,<<"Fax-Identity-Number">>
                                         ,<<"Fax-Timezone">>
                                         ,<<"Intercept-Unbridged-Only">>
-                                        ,<<"Simplify-Loopback">> %% loopback_bowout flag
                                         ,<<"Loopback-Bowout">>
+                                        ,<<"Simplify-Loopback">> %% loopback_bowout flag
                                         ,<<"Start-Control-Process">>
                                              | kapi_dialplan:optional_bridge_req_headers()
                                         ]).

--- a/core/kazoo_amqp/src/api/kapi_route.hrl
+++ b/core/kazoo_amqp/src/api/kapi_route.hrl
@@ -35,6 +35,7 @@
                                     ,<<"Message-ID">>
                                     ,<<"Orig-IP">>
                                     ,<<"Orig-Port">>
+                                    ,<<"Origination-Call-ID">>
                                     ,<<"Prepend-CID-Name">>
                                     ,<<"Resource-Type">>
                                     ,<<"Ringback-Media">>

--- a/core/kazoo_amqp/src/api/kz_api.erl
+++ b/core/kazoo_amqp/src/api/kz_api.erl
@@ -24,7 +24,7 @@
         ,default_headers/4
         ,default_headers/5
 
-        ,call_id/1
+        ,call_id/1, call_id/2
         ,account_id/1
         ,server_id/1
         ,queue_id/1
@@ -125,11 +125,15 @@ account_id(Props) when is_list(Props) ->
 account_id(JObj) ->
     kz_json:get_value(?KEY_API_ACCOUNT_ID, JObj).
 
--spec call_id(kz_term:api_terms()) -> kz_term:api_binary().
-call_id(Props) when is_list(Props) ->
-    props:get_value(?KEY_API_CALL_ID, Props);
-call_id(JObj) ->
-    kz_json:get_value(?KEY_API_CALL_ID, JObj).
+-spec call_id(kz_term:api_terms()) -> kz_term:api_ne_binary().
+call_id(API) ->
+    call_id(API, 'undefined').
+
+-spec call_id(kz_term:api_terms(), Default) -> kz_term:ne_binary() | Default.
+call_id(Props, Default) when is_list(Props) ->
+    props:get_ne_binary_value(?KEY_API_CALL_ID, Props, Default);
+call_id(JObj, Default) ->
+    kz_json:get_ne_binary_value(?KEY_API_CALL_ID, JObj, Default).
 
 -spec defer_response(kz_term:api_terms()) -> kz_term:api_binary().
 defer_response(Props) when is_list(Props) ->

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -102,14 +102,14 @@ binding({Common, Specific}) when is_atom(Common), is_binary(Specific) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec bind(atom() | {atom(), binary()}, module(), atom()) -> any().
+-spec bind(atom() | {atom(), binary()}, module(), atom()) -> kazoo_bindings:bind_result().
 bind(Event, M, F) -> kazoo_bindings:bind(binding(Event), M, F).
 
 %%------------------------------------------------------------------------------
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec unbind(atom() | {atom(), binary()}, module(), atom()) -> any().
+-spec unbind(atom() | {atom(), binary()}, module(), atom()) -> kazoo_bindings:unbind_result().
 unbind(Event, M, F) -> kazoo_bindings:unbind(binding(Event), M, F).
 
 %%------------------------------------------------------------------------------
@@ -254,7 +254,8 @@ blocking_refresh(Pause) ->
 %%------------------------------------------------------------------------------
 -spec register_views() -> 'ok'.
 register_views() ->
-    kazoo_bindings:map(binding('register_views'), []).
+    _ = kazoo_bindings:map(binding('register_views'), []),
+    'ok'.
 
 %%------------------------------------------------------------------------------
 %% @doc Register views from specific `App' application.
@@ -264,7 +265,8 @@ register_views() ->
 %%------------------------------------------------------------------------------
 -spec register_views(kz_term:ne_binary() | atom()) -> 'ok'.
 register_views(?NE_BINARY=App) ->
-    kazoo_bindings:map(binding({'register_views', App}), []);
+    _ = kazoo_bindings:map(binding({'register_views', App}), []),
+    'ok';
 register_views(App) when is_atom(App) ->
     register_views(kz_term:to_binary(App)).
 
@@ -274,7 +276,7 @@ register_views(App) when is_atom(App) ->
 %%------------------------------------------------------------------------------
 -spec bind_and_register_views(atom() | kz_term:ne_binary(), atom(), atom()) -> 'ok'.
 bind_and_register_views(_AppName, Module, Function) ->
-    bind('register_views', Module, Function),
+    _ = bind('register_views', Module, Function),
     %% bind({'register_views', kz_term:to_binary(AppName)}, Module, Function),
     _ = Module:Function(),
     'ok'.
@@ -994,11 +996,11 @@ show_status(CallId, 'true', Resp) ->
 
 -spec last_migrate_version() -> kz_term:ne_binary().
 last_migrate_version() ->
-    kapps_config:get_ne_binary(?MODULE, <<"migrate_current_version">>, <<"3.22">>).
+    kapps_config:get_ne_binary(<<?MODULE_STRING>>, <<"migrate_current_version">>, <<"3.22">>).
 
 -spec set_last_migrate_version(kz_term:ne_binary()) -> {'ok', kz_json:object()}.
 set_last_migrate_version(Version) ->
-    kapps_config:set(?MODULE, <<"migrate_current_version">>, Version).
+    kapps_config:set(<<?MODULE_STRING>>, <<"migrate_current_version">>, Version).
 
 -spec migrate_system() -> 'ok'.
 migrate_system() ->

--- a/core/kazoo_data/src/kzs_plan.erl
+++ b/core/kazoo_data/src/kzs_plan.erl
@@ -386,7 +386,7 @@ bind() ->
                         ], <<".">>),
     kazoo_bindings:bind(RK, fun handle_new/1).
 
--spec handle_new(kz_json:object()) -> 'ok'.
+-spec handle_new(kz_json:objects()) -> 'ok'.
 handle_new([JObj]) ->
     AccountId = kz_json:get_ne_binary_value(<<"ID">>, JObj),
     lager:warning("received new storage for account ~s", [AccountId]),

--- a/core/kazoo_documents/src/kzd_clicktocall.erl
+++ b/core/kazoo_documents/src/kzd_clicktocall.erl
@@ -1,19 +1,30 @@
 %%%-----------------------------------------------------------------------------
 %%% @copyright (C) 2010-2018, 2600Hz
-%%% @doc
+%%% @doc Accessors for `clicktocall' document.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kzd_clicktocall).
 
 -export([new/0]).
 -export([auth_required/1, auth_required/2, set_auth_required/2]).
+-export([bypass_media/1, bypass_media/2, set_bypass_media/2]).
 -export([caller_id_number/1, caller_id_number/2, set_caller_id_number/2]).
+-export([custom_application_vars/1, custom_application_vars/2, set_custom_application_vars/2]).
+-export([custom_application_var/2, custom_application_var/3, set_custom_application_var/3]).
+-export([custom_sip_headers/1, custom_sip_headers/2, set_custom_sip_headers/2]).
 -export([dial_first/1, dial_first/2, set_dial_first/2]).
 -export([extension/1, extension/2, set_extension/2]).
+-export([media/1, media/2, set_media/2]).
+-export([media_ignore_early_media/1, media_ignore_early_media/2, set_media_ignore_early_media/2]).
+-export([music_on_hold/1, music_on_hold/2, set_music_on_hold/2]).
+-export([music_on_hold_media_id/1, music_on_hold_media_id/2, set_music_on_hold_media_id/2]).
 -export([name/1, name/2, set_name/2]).
 -export([outbound_callee_id_name/1, outbound_callee_id_name/2, set_outbound_callee_id_name/2]).
 -export([outbound_callee_id_number/1, outbound_callee_id_number/2, set_outbound_callee_id_number/2]).
+-export([presence_id/1, presence_id/2, set_presence_id/2]).
+-export([ringback/1, ringback/2, set_ringback/2]).
 -export([throttle/1, throttle/2, set_throttle/2]).
+-export([timeout/1, timeout/2, set_timeout/2]).
 -export([whitelist/1, whitelist/2, set_whitelist/2]).
 
 
@@ -40,6 +51,18 @@ auth_required(Doc, Default) ->
 set_auth_required(Doc, AuthRequired) ->
     kz_json:set_value([<<"auth_required">>], AuthRequired, Doc).
 
+-spec bypass_media(doc()) -> any().
+bypass_media(Doc) ->
+    bypass_media(Doc, 'undefined').
+
+-spec bypass_media(doc(), Default) -> any() | Default.
+bypass_media(Doc, Default) ->
+    kz_json:get_value([<<"bypass_media">>], Doc, Default).
+
+-spec set_bypass_media(doc(), any()) -> doc().
+set_bypass_media(Doc, BypassMedia) ->
+    kz_json:set_value([<<"bypass_media">>], BypassMedia, Doc).
+
 -spec caller_id_number(doc()) -> kz_term:api_binary().
 caller_id_number(Doc) ->
     caller_id_number(Doc, 'undefined').
@@ -51,6 +74,42 @@ caller_id_number(Doc, Default) ->
 -spec set_caller_id_number(doc(), binary()) -> doc().
 set_caller_id_number(Doc, CallerIdNumber) ->
     kz_json:set_value([<<"caller_id_number">>], CallerIdNumber, Doc).
+
+-spec custom_application_vars(doc()) -> kz_json:object().
+custom_application_vars(Doc) ->
+    custom_application_vars(Doc, kz_json:new()).
+
+-spec custom_application_vars(doc(), Default) -> kz_json:object() | Default.
+custom_application_vars(Doc, Default) ->
+    kz_json:get_json_value([<<"custom_application_vars">>], Doc, Default).
+
+-spec set_custom_application_vars(doc(), kz_json:object()) -> doc().
+set_custom_application_vars(Doc, CustomApplicationVars) ->
+    kz_json:set_value([<<"custom_application_vars">>], CustomApplicationVars, Doc).
+
+-spec custom_application_var(doc(), kz_json:key()) -> kz_term:api_binary().
+custom_application_var(Doc, CustomApplicationVar) ->
+    custom_application_var(Doc, CustomApplicationVar, 'undefined').
+
+-spec custom_application_var(doc(), kz_json:key(), Default) -> binary() | Default.
+custom_application_var(Doc, CustomApplicationVar, Default) ->
+    kz_json:get_binary_value([<<"custom_application_vars">>, CustomApplicationVar], Doc, Default).
+
+-spec set_custom_application_var(doc(), kz_json:key(), binary()) -> doc().
+set_custom_application_var(Doc, CustomApplicationVar, Value) ->
+    kz_json:set_value([<<"custom_application_vars">>, CustomApplicationVar], Value, Doc).
+
+-spec custom_sip_headers(doc()) -> kz_term:api_object().
+custom_sip_headers(Doc) ->
+    custom_sip_headers(Doc, 'undefined').
+
+-spec custom_sip_headers(doc(), Default) -> kz_json:object() | Default.
+custom_sip_headers(Doc, Default) ->
+    kz_json:get_json_value([<<"custom_sip_headers">>], Doc, Default).
+
+-spec set_custom_sip_headers(doc(), kz_json:object()) -> doc().
+set_custom_sip_headers(Doc, CustomSipHeaders) ->
+    kz_json:set_value([<<"custom_sip_headers">>], CustomSipHeaders, Doc).
 
 -spec dial_first(doc()) -> kz_term:api_binary().
 dial_first(Doc) ->
@@ -75,6 +134,54 @@ extension(Doc, Default) ->
 -spec set_extension(doc(), binary()) -> doc().
 set_extension(Doc, Extension) ->
     kz_json:set_value([<<"extension">>], Extension, Doc).
+
+-spec media(doc()) -> kz_term:api_object().
+media(Doc) ->
+    media(Doc, 'undefined').
+
+-spec media(doc(), Default) -> kz_json:object() | Default.
+media(Doc, Default) ->
+    kz_json:get_json_value([<<"media">>], Doc, Default).
+
+-spec set_media(doc(), kz_json:object()) -> doc().
+set_media(Doc, Media) ->
+    kz_json:set_value([<<"media">>], Media, Doc).
+
+-spec media_ignore_early_media(doc()) -> kz_term:api_boolean().
+media_ignore_early_media(Doc) ->
+    media_ignore_early_media(Doc, 'undefined').
+
+-spec media_ignore_early_media(doc(), Default) -> boolean() | Default.
+media_ignore_early_media(Doc, Default) ->
+    kz_json:get_boolean_value([<<"media">>, <<"ignore_early_media">>], Doc, Default).
+
+-spec set_media_ignore_early_media(doc(), boolean()) -> doc().
+set_media_ignore_early_media(Doc, MediaIgnoreEarlyMedia) ->
+    kz_json:set_value([<<"media">>, <<"ignore_early_media">>], MediaIgnoreEarlyMedia, Doc).
+
+-spec music_on_hold(doc()) -> kz_term:api_object().
+music_on_hold(Doc) ->
+    music_on_hold(Doc, 'undefined').
+
+-spec music_on_hold(doc(), Default) -> kz_json:object() | Default.
+music_on_hold(Doc, Default) ->
+    kz_json:get_json_value([<<"music_on_hold">>], Doc, Default).
+
+-spec set_music_on_hold(doc(), kz_json:object()) -> doc().
+set_music_on_hold(Doc, MusicOnHold) ->
+    kz_json:set_value([<<"music_on_hold">>], MusicOnHold, Doc).
+
+-spec music_on_hold_media_id(doc()) -> kz_term:api_binary().
+music_on_hold_media_id(Doc) ->
+    music_on_hold_media_id(Doc, 'undefined').
+
+-spec music_on_hold_media_id(doc(), Default) -> binary() | Default.
+music_on_hold_media_id(Doc, Default) ->
+    kz_json:get_binary_value([<<"music_on_hold">>, <<"media_id">>], Doc, Default).
+
+-spec set_music_on_hold_media_id(doc(), binary()) -> doc().
+set_music_on_hold_media_id(Doc, MusicOnHoldMediaId) ->
+    kz_json:set_value([<<"music_on_hold">>, <<"media_id">>], MusicOnHoldMediaId, Doc).
 
 -spec name(doc()) -> kz_term:api_ne_binary().
 name(Doc) ->
@@ -112,6 +219,30 @@ outbound_callee_id_number(Doc, Default) ->
 set_outbound_callee_id_number(Doc, OutboundCalleeIdNumber) ->
     kz_json:set_value([<<"outbound_callee_id_number">>], OutboundCalleeIdNumber, Doc).
 
+-spec presence_id(doc()) -> kz_term:api_binary().
+presence_id(Doc) ->
+    presence_id(Doc, 'undefined').
+
+-spec presence_id(doc(), Default) -> binary() | Default.
+presence_id(Doc, Default) ->
+    kz_json:get_binary_value([<<"presence_id">>], Doc, Default).
+
+-spec set_presence_id(doc(), binary()) -> doc().
+set_presence_id(Doc, PresenceId) ->
+    kz_json:set_value([<<"presence_id">>], PresenceId, Doc).
+
+-spec ringback(doc()) -> kz_term:api_binary().
+ringback(Doc) ->
+    ringback(Doc, 'undefined').
+
+-spec ringback(doc(), Default) -> binary() | Default.
+ringback(Doc, Default) ->
+    kz_json:get_binary_value([<<"ringback">>], Doc, Default).
+
+-spec set_ringback(doc(), binary()) -> doc().
+set_ringback(Doc, Ringback) ->
+    kz_json:set_value([<<"ringback">>], Ringback, Doc).
+
 -spec throttle(doc()) -> kz_term:api_integer().
 throttle(Doc) ->
     throttle(Doc, 'undefined').
@@ -123,6 +254,18 @@ throttle(Doc, Default) ->
 -spec set_throttle(doc(), integer()) -> doc().
 set_throttle(Doc, Throttle) ->
     kz_json:set_value([<<"throttle">>], Throttle, Doc).
+
+-spec timeout(doc()) -> kz_term:api_integer().
+timeout(Doc) ->
+    timeout(Doc, 'undefined').
+
+-spec timeout(doc(), Default) -> integer() | Default.
+timeout(Doc, Default) ->
+    kz_json:get_integer_value([<<"timeout">>], Doc, Default).
+
+-spec set_timeout(doc(), integer()) -> doc().
+set_timeout(Doc, Timeout) ->
+    kz_json:set_value([<<"timeout">>], Timeout, Doc).
 
 -spec whitelist(doc()) -> kz_term:api_ne_binaries().
 whitelist(Doc) ->

--- a/core/kazoo_documents/src/kzd_clicktocall.erl.src
+++ b/core/kazoo_documents/src/kzd_clicktocall.erl.src
@@ -7,13 +7,24 @@
 
 -export([new/0]).
 -export([auth_required/1, auth_required/2, set_auth_required/2]).
+-export([bypass_media/1, bypass_media/2, set_bypass_media/2]).
 -export([caller_id_number/1, caller_id_number/2, set_caller_id_number/2]).
+-export([custom_application_vars/1, custom_application_vars/2, set_custom_application_vars/2]).
+-export([custom_application_var/2, custom_application_var/3, set_custom_application_var/3]).
+-export([custom_sip_headers/1, custom_sip_headers/2, set_custom_sip_headers/2]).
 -export([dial_first/1, dial_first/2, set_dial_first/2]).
 -export([extension/1, extension/2, set_extension/2]).
+-export([media/1, media/2, set_media/2]).
+-export([media_ignore_early_media/1, media_ignore_early_media/2, set_media_ignore_early_media/2]).
+-export([music_on_hold/1, music_on_hold/2, set_music_on_hold/2]).
+-export([music_on_hold_media_id/1, music_on_hold_media_id/2, set_music_on_hold_media_id/2]).
 -export([name/1, name/2, set_name/2]).
 -export([outbound_callee_id_name/1, outbound_callee_id_name/2, set_outbound_callee_id_name/2]).
 -export([outbound_callee_id_number/1, outbound_callee_id_number/2, set_outbound_callee_id_number/2]).
+-export([presence_id/1, presence_id/2, set_presence_id/2]).
+-export([ringback/1, ringback/2, set_ringback/2]).
 -export([throttle/1, throttle/2, set_throttle/2]).
+-export([timeout/1, timeout/2, set_timeout/2]).
 -export([whitelist/1, whitelist/2, set_whitelist/2]).
 
 
@@ -40,6 +51,18 @@ auth_required(Doc, Default) ->
 set_auth_required(Doc, AuthRequired) ->
     kz_json:set_value([<<"auth_required">>], AuthRequired, Doc).
 
+-spec bypass_media(doc()) -> any().
+bypass_media(Doc) ->
+    bypass_media(Doc, 'undefined').
+
+-spec bypass_media(doc(), Default) -> any() | Default.
+bypass_media(Doc, Default) ->
+    kz_json:get_value([<<"bypass_media">>], Doc, Default).
+
+-spec set_bypass_media(doc(), any()) -> doc().
+set_bypass_media(Doc, BypassMedia) ->
+    kz_json:set_value([<<"bypass_media">>], BypassMedia, Doc).
+
 -spec caller_id_number(doc()) -> kz_term:api_binary().
 caller_id_number(Doc) ->
     caller_id_number(Doc, 'undefined').
@@ -51,6 +74,42 @@ caller_id_number(Doc, Default) ->
 -spec set_caller_id_number(doc(), binary()) -> doc().
 set_caller_id_number(Doc, CallerIdNumber) ->
     kz_json:set_value([<<"caller_id_number">>], CallerIdNumber, Doc).
+
+-spec custom_application_vars(doc()) -> kz_json:object().
+custom_application_vars(Doc) ->
+    custom_application_vars(Doc, kz_json:new()).
+
+-spec custom_application_vars(doc(), Default) -> kz_json:object() | Default.
+custom_application_vars(Doc, Default) ->
+    kz_json:get_json_value([<<"custom_application_vars">>], Doc, Default).
+
+-spec set_custom_application_vars(doc(), kz_json:object()) -> doc().
+set_custom_application_vars(Doc, CustomApplicationVars) ->
+    kz_json:set_value([<<"custom_application_vars">>], CustomApplicationVars, Doc).
+
+-spec custom_application_var(doc(), kz_json:key()) -> kz_term:api_binary().
+custom_application_var(Doc, CustomApplicationVar) ->
+    custom_application_var(Doc, CustomApplicationVar, 'undefined').
+
+-spec custom_application_var(doc(), kz_json:key(), Default) -> binary() | Default.
+custom_application_var(Doc, CustomApplicationVar, Default) ->
+    kz_json:get_binary_value([<<"custom_application_vars">>, CustomApplicationVar], Doc, Default).
+
+-spec set_custom_application_var(doc(), kz_json:key(), binary()) -> doc().
+set_custom_application_var(Doc, CustomApplicationVar, Value) ->
+    kz_json:set_value([<<"custom_application_vars">>, CustomApplicationVar], Value, Doc).
+
+-spec custom_sip_headers(doc()) -> kz_term:api_object().
+custom_sip_headers(Doc) ->
+    custom_sip_headers(Doc, 'undefined').
+
+-spec custom_sip_headers(doc(), Default) -> kz_json:object() | Default.
+custom_sip_headers(Doc, Default) ->
+    kz_json:get_json_value([<<"custom_sip_headers">>], Doc, Default).
+
+-spec set_custom_sip_headers(doc(), kz_json:object()) -> doc().
+set_custom_sip_headers(Doc, CustomSipHeaders) ->
+    kz_json:set_value([<<"custom_sip_headers">>], CustomSipHeaders, Doc).
 
 -spec dial_first(doc()) -> kz_term:api_binary().
 dial_first(Doc) ->
@@ -75,6 +134,54 @@ extension(Doc, Default) ->
 -spec set_extension(doc(), binary()) -> doc().
 set_extension(Doc, Extension) ->
     kz_json:set_value([<<"extension">>], Extension, Doc).
+
+-spec media(doc()) -> kz_term:api_object().
+media(Doc) ->
+    media(Doc, 'undefined').
+
+-spec media(doc(), Default) -> kz_json:object() | Default.
+media(Doc, Default) ->
+    kz_json:get_json_value([<<"media">>], Doc, Default).
+
+-spec set_media(doc(), kz_json:object()) -> doc().
+set_media(Doc, Media) ->
+    kz_json:set_value([<<"media">>], Media, Doc).
+
+-spec media_ignore_early_media(doc()) -> kz_term:api_boolean().
+media_ignore_early_media(Doc) ->
+    media_ignore_early_media(Doc, 'undefined').
+
+-spec media_ignore_early_media(doc(), Default) -> boolean() | Default.
+media_ignore_early_media(Doc, Default) ->
+    kz_json:get_boolean_value([<<"media">>, <<"ignore_early_media">>], Doc, Default).
+
+-spec set_media_ignore_early_media(doc(), boolean()) -> doc().
+set_media_ignore_early_media(Doc, MediaIgnoreEarlyMedia) ->
+    kz_json:set_value([<<"media">>, <<"ignore_early_media">>], MediaIgnoreEarlyMedia, Doc).
+
+-spec music_on_hold(doc()) -> kz_term:api_object().
+music_on_hold(Doc) ->
+    music_on_hold(Doc, 'undefined').
+
+-spec music_on_hold(doc(), Default) -> kz_json:object() | Default.
+music_on_hold(Doc, Default) ->
+    kz_json:get_json_value([<<"music_on_hold">>], Doc, Default).
+
+-spec set_music_on_hold(doc(), kz_json:object()) -> doc().
+set_music_on_hold(Doc, MusicOnHold) ->
+    kz_json:set_value([<<"music_on_hold">>], MusicOnHold, Doc).
+
+-spec music_on_hold_media_id(doc()) -> kz_term:api_binary().
+music_on_hold_media_id(Doc) ->
+    music_on_hold_media_id(Doc, 'undefined').
+
+-spec music_on_hold_media_id(doc(), Default) -> binary() | Default.
+music_on_hold_media_id(Doc, Default) ->
+    kz_json:get_binary_value([<<"music_on_hold">>, <<"media_id">>], Doc, Default).
+
+-spec set_music_on_hold_media_id(doc(), binary()) -> doc().
+set_music_on_hold_media_id(Doc, MusicOnHoldMediaId) ->
+    kz_json:set_value([<<"music_on_hold">>, <<"media_id">>], MusicOnHoldMediaId, Doc).
 
 -spec name(doc()) -> kz_term:api_ne_binary().
 name(Doc) ->
@@ -112,6 +219,30 @@ outbound_callee_id_number(Doc, Default) ->
 set_outbound_callee_id_number(Doc, OutboundCalleeIdNumber) ->
     kz_json:set_value([<<"outbound_callee_id_number">>], OutboundCalleeIdNumber, Doc).
 
+-spec presence_id(doc()) -> kz_term:api_binary().
+presence_id(Doc) ->
+    presence_id(Doc, 'undefined').
+
+-spec presence_id(doc(), Default) -> binary() | Default.
+presence_id(Doc, Default) ->
+    kz_json:get_binary_value([<<"presence_id">>], Doc, Default).
+
+-spec set_presence_id(doc(), binary()) -> doc().
+set_presence_id(Doc, PresenceId) ->
+    kz_json:set_value([<<"presence_id">>], PresenceId, Doc).
+
+-spec ringback(doc()) -> kz_term:api_binary().
+ringback(Doc) ->
+    ringback(Doc, 'undefined').
+
+-spec ringback(doc(), Default) -> binary() | Default.
+ringback(Doc, Default) ->
+    kz_json:get_binary_value([<<"ringback">>], Doc, Default).
+
+-spec set_ringback(doc(), binary()) -> doc().
+set_ringback(Doc, Ringback) ->
+    kz_json:set_value([<<"ringback">>], Ringback, Doc).
+
 -spec throttle(doc()) -> kz_term:api_integer().
 throttle(Doc) ->
     throttle(Doc, 'undefined').
@@ -123,6 +254,18 @@ throttle(Doc, Default) ->
 -spec set_throttle(doc(), integer()) -> doc().
 set_throttle(Doc, Throttle) ->
     kz_json:set_value([<<"throttle">>], Throttle, Doc).
+
+-spec timeout(doc()) -> kz_term:api_integer().
+timeout(Doc) ->
+    timeout(Doc, 'undefined').
+
+-spec timeout(doc(), Default) -> integer() | Default.
+timeout(Doc, Default) ->
+    kz_json:get_integer_value([<<"timeout">>], Doc, Default).
+
+-spec set_timeout(doc(), integer()) -> doc().
+set_timeout(Doc, Timeout) ->
+    kz_json:set_value([<<"timeout">>], Timeout, Doc).
 
 -spec whitelist(doc()) -> kz_term:api_ne_binaries().
 whitelist(Doc) ->

--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -133,8 +133,8 @@ add_defaults(JObj, <<_/binary>> = Schema) ->
 add_defaults(JObj, SchemaJObj) ->
     try validate(SchemaJObj, JObj) of
         {'ok', WithDefaultsJObj} -> WithDefaultsJObj;
-        {'error', Err} ->
-            lager:debug("schema has errors : ~p ", [Err]),
+        {'error', Errors} ->
+            lager:info("errors applying defaults : ~p", [errors_to_jobj(Errors)]),
             JObj
     catch
         _Ex:_Err ->
@@ -843,7 +843,7 @@ default_object(Schema) ->
         {'ok', JObj} -> JObj;
         {'error', Err} ->
             lager:debug("failed to build default object for ~s due to errors: ~p"
-                       , [kz_doc:id(Schema), Err]
+                       ,[kz_doc:id(Schema), Err]
                        ),
             kz_json:new()
     catch

--- a/core/kazoo_translator/src/converters/kzt_twiml_dial.erl
+++ b/core/kazoo_translator/src/converters/kzt_twiml_dial.erl
@@ -435,18 +435,25 @@ conference_profile(AccountId, ConfProps) ->
       ,{<<"max-members">>, get_max_participants(ConfProps)}
       ,{<<"member-flags">>, conference_member_flags(ConfProps)}
       ,{<<"moderator-controls">>, props:get_binary_value('moderatorControls', ConfProps, <<"default">>)}
-      ,{<<"moh-sound">>, props:get_binary_value('waitUrl', ConfProps, <<"http://com.twilio.music.classical.s3.amazonaws.com/Mellotroniac_-_Flight_Of_Young_Hearts_Flute.mp3">>)}
-      ,{<<"rate">>, props:get_integer_value('rate', ConfProps, 48000)}
+      ,{<<"moh-sound">>, get_moh(ConfProps)}
+      ,{<<"rate">>, props:get_integer_value('rate', ConfProps, 16000)}
       ,{<<"tts-engine">>, kzt_twiml_util:get_engine(ConfProps)}
       ,{<<"tts-voice">>, kzt_twiml_util:get_voice(ConfProps)}
       ]).
 
+-spec get_moh(kz_term:proplist()) -> kz_term:ne_binary_value().
+get_moh(ConfProps) ->
+    Default = kapps_config:get_ne_binary(<<"pivot.twiml">>, <<"conference_moh">>, <<"$${hold_music}">>),
+    props:get_binary_value('waitUrl', ConfProps, Default).
+
+-spec conference_flags(kz_term:proplist()) -> kz_term:api_ne_binary_value().
 conference_flags(ConfProps) ->
     case props:get_is_true('startConferenceOnEnter', ConfProps, 'true') of
         'true' -> 'undefined';
         'false' -> <<"wait-mod">>
     end.
 
+-spec conference_member_flags(kz_term:proplist()) -> kz_term:api_ne_binary_value().
 conference_member_flags(ConfProps) ->
     case props:get_is_true('endConferenceOnExit', ConfProps, 'false') of
         'true' -> <<"endconf">>;

--- a/core/kazoo_translator/src/converters/kzt_twiml_util.erl
+++ b/core/kazoo_translator/src/converters/kzt_twiml_util.erl
@@ -81,7 +81,7 @@ get_finish_key(Props) ->
 
 -spec get_max_length(kz_term:proplist()) -> pos_integer().
 get_max_length(Props) ->
-    Max = kapps_config:get_integer(?MODULE, <<"max_length">>, 3600),
+    Max = kapps_config:get_integer(<<?MODULE_STRING>>, <<"max_length">>, 3600),
     case props:get_integer_value('maxLength', Props) of
         'undefined' -> Max;
         N when N > 0, N =< Max -> N

--- a/core/kazoo_translator/src/kzt_translator.erl
+++ b/core/kazoo_translator/src/kzt_translator.erl
@@ -8,29 +8,36 @@
 %%%-----------------------------------------------------------------------------
 -module(kzt_translator).
 
--export([exec/2, exec/3
+-export([exec/4
         ,get_user_vars/1
         ,set_user_vars/2
         ]).
 
 -include("kzt.hrl").
 
--spec exec(kapps_call:call(), binary()) -> exec_return().
-exec(Call, Cmds) ->
-    exec(Call, Cmds, <<"text/xml">>).
-
--spec exec(kapps_call:call(), binary(), kz_term:api_binary() | list()) -> exec_return().
-exec(Call, Cmds, 'undefined') ->
-    exec(Call, Cmds, <<"text/xml">>);
-exec(Call, Cmds, CT) when not is_binary(CT) ->
-    exec(Call, Cmds, kz_term:to_binary(CT));
-exec(Call, Cmds, CT) ->
+-spec exec(kz_term:ne_binary(), kapps_call:call(), binary(), kz_term:api_binary() | list()) ->
+                  exec_return().
+exec(RequesterQ, Call, 'undefined', Cmds) ->
+    exec(RequesterQ, Call, <<"text/xml">>, Cmds);
+exec(RequesterQ, Call, CT, Cmds) when not is_binary(CT) ->
+    exec(RequesterQ, Call, kz_term:to_binary(CT), Cmds);
+exec(RequesterQ, Call, CT, Cmds) ->
     case [{M, Cmd1} || M <- find_candidate_translators(just_the_type(CT)),
                        begin {IsRecognized, Cmd1} = is_recognized(M, Cmds), IsRecognized end
          ] of
         [] -> throw({'error', 'unrecognized_cmds'});
-        [{Translator, Cmds1}|_] -> Translator:exec(Call, Cmds1)
+        [{Translator, Cmds1}|_] ->
+            _ = publish_processing(RequesterQ, Call),
+            Translator:exec(Call, Cmds1)
     end.
+
+publish_processing(RequesterQ, Call) ->
+    PubFun = fun(P) -> kapi_pivot:publish_processing(RequesterQ, P) end,
+    kz_amqp_worker:cast([{<<"Call-ID">>, kapps_call:call_id(Call)}
+                         | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                        ]
+                       ,PubFun
+                       ).
 
 -spec just_the_type(kz_term:ne_binary()) -> kz_term:ne_binary().
 just_the_type(ContentType) ->

--- a/core/kazoo_translator/src/kzt_util.erl
+++ b/core/kazoo_translator/src/kzt_util.erl
@@ -360,7 +360,7 @@ get_request_vars(Call) ->
       ,{<<"CallStatus">>, get_call_status(Call)}
       ]).
 
--spec iteration(kapps_call:call()) -> kapps_call:call().
+-spec iteration(kapps_call:call()) -> pos_integer().
 iteration(Call) ->
     kapps_call:kvs_fetch('pivot_counter', 1, Call).
 


### PR DESCRIPTION
* refactor bindings

* update c2c schema to reflect what the code allows

* use accessor module

* remove blocking from c2c doc, should be a qs param

* add blocking response if requested

* more logging around starting kapps

* handle already_started error

* don't update if the diff is empty

* don't perform update when no changes occurred

* default to system hold music

* start to update docs with json responses

* simplify loopback

* address dialyzer complaints

* add default conference moh to system_config

* update description

* publish a processing message to let cf_pivot go

* add processing api

* format

* cleanup specs

* update logging

* use gen_listener's AMQP channel

* add bindings for origination-call-id if present

* don't simplify

* take a default

* nicer logging

* set origination-call-id from route_req

* update spec/accessor

* add schema field

* make sure call-id is a binary

* fix spec

* log schema errors when applying defaults

* log the updated doc before saving

* more logging for insight

* if the doc doesn't exist, save it

* less verbose logging

* if the event is for a loopback, use call-id or unique-id only

faxes uses origination-call-id for real legs to carriers and so needs
the events publised using the asked-for origination-call-id.

c2c and others use loopbacks with origination-call-id but the cf_exe
binds to the loopback-b leg (a FS UUID). Events are then published
using the origination-call-id in the routing key when the call-id is
the FS UUID, and cf_exe doesn't receive them.

* remove origination bindings now that events are published with call-id

* default to not loopback

* log reasons to stop