### PR TITLE
kazoo_attachments: Fixed storing recordings to external url

### DIFF
--- a/core/kazoo_attachments/src/kz_att_http.erl
+++ b/core/kazoo_attachments/src/kz_att_http.erl
@@ -83,7 +83,7 @@ format_verb(<<"PUT">>) ->
     'put';
 format_verb(<<"put">>) ->
     'put';
-format_verb(Value) ->
+format_verb(Value) when not erlang:is_binary(Value) ->
     format_verb(kz_term:to_binary(Value)).
 
 -spec fetch_attachment(gen_attachment:handler_props()

--- a/core/kazoo_attachments/src/kz_att_http.erl
+++ b/core/kazoo_attachments/src/kz_att_http.erl
@@ -82,7 +82,9 @@ format_verb(<<"post">>) ->
 format_verb(<<"PUT">>) ->
     'put';
 format_verb(<<"put">>) ->
-    'put'.
+    'put';
+format_verb(Value) ->
+    format_verb(kz_term:to_binary(Value)).
 
 -spec fetch_attachment(gen_attachment:handler_props()
                       ,gen_attachment:db_name()


### PR DESCRIPTION
Required cherry-pick into 4.3 branch