### PR TITLE
[master] send to port authority and submitter in two passes, fix fields

### DIFF
--- a/applications/teletype/priv/templates/port_request_admin.html
+++ b/applications/teletype/priv/templates/port_request_admin.html
@@ -38,7 +38,7 @@
                 </tr>
                 <tr>
                     <td bgcolor="#ffffff" style="text-align:left;padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
-                        <span style="margin:4px 0;padding:25px 0 0;font-size:.9em;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;"><b>Submitted On:</b>&nbsp;{{port_request.created.local|date:"l, F j, Y h:i A"}} ({{port_request.created.timezone}})</span><br>
+                        <span style="margin:4px 0;padding:25px 0 0;font-size:.9em;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;"><b>Submitted on:</b>&nbsp;{{port_request.created.local|date:"l, F j, Y h:i A"}} ({{port_request.created.timezone}})</span><br>
                     </td>
                 </tr>
                 <tr>
@@ -72,7 +72,7 @@
                             </tr>
                             <tr>
                                 <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Requested Port Date</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{% if port_request.requested_port_date %}{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% else %}Not scheduled{% endif %}</td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{% if port_request.requested_port_date %}{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% else %}not scheduled yet{% endif %}</td>
                             </tr>
                             <tr>
                                 <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Losing Carrier</b></td>
@@ -83,45 +83,71 @@
                                 <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.winning_carrier}}</td>
                             </tr>
                             <tr>
-                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Carrier Reference Number</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.carrier_reference_number}}</td>
+                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Reference Number</b></td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.reference_number}}</td>
                             </tr>
                             <tr>
                                 <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Customer Contact</b></td>
                                 <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{ port_request.customer_contact|join:", "}}</td>
                             </tr>
-                            <tr>
-                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Billing Name</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.bill_name}}</td>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">
+                        <h3 style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">Billing Details</h3>
+                    </td>
+                </tr>
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
+                        <ul style="margin:0 25px;padding:0;">
+                            <li style="margin:0 20px 10px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Account Name on Bill:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.name}}</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Street Pre-Direction:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.street_pre_dir}}</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Street Number:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.street_number}}</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Street Name:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.street_name}}</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Street Type:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.street_type}}</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Street Post-Direction:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.street_post_dir}}</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Address Line 2:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.extended_address}}</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>City:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.locality}}</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>State:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.region}}</span></li>
+                            <li style="margin:10px 20px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Postal Code:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.address.postal_code}}</span></li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">
+                        <h3 style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">Carrier Account Details</h3>
+                    </td>
+                </tr>
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
+                        <ul style="margin:0 25px;padding:0;">
+                            <li style="margin:0 20px 10px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>Account Name:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.account.number}}</span></li>
+                            <li style="margin:0 20px 10px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>PIN:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.account.pin}}</span></li>
+                            <li style="margin:0 20px 10px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;"><b>BTN:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.bill.account.btn}}</span></li>
+                        </ul>
+                    </td>
+                </tr>
+            </table>
+            {% if port_request.signee_name or port_request.signing_date %}
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <tr><td height="50" style="background-color:#ffffff;font-size:50px;line-height:50px;">&nbsp;</td></tr>
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:0 20px;">
+                        <table role="presentation" aria-hidden="true" border="0" cellpadding="0" cellspacing="0" align="center" width="100%" style="max-width:560px;">
+                            <tr height="24">
+                                <td align="center" bgcolor="#ffffff" style="padding:10px 20px;font-family:'Open Sans',sans-serif;color:#999999"><b>Signee Name</b></td>
+                                <td align="center" bgcolor="#ffffff" style="padding:10px 20px;font-family:'Open Sans',sans-serif;color:#999999;"><b>Signing Date</b></span></td>
                             </tr>
                             <tr>
