### PR TITLE
[4.3] kazoo_speech: Added support for empty ASR responce. (#5538)

### DIFF
--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -383,8 +383,11 @@ maybe_transcribe(Db, MediaDoc, Bin, ContentType) ->
                                   ,kz_json:get_value(<<"text">>, Resp)
                                   ,Resp
                                   );
-        {'error', _E} ->
-            lager:info("error transcribing: ~p", [_E]),
+        {'error', ErrorCode} ->
+            lager:info("error transcribing: ~p", [ErrorCode]),
+            'undefined';
+        {'error', ErrorCode, Description} ->
+            lager:info("error transcribing: ~p, ~p", [ErrorCode, Description]),
             'undefined'
     end.
 


### PR DESCRIPTION
kazoo_voicemail: Fixed crash when ASR recognition is failed

kazoo_speech: Removed from logs  Google API key exposing

(cherry picked from commit 0d058db5b228ec32e26919523a144b1e78db597b)