### PR TITLE
[master] PORT-4: port requests listing by agent, account and descendants

### DIFF
--- a/applications/crossbar/doc/ref/comments.md
+++ b/applications/crossbar/doc/ref/comments.md
@@ -2,7 +2,15 @@
 
 ## About Comments
 
-## Schema
+#### Schema
+
+Schema for comments
+
+
+
+Key | Description | Type | Default | Required | Support Level
+--- | ----------- | ---- | ------- | -------- | -------------
+`comments` | The history of comments made on a object | `["array(", "[#/definitions/comment](#comment)", ")"]` |   | `false` |  
 
 
 

--- a/applications/crossbar/doc/ref/port_requests.md
+++ b/applications/crossbar/doc/ref/port_requests.md
@@ -10,27 +10,32 @@ Schema for a port request
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
+`bill.account_number` | Account Number to identify account | `string()` |   | `false` |  
+`bill.btn` | Billing Telephone Number (BTN) to identify account | `string()` |   | `false` |  
 `bill.carrier` | The name of the losing carrier | `string()` |   | `false` |  
-`bill.extended_address` | The suite/floor/apt of the billing address the losing carrier has on record | `string()` |   | `false` |  
 `bill.locality` | The locality (city) of the billing address the losing carrier has on record | `string()` |   | `false` |  
 `bill.name` | The losing carrier billing/account name | `string()` |   | `false` |  
+`bill.pin` | Personal Identification Number (PIN) to identify account | `string()` |   | `false` |  
 `bill.postal_code` | The zip/postal code of the billing address the losing carrier has on record | `string()` |   | `false` |  
 `bill.region` | The region (state) of the billing address the losing carrier has on record | `string()` |   | `false` |  
 `bill.street_address` | The street name of the billing address the losing carrier has on record | `string()` |   | `false` |  
 `bill.street_number` | The street number of the billing address the losing carrier has on record | `string()` |   | `false` |  
+`bill.street_post_dir` | Street Post-Direction | `string('E' | 'N' | 'NE' | 'NW' | 'S' | 'SE' | 'SW' | 'W')` |   | `false` |  
+`bill.street_pre_dir` | Street Pre-Direction | `string('E' | 'N' | 'NE' | 'NW' | 'S' | 'SE' | 'SW' | 'W')` |   | `false` |  
 `bill.street_type` | The street type of the billing address the losing carrier has on record | `string()` |   | `false` |  
 `bill` | Billing information of the losing carrier | `object()` |   | `false` |  
-`comments` | The history of comments made on a port request | `array(object())` |   | `false` |  
+`comments` | The history of comments made on a port request | `["array(", "[#/definitions/comment](#comment)", ")"]` |   | `false` |  
 `name` | A friendly name for the port request | `string(1..128)` |   | `true` |  
 `notifications.email.send_to` | A list or string of email recipient(s) | `string() | array(string())` |   | `false` |  
 `notifications.email` | Inbound Email Notifications | `object()` |   | `false` |  
 `notifications` | Status notifications | `object()` |   | `false` |  
 `numbers./\+?[0-9]+/` |   | `object()` |   | `false` |  
 `numbers` | The numbers to port in | `object()` |   | `true` |  
-`port_state` | What state the port request is currently in | `string('unconfirmed' | 'pending' | 'submitted' | 'scheduled' | 'completed' | 'rejected' | 'canceled')` | `unconfirmed` | `false` |  
+`reference_number` | Winning carrier reference number or order ID | `string()` |   | `false` |  
 `signee_name` | The name of the person authorizing the release of numbers from the losing carrier | `string()` |   | `false` |  
 `signing_date` | The date in Gregorian timestamp on which the document releasing the numbers from the losing carrier was signed | `integer()` |   | `false` |  
 `transfer_date` | Requested transfer date in Gregorian timestamp | `integer()` |   | `false` |  
+`winning_carrier` | The name of winning carrier | `string()` |   | `false` |  
 
 
 
@@ -92,76 +97,6 @@ curl -v -X PATCH \
 curl -v -X DELETE \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/{PORT_REQUEST_ID}
