### PR TITLE
storing superduper and account admin in context

### DIFF
--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -183,6 +183,8 @@
                     ,magic_pathed = 'false' :: boolean()
                     ,should_paginate :: kz_term:api_boolean()
                     ,host_url = <<>> :: binary()
+                    ,is_superduper_admin = 'undefined' :: kz_term:api_boolean()
+                    ,is_account_admin = 'undefined' :: kz_term:api_boolean()
                     }).
 
 -define(MAX_RANGE, kapps_config:get_pos_integer(?CONFIG_CAT

--- a/applications/crossbar/src/modules/cb_templates.erl
+++ b/applications/crossbar/src/modules/cb_templates.erl
@@ -233,7 +233,7 @@ import_template_docs([Id|Ids], TemplateDb, AccountId, AccountDb) ->
             import_template_docs(Ids, TemplateDb, AccountId, AccountDb)
     end.
 
--spec import_template_doc(kz_term:ne_binaries(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
+-spec import_template_doc(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 import_template_doc(Id, TemplateDb, AccountId, AccountDb, JObj) ->
     AttachmentNames = kz_doc:attachment_names(JObj),
     Updates = [{kz_doc:path_account_id(), AccountId}


### PR DESCRIPTION
Since multiple modules are checking for superduper admin and account admin, this PR is adding those keys to `cb_context` record after Auth token validation so it is accessible in all modules.