### PR TITLE
Improve execution time for automatic compaction job

### DIFF
--- a/applications/tasks/src/modules/kt_compaction_reporter.erl
+++ b/applications/tasks/src/modules/kt_compaction_reporter.erl
@@ -1,0 +1,503 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2019-, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kt_compaction_reporter).
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0]).
+-export([start_tracking_job/3
+        ,start_tracking_job/4
+        ,stop_tracking_job/1
+        ,set_job_dbs/2
+        ,current_db/2
+        ,skipped_db/2
+        ,finished_db/3
+        ,add_found_shards/2
+        ,finished_shard/2
+        ]).
+%% "Mirrors" for SUP commands
+-export([status/0, history/0, history/2, job_info/1]).
+
+%% gen_server's callbacks
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,code_change/3
+        ,terminate/2
+        ]).
+
+-define(SERVER, ?MODULE).
+-define(COMPACTION_VIEW, <<"compaction_jobs/crossbar_listing">>).
+
+-type call_id() :: kz_term:ne_binary().
+-type compaction_stats() :: #{%% Databases
+                              'id' => kz_term:ne_binary()
+                             ,'found_dbs' => pos_integer() %% Number of dbs found to be compacted
+                             ,'compacted_dbs' => non_neg_integer() %% Number of dbs compacted so far
+                             ,'queued_dbs' => non_neg_integer() %% remaining dbs to be compacted
+                             ,'skipped_dbs' => non_neg_integer() %% dbs skipped because not data_size nor disk-data's ratio thresholds are met.
+                             ,'current_db' => kz_term:api_ne_binary()
+                             ,'processed_dbs' => kz_term:ne_binaries() %% `Encoded' DBs already processed, avoids processing duplicated events like skipped, finished, etc.
+                              %% Shards
+                             ,'found_shards' => non_neg_integer() %% Number of shards found so far
+                             ,'compacted_shards' => non_neg_integer() %% Number of shards compacted so far
+                              %% Storage
+                             ,'disk_start' => non_neg_integer() %% disk_size sum of all dbs in bytes before compaction (for history command)
+                             ,'disk_end' => non_neg_integer() %% disk_size sum of all dbs in bytes after compaction (for history command)
+                             ,'data_start' => non_neg_integer() %% data_size sum of all dbs in bytes before compaction (for history command)
+                             ,'data_end' => non_neg_integer() %% data_size sum of all dbs in bytes after compaction (for history command)
+                             ,'recovered_disk' => non_neg_integer() %% bytes recovered so far (for status command)
+                              %% Worker
+                             ,'pid' => pid() %% worker's pid
+                             ,'node' => node() %% node where the worker is running
+                             ,'started' => kz_time:gregorian_seconds() %% datetime (in seconds) when the compaction started
+                             ,'finished' => 'undefined' | kz_time:gregorian_seconds() %% datetime (in seconds) when the compaction ended
+                             }.
+-type state() :: #{call_id() => compaction_stats()}.
+
+
+%%%=============================================================================
+%%% API
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec start_link() -> kz_types:startlink_ret().
+start_link() ->
+    case gen_server:start_link({'local', ?MODULE}, ?MODULE, [], []) of
+        {'error', {'already_started', Pid}} ->
+            'true' = link(Pid),
+            {'ok', Pid};
+        Other -> Other
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Start tracking a compaction job
+%% @end
+%%------------------------------------------------------------------------------
+-spec start_tracking_job(pid(), node(), call_id()) -> 'ok'.
+start_tracking_job(Pid, Node, CallId) ->
+    start_tracking_job(Pid, Node, CallId, []).
+
+%%------------------------------------------------------------------------------
+%% @doc Start tracking a compaction job
+%% @end
+%%------------------------------------------------------------------------------
+-spec start_tracking_job(pid(), node(), call_id(), [kt_compactor:db_and_sizes()]) -> 'ok'.
+start_tracking_job(Pid, Node, CallId, DbsAndSizes) ->
+    gen_server:cast(?SERVER, {'new_job', Pid, Node, CallId, DbsAndSizes}).
+
+%%------------------------------------------------------------------------------
+%% @doc Stop tracking compaction job, save current state on db.
+%% @end
+%%------------------------------------------------------------------------------
+-spec stop_tracking_job(call_id()) -> 'ok'.
+stop_tracking_job(CallId) ->
+    gen_server:cast(?SERVER, {'stop_job', CallId}).
+
+%%------------------------------------------------------------------------------
+%% @doc Some jobs like `compact_all' and `compact_node' doesn't know the list of dbs to
+%% be compacted at the beginning of the job, so we wait for that job to report the dbs
+%% once it has the list of dbs to be compacted prior to start compacting them.
+%% @end
+%%------------------------------------------------------------------------------
+-spec set_job_dbs(call_id(), kt_compactor:dbs_and_sizes()) -> 'ok'.
+set_job_dbs(CallId, DbsAndSizes) ->
+    gen_server:cast(?SERVER, {'set_job_dbs', CallId, DbsAndSizes}).
+
+%%------------------------------------------------------------------------------
+%% @doc Set current db being compacted for the given job id.
+%% @end
+%%------------------------------------------------------------------------------
+-spec current_db(call_id(), kz_term:ne_binary()) -> 'ok'.
+current_db(CallId, Db) ->
+    gen_server:cast(?SERVER, {'current_db', CallId, normalize_db(Db)}).
+
+%%------------------------------------------------------------------------------
+%% @doc Notifies when a database has been skipped by the compactor worker. This happens
+%% when not data_size nor disk-data's ratio thresholds are met.
+%% @end
+%%------------------------------------------------------------------------------
+-spec skipped_db(call_id(), kz_term:ne_binary()) -> 'ok'.
+skipped_db(CallId, Db) when is_binary(Db) ->
+    gen_server:cast(?SERVER, {'skipped_db', CallId, normalize_db(Db)}).
+
+%%------------------------------------------------------------------------------
+%% @doc Set db already compacted for the given job id.
+%% @end
+%%------------------------------------------------------------------------------
+-spec finished_db(call_id(), kz_term:ne_binary(), kt_compactor:rows()) -> 'ok'.
+finished_db(CallId, Db, Rows) ->
+    gen_server:cast(?SERVER, {'finished_db', CallId, normalize_db(Db), Rows}).
+
+%%------------------------------------------------------------------------------
+%% @doc Increases `found_shards' value by adding `ShardsCount' to it for the given job id.
+%% @end
+%%------------------------------------------------------------------------------
+-spec add_found_shards(call_id(), non_neg_integer()) -> 'ok'.
+add_found_shards(CallId, ShardsCount) when is_number(ShardsCount) ->
+    gen_server:cast(?SERVER, {'add_found_shards', CallId, ShardsCount}).
+
+%%------------------------------------------------------------------------------
+%% @doc Increases the counter of `compacted_shards' for the given job id.
+%% @end
+%%------------------------------------------------------------------------------
+-spec finished_shard(call_id(), kz_term:ne_binary()) -> 'ok'.
+finished_shard(CallId, Shard) ->
+    gen_server:cast(?SERVER, {'finished_shard', CallId, Shard}).
+
+%%------------------------------------------------------------------------------
+%% @doc Return the status for every compaction job currently running.
+%% @end
+%%------------------------------------------------------------------------------
+-spec status() -> [kz_term:proplist()].
+status() ->
+    %% Result is a list of proplists or an empty list.
+    gen_server:call(?SERVER, 'status').
+
+%%------------------------------------------------------------------------------
+%% @doc Returns history for the current Year and Month.
+%% @end
+%%------------------------------------------------------------------------------
+-spec history() -> {'ok', kz_json:json_terms()} | {'error', atom()}.
+history() ->
+    {Year, Month, _} = erlang:date(),
+    history(Year, Month).
+
+%%------------------------------------------------------------------------------
+%% @doc Return compaction history for the given year and month (YYYY, MM).
+%% @end
+%%------------------------------------------------------------------------------
+-spec history(kz_time:year(), kz_time:month()) -> {'ok', kz_json:json_terms()} |
+                                                  {'error', atom()}.
+history(Year, Month) when is_integer(Year)
+                          andalso is_integer(Month) ->
+    {'ok', AccountId} = kapps_util:get_master_account_id(),
+    Opts = [{'year', Year}, {'month', Month}, 'include_docs'],
+    kazoo_modb:get_results(AccountId, ?COMPACTION_VIEW, Opts).
+
+%%------------------------------------------------------------------------------
+%% @doc Return the information for the given job id
+%% @end
+%%------------------------------------------------------------------------------
+-spec job_info(kz_term:ne_binary()) -> kz_term:proplist() | atom().
+job_info(<<JobId/binary>>) ->
+    {'ok', AccountId} = kapps_util:get_master_account_id(),
+    case kazoo_modb:open_doc(AccountId, JobId) of
+        {'ok', JObj} ->
+            Int = fun(Key) -> kz_json:get_integer_value(Key, JObj) end,
+            Str = fun(Key) -> kz_json:get_string_value(Key, JObj) end,
+            DiskStart = Int([<<"storage">>, <<"disk">>, <<"start">>]),
+            DiskEnd = Int([<<"storage">>, <<"disk">>, <<"end">>]),
+            Start = Int([<<"worker">>, <<"started">>]),
+            End = Int([<<"worker">>, <<"finished">>]),
+            [{<<"id">>, kz_doc:id(JObj)}
+            ,{<<"found_dbs">>, Str([<<"databases">>, <<"found">>])}
+            ,{<<"compacted_dbs">>, Str([<<"databases">>, <<"compacted">>])}
+            ,{<<"skipped_dbs">>, Str([<<"databases">>, <<"skipped">>])}
+            ,{<<"found_shards">>, Str([<<"shards">>, <<"found">>])}
+            ,{<<"compacted_shards">>, Str([<<"shards">>, <<"compacted">>])}
+            ,{<<"disk_start">>, kz_term:to_binary(DiskStart)}
+            ,{<<"disk_end">>, kz_term:to_binary(DiskEnd)}
+            ,{<<"data_start">>, Str([<<"storage">>, <<"data">>, <<"start">>])}
+            ,{<<"data_end">>, Str([<<"storage">>, <<"data">>, <<"end">>])}
+            ,{<<"recovered_disk">>, kz_util:pretty_print_bytes(DiskStart - DiskEnd)}
+            ,{<<"node">>, Str([<<"worker">>, <<"node">>])}
+            ,{<<"pid">>, Str([<<"worker">>, <<"pid">>])}
+            ,{<<"started">>, kz_term:to_list(kz_time:pretty_print_datetime(Start))}
+            ,{<<"finished">>, kz_term:to_list(kz_time:pretty_print_datetime(End))}
+            ,{<<"exec_time">>
+             ,kz_term:to_list(kz_time:pretty_print_elapsed_s(End - Start))
+             }
+            ];
+        {'error', Reason} ->
+            Reason
+    end.
+
+%%%=============================================================================
+%%% gen_server callbacks
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc Initializes the server.
+%% @end
+%%------------------------------------------------------------------------------
+-spec init([]) -> {'ok', state()}.
+init([]) ->
+    {'ok', #{}}.
+
+%%------------------------------------------------------------------------------
+%% @doc Handling call messages.
+%% @end
+%%------------------------------------------------------------------------------
+-spec handle_call(any(), kz_term:pid_ref(), state()) -> kz_types:handle_call_ret_state(state()).
+handle_call('status', _From, State) ->
+    Ret = maps:fold(fun stats_to_status_fold/3, [], State),
+    {'reply', Ret, State};
+
+handle_call(_Request, _From, State) ->
+    lager:debug("unhandled call ~p from ~p", [_Request, _From]),
+    {'reply', {'error', 'not_implemented'}, State}.
+
+%%------------------------------------------------------------------------------
+%% @doc Handling cast messages.
+%% @end
+%%------------------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
+handle_cast({'new_job', Pid, Node, CallId, DbsAndSizes}, State) ->
+    TotalDbs = length(DbsAndSizes),
+    Stats = #{'id' => CallId
+             ,'found_dbs' => TotalDbs
+             ,'compacted_dbs' => 0
+             ,'queued_dbs' => TotalDbs
+             ,'skipped_dbs' => 0
+             ,'current_db' => 'undefined'
+             ,'processed_dbs' => []
+             ,'found_shards' => 0
+             ,'compacted_shards' => 0
+             ,'disk_start' => 0
+             ,'disk_end' => 0
+             ,'data_start' => 0
+             ,'data_end' => 0
+             ,'recovered_disk' => 0
+             ,'pid' => Pid
+             ,'node' => Node
+             ,'started' => kz_time:now_s()
+             ,'finished' => 'undefined'
+             },
+    {'noreply', State#{CallId => Stats}};
+
+handle_cast({'stop_job', CallId}, State) ->
+    NewState =
+        case maps:take(CallId, State) of
+            'error' ->
+                lager:debug("invalid id provided for stopping job tracking: ~p", [CallId]),
+                State;
+            {Stats = #{'started' := Started}, State1} ->
+                Finished = kz_time:now_s(),
+                Elapsed = Finished - Started,
+                lager:debug("~s finished, took ~s (~ps)"
+                           ,[CallId, kz_time:pretty_print_elapsed_s(Elapsed), Elapsed]
+                           ),
+                'ok' = save_compaction_stats(Stats#{'finished' => Finished}),
+                State1
+        end,
+    {'noreply', NewState};
+
+handle_cast({'set_job_dbs', CallId, DbsAndSizes}, State) ->
+    NewState =
+        case maps:get(CallId, State, 'undefined') of
+            'undefined' ->
+                State;
+            Stats ->
+                TotalDbs = length(DbsAndSizes),
+                State#{CallId => Stats#{'found_dbs' => TotalDbs
+                                       ,'queued_dbs' => TotalDbs
+                                       }}
+        end,
+    {'noreply', NewState};
+
+handle_cast({'current_db', CallId, Db}, State) ->
+    NewState =
+        case maps:get(CallId, State, 'undefined') of
+            'undefined' -> State;
+            Stats -> State#{CallId => Stats#{'current_db' => Db}}
+        end,
+    {'noreply', NewState};
+
+handle_cast({'skipped_db', CallId, Db}, State) ->
+    Stats = maps:get(CallId, State, 'undefined'),
+    NewState =
+        case Stats =/= 'undefined'
+            andalso not lists:member(Db, maps:get('processed_dbs', Stats))
+        of
+            'false' ->
+                State;
+            'true' ->
+                lager:debug("~p db does not need compaction, skipped", [Db]),
+                State#{CallId => Stats#{'skipped_dbs' => maps:get('skipped_dbs', Stats) + 1}}
+        end,
+    {'noreply', NewState};
+
+handle_cast({'finished_db', CallId, Db, [FRow | _]}, State) ->
+    Stats = maps:get(CallId, State, 'undefined'),
+    NewState =
+        case Stats =/= 'undefined'
+            andalso not lists:member(Db, maps:get('processed_dbs', Stats))
+        of
+            'false' ->
+                State;
+            'true' ->
+                #{'recovered_disk' := CurrentRec
+                 ,'disk_start' := DiskStart
+                 ,'disk_end' := DiskEnd
+                 ,'data_start' := DataStart
+                 ,'data_end' := DataEnd
+                 ,'found_dbs' := Found
+                 ,'skipped_dbs' := Skipped
+                 ,'queued_dbs' := Queued
+                 ,'processed_dbs' := ProcessedDBs
+                 } = Stats,
+                [_, _, OldDisk, OldData, NewDisk, NewData] = FRow,
+                Recovered = (OldDisk-NewDisk),
+                NewQueued = Queued - 1,
+                lager:debug("recovered ~p bytes after compacting ~p db", [Recovered, Db]),
+                State#{CallId => Stats#{'recovered_disk' => CurrentRec + Recovered
+                                       ,'disk_start' => DiskStart + OldDisk
+                                       ,'disk_end' => DiskEnd + NewDisk
+                                       ,'data_start' => DataStart + OldData
+                                       ,'data_end' => DataEnd + NewData
+                                       ,'compacted_dbs' => Found - NewQueued - Skipped
+                                       ,'queued_dbs' => NewQueued
+                                       ,'current_db' => 'undefined'
+                                       ,'processed_dbs' => [Db | ProcessedDBs]
+                                       }}
+        end,
+    {'noreply', NewState};
+
+handle_cast({'add_found_shards', CallId, ShardsCount}, State) ->
+    NewState =
+        case maps:get(CallId, State, 'undefined') of
+            'undefined' ->
+                State;
+            Stats ->
+                lager:debug("adding ~p to the number of found shards", [ShardsCount]),
+                CurrentShards = maps:get('found_shards', Stats),
+                State#{CallId => Stats#{'found_shards' => CurrentShards + ShardsCount}}
+        end,
+    {'noreply', NewState};
+
+handle_cast({'finished_shard', CallId, _Shard}, State) ->
+    NewState =
+        case maps:get(CallId, State, 'undefined') of
+            'undefined' ->
+                State;
+            Stats ->
+                Compacted = maps:get('compacted_shards', Stats),
+                State#{CallId => Stats#{'compacted_shards' => Compacted + 1}}
+        end,
+    {'noreply', NewState};
+
+handle_cast(_Msg, State) ->
+    lager:debug("unhandled cast ~p", [_Msg]),
+    {'noreply', State}.
+
+%%------------------------------------------------------------------------------
+%% @doc Handling all non call/cast messages.
+%% @end
+%%------------------------------------------------------------------------------
+-spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    lager:debug("unhandled message ~p", [_Info]),
+    {'noreply', State}.
+
+%%------------------------------------------------------------------------------
+%% @doc This function is called by a `gen_server' when it is about to
+%% terminate. It should be the opposite of `Module:init/1' and do any
+%% necessary cleaning up. When it returns, the `gen_server' terminates
+%% with Reason. The return value is ignored.
+%% @end
+%%------------------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("~s terminating with reason: ~p~n when state was: ~p"
+               ,[?MODULE, _Reason, _State]
+               ).
+
+%%------------------------------------------------------------------------------
+%% @doc Convert process state when code is changed.
+%% @end
+%%------------------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc Converts current state into a list of proplists including only some `Keys'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec stats_to_status_fold(kz_term:ne_binary(), compaction_stats(), [kz_term:proplist()]) ->
+                                  [kz_term:proplist()].
+stats_to_status_fold(_CallId, Stats = #{'queued_dbs' := QueuedDBs}, Acc) ->
+    Keys = ['id', 'found_dbs', 'compacted_dbs', 'queued_dbs', 'skipped_dbs', 'current_db',
+            'found_shards', 'compacted_shards', 'recovered_disk', 'pid', 'node', 'started'],
+    ToBin = fun(Something) -> kz_term:to_binary(Something) end,
+    StatsProp = [{ToBin(Key), ToBin(maps:get(Key, Stats))} || Key <- Keys],
+    case QueuedDBs =:= 0 of
+        'true' ->
+            %% This happens when it finishes compacting on the first node so now
+            %% `found_dbs = compacted_dbs + skipped_dbs' which means `queued_dbs = 0' and
+            %% also it means it is still compacting on other nodes otherwise this status
+            %% were not being build.
+            MsgProp = [{<<"msg">>, <<"Still compacting on other nodes">>}],
+            [StatsProp ++ MsgProp | Acc];
+        'false' ->
+            [StatsProp | Acc]
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Save compaction job stats on db.
+%% @end
+%%------------------------------------------------------------------------------
+-spec save_compaction_stats(compaction_stats()) -> 'ok'.
+save_compaction_stats(#{'id' := Id
+                       ,'found_dbs' := FoundDBs
+                       ,'compacted_dbs' := CompactedDBs
+                       ,'queued_dbs' := QueuedDBs
+                       ,'skipped_dbs' := SkippedDBs
+                       ,'found_shards' := FoundShards
+                       ,'compacted_shards' := CompactedShards
+                       ,'disk_start' := DiskStart
+                       ,'disk_end' := DiskEnd
+                       ,'data_start' := DataStart
+                       ,'data_end' := DataEnd
+                       ,'pid' := Pid
+                       ,'node' := Node
+                       ,'started' := Started
+                       ,'finished' := Finished
+                       } = Stats) ->
+    Map = #{<<"_id">> => Id
+           ,<<"databases">> => #{<<"found">> => FoundDBs
+                                ,<<"compacted">> => CompactedDBs
+                                ,<<"queued">> => QueuedDBs
+                                ,<<"skipped">> => SkippedDBs
+                                }
+           ,<<"shards">> => #{<<"found">> => FoundShards
+                             ,<<"compacted">> => CompactedShards
+                             }
+           ,<<"storage">> => #{<<"disk">> =>
+                                   #{<<"start">> => DiskStart
+                                    ,<<"end">> => DiskEnd
+                                    }
+                              ,<<"data">> =>
+                                   #{<<"start">> => DataStart
+                                    ,<<"end">> => DataEnd
+                                    }
+                              }
+           ,<<"worker">> => #{<<"pid">> => kz_term:to_binary(Pid)
+                             ,<<"node">> => kz_term:to_binary(Node)
+                             ,<<"started">> => Started
+                             ,<<"finished">> => Finished
+                             }
+           ,<<"pvt_type">> => <<"compaction_job">>
+           ,<<"pvt_created">> => kz_time:now_s()
+           },
+    lager:debug("saving stats after compaction job completion: ~p", [Stats]),
+    {'ok', AccountId} = kapps_util:get_master_account_id(),
+    {'ok', Doc} = kazoo_modb:save_doc(AccountId, kz_json:from_map(Map)),
+    lager:debug("created doc after compaction job completion: ~p", [Doc]),
+    'ok'.
+
+-spec normalize_db(kz_term:ne_binary()) -> kz_term:ne_binary().
+normalize_db(Db) ->
+    kz_util:uri_decode(Db).

