### PR TITLE
make schemas comply with OAS3 Schema

### DIFF
--- a/applications/callflow/doc/after_bridge.md
+++ b/applications/callflow/doc/after_bridge.md
@@ -13,7 +13,7 @@ Validator for the after_bridge callflow data object
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `action` | What action to perform after a call is bridged | `string('park' | 'transfer' | 'hangup')` |   | `false` |  
-`data` | The number to transfer to, or a boolean, depending on the 'action' | `string() | boolean()` |   | `false` |  
+`data` | The number to transfer to, or a boolean, depending on the 'action' | `boolean() | string()` |   | `false` |  
 
 
 

--- a/applications/callflow/doc/faxbox.md
+++ b/applications/callflow/doc/faxbox.md
@@ -14,7 +14,7 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `faxbox_id` | ID of the faxbox | `string()` |   | `false` |  
 `id` | ID of the faxbox | `string()` |   | `false` |  
-`media.fax_option` | Caller flag for T38 settings | `string('auto' | 'true' | 'false') | boolean()` |   | `false` |  
+`media.fax_option` | Caller flag for T38 settings | `boolean() | string('auto' | 'true' | 'false')` |   | `false` |  
 `media` |   | `object()` |   | `false` |  
 
 

--- a/applications/callflow/doc/receive_fax.md
+++ b/applications/callflow/doc/receive_fax.md
@@ -12,7 +12,7 @@ Validator for the receive_fax callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`media.fax_option` | Caller flag for T38 settings | `string('auto' | 'true' | 'false') | boolean()` |   | `false` |  
+`media.fax_option` | Caller flag for T38 settings | `string('auto' | 'false' | 'true') | boolean()` |   | `false` |  
 `media` |   | `object()` |   | `false` |  
 `owner_id` | User ID to send fax to | `string()` |   | `false` |  
 

--- a/applications/callflow/doc/ref/after_bridge.md
+++ b/applications/callflow/doc/ref/after_bridge.md
@@ -11,7 +11,7 @@ Validator for the after_bridge callflow data object
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `action` | What action to perform after a call is bridged | `string('park' | 'transfer' | 'hangup')` |   | `false` |  
-`data` | The number to transfer to, or a boolean, depending on the 'action' | `string() | boolean()` |   | `false` |  
+`data` | The number to transfer to, or a boolean, depending on the 'action' | `boolean() | string()` |   | `false` |  
 
 
 

--- a/applications/callflow/doc/ref/faxbox.md
+++ b/applications/callflow/doc/ref/faxbox.md
@@ -12,7 +12,7 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `faxbox_id` | ID of the faxbox | `string()` |   | `false` |  
 `id` | ID of the faxbox | `string()` |   | `false` |  
-`media.fax_option` | Caller flag for T38 settings | `string('auto' | 'true' | 'false') | boolean()` |   | `false` |  
+`media.fax_option` | Caller flag for T38 settings | `boolean() | string('auto' | 'true' | 'false')` |   | `false` |  
 `media` |   | `object()` |   | `false` |  
 
 

--- a/applications/callflow/doc/ref/missed_call_alert.md
+++ b/applications/callflow/doc/ref/missed_call_alert.md
@@ -10,7 +10,7 @@ Validator for the missed_call_alert callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`recipients.[].id` | The email address/user ID or the list of email addresses/user IDs based on specified type | `string() | array()` |   | `true` |  
+`recipients.[].id` | The email address/user ID or the list of email addresses/user IDs based on specified type | `string() | array(string())` |   | `true` |  
 `recipients.[].type` | Controls if the ID of this object is a Kazoo user ID or an email address | `string('user' | 'email')` |   | `true` |  
 `recipients` | One or more specific email addresses, Kazoo user ids or a combination of both | `array(object())` |   | `true` |  
 

--- a/applications/callflow/doc/ref/receive_fax.md
+++ b/applications/callflow/doc/ref/receive_fax.md
@@ -10,7 +10,7 @@ Validator for the receive_fax callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`media.fax_option` | Caller flag for T38 settings | `string('auto' | 'true' | 'false') | boolean()` |   | `false` |  
+`media.fax_option` | Caller flag for T38 settings | `string('auto' | 'false' | 'true') | boolean()` |   | `false` |  
 `media` |   | `object()` |   | `false` |  
 `owner_id` | User ID to send fax to | `string()` |   | `false` |  
 

--- a/applications/callflow/doc/ref/route_to_cid.md
+++ b/applications/callflow/doc/ref/route_to_cid.md
@@ -15,7 +15,8 @@ Key | Description | Type | Default | Required | Support Level
 `cid_types.[]` |   | `string()` |   | `false` |  
 `cid_types` | CID types to perform search: internal, external, custom | `array(string())` | `["internal"]` | `false` |  
 `delay` | How long to delay ringing the device, in seconds | `integer()` | `0` | `false` |  
-`endpoint_types` | Endpoint types to perform search: user, device | `array()` | `[]` | `false` |  
+`endpoint_types.[]` |   | `string()` |   | `false` |  
+`endpoint_types` | Endpoint types to perform search: user, device | `array(string())` | `[]` | `false` |  
 `static_invite` | Override the SIP Username | `string()` |   | `false` |  
 `suppress_clid` | Suppress sending caller ID | `boolean()` |   | `false` |  
 `timeout` | Time, in seconds, to wait for device to bridge | `integer()` | `0` | `false` |  

--- a/applications/callflow/doc/ref/send_dtmf.md
+++ b/applications/callflow/doc/ref/send_dtmf.md
@@ -11,7 +11,7 @@ Validator for the Send DTMF callflow action
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `digits` | String of DTMF tones to send | `string()` |   | `true` |  
-`duration_ms` | How long, in milliseconds, to send each DTMF | `string() | integer()` | `2000` | `false` |  
+`duration_ms` | How long, in milliseconds, to send each DTMF | `integer() | string()` | `2000` | `false` |  
 
 
 

--- a/applications/callflow/doc/ref/transfer.md
+++ b/applications/callflow/doc/ref/transfer.md
@@ -10,7 +10,8 @@ Validator for the transfer callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`captures` | What to default to using if no capture group is present | `array()` | `["no_match"]` | `false` |  
+`captures.[]` |   | `string()` |   | `false` |  
+`captures` | What to default to using if no capture group is present | `array(string())` | `["no_match"]` | `false` |  
 `leg` | Which leg to transfer (transferee) | `string('self' | 'bleg')` |   | `false` |  
 `target` | The target destination (extension or DID) | `string()` |   | `false` |  
 `transfer_type` | The type of transfer to perform | `string('attended' | 'blind')` | `blind` | `false` |  

