### PR TITLE
SSSU-68: add ability to set a custom label for BLF keys

### DIFF
--- a/applications/crossbar/doc/ref/devices.md
+++ b/applications/crossbar/doc/ref/devices.md
@@ -46,17 +46,13 @@ Key | Description | Type | Default | Required | Support Level
 `outbound_flags` | List of flags (features) this device requires when making outbound calls | `array(string()) | object()` |   | `false` |  
 `owner_id` | The ID of the user object that 'owns' the device | `string(32)` |   | `false` |  
 `presence_id` | Static presence ID (used instead of SIP username) | `string()` |   | `false` | `supported`
-`provision.combo_keys./^[0-9]+$/.type` | Feature key type | `string('line' | 'presence' | 'parking' | 'personal_parking' | 'speed_dial')` |   | `true` |  
-`provision.combo_keys./^[0-9]+$/.value` | Feature key value | `integer() | string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10')` |   | `false` |  
-`provision.combo_keys./^[0-9]+$/` |   | `object() | null()` |   | `false` |  
-`provision.combo_keys` | Feature Keys | `object()` |   | `false` |  
+`provision.combo_keys./^[0-9]+$/` |   | [#/definitions/devices.combo_key](#devicescombo_key) |   | `false` |  
+`provision.combo_keys` |   | `object()` |   | `false` |  
 `provision.endpoint_brand` | Brand of the phone | `string()` |   | `false` |  
 `provision.endpoint_family` | Family name of the phone | `string()` |   | `false` |  
 `provision.endpoint_model` | Model name of the phone | `string() | array(string())` |   | `false` |  
-`provision.feature_keys./^[0-9]+$/.type` | Feature key type | `string('presence' | 'parking' | 'personal_parking' | 'speed_dial')` |   | `true` |  
-`provision.feature_keys./^[0-9]+$/.value` | Feature key value | `integer() | string('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10')` |   | `true` |  
-`provision.feature_keys./^[0-9]+$/` |   | `object() | null()` |   | `false` |  
-`provision.feature_keys` | Feature Keys | `object()` |   | `false` |  
+`provision.feature_keys./^[0-9]+$/` |   | [#/definitions/devices.combo_key](#devicescombo_key) |   | `false` |  
+`provision.feature_keys` |   | `object()` |   | `false` |  
 `provision.id` | Provisioner Template ID | `string()` |   | `false` |  
 `provision` | Provision data | `object()` |   | `false` |  
 `register_overwrite_notify` | When true enables overwrite notifications | `boolean()` | `false` | `false` |  
@@ -150,6 +146,14 @@ Custom SIP headers applied to an INVITE
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `^[a-zA-z0-9_\-]+$` | The SIP header to add | `string()` |   | `false` |  
+
+### devices.combo_key
+
+Device provisioner Combo/Feature Key
+
+
+Key | Description | Type | Default | Required | Support Level
+--- | ----------- | ---- | ------- | -------- | -------------
 
 ### dialplans
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -5301,7 +5301,10 @@
                                 }
                             ]
                         }
-                    }
+                    },
+                    "required": [
+                        "type"
+                    ]
                 },
                 {
                     "properties": {
@@ -5340,11 +5343,11 @@
                                 }
                             ]
                         }
-                    }
+                    },
+                    "required": [
+                        "type"
+                    ]
                 }
