### PR TITLE
ACDc developments

### DIFF
--- a/applications/acdc/src/acdc_agent_handler.erl
+++ b/applications/acdc/src/acdc_agent_handler.erl
@@ -285,6 +285,9 @@ handle_member_message(JObj, Props, <<"connect_req">>) ->
 handle_member_message(JObj, Props, <<"connect_win">>) ->
     'true' = kapi_acdc_queue:member_connect_win_v(JObj),
     acdc_agent_fsm:member_connect_win(props:get_value('fsm_pid', Props), JObj);
+handle_member_message(JObj, Props, <<"connect_satisfied">>) ->
+    'true' = kapi_acdc_queue:member_connect_satisfied_v(JObj),
+    acdc_agent_fsm:member_connect_satisfied(props:get_value('fsm_pid', Props), JObj);
 handle_member_message(_, _, EvtName) ->
     lager:debug("not handling member event ~s", [EvtName]).
 

--- a/applications/acdc/src/acdc_agent_util.erl
+++ b/applications/acdc/src/acdc_agent_util.erl
@@ -43,7 +43,10 @@ most_recent_status(AccountId, AgentId) ->
     case most_recent_ets_status(AccountId, AgentId) of
         {'ok', _}=OK -> OK;
         {'error', _ErrJObj} ->
-            lager:debug("failed to get ETS stats: ~p", [kz_json:get_value(<<"Error-Reason">>, _ErrJObj)]),
+            case kz_json:is_valid_json_object(_ErrJObj) of
+                true  -> lager:debug("failed to get ETS stats: ~p", [kz_json:get_value(<<"Error-Reason">>, _ErrJObj)]);
+                false -> lager:debug("failed to get ETS stats: ~p", [_ErrJObj])
+            end,
             most_recent_db_status(AccountId, AgentId)
     end.
 

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -58,6 +58,7 @@
 -record(state, {queue_proc :: pid()
                ,manager_proc :: pid()
                ,connect_resps = [] :: kz_json:objects()
+               ,connect_wins = [] :: kz_json:objects()
                ,collect_ref :: kz_term:api_reference()
                ,account_id :: kz_term:ne_binary()
                ,account_db :: kz_term:ne_binary()
@@ -69,7 +70,7 @@
 
                ,member_call :: kapps_call:call() | 'undefined'
                ,member_call_start :: kz_term:api_non_neg_integer()
-               ,member_call_winner :: kz_term:api_object() %% who won the call
+               ,member_call_winners :: [kz_term:api_object()] %% who won the call
 
                                       %% Config options
                ,name :: kz_term:ne_binary()
@@ -217,6 +218,7 @@ init([MgrPid, ListenerPid, QueueJObj]) ->
            ,recording_url = kz_json:get_ne_value(<<"call_recording_url">>, QueueJObj)
            ,cdr_url = kz_json:get_ne_value(<<"cdr_url">>, QueueJObj)
            ,member_call = 'undefined'
+           ,member_call_winners = []
 
            ,notifications = kz_json:get_value(<<"notifications">>, QueueJObj)
            }
@@ -449,6 +451,7 @@ connecting('cast', {'accepted', AcceptJObj}, #state{queue_proc=Srv
                                                    ,member_call=Call
                                                    ,account_id=AccountId
                                                    ,queue_id=QueueId
+                                                   ,connect_wins=Wins
                                                    }=State) ->
     case accept_is_for_call(AcceptJObj, Call) of
         'true' ->
