### PR TITLE
Handle new device only on successful save

### DIFF
--- a/applications/crossbar/src/modules_v2/cb_devices_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_devices_v2.erl
@@ -278,9 +278,17 @@ patch(Context, Id) ->
 -spec put(cb_context:context()) -> cb_context:context().
 put(Context) ->
     Context1 = crossbar_doc:save(Context),
-    _ = maybe_aggregate_device('undefined', Context1),
-    _ = kz_util:spawn(fun update_device_provisioning/1, [Context1]),
-    maybe_add_mobile_mdn(Context1).
+
+    case cb_context:resp_status(Context1) of
+        'success' -> handle_new_device(Context1);
+        _Status -> Context1
+    end.
+
+-spec handle_new_device(cb_context:context()) -> cb_context:context().
+handle_new_device(Context) ->
+    _ = maybe_aggregate_device('undefined', Context),
+    _ = kz_util:spawn(fun update_device_provisioning/1, [Context]),
+    maybe_add_mobile_mdn(Context).
 
 -spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context, DeviceId) ->
@@ -863,16 +871,16 @@ add_mobile_mdn(Context) ->
           ,{<<"device-id">>, kz_doc:id(cb_context:doc(Context))}
           ]),
     PublicFields = kz_json:from_list([{<<"mobile">>, MobileField}]),
-    Options = [{assign_to, cb_context:account_id(Context)}
+    Options = [{'assign_to', cb_context:account_id(Context)}
               ,{'public_fields', PublicFields}
               ,{'module_name', ?CARRIER_MDN}
                |knm_number_options:mdn_options()
               ],
     case knm_number:create(Normalized, Options) of
-        {error, _}=Error ->
+        {'error', _}=Error ->
             _ = crossbar_doc:delete(Context),
             cb_phone_numbers_v2:set_response(Error, Context);
-        {ok, _} ->
+        {'ok', _} ->
             lager:debug("created new mdn ~s with public fields set to ~s"
                        ,[Normalized, kz_json:encode(PublicFields)]
                        ),


### PR DESCRIPTION
When a device is dry-run'd with a 402 accept charges, the
'maybe_add_mobile_mdn/1' call would still add the number to the
account. On the subsequent PUT to accept charges, since the number now
exists, the PUT will fail and the device will not be created.

Instead, we check that the save was successful (since 402 is an
'error') before handling the new device. This is more in line with how
it used to work when crossbar_services:maybe_dry_run/2 took a callback
function if not dry-running.