### PR TITLE
KAZOO-6017: Update CCVs to update presence id

### DIFF
--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -268,6 +268,7 @@ update_ccvs(Call) ->
               [{<<"Hold-Media">>, kz_attributes:moh_attributes(<<"media_id">>, Call)}
               ,{<<"Caller-ID-Name">>, CIDName}
               ,{<<"Caller-ID-Number">>, CIDNumber}
+              ,{<<"Presence-ID">>, kz_attributes:presence_id(Call)}
                | get_incoming_security(Call)
               ]),
     kapps_call:set_custom_channel_vars(Props, Call).


### PR DESCRIPTION
Presence is not being tracked for hotdesked users on outbound calls. Adding the Presence-ID to the CCVs avoids the Presence-ID defaulting to the phones SIP username.