### PR TITLE
PISTON-632: wrong field check for T38 on endpoint doc in kz_endpoint

### DIFF
--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1171,7 +1171,7 @@ maybe_get_t38(Endpoint, Call) ->
         'false' -> [];
         'true' ->
             kapps_call_command:get_inbound_t38_settings(Opt
-                                                       ,kz_json:get_value(<<"Fax-T38-Enabled">>, Endpoint)
+                                                       ,kz_json:is_true([<<"media">>, <<"fax_option">>], Endpoint)
                                                        )
     end.
 


### PR DESCRIPTION
The Endpoint object at this point is a couch JObj, not a parsed endpoint, so look for the doc fields, not the props