### PR TITLE
ACDc developments

### DIFF
--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -634,7 +634,7 @@ ready('cast', {'member_connect_win', JObj}, #state{agent_listener=AgentListener
     end;
 ready('cast', {'member_connect_satisfied', _}, State) ->
     lager:info("unexpected connect_satisfied"),
-   {'next_state', 'ready', State};
+    {'next_state', 'ready', State};
 ready('cast', {'member_connect_req', _}, #state{max_connect_failures=Max
                                                ,connect_failures=Fails
                                                ,account_id=AccountId
@@ -714,29 +714,29 @@ ringing('cast', {'member_connect_win', JObj}, #state{agent_listener=AgentListene
 
     {'next_state', 'ringing', State};
 ringing('cast', {'member_connect_satisfied', JObj}, #state{agent_listener=AgentListener
-                                                         ,member_call_id=MemberCallId
-                                                         ,account_id=AccountId
-                                                         ,member_call_queue_id=QueueId
-                                                         ,agent_id=AgentId
-                                                         ,connect_failures=Fails
-                                                         ,max_connect_failures=MaxFails
-                                                         }=State) ->
+                                                          ,member_call_id=MemberCallId
+                                                          ,account_id=AccountId
+                                                          ,member_call_queue_id=QueueId
+                                                          ,agent_id=AgentId
+                                                          ,connect_failures=Fails
+                                                          ,max_connect_failures=MaxFails
+                                                          }=State) ->
     lager:info("Received connect_satisfied: check if I should hangup: ~p", [JObj]),
     CallId = kz_json:get_ne_binary_value([<<"Call">>, <<"Call-ID">>], JObj, []),
     case CallId =:= MemberCallId of
-       true ->
-           lager:info("Hanging up: someother agent replies"),
-           acdc_agent_listener:channel_hungup(AgentListener, MemberCallId),
-           acdc_stats:call_missed(AccountId, QueueId, AgentId, MemberCallId, <<"LOSE_RACE">>),
-           acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_GREEN),
+        true ->
+            lager:info("Hanging up: someother agent replies"),
+            acdc_agent_listener:channel_hungup(AgentListener, MemberCallId),
+            acdc_stats:call_missed(AccountId, QueueId, AgentId, MemberCallId, <<"LOSE_RACE">>),
+            acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_GREEN),
 
-           State1 = clear_call(State, 'failed'),
-           StateName1 = return_to_state(Fails+1, MaxFails),
-           case StateName1 of
-               'paused' -> {'next_state', 'paused', State1};
-               'ready' -> apply_state_updates(State1)
-           end;
-       _ -> {'next_state', 'ringing', State}
+            State1 = clear_call(State, 'failed'),
+            StateName1 = return_to_state(Fails+1, MaxFails),
+            case StateName1 of
+                'paused' -> {'next_state', 'paused', State1};
+                'ready' -> apply_state_updates(State1)
+            end;
+        _ -> {'next_state', 'ringing', State}
     end;
 ringing('cast', {'originate_ready', JObj}, #state{agent_listener=AgentListener}=State) ->
     CallId = kz_json:get_value(<<"Call-ID">>, JObj),

--- a/applications/acdc/src/acdc_agent_handler.erl
+++ b/applications/acdc/src/acdc_agent_handler.erl
@@ -285,6 +285,9 @@ handle_member_message(JObj, Props, <<"connect_req">>) ->
 handle_member_message(JObj, Props, <<"connect_win">>) ->
     'true' = kapi_acdc_queue:member_connect_win_v(JObj),
     acdc_agent_fsm:member_connect_win(props:get_value('fsm_pid', Props), JObj);
+handle_member_message(JObj, Props, <<"connect_satisfied">>) ->
+    'true' = kapi_acdc_queue:member_connect_satisfied_v(JObj),
+    acdc_agent_fsm:member_connect_satisfied(props:get_value('fsm_pid', Props), JObj);
 handle_member_message(_, _, EvtName) ->
     lager:debug("not handling member event ~s", [EvtName]).
 

--- a/applications/acdc/src/acdc_agent_util.erl
+++ b/applications/acdc/src/acdc_agent_util.erl
@@ -43,7 +43,10 @@ most_recent_status(AccountId, AgentId) ->
     case most_recent_ets_status(AccountId, AgentId) of
         {'ok', _}=OK -> OK;
         {'error', _ErrJObj} ->
-            lager:debug("failed to get ETS stats: ~p", [kz_json:get_value(<<"Error-Reason">>, _ErrJObj)]),
+            case kz_json:is_valid_json_object(_ErrJObj) of
+                true  -> lager:debug("failed to get ETS stats: ~p", [kz_json:get_value(<<"Error-Reason">>, _ErrJObj)]);
+                false -> lager:debug("failed to get ETS stats: ~p", [_ErrJObj])
+            end,
             most_recent_db_status(AccountId, AgentId)
     end.
 

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -898,7 +898,7 @@ maybe_pick_winner(#state{connect_resps=CRs
                                                                                    ]),
                                               acdc_queue_listener:member_connect_win(Srv, NewAgent, QueueOpts),
                                               [NewAgent|Wins] end,
