### PR TITLE
[master] check only data for preview, remove private comment if not superduper

### DIFF
--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -1464,9 +1464,41 @@ leak_attachments_fold(_Attachment, Props, Acc) ->
 load_smtp_log_doc(?MATCH_MODB_PREFIX(YYYY,MM,_) = Id, Context) ->
     Year  = kz_term:to_integer(YYYY),
     Month = kz_term:to_integer(MM),
-    crossbar_doc:load(Id
-                     ,cb_context:set_account_modb(Context, Year, Month)
-                     ,?TYPE_CHECK_OPTION(?PVT_TYPE_SMTPLOG)).
+    IsSuperAdmin = cb_context:is_superduper_admin(Context),
+    C1 = crossbar_doc:load(Id
+                          ,cb_context:set_account_modb(Context, Year, Month)
+                          ,?TYPE_CHECK_OPTION(?PVT_TYPE_SMTPLOG)
+                          ),
+    case cb_context:resp_status(C1) of
+        'success' ->
+            TemplateId = kz_json:get_ne_binary_value(<<"template_id">>, cb_context:doc(C1)),
+            maybe_remove_private_comment(C1, TemplateId, IsSuperAdmin);
+        _ ->
+            C1
+    end.
+
+-spec maybe_remove_private_comment(cb_context:context(), kz_term:ne_binary(), boolean()) -> cb_context:context().
+maybe_remove_private_comment(Context, <<"port_comment">>, 'false') ->
+    case kz_json:is_true([<<"macros">>, <<"port_request">>, <<"comment">>, <<"superduper_comment">>]
+                        ,cb_context:doc(Context)
+                        ,'false'
+                        )
+    of
+        'true' ->
+            Doc = kz_json:delete_keys([[<<"macros">>, <<"port_request">>, <<"comment">>]
+                                      ,<<"rendered_templates">>
+                                      ]
+                                     ,cb_context:doc(Context)
+                                     ),
+            Setters = [{fun cb_context:set_doc/2, Doc}
+                      ,{fun cb_context:set_resp_data/2, Doc}
+                      ],
+            cb_context:setters(Context, Setters);
+        'false' ->
+            Context
+    end;
+maybe_remove_private_comment(Context, _, _) ->
+    Context.
 
 -spec maybe_update_db(cb_context:context()) -> cb_context:context().
 maybe_update_db(Context) ->


### PR DESCRIPTION
* When notification is preview, only check inside data object to get `to` addresses
* When getting SMTP log from API in debug app with non-superduper logged in, if template is port_comment and its comment is private, remove the comment and rendered template to hide the private comment.