-```
-
-## Fetch
-
-> GET /v2/accounts/{ACCOUNT_ID}/port_requests/unconfirmed
-
-```shell
-curl -v -X GET \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/unconfirmed
-```
-
-## Fetch
-
-> GET /v2/accounts/{ACCOUNT_ID}/port_requests/canceled
-
-```shell
-curl -v -X GET \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/canceled
-```
-
-## Fetch
-
-> GET /v2/accounts/{ACCOUNT_ID}/port_requests/rejected
-
-```shell
-curl -v -X GET \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/rejected
-```
-
-## Fetch
-
-> GET /v2/accounts/{ACCOUNT_ID}/port_requests/completed
-
-```shell
-curl -v -X GET \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/completed
-```
-
-## Fetch
-
-> GET /v2/accounts/{ACCOUNT_ID}/port_requests/scheduled
-
-```shell
-curl -v -X GET \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/scheduled
-```
-
-## Fetch
-
-> GET /v2/accounts/{ACCOUNT_ID}/port_requests/pending
-
-```shell
-curl -v -X GET \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/pending
-```
-
-## Fetch
-
-> GET /v2/accounts/{ACCOUNT_ID}/port_requests/submitted
-
-```shell
-curl -v -X GET \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/port_requests/submitted
 ```
 
 ## Fetch

--- a/applications/crossbar/doc/ref/whitelabel.md
+++ b/applications/crossbar/doc/ref/whitelabel.md
@@ -21,7 +21,7 @@ Key | Description | Type | Default | Required | Support Level
 `nav.learn_more` | The URL to use when the 'Learn More!' link is clicked | `string()` |   | `false` | `supported`
 `nav` | Properties related to navigation in the UI | `object()` |   | `false` |  
 `outbound_trunks_price` | The price to show for outbound trunks, this is currently only for display purposes | `string()` |   | `false` | `beta`
-`port.authority` | The email(s) to be used for admin port requests | `string() | array(string())` |   | `false` | `supported`
+`port.authority` | The account ID(s) to be used for administrating port requests | `string() | array(string())` |   | `false` | `supported`
 `port.features` | The URL to use when the features link is clicked | `string()` |   | `false` | `supported`
 `port.loa` | The URL to use when the LOA link is clicked | `string()` |   | `false` | `supported`
 `port.resporg` | The URL to use when the resporg link is clicked | `string()` |   | `false` | `supported`

--- a/applications/crossbar/doc/whitelabeling.md
+++ b/applications/crossbar/doc/whitelabeling.md
@@ -21,7 +21,7 @@ Key | Description | Type | Default | Required | Support Level
 `nav.learn_more` | The URL to use when the 'Learn More!' link is clicked | `string()` |   | `false` | `supported`
 `nav` | Properties related to navigation in the UI | `object()` |   | `false` |  
 `outbound_trunks_price` | The price to show for outbound trunks, this is currently only for display purposes | `string()` |   | `false` | `beta`
-`port.authority` | The email(s) to be used for admin port requests | `string() | array(string())` |   | `false` | `supported`
+`port.authority` | The account ID(s) to be used for administrating port requests | `string() | array(string())` |   | `false` | `supported`
 `port.features` | The URL to use when the features link is clicked | `string()` |   | `false` | `supported`
 `port.loa` | The URL to use when the LOA link is clicked | `string()` |   | `false` | `supported`
 `port.resporg` | The URL to use when the resporg link is clicked | `string()` |   | `false` | `supported`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -4281,6 +4281,59 @@
             ],
             "type": "object"
         },
+        "comment": {
+            "description": "Schema for a single comment",
+            "properties": {
+                "account_id": {
+                    "description": "Account ID of the commenter.",
+                    "type": "string"
+                },
+                "action_required": {
+                    "default": false,
+                    "description": "Specficied if an action is required by the user.",
+                    "type": "boolean"
+                },
+                "author": {
+                    "description": "Full name of the author",
+                    "type": "string"
+                },
+                "content": {
+                    "description": "Content of the comment",
+                    "type": "string"
+                },
+                "is_private": {
+                    "default": false,
+                    "description": "Specified if this comment is private",
+                    "type": "boolean"
+                },
+                "timestamp": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "description": "User ID of the commenter",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "author",
+                "content",
+                "timestamp"
+            ],
+            "type": "object"
+        },
+        "comments": {
+            "description": "Schema for comments",
+            "properties": {
+                "comments": {
+                    "description": "The history of comments made on a object",
+                    "items": {
+                        "$ref": "#/definitions/comment"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "conferences": {
             "description": "Schema for conferences",
             "properties": {
@@ -18079,6 +18132,9 @@
                 },
                 "To": {
                     "type": "string"
+                },
+                "Version": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -18159,6 +18215,9 @@
                     "type": "string"
                 },
                 "To": {
+                    "type": "string"
+                },
+                "Version": {
                     "type": "string"
                 }
             },
@@ -18318,6 +18377,9 @@
                     "type": "string"
                 },
                 "To": {
+                    "type": "string"
+                },
+                "Version": {
                     "type": "string"
                 }
             },
@@ -18642,6 +18704,9 @@
                     "type": "string"
                 },
                 "To": {
+                    "type": "string"
+                },
+                "Version": {
                     "type": "string"
                 }
             },
@@ -25837,12 +25902,16 @@
                 "bill": {
                     "description": "Billing information of the losing carrier",
                     "properties": {
-                        "carrier": {
-                            "description": "The name of the losing carrier",
+                        "account_number": {
+                            "description": "Account Number to identify account",
                             "type": "string"
                         },
-                        "extended_address": {
-                            "description": "The suite/floor/apt of the billing address the losing carrier has on record",
+                        "btn": {
+                            "description": "Billing Telephone Number (BTN) to identify account",
+                            "type": "string"
+                        },
+                        "carrier": {
+                            "description": "The name of the losing carrier",
                             "type": "string"
                         },
                         "locality": {
@@ -25851,6 +25920,10 @@
                         },
                         "name": {
                             "description": "The losing carrier billing/account name",
+                            "type": "string"
+                        },
+                        "pin": {
+                            "description": "Personal Identification Number (PIN) to identify account",
                             "type": "string"
                         },
                         "postal_code": {
@@ -25869,6 +25942,34 @@
                             "description": "The street number of the billing address the losing carrier has on record",
                             "type": "string"
                         },
+                        "street_post_dir": {
+                            "description": "Street Post-Direction",
+                            "enum": [
+                                "E",
+                                "N",
+                                "NE",
+                                "NW",
+                                "S",
+                                "SE",
+                                "SW",
+                                "W"
+                            ],
+                            "type": "string"
+                        },
+                        "street_pre_dir": {
+                            "description": "Street Pre-Direction",
+                            "enum": [
+                                "E",
+                                "N",
+                                "NE",
+                                "NW",
+                                "S",
+                                "SE",
+                                "SW",
+                                "W"
+                            ],
+                            "type": "string"
+                        },
                         "street_type": {
                             "description": "The street type of the billing address the losing carrier has on record",
                             "type": "string"
@@ -25879,7 +25980,7 @@
                 "comments": {
                     "description": "The history of comments made on a port request",
                     "items": {
-                        "type": "object"
+                        "$ref": "#/definitions/comment"
                     },
                     "type": "array"
                 },
@@ -25922,18 +26023,8 @@
                     "minProperties": 1,
                     "type": "object"
                 },
-                "port_state": {
-                    "default": "unconfirmed",
-                    "description": "What state the port request is currently in",
-                    "enum": [
-                        "unconfirmed",
-                        "pending",
-                        "submitted",
-                        "scheduled",
-                        "completed",
-                        "rejected",
-                        "canceled"
-                    ],
+                "reference_number": {
+                    "description": "Winning carrier reference number or order ID",
                     "type": "string"
                 },
                 "signee_name": {
@@ -25947,6 +26038,10 @@
                 "transfer_date": {
                     "description": "Requested transfer date in Gregorian timestamp",
                     "type": "integer"
+                },
+                "winning_carrier": {
+                    "description": "The name of winning carrier",
+                    "type": "string"
                 }
             },
             "required": [
@@ -35592,7 +35687,7 @@
                     "description": "Parameters related to white-labeling port requests",
                     "properties": {
                         "authority": {
-                            "description": "The email(s) to be used for admin port requests",
+                            "description": "The account ID(s) to be used for administrating port requests",
                             "oneOf": [
                                 {
                                     "type": "string"
@@ -37956,6 +38051,14 @@
             "put": {
                 "parameters": [
                     {
+                        "in": "body",
+                        "name": "comments",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/comments"
+                        }
+                    },
+                    {
                         "$ref": "#/parameters/auth_token_header"
                     },
                     {
@@ -38008,6 +38111,14 @@
             },
             "post": {
                 "parameters": [
+                    {
+                        "in": "body",
+                        "name": "comments",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/comments"
+                        }
+                    },
                     {
                         "$ref": "#/parameters/auth_token_header"
                     },
@@ -41991,126 +42102,7 @@
                 }
             }
         },
-        "/accounts/{ACCOUNT_ID}/port_requests/canceled": {
-            "get": {
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/auth_token_header"
-                    },
-                    {
-                        "$ref": "#/parameters/ACCOUNT_ID"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "request succeeded"
-                    }
-                }
-            }
-        },
-        "/accounts/{ACCOUNT_ID}/port_requests/completed": {
-            "get": {
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/auth_token_header"
-                    },
-                    {
-                        "$ref": "#/parameters/ACCOUNT_ID"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "request succeeded"
-                    }
-                }
-            }
-        },
         "/accounts/{ACCOUNT_ID}/port_requests/last_submitted": {
-            "get": {
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/auth_token_header"
-                    },
-                    {
-                        "$ref": "#/parameters/ACCOUNT_ID"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "request succeeded"
-                    }
-                }
-            }
-        },
-        "/accounts/{ACCOUNT_ID}/port_requests/pending": {
-            "get": {
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/auth_token_header"
-                    },
-                    {
-                        "$ref": "#/parameters/ACCOUNT_ID"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "request succeeded"
-                    }
-                }
-            }
-        },
-        "/accounts/{ACCOUNT_ID}/port_requests/rejected": {
-            "get": {
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/auth_token_header"
-                    },
-                    {
-                        "$ref": "#/parameters/ACCOUNT_ID"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "request succeeded"
-                    }
-                }
-            }
-        },
-        "/accounts/{ACCOUNT_ID}/port_requests/scheduled": {
-            "get": {
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/auth_token_header"
-                    },
-                    {
-                        "$ref": "#/parameters/ACCOUNT_ID"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "request succeeded"
-                    }
-                }
-            }
-        },
-        "/accounts/{ACCOUNT_ID}/port_requests/submitted": {
-            "get": {
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/auth_token_header"
-                    },
-                    {
-                        "$ref": "#/parameters/ACCOUNT_ID"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "request succeeded"
-                    }
-                }
-            }
-        },
-        "/accounts/{ACCOUNT_ID}/port_requests/unconfirmed": {
             "get": {
                 "parameters": [
                     {

--- a/applications/crossbar/priv/couchdb/schemas/comment.json
+++ b/applications/crossbar/priv/couchdb/schemas/comment.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "comment",
+    "description": "Schema for a single comment",
+    "properties": {
+        "account_id": {
+            "description": "Account ID of the commenter.",
+            "type": "string"
+        },
+        "action_required": {
+            "default": false,
+            "description": "Specficied if an action is required by the user.",
+            "type": "boolean"
+        },
+        "author": {
+            "description": "Full name of the author",
+            "type": "string"
+        },
+        "content": {
+            "description": "Content of the comment",
+            "type": "string"
+        },
+        "is_private": {
+            "default": false,
+            "description": "Specified if this comment is private",
+            "type": "boolean"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "user_id": {
+            "description": "User ID of the commenter",
+            "type": "string"
+        }
+    },
+    "required": [
+        "author",
+        "content",
+        "timestamp"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/comments.json
+++ b/applications/crossbar/priv/couchdb/schemas/comments.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "comments",
+    "description": "Schema for comments",
+    "properties": {
+        "comments": {
+            "description": "The history of comments made on a object",
+            "items": {
+                "$ref": "comment"
+            },
+            "type": "array"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_cancel.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_cancel.json
@@ -71,6 +71,9 @@
         },
         "To": {
             "type": "string"
+        },
+        "Version": {
+            "type": "string"
         }
     },
     "required": [

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_comment.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_comment.json
@@ -74,6 +74,9 @@
         },
         "To": {
             "type": "string"
+        },
+        "Version": {
+            "type": "string"
         }
     },
     "required": [

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_rejected.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.port_rejected.json
@@ -71,6 +71,9 @@
         },
         "To": {
             "type": "string"
+        },
+        "Version": {
+            "type": "string"
         }
     },
     "required": [

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.ported.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.ported.json
@@ -74,6 +74,9 @@
         },
         "To": {
             "type": "string"
+        },
+        "Version": {
+            "type": "string"
         }
     },
     "required": [

--- a/applications/crossbar/priv/couchdb/schemas/port_requests.json
+++ b/applications/crossbar/priv/couchdb/schemas/port_requests.json
@@ -6,12 +6,16 @@
         "bill": {
             "description": "Billing information of the losing carrier",
             "properties": {
-                "carrier": {
-                    "description": "The name of the losing carrier",
+                "account_number": {
+                    "description": "Account Number to identify account",
                     "type": "string"
                 },
-                "extended_address": {
-                    "description": "The suite/floor/apt of the billing address the losing carrier has on record",
+                "btn": {
+                    "description": "Billing Telephone Number (BTN) to identify account",
+                    "type": "string"
+                },
+                "carrier": {
+                    "description": "The name of the losing carrier",
                     "type": "string"
                 },
                 "locality": {
@@ -20,6 +24,10 @@
                 },
                 "name": {
                     "description": "The losing carrier billing/account name",
+                    "type": "string"
+                },
+                "pin": {
+                    "description": "Personal Identification Number (PIN) to identify account",
                     "type": "string"
                 },
                 "postal_code": {
@@ -38,6 +46,34 @@
                     "description": "The street number of the billing address the losing carrier has on record",
                     "type": "string"
                 },
+                "street_post_dir": {
+                    "description": "Street Post-Direction",
+                    "enum": [
+                        "E",
+                        "N",
+                        "NE",
+                        "NW",
+                        "S",
+                        "SE",
+                        "SW",
+                        "W"
+                    ],
+                    "type": "string"
+                },
+                "street_pre_dir": {
+                    "description": "Street Pre-Direction",
+                    "enum": [
+                        "E",
+                        "N",
+                        "NE",
+                        "NW",
+                        "S",
+                        "SE",
+                        "SW",
+                        "W"
+                    ],
+                    "type": "string"
+                },
                 "street_type": {
                     "description": "The street type of the billing address the losing carrier has on record",
                     "type": "string"
@@ -48,7 +84,7 @@
         "comments": {
             "description": "The history of comments made on a port request",
             "items": {
-                "type": "object"
+                "$ref": "comment"
             },
             "type": "array"
         },
@@ -96,18 +132,8 @@
             },
             "type": "object"
         },
-        "port_state": {
-            "default": "unconfirmed",
-            "description": "What state the port request is currently in",
-            "enum": [
-                "unconfirmed",
-                "pending",
-                "submitted",
-                "scheduled",
-                "completed",
-                "rejected",
-                "canceled"
-            ],
+        "reference_number": {
+            "description": "Winning carrier reference number or order ID",
             "type": "string"
         },
         "signee_name": {
@@ -121,6 +147,10 @@
         "transfer_date": {
             "description": "Requested transfer date in Gregorian timestamp",
             "type": "integer"
+        },
+        "winning_carrier": {
+            "description": "The name of winning carrier",
+            "type": "string"
         }
     },
     "required": [

--- a/applications/crossbar/priv/couchdb/schemas/whitelabel.json
+++ b/applications/crossbar/priv/couchdb/schemas/whitelabel.json
@@ -70,7 +70,7 @@
             "description": "Parameters related to white-labeling port requests",
             "properties": {
                 "authority": {
-                    "description": "The email(s) to be used for admin port requests",
+                    "description": "The account ID(s) to be used for administrating port requests",
                     "oneOf": [
                         {
                             "type": "string"

--- a/applications/crossbar/src/crossbar_services.erl
+++ b/applications/crossbar/src/crossbar_services.erl
@@ -14,6 +14,10 @@
         ]).
 -export([reconcile/1]).
 -export([audit_log/1]).
+-export([audit_log_auth/1
+        ,audit_log_agent/1
+        ,audit_log_request/1
+        ]).
 -export([transaction_to_error/2]).
 
 -include("crossbar.hrl").
@@ -147,14 +151,14 @@ audit_log_request(Context) ->
     ,{<<"path">>, cb_context:raw_path(Context)}
     ].
 
--spec audit_log_agent(cb_context:context()) -> kz_term:proplist().
+-spec audit_log_agent(cb_context:context()) -> kz_term:api_proplist().
 audit_log_agent(Context) ->
     case cb_context:auth_user_id(Context) of
         'undefined' -> 'undefined';
         UserId -> audit_log_user(Context, UserId)
     end.
 
--spec audit_log_user(cb_context:context(), kz_term:ne_binary()) -> kz_term:proplist().
+-spec audit_log_user(cb_context:context(), kz_term:ne_binary()) -> kz_term:api_proplist().
 audit_log_user(Context, UserId) ->
     AccountDb = kz_util:format_account_db(
                   cb_context:auth_account_id(Context)
@@ -167,6 +171,7 @@ audit_log_user(Context, UserId) ->
             ,{<<"account_id">>, cb_context:auth_account_id(Context)}
             ,{<<"first_name">>, kzd_users:first_name(JObj)}
             ,{<<"last_name">>, kzd_users:last_name(JObj)}
+            ,{<<"full_name">>, kzd_users:full_name(JObj, kzd_users:username(JObj, kzd_users:email(JObj)))}
             ]
     end.
 

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -1325,7 +1325,7 @@ normalize_available_port(Value, Acc, Context) ->
     AuthAccountId = cb_context:auth_account_id(Context),
 
     case kz_services_reseller:is_reseller(AuthAccountId)
-        andalso cb_port_requests:authority(AccountId)
+        andalso kzd_port_requests:find_port_authority(AccountId)
     of
         'false' -> Acc;
 
@@ -1487,8 +1487,10 @@ load_smtp_log_doc(?MATCH_MODB_PREFIX(YYYY,MM,_) = Id, Context) ->
 -spec maybe_remove_private_data(kz_json:object(), kz_term:ne_binary(), boolean()) -> kz_json:object().
 maybe_remove_private_data(JObj, <<"port_comment">>, 'false') ->
     CommentPath = [<<"macros">>, <<"port_request">>, <<"comment">>],
-    SuperPath = CommentPath ++ [<<"superduper_comment">>],
-    case kz_json:is_true(SuperPath, JObj, 'false') of
+    SuperPaths = [CommentPath ++ [<<"superduper_comment">>]
+                 ,CommentPath ++ [<<"is_private">>]
+                 ],
+    case kz_term:is_true(kz_json:get_first_defined(SuperPaths, JObj, 'false')) of
         'true' ->
             DeletePaths = [CommentPath
                           ,<<"rendered_templates">>

--- a/applications/crossbar/test/cb_alerts_tests.erl
+++ b/applications/crossbar/test/cb_alerts_tests.erl
@@ -341,11 +341,11 @@ account_active_ports() ->
 
 -spec unconfirmed_port_request() -> kzd_port_requests:doc().
 unconfirmed_port_request() ->
-    kzd_port_requests:set_port_state(example_port_request(), <<"unconfirmed">>).
+    kz_json:set_value(<<"pvt_port_state">>, <<"unconfirmed">>, example_port_request()).
 
 -spec rejected_port_request() -> kzd_port_requests:doc().
 rejected_port_request() ->
-    kzd_port_requests:set_port_state(example_port_request(), <<"rejected">>).
+    kz_json:set_value(<<"pvt_port_state">>, <<"unconfirmed">>, example_port_request()).
 
 -spec swap_comments(kzd_port_requests:doc()) -> kzd_port_requests:doc().
 swap_comments(Port) ->

--- a/applications/teletype/src/teletype_port_utils.erl
+++ b/applications/teletype/src/teletype_port_utils.erl
@@ -31,7 +31,8 @@ port_request_data(DataJObj, TemplateId) ->
 
 -spec port_request_data(kz_json:object(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 port_request_data(DataJObj, TemplateId, PortReqJObj) ->
-    Routines = [fun fix_numbers/3
+    Routines = [fun fix_port_authority/3
+               ,fun fix_numbers/3
                ,fun fix_billing/3
                ,fun fix_reference_number/3
                ,fun fix_port_state/3
@@ -51,30 +52,47 @@ port_request_data(DataJObj, TemplateId, PortReqJObj) ->
     NewData = kz_json:set_value(<<"port_request">>, JObj, DataJObj),
     maybe_add_attachments(maybe_fix_emails(NewData, TemplateId), TemplateId).
 
+-spec fix_port_authority(kz_json:object(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
+fix_port_authority(_DataJObj, _TemplateId, PortReqJObj) ->
+    {'ok', MasterId} = kapps_util:get_master_account_id(),
+    case kzd_port_requests:find_port_authority(PortReqJObj) of
+        'undefined' ->
+            lager:debug("port authority is undefined, using master as port authority"),
+            kz_json:set_value(<<"port_authority">>
+                             ,kz_json:from_list(teletype_util:find_account_params(MasterId))
+                             ,PortReqJObj
+                             );
+        PortAuthority ->
+            kz_json:set_value(<<"port_authority">>
+                             ,kz_json:from_list(teletype_util:find_account_params(PortAuthority))
+                             ,PortReqJObj
+                             )
+    end.
+
 -spec fix_numbers(kz_json:object(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 fix_numbers(_DataJObj, _TemplateId, PortReqJObj) ->
     Numbers = kz_json:foldl(fun (Number, _Value, Acc) -> [Number|Acc] end
                            ,[]
                            ,get_numbers(PortReqJObj)
                            ),
-    kz_json:set_value(<<"numbers">>, Numbers, PortReqJObj).
+    kzd_port_requests:set_numbers(PortReqJObj, Numbers).
 
 -spec get_numbers(kz_json:object()) -> kz_term:ne_binaries().
 get_numbers(PortReqJObj) ->
-    case kz_json:get_value(?PORT_PVT_STATE, PortReqJObj) of
+    case kzd_port_requests:pvt_port_state(PortReqJObj) of
         ?PORT_COMPLETED ->
             %% in case the doc is not saved/replicated yet, use numbers key
-            Default = kz_json:get_json_value(<<"numbers">>, PortReqJObj, kz_json:new()),
-            kz_json:get_json_value(<<"ported_numbers">>, PortReqJObj, Default);
+            Default = kzd_port_requests:numbers(PortReqJObj, kz_json:new()),
+            kzd_port_requests:pvt_ported_numbers(PortReqJObj, Default);
         _ ->
-            kz_json:get_json_value(<<"numbers">>, PortReqJObj, kz_json:new())
+            kzd_port_requests:numbers(PortReqJObj, kz_json:new())
     end.
 
 -spec fix_billing(kz_json:object(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 fix_billing(_DataJObj, _TemplateId, PortReqJObj) ->
     kz_json:foldl(fun (Key, Value, Acc) -> kz_json:set_value(<<"bill_", Key/binary>>, Value, Acc) end
                  ,fix_bill_object(PortReqJObj)
-                 ,kz_json:get_json_value(<<"bill">>, PortReqJObj, kz_json:new())
+                 ,kzd_port_requests:bill(PortReqJObj, kz_json:new())
                  ).
 
 -spec fix_bill_object(kz_json:object()) -> kz_json:object().
@@ -121,16 +139,14 @@ fix_bill_object(PortReqJObj, Category, KeyName) ->
 
 -spec fix_reference_number(kz_json:object(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 fix_reference_number(_DataJObj, _TemplateId, PortReqJObj) ->
-    kz_json:set_value(<<"reference_number">>
-                     ,kz_json:get_ne_binary_value(<<"reference_number">>, PortReqJObj, <<"-">>)
-                     ,PortReqJObj
-                     ).
-
+    kzd_port_requests:set_reference_number(PortReqJObj
+                                          ,kzd_port_requests:reference_number(PortReqJObj, <<"-">>)
+                                          ).
 
 -spec fix_port_state(kz_json:object(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 fix_port_state(_DataJObj, _TemplateId, PortReqJObj) ->
     kz_json:set_value(<<"port_state">>
-                     ,kz_json:get_ne_binary_value(?PORT_PVT_STATE, PortReqJObj)
+                     ,kzd_port_requests:pvt_port_state(PortReqJObj)
                      ,PortReqJObj
                      ).
 
@@ -140,7 +156,7 @@ fix_comments(DataJObj, _TemplateId, PortReqJObj) ->
     case get_the_comment(DataJObj, PortReqJObj, IsPreview) of
         'undefined' -> kz_json:delete_key(<<"comments">>, PortReqJObj);
         Comment ->
-            Timestamp = kz_json:get_integer_value(<<"timestamp">>, Comment),
+            Timestamp = kzd_comment:timestamp(Comment),
             Date = kz_json:from_list(teletype_util:fix_timestamp(Timestamp, DataJObj)),
             Props = [{<<"date">>, Date}
                     ,{<<"timestamp">>, kz_json:get_value(<<"local">>, Date)} %% backward compatibility
@@ -154,7 +170,7 @@ fix_comments(DataJObj, _TemplateId, PortReqJObj) ->
 
 -spec get_the_comment(kz_json:object(), kz_json:object(), boolean()) -> kz_term:api_object().
 get_the_comment(_, PortReqJObj, 'true') ->
-    hd(kz_json:get_value(<<"comments">>, PortReqJObj));
+    hd(kzd_port_requests:comments(PortReqJObj));
 get_the_comment(DataJObj, _, 'false') ->
     kz_json:get_json_value(<<"comment">>, DataJObj).
 
@@ -174,11 +190,7 @@ fix_date_fold(Key, JObj, 'true') ->
     Date = kz_json:from_list(teletype_util:fix_timestamp(kz_time:now_s(), JObj)),
     kz_json:set_value(Key, Date, JObj);
 fix_date_fold(<<"ported_date">> = Key, JObj, 'false') ->
-    case [TransitionJObj
-          || TransitionJObj <- kz_json:get_list_value(<<"pvt_transitions">>, JObj, []),
-             kz_json:get_ne_binary_value([<<"transition">>, <<"new">>], TransitionJObj) =:= ?PORT_COMPLETED
-         ]
-    of
+    case kzd_port_requests:get_transition(JObj, ?PORT_COMPLETED) of
         [] -> JObj;
         [Completed|_] ->
             Timestamp = kz_json:get_integer_value([<<"transition">>, <<"timestamp">>], Completed),
@@ -195,7 +207,7 @@ fix_date_fold(Key, JObj, 'false') ->
 
 -spec fix_notifications(kz_json:object(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 fix_notifications(_DataJObj, _TemplateId, PortReqJObj) ->
-    case kz_json:get_value([<<"notifications">>, <<"email">>, <<"send_to">>], PortReqJObj) of
+    case kzd_port_requests:notifications_email_send_to(PortReqJObj) of
         <<_/binary>> =Email -> kz_json:set_value(<<"customer_contact">>, [Email], PortReqJObj);
         [_|_]=Emails -> kz_json:set_value(<<"customer_contact">>, Emails, PortReqJObj);
         _ -> PortReqJObj
@@ -240,9 +252,9 @@ maybe_add_reason(DataJObj, _TemplateId, PortReqJObj) ->
         'undefined' -> PortReqJObj;
         Reason ->
             UserInfo = get_commenter_info(DataJObj),
-            Timestamp = kz_json:get_integer_value(<<"timestamp">>, Reason),
+            Timestamp = kzd_comment:timestamp(Reason),
             Date = kz_json:from_list(teletype_util:fix_timestamp(Timestamp, DataJObj)),
-            Props = [{<<"content">>, kz_json:get_ne_binary_value(<<"content">>, Reason)}
+            Props = [{<<"content">>, kzd_comment:content(Reason)}
                     ,{<<"date">>, Date}
                     ,{<<"user">>, kz_json:from_list(UserInfo)}
                     ],
@@ -279,7 +291,7 @@ maybe_add_user_data(DataJObj, Author, 'true') ->
         'undefined' ->
             [{<<"author">>, Author}];
         UserDoc ->
-            [{<<"author">>, first_last_name(kzd_users:first_name(UserDoc), kzd_users:last_name(UserDoc))}
+            [{<<"author">>, kzd_users:full_name(UserDoc, <<"An agent">>)}
              | teletype_util:user_params(UserDoc)
             ]
     end;
@@ -300,20 +312,10 @@ maybe_add_user_data(DataJObj, Author, 'false') ->
         {'error', _} ->
             [{<<"author">>, Author}];
         {'ok', UserDoc} ->
-            [{<<"author">>, first_last_name(kzd_users:first_name(UserDoc), kzd_users:last_name(UserDoc))}
+            [{<<"author">>, kzd_users:full_name(UserDoc, <<"An agent">>)}
              | teletype_util:user_params(UserDoc)
             ]
     end.
-
--spec first_last_name(kz_term:api_binary(), kz_term:api_binary()) -> kz_term:ne_binary().
-first_last_name(?NE_BINARY = First, ?NE_BINARY = Last) ->
-    <<First/binary, " ", Last/binary>>;
-first_last_name(_, ?NE_BINARY = Last) ->
-    <<Last/binary>>;
-first_last_name(?NE_BINARY = First, _) ->
-    <<First/binary>>;
-first_last_name(_, _) ->
-    <<"An agent">>.
 
 -spec is_attachable_template(kz_term:ne_binary()) -> boolean().
 is_attachable_template(TemplateId) ->
@@ -385,7 +387,8 @@ maybe_fix_emails(DataJObj, TemplateId, 'false') ->
 -spec maybe_set_from_email(kz_json:object(), boolean()) -> kz_json:object().
 maybe_set_from_email(DataJObj, 'true') ->
     DefaultFrom = teletype_util:default_from_address(),
-    Initiator = kz_json:get_value([<<"port_request">>, <<"notifications">>, <<"email">>, <<"send_to">>], DataJObj, DefaultFrom),
+    PortReq = kz_json:get_value(<<"port_request">>, DataJObj),
+    Initiator = kzd_port_requests:notifications_email_send_to(PortReq, DefaultFrom),
     kz_json:set_value(<<"from">>, Initiator, DataJObj);
 maybe_set_from_email(DataJObj, 'false') ->
     DataJObj.
@@ -406,8 +409,11 @@ maybe_get_submitter(DataJObj, TemplateId, 'false') ->
 
 -spec is_comment_private(kz_json:object(), kz_term:ne_binary()) -> boolean().
 is_comment_private(DataJObj, TemplateId) ->
+    SuperPaths = [[<<"comment">>, <<"superduper_comment">>]
+                 ,[<<"comment">>, <<"is_private">>]
+                 ],
     teletype_port_comment:id() =:= TemplateId
-        andalso kz_json:is_true([<<"comment">>, <<"superduper_comment">>], DataJObj, 'false').
+        andalso kz_term:is_true(kz_json:get_first_defined(SuperPaths, DataJObj, 'false')).
 
 -spec get_port_submitter_emails(kz_json:object()) -> kz_term:api_binaries().
 get_port_submitter_emails(DataJObj) ->
@@ -436,7 +442,7 @@ maybe_get_port_authority(DataJObj, TemplateId, 'true') ->
 -spec get_authority_emails(kz_json:object(), kz_term:ne_binary()) -> kz_term:api_binaries().
 get_authority_emails(DataJObj, TemplateId) ->
     PortDoc = kz_json:get_json_value(<<"port_request">>, DataJObj),
-    case kzd_port_requests:find_port_authority(PortDoc) of
+    case kz_json:get_ne_binary_value([<<"port_authority">>, <<"id">>], PortDoc) of
         'undefined' ->
             lager:debug("using master as port authority"),
             maybe_use_master_admins(TemplateId, 'undefined');

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -621,8 +621,8 @@ cnam_request_definition() ->
                                ,<<"Number">>
                                ,<<"Number-State">>
                                ,<<"Port">>
-                               ,<<"Port-Request-ID">>
                                ,<<"Reason">>
+                               ,<<"Version">> %% for stupid notify app (port_request)
                                     | ?DEFAULT_OPTIONAL_HEADERS
                                ]).
 %%------------------------------------------------------------------------------
@@ -640,6 +640,7 @@ port_cancel_definition() ->
                     ,binding = ?BINDING_STRING(<<"number">>, <<"port_cancel">>)
                     ,restrict_to = 'port_cancel'
                     ,required_headers = [<<"Account-ID">>
+                                        ,<<"Port-Request-ID">>
                                         ]
                     ,optional_headers = ?PORT_OPTIONAL_HEADERS
                     ,values = ?NOTIFY_VALUES(<<"port_cancel">>)
@@ -660,6 +661,7 @@ port_comment_definition() ->
                     ,binding = ?BINDING_STRING(<<"number">>, <<"port_comment">>)
                     ,restrict_to = 'port_comment'
                     ,required_headers = [<<"Account-ID">>
+                                        ,<<"Port-Request-ID">>
                                         ,<<"Comment">>
                                         ]
                     ,optional_headers = ?PORT_OPTIONAL_HEADERS -- [<<"Reason">>]
@@ -681,6 +683,7 @@ port_pending_definition() ->
                     ,binding = ?BINDING_STRING(<<"number">>, <<"port_pending">>)
                     ,restrict_to = 'port_pending'
                     ,required_headers = [<<"Account-ID">>
+                                        ,<<"Port-Request-ID">>
                                         ]
                     ,optional_headers = ?PORT_OPTIONAL_HEADERS
                     ,values = ?NOTIFY_VALUES(<<"port_pending">>)
@@ -701,6 +704,7 @@ port_rejected_definition() ->
                     ,binding = ?BINDING_STRING(<<"number">>, <<"port_rejected">>)
                     ,restrict_to = 'port_rejected'
                     ,required_headers = [<<"Account-ID">>
+                                        ,<<"Port-Request-ID">>
                                         ]
                     ,optional_headers = ?PORT_OPTIONAL_HEADERS
                     ,values = ?NOTIFY_VALUES(<<"port_rejected">>)
@@ -721,10 +725,9 @@ port_request_definition() ->
                     ,binding = ?BINDING_STRING(<<"number">>, <<"port_request">>)
                     ,restrict_to = 'port_request'
                     ,required_headers = [<<"Account-ID">>
+                                        ,<<"Port-Request-ID">>
                                         ]
-                    ,optional_headers = [<<"Version">> %% for stupid notify app
-                                             |?PORT_OPTIONAL_HEADERS
-                                        ]
+                    ,optional_headers = ?PORT_OPTIONAL_HEADERS
                     ,values = ?NOTIFY_VALUES(<<"port_request">>)
                     ,types = [{<<"Reason">>, fun kz_json:is_json_object/1}]
                     }.
@@ -743,6 +746,7 @@ port_scheduled_definition() ->
                     ,binding = ?BINDING_STRING(<<"number">>, <<"port_scheduled">>)
                     ,restrict_to = 'port_scheduled'
                     ,required_headers = [<<"Account-ID">>
+                                        ,<<"Port-Request-ID">>
                                         ]
                     ,optional_headers = ?PORT_OPTIONAL_HEADERS
                     ,values = ?NOTIFY_VALUES(<<"port_scheduled">>)
@@ -763,6 +767,7 @@ port_unconfirmed_definition() ->
                     ,binding = ?BINDING_STRING(<<"number">>, <<"port_unconfirmed">>)
                     ,restrict_to = 'port_unconfirmed'
                     ,required_headers = [<<"Account-ID">>
+                                        ,<<"Port-Request-ID">>
                                         ]
                     ,optional_headers = ?PORT_OPTIONAL_HEADERS
                     ,values = ?NOTIFY_VALUES(<<"port_unconfirmed">>)
@@ -783,6 +788,7 @@ ported_definition() ->
                     ,binding = ?BINDING_STRING(<<"number">>, <<"ported">>)
                     ,restrict_to = 'ported'
                     ,required_headers = [<<"Account-ID">>
+                                        ,<<"Port-Request-ID">>
                                         ]
                     ,optional_headers = ?PORT_OPTIONAL_HEADERS
                     ,values = ?NOTIFY_VALUES(<<"ported">>)

--- a/core/kazoo_data/src/kzs_util.erl
+++ b/core/kazoo_data/src/kzs_util.erl
@@ -28,6 +28,7 @@ db_classification(<<"_users">>) -> 'external';
 db_classification(<<"_dbs">>) -> 'external';
 db_classification(<<"users">>) -> 'external';
 db_classification(<<"dbs">>) -> 'external';
+db_classification(<<"_metadata">>) -> 'external';
 db_classification(<<"_nodes">>) -> 'external';
 db_classification(<<"nodes">>) -> 'external';
 db_classification(<<"_replicator">>) -> 'external';

--- a/core/kazoo_documents/src/kzd_comment.erl
+++ b/core/kazoo_documents/src/kzd_comment.erl
@@ -1,0 +1,111 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc Accessors for `comment' document.
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kzd_comment).
+
+-export([new/0]).
+-export([account_id/1, account_id/2, set_account_id/2]).
+-export([action_required/1, action_required/2, set_action_required/2]).
+-export([author/1, author/2, set_author/2]).
+-export([content/1, content/2, set_content/2]).
+-export([is_private/1, is_private/2, set_is_private/2]).
+-export([timestamp/1, timestamp/2, set_timestamp/2]).
+-export([user_id/1, user_id/2, set_user_id/2]).
+
+
+-include("kz_documents.hrl").
+
+-type doc() :: kz_json:object().
+-export_type([doc/0]).
+
+-define(SCHEMA, <<"comment">>).
+
+-spec new() -> doc().
+new() ->
+    kz_json_schema:default_object(?SCHEMA).
+
+-spec account_id(doc()) -> kz_term:api_binary().
+account_id(Doc) ->
+    account_id(Doc, 'undefined').
+
+-spec account_id(doc(), Default) -> binary() | Default.
+account_id(Doc, Default) ->
+    kz_json:get_binary_value([<<"account_id">>], Doc, Default).
+
+-spec set_account_id(doc(), binary()) -> doc().
+set_account_id(Doc, AccountId) ->
+    kz_json:set_value([<<"account_id">>], AccountId, Doc).
+
+-spec action_required(doc()) -> boolean().
+action_required(Doc) ->
+    action_required(Doc, false).
+
+-spec action_required(doc(), Default) -> boolean() | Default.
+action_required(Doc, Default) ->
+    kz_json:get_boolean_value([<<"action_required">>], Doc, Default).
+
+-spec set_action_required(doc(), boolean()) -> doc().
+set_action_required(Doc, ActionRequired) ->
+    kz_json:set_value([<<"action_required">>], ActionRequired, Doc).
+
+-spec author(doc()) -> kz_term:api_binary().
+author(Doc) ->
+    author(Doc, 'undefined').
+
+-spec author(doc(), Default) -> binary() | Default.
+author(Doc, Default) ->
+    kz_json:get_binary_value([<<"author">>], Doc, Default).
+
+-spec set_author(doc(), binary()) -> doc().
+set_author(Doc, Author) ->
+    kz_json:set_value([<<"author">>], Author, Doc).
+
+-spec content(doc()) -> kz_term:api_binary().
+content(Doc) ->
+    content(Doc, 'undefined').
+
+-spec content(doc(), Default) -> binary() | Default.
+content(Doc, Default) ->
+    kz_json:get_binary_value([<<"content">>], Doc, Default).
+
+-spec set_content(doc(), binary()) -> doc().
+set_content(Doc, Content) ->
+    kz_json:set_value([<<"content">>], Content, Doc).
+
+-spec is_private(doc()) -> boolean().
+is_private(Doc) ->
+    is_private(Doc, false).
+
+-spec is_private(doc(), Default) -> boolean() | Default.
+is_private(Doc, Default) ->
+    kz_json:get_boolean_value([<<"is_private">>], Doc, Default).
+
+-spec set_is_private(doc(), boolean()) -> doc().
+set_is_private(Doc, IsPrivate) ->
+    kz_json:set_value([<<"is_private">>], IsPrivate, Doc).
+
+-spec timestamp(doc()) -> kz_term:api_integer().
+timestamp(Doc) ->
+    timestamp(Doc, 'undefined').
+
+-spec timestamp(doc(), Default) -> integer() | Default.
+timestamp(Doc, Default) ->
+    kz_json:get_integer_value([<<"timestamp">>], Doc, Default).
+
+-spec set_timestamp(doc(), integer()) -> doc().
+set_timestamp(Doc, Timestamp) ->
+    kz_json:set_value([<<"timestamp">>], Timestamp, Doc).
+
+-spec user_id(doc()) -> kz_term:api_binary().
+user_id(Doc) ->
+    user_id(Doc, 'undefined').
+
+-spec user_id(doc(), Default) -> binary() | Default.
+user_id(Doc, Default) ->
+    kz_json:get_binary_value([<<"user_id">>], Doc, Default).
+
+-spec set_user_id(doc(), binary()) -> doc().
+set_user_id(Doc, UserId) ->
+    kz_json:set_value([<<"user_id">>], UserId, Doc).

