### PR TITLE
[4.3] HELP-40835: add metadata to mailbox message

### DIFF
--- a/applications/crossbar/doc/storage.http.md
+++ b/applications/crossbar/doc/storage.http.md
@@ -56,7 +56,8 @@ If both the PUT/POST and the GET are successful, the API request to create the s
 
 Now, when a voicemail is saved to the account, your web server will receive a PUT/POST request to `PUT req /some_prefix/{ACCOUNT_ID}/{MESSAGE_ID}/uploaded_file_{TIMESTAMP}.mp3` with the binary data as the body. Your web server will then need to respond with a 201 to let KAZOO know storing the data was successful.
 
-!!!note save processing of the file for a later process; return the 201 to KAZOO as soon as your server confirms storing the file was successful locally.
+!!! note
+Save processing of the file for a later process; return the 201 to KAZOO as soon as your server confirms storing the file was successful locally.
 
 ### Multipart requests
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -33159,6 +33159,17 @@
             },
             "type": "object"
         },
+        "system_config.system_data": {
+            "description": "Schema for system_data system_config",
+            "properties": {
+                "allow_validation_overrides": {
+                    "default": false,
+                    "description": "Whether to allow storage plans to skip validating attachment settings",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "system_config.tasks": {
             "description": "Schema for tasks system_config",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.system_data.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.system_data.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.system_data",
+    "description": "Schema for system_data system_config",
+    "properties": {
+        "allow_validation_overrides": {
+            "default": false,
+            "description": "Whether to allow storage plans to skip validating attachment settings",
+            "type": "boolean"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/src/modules/cb_storage.erl
+++ b/applications/crossbar/src/modules/cb_storage.erl
@@ -396,16 +396,31 @@ doc_id(Context) -> doc_id(scope(Context)).
 maybe_check_storage_settings(Context, ReqVerb) when ReqVerb =:= ?HTTP_PUT
                                                     orelse ReqVerb =:= ?HTTP_POST
                                                     orelse ReqVerb =:= ?HTTP_PATCH ->
+    SystemAllowsSkippingValidation = kzs_plan:should_allow_validation_overrides(),
+    ValidateSettings = kz_term:is_true(cb_context:req_value(Context, <<"validate_settings">>, 'true')),
     case cb_context:resp_status(Context) of
-        'success' ->
+        'success' when ValidateSettings ->
             lager:debug("validating storage settings"),
             Attachments = kz_json:get_json_value(<<"attachments">>, cb_context:doc(Context)),
             validate_attachments_settings(Attachments, Context);
+        'success' when SystemAllowsSkippingValidation ->
+            lager:notice("client has explicitly disabled validating attachment settings"),
+            Context;
+        'success' ->
+            lager:notice("system does not allow client to disable validation"),
+            error_must_validate_settings(Context);
         _ ->
             Context
     end;
 maybe_check_storage_settings(Context, _ReqVerb) ->
     Context.
+
+error_must_validate_settings(Context) ->
+    cb_context:add_validation_error([<<"validate_settings">>]
+                                   ,<<"forbidden">>
+                                   ,kz_json:from_list([{<<"message">>, <<"The system does not allow bypassing settings validation">>}])
+                                   ,Context
+                                   ).
 
 -spec validate_attachments_settings(kz_json:object()
                                    ,cb_context:context()

--- a/core/kazoo_data/src/kzs_plan.erl
+++ b/core/kazoo_data/src/kzs_plan.erl
@@ -7,7 +7,11 @@
 
 -export([plan/0, plan/1, plan/2, plan/3]).
 
--export([get_dataplan/2]).
+-export([get_dataplan/2
+        ,should_allow_validation_overrides/0
+        ,allow_validation_overrides/0
+        ,disallow_validation_overrides/0
+        ]).
 
 -export([init/1, reload/0, reload/1, reload/2]).
 
@@ -29,6 +33,20 @@
 -define(KZS_PLAN_INIT_SLICE, 100).
 -define(KZS_PLAN_INIT_VIEW, <<"storage/accounts">>).
 -define(KZS_PLAN_ACCOUNT_VIEW, <<"storage/storage_by_account">>).
+
+-spec should_allow_validation_overrides() -> boolean().
+should_allow_validation_overrides() ->
+    kapps_config:get_boolean(?KZ_DATA_DB, <<"allow_validation_overrides">>, 'false').
+
+-spec allow_validation_overrides() -> 'true'.
+allow_validation_overrides() ->
+    {'ok', _} = kapps_config:set_default(?KZ_DATA_DB, <<"allow_validation_overrides">>, 'true'),
+    'true'.
+
+-spec disallow_validation_overrides() -> 'false'.
+disallow_validation_overrides() ->
+    {'ok', _} = kapps_config:set_default(?KZ_DATA_DB, <<"allow_validation_overrides">>, 'false'),
+    'false'.
 
 -spec plan() -> map().
 plan() ->
@@ -106,10 +124,10 @@ system_dataplan(DBName, _Classification)
     #{tag => SysTag, server => kz_dataconnections:get_server(SysTag)};
 system_dataplan(_DBName, 'numbers') ->
     Plan = ?CACHED_SYSTEM_DATAPLAN,
-    dataplan_type_match(<<"system">>, <<"numbers">>, Plan);
+    dataplan_type_match(?SYSTEM_DATAPLAN, <<"numbers">>, Plan);
 system_dataplan(DBName, _Classification) ->
     Plan = ?CACHED_SYSTEM_DATAPLAN,
-    dataplan_type_match(<<"system">>, DBName, Plan).
+    dataplan_type_match(?SYSTEM_DATAPLAN, DBName, Plan).
 
 account_dataplan(AccountDb) ->
     AccountId = kz_util:format_account_id(AccountDb),

--- a/doc/engineering/make.md
+++ b/doc/engineering/make.md
@@ -82,7 +82,7 @@ Runs the equivalent Dialyzer run that CI runs. Just runs Dialyzer on source file
 
 This is a great option if you have a beefier computer available. It will take the source files changed, run a first pass to find all modules being called, and will make a second pass using all the changed and called modules together in one big run.
 
-!!!warning
+!!! warning
 CPU/memory/time intensive.
 
 ### `make dialyze-changed`


### PR DESCRIPTION
Also backport the skipping of validation settings when creating a storage plan via API.