### PR TITLE
HELP-41788 use same timeout as originate

### DIFF
--- a/applications/stepswitch/src/stepswitch_bridge.erl
+++ b/applications/stepswitch/src/stepswitch_bridge.erl
@@ -109,7 +109,7 @@ init([Endpoints, OffnetReq]) ->
                          ,request_handler=self()
                          ,control_queue=ControlQ
                          ,response_queue=kapi_offnet_resource:server_id(OffnetReq)
-                         ,timeout=erlang:send_after(30000, self(), 'bridge_timeout')
+                         ,timeout=erlang:send_after(120000, self(), 'bridge_timeout')
                          ,call_id=kapi_offnet_resource:call_id(OffnetReq)
                          }}
     end.


### PR DESCRIPTION
* this will need better handling. right now we wait for the
channel_bridge event which may take some time even when the the call
progresses.