--- a/applications/callflow/doc/route_to_cid.md
+++ b/applications/callflow/doc/route_to_cid.md
@@ -50,7 +50,8 @@ Key | Description | Type | Default | Required | Support Level
 `cid_types.[]` |   | `string()` |   | `false` |  
 `cid_types` | CID types to perform search: internal, external, custom | `array(string())` | `["internal"]` | `false` |  
 `delay` | How long to delay ringing the device, in seconds | `integer()` | `0` | `false` |  
-`endpoint_types` | Endpoint types to perform search: user, device | `array()` | `[]` | `false` |  
+`endpoint_types.[]` |   | `string()` |   | `false` |  
+`endpoint_types` | Endpoint types to perform search: user, device | `array(string())` | `[]` | `false` |  
 `static_invite` | Override the SIP Username | `string()` |   | `false` |  
 `suppress_clid` | Suppress sending caller ID | `boolean()` |   | `false` |  
 `timeout` | Time, in seconds, to wait for device to bridge | `integer()` | `0` | `false` |  

--- a/applications/callflow/doc/send_dtmf.md
+++ b/applications/callflow/doc/send_dtmf.md
@@ -13,7 +13,7 @@ Validator for the Send DTMF callflow action
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `digits` | String of DTMF tones to send | `string()` |   | `true` |  
-`duration_ms` | How long, in milliseconds, to send each DTMF | `string() | integer()` | `2000` | `false` |  
+`duration_ms` | How long, in milliseconds, to send each DTMF | `integer() | string()` | `2000` | `false` |  
 
 
 

--- a/applications/callflow/doc/transfer.md
+++ b/applications/callflow/doc/transfer.md
@@ -10,7 +10,8 @@ Validator for the transfer callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`captures` | What to default to using if no capture group is present | `array()` | `["no_match"]` | `false` |  
+`captures.[]` |   | `string()` |   | `false` |  
+`captures` | What to default to using if no capture group is present | `array(string())` | `["no_match"]` | `false` |  
 `leg` | Which leg to transfer (transferee) | `string('self' | 'bleg')` |   | `false` |  
 `target` | The target destination (extension or DID) | `string()` |   | `false` |  
 `transfer_type` | The type of transfer to perform | `string('attended' | 'blind')` | `blind` | `false` |  

--- a/applications/crossbar/doc/ref/clicktocall.md
+++ b/applications/crossbar/doc/ref/clicktocall.md
@@ -11,7 +11,7 @@ Click-to-call allows you to create URLs that can be POSTed to with a phone numbe
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `auth_required` | Determines if this click to call requires valid auth-tokens when invoked | `boolean()` | `true` | `false` |  
-`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('true' | 'false' | 'auto')` |   | `false` |  
+`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('auto' | 'false' | 'true')` |   | `false` |  
 `caller_id_number` | Explicitly set caller id number | `string()` |   | `false` |  
 `custom_application_vars./[a-zA-Z0-9\-_]+/` |   | `string()` |   | `false` |  
 `custom_application_vars` | Key-value pairs to set as custom_application_vars on the channel | `object()` | `{}` | `false` |  

--- a/applications/crossbar/doc/ref/devices.md
+++ b/applications/crossbar/doc/ref/devices.md
@@ -47,14 +47,14 @@ Key | Description | Type | Default | Required | Support Level
 `owner_id` | The ID of the user object that 'owns' the device | `string(32)` |   | `false` |  
 `presence_id` | Static presence ID (used instead of SIP username) | `string()` |   | `false` | `supported`
 `provision.combo_keys./^[0-9]+$/.type` | Feature key type | `string('line' | 'presence' | 'parking' | 'personal_parking' | 'speed_dial')` |   | `true` |  
-`provision.combo_keys./^[0-9]+$/.value` | Feature key value | `string() | integer()` |   | `false` |  
+`provision.combo_keys./^[0-9]+$/.value` | Feature key value | `integer() | string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10')` |   | `false` |  
 `provision.combo_keys./^[0-9]+$/` |   | `object() | null()` |   | `false` |  
 `provision.combo_keys` | Feature Keys | `object()` |   | `false` |  
 `provision.endpoint_brand` | Brand of the phone | `string()` |   | `false` |  
 `provision.endpoint_family` | Family name of the phone | `string()` |   | `false` |  
-`provision.endpoint_model` | Model name of the phone | `string() | integer()` |   | `false` |  
+`provision.endpoint_model` | Model name of the phone | `string() | array(string())` |   | `false` |  
 `provision.feature_keys./^[0-9]+$/.type` | Feature key type | `string('presence' | 'parking' | 'personal_parking' | 'speed_dial')` |   | `true` |  
-`provision.feature_keys./^[0-9]+$/.value` | Feature key value | `string() | integer()` |   | `true` |  
+`provision.feature_keys./^[0-9]+$/.value` | Feature key value | `integer() | string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10')` |   | `true` |  
 `provision.feature_keys./^[0-9]+$/` |   | `object() | null()` |   | `false` |  
 `provision.feature_keys` | Feature Keys | `object()` |   | `false` |  
 `provision.id` | Provisioner Template ID | `string()` |   | `false` |  
@@ -171,7 +171,7 @@ Key | Description | Type | Default | Required | Support Level
 `audio.codecs.[]` |   | `string('OPUS' | 'CELT@32000h' | 'G7221@32000h' | 'G7221@16000h' | 'G722' | 'speex@32000h' | 'speex@16000h' | 'PCMU' | 'PCMA' | 'G729' | 'GSM' | 'CELT@48000h' | 'CELT@64000h' | 'G722_16' | 'G722_32' | 'CELT_48' | 'CELT_64' | 'Speex' | 'speex')` |   | `false` |  
 `audio.codecs` | A list of audio codecs the endpoint supports | `array(string('OPUS' | 'CELT@32000h' | 'G7221@32000h' | 'G7221@16000h' | 'G722' | 'speex@32000h' | 'speex@16000h' | 'PCMU' | 'PCMA' | 'G729' | 'GSM' | 'CELT@48000h' | 'CELT@64000h' | 'G722_16' | 'G722_32' | 'CELT_48' | 'CELT_64' | 'Speex' | 'speex'))` |   | `false` |  
 `audio` | The audio media parameters | `object()` | `{}` | `false` |  
-`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('true' | 'false' | 'auto')` |   | `false` |  
+`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('auto' | 'false' | 'true')` |   | `false` |  
 `encryption.enforce_security` | Is Encryption Enabled? | `boolean()` | `false` | `false` |  
 `encryption.methods.[]` |   | `string('zrtp' | 'srtp')` |   | `false` |  
 `encryption.methods` | Supported Encryption Types | `array(string('zrtp' | 'srtp'))` | `[]` | `false` |  

--- a/applications/crossbar/doc/ref/faxes.md
+++ b/applications/crossbar/doc/ref/faxes.md
@@ -20,11 +20,9 @@ Key | Description | Type | Default | Required | Support Level
 `document` | Parameters related to the storage of a fax document | `object()` |   | `false` |  
 `from_name` | The sender name for the fax | `string()` |   | `false` |  
 `from_number` | The sender number for the fax | `string()` |   | `true` |  
