### PR TITLE
PISTON-695: shared ringback set btwn ecallmgr_fs_transfer/bridge

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_bridge.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_bridge.erl
@@ -34,7 +34,7 @@ call_command(Node, UUID, JObj) ->
 
             {'ok', Channel} = ecallmgr_fs_channel:fetch(UUID, 'record'),
 
-            _ = handle_ringback(Node, UUID, JObj),
+            ecallmgr_call_command:set_ringback(Node, UUID, JObj),
             _ = maybe_early_media(Node, UUID, JObj, Endpoints),
             _ = maybe_b_leg_events(Node, UUID, JObj),
             BridgeJObj = add_endpoints_channel_actions(Node, UUID, JObj),
@@ -79,23 +79,6 @@ unbridge(UUID, JObj) ->
 %% @doc Bridge command helpers
 %% @end
 %%------------------------------------------------------------------------------
--spec handle_ringback(atom(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
-handle_ringback(Node, UUID, JObj) ->
-    case kz_json:get_first_defined([<<"Ringback">>
-                                   ,[<<"Custom-Channel-Vars">>, <<"Ringback">>]
-                                   ]
-                                  ,JObj
-                                  )
-    of
-        'undefined' ->
-            {'ok', Default} = ecallmgr_util:get_setting(<<"default_ringback">>),
-            ecallmgr_fs_command:set(Node, UUID, [{<<"ringback">>, kz_term:to_binary(Default)}]);
-        Media ->
-            Stream = ecallmgr_util:media_path(Media, 'extant', UUID, JObj),
-            lager:debug("bridge has custom ringback: ~s", [Stream]),
-            ecallmgr_fs_command:set(Node, UUID, [{<<"ringback">>, Stream}])
-    end.
-
 -spec maybe_early_media(atom(), kz_term:ne_binary(), kz_json:object(), kz_json:objects()) -> ecallmgr_util:send_cmd_ret().
 maybe_early_media(Node, UUID, JObj, Endpoints) ->
     Separator = ecallmgr_util:get_dial_separator(JObj, Endpoints),

--- a/applications/ecallmgr/src/ecallmgr_fs_transfer.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_transfer.erl
@@ -22,6 +22,8 @@ attended(Node, UUID, JObj) ->
 
     ReqURI = <<TransferTo/binary, "@", Realm/binary>>,
 
+    ecallmgr_call_command:set_ringback(Node, UUID, JObj),
+
     Vars = [{<<"Ignore-Early-Media">>, <<"ring_ready">>}
            ,{<<"Simplify-Loopback">>, <<"false">>}
            ,{<<"Loopback-Bowout">>, <<"true">>}


### PR DESCRIPTION
Share ringback set command between ecallmgr_fs_transfer and ecallmgr_fs_bridge so that ecallmgr_fs_transfer:attended will have a ringback even when the transferring leg did not have the ringback variables set yet. It seems that channels originated using kapi_resource:publish_originate_req/1 to predefined endpoints will not have that var set because it is only set by either kapps_call_command:bridge or the XML dialplan