--- a/core/kazoo_documents/src/kzd_comment.erl.src
+++ b/core/kazoo_documents/src/kzd_comment.erl.src
@@ -1,0 +1,111 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc Accessors for `comment' document.
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kzd_comment).
+
+-export([new/0]).
+-export([account_id/1, account_id/2, set_account_id/2]).
+-export([action_required/1, action_required/2, set_action_required/2]).
+-export([author/1, author/2, set_author/2]).
+-export([content/1, content/2, set_content/2]).
+-export([is_private/1, is_private/2, set_is_private/2]).
+-export([timestamp/1, timestamp/2, set_timestamp/2]).
+-export([user_id/1, user_id/2, set_user_id/2]).
+
+
+-include("kz_documents.hrl").
+
+-type doc() :: kz_json:object().
+-export_type([doc/0]).
+
+-define(SCHEMA, <<"comment">>).
+
+-spec new() -> doc().
+new() ->
+    kz_json_schema:default_object(?SCHEMA).
+
+-spec account_id(doc()) -> kz_term:api_binary().
+account_id(Doc) ->
+    account_id(Doc, 'undefined').
+
+-spec account_id(doc(), Default) -> binary() | Default.
+account_id(Doc, Default) ->
+    kz_json:get_binary_value([<<"account_id">>], Doc, Default).
+
+-spec set_account_id(doc(), binary()) -> doc().
+set_account_id(Doc, AccountId) ->
+    kz_json:set_value([<<"account_id">>], AccountId, Doc).
+
+-spec action_required(doc()) -> boolean().
+action_required(Doc) ->
+    action_required(Doc, false).
+
+-spec action_required(doc(), Default) -> boolean() | Default.
+action_required(Doc, Default) ->
+    kz_json:get_boolean_value([<<"action_required">>], Doc, Default).
+
+-spec set_action_required(doc(), boolean()) -> doc().
+set_action_required(Doc, ActionRequired) ->
+    kz_json:set_value([<<"action_required">>], ActionRequired, Doc).
+
+-spec author(doc()) -> kz_term:api_binary().
+author(Doc) ->
+    author(Doc, 'undefined').
+
+-spec author(doc(), Default) -> binary() | Default.
+author(Doc, Default) ->
+    kz_json:get_binary_value([<<"author">>], Doc, Default).
+
+-spec set_author(doc(), binary()) -> doc().
+set_author(Doc, Author) ->
+    kz_json:set_value([<<"author">>], Author, Doc).
+
+-spec content(doc()) -> kz_term:api_binary().
+content(Doc) ->
+    content(Doc, 'undefined').
+
+-spec content(doc(), Default) -> binary() | Default.
+content(Doc, Default) ->
+    kz_json:get_binary_value([<<"content">>], Doc, Default).
+
+-spec set_content(doc(), binary()) -> doc().
+set_content(Doc, Content) ->
+    kz_json:set_value([<<"content">>], Content, Doc).
+
+-spec is_private(doc()) -> boolean().
+is_private(Doc) ->
+    is_private(Doc, false).
+
+-spec is_private(doc(), Default) -> boolean() | Default.
+is_private(Doc, Default) ->
+    kz_json:get_boolean_value([<<"is_private">>], Doc, Default).
+
+-spec set_is_private(doc(), boolean()) -> doc().
+set_is_private(Doc, IsPrivate) ->
+    kz_json:set_value([<<"is_private">>], IsPrivate, Doc).
+
+-spec timestamp(doc()) -> kz_term:api_integer().
+timestamp(Doc) ->
+    timestamp(Doc, 'undefined').
+
+-spec timestamp(doc(), Default) -> integer() | Default.
+timestamp(Doc, Default) ->
+    kz_json:get_integer_value([<<"timestamp">>], Doc, Default).
+
+-spec set_timestamp(doc(), integer()) -> doc().
+set_timestamp(Doc, Timestamp) ->
+    kz_json:set_value([<<"timestamp">>], Timestamp, Doc).
+
+-spec user_id(doc()) -> kz_term:api_binary().
+user_id(Doc) ->
+    user_id(Doc, 'undefined').
+
+-spec user_id(doc(), Default) -> binary() | Default.
+user_id(Doc, Default) ->
+    kz_json:get_binary_value([<<"user_id">>], Doc, Default).
+
+-spec set_user_id(doc(), binary()) -> doc().
+set_user_id(Doc, UserId) ->
+    kz_json:set_value([<<"user_id">>], UserId, Doc).

--- a/core/kazoo_documents/src/kzd_comments.erl
+++ b/core/kazoo_documents/src/kzd_comments.erl
@@ -1,0 +1,33 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc Accessors for `comments' document.
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kzd_comments).
+
+-export([new/0]).
+-export([comments/1, comments/2, set_comments/2]).
+
+
+-include("kz_documents.hrl").
+
+-type doc() :: kz_json:object().
+-export_type([doc/0]).
+
+-define(SCHEMA, <<"comments">>).
+
+-spec new() -> doc().
+new() ->
+    kz_json_schema:default_object(?SCHEMA).
+
+-spec comments(doc()) -> kz_term:api_objects().
+comments(Doc) ->
+    comments(Doc, 'undefined').
+
+-spec comments(doc(), Default) -> kz_json:objects() | Default.
+comments(Doc, Default) ->
+    kz_json:get_list_value([<<"comments">>], Doc, Default).
+
+-spec set_comments(doc(), kz_json:objects()) -> doc().
+set_comments(Doc, Comments) ->
+    kz_json:set_value([<<"comments">>], Comments, Doc).