-                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Billing Street Number</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.bill_street_number}}</td>
-                            </tr>
-                            <tr>
-                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Billing Street</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.bill_street_address}}</td>
-                            </tr>
-                            <tr>
-                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Billing Street Type</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.bill_street_type}}</td>
-                            </tr>
-                            <tr>
-                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Billing City</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.bill_locality}}</td>
-                            </tr>
-                            <tr>
-                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Billing State</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.bill_region}}</td>
-                            </tr>
-                            <tr>
-                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Billing Postal Code</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.bill_postal_code}}</td>
+                                <td align="center" bgcolor="#ffffff" style="padding:10px 20px;font-family:'Open Sans',sans-serif;color:#999999;">{% firstof port_request.signee_name "-" %}</td>
+                                <td align="center" bgcolor="#ffffff" style="padding:10px 20px;font-family:'Open Sans',sans-serif;color:#999999">{% firstof port_request.signing_date.local|date:"l, F j, Y h:i A" %}</td>
                             </tr>
                         </table>
                     </td>
                 </tr>
             </table>
+            {% endif %}
             <!-- Pre-Footer -->
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
                 <!-- Clear Spacer -->

--- a/applications/teletype/priv/templates/port_request_admin.text
+++ b/applications/teletype/priv/templates/port_request_admin.text
@@ -1,7 +1,7 @@
                 Port Request Submitted (Admin Report)
 
 
-Submitted On: {{port_request.created.local|date:"l, F j, Y h:i A"}} ({{port_request.created.timezone}})
+Submitted on: {{port_request.created.local|date:"l, F j, Y h:i A"}} ({{port_request.created.timezone}})
 
 Request "{{port_request.name}}" to port numbers into account '{{account.name}}' has been submitted.
 
@@ -12,18 +12,36 @@ Request "{{port_request.name}}" to port numbers into account '{{account.name}}' 
     Port ID:  {{port_request.id}}
     State:  {{port_request.port_state}}
     Numbers:  Numbers: {{ port_request.numbers|join:", "|stringformat:"s"|wordwrap:40 }}
-    Requested Port Date:  {% if port_request.requested_port_date %}{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% else %}Not scheduled{% endif %}
+    Requested Port Date:  {% if port_request.requested_port_date %}{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% else %}not scheduled yet{% endif %}
     Losing Carrier:  {{port_request.losing_carrier}}
     Winning Carrier:  {{port_request.winning_carrier}}
-    Carrier Reference Number:  {{port_request.carrier_reference_number}}
+    Carrier Reference Number:  {{port_request.reference_number}}
     Customer Contact:  {{ port_request.customer_contact|join:", "}}
-    Billing Name:  {{port_request.bill_name}}
-    Billing Street Number:  {{port_request.bill_street_number}}
-    Billing Street:  {{port_request.bill_street_address}}
-    Billing Street Type:  {{port_request.bill_street_type}}
-    Billing City:  {{port_request.bill_locality}}
-    Billing State:  {{port_request.bill_region}}
-    Billing Postal Code:  {{port_request.bill_postal_code}}
+
+=== Billing Details ===
+
+    Account Name on Bill:  {{port_request.bill.address.name}}
+    Street Pre-Direction:  {{port_request.bill.address.street_pre_dir}}
+    Street Number:  {{port_request.bill.address.street_number}}
+    Street Name:  {{port_request.bill.address.street_name}}
+    Street Type:  {{port_request.bill.address.street_type}}
+    Street Post-Direction:  {{port_request.bill.address.street_post_dir}}
+    Address Line 2:  {{port_request.bill.address.extended_address}}
+    City:  {{port_request.bill.address.locality}}
+    State:  {{port_request.bill.address.region}}
+    Postal Code:  {{port_request.bill.address.postal_code}}
+
+=== Carrier Account Details ===
+
+    Account Name:  {{port_request.bill.account.number}}
+    PIN:  {{port_request.bill.account.pin}}
+    BTN:  {{port_request.bill.account.btn}}
+
+
+
+Signee Name:  {% firstof port_request.signee_name "-" %}
+Signing Date:  {% firstof port_request.signing_date.local|date:"l, F j, Y h:i A" %}
+
 
 
 

--- a/applications/teletype/src/teletype_port_utils.erl
+++ b/applications/teletype/src/teletype_port_utils.erl
@@ -77,6 +77,7 @@ fix_billing(_DataJObj, _TemplateId, PortReqJObj) ->
                  ,kz_json:get_json_value(<<"bill">>, PortReqJObj, kz_json:new())
                  ).
 
