### PR TITLE
HELP-40948: disable transfer follows when starting recording by config

### DIFF
--- a/applications/callflow/doc/record_call.md
+++ b/applications/callflow/doc/record_call.md
@@ -10,16 +10,17 @@ Validator for the Record Call callflow action
 
 Key | Description | Type | Default | Required | Support
 --- | ----------- | ---- | ------- | -------- | --------
-`action` | Whether to start or stop the recording | `string('start', 'stop')` | `start` | `true` | 
-`format` | What format to store the recording on disk | `string('mp3', 'wav')` |   | `false` | 
-`label` | Label to include in the origin of call recording | `string()` |   | `false` | 
-`media_name` | the name of media | `string` |   | `false` | 
+`action` | Whether to start or stop the recording | `string('start', 'stop')` | `start` | `true` |
+`format` | What format to store the recording on disk | `string('mp3', 'wav')` |   | `false` |
+`label` | Label to include in the origin of call recording | `string()` |   | `false` |
+`media_name` | the name of media | `string` |   | `false` |
 `record_min_sec` | The minimum length, in seconds, the recording must be to be considered successful. Otherwise it is deleted | `integer` |   | `false` |
-`record_on_answer` | Whether to delay the recording until the channel is answered | `boolean` | `false` | `false` | 
-`record_on_bridge` | Whether to delay the recording until the channel is bridged | `boolean` | `false` | `false` | 
-`record_sample_rate` | What sampling rate to use on the recording | `integer` |   | `false` | 
-`time_limit` | Time limit, in seconds, for the recording | `integer` | `3600` | `false` | 
-`url` | The URL to use when sending the recording for storage | `string` |   | `false` | 
+`record_on_answer` | Whether to delay the recording until the channel is answered | `boolean` | `false` | `false` |
+`record_on_bridge` | Whether to delay the recording until the channel is bridged | `boolean` | `false` | `false` |
+`record_sample_rate` | What sampling rate to use on the recording | `integer` |   | `false` |
+`should_follow_transfer` | If true, the recording will continue after a transfer on the active leg | `boolean()` | `true` | `false` |
+`time_limit` | Time limit, in seconds, for the recording | `integer` | `3600` | `false` |
+`url` | The URL to use when sending the recording for storage | `string` |   | `false` |
 
 ## Storage of recordings
 

--- a/applications/callflow/doc/ref/record_call.md
+++ b/applications/callflow/doc/ref/record_call.md
@@ -20,6 +20,7 @@ Key | Description | Type | Default | Required | Support Level
 `record_on_answer` | Whether to delay the recording until the channel is answered | `boolean()` | `false` | `false` |  
 `record_on_bridge` | Whether to delay the recording until the channel is bridged | `boolean()` | `false` | `false` |  
 `record_sample_rate` | What sampling rate to use on the recording | `integer()` |   | `false` |  
+`should_follow_transfer` | If true, the recording will continue after a transfer on the active leg | `boolean()` | `true` | `false` |  
 `time_limit` | Time limit, in seconds, for the recording | `integer()` | `3600` | `false` |  
 `url` | The URL to use when sending the recording for storage | `string()` |   | `false` |  
 

--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -342,11 +342,10 @@ maybe_start_onnet_endpoint_recording('undefined', _To, Call) -> Call;
 maybe_start_onnet_endpoint_recording(EndpointId, To, Call) ->
     case kz_endpoint:get(EndpointId, Call) of
         {'ok', Endpoint} ->
-            Call1 = kapps_call:kvs_store('recording_follow_transfer', 'false', Call),
             maybe_start_call_recording(?ENDPOINT_OUTBOUND_RECORDING(To)
                                       ,?ENDPOINT_OUTBOUND_RECORDING_LABEL(To)
                                       ,Endpoint
-                                      ,Call1
+                                      ,Call
                                       );
         _ -> Call
     end.
@@ -361,7 +360,10 @@ maybe_start_call_recording('undefined', _, Call) ->
 maybe_start_call_recording(Data, Label, Call) ->
     case kz_json:is_false(<<"enabled">>, Data) of
         'true' -> Call;
-        'false' -> kapps_call:start_recording(kz_json:set_value(<<"origin">>, Label, Data), Call)
+        'false' ->
+            lager:info("starting call recording by configuration"),
+            Call1 = kapps_call:kvs_store('recording_follow_transfer', 'false', Call),
+            kapps_call:start_recording(kz_json:set_value(<<"origin">>, Label, Data), Call1)
     end.
 
 -spec get_incoming_security(kapps_call:call()) -> kz_term:proplist().
