### PR TITLE
[4.2] KAZOO-6004: ensure account has min 3 characters length when e911 caller_name is missing

### DIFF
--- a/core/kazoo_number_manager/src/providers/knm_providers.erl
+++ b/core/kazoo_number_manager/src/providers/knm_providers.erl
@@ -114,7 +114,7 @@ e911_caller_name(Number, 'undefined') ->
     AccountId = knm_phone_number:assigned_to(knm_number:phone_number(Number)),
     case kzd_accounts:fetch_name(AccountId) of
         undefined -> ?E911_NAME_DEFAULT;
-        Name -> Name
+        Name -> kz_binary:pad(Name, 3, <<" ">>)
     end.
 -endif.
 


### PR DESCRIPTION
master: https://github.com/2600hz/kazoo/pull/5278
4.3: https://github.com/2600hz/kazoo/pull/5280