-                                              [], Winners),
+                                      [], Winners),
 
             {'connecting', State#state{connect_resps=Rest
                                       ,connect_wins=ConnectWins

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -844,9 +844,9 @@ maybe_delay_connect_re_req(MgrSrv, ListenerSrv, #state{member_call=Call}=State) 
 accept_is_for_call(AcceptJObj, Call) ->
     kz_json:get_value(<<"Call-ID">>, AcceptJObj) =:= kapps_call:call_id(Call).
 
--spec update_agent(kz_json:object(), kz_json:object()) -> kz_json:object().
+-spec update_agent(kz_json:object(), kz_json:objects()) -> kz_json:object().
 update_agent(Agent, Winners) ->
-    AgentProcessIDs = [kz_json:get_value(<<"Process-ID">>, Winner) || Winner <- Winners, kz_json:get_value(<<"Process-ID">>, Winner) /= 'undefined'],
+    AgentProcessIDs = [ProcessId || Winner <- Winners, ProcessId <- [kz_json:get_ne_binary_value(<<"Process-ID">>, Winner)], ProcessId =/= 'undefined'],
     kz_json:set_value(<<"Agent-Process-IDs">>, AgentProcessIDs, Agent).
 
 -spec handle_agent_responses(state()) -> {atom(), state()}.

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -72,7 +72,7 @@
                ,member_call_start :: kz_term:api_non_neg_integer()
                ,member_call_winners :: [kz_term:api_object()] %% who won the call
 
-                                      %% Config options
+                                       %% Config options
                ,name :: kz_term:ne_binary()
                ,connection_timeout :: pos_integer()
                ,agent_ring_timeout = 10 :: pos_integer() % how long to ring an agent before giving up
@@ -594,8 +594,8 @@ connecting('info', {'timeout', AgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{ag
                                              ,member_call_winners=[]
                                              }};
 connecting('info', {'timeout', _AgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{member_call_winners=[_Winner|Winners]}=State)->
-    % TODO: we should detect who told timeout and remove him
-    % I remove the first (but this is not the right way)
+                                                % TODO: we should detect who told timeout and remove him
+                                                % I remove the first (but this is not the right way)
     {'next_state', 'connect_req', State#state{member_call_winners=Winners}};
 connecting('info', {'timeout', _OtherAgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{agent_ring_timer_ref=_AgentRef}=State) ->
     lager:debug("unknown agent ref: ~p known: ~p", [_OtherAgentRef, _AgentRef]),
@@ -892,13 +892,13 @@ maybe_pick_winner(#state{connect_resps=CRs
                         ],
 
             ConnectWins = lists:foldl(fun(Winner, Wins) ->
-                                          NewAgent = update_agent(Winner, Winners),
-                                          lager:debug("sending win to ~s(~s)", [kz_json:get_value(<<"Agent-ID">>, Winner)
-                                                                               ,kz_json:get_value(<<"Process-ID">>, Winner)
-                                                                               ]),
-                                          acdc_queue_listener:member_connect_win(Srv, NewAgent, QueueOpts),
-                                          [NewAgent|Wins] end,
-                                          [], Winners),
+                                              NewAgent = update_agent(Winner, Winners),
+                                              lager:debug("sending win to ~s(~s)", [kz_json:get_value(<<"Agent-ID">>, Winner)
+                                                                                   ,kz_json:get_value(<<"Process-ID">>, Winner)
+                                                                                   ]),
+                                              acdc_queue_listener:member_connect_win(Srv, NewAgent, QueueOpts),
+                                              [NewAgent|Wins] end,
+                                              [], Winners),
 
             {'connecting', State#state{connect_resps=Rest
                                       ,connect_wins=ConnectWins

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -58,6 +58,7 @@
 -record(state, {queue_proc :: pid()
                ,manager_proc :: pid()
                ,connect_resps = [] :: kz_json:objects()
+               ,connect_wins = [] :: kz_json:objects()
                ,collect_ref :: kz_term:api_reference()
                ,account_id :: kz_term:ne_binary()
                ,account_db :: kz_term:ne_binary()
@@ -69,7 +70,7 @@
 
                ,member_call :: kapps_call:call() | 'undefined'
                ,member_call_start :: kz_term:api_non_neg_integer()
-               ,member_call_winner :: kz_term:api_object() %% who won the call
+               ,member_call_winners :: [kz_term:api_object()] %% who won the call
 
                                       %% Config options
                ,name :: kz_term:ne_binary()
@@ -217,6 +218,7 @@ init([MgrPid, ListenerPid, QueueJObj]) ->
            ,recording_url = kz_json:get_ne_value(<<"call_recording_url">>, QueueJObj)
            ,cdr_url = kz_json:get_ne_value(<<"cdr_url">>, QueueJObj)
            ,member_call = 'undefined'
+           ,member_call_winners = []
 
            ,notifications = kz_json:get_value(<<"notifications">>, QueueJObj)
            }
@@ -281,9 +283,7 @@ ready({'call', From}, 'status', #state{cdr_url=Url
 ready({'call', From}, 'current_call', State) ->
     {'next_state', 'ready', State, {'reply', From, 'undefined'}};
 ready({'call', From}, Event, State) ->
-    handle_sync_event(Event, From, ready, State);
-ready('info', {'timeout', _, ?COLLECT_RESP_MESSAGE}, State) ->
-    {'next_state', 'ready', State}.
+    handle_sync_event(Event, From, ready, State).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -451,6 +451,7 @@ connecting('cast', {'accepted', AcceptJObj}, #state{queue_proc=Srv
                                                    ,member_call=Call
                                                    ,account_id=AccountId
                                                    ,queue_id=QueueId
+                                                   ,connect_wins=Wins
                                                    }=State) ->
     case accept_is_for_call(AcceptJObj, Call) of
         'true' ->
@@ -458,6 +459,7 @@ connecting('cast', {'accepted', AcceptJObj}, #state{queue_proc=Srv
             CallId = kapps_call:call_id(Call),
             webseq:evt(?WSD_ID, self(), CallId, <<"member call - agent acceptance">>),
 
+            lists:foreach(fun(Win) -> acdc_queue_listener:member_connect_satisfied(Srv, Win, []) end, Wins),
             acdc_queue_listener:finish_member_call(Srv, AcceptJObj),
             acdc_stats:call_handled(AccountId, QueueId, CallId
                                    ,kz_json:get_value(<<"Agent-ID">>, AcceptJObj)
@@ -470,7 +472,7 @@ connecting('cast', {'accepted', AcceptJObj}, #state{queue_proc=Srv
 
 connecting('cast', {'retry', RetryJObj}, #state{agent_ring_timer_ref=AgentRef
                                                ,collect_ref=CollectRef
-                                               ,member_call_winner=Winner
+                                               ,member_call_winners=[Winner|[]]
                                                }=State) ->
     RetryProcId = kz_json:get_value(<<"Process-ID">>, RetryJObj),
     RetryAgentId = kz_json:get_value(<<"Agent-ID">>, RetryJObj),
@@ -488,7 +490,7 @@ connecting('cast', {'retry', RetryJObj}, #state{agent_ring_timer_ref=AgentRef
             webseq:evt(?WSD_ID, webseq:process_pid(RetryJObj), self(), <<"member call - retry">>),
 
             {'next_state', 'connect_req', State#state{agent_ring_timer_ref='undefined'
-                                                     ,member_call_winner='undefined'
+                                                     ,member_call_winners=[]
                                                      ,collect_ref='undefined'
                                                      }};
         {RetryAgentId, _OtherProcId} ->
@@ -498,6 +500,12 @@ connecting('cast', {'retry', RetryJObj}, #state{agent_ring_timer_ref=AgentRef
             lager:debug("recv retry from unknown agent ~s(~s)", [RetryAgentId, RetryProcId]),
             {'next_state', 'connecting', State}
     end;
+connecting('cast', {'retry', RetryJObj}, #state{member_call_winners=Winners}=State) ->
+    RetryAgentId = kz_json:get_value(<<"Agent-ID">>, RetryJObj),
+    RetryProcId = kz_json:get_value(<<"Process-ID">>, RetryJObj),
+    lager:info("~p told to retry but we have other winners", [RetryAgentId]),
+    {_Loser, Rest} = lists:partition(fun(Winner) -> {kz_json:get_value(<<"Agent-ID">>, Winner), kz_json:get_value(<<"Process-ID">>, Winner)} == {RetryAgentId, RetryProcId} end, Winners),
+    {'next_state', 'connecting', State#state{member_call_winners=Rest}};
 
 connecting('cast', {'member_hungup', CallEvt}, #state{queue_proc=Srv
                                                      ,account_id=AccountId
@@ -573,7 +581,7 @@ connecting({'call', From}, Event, State) ->
     handle_sync_event(Event, From, connecting, State);
 
 connecting('info', {'timeout', AgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{agent_ring_timer_ref=AgentRef
-                                                                             ,member_call_winner=Winner
+                                                                             ,member_call_winners=[Winner|[]]
                                                                              ,queue_proc=Srv
                                                                              }=State) ->
     lager:debug("timed out waiting for agent to pick up"),
@@ -583,8 +591,12 @@ connecting('info', {'timeout', AgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{ag
     acdc_queue_listener:timeout_agent(Srv, Winner),
 
     {'next_state', 'connect_req', State#state{agent_ring_timer_ref='undefined'
-                                             ,member_call_winner='undefined'
+                                             ,member_call_winners=[]
                                              }};
+connecting('info', {'timeout', _AgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{member_call_winners=[_Winner|Winners]}=State)->
+    % TODO: we should detect who told timeout and remove him
+    % I remove the first (but this is not the right way)
+    {'next_state', 'connect_req', State#state{member_call_winners=Winners}};
 connecting('info', {'timeout', _OtherAgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{agent_ring_timer_ref=_AgentRef}=State) ->
     lager:debug("unknown agent ref: ~p known: ~p", [_OtherAgentRef, _AgentRef]),
     {'next_state', 'connect_req', State};
@@ -593,11 +605,11 @@ connecting('info', {'timeout', ConnRef, ?CONNECTION_TIMEOUT_MESSAGE}, #state{que
                                                                             ,account_id=AccountId
                                                                             ,queue_id=QueueId
                                                                             ,member_call=Call
-                                                                            ,member_call_winner=Winner
+                                                                            ,member_call_winners=Winners
                                                                             }=State) ->
     lager:debug("connection timeout occurred, bounce the caller out of the queue"),
 
-    maybe_timeout_winner(Srv, Winner),
+    lists:foreach(fun(Winner) -> maybe_timeout_winner(Srv, Winner) end, Winners),
     CallId = kapps_call:call_id(Call),
     acdc_stats:call_abandoned(AccountId, QueueId, CallId, ?ABANDON_TIMEOUT),
 
@@ -710,7 +722,7 @@ clear_member_call(#state{connection_timer_ref=ConnRef
                ,connection_timer_ref='undefined'
                ,agent_ring_timer_ref='undefined'
                ,member_call_start='undefined'
-               ,member_call_winner='undefined'
+               ,member_call_winners=[]
                }.
 
 update_properties(QueueJObj, State) ->
@@ -833,8 +845,9 @@ accept_is_for_call(AcceptJObj, Call) ->
     kz_json:get_value(<<"Call-ID">>, AcceptJObj) =:= kapps_call:call_id(Call).
 
 -spec update_agent(kz_json:object(), kz_json:object()) -> kz_json:object().
-update_agent(Agent, Winner) ->
-    kz_json:set_value(<<"Agent-Process-ID">>, kz_json:get_value(<<"Process-ID">>, Winner), Agent).
+update_agent(Agent, Winners) ->
+    AgentProcessIDs = [kz_json:get_value(<<"Process-ID">>, Winner) || Winner <- Winners, kz_json:get_value(<<"Process-ID">>, Winner) /= 'undefined'],
+    kz_json:set_value(<<"Agent-Process-IDs">>, AgentProcessIDs, Agent).
 
 -spec handle_agent_responses(state()) -> {atom(), state()}.
 handle_agent_responses(#state{collect_ref=Ref
@@ -868,7 +881,7 @@ maybe_pick_winner(#state{connect_resps=CRs
                         ,notifications=Notifications
                         }=State) ->
     case acdc_queue_manager:pick_winner(Mgr, CRs) of
-        {[Winner|_]=Agents, Rest} ->
+        {Winners, Rest} ->
             QueueOpts = [{<<"Ring-Timeout">>, RingTimeout}
                         ,{<<"Wrapup-Timeout">>, AgentWrapup}
                         ,{<<"Caller-Exit-Key">>, CallerExitKey}
@@ -878,17 +891,20 @@ maybe_pick_winner(#state{connect_resps=CRs
                         ,{<<"Notifications">>, Notifications}
                         ],
 
-            _ = [acdc_queue_listener:member_connect_win(Srv, update_agent(Agent, Winner), QueueOpts)
-                 || Agent <- Agents
-                ],
+            ConnectWins = lists:foldl(fun(Winner, Wins) ->
+                                          NewAgent = update_agent(Winner, Winners),
+                                          lager:debug("sending win to ~s(~s)", [kz_json:get_value(<<"Agent-ID">>, Winner)
+                                                                               ,kz_json:get_value(<<"Process-ID">>, Winner)
+                                                                               ]),
+                                          acdc_queue_listener:member_connect_win(Srv, NewAgent, QueueOpts),
+                                          [NewAgent|Wins] end,
+                                          [], Winners),
 
-            lager:debug("sending win to ~s(~s)", [kz_json:get_value(<<"Agent-ID">>, Winner)
-                                                 ,kz_json:get_value(<<"Process-ID">>, Winner)
-                                                 ]),
             {'connecting', State#state{connect_resps=Rest
+                                      ,connect_wins=ConnectWins
                                       ,collect_ref='undefined'
                                       ,agent_ring_timer_ref=start_agent_ring_timer(RingTimeout)
-                                      ,member_call_winner=Winner
+                                      ,member_call_winners=Winners
                                       }};
         'undefined' ->
             lager:debug("no more responses to choose from"),

--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -321,10 +321,10 @@ handle_cast({'member_connect_win', RespJObj, QueueOpts}, #state{my_q=MyQ
     send_member_connect_win(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts),
     {'noreply', State#state{agent_id=kz_json:get_value(<<"Agent-ID">>, RespJObj)}, 'hibernate'};
 handle_cast({'member_connect_satisfied', RespJObj, QueueOpts}, #state{my_q=MyQ
-                                                                    ,my_id=MyId
-                                                                    ,call=Call
-                                                                    ,queue_id=QueueId
-                                                                    }=State) ->
+                                                                     ,my_id=MyId
+                                                                     ,call=Call
+                                                                     ,queue_id=QueueId
+                                                                     }=State) ->
     lager:debug("agent process satisfied the connect, sending the satisfied"),
     send_member_connect_satisfied(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts),
     {'noreply', State, 'hibernate'};
@@ -559,12 +559,12 @@ send_member_connect_satisfied(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts) ->
     CallJSON = kapps_call:to_json(Call),
     Q = kz_json:get_value(<<"Server-ID">>, RespJObj),
     Satisfied = props:filter_undefined(
-           [{<<"Call">>, CallJSON}
-           ,{<<"Process-ID">>, MyId}
-           ,{<<"Agent-Process-IDs">>, kz_json:get_list_value(<<"Agent-Process-IDs">>, RespJObj)}
-           ,{<<"Queue-ID">>, QueueId}
-            | QueueOpts ++ kz_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
-           ]),
+                  [{<<"Call">>, CallJSON}
+                  ,{<<"Process-ID">>, MyId}
+                  ,{<<"Agent-Process-IDs">>, kz_json:get_list_value(<<"Agent-Process-IDs">>, RespJObj)}
+                  ,{<<"Queue-ID">>, QueueId}
+                   | QueueOpts ++ kz_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
+                  ]),
     publish(Q, Satisfied, fun kapi_acdc_queue:publish_member_connect_satisfied/2).
 
 -spec send_agent_timeout(kz_json:object(), kapps_call:call(), kz_term:ne_binary()) -> 'ok'.

--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -776,8 +776,8 @@ add_agent('mi', AgentId, #strategy_state{agents=AgentL
                      ,details=incr_agent(AgentId, Details)
                      };
 add_agent('all', AgentId, #strategy_state{agents=AgentQueue
-                                        ,details=Details
-                                        }=SS) ->
+                                         ,details=Details
+                                         }=SS) ->
     SS#strategy_state{agents=queue:in(AgentId, AgentQueue)
                      ,details=incr_agent(AgentId, Details)
                      }.
@@ -809,8 +809,8 @@ remove_agent('mi', AgentId, #strategy_state{agents=AgentL
                              }
     end;
 remove_agent('all', AgentId, #strategy_state{agents=AgentQueue
-                                           ,details=Details
-                                           }=SS) ->
+                                            ,details=Details
+                                            }=SS) ->
     case dict:find(AgentId, Details) of
         {'ok', {Count, _}} when Count > 1 ->
             SS#strategy_state{details=decr_agent(AgentId, Details)};

--- a/applications/acdc/src/acdc_queue_manager.hrl
+++ b/applications/acdc/src/acdc_queue_manager.hrl
@@ -2,7 +2,7 @@
 
 %% rr :: Round Robin
 %% mi :: Most Idle
--type queue_strategy() :: 'rr' | 'mi'.
+-type queue_strategy() :: 'rr' | 'mi' | 'all'.
 
 -type queue_strategy_state() :: queue:queue() | kz_term:ne_binaries().
 -type ss_details() :: {non_neg_integer(), 'busy' | 'undefined'}.

--- a/applications/acdc/src/kapi_acdc_queue.erl
+++ b/applications/acdc/src/kapi_acdc_queue.erl
@@ -317,15 +317,15 @@ member_connect_win_v(JObj) ->
 -define(MEMBER_CONNECT_SATISFIED_TYPES, []).
 
 -spec member_connect_satisfied(kz_term:api_terms()) ->
-                               {'ok', iolist()} |
-                               {'error', string()}.
+                                      {'ok', iolist()} |
+                                      {'error', string()}.
 member_connect_satisfied(Props) when is_list(Props) ->
     case member_connect_satisfied_v(Props) of
-       'true' -> kz_api:build_message(Props, ?MEMBER_CONNECT_SATISFIED_HEADERS, ?OPTIONAL_MEMBER_CONNECT_SATISFIED_HEADERS);
-       'false' -> {'error', "Proplist failed validation for member_connect_satisfied"}
+        'true' -> kz_api:build_message(Props, ?MEMBER_CONNECT_SATISFIED_HEADERS, ?OPTIONAL_MEMBER_CONNECT_SATISFIED_HEADERS);
+        'false' -> {'error', "Proplist failed validation for member_connect_satisfied"}
     end;
 member_connect_satisfied(JObj) ->
-       member_connect_satisfied(kz_json:to_proplist(JObj)).
+    member_connect_satisfied(kz_json:to_proplist(JObj)).
 
 -spec member_connect_satisfied_v(kz_term:api_terms()) -> boolean().
 member_connect_satisfied_v(Prop) when is_list(Prop) ->
@@ -853,7 +853,7 @@ publish_member_connect_satisfied(Q, JObj) ->
 -spec publish_member_connect_satisfied(kz_term:ne_binary(), kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
 publish_member_connect_satisfied(Q, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?MEMBER_CONNECT_SATISFIED_VALUES, fun member_connect_satisfied/1),
-     kz_amqp_util:targeted_publish(Q, Payload, ContentType).
+    kz_amqp_util:targeted_publish(Q, Payload, ContentType).
 
 -spec publish_agent_timeout(kz_term:ne_binary(), kz_term:api_terms()) -> 'ok'.
 publish_agent_timeout(Q, JObj) ->

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6725,6 +6725,40 @@
             ],
             "type": "object"
         },
+        "kapi.acdc_queue.member_connect_satisfied": {
+            "description": "AMQP API for acdc_queue.member_connect_satisfied",
+            "properties": {
+                "Agent-Process-IDs": {
+                    "type": "string"
+                },
+                "Call": {
+                    "type": "object"
+                },
+                "Event-Category": {
+                    "enum": [
+                        "member"
+                    ],
+                    "type": "string"
+                },
+                "Event-Name": {
+                    "enum": [
+                        "connect_satisfied"
+                    ],
+                    "type": "string"
+                },
+                "Process-ID": {
+                    "type": "string"
+                },
+                "Queue-ID": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Call",
+                "Queue-ID"
+            ],
+            "type": "object"
+        },
         "kapi.acdc_queue.member_connect_win": {
             "description": "AMQP API for acdc_queue.member_connect_win",
             "properties": {

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6421,8 +6421,8 @@
         "kapi.acdc_queue.agent_timeout": {
             "description": "AMQP API for acdc_queue.agent_timeout",
             "properties": {
-                "Agent-Process-ID": {
-                    "type": "string"
+                "Agent-Process-IDs": {
+                    "type": "array"
                 },
                 "Call-ID": {
                     "type": "string"
@@ -6728,8 +6728,8 @@
         "kapi.acdc_queue.member_connect_win": {
             "description": "AMQP API for acdc_queue.member_connect_win",
             "properties": {
-                "Agent-Process-ID": {
-                    "type": "string"
+                "Agent-Process-IDs": {
+                    "type": "array"
                 },
                 "CDR-Url": {
                     "type": "string"

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6729,7 +6729,7 @@
             "description": "AMQP API for acdc_queue.member_connect_satisfied",
             "properties": {
                 "Agent-Process-IDs": {
-                    "type": "string"
+                    "type": "array"
                 },
                 "Call": {
                     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.agent_timeout.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.agent_timeout.json
@@ -3,8 +3,8 @@
     "_id": "kapi.acdc_queue.agent_timeout",
     "description": "AMQP API for acdc_queue.agent_timeout",
     "properties": {
-        "Agent-Process-ID": {
-            "type": "string"
+        "Agent-Process-IDs": {
+            "type": "array"
         },
         "Call-ID": {
             "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.member_connect_satisfied.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.member_connect_satisfied.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "kapi.acdc_queue.member_connect_satisfied",
-    "description": "AMQP API for acdc_queue.member_connect_statisfied",
+    "description": "AMQP API for acdc_queue.member_connect_satisfied",
     "properties": {
         "Agent-Process-IDs": {
             "type": "array"

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.member_connect_satisfied.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.member_connect_satisfied.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.acdc_queue.member_connect_satisfied",
+    "description": "AMQP API for acdc_queue.member_connect_statisfied",
+    "properties": {
+        "Agent-Process-IDs": {
+            "type": "array"
+        },
+        "Call": {
+            "type": "object"
+        },
+        "Event-Category": {
+            "enum": [
+                "member"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "connect_satisfied"
+            ],
+            "type": "string"
+        },
+        "Process-ID": {
+            "type": "string"
+        },
+        "Queue-ID": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Call",
+        "Queue-ID"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.member_connect_win.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.member_connect_win.json
@@ -3,8 +3,8 @@
     "_id": "kapi.acdc_queue.member_connect_win",
     "description": "AMQP API for acdc_queue.member_connect_win",
     "properties": {
-        "Agent-Process-ID": {
-            "type": "string"
+        "Agent-Process-IDs": {
+            "type": "array"
         },
         "CDR-Url": {
             "type": "string"


### PR DESCRIPTION
-Created new strategy: "ring_all". It allows to ring all agents like a ring group.
-Added the possibility to have more than one winner.
-Added event member_call_satisfied for telling to agents that the request has been satisfied
-Bug fix