### PR TITLE
Rebuild deps when the deps.mk changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ compile_commands.json
 
 /make/core.mk
 /make/cover.mk
+/make/.deps.mk.*
 /core/*/cover/*.html
 /applications/*/cover/*.html
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ check: ERLC_OPTS += -DPROPER
 check: compile-test eunit clean-kazoo kazoo
 
 clean-deps: clean-deps-hash
-	$(if $(wildcard deps/), $(MAKE) -C deps/ clean)
 	$(if $(wildcard deps/), rm -r deps/)
 	$(if $(wildcard .erlang.mk/), rm -r .erlang.mk/)
 

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,20 @@ clean-deps:
 	$(if $(wildcard deps/), $(MAKE) -C deps/ clean)
 	$(if $(wildcard deps/), rm -r deps/)
 	$(if $(wildcard .erlang.mk/), rm -r .erlang.mk/)
+	$(if $(wildcard make/.deps.mk.*), rm make/.deps.mk.*)
 
 .erlang.mk:
 	wget 'https://raw.githubusercontent.com/ninenines/erlang.mk/2018.03.01/erlang.mk' -O $(ROOT)/erlang.mk
 	@ERLANG_MK_COMMIT=$(ERLANG_MK_COMMIT) $(MAKE) -f erlang.mk erlang-mk
 
-deps: deps/Makefile
+DEPS_HASH := $(shell md5sum make/deps.mk | cut -d' ' -f1)
+DEPS_HASH_FILE := make/.deps.mk.$(DEPS_HASH)
+
+deps: $(DEPS_HASH_FILE)
+
+$(DEPS_HASH_FILE): deps/Makefile
 	@$(MAKE) -C deps/ all
+	touch $(DEPS_HASH_FILE)
 deps/Makefile: .erlang.mk
 	mkdir -p deps
 	@$(MAKE) -f erlang.mk deps
@@ -87,7 +94,7 @@ core:
 apps: core
 	@$(MAKE) -j$(JOBS) -C applications/ all
 
-kazoo: apps $(TAGS)
+kazoo: deps apps $(TAGS)
 
 tags: $(TAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ check: ERLC_OPTS += -DPROPER
 check: compile-test eunit clean-kazoo kazoo
 
 clean-deps: clean-deps-hash
-	$(if $(wildcard deps/), rm -r deps/)
+	$(if $(wildcard deps/), rm -rf deps/)
 	$(if $(wildcard .erlang.mk/), rm -r .erlang.mk/)
 
 clean-deps-hash:

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,12 @@ coverage-report:
 check: ERLC_OPTS += -DPROPER
 check: compile-test eunit clean-kazoo kazoo
 
-clean-deps:
+clean-deps: clean-deps-hash
 	$(if $(wildcard deps/), $(MAKE) -C deps/ clean)
 	$(if $(wildcard deps/), rm -r deps/)
 	$(if $(wildcard .erlang.mk/), rm -r .erlang.mk/)
+
+clean-deps-hash:
 	$(if $(wildcard make/.deps.mk.*), rm make/.deps.mk.*)
 
 .erlang.mk:
@@ -80,9 +82,12 @@ DEPS_HASH_FILE := make/.deps.mk.$(DEPS_HASH)
 
 deps: $(DEPS_HASH_FILE)
 
-$(DEPS_HASH_FILE): deps/Makefile
+$(DEPS_HASH_FILE):
+	@$(MAKE) clean-deps
+	@$(MAKE) deps/Makefile
 	@$(MAKE) -C deps/ all
 	touch $(DEPS_HASH_FILE)
+
 deps/Makefile: .erlang.mk
 	mkdir -p deps
 	@$(MAKE) -f erlang.mk deps

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,3 +1,4 @@
+## 3rd party dependencies
 DEPS = amqp_client \
 	apns \
 	certifi \


### PR DESCRIPTION
Especially when switching version branches, outdated deps can hang around and cause issues to arise later (because a feature was developed using the old "cached" dep but the real dep had API changes that render the feature broken).