+-spec fix_bill_object(kz_json:object()) -> kz_json:object().
 fix_bill_object(PortReqJObj) ->
     KeyMap = [{<<"account">>, [{<<"account_number">>, <<"number">>}
                               ,<<"pin">>
@@ -98,6 +99,8 @@ fix_bill_object(PortReqJObj) ->
              ],
     fix_bill_object(PortReqJObj, KeyMap).
 
+-spec fix_bill_object(kz_json:object(), [{kz_term:ne_binary(), [kz_term:ne_binary() | {kz_term:ne_binary(), kz_term:ne_binary()}]}]) ->
+                             kz_json:object().
 fix_bill_object(PortReqJObj, []) -> PortReqJObj;
 fix_bill_object(PortReqJObj, [{Category, KeyMaps} | Rest]) ->
     NewPort = lists:foldl(fun(KeyMap, Acc) -> fix_bill_object(Acc, Category, KeyMap) end
@@ -106,6 +109,8 @@ fix_bill_object(PortReqJObj, [{Category, KeyMaps} | Rest]) ->
                          ),
     fix_bill_object(NewPort, Rest).
 
+-spec fix_bill_object(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary() | {kz_term:ne_binary(), kz_term:ne_binary()}) ->
+                             kz_json:object().
 fix_bill_object(PortReqJObj, Category, {OldKeyName, NewKeyName}) ->
     kz_json:set_value([<<"bill">>, Category, NewKeyName]
                      ,kz_json:get_ne_binary_value([<<"bill">>, OldKeyName], PortReqJObj, <<"-">>)

--- a/applications/teletype/src/templates/teletype_port_cancel.erl
+++ b/applications/teletype/src/templates/teletype_port_cancel.erl
@@ -98,10 +98,20 @@ handle_port_request(DataJObj) ->
                                     ),
 
     Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?TEMPLATE_ID),
+
+    lager:debug("sending ~s to port authority: ~p"
+               ,[?TEMPLATE_ID, props:get_value(<<"to">>, Emails)]
+               ),
     _ = teletype_util:send_email(Emails, Subject, RenderedTemplates),
 
-    AuthorityEmails = kz_json:get_value(<<"authority_emails">>, DataJObj, []),
+    AuthorityEmails = props:set_value(<<"to">>
+                                     ,kz_json:get_value(<<"authority_emails">>, DataJObj, [])
+                                     ,Emails
+                                     ),
 
+    lager:debug("sending ~s to port sumbitter (or template default): ~p"
+               ,[?TEMPLATE_ID, props:get_value(<<"to">>, AuthorityEmails)]
+               ),
     case teletype_util:send_email(AuthorityEmails, Subject, RenderedTemplates) of
         'ok' -> teletype_util:notification_completed(?TEMPLATE_ID);
         {'error', Reason} ->

--- a/applications/teletype/src/templates/teletype_port_comment.erl
+++ b/applications/teletype/src/templates/teletype_port_comment.erl
@@ -99,11 +99,23 @@ handle_port_request(DataJObj) ->
                                     ),
 
     Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?TEMPLATE_ID),
+    maybe_send_to_submitter(Emails, Subject, RenderedTemplates),
 
-    case teletype_util:send_email(Emails, Subject, RenderedTemplates) of
+    AuthorityEmails = kz_json:get_value(<<"authority_emails">>, DataJObj, []),
+
+    case teletype_util:send_email(AuthorityEmails, Subject, RenderedTemplates) of
         'ok' -> teletype_util:notification_completed(?TEMPLATE_ID);
-        {'error', Reason} -> teletype_util:notification_failed(?TEMPLATE_ID, Reason)
+        {'error', Reason} ->
+            lager:debug("unable to send emails to port authority: ~p", [Reason]),
+            teletype_util:notification_failed(?TEMPLATE_ID, Reason)
     end.
+
+-spec maybe_send_to_submitter(email_map(), kz_term:ne_binary(), rendered_templates()) -> 'ok'.
+maybe_send_to_submitter([], _, _) ->
+    lager:debug("no port submitter email addresses were found in data or template");
+maybe_send_to_submitter(Emails, Subject, RenderedTemplates) ->
+    _ = teletype_util:send_email(Emails, Subject, RenderedTemplates),
+    'ok'.
 
 -spec user_data(kz_json:object()) -> kz_term:proplist().
 user_data(DataJObj) ->