--- a/applications/tasks/src/modules/kt_compactor.erl
+++ b/applications/tasks/src/modules/kt_compactor.erl
@@ -8,7 +8,7 @@
 
 %% behaviour: tasks_provider
 
--export([init/0]).
+-export([init/0, get_all_dbs_and_sort_by_disk/0]).
 
 -export([compact_all/2
         ,compact_node/3
@@ -22,6 +22,11 @@
 -export([help/1, help/2, help/3
         ,output_header/1
         ]).
+
+-ifdef(TEST).
+-export([sort_by_disk_size/1
+        ]).
+-endif.
 
 -include("tasks.hrl").
 -include("src/modules/kt_compactor.hrl").
@@ -37,6 +42,13 @@
        ).
 
 -type rows() :: [kz_csv:row()] | [].
+-type db_and_sizes() :: {kz_term:ne_binary(), kt_compactor_worker:db_disk_and_data()}.
+-type dbs_and_sizes() :: [db_and_sizes()].
+
+-export_type([rows/0
+             ,db_and_sizes/0
+             ,dbs_and_sizes/0
+             ]).
 
 %%%=============================================================================
 %%% API
@@ -48,26 +60,30 @@
 %%------------------------------------------------------------------------------
 -spec init() -> 'ok'.
 init() ->
-    kapps_maintenance:refresh(kazoo_couch:get_admin_nodes()),
-    set_node_defaults(),
+    AdminNodes = kazoo_couch:get_admin_nodes(),
+    %% Refresh `nodes | _nodes' db
+    kapps_maintenance:refresh(AdminNodes),
+    %% Refresh `dbs | _dbs' db needed for the compactor/listing_by_node view.
+    kapps_maintenance:refresh(kazoo_couch:get_admin_dbs()),
+    set_node_defaults(AdminNodes),
 
     case ?COMPACT_AUTOMATICALLY of
         'false' -> lager:info("node ~s not configured to compact automatically", [node()]);
         'true' ->
             lager:info("node ~s configured to compact automatically", [node()]),
-            _ = tasks_bindings:bind(?TRIGGER_ALL_DBS, ?MODULE, 'compact_db')
+            %% By default, `do_compact_db/1' sets `?HEUR_RATIO' as the Heuristic to use.
+            _ = tasks_bindings:bind(?TRIGGER_ALL_DBS, ?MODULE, 'do_compact_db')
     end,
 
     _ = tasks_bindings:bind(<<"tasks.help">>, ?MODULE, 'help'),
     _ = tasks_bindings:bind(<<"tasks."?CATEGORY".output_header">>, ?MODULE, 'output_header'),
     tasks_bindings:bind_actions(<<"tasks."?CATEGORY>>, ?MODULE, ?ACTIONS).
 
--spec set_node_defaults() -> 'ok'.
-set_node_defaults() ->
-    {'ok', Nodes} = kz_datamgr:all_docs(kazoo_couch:get_admin_nodes()),
-    lists:foreach(fun set_node_defaults/1, Nodes).
+-spec set_node_defaults(kz_term:ne_binary() | kz_json:object()) -> 'ok'.
+set_node_defaults(AdminNodes) when is_binary(AdminNodes) ->
+    {'ok', Nodes} = kz_datamgr:all_docs(AdminNodes),
+    lists:foreach(fun set_node_defaults/1, Nodes);
 
--spec set_node_defaults(kz_json:object()) -> 'ok'.
 set_node_defaults(NodeJObj) ->
     Node = kz_doc:id(NodeJObj),
     set_node_api_port(Node),
@@ -135,7 +151,12 @@ output_header(<<"compact_db">>) -> ?OUTPUT_HEADER.
 compact_all(Extra, 'init') ->
     {'ok', is_allowed(Extra)};
 compact_all(_Extra, 'true') ->
-    {do_compact_all(), 'stop'};
+    %% Dbs to be compacted will be set at `do_compact_all/0'
+    Rows = track_job(<<"compact_all_", (kz_binary:rand_hex(4))/binary>>
+                    ,fun do_compact_all/0
+                    ,[]
+                    ),
+    {Rows, 'stop'};
 compact_all(_Extra, 'false') ->
     {<<"compaction is only allowed by system administrators">>, 'stop'}.
 
@@ -145,7 +166,12 @@ compact_node(Extra, 'init', Args) ->
 compact_node(_Extra, 'false', _Args) ->
     {<<"compaction is only allowed by system administrators">>, 'stop'};
 compact_node(_Extra, 'true', #{<<"node">> := Node}=Row) ->
-    {do_compact_node(Node, heuristic_from_flag(maps:get(<<"force">>, Row))), 'true'}.
+    %% Dbs to be compacted will be set at `do_compact_node/4'
+    Rows = track_job(<<"compact_node_", (kz_binary:rand_hex(4))/binary>>
+                    ,fun do_compact_node/2
+                    ,[Node, heuristic_from_flag(maps:get(<<"force">>, Row))]
+                    ),
+    {Rows, 'true'}.
 
 -spec compact_db(kz_tasks:extra_args(), kz_tasks:iterator(), kz_tasks:args()) -> kz_tasks:iterator().
 compact_db(Extra, 'init', Args) ->
@@ -153,18 +179,48 @@ compact_db(Extra, 'init', Args) ->
 compact_db(_Extra, 'false', _Args) ->
     {<<"compaction is only allowed by system administrators">>, 'stop'};
 compact_db(_Extra, 'true', #{<<"database">> := Database}=Row) ->
-    {do_compact_db(Database, heuristic_from_flag(maps:get(<<"force">>, Row))), 'true'}.
+    Rows = track_job(<<"compact_db_", (kz_binary:rand_hex(4))/binary>>
+                    ,fun do_compact_db/2
+                    ,[Database, heuristic_from_flag(maps:get(<<"force">>, Row))]
+                    ,get_dbs_sizes([Database])
+                    ),
+    {Rows, 'true'}.
 
 -spec compact_db(kz_term:ne_binary()) -> 'ok'.
 compact_db(Database) ->
-    Rows = do_compact_db(Database, ?HEUR_NONE),
-    print_csv(Rows).
+    CallIdBin = kz_term:to_binary(kz_util:get_callid()),
+    print_csv(maybe_track_compact_db(Database, ?HEUR_NONE, CallIdBin)).
+
+-spec maybe_track_compact_db(kz_term:ne_binary(), heuristic(), kz_term:ne_binary()) -> rows().
+maybe_track_compact_db(Db, Heur, <<"undefined">>) ->
+    %% If not callid defined yet, then this function was call directly with a db name so
+    %% it creates a new callid to track this db-only compaction job.
+    CallId = <<"compact_db_", (kz_binary:rand_hex(4))/binary>>,
+    track_job(CallId, fun do_compact_db/2, [Db, Heur], get_dbs_sizes([Db]));
+maybe_track_compact_db(Db, Heur, <<"sup_", _/binary>> = SupId) ->
+    %% If callid starts with `sup_', then this function was called via a SUP command
+    %% so it creates a new callid (remove the `@' sign + anything at the right of it) to
+    %% track this db-only compaction job.
+    CallId = supid_to_callid(SupId),
+    track_job(CallId, fun do_compact_db/2, [Db, Heur], get_dbs_sizes([Db]));
+maybe_track_compact_db(Db, Heur, _CallId) ->
+    %% If there is already a callid defined, then do_compact_db/2 will use it for updating
+    %% the corresponding compaction's job stats.
+    do_compact_db(Db, Heur).
 
 -spec print_csv(iolist()) -> 'ok'.
 print_csv(Rows) ->
-    io:format("~s~n", [kz_binary:join(?OUTPUT_HEADER)]),
-    [io:format("~s~n", [kz_binary:join(Row)]) || Row <- Rows],
+    log_and_print("~s~n", [kz_binary:join(?OUTPUT_HEADER)]),
+    [log_and_print("~s~n", [kz_binary:join(Row)]) || Row <- Rows],
     'ok'.
+
+-spec log_and_print(string(), [binary()]) -> 'ok'.
+log_and_print(FormatStr, Values) ->
+    %% Writes to *.log files. Useful because it also saves the process' callid this log
+    %% line belongs to.
+    lager:debug(FormatStr, Values),
+    %% Writes to stdout. Useful for SUP commands to show output.
+    io:format(FormatStr, Values).
 
 -spec heuristic_from_flag(kz_term:api_ne_binary()) -> heuristic().
 heuristic_from_flag(Force) ->
@@ -181,14 +237,28 @@ is_allowed(ExtraArgs) ->
 
 -spec do_compact_all() -> rows().
 do_compact_all() ->
-    {'ok', Dbs} = kz_datamgr:db_info(),
-    Shuffled = kz_term:shuffle_list(Dbs),
-    lists:foldl(fun do_compact_db_fold/2, [], Shuffled).
+    CallId = kz_util:get_callid(),
+    Sorted = get_all_dbs_and_sort_by_disk(),
+    'ok' = kt_compaction_reporter:set_job_dbs(CallId, Sorted),
+    SortedWithoutSizes = [Db || {Db, _Sizes} <- Sorted],
+    lists:foldl(fun do_compact_db_fold/2, [], SortedWithoutSizes).
 
 -spec compact_node(kz_term:ne_binary()) -> 'ok'.
 compact_node(Node) ->
-    Rows = do_compact_node(Node, ?HEUR_NONE),
-    print_csv(Rows).
+    %% Same as compact_db/1 but for nodes instead of dbs.
+    CallId = kz_term:to_binary(kz_util:get_callid()),
+    print_csv(maybe_track_compact_node(Node, ?HEUR_NONE, CallId)).
+
+-spec maybe_track_compact_node(kz_term:ne_binary(), heuristic(), kz_term:ne_binary()) -> rows().
+maybe_track_compact_node(Node, Heur, <<"undefined">>) ->
+    %% Dbs to be compacted will be set at `do_compact_node/4'
+    CallId = <<"compact_node_", (kz_binary:rand_hex(4))/binary>>,
+    track_job(CallId, fun do_compact_node/2, [Node, Heur]);
+maybe_track_compact_node(Node, Heur, <<"sup_", _/binary>> = SupId) ->
+    %% Triggered via SUP command
+    track_job(supid_to_callid(SupId), fun do_compact_node/2, [Node, Heur]);
+maybe_track_compact_node(Node, Heur, _CallId) ->
+    do_compact_node(Node, Heur).
 
 -spec do_compact_node(kz_term:ne_binary(), heuristic()) ->
                              rows().
@@ -217,13 +287,20 @@ do_compact_node(Node, Heuristic, APIConn, AdminConn) ->
         {'error', _E} -> lager:warning("error getting databases on node ~s: ~p", [Node, _E]), [];
         {'ok', ViewResults} ->
             NodeDBs = [kz_doc:id(ViewResult) || ViewResult <- ViewResults],
-            do_compact_node(Node, Heuristic, APIConn, AdminConn, NodeDBs)
+            Sorted = sort_by_disk_size(get_dbs_sizes(NodeDBs)),
+            'ok' = kt_compaction_reporter:set_job_dbs(kz_util:get_callid(), Sorted),
+            SortedWithoutSizes = [Db || {Db, _Sizes} <- Sorted],
+            do_compact_node(Node, Heuristic, APIConn, AdminConn, SortedWithoutSizes)
     end.
 
 -spec do_compact_node(kz_term:ne_binary(), heuristic(), kz_data:connection(), kz_data:connection(), kz_term:ne_binaries()) -> rows().
 do_compact_node(Node, Heuristic, APIConn, AdminConn, Databases) ->
+    CallId = kz_util:get_callid(),
     lists:foldl(fun(Database, Acc) ->
-                        do_compact_node_db(Node, Heuristic, APIConn, AdminConn, Database, Acc)
+                        'ok' = kt_compaction_reporter:current_db(CallId, Database),
+                        NewAcc = do_compact_node_db(Node, Heuristic, APIConn, AdminConn, Database, Acc),
+                        'ok' = kt_compaction_reporter:finished_db(CallId, Database, NewAcc),
+                        NewAcc
                 end
                ,[]
                ,Databases
@@ -232,6 +309,8 @@ do_compact_node(Node, Heuristic, APIConn, AdminConn, Databases) ->
 -spec do_compact_node_db(kz_term:ne_binary(), heuristic(), kz_data:connection(), kz_data:connection(), kz_term:ne_binary(), rows()) -> rows().
 do_compact_node_db(Node, Heuristic, APIConn, AdminConn, Database, Acc) ->
     Compactor = node_compactor(Node, Heuristic, APIConn, AdminConn, Database),
+    Shards = kt_compactor_worker:compactor_shards(Compactor),
+    'ok' = kt_compaction_reporter:add_found_shards(kz_util:get_callid(), length(Shards)),
     do_compact_node_db(Compactor, Acc).
 
 -spec do_compact_node_db(kt_compactor_worker:compactor(), rows()) -> rows().
@@ -274,8 +353,9 @@ do_compact_db_by_nodes(?MATCH_MODB_SUFFIX_RAW(_AccountId, _Year, _Month)=MODB, H
     lager:info("formatting raw modb ~s", [MODB]),
     do_compact_db_by_nodes(kz_util:format_account_modb(MODB, 'unencoded'), Heuristic);
 do_compact_db_by_nodes(Database, Heuristic) ->
-    lager:debug("opening in ~s: ~s", [kazoo_couch:get_admin_dbs(), Database]),
-    {'ok', DbInfo} = kz_datamgr:open_doc(kazoo_couch:get_admin_dbs(), Database),
+    AdminDbs = kazoo_couch:get_admin_dbs(),
+    lager:debug("opening in ~s: ~s", [AdminDbs, Database]),
+    {'ok', DbInfo} = kz_datamgr:open_doc(AdminDbs, Database),
     kz_json:foldl(fun(Node, _, Rows) ->
                           do_compact_db_by_node(Node, Heuristic, Database, Rows)
                   end
@@ -325,8 +405,8 @@ get_node_connections(Node, #server{options=Options}) ->
     NodeAdminPort = ?NODE_ADMIN_PORT(Node),
 
     lager:debug("getting connection information for ~s, ~p and ~p", [Host, NodeAPIPort, NodeAdminPort]),
-    C1 = couchbeam:server_connection(Hostname, NodeAPIPort, "", Options),
-    C2 = couchbeam:server_connection(Hostname, NodeAdminPort, "", Options),
+    C1 = couchbeam:server_connection(Hostname, NodeAPIPort, <<"">>, Options),
+    C2 = couchbeam:server_connection(Hostname, NodeAdminPort, <<"">>, Options),
 
     try {kz_couch_util:connection_info(C1),
          kz_couch_util:connection_info(C2)
@@ -355,3 +435,73 @@ get_node_connections(Node, #server{options=Options}) ->
             lager:warning("failed to connect to ~s: ~s: ~p", [Host, _E, _R]),
             {'error', 'no_connection'}
     end.
+
+-spec get_all_dbs_and_sort_by_disk() -> [db_and_sizes()].
+get_all_dbs_and_sort_by_disk() ->
+    sort_by_disk_size(get_dbs_and_sizes()).
+
+-spec get_dbs_and_sizes() -> [db_and_sizes()].
+get_dbs_and_sizes() ->
+    {'ok', Dbs} = kz_datamgr:db_info(),
+    get_dbs_sizes(Dbs).
+
+-spec get_dbs_sizes(kz_term:ne_binaries()) -> [db_and_sizes()].
+get_dbs_sizes(Dbs) ->
+    #{'server' := {_App, #server{}=Conn}} = kzs_plan:plan(),
+    F = fun(Db, State) -> get_db_disk_and_data_fold(Conn, Db, State, 20) end,
+    {DbsAndSizes, _} = lists:foldl(F, {[], 0}, Dbs),
+    DbsAndSizes.
+
+-spec get_db_disk_and_data_fold(#server{}
+                               ,kz_term:ne_binary()
+                               ,{[db_and_sizes()], non_neg_integer()}
+                               , pos_integer()
+                               ) -> {[db_and_sizes()], pos_integer()}.
+get_db_disk_and_data_fold(Conn, UnencDb, {_, Counter} = State, ChunkSize)
+  when Counter rem ChunkSize =:= 0 ->
+    %% Every `ChunkSize' handled requests, sleep 100ms (give the db a rest).
+    timer:sleep(100),
+    do_get_db_disk_and_data_fold(Conn, UnencDb, State);
+get_db_disk_and_data_fold(Conn, UnencDb, State, _ChunkSize) ->
+    do_get_db_disk_and_data_fold(Conn, UnencDb, State).
+
+-spec do_get_db_disk_and_data_fold(#server{}
+                                  ,kz_term:ne_binary()
+                                  ,{[db_and_sizes()], non_neg_integer()}
+                                  ) -> {[db_and_sizes()], pos_integer()}.
+do_get_db_disk_and_data_fold(Conn, UnencDb, {Acc, Counter}) ->
+    EncDb = kz_util:uri_encode(UnencDb),
+    {[{UnencDb, kt_compactor_worker:get_db_disk_and_data(Conn, EncDb)} | Acc]
+    ,Counter + 1
+    }.
+
+-spec sort_by_disk_size([db_and_sizes()]) -> [db_and_sizes()].
+sort_by_disk_size(DbsSizes) when is_list(DbsSizes) ->
+    lists:sort(fun sort_by_disk_size/2, DbsSizes).
+
+-spec sort_by_disk_size(db_and_sizes(), db_and_sizes()) -> boolean().
+sort_by_disk_size({_UnencDb1, {DiskSize1, _}}, {_UnencDb2, {DiskSize2, _}}) ->
+    DiskSize1 > DiskSize2;
+sort_by_disk_size({_UnencDb1, {_DiskSize1, _}}, {_UnencDb2, _Else}) -> %% Else = 'not_found' | 'undefined'
+    'true';
+sort_by_disk_size({_UnencDb1, _Else}, {_UnencDb2, {_DiskSize2, _}}) -> %% Else = 'not_found' | 'undefined'
+    'false'.
+
+-spec track_job(kz_term:ne_binary(), function(), [term()]) -> rows().
+track_job(CallId, Fun, Args) ->
+    track_job(CallId, Fun, Args, []).
+
+-spec track_job(kz_term:ne_binary(), function(), [term()], dbs_and_sizes()) -> rows().
+track_job(CallId, Fun, Args, Dbs) when is_function(Fun)
+                                       andalso is_list(Args) ->
+    kz_util:put_callid(CallId),
+    'ok' = kt_compaction_reporter:start_tracking_job(self(), node(), CallId, Dbs),
+    Rows = erlang:apply(Fun, Args),
+    'ok' = kt_compaction_reporter:stop_tracking_job(CallId),
+    kz_util:put_callid('undefined'), % Reset callid
+    Rows.
+
+%% SupId = <<"sup_0351@fqdn.hostname.com">>, CallId = <<"sup_0351">>.
+-spec supid_to_callid(kz_term:ne_binary()) -> kz_term:ne_binary().
+supid_to_callid(SupId) ->
+    hd(binary:split(SupId, <<"@">>)).

--- a/applications/tasks/src/modules/kt_compactor.hrl
+++ b/applications/tasks/src/modules/kt_compactor.hrl
@@ -8,8 +8,12 @@
 
 -type heuristic() :: ?HEUR_NONE | ?HEUR_RATIO.
 
+%% Ratio of legacy data, including metadata, to current data in the database file size.
+%% The percentage is expressed as an integer percentage. Taken
+%% from http://docs.couchdb.org/en/stable/config/compaction.html#compactions
+%% `db_framentation' section.
 -define(MIN_RATIO
-       ,kapps_config:get_float(?SYSCONFIG_COUCH, <<"min_ratio">>, 1.2)
+       ,kapps_config:get_float(?SYSCONFIG_COUCH, <<"min_ratio">>, 25)
        ).
 -define(MIN_DATA
        ,kapps_config:get_integer(?SYSCONFIG_COUCH, <<"min_data_size">>, 131072)  %% 128Kb

--- a/applications/tasks/src/tasks_bindings.erl
+++ b/applications/tasks/src/tasks_bindings.erl
@@ -228,9 +228,9 @@ init_mod(ModuleName) ->
     maybe_init_mod(ModuleName).
 
 maybe_init_mod(ModuleName) ->
+    maybe_init_mod(ModuleName, kz_module:is_exported(ModuleName, 'init', 0)).
+
+maybe_init_mod(_M, 'false') -> 'ok';
+maybe_init_mod(ModuleName, 'true') ->
     lager:debug("trying to init module: ~p", [ModuleName]),
-    try (kz_term:to_atom(ModuleName, 'true')):init()
-    catch
-        _E:_R ->
-            lager:warning("failed to initialize ~s: ~p, ~p.", [ModuleName, _E, _R])
-    end.
+    (kz_term:to_atom(ModuleName, 'true')):init().

--- a/applications/tasks/src/tasks_maintenance.erl
+++ b/applications/tasks/src/tasks_maintenance.erl
@@ -262,9 +262,9 @@ maybe_print_compaction_history({'ok', JObjs}) ->
              ,"finished_at"
              ,"exec_time"
              ],
-    HLine = "+---------------------+------+---------+-------+---------------+-------------------+-------------------+------------+",
+    HLine = "+-----------------------+--------+-----------+---------+------------+---------------------+---------------------+--------------+",
     %% Format string for printing header and values of the table including "columns".
-    FStr = "|~.21s|~.6s|~.9s|~.7s|~.15s|~.19s|~.19s|~.12s|~n",
+    FStr = "| ~.21s | ~6.6s | ~9.9s | ~7.7s | ~10.10s | ~.19s | ~.19s | ~12.12s |~n",
     %% Print top line of table, then prints the header and then another line below.
     io:format("~s~n" ++ FStr ++ "~s~n", [HLine] ++ Header ++ [HLine]),
     lists:foreach(fun(Obj) -> print_compaction_history_row(Obj, FStr) end, JObjs),
@@ -286,7 +286,7 @@ print_compaction_history_row(JObj, FStr) ->
           ,Str([<<"databases">>, <<"found">>])
           ,Str([<<"databases">>, <<"compacted">>])
           ,Str([<<"databases">>, <<"skipped">>])
-          ,kz_util:pretty_print_bytes(DiskStartInt - DiskEndInt)
+          ,kz_util:pretty_print_bytes(DiskStartInt - DiskEndInt, 'truncated')
           ,kz_term:to_list(kz_time:pretty_print_datetime(StartInt))
           ,kz_term:to_list(kz_time:pretty_print_datetime(EndInt))
           ,kz_term:to_list(kz_time:pretty_print_elapsed_s(EndInt - StartInt))

--- a/applications/tasks/src/tasks_sup.erl
+++ b/applications/tasks/src/tasks_sup.erl
@@ -26,6 +26,8 @@
                   ,?WORKER('kz_account_crawler')
                    %% Standalone tasks
                   ,?WORKER('kz_notify_resend')
+                   %% Compaction jobs reporter
+                  ,?WORKER('kt_compaction_reporter')
                   ]).
 
 %%==============================================================================

--- a/applications/tasks/src/tasks_sup.erl
+++ b/applications/tasks/src/tasks_sup.erl
@@ -55,7 +55,7 @@ start_link() ->
 %%------------------------------------------------------------------------------
 -spec init(any()) -> kz_types:sup_init_ret().
 init([]) ->
-    kz_util:set_startup(),
+    _ = kz_util:set_startup(),
     RestartStrategy = 'one_for_one',
     MaxRestarts = 5,
     MaxSecondsBetweenRestarts = 10,

--- a/applications/tasks/test/kt_compactor_tests.erl
+++ b/applications/tasks/test/kt_compactor_tests.erl
@@ -1,0 +1,47 @@
+-module(kt_compactor_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+sort_by_disk_size_test_() ->
+    TestF = fun kt_compactor:sort_by_disk_size/1,
+
+    Db1 = new_db_disk_and_data(11111, 55555),
+    Db2 = new_db_disk_and_data(22222, 44444),
+    Db3 = new_db_disk_and_data(33333, 33333),
+    Db4 = new_db_disk_and_data(44444, 22222),
+    Db5 = new_db_disk_and_data(55555, 11111),
+    Undefined = new_db_disk_and_data('undefined'),
+    NotFound = new_db_disk_and_data('not_found'),
+
+    Expected1 = [Db3, Db2, Db1],
+    Expected2 = [Db5, Db4, Db3, Db2, Db1],
+    Expected3 = [Db4, Db2, Undefined],
+    Expected4 = [Db3, Db1, NotFound],
+
+    [{"only sort by disk_size and ignore data_size"
+     ,?_assertEqual(Expected1, TestF(kz_term:shuffle_list(Expected1)))
+     }
+    ,{"only sort by disk_size and ignore data_size"
+     ,?_assertEqual(Expected2, TestF(kz_term:shuffle_list(Expected2)))
+     }
+    ,{"sort undefined disk_and_data values too"
+     ,?_assertEqual(Expected3, TestF(kz_term:shuffle_list(Expected3)))
+     }
+    ,{"sort not_found disk_and_data values too"
+     ,?_assertEqual(Expected4, TestF(kz_term:shuffle_list(Expected4)))
+     }
+    ].
+
+%% =======================================================================================
+%% Helpers
+%% =======================================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+new_db_disk_and_data(UndefinedOrNotFound) ->
+    {kz_binary:rand_hex(4), UndefinedOrNotFound}.
+
+new_db_disk_and_data(DiskSize, DataSize) ->
+    {kz_binary:rand_hex(4), {DiskSize, DataSize}}.

--- a/core/kazoo_modb/priv/couchdb/views/compaction_jobs.json
+++ b/core/kazoo_modb/priv/couchdb/views/compaction_jobs.json
@@ -1,0 +1,25 @@
+{
+    "_id": "_design/compaction_jobs",
+    "kazoo": {
+        "view_map": [
+            {
+                "classification": "modb"
+            }
+        ]
+    },
+    "language": "javascript",
+    "views": {
+        "crossbar_listing": {
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'compaction_job' || doc.pvt_deleted) return;",
+                "  emit(doc.pvt_created, {",
+                "    'id': doc._id,",
+                "    'node': doc.worker.node,",
+                "    'pid': doc.worker.pid,",
+                "  });",
+                "}"
+            ]
+        }
+    }
+}

--- a/core/kazoo_tasks/src/kz_tasks.erl
+++ b/core/kazoo_tasks/src/kz_tasks.erl
@@ -422,7 +422,7 @@ status(#{started := 'undefined'}) ->
 status(#{started := Started
         ,finished := 'undefined'
         })
-  when Started /= 'undefined' ->
+  when Started =/= 'undefined' ->
     ?STATUS_EXECUTING;
 
 %% For tasks with CSV input
@@ -431,15 +431,30 @@ status(#{finished := Finished
         ,total_rows_failed := 0
         ,total_rows_succeeded := TotalRows
         })
-  when Finished /= 'undefined',
+  when Finished =/= 'undefined',
        is_integer(TotalRows), TotalRows > 0 ->
+    ?STATUS_SUCCESS;
+%% Jobs like `compact_node' return a different number of rows compared to the number
+%% of succeeded rows.
+%% total_rows = number of nodes that were provided within the input csv file.
+%% total_rows_succeeded = number of dbs compacted on all the nodes provided within the input csv file.
+status(#{finished := Finished
+        ,total_rows := TotalRows
+        ,total_rows_failed := 0
+        ,total_rows_succeeded := TotalRowsSucceeded
+        })
+  when Finished =/= 'undefined',
+       is_integer(TotalRows),
+       is_integer(TotalRowsSucceeded),
+       TotalRows > 0,
+       TotalRowsSucceeded >= TotalRows ->
     ?STATUS_SUCCESS;
 status(#{finished := Finished
         ,total_rows := TotalRows
         ,total_rows_failed := TotalRows
         ,total_rows_succeeded := 0
         })
