### PR TITLE
HELP-40835: allow client to opt-out of validation checks

### DIFF
--- a/applications/crossbar/doc/storage.http.md
+++ b/applications/crossbar/doc/storage.http.md
@@ -56,7 +56,8 @@ If both the PUT/POST and the GET are successful, the API request to create the s
 
 Now, when a voicemail is saved to the account, your web server will receive a PUT/POST request to `PUT req /some_prefix/{ACCOUNT_ID}/{MESSAGE_ID}/uploaded_file_{TIMESTAMP}.mp3` with the binary data as the body. Your web server will then need to respond with a 201 to let KAZOO know storing the data was successful.
 
-!!!note save processing of the file for a later process; return the 201 to KAZOO as soon as your server confirms storing the file was successful locally.
+!!! note
+Save processing of the file for a later process; return the 201 to KAZOO as soon as your server confirms storing the file was successful locally.
 
 ### Multipart requests
 

--- a/applications/crossbar/doc/storage.md
+++ b/applications/crossbar/doc/storage.md
@@ -499,3 +499,6 @@ curl -v -X PUT \
     -d '{"data":{...}}' \
   http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/storage?validate_settings=false
 ```
+
+!!! danger
+If the storage backend is unable to process the storage request, you could lose the data attempting to be stored.

--- a/applications/crossbar/doc/storage.md
+++ b/applications/crossbar/doc/storage.md
@@ -507,8 +507,6 @@ If the storage backend is unable to process the storage request, you could lose 
 
 By default, Kazoo will not allow clients to skip settings validation. Clients that include the `validate_settings` request parameter on these systems will receive a 400 validation error indicating attachment storage settings must be tested.
 
-Sysadmins can allow clients by setting a `system_config` flag:
+Sysadmins can allow clients by setting a `system_config` flag: `sup kzs_plan allow_validation_overrides`
 
-```shell
-sup kapps_config set_default system_data allow_validation_overrides false
-```
+Disabling it later is similar: `sup kzs_plan disallow_validation_overrides`

--- a/applications/crossbar/doc/storage.md
+++ b/applications/crossbar/doc/storage.md
@@ -483,3 +483,19 @@ curl -v -X DELETE \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/storage/plans/{STORAGE_PLAN_ID}
 ```
+
+## Skipping attachment settings validation
+
+When a storage plan is PUT/POSTed to Crossbar, KAZOO will attempt to use the attachments' settings and store a small text file to verify that files can be stored remotely. KAZOO will then issue a GET request to read the file back to test retrieval.
+
+For "dumb" storage backends this is typically a non-issue as storing/retrieving files is what the backend does!
+
+For "smart" backends, where a custom handler (like an HTTP web app) is accepting the files, adding code to handle this test file's storage/retrieval could place an unnecessary burden on the backend or be redundant after the first test if using the same destination for all accounts. As such, a request parameter can be included to skip this portion of the validation:
+
+```shell
+curl -v -X PUT \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"data":{...}}' \
+  http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/storage?validate_settings=false
+```

--- a/applications/crossbar/doc/storage.md
+++ b/applications/crossbar/doc/storage.md
@@ -502,3 +502,13 @@ curl -v -X PUT \
 
 !!! danger
 If the storage backend is unable to process the storage request, you could lose the data attempting to be stored.
+
+### Enabling This Feature
+
+By default, Kazoo will not allow clients to skip settings validation. Clients that include the `validate_settings` request parameter on these systems will receive a 400 validation error indicating attachment storage settings must be tested.
+
+Sysadmins can allow clients by setting a `system_config` flag:
+
+```shell
+sup kapps_config set_default system_data allow_validation_overrides false
+```

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -33628,6 +33628,17 @@
             },
             "type": "object"
         },