--- a/applications/teletype/src/templates/teletype_port_pending.erl
+++ b/applications/teletype/src/templates/teletype_port_pending.erl
@@ -7,6 +7,7 @@
 -module(teletype_port_pending).
 
 -export([init/0
+        ,id/0
         ,handle_req/1
         ]).
 
@@ -30,6 +31,9 @@
 -define(TEMPLATE_CC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_BCC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_REPLY_TO, teletype_util:default_reply_to()).
+
+-spec id() -> kz_term:ne_binary().
+id() -> ?TEMPLATE_ID.
 
 -spec init() -> 'ok'.
 init() ->

--- a/applications/teletype/src/templates/teletype_port_rejected.erl
+++ b/applications/teletype/src/templates/teletype_port_rejected.erl
@@ -98,10 +98,20 @@ handle_port_request(DataJObj) ->
                                     ),
 
     Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?TEMPLATE_ID),
+
+    lager:debug("sending ~s to port authority: ~p"
+               ,[?TEMPLATE_ID, props:get_value(<<"to">>, Emails)]
+               ),
     _ = teletype_util:send_email(Emails, Subject, RenderedTemplates),
 
-    AuthorityEmails = kz_json:get_value(<<"authority_emails">>, DataJObj, []),
+    AuthorityEmails = props:set_value(<<"to">>
+                                     ,kz_json:get_value(<<"authority_emails">>, DataJObj, [])
+                                     ,Emails
+                                     ),
 
+    lager:debug("sending ~s to port sumbitter (or template default): ~p"
+               ,[?TEMPLATE_ID, props:get_value(<<"to">>, AuthorityEmails)]
+               ),
     case teletype_util:send_email(AuthorityEmails, Subject, RenderedTemplates) of
         'ok' -> teletype_util:notification_completed(?TEMPLATE_ID);
         {'error', Reason} ->

--- a/applications/teletype/src/templates/teletype_port_rejected.erl
+++ b/applications/teletype/src/templates/teletype_port_rejected.erl
@@ -7,6 +7,7 @@
 -module(teletype_port_rejected).
 
 -export([init/0
+        ,id/0
         ,handle_req/1
         ]).
 
@@ -30,6 +31,9 @@
 -define(TEMPLATE_CC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_BCC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_REPLY_TO, teletype_util:default_reply_to()).
+
+-spec id() -> kz_term:ne_binary().
+id() -> ?TEMPLATE_ID.
 
 -spec init() -> 'ok'.
 init() ->
@@ -94,8 +98,13 @@ handle_port_request(DataJObj) ->
                                     ),
 
     Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?TEMPLATE_ID),
+    _ = teletype_util:send_email(Emails, Subject, RenderedTemplates),
 
-    case teletype_util:send_email(Emails, Subject, RenderedTemplates) of
+    AuthorityEmails = kz_json:get_value(<<"authority_emails">>, DataJObj, []),
+
+    case teletype_util:send_email(AuthorityEmails, Subject, RenderedTemplates) of
         'ok' -> teletype_util:notification_completed(?TEMPLATE_ID);
-        {'error', Reason} -> teletype_util:notification_failed(?TEMPLATE_ID, Reason)
+        {'error', Reason} ->
+            lager:debug("unable to send emails to port authority: ~p", [Reason]),
+            teletype_util:notification_failed(?TEMPLATE_ID, Reason)
     end.

--- a/applications/teletype/src/templates/teletype_port_request.erl
+++ b/applications/teletype/src/templates/teletype_port_request.erl
@@ -100,10 +100,19 @@ handle_port_request(DataJObj) ->
     Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?TEMPLATE_ID),
     EmailAttachements = kz_json:get_value(<<"attachments">>, DataJObj),
 
+    lager:debug("sending ~s to port authority: ~p"
+               ,[?TEMPLATE_ID, props:get_value(<<"to">>, Emails)]
+               ),
     _ = teletype_util:send_email(Emails, Subject, RenderedTemplates, EmailAttachements),
 
