### PR TITLE
PISTON-653: JSON-encode kz_json CAVs when set on a channel

### DIFF
--- a/applications/ecallmgr/src/ecallmgr.hrl
+++ b/applications/ecallmgr/src/ecallmgr.hrl
@@ -182,6 +182,7 @@
 %% message
 -define(CHANNEL_VAR_PREFIX, "ecallmgr_").
 -define(APPLICATION_VAR_PREFIX, "cav_").
+-define(JSON_APPLICATION_VAR_PREFIX, "json_cav_").
 
 -define(CCV(Key), <<?CHANNEL_VAR_PREFIX, Key/binary>>).
 -define(GET_CCV(Key), <<"variable_", ?CHANNEL_VAR_PREFIX, Key/binary>>).
@@ -195,6 +196,9 @@
 -define(GET_CAV(Key), <<"variable_", ?APPLICATION_VAR_PREFIX, Key/binary>>).
 -define(SET_CAV(Key, Value), <<?APPLICATION_VAR_PREFIX, Key/binary, "=", Value/binary>>).
 -define(GET_CAV_HEADER(Key), <<"variable_sip_h_X-", ?APPLICATION_VAR_PREFIX, Key/binary>>).
+
+-define(JSON_CAV(Key), <<?JSON_APPLICATION_VAR_PREFIX, Key/binary>>).
+-define(GET_JSON_CAV(Key), <<"variable_", ?JSON_APPLICATION_VAR_PREFIX, Key/binary>>).
 
 -define(CREDS_KEY(Realm, Username), {'authn', Username, Realm}).
 

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -423,6 +423,8 @@ custom_application_vars_fold({?CAV(Key), V}, Acc) ->
     props:set_value(Key, V, Acc);
 custom_application_vars_fold({?GET_CAV_HEADER(Key), V}, Acc) ->
     props:insert_value(Key, V, Acc);
+custom_application_vars_fold({?GET_JSON_CAV(Key), V}, Acc) ->
+    props:set_value(Key, kz_json:decode(V), Acc);
 custom_application_vars_fold(_KV, Acc) -> Acc.
 
 -spec application_var_map({kz_term:ne_binary(), kz_term:ne_binary()}) -> {kz_term:ne_binary(), kz_term:ne_binary() | kz_term:ne_binaries()}.
@@ -653,6 +655,7 @@ get_fs_kv(Key, Val, _) ->
 -spec get_fs_key(kz_term:ne_binary()) -> binary().
 get_fs_key(?CCV(Key)) -> get_fs_key(Key);
 get_fs_key(?CAV(_)=CAV) -> CAV;
+get_fs_key(?JSON_CAV(_)=JSONCAV) -> JSONCAV;
 get_fs_key(<<"X-", _/binary>>=Key) -> <<"sip_h_", Key/binary>>;
 get_fs_key(Key) ->
     case lists:keyfind(Key, 1, ?SPECIAL_CHANNEL_VARS) of
@@ -688,6 +691,8 @@ get_fs_key_and_value(<<"ringback">>=Key, Value, _UUID) ->
     ];
 get_fs_key_and_value(?CCV(Key), Val, UUID) ->
     get_fs_key_and_value(Key, Val, UUID);
+get_fs_key_and_value(?JSON_CAV(_)=JSONCAV, Val, _UUID) ->
+    {get_fs_key(JSONCAV), maybe_sanitize_fs_value(JSONCAV, kz_json:encode(Val))};
 get_fs_key_and_value(Key, Val, _UUID)
   when is_binary(Val);
        is_atom(Val);


### PR DESCRIPTION
We would like to be able to have our pivot users set more complex structures for CAVs (also would apply to CCVs) using JSON. kapps_call and kapps_call_command can already pass these through to ecallmgr, however they are discarded because of their type. This PR encodes them as binary and they are then retrievable in blackhole events, CDRs, etc. We are leaving it up to the user to decode them