### PR TITLE
Update targets to properly handle -j

### DIFF
--- a/core/kazoo_documents/Makefile
+++ b/core/kazoo_documents/Makefile
@@ -12,6 +12,8 @@ all: compile
 
 compile: compile-autogen $(ERL_FILES)
 
+compile-test: compile-autogen $(ERL_FILES)
+
 compile-autogen: $(addsuffix -compile,$(SRC_FILES))
 
 clean: clean-autogen

--- a/core/kazoo_documents/test/kzd_test_fixtures.erl
+++ b/core/kazoo_documents/test/kzd_test_fixtures.erl
@@ -9,17 +9,17 @@
 setup() ->
     ?LOG_DEBUG(":: Setting up Kazoo FixtureDB"),
 
-    {ok, _} = application:ensure_all_started(kazoo_config),
+    {'ok', _} = application:ensure_all_started('kazoo_config'),
     kazoo_fixturedb:start().
 
 cleanup(LinkPid) ->
-    _DataLink = erlang:exit(LinkPid, normal),
-    Ref = monitor(process, LinkPid),
+    _DataLink = erlang:exit(LinkPid, 'normal'),
+    Ref = monitor('process', LinkPid),
     receive
-        {'DOWN', Ref, process, LinkPid, _Reason} ->
-            _KConfig = application:stop(kazoo_config),
+        {'DOWN', Ref, 'process', LinkPid, _Reason} ->
+            _KConfig = application:stop('kazoo_config'),
             ?LOG_DEBUG(":: Stopped Kazoo FixtureDB, data_link: ~p kazoo_config: ~p", [_DataLink, _KConfig])
-    after 1000 ->
-            _KConfig = application:stop(kazoo_config),
+    after ?MILLISECONDS_IN_SECOND ->
+            _KConfig = application:stop('kazoo_config'),
             ?LOG_DEBUG(":: Stopped Kazoo FixtureDB, data_link: timeout kazoo_config: ~p", [_KConfig])
     end.

--- a/core/kazoo_fixturedb/src/kz_fixturedb_util.erl
+++ b/core/kazoo_fixturedb/src/kz_fixturedb_util.erl
@@ -133,28 +133,31 @@ update_revision(JObj) ->
 %%------------------------------------------------------------------------------
 -spec start_me() -> pid().
 start_me() ->
-    start_me(false).
+    start_me('false').
 
 -spec start_me(boolean()) -> pid().
 start_me(SilentLager) ->
     ?LOG_DEBUG(":: Starting up Kazoo FixtureDB"),
-    {ok, _} = application:ensure_all_started(kazoo_config),
-    {ok, Pid} = kazoo_data_link_sup:start_link(),
+    {'ok', _} = application:ensure_all_started('kazoo_config'),
+    Pid = case kazoo_data_link_sup:start_link() of
+              {'ok', P} -> P;
+              {'error', {'already_started', P}} -> P
+          end,
     'ignore' = kazoo_data_bootstrap:start_link(),
 
     _ = case SilentLager of
-            true ->
-                _ = lager:set_loglevel(lager_console_backend, none),
-                _ = lager:set_loglevel(lager_file_backend, none),
-                lager:set_loglevel(lager_syslog_backend, none);
-            false -> ok
+            'true' ->
+                _ = lager:set_loglevel('lager_console_backend', 'none'),
+                _ = lager:set_loglevel('lager_file_backend', 'none'),
+                lager:set_loglevel('lager_syslog_backend', 'none');
+            'false' -> 'ok'
         end,
     Pid.
 
--spec stop_me(pid()) -> ok.
+-spec stop_me(pid()) -> 'ok'.
 stop_me(Pid) ->
-    _ = erlang:exit(Pid, normal),
-    _ = application:stop(kazoo_config),
+    _ = erlang:exit(Pid, 'normal'),
+    _ = application:stop('kazoo_config'),
     ?LOG_DEBUG(":: Stopped Kazoo FixtureDB").
 
 -spec get_doc_path(kz_term:ne_binary(), kz_term:ne_binary()) -> file:filename_all().

--- a/make/kz.mk
+++ b/make/kz.mk
@@ -104,7 +104,6 @@ json: JSON = $(shell find . -name '*.json')
 json:
 	@$(ROOT)/scripts/format-json.sh $(JSON)
 
-
 compile-test: clean-test $(COMPILE_MOAR) test/$(PROJECT).app json
 
 test/$(PROJECT).app: ERLC_OPTS += -DTEST


### PR DESCRIPTION
Speeds up most targets that operate over the core/applications code (like clean, eunit, etc).