### PR TITLE
Ensure acdc request time range is within configured cleanup window

### DIFF
--- a/applications/acdc/src/cb_agents.erl
+++ b/applications/acdc/src/cb_agents.erl
@@ -299,12 +299,12 @@ fetch_all_current_agent_stats(Context) ->
 -spec fetch_all_current_stats(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 fetch_all_current_stats(Context, AgentId) ->
     Now = kz_time:now_s(),
-    Yday = Now - ?SECONDS_IN_DAY,
+    From = Now - min(?SECONDS_IN_DAY, ?ACDC_CLEANUP_WINDOW),
 
     Req = props:filter_undefined(
             [{<<"Account-ID">>, cb_context:account_id(Context)}
             ,{<<"Agent-ID">>, AgentId}
-            ,{<<"Start-Range">>, Yday}
+            ,{<<"Start-Range">>, From}
             ,{<<"End-Range">>, Now}
              | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
             ]),
@@ -342,12 +342,12 @@ fetch_current_status(Context, AgentId, 'true') ->
                                         cb_context:context().
 fetch_all_current_statuses(Context, AgentId, Status) ->
     Now = kz_time:now_s(),
-    Yday = Now - ?SECONDS_IN_DAY,
+    From = Now - min(?SECONDS_IN_DAY, ?ACDC_CLEANUP_WINDOW),
 
     Opts = props:filter_undefined(
              [{<<"Status">>, Status}
              ,{<<"Agent-ID">>, AgentId}
-             ,{<<"Start-Range">>, Yday}
+             ,{<<"Start-Range">>, From}
              ,{<<"End-Range">>, Now}
              ,{<<"Limit">>, cb_context:req_value(Context, <<"limit">>)}
              ]),

--- a/applications/acdc/src/cb_queues.erl
+++ b/applications/acdc/src/cb_queues.erl
@@ -648,10 +648,15 @@ fetch_all_queue_stats(Context) ->
 -spec fetch_all_current_queue_stats(cb_context:context()) -> cb_context:context().
 fetch_all_current_queue_stats(Context) ->
     lager:debug("querying for all recent stats"),
+    Now = kz_time:now_s(),
+    From = Now - min(?SECONDS_IN_DAY, ?ACDC_CLEANUP_WINDOW),
+
     Req = props:filter_undefined(
             [{<<"Account-ID">>, cb_context:account_id(Context)}
             ,{<<"Status">>, cb_context:req_value(Context, <<"status">>)}
             ,{<<"Agent-ID">>, cb_context:req_value(Context, <<"agent_id">>)}
+            ,{<<"Start-Range">>, From}
+            ,{<<"End-Range">>, Now}
              | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
             ]),
     fetch_from_amqp(Context, Req).


### PR DESCRIPTION
Make sure that current status and stats requests for agents and queues, with a specified time range, falls within the ACDC clean up window.

If clean up window is greater than a day, ensure to fetch current stats for only the last 24 hours. If clean up window is less than a day, ensure we are not looking for a longer time range than the window.