-  when Finished /= 'undefined',
+  when Finished =/= 'undefined',
        is_integer(TotalRows), TotalRows > 0 ->
     ?STATUS_FAILURE;
 status(#{finished := Finished
@@ -447,7 +462,7 @@ status(#{finished := Finished
         ,total_rows_failed := TotalFailed
         ,total_rows_succeeded := TotalSucceeded
         })
-  when Finished /= 'undefined',
+  when Finished =/= 'undefined',
        is_integer(TotalRows), is_integer(TotalFailed), is_integer(TotalSucceeded),
        TotalRows > TotalFailed, TotalRows > TotalSucceeded ->
     ?STATUS_PARTIAL;
@@ -458,14 +473,14 @@ status(#{finished := Finished
         ,total_rows_failed := 0
         ,total_rows_succeeded := 0
         })
-  when Finished /= 'undefined' ->
+  when Finished =/= 'undefined' ->
     ?STATUS_SUCCESS;
 status(#{finished := Finished
         ,total_rows := 'undefined'
         ,total_rows_failed := 0
         ,total_rows_succeeded := TotalSucceeded
         })
-  when Finished /= 'undefined',
+  when Finished =/= 'undefined',
        is_integer(TotalSucceeded), TotalSucceeded > 0 ->
     ?STATUS_SUCCESS;
 status(#{finished := Finished
@@ -473,7 +488,7 @@ status(#{finished := Finished
         ,total_rows_failed := TotalFailed
         ,total_rows_succeeded := 0
         })
-  when Finished /= 'undefined',
+  when Finished =/= 'undefined',
        is_integer(TotalFailed), TotalFailed > 0 ->
     ?STATUS_FAILURE;
 status(#{finished := Finished
@@ -481,7 +496,7 @@ status(#{finished := Finished
         ,total_rows_failed := TotalFailed
         ,total_rows_succeeded := TotalSucceeded
         })
-  when Finished /= 'undefined',
+  when Finished =/= 'undefined',
        is_integer(TotalFailed), is_integer(TotalSucceeded) ->
     ?STATUS_PARTIAL;
 


### PR DESCRIPTION
By:
- Sorting databases by `disk_size` from bigger to smaller before being sent to the compactor worker
- Using `ratio` as the heuristic by default

Also:
- Improve progress logging
- Track all kt_compactor compaction jobs (compact_db, compact_all, compact_node) stats as well as auto_compaction job triggered by kz_tasks_trigger module for progress and history reports via sup commands.