### PR TITLE
[4.3] Phonebook: allow patching of port documents and move push to phonebook to staging state change 

### DIFF
--- a/applications/crossbar/doc/port_requests.md
+++ b/applications/crossbar/doc/port_requests.md
@@ -730,7 +730,40 @@ curl -v -X POST \
     "status": "success"
 }
 ```
+## Patch a port request
 
+> PATCH /v2/accounts/{ACCOUNT_ID}/port_requests/{PORT_REQUEST_ID}
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -d '{"data":{"your_custom_info":{"carrier_port_id": "apc-8535937-gtk123", "carrier_name": "ace phone co"}}' \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/{PORT_REQUEST_ID}
+```
+
+```json
+{
+    "auth_token": "{AUTH_TOKEN}",
+    "data": {
+        "created": 63630097779,
+        "id": "{PORT_REQUEST_ID}",
+        "name": "{PORT_REQUEST_NAME}",
+        "numbers": {
+            "{PHONE_NUMBER}": {
+                "state": "NY"
+            }
+        },
+        "port_state": "unconfirmed",
+        "sent": false,
+        "updated": 63630104652,
+        "uploads": {},
+        "your_custom_info": {
+            "carrier_port_id": "apc-8535937-gtk123",
+            "carrier_name": "ace phone co"
+        }
+    }
+}
+```
 
 #### DELETE a port request
 

--- a/applications/crossbar/doc/ref/port_requests.md
+++ b/applications/crossbar/doc/ref/port_requests.md
@@ -71,6 +71,16 @@ curl -v -X POST \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/{PORT_REQUEST_ID}
 ```
 
+## Patch
+
+> PATCH /v2/accounts/{ACCOUNT_ID}/port_requests/{PORT_REQUEST_ID}
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/{PORT_REQUEST_ID}
+```
+
 ## Remove
 
 > DELETE /v2/accounts/{ACCOUNT_ID}/port_requests/{PORT_REQUEST_ID}

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -40869,6 +40869,24 @@
                     }
                 }
             },
+            "patch": {
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/auth_token_header"
+                    },
+                    {
+                        "$ref": "#/parameters/PORT_REQUEST_ID"
+                    },
+                    {
+                        "$ref": "#/parameters/ACCOUNT_ID"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "request succeeded"
+                    }
+                }
+            },
             "post": {
                 "parameters": [
                     {

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -145,11 +145,11 @@ new() -> #cb_context{}.
 is_context(#cb_context{}) -> 'true';
 is_context(_) -> 'false'.
 
--spec req_value(context(), kz_json:path()) -> kz_json:api_json_term().
+-spec req_value(context(), kz_json:get_key()) -> kz_json:api_json_term().
 req_value(#cb_context{}=Context, Key) ->
     req_value(Context, Key, 'undefined').
 
--spec req_value(context(), kz_json:path(), Default) -> kz_json:json_term() | Default.
+-spec req_value(context(), kz_json:get_key(), Default) -> kz_json:json_term() | Default.
 req_value(#cb_context{req_data=ReqData
                      ,query_json=QS
                      ,req_json=JObj
@@ -1055,7 +1055,7 @@ build_system_error(Code, Error, JObj, Context) ->
 %% @doc Add a validation error to the list of request errors.
 %% @end
 %%------------------------------------------------------------------------------
--spec add_validation_error(kz_json:path(), kz_term:ne_binary(), kz_term:ne_binary() | kz_json:object(), context()) ->
+-spec add_validation_error(kz_json:get_key(), kz_term:ne_binary(), kz_term:ne_binary() | kz_json:object(), context()) ->
                                   context().
 add_validation_error(<<_/binary>> = Property, Code, Message, Context) ->
     add_validation_error([Property], Code, Message, Context);

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -804,12 +804,14 @@ load_summary_by_number(Context, Number) ->
 load_global_summary_by_number(Context, Number) ->
     load_summary(Context, {'keymap', Number}, ?PORT_REQ_NUMBERS).
 
--spec load_account_summary_by_number(cb_context:context(), kz_term:ne_binaries()) -> cb_context:context().
+-spec load_account_summary_by_number(cb_context:context(), [kz_term:ne_binaries()]) ->
+                                            cb_context:context().
 load_account_summary_by_number(Context, Keys) ->
     load_summary(Context, {'keys', Keys}, ?ALL_PORT_REQ_NUMBERS).
 
 -spec load_summary(cb_context:context()
-                  ,{'keymap'|'keys', kz_term:ne_binary()}
+                  ,{'keymap', kz_term:ne_binary()} |
+                   {'keys', [kz_term:ne_binaries()]}
                   ,kz_term:ne_binary()
                   ) -> cb_context:context().
 load_summary(Context, Key, View) ->
@@ -832,11 +834,11 @@ load_summary(Context, Key, View) ->
 last_submitted(Context) ->
     AccountId = cb_context:account_id(Context),
     C1 = cb_context:store(Context, 'is_superduper_admin', cb_context:is_superduper_admin(Context)),
-    Options = [{startkey, [AccountId]}
-              ,{endkey, [AccountId, kz_json:new()]}
+    Options = [{'startkey', [AccountId]}
+              ,{'endkey', [AccountId, kz_json:new()]}
               ,{'mapper', fun  normalize_last_submitted/3}
               ,{'databases', [?KZ_PORT_REQUESTS_DB]}
-              ,include_docs
+              ,'include_docs'
               ],
     crossbar_view:load(C1, <<"port_requests/listing_submitted">>, Options).
 


### PR DESCRIPTION
QF: moved the port_request push to phonebook to inside state change to pending

make fmt

fixed docs

make apis

added example to docs

fix return value

bad args for cb_context:load()

there is already a loader funciton here

there is already a loader funciton here

fixed global listing by number

removed restriction on superduper admin user to support api_keys