### PR TITLE
[master]  git is being silly about trailing slash

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -105,7 +105,7 @@ dep_parse_trans = git https://github.com/lazedo/parse_trans
 
 dep_horse = git https://github.com/ninenines/horse
 
-dep_proper = git https://github.com/proper-testing/proper/ v1.3
+dep_proper = git https://github.com/proper-testing/proper v1.3
 
 dep_syslog = git https://github.com/2600hz/erlang-syslog bbad537a1cb5e4f37e672d2e2665659e850662d0
 


### PR DESCRIPTION
it is git version 2.11.0, it is silly.