-            ],
-            "required": [
-                "type"
             ],
             "type": [
                 "object",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -5080,7 +5080,6 @@
                     "description": "Provision data",
                     "properties": {
                         "combo_keys": {
-                            "description": "Feature Keys",
                             "type": "object"
                         },
                         "endpoint_brand": {
@@ -5106,7 +5105,6 @@
                             ]
                         },
                         "feature_keys": {
-                            "description": "Feature Keys",
                             "type": "object"
                         },
                         "id": {
@@ -5246,6 +5244,112 @@
                 "name"
             ],
             "type": "object"
+        },
+        "devices.combo_key": {
+            "description": "Device provisioner Combo/Feature Key",
+            "oneOf": [
+                {
+                    "properties": {
+                        "type": {
+                            "description": "Feature key type",
+                            "enum": [
+                                "parking"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Feature key value",
+                            "oneOf": [
+                                {
+                                    "maximum": 10,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                },
+                                {
+                                    "enum": [
+                                        "1",
+                                        "2",
+                                        "3",
+                                        "4",
+                                        "5",
+                                        "6",
+                                        "7",
+                                        "8",
+                                        "9",
+                                        "10"
+                                    ],
+                                    "type": "string"
+                                },
+                                {
+                                    "properties": {
+                                        "label": {
+                                            "description": "Label to display for Feature key",
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "description": "Feature key value",
+                                            "maximum": 10,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "label",
+                                        "value"
+                                    ],
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "description": "Feature key type",
+                            "enum": [
+                                "line",
+                                "presence",
+                                "personal_parking",
+                                "speed_dial"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Feature key value",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "properties": {
+                                        "label": {
+                                            "description": "Label to display for Feature key",
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "description": "Feature key value",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "label",
+                                        "value"
+                                    ],
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            "required": [
+                "type"
+            ],
+            "type": [
+                "object",
+                "null"
+            ]
         },
         "devices_notify": {
             "description": "Schema for Crossbar devices notify API",

--- a/applications/crossbar/priv/couchdb/schemas/devices.combo_key.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.combo_key.json
@@ -56,7 +56,10 @@
                         }
                     ]
                 }
-            }
+            },
+            "required": [
+                "type"
+            ]
         },
         {
             "properties": {
@@ -95,11 +98,11 @@
                         }
                     ]
                 }
-            }
+            },
+            "required": [
+                "type"
+            ]
         }
-    ],
-    "required": [
-        "type"
     ],
     "type": [
         "object",

--- a/applications/crossbar/priv/couchdb/schemas/devices.combo_key.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.combo_key.json
@@ -1,0 +1,113 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "devices.combo_key",
+    "description": "Device provisioner Combo/Feature Key",
+    "oneOf": [
+        {
+            "properties": {
+                "type": {
+                    "description": "Feature key type",
+                    "enum": [
+                        "parking"
+                    ],
+                    "type": "string"
+                },
+                "value": {
+                    "description": "Feature key value",
+                    "oneOf": [
+                        {
+                            "maximum": 10,
+                            "minimum": 1,
+                            "type": "integer"
+                        },
+                        {
+                            "enum": [
+                                "1",
+                                "2",
+                                "3",
+                                "4",
+                                "5",
+                                "6",
+                                "7",
+                                "8",
+                                "9",
+                                "10"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "properties": {
+                                "label": {
+                                    "description": "Label to display for Feature key",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "description": "Feature key value",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "label",
+                                "value"
+                            ],
+                            "type": "object"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": [
+                "object",
+                "null"
+            ]
+        },
+        {
+            "properties": {
+                "type": {
+                    "description": "Feature key type",
+                    "enum": [
+                        "line",
+                        "presence",
+                        "personal_parking",
+                        "speed_dial"
+                    ],
+                    "type": "string"
+                },
+                "value": {
+                    "description": "Feature key value",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "properties": {
+                                "label": {
+                                    "description": "Label to display for Feature key",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "description": "Feature key value",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "label",
+                                "value"
+                            ],
+                            "type": "object"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": [
+                "object",
+                "null"
+            ]
+        }
+    ]
+}

--- a/applications/crossbar/priv/couchdb/schemas/devices.combo_key.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.combo_key.json
@@ -43,6 +43,18 @@
                                 },
                                 "value": {
                                     "description": "Feature key value",
+                                    "enum": [
+                                        "1",
+                                        "2",
+                                        "3",
+                                        "4",
+                                        "5",
+                                        "6",
+                                        "7",
+                                        "8",
+                                        "9",
+                                        "10"
+                                    ],
                                     "type": "string"
                                 }
                             },

--- a/applications/crossbar/priv/couchdb/schemas/devices.combo_key.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.combo_key.json
@@ -43,19 +43,9 @@
                                 },
                                 "value": {
                                     "description": "Feature key value",
-                                    "enum": [
-                                        "1",
-                                        "2",
-                                        "3",
-                                        "4",
-                                        "5",
-                                        "6",
-                                        "7",
-                                        "8",
-                                        "9",
-                                        "10"
-                                    ],
-                                    "type": "string"
+                                    "maximum": 10,
+                                    "minimum": 1,
+                                    "type": "integer"
                                 }
                             },
                             "required": [
@@ -66,14 +56,7 @@
                         }
                     ]
                 }
-            },
-            "required": [
-                "type"
-            ],
-            "type": [
-                "object",
-                "null"
-            ]
+            }
         },
         {
             "properties": {
@@ -112,14 +95,14 @@
                         }
                     ]
                 }