+        "system_config.system_data": {
+            "description": "Schema for system_data system_config",
+            "properties": {
+                "allow_validation_overrides": {
+                    "default": false,
+                    "description": "Whether to allow storage plans to skip validating attachment settings",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "system_config.tasks": {
             "description": "Schema for tasks system_config",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.system_data.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.system_data.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.system_data",
+    "description": "Schema for system_data system_config",
+    "properties": {
+        "allow_validation_overrides": {
+            "default": false,
+            "description": "Whether to allow storage plans to skip validating attachment settings",
+            "type": "boolean"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/src/modules/cb_storage.erl
+++ b/applications/crossbar/src/modules/cb_storage.erl
@@ -396,7 +396,7 @@ doc_id(Context) -> doc_id(scope(Context)).
 maybe_check_storage_settings(Context, ReqVerb) when ReqVerb =:= ?HTTP_PUT
                                                     orelse ReqVerb =:= ?HTTP_POST
                                                     orelse ReqVerb =:= ?HTTP_PATCH ->
-    SystemAllowsSkippingValidation = kapps_config:get_boolean(?KZ_DATA_DB, <<"allow_validation_overrides">>, 'false'),
+    SystemAllowsSkippingValidation = kzs_plan:should_allow_validation_overrides(),
     ValidateSettings = kz_term:is_true(cb_context:req_value(Context, <<"validate_settings">>, 'true')),
     case cb_context:resp_status(Context) of
         'success' when ValidateSettings ->

--- a/applications/crossbar/src/modules/cb_storage.erl
+++ b/applications/crossbar/src/modules/cb_storage.erl
@@ -417,7 +417,7 @@ maybe_check_storage_settings(Context, _ReqVerb) ->
 
 error_must_validate_settings(Context) ->
     cb_context:add_validation_error([<<"validate_settings">>]
-                                   ,400
+                                   ,<<"forbidden">>
                                    ,kz_json:from_list([{<<"message">>, <<"The system does not allow bypassing settings validation">>}])
                                    ,Context
                                    ).

--- a/applications/crossbar/src/modules/cb_storage.erl
+++ b/applications/crossbar/src/modules/cb_storage.erl
@@ -396,11 +396,15 @@ doc_id(Context) -> doc_id(scope(Context)).
 maybe_check_storage_settings(Context, ReqVerb) when ReqVerb =:= ?HTTP_PUT
                                                     orelse ReqVerb =:= ?HTTP_POST
                                                     orelse ReqVerb =:= ?HTTP_PATCH ->
+    ValidateSettings = kz_term:is_true(cb_context:req_value(Context, <<"validate_settings">>, 'true')),
     case cb_context:resp_status(Context) of
-        'success' ->
+        'success' when ValidateSettings ->
             lager:debug("validating storage settings"),
             Attachments = kz_json:get_json_value(<<"attachments">>, cb_context:doc(Context)),
             validate_attachments_settings(Attachments, Context);
+        'success' ->
+            lager:notice("client has explicitly disabled validating attachment settings"),
+            Context;
         _ ->
             Context
     end;

--- a/core/kazoo_data/src/kzs_plan.erl
+++ b/core/kazoo_data/src/kzs_plan.erl
@@ -9,6 +9,8 @@
 
 -export([get_dataplan/2
         ,should_allow_validation_overrides/0
+        ,allow_validation_overrides/0
+        ,disallow_validation_overrides/0
         ]).
 
 -export([init/1, reload/0, reload/1, reload/2]).
@@ -35,6 +37,16 @@
 -spec should_allow_validation_overrides() -> boolean().
 should_allow_validation_overrides() ->
     kapps_config:get_boolean(?KZ_DATA_DB, <<"allow_validation_overrides">>, 'false').
+
+-spec allow_validation_overrides() -> 'true'.
+allow_validation_overrides() ->
+    {'ok', _} = kapps_config:set_default(?KZ_DATA_DB, <<"allow_validation_overrides">>, 'true'),
+    'true'.
+
+-spec disallow_validation_overrides() -> 'false'.
+disallow_validation_overrides() ->
+    {'ok', _} = kapps_config:set_default(?KZ_DATA_DB, <<"allow_validation_overrides">>, 'false'),
+    'false'.
 
 -spec plan() -> map().
 plan() ->

--- a/core/kazoo_data/src/kzs_plan.erl
+++ b/core/kazoo_data/src/kzs_plan.erl
@@ -7,7 +7,9 @@
 
 -export([plan/0, plan/1, plan/2, plan/3]).
 
--export([get_dataplan/2]).
+-export([get_dataplan/2
+        ,should_allow_validation_overrides/0
+        ]).
 
 -export([init/1, reload/0, reload/1, reload/2]).
 
@@ -29,6 +31,10 @@
 -define(KZS_PLAN_INIT_SLICE, 100).
 -define(KZS_PLAN_INIT_VIEW, <<"storage/accounts">>).
 -define(KZS_PLAN_ACCOUNT_VIEW, <<"storage/storage_by_account">>).
+
+-spec should_allow_validation_overrides() -> boolean().
+should_allow_validation_overrides() ->
+    kapps_config:get_boolean(?KZ_DATA_DB, <<"allow_validation_overrides">>, 'false').
 
 -spec plan() -> map().
 plan() ->
@@ -106,10 +112,10 @@ system_dataplan(DBName, _Classification)
     #{tag => SysTag, server => kz_dataconnections:get_server(SysTag)};
 system_dataplan(_DBName, 'numbers') ->
     Plan = ?CACHED_SYSTEM_DATAPLAN,
-    dataplan_type_match(<<"system">>, <<"numbers">>, Plan);
+    dataplan_type_match(?SYSTEM_DATAPLAN, <<"numbers">>, Plan);
 system_dataplan(DBName, _Classification) ->
     Plan = ?CACHED_SYSTEM_DATAPLAN,
-    dataplan_type_match(<<"system">>, DBName, Plan).
+    dataplan_type_match(?SYSTEM_DATAPLAN, DBName, Plan).
 
 account_dataplan(AccountDb) ->
     AccountId = kz_util:format_account_id(AccountDb),

--- a/doc/engineering/make.md
+++ b/doc/engineering/make.md
@@ -82,7 +82,7 @@ Runs the equivalent Dialyzer run that CI runs. Just runs Dialyzer on source file
 
 This is a great option if you have a beefier computer available. It will take the source files changed, run a first pass to find all modules being called, and will make a second pass using all the changed and called modules together in one big run.
 
-!!!warning
+!!! warning
 CPU/memory/time intensive.
 
 ### `make dialyze-changed`


### PR DESCRIPTION
When creating a storage plan, Kazoo checks the settings by storing a
small text file with the attachment's settings and then reading it
back. This typically works fine for "dumb" storage backends.

However, it could be a hinderance when the storage backend is "smart"
but only for the specific files it expects to receive. Adding code to
handle the writing and reading of the test file is burdensome to the
storage backend. Presumably once the backend is receiving files
properly, executing more validation checks (for new account storage
plans) could be a waste of time.

This change allows the skipping of the validation of the attachment's
settings during the API request; only JSON and internal KAZOO
validation will be performed.