-    AuthorityEmails = kz_json:get_value(<<"authority_emails">>, DataJObj, []),
+    AuthorityEmails = props:set_value(<<"to">>
+                                     ,kz_json:get_value(<<"authority_emails">>, DataJObj, [])
+                                     ,Emails
+                                     ),
 
+    lager:debug("sending ~s to port sumbitter (or template default): ~p"
+               ,[?TEMPLATE_ID, props:get_value(<<"to">>, AuthorityEmails)]
+               ),
     case teletype_util:send_email(AuthorityEmails, Subject, RenderedTemplates, EmailAttachements) of
         'ok' -> teletype_util:notification_completed(?TEMPLATE_ID);
         {'error', Reason} ->

--- a/applications/teletype/src/templates/teletype_port_request.erl
+++ b/applications/teletype/src/templates/teletype_port_request.erl
@@ -100,7 +100,13 @@ handle_port_request(DataJObj) ->
     Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?TEMPLATE_ID),
     EmailAttachements = kz_json:get_value(<<"attachments">>, DataJObj),
 
-    case teletype_util:send_email(Emails, Subject, RenderedTemplates, EmailAttachements) of
+    _ = teletype_util:send_email(Emails, Subject, RenderedTemplates, EmailAttachements),
+
+    AuthorityEmails = kz_json:get_value(<<"authority_emails">>, DataJObj, []),
+
+    case teletype_util:send_email(AuthorityEmails, Subject, RenderedTemplates, EmailAttachements) of
         'ok' -> teletype_util:notification_completed(?TEMPLATE_ID);
-        {'error', Reason} -> teletype_util:notification_failed(?TEMPLATE_ID, Reason)
+        {'error', Reason} ->
+            lager:debug("unable to send emails to port authority: ~p", [Reason]),
+            teletype_util:notification_failed(?TEMPLATE_ID, Reason)
     end.

--- a/applications/teletype/src/templates/teletype_port_request_admin.erl
+++ b/applications/teletype/src/templates/teletype_port_request_admin.erl
@@ -96,10 +96,19 @@ handle_port_request(DataJObj) ->
     Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?TEMPLATE_ID),
     EmailAttachements = kz_json:get_value(<<"attachments">>, DataJObj),
 
+    lager:debug("sending ~s to port sumbitter (or template default): ~p"
+               ,[?TEMPLATE_ID, props:get_value(<<"to">>, Emails)]
+               ),
     _ = teletype_util:send_email(Emails, Subject, RenderedTemplates, EmailAttachements),
 
-    AuthorityEmails = kz_json:get_value(<<"authority_emails">>, DataJObj, []),
+    AuthorityEmails = props:set_value(<<"to">>
+                                     ,kz_json:get_value(<<"authority_emails">>, DataJObj, [])
+                                     ,Emails
+                                     ),
 
+    lager:debug("sending ~s to port authority: ~p"
+               ,[?TEMPLATE_ID, props:get_value(<<"to">>, AuthorityEmails)]
+               ),
     case teletype_util:send_email(AuthorityEmails, Subject, RenderedTemplates, EmailAttachements) of
         'ok' -> teletype_util:notification_completed(?TEMPLATE_ID);
         {'error', Reason} ->

--- a/applications/teletype/src/templates/teletype_port_request_admin.erl
+++ b/applications/teletype/src/templates/teletype_port_request_admin.erl
@@ -96,9 +96,15 @@ handle_port_request(DataJObj) ->
     Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?TEMPLATE_ID),
     EmailAttachements = kz_json:get_value(<<"attachments">>, DataJObj),
 
-    case teletype_util:send_email(Emails, Subject, RenderedTemplates, EmailAttachements) of
+    _ = teletype_util:send_email(Emails, Subject, RenderedTemplates, EmailAttachements),
+
+    AuthorityEmails = kz_json:get_value(<<"authority_emails">>, DataJObj, []),
+
+    case teletype_util:send_email(AuthorityEmails, Subject, RenderedTemplates, EmailAttachements) of
         'ok' -> teletype_util:notification_completed(?TEMPLATE_ID);
