### PR TITLE
PISTON-668: handle system_limit for to_atom on long path tokens

### DIFF
--- a/core/kazoo_stdlib/src/kz_module.erl
+++ b/core/kazoo_stdlib/src/kz_module.erl
@@ -35,7 +35,8 @@ is_exported(Module, Function, Arity) ->
                    ,kz_term:to_integer(Arity)
                    )
     catch
-        'error':'badarg' -> 'false'
+        'error':'badarg' -> 'false';
+        'error':'system_limit' -> 'false'
     end.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
When calling an API that has long path tokens (e.g. GET /v1/user_auth/<jwt>) a crash introduced in 2f35988 prevents the API req from completing. The prior catch all catch clause handled the 'system_limit' error. Adding the specific catch for that error in this PR.