### PR TITLE
allow configuration for a distributed proxy

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -31358,6 +31358,10 @@
                     "description": "media default language",
                     "type": "string"
                 },
+                "distributed_proxy": {
+                    "description": "media distributed_proxy",
+                    "type": "object"
+                },
                 "fix_media_names": {
                     "default": true,
                     "description": "media fix media names",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.media.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.media.json
@@ -31,6 +31,10 @@
             "description": "media default language",
             "type": "string"
         },
+        "distributed_proxy": {
+            "description": "media distributed_proxy",
+            "type": "object"
+        },
         "fix_media_names": {
             "default": true,
             "description": "media fix media names",

--- a/core/kazoo_media/src/kz_media_file.erl
+++ b/core/kazoo_media/src/kz_media_file.erl
@@ -89,15 +89,9 @@ proxy_uri(#media_store_path{db = Db
          ,StreamType
          ) ->
     _ = maybe_prepare_proxy(StreamType, Store),
-    Host = kz_media_util:proxy_host(),
-    Port = kapps_config:get_integer(?CONFIG_CAT, <<"proxy_port">>, 24517),
-    Permissions = case StreamType =:= <<"store">> of
-                      'true' -> 'proxy_store';
-                      'false' -> 'proxy_playback'
-                  end,
     Path = kz_util:uri_encode(base64:encode(term_to_binary({Db, Id, Attachment, Options}))),
     File = kz_util:uri_encode(Attachment),
-    UrlParts = [kz_media_util:base_url(Host, Port, Permissions)
+    UrlParts = [kz_media_util:proxy_base_url(StreamType)
                ,StreamType
                ,Path
                ,File


### PR DESCRIPTION
allows haproxy configuration of media proxy (maybe with ssl termination).
ex: https://media-proxy.mydomain.com => 
{ apps001.prod.kazoo.local:24517 , apps002.prod.kazoo.local:24517 }