-`notifications.email.send_to.[]` |   | `string()` |   | `false` |  
-`notifications.email.send_to` | A list or string of email recipient(s) | `string() | array(string())` |   | `false` |  
+`notifications.email.send_to` | A list or string of email recipient(s) | `array(string()) | string()` |   | `false` |  
 `notifications.email` | Email notifications | `object()` |   | `false` |  
-`notifications.sms.send_to.[]` |   | `string()` |   | `false` |  
-`notifications.sms.send_to` | A list or string of sms recipient(s) | `string() | array(string())` |   | `false` |  
+`notifications.sms.send_to` | A list or string of sms recipient(s) | `array(string()) | string()` |   | `false` |  
 `notifications.sms` | SMS notifications | `object()` |   | `false` |  
 `notifications` | Status notifications | `object()` |   | `false` |  
 `retries` | The number of times to retry | `integer()` | `1` | `false` |  

--- a/applications/crossbar/doc/ref/port_requests.md
+++ b/applications/crossbar/doc/ref/port_requests.md
@@ -22,7 +22,6 @@ Key | Description | Type | Default | Required | Support Level
 `bill` | Billing information of the losing carrier | `object()` |   | `false` |  
 `comments` | The history of comments made on a port request | `array(object())` |   | `false` |  
 `name` | A friendly name for the port request | `string(1..128)` |   | `true` |  
-`notifications.email.send_to.[]` |   | `string()` |   | `false` |  
 `notifications.email.send_to` | A list or string of email recipient(s) | `string() | array(string())` |   | `false` |  
 `notifications.email` | Inbound Email Notifications | `object()` |   | `false` |  
 `notifications` | Status notifications | `object()` |   | `false` |  

--- a/applications/crossbar/doc/ref/resources.md
+++ b/applications/crossbar/doc/ref/resources.md
@@ -84,7 +84,7 @@ Key | Description | Type | Default | Required | Support Level
 `audio.codecs.[]` |   | `string('OPUS' | 'CELT@32000h' | 'G7221@32000h' | 'G7221@16000h' | 'G722' | 'speex@32000h' | 'speex@16000h' | 'PCMU' | 'PCMA' | 'G729' | 'GSM' | 'CELT@48000h' | 'CELT@64000h' | 'G722_16' | 'G722_32' | 'CELT_48' | 'CELT_64' | 'Speex' | 'speex')` |   | `false` |  
 `audio.codecs` | A list of audio codecs the endpoint supports | `array(string('OPUS' | 'CELT@32000h' | 'G7221@32000h' | 'G7221@16000h' | 'G722' | 'speex@32000h' | 'speex@16000h' | 'PCMU' | 'PCMA' | 'G729' | 'GSM' | 'CELT@48000h' | 'CELT@64000h' | 'G722_16' | 'G722_32' | 'CELT_48' | 'CELT_64' | 'Speex' | 'speex'))` |   | `false` |  
 `audio` | The audio media parameters | `object()` | `{}` | `false` |  
-`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('true' | 'false' | 'auto')` |   | `false` |  
+`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('auto' | 'false' | 'true')` |   | `false` |  
 `encryption.enforce_security` | Is Encryption Enabled? | `boolean()` | `false` | `false` |  
 `encryption.methods.[]` |   | `string('zrtp' | 'srtp')` |   | `false` |  
 `encryption.methods` | Supported Encryption Types | `array(string('zrtp' | 'srtp'))` | `[]` | `false` |  

--- a/applications/crossbar/doc/ref/storage.md
+++ b/applications/crossbar/doc/ref/storage.md
@@ -8,8 +8,8 @@
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`^_` | Ignores CouchDB fields prefixed by underscores | `string() | integer() | boolean() | object()` |   | `false` |  
-`^pvt_` | Ignores Kazoo private fields prefixed by pvt_ | `string() | integer() | boolean()` |   | `false` |  
+`^_` | Ignores CouchDB fields prefixed by underscores | `boolean() | integer() | object() | string()` |   | `false` |  
+`^pvt_` | Ignores Kazoo private fields prefixed by pvt_ | `boolean() | integer() | string()` |   | `false` |  
 `attachments` | Defines where and how to store attachments | [#/definitions/storage.attachments](#storageattachments) |   | `false` |  
 `connections` | Describes alternative connections to use (such as alternative CouchDB instances | [#/definitions/storage.connections](#storageconnections) |   | `false` |  
 `id` | ID of the storage document | `string()` |   | `false` |  

--- a/applications/crossbar/doc/ref/users.md
+++ b/applications/crossbar/doc/ref/users.md
@@ -146,7 +146,7 @@ Key | Description | Type | Default | Required | Support Level
 `audio.codecs.[]` |   | `string('OPUS' | 'CELT@32000h' | 'G7221@32000h' | 'G7221@16000h' | 'G722' | 'speex@32000h' | 'speex@16000h' | 'PCMU' | 'PCMA' | 'G729' | 'GSM' | 'CELT@48000h' | 'CELT@64000h' | 'G722_16' | 'G722_32' | 'CELT_48' | 'CELT_64' | 'Speex' | 'speex')` |   | `false` |  
 `audio.codecs` | A list of audio codecs the endpoint supports | `array(string('OPUS' | 'CELT@32000h' | 'G7221@32000h' | 'G7221@16000h' | 'G722' | 'speex@32000h' | 'speex@16000h' | 'PCMU' | 'PCMA' | 'G729' | 'GSM' | 'CELT@48000h' | 'CELT@64000h' | 'G722_16' | 'G722_32' | 'CELT_48' | 'CELT_64' | 'Speex' | 'speex'))` |   | `false` |  
 `audio` | The audio media parameters | `object()` | `{}` | `false` |  
-`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('true' | 'false' | 'auto')` |   | `false` |  
+`bypass_media` | Default bypass media mode (The string type is deprecated, please use this as a boolean) | `boolean() | string('auto' | 'false' | 'true')` |   | `false` |  
 `encryption.enforce_security` | Is Encryption Enabled? | `boolean()` | `false` | `false` |  
 `encryption.methods.[]` |   | `string('zrtp' | 'srtp')` |   | `false` |  
 `encryption.methods` | Supported Encryption Types | `array(string('zrtp' | 'srtp'))` | `[]` | `false` |  

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1461,9 +1461,13 @@
                 },
                 "data": {
                     "description": "The number to transfer to, or a boolean, depending on the 'action'",
-                    "type": [
-                        "string",
-                        "boolean"
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string"
+                        }
                     ]
                 }
             },
