### PR TITLE
set the auth-realm if supplied

### DIFF
--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -667,6 +667,7 @@ gateway_to_endpoint(DestinationNumber
                             ,codecs=Codecs
                             ,username=Username
                             ,password=Password
+                            ,realm=AuthRealm
                             ,sip_headers=SipHeaders
                             ,sip_interface=SipInterface
                             ,endpoint_type=EndpointType
@@ -697,6 +698,7 @@ gateway_to_endpoint(DestinationNumber
         ,{<<"Codecs">>, Codecs}
         ,{<<"Auth-User">>, Username}
         ,{<<"Auth-Password">>, Password}
+        ,{<<"Auth-Realm">>, AuthRealm}
         ,{<<"Custom-SIP-Headers">>, SipHeaders}
         ,{<<"SIP-Interface">>, SipInterface}
         ,{<<"Endpoint-Type">>, EndpointType}


### PR DESCRIPTION
Currently the bridge string is generated without the sip_auth_realm channel var, causing some upstreams to reject the calls due to the missing realm.

Include the realm if set in the gateway definition.