### PR TITLE
Voicemail callback

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -924,7 +924,7 @@ play_messages([H|T]=Messages, PrevMessages, Count, #mailbox{seek_duration=SeekDu
                 Number ->
                     lager:info("caller chose to callback number ~s", [Number]),
                     case maybe_branch_call(Call, Number, Box) of
-                        'ok' -> 'complete';
+                        'ok' -> 'ok';
                         _ -> play_messages(Messages, PrevMessages, Count, Box, Call)
                     end
             end;


### PR DESCRIPTION
This PR allow make callback to `caller_id_number` of voicemail message.
By default is used key `8` for callback.
PR is created to callback from offnet also as voicemail box owner. If `authorizing_id` or `owner_id` is `undefined`, then callback is initiated with account permissions.
Designed to use/apply dialplans (device/user/account) - please check implementation.
Now no new announcements is create/used. Please look currently defined, may be you can suggest other announcements that will be more appropriate.