--- a/core/kazoo_documents/src/kzd_comments.erl.src
+++ b/core/kazoo_documents/src/kzd_comments.erl.src
@@ -1,0 +1,33 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc Accessors for `comments' document.
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kzd_comments).
+
+-export([new/0]).
+-export([comments/1, comments/2, set_comments/2]).
+
+
+-include("kz_documents.hrl").
+
+-type doc() :: kz_json:object().
+-export_type([doc/0]).
+
+-define(SCHEMA, <<"comments">>).
+
+-spec new() -> doc().
+new() ->
+    kz_json_schema:default_object(?SCHEMA).
+
+-spec comments(doc()) -> kz_term:api_objects().
+comments(Doc) ->
+    comments(Doc, 'undefined').
+
+-spec comments(doc(), Default) -> kz_json:objects() | Default.
+comments(Doc, Default) ->
+    kz_json:get_list_value([<<"comments">>], Doc, Default).
+
+-spec set_comments(doc(), kz_json:objects()) -> doc().
+set_comments(Doc, Comments) ->
+    kz_json:set_value([<<"comments">>], Comments, Doc).

--- a/core/kazoo_documents/src/kzd_port_requests.erl
+++ b/core/kazoo_documents/src/kzd_port_requests.erl
@@ -7,14 +7,18 @@
 
 -export([new/0]).
 -export([bill/1, bill/2, set_bill/2]).
+-export([bill_account_number/1, bill_account_number/2, set_bill_account_number/2]).
+-export([bill_btn/1, bill_btn/2, set_bill_btn/2]).
 -export([bill_carrier/1, bill_carrier/2, set_bill_carrier/2]).
--export([bill_extended_address/1, bill_extended_address/2, set_bill_extended_address/2]).
 -export([bill_locality/1, bill_locality/2, set_bill_locality/2]).
 -export([bill_name/1, bill_name/2, set_bill_name/2]).
+-export([bill_pin/1, bill_pin/2, set_bill_pin/2]).
 -export([bill_postal_code/1, bill_postal_code/2, set_bill_postal_code/2]).
 -export([bill_region/1, bill_region/2, set_bill_region/2]).
 -export([bill_street_address/1, bill_street_address/2, set_bill_street_address/2]).
 -export([bill_street_number/1, bill_street_number/2, set_bill_street_number/2]).
+-export([bill_street_post_dir/1, bill_street_post_dir/2, set_bill_street_post_dir/2]).
+-export([bill_street_pre_dir/1, bill_street_pre_dir/2, set_bill_street_pre_dir/2]).
 -export([bill_street_type/1, bill_street_type/2, set_bill_street_type/2]).
 -export([comments/1, comments/2, set_comments/2]).
 -export([name/1, name/2, set_name/2]).
@@ -23,12 +27,23 @@
 -export([notifications_email_send_to/1, notifications_email_send_to/2, set_notifications_email_send_to/2]).
 -export([numbers/1, numbers/2, set_numbers/2]).
 -export([number/2, number/3, set_number/3]).
--export([port_state/1, port_state/2, set_port_state/2]).
+-export([reference_number/1, reference_number/2, set_reference_number/2]).
 -export([signee_name/1, signee_name/2, set_signee_name/2]).
 -export([signing_date/1, signing_date/2, set_signing_date/2]).
 -export([transfer_date/1, transfer_date/2, set_transfer_date/2]).
+-export([winning_carrier/1, winning_carrier/2, set_winning_carrier/2]).
 
--export([port_authority/1, port_authority/2, set_port_authority/2]).
+%% Private fields
+-export([pvt_account_name/1, pvt_account_name/2, set_pvt_account_name/2]).
+-export([pvt_port_authority/1, pvt_port_authority/2, set_pvt_port_authority/2]).
+-export([pvt_port_authority_name/1, pvt_port_authority_name/2, set_pvt_port_authority_name/2]).
+-export([pvt_port_state/1, pvt_port_state/2, set_pvt_port_state/2]).
+-export([pvt_ported_numbers/1, pvt_ported_numbers/2, set_pvt_ported_numbers/2]).
+-export([pvt_sent/1, pvt_sent/2, set_pvt_sent/2]).
+-export([pvt_transitions/1, pvt_transitions/2, set_pvt_tranisitions/2]).
+
+%% Utilities
+-export([get_transition/2]).
 -export([find_port_authority/1]).
 
 
@@ -55,6 +70,30 @@ bill(Doc, Default) ->
 set_bill(Doc, Bill) ->
     kz_json:set_value([<<"bill">>], Bill, Doc).
 
+-spec bill_account_number(doc()) -> kz_term:api_binary().
+bill_account_number(Doc) ->
+    bill_account_number(Doc, 'undefined').
+
+-spec bill_account_number(doc(), Default) -> binary() | Default.
+bill_account_number(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"account_number">>], Doc, Default).
+
+-spec set_bill_account_number(doc(), binary()) -> doc().
+set_bill_account_number(Doc, BillAccountNumber) ->
+    kz_json:set_value([<<"bill">>, <<"account_number">>], BillAccountNumber, Doc).
+
+-spec bill_btn(doc()) -> kz_term:api_binary().
+bill_btn(Doc) ->
+    bill_btn(Doc, 'undefined').
+
+-spec bill_btn(doc(), Default) -> binary() | Default.
+bill_btn(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"btn">>], Doc, Default).
+
+-spec set_bill_btn(doc(), binary()) -> doc().
+set_bill_btn(Doc, BillBtn) ->
+    kz_json:set_value([<<"bill">>, <<"btn">>], BillBtn, Doc).
+
 -spec bill_carrier(doc()) -> kz_term:api_binary().
 bill_carrier(Doc) ->
     bill_carrier(Doc, 'undefined').
@@ -66,18 +105,6 @@ bill_carrier(Doc, Default) ->
 -spec set_bill_carrier(doc(), binary()) -> doc().
 set_bill_carrier(Doc, BillCarrier) ->
     kz_json:set_value([<<"bill">>, <<"carrier">>], BillCarrier, Doc).
-
--spec bill_extended_address(doc()) -> kz_term:api_binary().
-bill_extended_address(Doc) ->
-    bill_extended_address(Doc, 'undefined').
-
--spec bill_extended_address(doc(), Default) -> binary() | Default.
-bill_extended_address(Doc, Default) ->
-    kz_json:get_binary_value([<<"bill">>, <<"extended_address">>], Doc, Default).
-
--spec set_bill_extended_address(doc(), binary()) -> doc().
-set_bill_extended_address(Doc, BillExtendedAddress) ->
-    kz_json:set_value([<<"bill">>, <<"extended_address">>], BillExtendedAddress, Doc).
 
 -spec bill_locality(doc()) -> kz_term:api_binary().
 bill_locality(Doc) ->
@@ -102,6 +129,18 @@ bill_name(Doc, Default) ->
 -spec set_bill_name(doc(), binary()) -> doc().
 set_bill_name(Doc, BillName) ->
     kz_json:set_value([<<"bill">>, <<"name">>], BillName, Doc).
+
+-spec bill_pin(doc()) -> kz_term:api_binary().
+bill_pin(Doc) ->
+    bill_pin(Doc, 'undefined').
+
+-spec bill_pin(doc(), Default) -> binary() | Default.
+bill_pin(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"pin">>], Doc, Default).
+
+-spec set_bill_pin(doc(), binary()) -> doc().
+set_bill_pin(Doc, BillPin) ->
+    kz_json:set_value([<<"bill">>, <<"pin">>], BillPin, Doc).
 
 -spec bill_postal_code(doc()) -> kz_term:api_binary().
 bill_postal_code(Doc) ->
@@ -150,6 +189,30 @@ bill_street_number(Doc, Default) ->
 -spec set_bill_street_number(doc(), binary()) -> doc().
 set_bill_street_number(Doc, BillStreetNumber) ->
     kz_json:set_value([<<"bill">>, <<"street_number">>], BillStreetNumber, Doc).
+
+-spec bill_street_post_dir(doc()) -> kz_term:api_binary().
+bill_street_post_dir(Doc) ->
+    bill_street_post_dir(Doc, 'undefined').
+
+-spec bill_street_post_dir(doc(), Default) -> binary() | Default.
+bill_street_post_dir(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"street_post_dir">>], Doc, Default).
+
+-spec set_bill_street_post_dir(doc(), binary()) -> doc().
+set_bill_street_post_dir(Doc, BillStreetPostDir) ->
+    kz_json:set_value([<<"bill">>, <<"street_post_dir">>], BillStreetPostDir, Doc).
+
+-spec bill_street_pre_dir(doc()) -> kz_term:api_binary().
+bill_street_pre_dir(Doc) ->
+    bill_street_pre_dir(Doc, 'undefined').
+
+-spec bill_street_pre_dir(doc(), Default) -> binary() | Default.
+bill_street_pre_dir(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"street_pre_dir">>], Doc, Default).
+
+-spec set_bill_street_pre_dir(doc(), binary()) -> doc().
+set_bill_street_pre_dir(Doc, BillStreetPreDir) ->
+    kz_json:set_value([<<"bill">>, <<"street_pre_dir">>], BillStreetPreDir, Doc).
 
 -spec bill_street_type(doc()) -> kz_term:api_binary().
 bill_street_type(Doc) ->
@@ -247,17 +310,17 @@ number(Doc, Number, Default) ->
 set_number(Doc, Number, Value) ->
     kz_json:set_value([<<"numbers">>, Number], Value, Doc).
 
--spec port_state(doc()) -> binary().
-port_state(Doc) ->
-    port_state(Doc, <<"unconfirmed">>).
+-spec reference_number(doc()) -> kz_term:api_binary().
+reference_number(Doc) ->
+    reference_number(Doc, 'undefined').
 
--spec port_state(doc(), Default) -> binary() | Default.
-port_state(Doc, Default) ->
-    kz_json:get_binary_value([<<"port_state">>], Doc, Default).
+-spec reference_number(doc(), Default) -> binary() | Default.
+reference_number(Doc, Default) ->
+    kz_json:get_binary_value([<<"reference_number">>], Doc, Default).
 
--spec set_port_state(doc(), binary()) -> doc().
-set_port_state(Doc, PortState) ->
-    kz_json:set_value([<<"port_state">>], PortState, Doc).
+-spec set_reference_number(doc(), binary()) -> doc().
+set_reference_number(Doc, ReferenceNumber) ->
+    kz_json:set_value([<<"reference_number">>], ReferenceNumber, Doc).
 
 -spec signee_name(doc()) -> kz_term:api_binary().
 signee_name(Doc) ->
@@ -295,64 +358,210 @@ transfer_date(Doc, Default) ->
 set_transfer_date(Doc, TransferDate) ->
     kz_json:set_value([<<"transfer_date">>], TransferDate, Doc).
 
--spec port_authority(doc()) -> kz_term:api_ne_binary().
-port_authority(Doc) ->
-    port_authority(Doc, 'undefined').
+-spec winning_carrier(doc()) -> kz_term:api_binary().
+winning_carrier(Doc) ->
+    winning_carrier(Doc, 'undefined').
 
--spec port_authority(doc(), Default) -> kz_term:api_ne_binary() | Default.
-port_authority(Doc, Default) ->
+-spec winning_carrier(doc(), Default) -> binary() | Default.
+winning_carrier(Doc, Default) ->
+    kz_json:get_binary_value([<<"winning_carrier">>], Doc, Default).
+
+-spec set_winning_carrier(doc(), binary()) -> doc().
+set_winning_carrier(Doc, WinningCarrier) ->
+    kz_json:set_value([<<"winning_carrier">>], WinningCarrier, Doc).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec pvt_account_name(doc()) -> kz_term:api_ne_binary().
+pvt_account_name(Doc) ->
+    pvt_account_name(Doc, 'undefined').
+
+-spec pvt_account_name(doc(), Default) -> kz_term:ne_binary() | Default.
+pvt_account_name(Doc, Default) ->
+    kz_json:get_ne_binary_value([<<"pvt_account_name">>], Doc, Default).
+
+-spec set_pvt_account_name(doc(), kz_term:ne_binary()) -> doc().
+set_pvt_account_name(Doc, Name) ->
+    kz_json:set_value([<<"pvt_account_name">>], Name, Doc).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec pvt_port_authority(doc()) -> kz_term:api_ne_binary().
+pvt_port_authority(Doc) ->
+    pvt_port_authority(Doc, 'undefined').
+
+-spec pvt_port_authority(doc(), Default) -> kz_term:api_ne_binary() | Default.
+pvt_port_authority(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"pvt_port_authority">>], Doc, Default).
 
--spec set_port_authority(doc(), kz_term:api_binary()) -> doc().
-set_port_authority(Doc, PortAuthority) ->
+-spec set_pvt_port_authority(doc(), kz_term:api_binary()) -> doc().
+set_pvt_port_authority(Doc, PortAuthority) ->
     kz_json:set_value([<<"pvt_port_authority">>], PortAuthority, Doc).
 
--spec find_port_authority(doc()) -> kz_term:api_binary().
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec pvt_port_authority_name(doc()) -> kz_term:api_ne_binary().
+pvt_port_authority_name(Doc) ->
+    pvt_port_authority_name(Doc, 'undefined').
+
+-spec pvt_port_authority_name(doc(), Default) -> kz_term:api_ne_binary() | Default.
+pvt_port_authority_name(Doc, Default) ->
+    kz_json:get_ne_binary_value([<<"pvt_port_authority_name">>], Doc, Default).
+
+-spec set_pvt_port_authority_name(doc(), kz_term:api_binary()) -> doc().
+set_pvt_port_authority_name(Doc, PortAuthority) ->
+    kz_json:set_value([<<"pvt_port_authority_name">>], PortAuthority, Doc).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec pvt_port_state(doc()) -> kz_term:api_ne_binary().
+pvt_port_state(Doc) ->
+    pvt_port_state(Doc, 'undefined').
+
+-spec pvt_port_state(doc(), Default) -> kz_term:api_ne_binary() | Default.
+pvt_port_state(Doc, Default) ->
+    kz_json:get_ne_binary_value([<<"pvt_port_state">>], Doc, Default).
+
+-spec set_pvt_port_state(doc(), kz_term:api_binary()) -> doc().
+set_pvt_port_state(Doc, PortAuthority) ->
+    kz_json:set_value([<<"pvt_port_state">>], PortAuthority, Doc).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec pvt_ported_numbers(doc()) -> kz_term:api_object().
+pvt_ported_numbers(Doc) ->
+    pvt_ported_numbers(Doc, 'undefined').
+
+-spec pvt_ported_numbers(doc(), Default) -> kz_json:object() | Default.
+pvt_ported_numbers(Doc, Default) ->
+    kz_json:get_json_value([<<"pvt_ported_numbers">>], Doc, Default).
+
+-spec set_pvt_ported_numbers(doc(), kz_json:object()) -> doc().
+set_pvt_ported_numbers(Doc, Numbers) ->
+    kz_json:set_value([<<"pvt_ported_numbers">>], Numbers, Doc).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec pvt_sent(doc()) -> kz_term:api_boolean().
+pvt_sent(Doc) ->
+    pvt_port_state(Doc, 'undefined').
+
+-spec pvt_sent(doc(), Default) -> kz_term:api_boolean() | Default.
+pvt_sent(Doc, Default) ->
+    kz_json:get_ne_binary_value([<<"pvt_sent">>], Doc, Default).
+
+-spec set_pvt_sent(doc(), kz_term:api_boolean()) -> doc().
+set_pvt_sent(Doc, IsSent) ->
+    kz_json:set_value([<<"pvt_sent">>], IsSent, Doc).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec pvt_transitions(doc()) -> kz_term:api_objects().
+pvt_transitions(Doc) ->
+    pvt_transitions(Doc, 'undefined').
+
+-spec pvt_transitions(doc(), Default) -> kz_term:api_objects() | Default.
+pvt_transitions(Doc, Default) ->
+    kz_json:get_list_value([<<"pvt_transitions">>], Doc, Default).
+
+-spec set_pvt_tranisitions(doc(), kz_term:api_objects()) -> doc().
+set_pvt_tranisitions(Doc, Transitions) ->
+    kz_json:set_value([<<"pvt_transitions">>], Transitions, Doc).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec get_transition(doc(), kz_term:ne_binary()) -> kz_json:objects().
+get_transition(Doc, ToState) ->
+    ToStatePath = [<<"transition">>, <<"new">>],
+    [Transition
+     || Transition <- pvt_transitions(Doc, []),
+        kz_json:get_ne_binary_value(ToStatePath, Transition) =:= ToState
+    ].
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec find_port_authority(doc() | kz_term:api_ne_binary()) -> kz_term:api_ne_binary().
+find_port_authority(?NE_BINARY = AccountId) ->
+    case kapps_util:get_master_account_id() of
+        {'ok', MasterAccountId} ->
+            find_port_authority(MasterAccountId, AccountId, AccountId);
+        {'error', _} ->
+            lager:debug("failed to find port authority, master account is undefined"),
+            'undefined'
+    end;
 find_port_authority(Doc) ->
-    case port_authority(Doc) of
-        'undefined' ->
-            AccountId = kz_doc:account_id(Doc),
-            case kapps_util:get_master_account_id() of
-                {'ok', MasterAccountId} ->
-                    PortAuthority = find_port_authority(MasterAccountId, AccountId),
+    case kz_json:is_json_object(Doc) of
+        'true' ->
+            case pvt_port_authority(Doc) of
+                'undefined' ->
+                    find_port_authority(kz_doc:account_id(Doc));
+                PortAuthority ->
                     lager:debug("using account ~s as port authority", [PortAuthority]),
-                    PortAuthority;
-                {'error', _} ->
-                    lager:debug("failed to find port authority, master account is undefined"),
-                    'undefined'
+                    PortAuthority
             end;
-        PortAuthority ->
-            lager:debug("using account ~s as port authority", [PortAuthority]),
-            PortAuthority
+        'false' ->
+            'undefined'
     end.
 
--spec find_port_authority(kz_term:ne_binary(), kz_term:api_ne_binary()) -> kz_term:api_binary().
-find_port_authority(?NE_BINARY = MasterAccountId, 'undefined') ->
+-spec find_port_authority(kz_term:api_ne_binary(), kz_term:ne_binary(), kz_term:api_ne_binary()) ->
+                                 kz_term:api_binary().
+find_port_authority('undefined', _, 'undefined') ->
+    lager:debug("master and account id is undefined"),
+    'undefined';
+find_port_authority(MasterAccountId, SubmittedAccountId, 'undefined') ->
     lager:debug("account id is undefined, checking master"),
-    find_port_authority(MasterAccountId, MasterAccountId);
-find_port_authority(MasterAccountId, MasterAccountId) ->
-    case kzd_whitelabel:fetch(MasterAccountId) of
-        {'error', _R} ->
-            lager:debug("failed to find master whitelabel, assuming master is port authority"),
-            MasterAccountId;
-        {'ok', JObj} ->
-            lager:debug("checking master whitelabel port authority if defined"),
-            kzd_whitelabel:port_authority(JObj, MasterAccountId)
+    find_port_authority(MasterAccountId, SubmittedAccountId, MasterAccountId);
+find_port_authority(MasterAccountId, _, MasterAccountId) ->
+    lager:debug("using master account ~s as port authority", [MasterAccountId]),
+    MasterAccountId;
+find_port_authority(MasterAccountId, SubmittedAccountId, AccountId) ->
+    WhiteAuthority = kzd_whitelabel:fetch_port_authority(AccountId, 'undefined'),
+    find_port_authority(MasterAccountId, SubmittedAccountId, AccountId, WhiteAuthority).
+
+-spec find_port_authority(kz_term:api_ne_binary(), kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) ->
+                                 kz_term:api_binary().
+find_port_authority(MasterAccountId, SubmittedAccountId, AccountId, 'undefined') ->
+    ParentId = kzd_accounts:get_authoritative_parent_id(AccountId, MasterAccountId),
+    lager:debug("no port authority key found for ~s, checking parent ~s", [AccountId, ParentId]),
+    case ParentId of
+        AccountId ->
+            lager:debug("reached to top level account"),
+            find_port_authority(MasterAccountId, SubmittedAccountId, MasterAccountId);
+        ParentId ->
+            find_port_authority(MasterAccountId, SubmittedAccountId, ParentId)
     end;
-find_port_authority(MasterAccountId, AccountId) ->
-    case kzd_whitelabel:fetch(AccountId) of
-        {'error', _R} ->
-            ParentId = kzd_accounts:get_authoritative_parent_id(AccountId, MasterAccountId),
-            lager:debug("failed to find whitelabel for ~s, checking parent ~s", [AccountId, ParentId]),
-            find_port_authority(MasterAccountId, ParentId);
-        {'ok', JObj} ->
-            case kzd_whitelabel:port_authority(JObj) of
-                'undefined' ->
-                    ParentId = kzd_accounts:get_authoritative_parent_id(AccountId, MasterAccountId),
-                    lager:debug("undefined port authority in account ~s, checking parent ~s"
-                               ,[AccountId, ParentId]
-                               ),
-                    find_port_authority(MasterAccountId, ParentId);
-                Id -> Id
-            end
-    end.
+find_port_authority(MasterAccountId, AccountId, AccountId, AccountId) ->
+    ParentId = kzd_accounts:get_authoritative_parent_id(AccountId, MasterAccountId),
+    lager:debug("port authority is same as submitted account ~s, checking parent ~s port authority"
+               ,[AccountId, ParentId]
+               ),
+    case ParentId of
+        AccountId ->
+            lager:debug("reached to top level account"),
+            find_port_authority(MasterAccountId, AccountId, MasterAccountId);
+        ParentId ->
+            find_port_authority(MasterAccountId, AccountId, ParentId)
+    end;
+find_port_authority(MasterAccountId, SubmittedAccountId, _, MasterAccountId) ->
+    find_port_authority(MasterAccountId, SubmittedAccountId, MasterAccountId);
+find_port_authority(_, _, _, PortAuthority) ->
+    lager:debug("using account ~s as port authority", [PortAuthority]),
+    PortAuthority.

--- a/core/kazoo_documents/src/kzd_port_requests.erl.src
+++ b/core/kazoo_documents/src/kzd_port_requests.erl.src
@@ -7,14 +7,18 @@
 
 -export([new/0]).
 -export([bill/1, bill/2, set_bill/2]).
+-export([bill_account_number/1, bill_account_number/2, set_bill_account_number/2]).
+-export([bill_btn/1, bill_btn/2, set_bill_btn/2]).
 -export([bill_carrier/1, bill_carrier/2, set_bill_carrier/2]).
--export([bill_extended_address/1, bill_extended_address/2, set_bill_extended_address/2]).
 -export([bill_locality/1, bill_locality/2, set_bill_locality/2]).
 -export([bill_name/1, bill_name/2, set_bill_name/2]).
+-export([bill_pin/1, bill_pin/2, set_bill_pin/2]).
 -export([bill_postal_code/1, bill_postal_code/2, set_bill_postal_code/2]).
 -export([bill_region/1, bill_region/2, set_bill_region/2]).
 -export([bill_street_address/1, bill_street_address/2, set_bill_street_address/2]).
 -export([bill_street_number/1, bill_street_number/2, set_bill_street_number/2]).
+-export([bill_street_post_dir/1, bill_street_post_dir/2, set_bill_street_post_dir/2]).
+-export([bill_street_pre_dir/1, bill_street_pre_dir/2, set_bill_street_pre_dir/2]).
 -export([bill_street_type/1, bill_street_type/2, set_bill_street_type/2]).
 -export([comments/1, comments/2, set_comments/2]).
 -export([name/1, name/2, set_name/2]).
@@ -23,10 +27,11 @@
 -export([notifications_email_send_to/1, notifications_email_send_to/2, set_notifications_email_send_to/2]).
 -export([numbers/1, numbers/2, set_numbers/2]).
 -export([number/2, number/3, set_number/3]).
--export([port_state/1, port_state/2, set_port_state/2]).
+-export([reference_number/1, reference_number/2, set_reference_number/2]).
 -export([signee_name/1, signee_name/2, set_signee_name/2]).
 -export([signing_date/1, signing_date/2, set_signing_date/2]).
 -export([transfer_date/1, transfer_date/2, set_transfer_date/2]).
+-export([winning_carrier/1, winning_carrier/2, set_winning_carrier/2]).
 
 
 -include("kz_documents.hrl").
@@ -52,6 +57,30 @@ bill(Doc, Default) ->
 set_bill(Doc, Bill) ->
     kz_json:set_value([<<"bill">>], Bill, Doc).
 
+-spec bill_account_number(doc()) -> kz_term:api_binary().
+bill_account_number(Doc) ->
+    bill_account_number(Doc, 'undefined').
+
+-spec bill_account_number(doc(), Default) -> binary() | Default.
+bill_account_number(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"account_number">>], Doc, Default).
+
+-spec set_bill_account_number(doc(), binary()) -> doc().
+set_bill_account_number(Doc, BillAccountNumber) ->
+    kz_json:set_value([<<"bill">>, <<"account_number">>], BillAccountNumber, Doc).
+
+-spec bill_btn(doc()) -> kz_term:api_binary().
+bill_btn(Doc) ->
+    bill_btn(Doc, 'undefined').
+
+-spec bill_btn(doc(), Default) -> binary() | Default.
+bill_btn(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"btn">>], Doc, Default).
+
+-spec set_bill_btn(doc(), binary()) -> doc().
+set_bill_btn(Doc, BillBtn) ->
+    kz_json:set_value([<<"bill">>, <<"btn">>], BillBtn, Doc).
+
 -spec bill_carrier(doc()) -> kz_term:api_binary().
 bill_carrier(Doc) ->
     bill_carrier(Doc, 'undefined').
@@ -63,18 +92,6 @@ bill_carrier(Doc, Default) ->
 -spec set_bill_carrier(doc(), binary()) -> doc().
 set_bill_carrier(Doc, BillCarrier) ->
     kz_json:set_value([<<"bill">>, <<"carrier">>], BillCarrier, Doc).
-
--spec bill_extended_address(doc()) -> kz_term:api_binary().
-bill_extended_address(Doc) ->
-    bill_extended_address(Doc, 'undefined').
-
--spec bill_extended_address(doc(), Default) -> binary() | Default.
-bill_extended_address(Doc, Default) ->
-    kz_json:get_binary_value([<<"bill">>, <<"extended_address">>], Doc, Default).
-
--spec set_bill_extended_address(doc(), binary()) -> doc().
-set_bill_extended_address(Doc, BillExtendedAddress) ->
-    kz_json:set_value([<<"bill">>, <<"extended_address">>], BillExtendedAddress, Doc).
 
 -spec bill_locality(doc()) -> kz_term:api_binary().
 bill_locality(Doc) ->
@@ -99,6 +116,18 @@ bill_name(Doc, Default) ->
 -spec set_bill_name(doc(), binary()) -> doc().
 set_bill_name(Doc, BillName) ->
     kz_json:set_value([<<"bill">>, <<"name">>], BillName, Doc).
+
+-spec bill_pin(doc()) -> kz_term:api_binary().
+bill_pin(Doc) ->
+    bill_pin(Doc, 'undefined').
+
+-spec bill_pin(doc(), Default) -> binary() | Default.
+bill_pin(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"pin">>], Doc, Default).
+
+-spec set_bill_pin(doc(), binary()) -> doc().
+set_bill_pin(Doc, BillPin) ->
+    kz_json:set_value([<<"bill">>, <<"pin">>], BillPin, Doc).
 
 -spec bill_postal_code(doc()) -> kz_term:api_binary().
 bill_postal_code(Doc) ->
@@ -147,6 +176,30 @@ bill_street_number(Doc, Default) ->
 -spec set_bill_street_number(doc(), binary()) -> doc().
 set_bill_street_number(Doc, BillStreetNumber) ->
     kz_json:set_value([<<"bill">>, <<"street_number">>], BillStreetNumber, Doc).
+
+-spec bill_street_post_dir(doc()) -> kz_term:api_binary().
+bill_street_post_dir(Doc) ->
+    bill_street_post_dir(Doc, 'undefined').
+
+-spec bill_street_post_dir(doc(), Default) -> binary() | Default.
+bill_street_post_dir(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"street_post_dir">>], Doc, Default).
+
+-spec set_bill_street_post_dir(doc(), binary()) -> doc().
+set_bill_street_post_dir(Doc, BillStreetPostDir) ->
+    kz_json:set_value([<<"bill">>, <<"street_post_dir">>], BillStreetPostDir, Doc).
+
+-spec bill_street_pre_dir(doc()) -> kz_term:api_binary().
+bill_street_pre_dir(Doc) ->
+    bill_street_pre_dir(Doc, 'undefined').
+
+-spec bill_street_pre_dir(doc(), Default) -> binary() | Default.
+bill_street_pre_dir(Doc, Default) ->
+    kz_json:get_binary_value([<<"bill">>, <<"street_pre_dir">>], Doc, Default).
+
+-spec set_bill_street_pre_dir(doc(), binary()) -> doc().
+set_bill_street_pre_dir(Doc, BillStreetPreDir) ->
+    kz_json:set_value([<<"bill">>, <<"street_pre_dir">>], BillStreetPreDir, Doc).
 
 -spec bill_street_type(doc()) -> kz_term:api_binary().
 bill_street_type(Doc) ->
@@ -244,17 +297,17 @@ number(Doc, Number, Default) ->
 set_number(Doc, Number, Value) ->
     kz_json:set_value([<<"numbers">>, Number], Value, Doc).
 
--spec port_state(doc()) -> binary().
-port_state(Doc) ->
-    port_state(Doc, <<"unconfirmed">>).
+-spec reference_number(doc()) -> kz_term:api_binary().
+reference_number(Doc) ->
+    reference_number(Doc, 'undefined').
 
--spec port_state(doc(), Default) -> binary() | Default.
-port_state(Doc, Default) ->
-    kz_json:get_binary_value([<<"port_state">>], Doc, Default).
+-spec reference_number(doc(), Default) -> binary() | Default.
+reference_number(Doc, Default) ->
+    kz_json:get_binary_value([<<"reference_number">>], Doc, Default).
 
--spec set_port_state(doc(), binary()) -> doc().
-set_port_state(Doc, PortState) ->
-    kz_json:set_value([<<"port_state">>], PortState, Doc).
+-spec set_reference_number(doc(), binary()) -> doc().
+set_reference_number(Doc, ReferenceNumber) ->
+    kz_json:set_value([<<"reference_number">>], ReferenceNumber, Doc).
 
 -spec signee_name(doc()) -> kz_term:api_binary().
 signee_name(Doc) ->
@@ -291,3 +344,15 @@ transfer_date(Doc, Default) ->
 -spec set_transfer_date(doc(), integer()) -> doc().
 set_transfer_date(Doc, TransferDate) ->
     kz_json:set_value([<<"transfer_date">>], TransferDate, Doc).
+
+-spec winning_carrier(doc()) -> kz_term:api_binary().
+winning_carrier(Doc) ->
+    winning_carrier(Doc, 'undefined').
+
+-spec winning_carrier(doc(), Default) -> binary() | Default.
+winning_carrier(Doc, Default) ->
+    kz_json:get_binary_value([<<"winning_carrier">>], Doc, Default).
+
+-spec set_winning_carrier(doc(), binary()) -> doc().
+set_winning_carrier(Doc, WinningCarrier) ->
+    kz_json:set_value([<<"winning_carrier">>], WinningCarrier, Doc).

--- a/core/kazoo_documents/src/kzd_users.erl
+++ b/core/kazoo_documents/src/kzd_users.erl
@@ -69,6 +69,9 @@
 -export([name/1]).
 -export([is_account_admin/1, is_account_admin/2]).
 -export([classifier_restriction/2, classifier_restriction/3, set_classifier_restriction/3]).
+-export([full_name/1, full_name/2]).
+
+-export([full_name/3]).
 
 -include("kz_documents.hrl").
 
@@ -948,3 +951,21 @@ set_classifier_restriction(Doc, Classifier, Action) ->
     set_call_restriction(Doc
                         ,kz_json:set_value([Classifier, <<"action">>], Action, Restrictions)
                         ).
+
+-spec full_name(kz_json:object()) -> kz_term:api_ne_binary().
+full_name(Doc) ->
+    full_name(Doc, 'undefined').
+
+-spec full_name(kz_json:object(), Default) -> kz_term:api_ne_binary() | Default.
+full_name(Doc, Default) ->
+    full_name(first_name(Doc), last_name(Doc), Default).
+
+-spec full_name(kz_term:api_binary(), kz_term:api_binary(), Default) -> kz_term:ne_binary() | Default.
+full_name(?NE_BINARY = First, ?NE_BINARY = Last, _) ->
+    <<First/binary, " ", Last/binary>>;
+full_name(_, ?NE_BINARY = Last, _) ->
+    <<Last/binary>>;
+full_name(?NE_BINARY = First, _, _) ->
+    <<First/binary>>;
+full_name(_, _, Default) ->
+    Default.

--- a/core/kazoo_number_manager/priv/couchdb/views/port_requests.json
+++ b/core/kazoo_number_manager/priv/couchdb/views/port_requests.json
@@ -17,6 +17,14 @@
                 "}"
             ]
         },
+        "agent_listing_by_state": {
+            "map": [
+                "function(doc) {",
+                "    if (doc.pvt_type != 'port_request' || doc.pvt_deleted) return;",
+                "    emit([doc.pvt_port_authority, doc.pvt_port_state, doc.pvt_modified], null);",
+                "}"
+            ]
+        },
         "all_port_in_numbers": {
             "map": [
                 "function(doc) {",

--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -60,6 +60,8 @@
         ]).
 -export([ensure_adminonly_features_are_reachable/0]).
 
+-export([migrate_port_requests/0]).
+
 -define(TIME_BETWEEN_ACCOUNTS_MS
        ,kapps_config:get_pos_integer(?KNM_CONFIG_CAT, <<"time_between_accounts_ms">>, ?MILLISECONDS_IN_SECOND)).
 
@@ -1022,3 +1024,7 @@ ensure_adminonly_features_are_reachable() ->
 migrate_carrier_module_settings() ->
     %% carrier modules needing to migrate settings
     knm_vitelity_util:migrate().
+
+-spec migrate_port_requests() -> 'ok'.
+migrate_port_requests() ->
+    knm_port_request:migrate().

--- a/core/kazoo_number_manager/src/knm.hrl
+++ b/core/kazoo_number_manager/src/knm.hrl
@@ -1,6 +1,6 @@
 -ifndef(KNM_HRL).
 -include_lib("kazoo_stdlib/include/kz_databases.hrl").
--include("knm_phone_number.hrl").
+-include_lib("kazoo_number_manager/include/knm_phone_number.hrl").
 
 -define(APP, 'kazoo_number_manager').
 -define(APP_VERSION, <<"4.0.0">>).

--- a/core/kazoo_proper/src/pqc_cb_comments.erl
+++ b/core/kazoo_proper/src/pqc_cb_comments.erl
@@ -1,0 +1,45 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_comments).
+
+%% Manual testing
+-export([seq/0
+        ]).
+
+%% API Shims
+
+-include_lib("proper/include/proper.hrl").
+-include("kazoo_proper.hrl").
+
+
+-spec seq() -> 'ok'.
+seq() ->
+    API = init_api(),
+    ?INFO("API ~p~n~n", [API]).
+
+init_api() ->
+    Model = initial_state(),
+    pqc_kazoo_model:api(Model).
+
+-spec initial_state() -> pqc_kazoo_model:model().
+initial_state() ->
+    _ = init_system(),
+    API = pqc_cb_api:authenticate(),
+    pqc_kazoo_model:new(API).
+
+init_system() ->
+    TestId = kz_binary:rand_hex(5),
+    kz_util:put_callid(TestId),
+
+    _ = kz_data_tracing:clear_all_traces(),
+    _ = [kapps_controller:start_app(App) ||
+            App <- ['crossbar']
+        ],
+    _ = [crossbar_maintenance:start_module(Mod) ||
+            Mod <- ['cb_cdrs']
+        ],
+
+    ?INFO("INIT FINISHED").

--- a/core/kazoo_proper/src/pqc_cb_port_requests.erl
+++ b/core/kazoo_proper/src/pqc_cb_port_requests.erl
@@ -1,0 +1,439 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_port_requests).
+
+%% Manual testing
+-export([seq/0
+        ,cleanup/0
+
+        ,test/0
+        ]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("kazoo_proper.hrl").
+-include_lib("kazoo_number_manager/include/knm_port_request.hrl").
+
+-define(ACCOUNTS_SETTINGS
+       ,#{<<"pqc_ports_normal">> => #{<<"numbers">> => [<<"+13335551234">>]
+                                     ,<<"parent_account">> => master
+                                     ,<<"port_authority">> => master
+                                     }
+         ,<<"pqc_ports_authority">> => #{<<"numbers">> => [<<"+13335554567">>]
+                                        ,<<"is_port_authority">> => true
+                                        ,<<"parent_account">> => master
+                                        ,<<"port_authority">> => master
+                                        }
+         ,<<"pqc_ports_sub01">> => #{<<"numbers">> => [<<"+13335554321">>]
+                                    ,<<"parent_account">> => <<"pqc_ports_authority">>
+                                    ,<<"port_authority">> => <<"pqc_ports_authority">>
+                                    }
+         }
+       ).
+
+%% sort child first
+-define(ACCOUNT_NAMES
+       ,[<<"pqc_ports_normal">>
+        ,<<"pqc_ports_sub01">>
+        ,<<"pqc_ports_authority">>
+        ]
+       ).
+
+-define(NUMBERS, (maps:fold(fun(_, #{<<"numbers">> := Nums}, Acc) -> Acc ++ Nums end
+                           ,[]
+                           ,?ACCOUNTS_SETTINGS
+                           )
+                 )
+       ).
+
+-type state() :: map().
+
+%%------------------------------------------------------------------------------
+%% @doc Required for complinig and passing edocification.
+%%
+%% This function is required because EUnit is adding this function autmatically
+%% if it is _not_ defined using parse transform.
+%%
+%% Also our Makefile is required spec for exported function and this automatically
+%% added function by EUnit doesn't have spec, make this module not compilable.
+%% @end
+%%------------------------------------------------------------------------------
+-spec test() -> any().
+test() ->
+    eunit:test(?MODULE).
+
+-spec seq() -> any().
+seq() ->
+    _ = init_system(),
+    eunit:test([{'setup'
+                ,fun initial_state/0
+                ,fun cleanup/1
+                ,fun all_port_seq/1
+                }
+               ], [verbose]).
+
+-spec init_system() -> 'ok'.
+init_system() ->
+    _ = kz_data_tracing:clear_all_traces(),
+    _ = [kapps_controller:start_app(App) ||
+            App <- ['crossbar', 'teletype']
+        ],
+    _ = [crossbar_maintenance:start_module(Mod) ||
+            Mod <- ['cb_port_requests'
+                   ,'cb_whitelabel'
+                   ,'cb_comments'
+                   ]
+        ],
+    'ok'.
+
+-spec initial_state() -> state().
+initial_state() ->
+    TestId = kz_binary:rand_hex(16),
+    kz_util:put_callid(TestId),
+
+    API = pqc_cb_api:authenticate(),
+    State = #{master => #{model => pqc_kazoo_model:new(API)
+                         ,account_id => pqc_cb_api:auth_account_id(API)
+                         ,account_name => kzd_accounts:fetch_name(pqc_cb_api:auth_account_id(API))
+                         }
+             },
+
+    try
+        lists:foldl(fun(Name, Acc) -> initialize_account(API, Name, Acc) end
+                   ,State
+                   ,lists:reverse(?ACCOUNT_NAMES)
+                   )
+    catch
+        _R:_T ->
+            ?debugFmt("exception ~p:~p", [_R, _T]),
+            kz_util:log_stacktrace(),
+            cleanup(State),
+            throw(failed)
+    end.
+
+-spec initialize_account(pqc_cb_api:state(), kz_term:ne_binary(), state()) -> state().
+initialize_account(API, AccountName, StateAcc) ->
+    Account = create_account(API, AccountName, StateAcc),
+    true = kz_term:is_ne_binary(Account),
+
+    AccountJObj = pqc_cb_response:data(Account),
+    AccountId = kz_doc:id(AccountJObj),
+    ?debugFmt("created account ~s(~s)", [AccountName, AccountId]),
+
+    _ = timer:sleep(500), %% too fast for kazoo
+    IsAuthority = maps:get(<<"is_port_authority">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS), false),
+    Whitelabel = create_whitelabel(API, AccountId, AccountName, IsAuthority),
+    true = kz_term:is_ne_binary(Whitelabel),
+
+    UserResp = create_admin_user(API, AccountId, AccountName),
+    true = kz_term:is_ne_binary(UserResp),
+    User = pqc_cb_response:data(UserResp),
+
+    AccountApi = pqc_cb_api:authenticate(kzd_accounts:name(AccountJObj)
+                                        ,kzd_users:username(User)
+                                        ,<<"qwerty">>
+                                        ),
+    _ = timer:sleep(500), %% too fast for kazoo
+    StateAcc#{AccountName => #{model => pqc_kazoo_model:new(AccountApi)
+                              ,account_id => AccountId
+                              ,account_name => AccountName
+                              ,admin => User
+                              }
+             }.
+
+-spec create_account(pqc_cb_api:state(), kz_term:ne_binary(), state()) -> pqc_cb_api:response().
+create_account(API, AccountName, State) ->
+    ParentName = maps:get(<<"parent_account">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS)),
+    AccountId = maps:get(account_id, maps:get(ParentName, State)),
+    pqc_cb_accounts:create_account(API, AccountName, AccountId).
+
+-spec create_admin_user(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+create_admin_user(API, AccountId, AccountName) ->
+    Email = <<"admin@", AccountName/binary, ".com">>,
+    Setters = [{fun kzd_users:set_first_name/2, <<AccountName/binary, "-admin">>}
+              ,{fun kzd_users:set_last_name/2, <<"LastName">>}
+              ,{fun kzd_users:set_email/2, Email}
+              ,{fun kzd_users:set_username/2, Email}
+              ,{fun kzd_users:set_priv_level/2, <<"admin">>}
+              ,{fun kzd_users:set_password/2, <<"qwerty">>}
+              ],
+    Envelope =
+        pqc_cb_api:create_envelope(
+          kz_json:set_value(<<"send_email_on_creation">>
+                           ,false
+                           ,kz_doc:setters(kzd_users:new(), Setters)
+                           )
+         ),
+
+    Url = string:join([pqc_cb_accounts:account_url(AccountId), "users"], "/"),
+    pqc_cb_api:make_request([201]
+                           ,fun kz_http:put/3
+                           ,Url
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec create_whitelabel(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), boolean()) ->
+                               pqc_cb_api:response().
+create_whitelabel(_, _, _, 'false') ->
+    <<"no whitelable for you">>;
+create_whitelabel(API, AccountId, AccountName, 'true') ->
+    Setters = [{fun kzd_whitelabel:set_port_authority/2, AccountId}
+              ,{fun kzd_whitelabel:set_port_support_email/2, <<"port_agent@", AccountName/binary, ".com">>}
+              ],
+    pqc_cb_whitelabel:create_whitelabel(API, Setters).
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    cleanup(pqc_cb_api:authenticate()).
+
+-spec cleanup(state()) -> 'ok'.
+cleanup(#{master := #{model := Model}}) ->
+    cleanup(pqc_kazoo_model:api(Model));
+cleanup(API) ->
+    ?debugFmt("do cleanup, okay?", []),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _ = cleanup_port_requests_db(),
+    _ = pqc_cb_api:cleanup(API),
+    'ok'.
+
+-spec cleanup_port_requests_db() -> 'ok'.
+cleanup_port_requests_db() ->
+    ViewOptions = [{'keys', ?NUMBERS}],
+    case kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB, <<"port_requests/listing_by_number">>, ViewOptions) of
+        {'ok', []} -> ok;
+        {'ok', Ports} ->
+            Ids = [kz_doc:id(P) || P <- Ports],
+            ?debugFmt("deleting ~p", [Ids]),
+            {ok, Result} = kz_datamgr:del_docs(?KZ_PORT_REQUESTS_DB, Ids),
+            _ = kz_datamgr:flush_cache_docs(?KZ_PORT_REQUESTS_DB),
+            _ = [?debugFmt("unabled to delete ~s: ~p", [kz_doc:id(Res), kz_json:get_value(<<"error">>, Res)])
+                 || Res <- Result,
+                    kz_term:is_ne_binary(kz_json:get_ne_binary_value(<<"error">>, Res))
+                ],
+            'ok';
+        {'error', _R} ->
+            ?debugFmt("uanbled to delete port requests: ~p", [_R])
+    end.
+
+-spec all_port_seq(state()) -> term().
+all_port_seq(State) ->
+    [{"creating ports", create_ports_seq(State)}
+    ,{"test agent port api", port_agent_seq(State)}
+    ,{"test account port api", port_account_seq(State)}
+    ,{"test descendants port api", port_descendants_seq(State)}
+    ].
+
+-spec create_ports_seq(state()) -> term().
+create_ports_seq(State) ->
+    [create_ports_seq(State, AccountName)
+     || AccountName <- ?ACCOUNT_NAMES
+    ].
+
+-spec create_ports_seq(state(), kz_term:ne_binary()) -> term().
+create_ports_seq(State, AccountName) ->
+    Model = maps:get(model, maps:get(AccountName, State)),
+    API = pqc_kazoo_model:api(Model),
+
+    Created = create_port(API, AccountName),
+
+    [{"creating ports for '" ++ kz_term:to_list(AccountName) ++ "'"
+     ,?IF(kz_term:is_ne_binary(Created), create_ports_seq(State, AccountName, Created), ?_assert(false))
+     }
+    ].
+
+-spec create_ports_seq(state(), kz_term:ne_binary(), pqc_cb_api:response()) -> term().
+create_ports_seq(State, AccountName, Resp) ->
+    WhoIsPortAuthority = maps:get(<<"port_authority">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS)),
+    AuthorityId = maps:get(account_id, maps:get(WhoIsPortAuthority, State)),
+    AuthorityName = maps:get(account_name, maps:get(WhoIsPortAuthority, State)),
+
+    JObj = pqc_cb_response:data(Resp),
+    ReadOnly = kz_json:get_json_value(<<"_read_only">>, JObj, kz_json:new()),
+    PortId = kz_doc:id(JObj),
+
+    [{"port id '" ++ kz_term:to_list(PortId) ++ "'"
+     ,?_assert(kz_term:is_ne_binary(PortId))
+     }
+    ,{"checking state"
+     ,?_assertEqual(?PORT_UNCONFIRMED, kz_json:get_ne_binary_value(<<"port_state">>, JObj))
+     }
+    ,{"account name"
+     ,?_assertEqual(AccountName, kz_json:get_ne_binary_value(<<"account_name">>, ReadOnly))
+     }
+    ,{"authority id"
+     ,?_assertEqual(AuthorityId, kz_json:get_ne_binary_value(<<"port_authority">>, ReadOnly))
+     }
+    ,{"authority name '" ++ kz_term:to_list(AuthorityName) ++ "'"
+     ,?_assertEqual(AuthorityName, kz_json:get_ne_binary_value(<<"port_authority_name">>, ReadOnly))
+     }
+    ].
+
+-spec port_agent_seq(state()) -> term().
+port_agent_seq(State) ->
+    [{"listing test", port_agent_list_seq(State)}
+    ].
+
+-spec port_agent_list_seq(state()) -> term().
+port_agent_list_seq(State) ->
+    self_list_seq(State, <<"pqc_ports_authority">>).
+
+-spec self_list_seq(state(), kz_term:ne_binary()) -> term().
+self_list_seq(State, AccountName) ->
+    [{'setup'
+     ,fun() ->
+              #{model := Model} = maps:get(AccountName, State),
+              list_account_ports(pqc_kazoo_model:api(Model))
+      end
+     ,fun(Fetched) ->
+              [{"non-empty result", ?_assert(kz_term:is_ne_binary(Fetched))}
+              ,?IF(kz_term:is_ne_binary(Fetched)
+                  ,self_list_seq(State, AccountName, Fetched)
+                  ,[]
+                  )
+              ]
+      end
+     }
+    ].
+
+-spec self_list_seq(state(), kz_term:ne_binary(), pqc_cb_api:response()) -> term().
+self_list_seq(State, AccountName, Resp) ->
+    WhoIsPortAuthority = maps:get(<<"port_authority">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS)),
+    AuthorityId = maps:get(account_id, maps:get(WhoIsPortAuthority, State)),
+    AuthorityName = maps:get(account_name, maps:get(WhoIsPortAuthority, State)),
+
+    PortNumbers = maps:get(<<"numbers">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS)),
+
+    JObj = pqc_cb_response:data(Resp),
+    AccountList = [Acc || Acc <- JObj,
+                          kz_json:get_value(<<"account_name">>, Acc) =:= AccountName
+                  ],
+    [[{"account '"++ kz_term:to_list(AccountName) ++ "' has ports"
+      ,?_assert(kz_term:is_not_empty(kz_json:get_list_value(<<"port_requests">>, hd(AccountList), [])))
+      }
+      | [{"has port for '" ++ kz_term:to_list(Num) ++ "'"
+         ,?_assert(kz_term:is_not_empty([N || A <- AccountList,
+                                              Ps <- kz_json:get_value(<<"port_requests">>, A),
+                                              N <- kz_json:get_keys(kzd_port_requests:numbers(Ps, kz_json:new())),
+                                              N =:= Num
+                                        ])
+                  )
+         }
+         || Num <- PortNumbers
+        ]
+     ]
+     | [[{"authority id '" ++ kz_term:to_list(AuthorityId) ++ "'"
+         ,?_assertEqual(AuthorityId, kz_json:get_value([<<"_read_only">>, <<"port_authority">>], Port))
+         }
+        ,{"authority name '" ++ kz_term:to_list(AuthorityName) ++ "'"
+         ,?_assertEqual(AuthorityName, kz_json:get_value([<<"_read_only">>, <<"port_authority_name">>], Port))
+         }
+        ]
+        || AccountPorts <- JObj,
+           Port <- kz_json:get_list_value(<<"port_requests">>, AccountPorts, [])
+       ]
+    ].
+
+-spec port_account_seq(state()) -> term().
+port_account_seq(#{master := #{model := Model}}) ->
+    API = pqc_kazoo_model:api(Model),
+    [{"get master's account ports"
+     ,?_assertEqual(true, have_ports(list_account_ports(API)))
+     }
+    ].
+
+-spec port_descendants_seq(state()) -> term().
+port_descendants_seq(#{master := #{model := Model}}) ->
+    API = pqc_kazoo_model:api(Model),
+    [{"get all master account descendants's ports"
+     ,?_assertEqual(true, have_ports(list_descendants_ports(API)))
+     }
+    ].
+
+-spec have_ports(pqc_cb_api:response()) -> boolean().
+have_ports({error, Error}) ->
+    ?debugFmt("we have some rror:~n~p~n", [Error]),
+    false;
+have_ports(Resp) ->
+    JObj = kz_json:decode(Resp),
+    kz_json:get_ne_binary_value(<<"status">>, JObj, <<"error">>) =/= <<"error">>
+        andalso is_list(kz_json:get_list_value(<<"data">>, JObj)).
+
+%% -spec ports_agent_url() -> string().
+%% ports_agent_url() ->
+%%     string:join([pqc_cb_api:v2_base_url(), "port_requests"], "/").
+
+-spec ports_account_url(string() | kz_term:ne_binary()) -> string().
+ports_account_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "port_requests"], "/").
+
+-spec ports_descendants_url(string() | kz_term:ne_binary()) -> string().
+ports_descendants_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "descendants", "port_requests"], "/").
+
+-spec create_port(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+create_port(API, AccountName) ->
+    AccountId = pqc_cb_api:auth_account_id(API),
+    Envelope = pqc_cb_api:create_envelope(seed_ports(AccountName)),
+
+    pqc_cb_api:make_request([201]
+                           ,fun kz_http:put/3
+                           ,ports_account_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+%% -spec list_agent_ports(pqc_cb_api:state()) -> pqc_cb_api:response().
+%% list_agent_ports(API) ->
+%%     pqc_cb_api:make_request([#{'response_codes' => [200]}]
+%%                            ,fun kz_http:get/2
+%%                            ,ports_agent_url()
+%%                            ,pqc_cb_api:request_headers(API)
+%%                            ).
+
+-spec list_account_ports(pqc_cb_api:state()) -> pqc_cb_api:response().
+list_account_ports(API) ->
+    pqc_cb_api:make_request([#{'response_codes' => [200]}]
+                           ,fun kz_http:get/2
+                           ,ports_account_url(pqc_cb_api:auth_account_id(API))
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec list_descendants_ports(pqc_cb_api:state()) -> pqc_cb_api:response().
+list_descendants_ports(API) ->
+    pqc_cb_api:make_request([#{'response_codes' => [200]}]
+                           ,fun kz_http:get/2
+                           ,ports_descendants_url(pqc_cb_api:auth_account_id(API))
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec seed_ports(kz_term:ne_binary()) -> kz_json:object().
+seed_ports(AccountName) ->
+    Rand = kz_binary:rand_hex(1),
+    PortName = <<AccountName/binary, "-", Rand/binary>>,
+    SendTo = <<PortName/binary, "@", AccountName/binary, ".com">>,
+
+    Numbers = kz_json:from_list([{Num, kz_json:new()}
+                                 || Num <- maps:get(<<"numbers">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS))
+                                ]),
+
+    Setters = [{fun kzd_port_requests:set_bill_account_number/2, <<"Seed">>}
+              ,{fun kzd_port_requests:set_bill_btn/2, <<"+15559993232">>}
+              ,{fun kzd_port_requests:set_bill_carrier/2, <<"Hello">>}
+              ,{fun kzd_port_requests:set_bill_locality/2, <<"CA">>}
+              ,{fun kzd_port_requests:set_bill_name/2, <<"Seed">>}
+              ,{fun kzd_port_requests:set_bill_pin/2, <<"1234">>}
+              ,{fun kzd_port_requests:set_bill_postal_code/2, <<"11111">>}
+              ,{fun kzd_port_requests:set_bill_street_address/2, <<"Somewhere">>}
+              ,{fun kzd_port_requests:set_bill_street_number/2, <<"1">>}
+              ,{fun kzd_port_requests:set_bill_street_type/2, <<"Freeway">>}
+              ,{fun kzd_port_requests:set_name/2, PortName}
+              ,{fun kzd_port_requests:set_notifications_email_send_to/2, SendTo}
+              ,{fun kzd_port_requests:set_numbers/2, Numbers}
+              ,{fun kzd_port_requests:set_signee_name/2, <<"kazoo_proper">>}
+              ,{fun kzd_port_requests:set_signing_date/2, kz_time:now_s()}
+              ,{fun kzd_port_requests:set_transfer_date/2, kz_time:now_s() + (10 * ?SECONDS_IN_DAY)}
+              ],
+    kz_doc:setters(kz_json:new(), Setters).

--- a/core/kazoo_proper/src/pqc_cb_whitelabel.erl
+++ b/core/kazoo_proper/src/pqc_cb_whitelabel.erl
@@ -1,0 +1,27 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_whitelabel).
+
+%% Manual testing
+-export([create_whitelabel/2
+        ]).
+
+-include("kazoo_proper.hrl").
+
+
+-spec create_whitelabel(pqc_cb_api:state(), kz_doc:setter_funs()) -> pqc_cb_api:response().
+create_whitelabel(API, Setters) ->
+    Envelope = pqc_cb_api:create_envelope(kz_doc:setters(kz_json:new(), Setters)),
+    pqc_cb_api:make_request([201]
+                           ,fun kz_http:put/3
+                           ,whitelabel_url(pqc_cb_api:auth_account_id(API))
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec whitelabel_url(string() | kz_term:ne_binary()) -> string().
+whitelabel_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "whitelabel"], "/").

--- a/rel/ci.relx.config.script
+++ b/rel/ci.relx.config.script
@@ -20,13 +20,15 @@ ToFilterOut = [rabbitmq_codegen
 Preparer = fun (List) -> [{E,load} || E <- List, not lists:member(E, ToFilterOut)] end,
 Base = [tools
        ,sasl
+       ,eunit
+       ,common_test
        ],
 
 BASE = [{default_release, {kazoo, VSN}}
        ,{release, {kazoo, VSN}
        ,Base ++ Preparer(Apps ++ Core ++ Deps)
        }],
-       
+
 APPS = [begin
           {ok, [{application, App, Settings}]} = file:consult(list_to_binary(["applications/", atom_to_list(App), "/ebin/", atom_to_list(App), ".app"])),
           AppDeps = proplists:get_value(applications, Settings, []),

--- a/rel/dev.relx.config.script
+++ b/rel/dev.relx.config.script
@@ -32,13 +32,15 @@ Base = [runtime_tools
        ,observer
        ,debugger
        ,sasl
+       ,eunit
+       ,common_test
        ],
 
 BASE = [{default_release, {kazoo, VSN}}
        ,{release, {kazoo, VSN}
        ,Base ++ Preparer(Apps ++ Core ++ Deps)
        }],
-       
+
 APPS = [begin
           {ok, [{application, App, Settings}]} = file:consult(list_to_binary(["applications/", atom_to_list(App), "/ebin/", atom_to_list(App), ".app"])),
           AppDeps = proplists:get_value(applications, Settings, []),


### PR DESCRIPTION
### Updated description

* Add commentor info (account_id, user_id, first/last name, author name) if any
* try to use `kzd_port_requests` accessors everywhere
* add almost all public fields to `kzd_port_requests`
* add private accessros to `kzd_port_requests`

### PORT-3 ###

* Don't send to phonebook if not port_authority of the port requests is not master.

### PORT-4 ###

1. Changes for port requests crossbar:
    * Listing by agent (port authority view), account and descendants
    * Add `port_requests/agent_listing_by_state` view to list ports by their `port_authority`
    * Change `kzd_port_requests:find_port_authority/1` to find first account with `port_authority` defined in their whitelabel document. If this port_authority is the same as port's `pvt_account_id` find port  authority of the `pvt_account_id`'s parent.
    * Rename `superduper_comment` to `is_private`
    * Check  if the commenter is port authority or not, and if not don't allow them to view or write private comment.
    * Don't allow to set `action_required` if comment is not private
    * Remove `/port_requests/{PORT_STATES}`, use `/port_requests?by_types=` instead
    * Change: add schemas for comments and comment.
    * Re-organize code for `cb_port_quests`
    * Handle private comment and action_required for both POST and PATCH in `cb_port_requests`
3. Other files:
    * `kapi_notifications`: add `Version` to all port notification AMQP message to make it writing less code for sending easier
    * `kapi_notifications`: add port request id to required headers for all ports notify.
    * `kzd_users`: add `full_name/1,2,3` to get full name based on first/last name if defined and non empty.
    * `crossbar_services`: Add user's full name to services audit log
    * `teletype`: set port_authority id in macros, use `kzd_users:full_name`

### PORT-5 ###

Kazoo number manager changes:

* Add `port_authority` (both account id and name) to port's doc.
* Add full name of the authenticated user to state transition
* Add port authority (id and name) to public fields as `_read_only`

### PORT-6 ###

* remove public fields before saving
* DO NOT USE `port_state` key, use `pvt_` version
* removed unused/unneeded/should_not_be_used `port_state` from schema

### PORT-8

in `cb_alerts`:

* get only current account active ports
* show full object of transition and comment
* filter private comments before getting last comment

### PORT-9

In PATCH for state transitioning, `cb_port_requests` checks if the requestor is port authority or superduper, if not checks if the submitter can move:

* to state unconfirmed (should we check previous state?): moves only if auth account id is:
    * port authority
    * matches pvt_account_id of port doc
    * is reseller of the port request account
    * is superduper
* to state submitted (should we check previous state?): moves only if auth account id is:
    * port authority
    * matches pvt_account_id of port doc
    * is reseller of the port request account
    * is superduper
* to state cancel only if previous state is unconfirmed and only if auth account id is:
    * port authority
    * matches pvt_account_id of port doc
    * is reseller of the port request account
    * is superduper
* to other states: : moves only if auth account id is:
    * port authority
    * is superduper

### PORT-14 ###

* add maintenance command to knm_port_requests to update port request docs
    * add `pvt_port authority` and `pvt_port_authority_name`
    * add `pvt_account_name`
    * rename `superduper_comment` to `is_private`