### PR TITLE
PISTON-698: set originate timeout for ecallmgr_fs_transfer:attended/3

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_transfer.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_transfer.erl
@@ -31,6 +31,7 @@ attended(Node, UUID, JObj) ->
            ,{<<"Outbound-Caller-ID-Name">>, kz_json:get_ne_binary_value(<<"Caller-ID-Name">>, JObj)}
            ,{<<"Outbound-Callee-ID-Number">>, TransferTo}
            ,{<<"Outbound-Callee-ID-Name">>, TransferTo}
+           ,{<<"Timeout">>, 60}
            ],
 
     Props = add_transfer_ccvs_to_vars(CCVs, Vars),

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -689,6 +689,10 @@ get_fs_key_and_value(<<"ringback">>=Key, Value, _UUID) ->
     [{<<"ringback">>, maybe_sanitize_fs_value(Key, Value)}
     ,{<<"transfer_ringback">>, maybe_sanitize_fs_value(<<"transfer_ringback">>, Value)}
     ];
+get_fs_key_and_value(<<"Timeout">>, Value, _UUID) ->
+    [{<<"call_timeout">>, maybe_sanitize_fs_value(<<"call_timeout">>, Value)}
+    ,{<<"originate_timeout">>, maybe_sanitize_fs_value(<<"originate_timeout">>, Value)}
+    ];
 get_fs_key_and_value(?CCV(Key), Val, UUID) ->
     get_fs_key_and_value(Key, Val, UUID);
 get_fs_key_and_value(?JSON_CAV(_)=JSONCAV, Val, _UUID) ->


### PR DESCRIPTION
Set a high timeout for att_xfer. By default the FS implementation of att_xfer will perform an originate that uses the current timeout channel vars on the call making the transfer. This can backfire if that timeout is lower than the desired timeout on the other side of the att_xfer loopback. So here we set it to a high value and rely on the bridges on the other side of the loopback to control the ringing timeout.