### PR TITLE
HELP-34627: Add global config option to failover only when devices un…

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -29851,6 +29851,11 @@
                     "description": "ecallmgr expires deviation time",
                     "type": "integer"
                 },
+                "failover_when_all_unreg": {
+                    "default": false,
+                    "description": "failover only when all devices are offline",
+                    "type": "boolean"
+                },
                 "fax_file_path": {
                     "default": "/tmp/",
                     "description": "ecallmgr fax file path",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
@@ -183,6 +183,11 @@
             "description": "ecallmgr expires deviation time",
             "type": "integer"
         },
+        "failover_when_all_unreg": {
+            "default": false,
+            "description": "failover only when all devices are offline",
+            "type": "boolean"
+        },
         "fax_file_path": {
             "default": "/tmp/",
             "description": "ecallmgr fax file path",

--- a/applications/ecallmgr/src/ecallmgr_fs_channels.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channels.erl
@@ -825,11 +825,15 @@ connection_cavs(#channel{}) -> 'undefined'.
 max_channel_uptime() ->
     kapps_config:get_integer(?APP_NAME, ?MAX_CHANNEL_UPTIME_KEY, 0).
 
--spec set_max_channel_uptime(non_neg_integer()) -> 'ok'.
+-spec set_max_channel_uptime(non_neg_integer()) ->
+                                    {'ok', kz_json:object()} |
+                                    {'error', kz_datamgr:data_error()}.
 set_max_channel_uptime(MaxAge) ->
     set_max_channel_uptime(MaxAge, 'true').
 
--spec set_max_channel_uptime(non_neg_integer(), boolean()) -> 'ok'.
+-spec set_max_channel_uptime(non_neg_integer(), boolean()) ->
+                                    {'ok', kz_json:object()} |
+                                    {'error', kz_datamgr:data_error()}.
 set_max_channel_uptime(MaxAge, 'true') ->
     kapps_config:set_default(?APP_NAME, ?MAX_CHANNEL_UPTIME_KEY, kz_term:to_integer(MaxAge));
 set_max_channel_uptime(MaxAge, 'false') ->

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -30,7 +30,7 @@
 
 -export([eventstr_to_proplist/1, varstr_to_proplist/1, get_setting/1, get_setting/2]).
 -export([is_node_up/1, is_node_up/2]).
--export([build_bridge_string/1, build_bridge_string/2]).
+-export([build_bridge_string/1, build_bridge_string/2, build_bridge_string/3]).
 -export([build_channel/1]).
 -export([build_bridge_channels/1, build_simple_channels/1]).
 -export([create_masquerade_event/2, create_masquerade_event/3]).
@@ -59,6 +59,10 @@
 
 -define(FS_MULTI_VAR_SEP, kapps_config:get_ne_binary(?APP_NAME, <<"multivar_separator">>, <<"~">>)).
 -define(FS_MULTI_VAR_SEP_PREFIX, "^^").
+
+%% HELP-34627 Preserve default failover behavior.
+-define(FAIL_IF_ALL_UNREG, 'true').
+
 
 -type send_cmd_ret() :: fs_sendmsg_ret() | fs_api_ret().
 -export_type([send_cmd_ret/0]).
@@ -690,11 +694,66 @@ build_bridge_string(Endpoints) ->
 
 -spec build_bridge_string(kz_json:objects(), kz_term:ne_binary()) -> kz_term:ne_binary().
 build_bridge_string(Endpoints, Separator) ->
+    %% HELP-34627: Branch here to handle only failover when all endpoints are unregistered.
+    build_bridge_string(Endpoints, Separator, kapps_config:get_boolean(?APP_NAME, <<"failover_when_all_unreg">>, 'false')).
+
+-spec build_bridge_string(kz_json:objects(), kz_term:ne_binary(), kz_term:api_boolean()) -> kz_term:ne_binary().
+build_bridge_string(Endpoints, Separator, ?FAIL_IF_ALL_UNREG) ->
+    lager:info("system_config.ecallmgr.failover_when_all_unreg is enabled."),
+    %% De-dupe the bridge strings by matching those with the same
+    %%  Invite-Format, To-IP, To-User, To-realm, To-DID, and Route.
+    %% Additionally split bridge strings out and only return failover endpoints if no devices registered.
+    BridgeStrings = filter_bridge_strings(build_bridge_channels(Endpoints)),
+    %% NOTE: don't use binary_join here as it will crash on an empty list...
+    kz_binary:join(lists:reverse(BridgeStrings), Separator);
+build_bridge_string(Endpoints, Separator, _DefaultFailover) ->
     %% De-dupe the bridge strings by matching those with the same
     %%  Invite-Format, To-IP, To-User, To-realm, To-DID, and Route
     BridgeStrings = build_bridge_channels(Endpoints),
     %% NOTE: don't use binary_join here as it will crash on an empty list...
     kz_binary:join(lists:reverse(BridgeStrings), Separator).
+
+-spec filter_bridge_strings(bridge_channels()) -> bridge_channels().
+filter_bridge_strings(Endpoints) ->
+    case classify_endpoints(Endpoints) of
+        {[], Failover} ->
+            lager:info("No device endpoints available, using failover routes."),
+            Failover;
+        {Devices, _} ->
+            lager:info("Device endpoints registered, ignoring failover routes."),
+            Devices
+    end.
+
+-spec classify_endpoints(bridge_channels()) -> {bridge_channels(), bridge_channels()}.
+classify_endpoints(Endpoints) ->
+    classify_endpoints(Endpoints, [], []).
+
+-spec classify_endpoints(bridge_channels(), bridge_channels(), bridge_channels()) -> {bridge_channels(), bridge_channels()}.
+classify_endpoints([], Devices, Failover) ->
+    {Devices, Failover};
+classify_endpoints([Endpoint | Endpoints], Devices, Failover) ->
+    case string:str(unicode:characters_to_list(Endpoint), "ecallmgr_Call-Forward='true'") of
+        %% Not a forwarding endpoint move along.
+        0 -> classify_endpoints(Endpoints, [Endpoint | Devices], Failover);
+        %% Determine if we should add the call forwarding route.
+        _ ->
+            F2 = maybe_use_fwd_endpoint(Failover, Endpoint) ++ Failover,
+            classify_endpoints(Endpoints, Devices, F2)
+    end.
+
+-spec maybe_use_fwd_endpoint(bridge_channels(), bridge_channel()) -> bridge_channel().
+maybe_use_fwd_endpoint([], Destination) ->
+    [Destination];
+maybe_use_fwd_endpoint([Endpoint | Endpoints], Destination) ->
+    SD = unicode:characters_to_list(Destination),
+    FwdDest = string:sub_string(SD
+                               ,string:str(unicode:characters_to_list(SD), "loopback/")
+                               ,string:len(unicode:characters_to_list(SD))
+                               ),
+    case string:str(unicode:characters_to_list(Endpoint), FwdDest) of
+        0 -> maybe_use_fwd_endpoint(Endpoints, Destination);
+        _ -> []
+    end.
 
 -spec endpoint_jobjs_to_records(kz_json:objects()) -> bridge_endpoints().
 endpoint_jobjs_to_records(Endpoints) ->

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -717,10 +717,10 @@ build_bridge_string(Endpoints, Separator, _DefaultFailover) ->
 filter_bridge_strings(Endpoints) ->
     case classify_endpoints(Endpoints) of
         {[], Failover} ->
-            lager:info("No device endpoints available, using failover routes."),
+            lager:info("no device endpoints available, using failover routes."),
             Failover;
         {Devices, _} ->
-            lager:info("Device endpoints registered, ignoring failover routes."),
+            lager:info("device endpoints registered, ignoring failover routes."),
             Devices
     end.
 
@@ -741,7 +741,7 @@ classify_endpoints([Endpoint | Endpoints], Devices, Failover) ->
             classify_endpoints(Endpoints, Devices, F2)
     end.
 
--spec maybe_use_fwd_endpoint(bridge_channels(), bridge_channel()) -> bridge_channel().
+-spec maybe_use_fwd_endpoint(bridge_channels(), bridge_channel()) -> bridge_channels().
 maybe_use_fwd_endpoint([], Destination) ->
     [Destination];
 maybe_use_fwd_endpoint([Endpoint | Endpoints], Destination) ->

--- a/core/kazoo_apps/src/kapps_config.erl
+++ b/core/kazoo_apps/src/kapps_config.erl
@@ -609,42 +609,43 @@ set_json(Category, Key, Value) ->
 %% @doc Set the key to the value in the given category but specific to this node.
 %% @end
 %%------------------------------------------------------------------------------
--spec set(config_category(), config_key(), any()) ->
+-spec set(config_category(), config_key(), kz_json:json_term()) ->
                  {'ok', kz_json:object()}.
 set(Category, Key, Value) ->
     set(Category, Key, Value, node()).
 
--spec set(config_category(), config_key(), any(), kz_term:ne_binary() | atom()) ->
-                 {'ok', kz_json:object()}.
+-spec set(config_category(), config_key(), kz_json:json_term(), kz_term:ne_binary() | atom()) ->
+                 {'ok', kz_json:object()} |
+                 {'error', kz_datamgr:data_error()}.
 set(Category, Key, Value, Node) ->
     update_category(Category, Key, Value, Node, []).
 
--spec set_default(config_category(), config_key(), any()) ->
-                         {'ok', kz_json:object()} | 'ok' |
-                         {'error', any()}.
+-spec set_default(config_category(), config_key(), kz_json:json_term()) ->
+                         {'ok', kz_json:object()} |
+                         {'error', kz_datamgr:data_error()}.
 set_default(Category, Key, Value) ->
     update_category(Category, Key, Value, ?KEY_DEFAULT, []).
 
 -spec update_default(config_category(), config_key(), kz_json:json_term()) ->
-                            {'ok', kz_json:object()} | 'ok' |
-                            {'error', any()}.
+                            {'ok', kz_json:object()} |
+                            {'error', kz_datamgr:data_error()}.
 update_default(Category, Key, Value) ->
     update_default(Category, Key, Value, []).
 
 -spec update_default(config_category(), config_key(), kz_json:json_term(), update_options()) ->
-                            {'ok', kz_json:object()} | 'ok' |
-                            {'error', any()}.
+                            {'ok', kz_json:object()} |
+                            {'error', kz_datamgr:data_error()}.
 update_default(Category, Key, Value, Options) ->
     update_category(Category, Key, Value, ?KEY_DEFAULT, Options).
 
--spec set_node(config_category(), config_key(), any(), kz_term:ne_binary() | atom()) ->
-                      'ok' |
-                      {'ok', kz_json:object()}.
+-spec set_node(config_category(), config_key(), kz_json:json_term(), kz_term:ne_binary() | atom()) ->
+                      {'ok', kz_json:object()} |
+                      {'error', kz_datamgr:data_error()}.
 set_node(Category, _, _, 'undefined') -> get_category(Category);
 set_node(Category, Key, Value, Node) ->
     update_category(Category, Key, Value, Node, [{'node_specific', 'true'}]).
 
--spec update_category(config_category(), config_key(), any(), kz_term:ne_binary() | atom(), update_options()) ->
+-spec update_category(config_category(), config_key(), kz_json:json_term(), kz_term:ne_binary() | atom(), update_options()) ->
                              {'ok', kz_json:object()} |
                              {'error', kz_datamgr:data_error()}.
 -ifdef(TEST).


### PR DESCRIPTION
Adds a new global system config option to handle a feature request to only use failover endpoints when all devices are offline.

In order to preserve existing failover functionality and prevent regression the generated bridge strings are filtered based on the existence of call forward headers and deduped based on destination.