@@ -1955,16 +1959,24 @@
                 },
                 "play_entry_tone": {
                     "description": "Should the Entry Tone be played",
-                    "type": [
-                        "boolean",
-                        "string"
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string"
+                        }
                     ]
                 },
                 "play_exit_tone": {
                     "description": "Should the Exit Tone be played",
-                    "type": [
-                        "boolean",
-                        "string"
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string"
+                        }
                     ]
                 },
                 "welcome_prompt": {
@@ -2209,14 +2221,18 @@
                     "properties": {
                         "fax_option": {
                             "description": "Caller flag for T38 settings",
-                            "enum": [
-                                "auto",
-                                true,
-                                false
-                            ],
-                            "type": [
-                                "string",
-                                "boolean"
+                            "oneOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "enum": [
+                                        "auto",
+                                        "true",
+                                        "false"
+                                    ],
+                                    "type": "string"
+                                }
                             ]
                         }
                     },
@@ -2519,9 +2535,18 @@
                         "properties": {
                             "id": {
                                 "description": "The email address/user ID or the list of email addresses/user IDs based on specified type",
-                                "type": [
-                                    "string",
-                                    "array"
+                                "oneOf": [
+                                    {
+                                        "format": "email",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "items": {
+                                            "format": "email",
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
                                 ]
                             },
                             "type": {
@@ -2957,14 +2982,18 @@
                     "properties": {
                         "fax_option": {
                             "description": "Caller flag for T38 settings",
-                            "enum": [
-                                "auto",
-                                true,
-                                false
-                            ],
-                            "type": [
-                                "string",
-                                "boolean"
+                            "oneOf": [
+                                {
+                                    "enum": [
+                                        "auto",
+                                        "false",
+                                        "true"
+                                    ],
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
                             ]
                         }
                     },
@@ -3358,6 +3387,9 @@
                 "endpoint_types": {
                     "default": [],
                     "description": "Endpoint types to perform search: user, device",
+                    "items": {
+                        "type": "string"
+                    },
                     "type": "array"
                 },
                 "static_invite": {
@@ -3386,9 +3418,13 @@
                 "duration_ms": {
                     "default": "2000",
                     "description": "How long, in milliseconds, to send each DTMF",
-                    "type": [
-                        "string",
-                        "integer"
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        }
                     ]
                 }
             },
@@ -3546,6 +3582,9 @@
                         "no_match"
                     ],
                     "description": "What to default to using if no capture group is present",
+                    "items": {
+                        "type": "string"
+                    },
                     "type": "array"
                 },
                 "leg": {
@@ -3986,14 +4025,18 @@
                 },
                 "bypass_media": {
                     "description": "Default bypass media mode (The string type is deprecated, please use this as a boolean)",
-                    "enum": [
-                        true,
-                        false,
-                        "auto"
-                    ],
-                    "type": [
-                        "boolean",
-                        "string"
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "enum": [
+                                "auto",
+                                "false",
+                                "true"
+                            ],
+                            "type": "string"
+                        }
                     ]
                 },
                 "caller_id_number": {
@@ -4247,16 +4290,24 @@
                 },
                 "play_entry_tone": {
                     "description": "Whether to play an entry tone, or the entry tone to play",
-                    "type": [
-                        "boolean",
-                        "string"
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string"
+                        }
                     ]
                 },
                 "play_exit_tone": {
                     "description": "Whether to play an exit tone, or the exit tone to play",
-                    "type": [
-                        "boolean",
-                        "string"
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string"
+                        }
                     ]
                 },
                 "play_name": {
@@ -4976,9 +5027,16 @@
                         },
                         "endpoint_model": {
                             "description": "Model name of the phone",
-                            "type": [
-                                "string",
-                                "integer"
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
                             ]
                         },
                         "feature_keys": {
@@ -5299,14 +5357,18 @@
                 },
                 "bypass_media": {
                     "description": "Default bypass media mode (The string type is deprecated, please use this as a boolean)",
-                    "enum": [
-                        true,
-                        false,
-                        "auto"
-                    ],
-                    "type": [
-                        "boolean",
-                        "string"
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "enum": [
+                                "auto",
+                                "false",
+                                "true"
+                            ],
+                            "type": "string"
+                        }
                     ]
                 },
                 "encryption": {
@@ -5461,14 +5523,18 @@
                                     "properties": {
                                         "send_to": {
                                             "description": "A list or string of email recipient(s)",
-                                            "format": "email",
-                                            "items": {
-                                                "format": "email",
-                                                "type": "string"
-                                            },
-                                            "type": [
-                                                "string",
-                                                "array"
+                                            "oneOf": [
+                                                {
+                                                    "items": {
+                                                        "format": "email",
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                {
+                                                    "format": "email",
+                                                    "type": "string"
+                                                }
                                             ]
                                         }
                                     },
@@ -5479,12 +5545,16 @@
                                     "properties": {
                                         "send_to": {
                                             "description": "A list or string of sms recipient(s)",
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "type": [
-                                                "string",
-                                                "array"
+                                            "oneOf": [
+                                                {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                }
                                             ]
                                         }
                                     },
@@ -5528,14 +5598,18 @@
                                     "properties": {
                                         "send_to": {
                                             "description": "A list or string of email recipient(s)",
-                                            "format": "email",
-                                            "items": {
-                                                "format": "email",
-                                                "type": "string"
-                                            },
-                                            "type": [
-                                                "string",
-                                                "array"
+                                            "oneOf": [
+                                                {
+                                                    "items": {
+                                                        "format": "email",
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                {
+                                                    "format": "email",
+                                                    "type": "string"
+                                                }
                                             ]
                                         }
                                     },
@@ -5546,12 +5620,16 @@
                                     "properties": {
                                         "send_to": {
                                             "description": "A list or string of sms recipient(s)",
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "type": [
-                                                "string",
-                                                "array"
+                                            "oneOf": [
+                                                {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                }
                                             ]
                                         }
                                     },
@@ -5650,14 +5728,18 @@
                             "properties": {
                                 "send_to": {
                                     "description": "A list or string of email recipient(s)",
-                                    "format": "email",
-                                    "items": {
-                                        "format": "email",
-                                        "type": "string"
-                                    },
-                                    "type": [
-                                        "string",
-                                        "array"
+                                    "oneOf": [
+                                        {
+                                            "items": {
+                                                "format": "email",
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "format": "email",
+                                            "type": "string"
+                                        }
                                     ]
                                 }
                             },
@@ -5668,12 +5750,16 @@
                             "properties": {
                                 "send_to": {
                                     "description": "A list or string of sms recipient(s)",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": [
-                                        "string",
-                                        "array"
+                                    "oneOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
                                     ]
                                 }
                             },
@@ -24083,11 +24169,15 @@
                     "properties": {
                         "exit_media": {
                             "description": "When a call is transferred from the menu after all retries exhausted this media can be played (prior to transfer if enabled)",
-                            "maxLength": 2048,
-                            "minLength": 3,
-                            "type": [
-                                "boolean",
-                                "string"
+                            "oneOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "maxLength": 2048,
+                                    "minLength": 3,
+                                    "type": "string"
+                                }
                             ]
                         },
                         "greeting": {
@@ -24098,20 +24188,28 @@
                         },
                         "invalid_media": {
                             "description": "When the collected digits don't result in a match or hunt this media can be played",
-                            "maxLength": 2048,
-                            "minLength": 3,
-                            "type": [
-                                "boolean",
-                                "string"
+                            "oneOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "maxLength": 2048,
+                                    "minLength": 3,
+                                    "type": "string"
+                                }
                             ]
                         },
                         "transfer_media": {
                             "description": "When a call is transferred from the menu, either after all retries exhausted or a successful hunt, this media can be played",
-                            "maxLength": 2048,
-                            "minLength": 3,
-                            "type": [
-                                "boolean",
-                                "string"
+                            "oneOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "maxLength": 2048,
+                                    "minLength": 3,
+                                    "type": "string"
+                                }
                             ]
                         }
                     },
@@ -24532,16 +24630,24 @@
                 },
                 "other_participant": {
                     "description": "The other participant ID to relate",
-                    "type": [
-                        "string",
-                        "integer"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
                     ]
                 },
                 "participant_id": {
                     "description": "The participant ID to relate",
-                    "type": [
-                        "string",
-                        "integer"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
                     ]
                 },
                 "relationship": {
@@ -24688,6 +24794,9 @@
                         "no_match"
                     ],
                     "description": "Capture groups?",
+                    "items": {
+                        "type": "string"
+                    },
                     "type": "array"
                 },
                 "leg": {
@@ -24743,6 +24852,23 @@
                         "#"
                     ],
                     "description": "What DTMF can terminate the TTS playback",
+                    "items": {
+                        "enum": [
+                            "1",
+                            "2",
+                            "3",
+                            "4",
+                            "5",
+                            "6",
+                            "7",
+                            "8",
+                            "9",
+                            "*",
+                            "0",
+                            "#"
+                        ],
+                        "type": "string"
+                    },
                     "type": "array"
                 },
                 "text": {
@@ -25196,14 +25322,18 @@
                             "properties": {
                                 "send_to": {
                                     "description": "A list or string of email recipient(s)",
-                                    "format": "email",
-                                    "items": {
-                                        "format": "email",
-                                        "type": "string"
-                                    },
-                                    "type": [
-                                        "string",
-                                        "array"
+                                    "oneOf": [
+                                        {
+                                            "format": "email",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "items": {
+                                                "format": "email",
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        }
                                     ]
                                 }
                             },
@@ -31082,10 +31212,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.cnam_request default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 }
             },
             "type": "object"
@@ -31096,10 +31233,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.deregister default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "html_content_transfer_encoding": {
                     "default": "7BIT",
@@ -31169,10 +31313,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.first_occurrence default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "html_content_transfer_encoding": {
                     "default": "7BIT",
@@ -31209,10 +31360,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.new_account default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "html_content_transfer_encoding": {
                     "default": "7BIT",
@@ -31231,12 +31389,18 @@
             "description": "Schema for notify.password_recovery system_config",
             "properties": {
                 "default_to": {
-                    "default": "",
                     "description": "notify.password_recovery default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "html_content_transfer_encoding": {
                     "default": "7BIT",
@@ -31261,10 +31425,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.port_cancel default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 }
             },
             "type": "object"
@@ -31279,10 +31450,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.port_request default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 }
             },
             "type": "object"
@@ -31292,12 +31470,18 @@
             "properties": {
                 "default_to": {
                     "description": "notify.port_request_admin default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "string",
-                        "array"
+                    "oneOf": [
+                        {
+                            "items": {
+                                "format": "email",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "format": "email",
+                            "type": "string"
+                        }
                     ]
                 }
             },
@@ -31309,10 +31493,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.ported default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "send_from_admin_email": {
                     "default": true,
@@ -31328,10 +31519,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.system_alert default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "enable_email_alerts": {
                     "default": true,
@@ -31361,10 +31559,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.topup default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "html_content_transfer_encoding": {
                     "default": "7BIT",
@@ -31385,10 +31590,17 @@
                 "default_to": {
                     "default": "",
                     "description": "notify.transaction default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "html_content_transfer_encoding": {
                     "default": "7BIT",
@@ -31413,12 +31625,18 @@
                 },
                 "default_to": {
                     "description": "notify.voicemail_full default to",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "string",
-                        "array"
+                    "oneOf": [
+                        {
+                            "items": {
+                                "format": "email",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "format": "email",
+                            "type": "string"
+                        }
                     ]
                 }
             },
@@ -31658,9 +31876,16 @@
                 },
                 "endpoints": {
                     "description": "number_manager.bandwidth endpoints",
-                    "type": [
-                        "string",
-                        "array"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     ]
                 },
                 "numbers_api_url": {
@@ -31784,9 +32009,16 @@
                 },
                 "endpoints": {
                     "description": "number_manager.other endpoints",
-                    "type": [
-                        "string",
-                        "array"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     ]
                 },
                 "phonebook_url": {
@@ -31881,9 +32113,16 @@
                 },
                 "routesip": {
                     "description": "number_manager.vitelity routesip",
-                    "type": [
-                        "string",
-                        "array"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     ]
                 },
                 "use_stepswitch_cnam": {

--- a/applications/crossbar/priv/couchdb/schemas/callflows.after_bridge.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.after_bridge.json
@@ -14,9 +14,13 @@
         },
         "data": {
             "description": "The number to transfer to, or a boolean, depending on the 'action'",
-            "type": [
-                "string",
-                "boolean"
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "string"
+                }
             ]
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/callflows.conference.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.conference.json
@@ -20,16 +20,24 @@
         },
         "play_entry_tone": {
             "description": "Should the Entry Tone be played",
-            "type": [
-                "boolean",
-                "string"
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "string"
+                }
             ]
         },
         "play_exit_tone": {
             "description": "Should the Exit Tone be played",
-            "type": [
-                "boolean",
-                "string"
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "string"
+                }
             ]
         },
         "welcome_prompt": {

--- a/applications/crossbar/priv/couchdb/schemas/callflows.faxbox.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.faxbox.json
@@ -15,14 +15,18 @@
             "properties": {
                 "fax_option": {
                     "description": "Caller flag for T38 settings",
-                    "enum": [
-                        "auto",
-                        true,
-                        false
-                    ],
-                    "type": [
-                        "string",
-                        "boolean"
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "enum": [
+                                "auto",
+                                "true",
+                                "false"
+                            ],
+                            "type": "string"
+                        }
                     ]
                 }
             },

--- a/applications/crossbar/priv/couchdb/schemas/callflows.missed_call_alert.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.missed_call_alert.json
@@ -9,9 +9,18 @@
                 "properties": {
                     "id": {
                         "description": "The email address/user ID or the list of email addresses/user IDs based on specified type",
-                        "type": [
-                            "string",
-                            "array"
+                        "oneOf": [
+                            {
+                                "format": "email",
+                                "type": "string"
+                            },
+                            {
+                                "items": {
+                                    "format": "email",
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
                         ]
                     },
                     "type": {

--- a/applications/crossbar/priv/couchdb/schemas/callflows.receive_fax.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.receive_fax.json
@@ -7,14 +7,18 @@
             "properties": {
                 "fax_option": {
                     "description": "Caller flag for T38 settings",
-                    "enum": [
-                        "auto",
-                        true,
-                        false
-                    ],
-                    "type": [
-                        "string",
-                        "boolean"
+                    "oneOf": [
+                        {
+                            "enum": [
+                                "auto",
+                                "false",
+                                "true"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "type": "boolean"
+                        }
                     ]
                 }
             },

--- a/applications/crossbar/priv/couchdb/schemas/callflows.route_to_cid.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.route_to_cid.json
@@ -30,6 +30,9 @@
         "endpoint_types": {
             "default": [],
             "description": "Endpoint types to perform search: user, device",
+            "items": {
+                "type": "string"
+            },
             "type": "array"
         },
         "static_invite": {

--- a/applications/crossbar/priv/couchdb/schemas/callflows.send_dtmf.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.send_dtmf.json
@@ -10,9 +10,13 @@
         "duration_ms": {
             "default": "2000",
             "description": "How long, in milliseconds, to send each DTMF",
-            "type": [
-                "string",
-                "integer"
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
             ]
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/callflows.transfer.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.transfer.json
@@ -8,6 +8,9 @@
                 "no_match"
             ],
             "description": "What to default to using if no capture group is present",
+            "items": {
+                "type": "string"
+            },
             "type": "array"
         },
         "leg": {

--- a/applications/crossbar/priv/couchdb/schemas/clicktocall.json
+++ b/applications/crossbar/priv/couchdb/schemas/clicktocall.json
@@ -10,14 +10,18 @@
         },
         "bypass_media": {
             "description": "Default bypass media mode (The string type is deprecated, please use this as a boolean)",
-            "enum": [
-                true,
-                false,
-                "auto"
-            ],
-            "type": [
-                "boolean",
-                "string"
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "enum": [
+                        "auto",
+                        "false",
+                        "true"
+                    ],
+                    "type": "string"
+                }
             ]
         },
         "caller_id_number": {

--- a/applications/crossbar/priv/couchdb/schemas/conferences.json
+++ b/applications/crossbar/priv/couchdb/schemas/conferences.json
@@ -148,19 +148,27 @@
         },
         "play_entry_tone": {
             "description": "Whether to play an entry tone, or the entry tone to play",
-            "support_level": "supported",
-            "type": [
-                "boolean",
-                "string"
-            ]
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "support_level": "supported"
         },
         "play_exit_tone": {
             "description": "Whether to play an exit tone, or the exit tone to play",
-            "support_level": "supported",
-            "type": [
-                "boolean",
-                "string"
-            ]
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "support_level": "supported"
         },
         "play_name": {
             "default": false,

--- a/applications/crossbar/priv/couchdb/schemas/devices.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.json
@@ -262,11 +262,27 @@
                                 },
                                 "value": {
                                     "description": "Feature key value",
-                                    "maximum": 10,
-                                    "minimum": 1,
-                                    "type": [
-                                        "string",
-                                        "integer"
+                                    "oneOf": [
+                                        {
+                                            "maximum": 10,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "enum": [
+                                                "1",
+                                                "2",
+                                                "3",
+                                                "4",
+                                                "5",
+                                                "6",
+                                                "7",
+                                                "8",
+                                                "9",
+                                                "10"
+                                            ],
+                                            "type": "string"
+                                        }
                                     ]
                                 }
                             },
@@ -291,9 +307,16 @@
                 },
                 "endpoint_model": {
                     "description": "Model name of the phone",
-                    "type": [
-                        "string",
-                        "integer"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     ]
                 },
                 "feature_keys": {
@@ -313,11 +336,27 @@
                                 },
                                 "value": {
                                     "description": "Feature key value",
-                                    "maximum": 10,
-                                    "minimum": 1,
-                                    "type": [
-                                        "string",
-                                        "integer"
+                                    "oneOf": [
+                                        {
+                                            "maximum": 10,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "enum": [
+                                                "1",
+                                                "2",
+                                                "3",
+                                                "4",
+                                                "5",
+                                                "6",
+                                                "7",
+                                                "8",
+                                                "9",
+                                                "10"
+                                            ],
+                                            "type": "string"
+                                        }
                                     ]
                                 }
                             },

--- a/applications/crossbar/priv/couchdb/schemas/endpoint.media.json
+++ b/applications/crossbar/priv/couchdb/schemas/endpoint.media.json
@@ -41,14 +41,18 @@
         },
         "bypass_media": {
             "description": "Default bypass media mode (The string type is deprecated, please use this as a boolean)",
-            "enum": [
-                true,
-                false,
-                "auto"
-            ],
-            "type": [
-                "boolean",
-                "string"
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "enum": [
+                        "auto",
+                        "false",
+                        "true"
+                    ],
+                    "type": "string"
+                }
             ]
         },
         "encryption": {

--- a/applications/crossbar/priv/couchdb/schemas/faxbox.json
+++ b/applications/crossbar/priv/couchdb/schemas/faxbox.json
@@ -101,14 +101,18 @@
                             "properties": {
                                 "send_to": {
                                     "description": "A list or string of email recipient(s)",
-                                    "format": "email",
-                                    "items": {
-                                        "format": "email",
-                                        "type": "string"
-                                    },
-                                    "type": [
-                                        "string",
-                                        "array"
+                                    "oneOf": [
+                                        {
+                                            "items": {
+                                                "format": "email",
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "format": "email",
+                                            "type": "string"
+                                        }
                                     ]
                                 }
                             },
@@ -120,12 +124,16 @@
                             "properties": {
                                 "send_to": {
                                     "description": "A list or string of sms recipient(s)",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": [
-                                        "string",
-                                        "array"
+                                    "oneOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
                                     ]
                                 }
                             },
@@ -172,14 +180,18 @@
                             "properties": {
                                 "send_to": {
                                     "description": "A list or string of email recipient(s)",
-                                    "format": "email",
-                                    "items": {
-                                        "format": "email",
-                                        "type": "string"
-                                    },
-                                    "type": [
-                                        "string",
-                                        "array"
+                                    "oneOf": [
+                                        {
+                                            "items": {
+                                                "format": "email",
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "format": "email",
+                                            "type": "string"
+                                        }
                                     ]
                                 }
                             },
@@ -191,12 +203,16 @@
                             "properties": {
                                 "send_to": {
                                     "description": "A list or string of sms recipient(s)",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": [
-                                        "string",
-                                        "array"
+                                    "oneOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
                                     ]
                                 }
                             },

--- a/applications/crossbar/priv/couchdb/schemas/faxes.json
+++ b/applications/crossbar/priv/couchdb/schemas/faxes.json
@@ -66,14 +66,18 @@
                     "properties": {
                         "send_to": {
                             "description": "A list or string of email recipient(s)",
-                            "format": "email",
-                            "items": {
-                                "format": "email",
-                                "type": "string"
-                            },
-                            "type": [
-                                "string",
-                                "array"
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "format": "email",
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "format": "email",
+                                    "type": "string"
+                                }
                             ]
                         }
                     },
@@ -84,12 +88,16 @@
                     "properties": {
                         "send_to": {
                             "description": "A list or string of sms recipient(s)",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "string",
-                                "array"
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "string"
+                                }
                             ]
                         }
                     },

--- a/applications/crossbar/priv/couchdb/schemas/menus.json
+++ b/applications/crossbar/priv/couchdb/schemas/menus.json
@@ -50,13 +50,17 @@
             "properties": {
                 "exit_media": {
                     "description": "When a call is transferred from the menu after all retries exhausted this media can be played (prior to transfer if enabled)",
-                    "maxLength": 2048,
-                    "minLength": 3,
-                    "support_level": "supported",
-                    "type": [
-                        "boolean",
-                        "string"
-                    ]
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "maxLength": 2048,
+                            "minLength": 3,
+                            "type": "string"
+                        }
+                    ],
+                    "support_level": "supported"
                 },
                 "greeting": {
                     "description": "The ID of a media object that should be used as the menu greeting",
@@ -67,23 +71,31 @@
                 },
                 "invalid_media": {
                     "description": "When the collected digits don't result in a match or hunt this media can be played",
-                    "maxLength": 2048,
-                    "minLength": 3,
-                    "support_level": "supported",
-                    "type": [
-                        "boolean",
-                        "string"
-                    ]
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "maxLength": 2048,
+                            "minLength": 3,
+                            "type": "string"
+                        }
+                    ],
+                    "support_level": "supported"
                 },
                 "transfer_media": {
                     "description": "When a call is transferred from the menu, either after all retries exhausted or a successful hunt, this media can be played",
-                    "maxLength": 2048,
-                    "minLength": 3,
-                    "support_level": "supported",
-                    "type": [
-                        "boolean",
-                        "string"
-                    ]
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "maxLength": 2048,
+                            "minLength": 3,
+                            "type": "string"
+                        }
+                    ],
+                    "support_level": "supported"
                 }
             },
             "support_level": "supported",

--- a/applications/crossbar/priv/couchdb/schemas/metaflows.relate.json
+++ b/applications/crossbar/priv/couchdb/schemas/metaflows.relate.json
@@ -9,16 +9,24 @@
         },
         "other_participant": {
             "description": "The other participant ID to relate",
-            "type": [
-                "string",
-                "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
             ]
         },
         "participant_id": {
             "description": "The participant ID to relate",
-            "type": [
-                "string",
-                "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
             ]
         },
         "relationship": {

--- a/applications/crossbar/priv/couchdb/schemas/metaflows.transfer.json
+++ b/applications/crossbar/priv/couchdb/schemas/metaflows.transfer.json
@@ -8,6 +8,9 @@
                 "no_match"
             ],
             "description": "Capture groups?",
+            "items": {
+                "type": "string"
+            },
             "type": "array"
         },
         "leg": {

--- a/applications/crossbar/priv/couchdb/schemas/metaflows.tts.json
+++ b/applications/crossbar/priv/couchdb/schemas/metaflows.tts.json
@@ -33,6 +33,23 @@
                 "#"
             ],
             "description": "What DTMF can terminate the TTS playback",
+            "items": {
+                "enum": [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                    "6",
+                    "7",
+                    "8",
+                    "9",
+                    "*",
+                    "0",
+                    "#"
+                ],
+                "type": "string"
+            },
             "type": "array"
         },
         "text": {

--- a/applications/crossbar/priv/couchdb/schemas/port_requests.json
+++ b/applications/crossbar/priv/couchdb/schemas/port_requests.json
@@ -66,14 +66,18 @@
                     "properties": {
                         "send_to": {
                             "description": "A list or string of email recipient(s)",
-                            "format": "email",
-                            "items": {
-                                "format": "email",
-                                "type": "string"
-                            },
-                            "type": [
-                                "string",
-                                "array"
+                            "oneOf": [
+                                {
+                                    "format": "email",
+                                    "type": "string"
+                                },
+                                {
+                                    "items": {
+                                        "format": "email",
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
                             ]
                         }
                     },

--- a/applications/crossbar/priv/couchdb/schemas/storage.json
+++ b/applications/crossbar/priv/couchdb/schemas/storage.json
@@ -4,19 +4,33 @@
     "patternProperties": {
         "^_": {
             "description": "Ignores CouchDB fields prefixed by underscores",
-            "type": [
-                "string",
-                "integer",
-                "boolean",
-                "object"
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "string"
+                }
             ]
         },
         "^pvt_": {
             "description": "Ignores Kazoo private fields prefixed by pvt_",
-            "type": [
-                "string",
-                "integer",
-                "boolean"
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
             ]
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.cnam_request.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.cnam_request.json
@@ -6,10 +6,17 @@
         "default_to": {
             "default": "",
             "description": "notify.cnam_request default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         }
     },
     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.deregister.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.deregister.json
@@ -6,10 +6,17 @@
         "default_to": {
             "default": "",
             "description": "notify.deregister default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         },
         "html_content_transfer_encoding": {
             "default": "7BIT",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.first_occurrence.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.first_occurrence.json
@@ -6,10 +6,17 @@
         "default_to": {
             "default": "",
             "description": "notify.first_occurrence default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         },
         "html_content_transfer_encoding": {
             "default": "7BIT",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.new_account.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.new_account.json
@@ -6,10 +6,17 @@
         "default_to": {
             "default": "",
             "description": "notify.new_account default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         },
         "html_content_transfer_encoding": {
             "default": "7BIT",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.password_recovery.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.password_recovery.json
@@ -4,12 +4,18 @@
     "description": "Schema for notify.password_recovery system_config",
     "properties": {
         "default_to": {
-            "default": "",
             "description": "notify.password_recovery default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         },
         "html_content_transfer_encoding": {
             "default": "7BIT",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.port_cancel.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.port_cancel.json
@@ -10,10 +10,17 @@
         "default_to": {
             "default": "",
             "description": "notify.port_cancel default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         }
     },
     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.port_request.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.port_request.json
@@ -10,10 +10,17 @@
         "default_to": {
             "default": "",
             "description": "notify.port_request default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         }
     },
     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.port_request_admin.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.port_request_admin.json
@@ -5,12 +5,18 @@
     "properties": {
         "default_to": {
             "description": "notify.port_request_admin default to",
-            "items": {
-                "type": "string"
-            },
-            "type": [
-                "string",
-                "array"
+            "oneOf": [
+                {
+                    "items": {
+                        "format": "email",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                {
+                    "format": "email",
+                    "type": "string"
+                }
             ]
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.ported.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.ported.json
@@ -6,10 +6,17 @@
         "default_to": {
             "default": "",
             "description": "notify.ported default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         },
         "send_from_admin_email": {
             "default": true,

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.system_alert.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.system_alert.json
@@ -6,10 +6,17 @@
         "default_to": {
             "default": "",
             "description": "notify.system_alert default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         },
         "enable_email_alerts": {
             "default": true,

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.topup.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.topup.json
@@ -6,10 +6,17 @@
         "default_to": {
             "default": "",
             "description": "notify.topup default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         },
         "html_content_transfer_encoding": {
             "default": "7BIT",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.transaction.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.transaction.json
@@ -6,10 +6,17 @@
         "default_to": {
             "default": "",
             "description": "notify.transaction default to",
-            "items": {
-                "type": "string"
-            },
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
         },
         "html_content_transfer_encoding": {
             "default": "7BIT",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.voicemail_full.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.voicemail_full.json
@@ -10,12 +10,18 @@
         },
         "default_to": {
             "description": "notify.voicemail_full default to",
-            "items": {
-                "type": "string"
-            },
-            "type": [
-                "string",
-                "array"
+            "oneOf": [
+                {
+                    "items": {
+                        "format": "email",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                {
+                    "format": "email",
+                    "type": "string"
+                }
             ]
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.bandwidth.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.bandwidth.json
@@ -20,9 +20,16 @@
         },
         "endpoints": {
             "description": "number_manager.bandwidth endpoints",
-            "type": [
-                "string",
-                "array"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
             ]
         },
         "numbers_api_url": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.other.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.other.json
@@ -10,9 +10,16 @@
         },
         "endpoints": {
             "description": "number_manager.other endpoints",
-            "type": [
-                "string",
-                "array"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
             ]
         },
         "phonebook_url": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.number_manager.vitelity.json
@@ -10,9 +10,16 @@
         },
         "routesip": {
             "description": "number_manager.vitelity routesip",
-            "type": [
-                "string",
-                "array"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
             ]
         },
         "use_stepswitch_cnam": {

--- a/core/kazoo_ast/src/kapps_config_usage.erl
+++ b/core/kazoo_ast/src/kapps_config_usage.erl
@@ -397,8 +397,13 @@ guess_properties(Document, Source, [_Key, ?FIELD_PROPERTIES|_]=Keys, Type, Defau
 type(['undefined']) ->
     [{?FIELD_TYPE, <<"array">>}];
 type({Type, [OrArrayType]}) ->
-    [{?FIELD_TYPE, [Type, <<"array">>]}
-    ,{<<"items">>, kz_json:from_list([{?FIELD_TYPE, OrArrayType}])}
+    [{<<"oneOf">>
+     ,[kz_json:from_list([{?FIELD_TYPE, Type}])
+      ,kz_json:from_list([{?FIELD_TYPE, <<"array">>}
+                         ,{<<"items">>, kz_json:from_list([{?FIELD_TYPE, OrArrayType}])}
+                         ])
+      ]
+     }
     ];
 type([Type]) ->
     [{?FIELD_TYPE, <<"array">>}

--- a/core/kazoo_ast/src/kp_data_usage.erl
+++ b/core/kazoo_ast/src/kp_data_usage.erl
@@ -101,11 +101,32 @@ maybe_insert_schema(F, [K|Ks], Default, Schema) ->
                         );
 maybe_insert_schema(F, [], Default, Schema) ->
     Updates = props:filter_undefined(
-                [{<<"type">>, guess_type(F, Default)}
-                ,{<<"default">>, check_default(Default)}
+                [{<<"default">>, check_default(Default)}
                 ,{<<"description">>, <<>>}
                 ]),
-    kz_json:insert_values(Updates, Schema).
+    kz_json:insert_values(Updates, insert_type(guess_type(F, Default), Schema)).
+
+insert_type(Types, Schema) ->
+    OneOf = kz_json:get_first_defined([<<"oneOf">>, <<"anyOf">>, <<"allOf">>], Schema),
+    insert_type(Types, Schema, OneOf).
+
+insert_type({Type, ItemsType}, Schema, 'undefined') ->
+    kz_json:insert_values([{<<"items">>, kz_json:from_list([{<<"type">>, ItemsType}])}
+                          ,{<<"type">>, Type}
+                          ], Schema);
+insert_type(Type, Schema, 'undefined' = _OneOf) ->
+    kz_json:insert_values([{<<"type">>, Type}], Schema);
+insert_type(Type, Schema, [_|_]=Of) ->
+    case lists:any(fun(Elem) -> kz_json:get_value(<<"type">>, Elem) =/= 'undefined' end, Of) of
+        'true' ->
+            case kz_json:get_value(<<"type">>, Schema) of
+                'undefined' -> 'ok';
+                _ -> io:format("schema can not define type both in (anyOf | allOf | oneOf) and root:~n~p~n", [Schema])
+            end,
+            kz_json:delete_key(<<"type">>, Schema);
+        'false' ->
+            insert_type(Type, Schema, 'undefined')
+    end.
 
 check_default({_M, _F, _A}) -> 'undefined';
 check_default([<<_/binary>>|_]=L) ->
@@ -130,9 +151,9 @@ check_default(Default) ->
 guess_type('get_value', <<_/binary>>) ->
     <<"string">>;
 guess_type('get_value', []) ->
-    <<"array">>;
+    {<<"array">>, 'undefined'};
 guess_type('get_ne_value', []) ->
-    <<"array">>;
+    {<<"array">>, 'undefined'};
 guess_type('get_value', ?EMPTY_JSON_OBJECT) ->
     <<"object">>;
 guess_type('get_value', I) when is_integer(I) ->
@@ -168,9 +189,9 @@ guess_type('get_float_value', _) ->
 guess_type('get_json_value', _) ->
     <<"object">>;
 guess_type('get_list_value', [<<_/binary>>|_]) ->
-    <<"array">>;
+    {<<"array">>, <<"string">>};
 guess_type('get_list_value', _L) ->
-    <<"array">>;
+    {<<"array">>, 'undefined'};
 guess_type('find', _) ->
     'undefined';
 guess_type('get_ne_value', <<_/binary>>) ->


### PR DESCRIPTION
In an effort to convert Swagger file to OpenAPI 3 for better documenting and testing, we need to fix some issues with JSON Schemas.

This pull request is fixing these issues:

* `type` – the value must be a single type and not an array of types. This pull request convert these types to use "oneOf" subschemas defining types.
* `items` – must be present if `type` is `array`. Properly adding or constructing `items` if type is `array`.

The rest of conversion and checks for JSON Schema to OAS3 Schema will be handled in another PR since we don't need to make those conversion directly on JSON Schema and they can be done just for writing to OAS3 file.