@@ -404,4 +406,3 @@ execute_callflow(Call) ->
     lager:info("call has been setup, beginning to process the call"),
     {'ok', Pid} = cf_exe_sup:new(Call),
     kapps_call:kvs_store('consumer_pid', Pid, Call).
-

--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -29,8 +29,9 @@ handle(Data0, Call) ->
 
 -spec handle(kz_json:object(), kapps_call:call(), kz_term:ne_binary()) -> kapps_call:call().
 handle(Data, Call, <<"start">>) ->
-    Call1 = kapps_call:kvs_store('recording_follow_transfer', 'true', Call),
-    lager:info("starting call recording via action"),
+    ShouldFollowTransfer = kz_json:is_true(<<"should_follow_transfer">>, Data, 'true'),
+    Call1 = kapps_call:kvs_store('recording_follow_transfer', ShouldFollowTransfer, Call),
+    lager:info("starting call recording via action (follow transfer: ~s)", [ShouldFollowTransfer]),
     cf_exe:update_call(kapps_call:start_recording(Data, Call1));
 
 handle(_Data, Call, <<"stop">>) ->

--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -29,7 +29,9 @@ handle(Data0, Call) ->
 
 -spec handle(kz_json:object(), kapps_call:call(), kz_term:ne_binary()) -> kapps_call:call().
 handle(Data, Call, <<"start">>) ->
-    cf_exe:update_call(kapps_call:start_recording(Data, Call));
+    Call1 = kapps_call:kvs_store('recording_follow_transfer', 'true', Call),
+    lager:info("starting call recording via action"),
+    cf_exe:update_call(kapps_call:start_recording(Data, Call1));
 
 handle(_Data, Call, <<"stop">>) ->
     cf_exe:update_call(kapps_call:stop_recording(Call)).

--- a/applications/callflow/src/module/cf_record_caller.erl
+++ b/applications/callflow/src/module/cf_record_caller.erl
@@ -51,12 +51,13 @@ record_caller(Data, Call, Url) ->
 
     _ = set_recording_url(Data, Call, Url, MediaName),
 
+    lager:info("recording caller starting"),
     _ = kapps_call_command:b_record(MediaName
                                    ,?ANY_DIGIT
                                    ,kzc_recording:get_timelimit(Data)
                                    ,Call
                                    ),
-    lager:debug("recording ended").
+    lager:debug("recording caller ended").
 
 -spec set_recording_url(kz_json:object(), kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary()) -> any().
 set_recording_url(Data, Call, Url, MediaName) ->

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -3130,6 +3130,11 @@
                     "description": "What sampling rate to use on the recording",
                     "type": "integer"
                 },
+                "should_follow_transfer": {
+                    "default": true,
+                    "description": "If true, the recording will continue after a transfer on the active leg",
+                    "type": "boolean"
+                },
                 "time_limit": {
                     "default": 3600,
                     "description": "Time limit, in seconds, for the recording",

--- a/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
@@ -58,6 +58,11 @@
             "description": "What sampling rate to use on the recording",
             "type": "integer"
         },
+        "should_follow_transfer": {
+            "default": true,
+            "description": "If true, the recording will continue after a transfer on the active leg",
+            "type": "boolean"
+        },
         "time_limit": {
             "default": 3600,
             "description": "Time limit, in seconds, for the recording",

--- a/core/kazoo_call/src/kapps_call.erl
+++ b/core/kazoo_call/src/kapps_call.erl
@@ -1497,7 +1497,7 @@ start_recording(Data0, Call) ->
                        ],
             exec(Routines, Call);
         _Err ->
-            lager:debug("error starting recording ~p", [_Err]),
+            lager:notice("error starting recording ~p", [_Err]),
             Call
     end.
 


### PR DESCRIPTION
When the caller is an authorized endpoint, prior to this change the
flag to have recordings follow transfers was always set, regardless of
whether the endpoint had recordings configured to be started
implicitly.

However, when the recording isn't started by config but is started via
callflow action (`cf_record_call`), the resulting recording will not
follow transfers which is unexpected behaviour.

This change now only sets the follow flag to false if the
recording-by-config is happening.

When starting recordings-by-action, always follow transfers.