### PR TITLE
Ensure most recent queue stat is returned for call

### DIFF
--- a/applications/acdc/src/acdc_stats.erl
+++ b/applications/acdc/src/acdc_stats.erl
@@ -353,8 +353,18 @@ find_call(CallId) ->
           }],
     case ets:select(call_table_id(), MS) of
         [] -> 'undefined';
-        [Stat] -> call_stat_to_json(Stat)
+        [Stat] -> call_stat_to_json(Stat);
+        Stats -> call_stat_to_json(get_recent_stat_for_call(Stats))
     end.
+
+-spec get_recent_stat_for_call(call_stats()) -> call_stat().
+get_recent_stat_for_call(Stats) ->
+    Sorted = lists:sort(fun sort_by_entered_timestamp/2, Stats),
+    lists:nth(1, Sorted).
+
+-spec sort_by_entered_timestamp(call_stat(), call_stat()) -> boolean().
+sort_by_entered_timestamp(#call_stat{entered_timestamp=ATimestamp}, #call_stat{entered_timestamp=BTimestamp}) ->
+    ATimestamp > BTimestamp.
 
 -record(state, {archive_ref :: reference()
                ,cleanup_ref :: reference()

--- a/applications/acdc/src/acdc_stats.hrl
+++ b/applications/acdc/src/acdc_stats.hrl
@@ -40,6 +40,7 @@
                    ,is_archived = 'false' :: boolean() | '$2' | '$3' | '_'
                    }).
 -type call_stat() :: #call_stat{}.
+-type call_stats() :: [call_stat()].
 
 
 -define(STATUS_STATUSES, [<<"logged_in">>, <<"logged_out">>, <<"ready">>


### PR DESCRIPTION
A call can enter more than one queue, for example in the case where all agents reject the call in the first queue and the callflow routes to a second queue. In this case, the find_call/1 function needs to account for multiple stats returned for a call, and should return the most recent stat, based on when the queue was entered.