@@ -456,6 +459,7 @@ connecting('cast', {'accepted', AcceptJObj}, #state{queue_proc=Srv
             CallId = kapps_call:call_id(Call),
             webseq:evt(?WSD_ID, self(), CallId, <<"member call - agent acceptance">>),
 
+            lists:foreach(fun(Win) -> acdc_queue_listener:member_connect_satisfied(Srv, Win, []) end, Wins),
             acdc_queue_listener:finish_member_call(Srv, AcceptJObj),
             acdc_stats:call_handled(AccountId, QueueId, CallId
                                    ,kz_json:get_value(<<"Agent-ID">>, AcceptJObj)
@@ -468,7 +472,7 @@ connecting('cast', {'accepted', AcceptJObj}, #state{queue_proc=Srv
 
 connecting('cast', {'retry', RetryJObj}, #state{agent_ring_timer_ref=AgentRef
                                                ,collect_ref=CollectRef
-                                               ,member_call_winner=Winner
+                                               ,member_call_winners=[Winner|[]]
                                                }=State) ->
     RetryProcId = kz_json:get_value(<<"Process-ID">>, RetryJObj),
     RetryAgentId = kz_json:get_value(<<"Agent-ID">>, RetryJObj),
@@ -486,7 +490,7 @@ connecting('cast', {'retry', RetryJObj}, #state{agent_ring_timer_ref=AgentRef
             webseq:evt(?WSD_ID, webseq:process_pid(RetryJObj), self(), <<"member call - retry">>),
 
             {'next_state', 'connect_req', State#state{agent_ring_timer_ref='undefined'
-                                                     ,member_call_winner='undefined'
+                                                     ,member_call_winners=[]
                                                      ,collect_ref='undefined'
                                                      }};
         {RetryAgentId, _OtherProcId} ->
@@ -496,6 +500,12 @@ connecting('cast', {'retry', RetryJObj}, #state{agent_ring_timer_ref=AgentRef
             lager:debug("recv retry from unknown agent ~s(~s)", [RetryAgentId, RetryProcId]),
             {'next_state', 'connecting', State}
     end;
+connecting('cast', {'retry', RetryJObj}, #state{member_call_winners=Winners}=State) ->
+    RetryAgentId = kz_json:get_value(<<"Agent-ID">>, RetryJObj),
+    RetryProcId = kz_json:get_value(<<"Process-ID">>, RetryJObj),
+    lager:info("~p told to retry but we have other winners", [RetryAgentId]),
+    {_Loser, Rest} = lists:partition(fun(Winner) -> {kz_json:get_value(<<"Agent-ID">>, Winner), kz_json:get_value(<<"Process-ID">>, Winner)} == {RetryAgentId, RetryProcId} end, Winners),
+    {'next_state', 'connecting', State#state{member_call_winners=Rest}};
 
 connecting('cast', {'member_hungup', CallEvt}, #state{queue_proc=Srv
                                                      ,account_id=AccountId
@@ -571,7 +581,7 @@ connecting({'call', From}, Event, State) ->
     handle_sync_event(Event, From, connecting, State);
 
 connecting('info', {'timeout', AgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{agent_ring_timer_ref=AgentRef
-                                                                             ,member_call_winner=Winner
+                                                                             ,member_call_winners=[Winner|[]]
                                                                              ,queue_proc=Srv
                                                                              }=State) ->
     lager:debug("timed out waiting for agent to pick up"),
@@ -581,8 +591,12 @@ connecting('info', {'timeout', AgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{ag
     acdc_queue_listener:timeout_agent(Srv, Winner),
 
     {'next_state', 'connect_req', State#state{agent_ring_timer_ref='undefined'
-                                             ,member_call_winner='undefined'
+                                             ,member_call_winners=[]
                                              }};
+connecting('info', {'timeout', _AgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{member_call_winners=[_Winner|Winners]}=State)->
+    % TODO: we should detect who told timeout and remove him
+    % I remove the first (but this is not the right way)
+    {'next_state', 'connect_req', State#state{member_call_winners=Winners}};
 connecting('info', {'timeout', _OtherAgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{agent_ring_timer_ref=_AgentRef}=State) ->
     lager:debug("unknown agent ref: ~p known: ~p", [_OtherAgentRef, _AgentRef]),
     {'next_state', 'connect_req', State};
@@ -591,11 +605,11 @@ connecting('info', {'timeout', ConnRef, ?CONNECTION_TIMEOUT_MESSAGE}, #state{que
                                                                             ,account_id=AccountId
                                                                             ,queue_id=QueueId
                                                                             ,member_call=Call
-                                                                            ,member_call_winner=Winner
+                                                                            ,member_call_winners=Winners
                                                                             }=State) ->
     lager:debug("connection timeout occurred, bounce the caller out of the queue"),
 
-    maybe_timeout_winner(Srv, Winner),
+    lists:foreach(fun(Winner) -> maybe_timeout_winner(Srv, Winner) end, Winners),
     CallId = kapps_call:call_id(Call),
     acdc_stats:call_abandoned(AccountId, QueueId, CallId, ?ABANDON_TIMEOUT),
 
@@ -708,7 +722,7 @@ clear_member_call(#state{connection_timer_ref=ConnRef
                ,connection_timer_ref='undefined'
                ,agent_ring_timer_ref='undefined'
                ,member_call_start='undefined'
-               ,member_call_winner='undefined'
+               ,member_call_winners=[]
                }.
 
 update_properties(QueueJObj, State) ->
@@ -831,8 +845,9 @@ accept_is_for_call(AcceptJObj, Call) ->
     kz_json:get_value(<<"Call-ID">>, AcceptJObj) =:= kapps_call:call_id(Call).
 
 -spec update_agent(kz_json:object(), kz_json:object()) -> kz_json:object().
-update_agent(Agent, Winner) ->
-    kz_json:set_value(<<"Agent-Process-ID">>, kz_json:get_value(<<"Process-ID">>, Winner), Agent).
+update_agent(Agent, Winners) ->
+    AgentProcessIDs = [kz_json:get_value(<<"Process-ID">>, Winner) || Winner <- Winners, kz_json:get_value(<<"Process-ID">>, Winner) /= 'undefined'],
+    kz_json:set_value(<<"Agent-Process-IDs">>, AgentProcessIDs, Agent).
 
 -spec handle_agent_responses(state()) -> {atom(), state()}.
 handle_agent_responses(#state{collect_ref=Ref
@@ -866,7 +881,7 @@ maybe_pick_winner(#state{connect_resps=CRs
                         ,notifications=Notifications
                         }=State) ->
     case acdc_queue_manager:pick_winner(Mgr, CRs) of
-        {[Winner|_]=Agents, Rest} ->
+        {Winners, Rest} ->
             QueueOpts = [{<<"Ring-Timeout">>, RingTimeout}
                         ,{<<"Wrapup-Timeout">>, AgentWrapup}
                         ,{<<"Caller-Exit-Key">>, CallerExitKey}
@@ -875,18 +890,21 @@ maybe_pick_winner(#state{connect_resps=CRs
                         ,{<<"Recording-URL">>, RecordUrl}
                         ,{<<"Notifications">>, Notifications}
                         ],
+            
+            ConnectWins = lists:foldl(fun(Winner, Wins) ->
+                                          NewAgent = update_agent(Winner, Winners),
+                                          lager:debug("sending win to ~s(~s)", [kz_json:get_value(<<"Agent-ID">>, Winner)
+                                                                               ,kz_json:get_value(<<"Process-ID">>, Winner)
+                                                                               ]),
+                                          acdc_queue_listener:member_connect_win(Srv, NewAgent, QueueOpts),
+                                          [NewAgent|Wins] end,
+                                          [], Winners),
 
-            _ = [acdc_queue_listener:member_connect_win(Srv, update_agent(Agent, Winner), QueueOpts)
-                 || Agent <- Agents
-                ],
-
-            lager:debug("sending win to ~s(~s)", [kz_json:get_value(<<"Agent-ID">>, Winner)
-                                                 ,kz_json:get_value(<<"Process-ID">>, Winner)
-                                                 ]),
             {'connecting', State#state{connect_resps=Rest
+                                      ,connect_wins=ConnectWins
                                       ,collect_ref='undefined'
                                       ,agent_ring_timer_ref=start_agent_ring_timer(RingTimeout)
-                                      ,member_call_winner=Winner
+                                      ,member_call_winners=Winners
                                       }};
         'undefined' ->
             lager:debug("no more responses to choose from"),

--- a/applications/acdc/src/acdc_queue_manager.hrl
+++ b/applications/acdc/src/acdc_queue_manager.hrl
@@ -2,7 +2,7 @@
 
 %% rr :: Round Robin
 %% mi :: Most Idle
--type queue_strategy() :: 'rr' | 'mi'.
+-type queue_strategy() :: 'rr' | 'mi' | 'all'.
 
 -type queue_strategy_state() :: queue:queue() | kz_term:ne_binaries().
 -type ss_details() :: {non_neg_integer(), 'busy' | 'undefined'}.

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6336,8 +6336,8 @@
         "kapi.acdc_queue.agent_timeout": {
             "description": "AMQP API for acdc_queue.agent_timeout",
             "properties": {
-                "Agent-Process-ID": {
-                    "type": "string"
+                "Agent-Process-IDs": {
+                    "type": "array"
                 },
                 "Call-ID": {
                     "type": "string"
@@ -6643,8 +6643,8 @@
         "kapi.acdc_queue.member_connect_win": {
             "description": "AMQP API for acdc_queue.member_connect_win",
             "properties": {
-                "Agent-Process-ID": {
-                    "type": "string"
+                "Agent-Process-IDs": {
+                    "type": "array"
                 },
                 "CDR-Url": {
                     "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.agent_timeout.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.agent_timeout.json
@@ -3,8 +3,8 @@
     "_id": "kapi.acdc_queue.agent_timeout",
     "description": "AMQP API for acdc_queue.agent_timeout",
     "properties": {
-        "Agent-Process-ID": {
-            "type": "string"
+        "Agent-Process-IDs": {
+            "type": "array"
         },
         "Call-ID": {
             "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.member_connect_win.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.member_connect_win.json
@@ -3,8 +3,8 @@
     "_id": "kapi.acdc_queue.member_connect_win",
     "description": "AMQP API for acdc_queue.member_connect_win",
     "properties": {
-        "Agent-Process-ID": {
-            "type": "string"
+        "Agent-Process-IDs": {
+            "type": "array"
         },
         "CDR-Url": {
             "type": "string"


### PR DESCRIPTION
- Created new strategy: "ring_all". It allows to ring all agents like a ring group.
- Added the possibility to have more than one winner.
- Added event member_call_satisfied for telling to agents that the request has been satisfied
- Bug fix