-            },
-            "required": [
-                "type"
-            ],
-            "type": [
-                "object",
-                "null"
-            ]
+            }
         }
+    ],
+    "required": [
+        "type"
+    ],
+    "type": [
+        "object",
+        "null"
     ]
 }

--- a/applications/crossbar/priv/couchdb/schemas/devices.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.json
@@ -245,57 +245,11 @@
             "description": "Provision data",
             "properties": {
                 "combo_keys": {
-                    "description": "Feature Keys",
                     "patternProperties": {
                         "^[0-9]+$": {
-                            "properties": {
-                                "type": {
-                                    "description": "Feature key type",
-                                    "enum": [
-                                        "line",
-                                        "presence",
-                                        "parking",
-                                        "personal_parking",
-                                        "speed_dial"
-                                    ],
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "description": "Feature key value",
-                                    "oneOf": [
-                                        {
-                                            "maximum": 10,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        {
-                                            "enum": [
-                                                "1",
-                                                "2",
-                                                "3",
-                                                "4",
-                                                "5",
-                                                "6",
-                                                "7",
-                                                "8",
-                                                "9",
-                                                "10"
-                                            ],
-                                            "type": "string"
-                                        }
-                                    ]
-                                }
-                            },
-                            "required": [
-                                "type"
-                            ],
-                            "type": [
-                                "object",
-                                "null"
-                            ]
+                            "$ref": "devices.combo_key"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "endpoint_brand": {
                     "description": "Brand of the phone",
@@ -320,57 +274,11 @@
                     ]
                 },
                 "feature_keys": {
-                    "description": "Feature Keys",
                     "patternProperties": {
                         "^[0-9]+$": {
-                            "properties": {
-                                "type": {
-                                    "description": "Feature key type",
-                                    "enum": [
-                                        "presence",
-                                        "parking",
-                                        "personal_parking",
-                                        "speed_dial"
-                                    ],
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "description": "Feature key value",
-                                    "oneOf": [
-                                        {
-                                            "maximum": 10,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        {
-                                            "enum": [
-                                                "1",
-                                                "2",
-                                                "3",
-                                                "4",
-                                                "5",
-                                                "6",
-                                                "7",
-                                                "8",
-                                                "9",
-                                                "10"
-                                            ],
-                                            "type": "string"
-                                        }
-                                    ]
-                                }
-                            },
-                            "required": [
-                                "type",
-                                "value"
-                            ],
-                            "type": [
-                                "object",
-                                "null"
-                            ]
+                            "$ref": "devices.combo_key"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "id": {
                     "description": "Provisioner Template ID",

--- a/applications/crossbar/priv/couchdb/schemas/devices.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.json
@@ -249,7 +249,8 @@
                         "^[0-9]+$": {
                             "$ref": "devices.combo_key"
                         }
-                    }
+                    },
+                    "type": "object"
                 },
                 "endpoint_brand": {
                     "description": "Brand of the phone",
@@ -278,7 +279,8 @@
                         "^[0-9]+$": {
                             "$ref": "devices.combo_key"
                         }
-                    }
+                    },
+                    "type": "object"
                 },
                 "id": {
                     "description": "Provisioner Template ID",

--- a/core/kazoo_documents/src/kzd_devices.erl.src
+++ b/core/kazoo_documents/src/kzd_devices.erl.src
@@ -44,12 +44,10 @@
 -export([presence_id/1, presence_id/2, set_presence_id/2]).
 -export([provision/1, provision/2, set_provision/2]).
 -export([provision_combo_keys/1, provision_combo_keys/2, set_provision_combo_keys/2]).
--export([provision_combo_key/2, provision_combo_key/3, set_provision_combo_key/3]).
 -export([provision_endpoint_brand/1, provision_endpoint_brand/2, set_provision_endpoint_brand/2]).
 -export([provision_endpoint_family/1, provision_endpoint_family/2, set_provision_endpoint_family/2]).
 -export([provision_endpoint_model/1, provision_endpoint_model/2, set_provision_endpoint_model/2]).
 -export([provision_feature_keys/1, provision_feature_keys/2, set_provision_feature_keys/2]).
--export([provision_feature_key/2, provision_feature_key/3, set_provision_feature_key/3]).
 -export([provision_id/1, provision_id/2, set_provision_id/2]).
 -export([register_overwrite_notify/1, register_overwrite_notify/2, set_register_overwrite_notify/2]).
 -export([ringtones/1, ringtones/2, set_ringtones/2]).
@@ -527,29 +525,17 @@ provision(Doc, Default) ->
 set_provision(Doc, Provision) ->
     kz_json:set_value([<<"provision">>], Provision, Doc).
 
--spec provision_combo_keys(doc()) -> kz_term:api_object().
+-spec provision_combo_keys(doc()) -> any().
 provision_combo_keys(Doc) ->
     provision_combo_keys(Doc, 'undefined').
 
--spec provision_combo_keys(doc(), Default) -> kz_json:object() | Default.
+-spec provision_combo_keys(doc(), Default) -> any() | Default.
 provision_combo_keys(Doc, Default) ->
-    kz_json:get_json_value([<<"provision">>, <<"combo_keys">>], Doc, Default).
+    kz_json:get_value([<<"provision">>, <<"combo_keys">>], Doc, Default).
 
--spec set_provision_combo_keys(doc(), kz_json:object()) -> doc().
+-spec set_provision_combo_keys(doc(), any()) -> doc().
 set_provision_combo_keys(Doc, ProvisionComboKeys) ->
     kz_json:set_value([<<"provision">>, <<"combo_keys">>], ProvisionComboKeys, Doc).
-
--spec provision_combo_key(doc(), kz_json:key()) -> any().
-provision_combo_key(Doc, ComboKey) ->
-    provision_combo_key(Doc, ComboKey, 'undefined').
-
--spec provision_combo_key(doc(), kz_json:key(), Default) -> any() | Default.
-provision_combo_key(Doc, ComboKey, Default) ->
-    kz_json:get_value([<<"provision">>, <<"combo_keys">>, ComboKey], Doc, Default).
-
--spec set_provision_combo_key(doc(), kz_json:key(), any()) -> doc().
-set_provision_combo_key(Doc, ComboKey, Value) ->
-    kz_json:set_value([<<"provision">>, <<"combo_keys">>, ComboKey], Value, Doc).
 
 -spec provision_endpoint_brand(doc()) -> kz_term:api_binary().
 provision_endpoint_brand(Doc) ->
@@ -587,29 +573,17 @@ provision_endpoint_model(Doc, Default) ->
 set_provision_endpoint_model(Doc, ProvisionEndpointModel) ->
     kz_json:set_value([<<"provision">>, <<"endpoint_model">>], ProvisionEndpointModel, Doc).
 
--spec provision_feature_keys(doc()) -> kz_term:api_object().
+-spec provision_feature_keys(doc()) -> any().
 provision_feature_keys(Doc) ->
     provision_feature_keys(Doc, 'undefined').
 
--spec provision_feature_keys(doc(), Default) -> kz_json:object() | Default.
+-spec provision_feature_keys(doc(), Default) -> any() | Default.
 provision_feature_keys(Doc, Default) ->
-    kz_json:get_json_value([<<"provision">>, <<"feature_keys">>], Doc, Default).
+    kz_json:get_value([<<"provision">>, <<"feature_keys">>], Doc, Default).
 
--spec set_provision_feature_keys(doc(), kz_json:object()) -> doc().
+-spec set_provision_feature_keys(doc(), any()) -> doc().
 set_provision_feature_keys(Doc, ProvisionFeatureKeys) ->
     kz_json:set_value([<<"provision">>, <<"feature_keys">>], ProvisionFeatureKeys, Doc).
-
--spec provision_feature_key(doc(), kz_json:key()) -> any().
-provision_feature_key(Doc, FeatureKey) ->
-    provision_feature_key(Doc, FeatureKey, 'undefined').
-
--spec provision_feature_key(doc(), kz_json:key(), Default) -> any() | Default.
-provision_feature_key(Doc, FeatureKey, Default) ->
-    kz_json:get_value([<<"provision">>, <<"feature_keys">>, FeatureKey], Doc, Default).
-
--spec set_provision_feature_key(doc(), kz_json:key(), any()) -> doc().
-set_provision_feature_key(Doc, FeatureKey, Value) ->
-    kz_json:set_value([<<"provision">>, <<"feature_keys">>, FeatureKey], Value, Doc).
 
 -spec provision_id(doc()) -> kz_term:api_binary().
 provision_id(Doc) ->

--- a/core/kazoo_documents/src/kzd_devices.erl.src
+++ b/core/kazoo_documents/src/kzd_devices.erl.src
@@ -44,10 +44,12 @@
 -export([presence_id/1, presence_id/2, set_presence_id/2]).
 -export([provision/1, provision/2, set_provision/2]).
 -export([provision_combo_keys/1, provision_combo_keys/2, set_provision_combo_keys/2]).
+-export([provision_combo_key/2, provision_combo_key/3, set_provision_combo_key/3]).
 -export([provision_endpoint_brand/1, provision_endpoint_brand/2, set_provision_endpoint_brand/2]).
 -export([provision_endpoint_family/1, provision_endpoint_family/2, set_provision_endpoint_family/2]).
 -export([provision_endpoint_model/1, provision_endpoint_model/2, set_provision_endpoint_model/2]).
 -export([provision_feature_keys/1, provision_feature_keys/2, set_provision_feature_keys/2]).
+-export([provision_feature_key/2, provision_feature_key/3, set_provision_feature_key/3]).
 -export([provision_id/1, provision_id/2, set_provision_id/2]).
 -export([register_overwrite_notify/1, register_overwrite_notify/2, set_register_overwrite_notify/2]).
 -export([ringtones/1, ringtones/2, set_ringtones/2]).
@@ -525,17 +527,29 @@ provision(Doc, Default) ->
 set_provision(Doc, Provision) ->
     kz_json:set_value([<<"provision">>], Provision, Doc).
 
--spec provision_combo_keys(doc()) -> any().
+-spec provision_combo_keys(doc()) -> kz_term:api_object().
 provision_combo_keys(Doc) ->
     provision_combo_keys(Doc, 'undefined').
 
--spec provision_combo_keys(doc(), Default) -> any() | Default.
+-spec provision_combo_keys(doc(), Default) -> kz_json:object() | Default.
 provision_combo_keys(Doc, Default) ->
-    kz_json:get_value([<<"provision">>, <<"combo_keys">>], Doc, Default).
+    kz_json:get_json_value([<<"provision">>, <<"combo_keys">>], Doc, Default).
 
--spec set_provision_combo_keys(doc(), any()) -> doc().
+-spec set_provision_combo_keys(doc(), kz_json:object()) -> doc().
 set_provision_combo_keys(Doc, ProvisionComboKeys) ->
     kz_json:set_value([<<"provision">>, <<"combo_keys">>], ProvisionComboKeys, Doc).
+
+-spec provision_combo_key(doc(), kz_json:key()) -> any().
+provision_combo_key(Doc, ComboKey) ->
+    provision_combo_key(Doc, ComboKey, 'undefined').
+
+-spec provision_combo_key(doc(), kz_json:key(), Default) -> any() | Default.
+provision_combo_key(Doc, ComboKey, Default) ->
+    kz_json:get_value([<<"provision">>, <<"combo_keys">>, ComboKey], Doc, Default).
+
+-spec set_provision_combo_key(doc(), kz_json:key(), any()) -> doc().
+set_provision_combo_key(Doc, ComboKey, Value) ->
+    kz_json:set_value([<<"provision">>, <<"combo_keys">>, ComboKey], Value, Doc).
 
 -spec provision_endpoint_brand(doc()) -> kz_term:api_binary().
 provision_endpoint_brand(Doc) ->
@@ -573,17 +587,29 @@ provision_endpoint_model(Doc, Default) ->
 set_provision_endpoint_model(Doc, ProvisionEndpointModel) ->
     kz_json:set_value([<<"provision">>, <<"endpoint_model">>], ProvisionEndpointModel, Doc).
 
--spec provision_feature_keys(doc()) -> any().
+-spec provision_feature_keys(doc()) -> kz_term:api_object().
 provision_feature_keys(Doc) ->
     provision_feature_keys(Doc, 'undefined').
 
--spec provision_feature_keys(doc(), Default) -> any() | Default.
+-spec provision_feature_keys(doc(), Default) -> kz_json:object() | Default.
 provision_feature_keys(Doc, Default) ->
-    kz_json:get_value([<<"provision">>, <<"feature_keys">>], Doc, Default).
+    kz_json:get_json_value([<<"provision">>, <<"feature_keys">>], Doc, Default).
 
--spec set_provision_feature_keys(doc(), any()) -> doc().
+-spec set_provision_feature_keys(doc(), kz_json:object()) -> doc().
 set_provision_feature_keys(Doc, ProvisionFeatureKeys) ->
     kz_json:set_value([<<"provision">>, <<"feature_keys">>], ProvisionFeatureKeys, Doc).
+
+-spec provision_feature_key(doc(), kz_json:key()) -> any().
+provision_feature_key(Doc, FeatureKey) ->
+    provision_feature_key(Doc, FeatureKey, 'undefined').
+
+-spec provision_feature_key(doc(), kz_json:key(), Default) -> any() | Default.
+provision_feature_key(Doc, FeatureKey, Default) ->
+    kz_json:get_value([<<"provision">>, <<"feature_keys">>, FeatureKey], Doc, Default).
+
+-spec set_provision_feature_key(doc(), kz_json:key(), any()) -> doc().
+set_provision_feature_key(Doc, FeatureKey, Value) ->
+    kz_json:set_value([<<"provision">>, <<"feature_keys">>, FeatureKey], Value, Doc).
 
 -spec provision_id(doc()) -> kz_term:api_binary().
 provision_id(Doc) ->

--- a/core/kazoo_provisioner/src/provisioner_v5.hrl
+++ b/core/kazoo_provisioner/src/provisioner_v5.hrl
@@ -1,5 +1,6 @@
 -ifndef(PROVISIONER_V5_HRL).
 
+-include_lib("kazoo_stdlib/include/kz_types.hrl").
 -include_lib("kazoo_stdlib/include/kz_databases.hrl").
 
 -define(MOD_CONFIG_CAT, <<"provisioner">>).


### PR DESCRIPTION
* Fix `devices` schema for `provision` field. Now it allows only integer 1..10 for parking or string 1..10 or object label, value. The rest of features code only allows arbitrary string or an object with label and value keys.
* Add ability to set a custom label for BLF keys if the value is an JSON object (with label and value keys)