### PR TITLE
[master] don't log json response, it breaks log and shell

### DIFF
--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -1563,7 +1563,6 @@ maybe_set_pull_response_stream({FileLength, TransportFun}, Req, Context)
     lager:debug("streaming file"),
     {{'stream', FileLength, TransportFun}, Req, Context};
 maybe_set_pull_response_stream(Other, Req, Context) ->
-    lager:debug("pull response: ~s", [Other]),
     {Other, Req, Context}.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
Don't log JSON response from crossbar, if the text has unicode or something that shell/log cannot show/print it breaks the shell.