-        {'error', Reason} -> teletype_util:notification_failed(?TEMPLATE_ID, Reason)
+        {'error', Reason} ->
+            lager:debug("unable to send emails to port authority: ~p", [Reason]),
+            teletype_util:notification_failed(?TEMPLATE_ID, Reason)
     end.
 
 -spec account_tree(kz_term:ne_binary()) -> kz_term:proplist().

--- a/applications/teletype/src/templates/teletype_port_scheduled.erl
+++ b/applications/teletype/src/templates/teletype_port_scheduled.erl
@@ -7,6 +7,7 @@
 -module(teletype_port_scheduled).
 
 -export([init/0
+        ,id/0
         ,handle_req/1
         ]).
 
@@ -30,6 +31,9 @@
 -define(TEMPLATE_CC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_BCC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_REPLY_TO, teletype_util:default_reply_to()).
+
+-spec id() -> kz_term:ne_binary().
+id() -> ?TEMPLATE_ID.
 
 -spec init() -> 'ok'.
 init() ->

--- a/applications/teletype/src/templates/teletype_port_unconfirmed.erl
+++ b/applications/teletype/src/templates/teletype_port_unconfirmed.erl
@@ -7,6 +7,7 @@
 -module(teletype_port_unconfirmed).
 
 -export([init/0
+        ,id/0
         ,handle_req/1
         ]).
 
@@ -30,6 +31,9 @@
 -define(TEMPLATE_CC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_BCC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_REPLY_TO, teletype_util:default_reply_to()).
+
+-spec id() -> kz_term:ne_binary().
+id() -> ?TEMPLATE_ID.
 
 -spec init() -> 'ok'.
 init() ->

--- a/applications/teletype/src/templates/teletype_ported.erl
+++ b/applications/teletype/src/templates/teletype_ported.erl
@@ -7,6 +7,7 @@
 -module(teletype_ported).
 
 -export([init/0
+        ,id/0
         ,handle_req/1
         ]).
 
@@ -30,6 +31,9 @@
 -define(TEMPLATE_CC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_BCC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
 -define(TEMPLATE_REPLY_TO, teletype_util:default_reply_to()).
+
+-spec id() -> kz_term:ne_binary().
+id() -> ?TEMPLATE_ID.
 
 -spec init() -> 'ok'.
 init() ->

--- a/core/kazoo_documents/src/kzd_port_requests.erl
+++ b/core/kazoo_documents/src/kzd_port_requests.erl
@@ -326,14 +326,20 @@ find_port_authority(Doc) ->
             PortAuthority
     end.
 
--spec find_port_authority(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_binary().
+-spec find_port_authority(kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> kz_term:api_binary().
+find_port_authority('undefined', 'undefined') ->
+    lager:debug("master and account id is undefined"),
+    'undefined';
+find_port_authority(?NE_BINARY = MasterAccountId, 'undefined') ->
+    lager:debug("account id is undefined, checking master"),
+    find_port_authority(MasterAccountId, MasterAccountId);
 find_port_authority(MasterAccountId, MasterAccountId) ->
     case kzd_whitelabel:fetch(MasterAccountId) of
         {'error', _R} ->
             lager:debug("failed to find master whitelabel, assuming master is port authority"),
             MasterAccountId;
         {'ok', JObj} ->
-            lager:debug("checking master whitelabel port authority"),
+            lager:debug("checking master whitelabel port authority if defined"),
             kzd_whitelabel:port_authority(JObj, MasterAccountId)
     end;
 find_port_authority(MasterAccountId, AccountId) ->


### PR DESCRIPTION
~~DON'T MERGE THIS YET!~~

Some fixes found during port request templates testing:

* fix/update: try to send templates: port cancel, port comment, port rejected, port request, port request admin in two passes:
  1. Pass 1: add only submitter to data only if it is not comment template with private comment). If user made a customization to template by changing email type to specify or admins, it will process accordingly otherwise it will b sent to submitter as default type is original. The result of this sending will be ignored.
  2. Pass 2: Will try to send another email to port authority, if it failed the whole process will be assumed failed. 
* fix: use correct key name for reference number
* update: add pre/post direction billing address
* reorganize bill object in macros
* show more field in admin template (signee name, signing date, carrier account number, pin and btn)

~~DON'T MERGE THIS YET!~~

Meeeeeeeeeeeeeeeeeeeeeeerge it!