### PR TITLE
Check that an EPMD registration exists

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -30864,6 +30864,17 @@
             },
             "type": "object"
         },
+        "system_config.epmd": {
+            "description": "Schema for epmd system_config",
+            "properties": {
+                "check_every_s": {
+                    "default": 60,
+                    "description": "epmd check_every_s",
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
         "system_config.fax": {
             "description": "Schema for fax system_config",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.epmd.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.epmd.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.epmd",
+    "description": "Schema for epmd system_config",
+    "properties": {
+        "check_every_s": {
+            "default": 60,
+            "description": "epmd check_every_s",
+            "type": "integer"
+        }
+    },
+    "type": "object"
+}

--- a/core/kazoo_apps/src/kazoo_apps_app.erl
+++ b/core/kazoo_apps/src/kazoo_apps_app.erl
@@ -16,7 +16,7 @@
 -spec start() -> {'ok', kz_term:atoms()}.
 start() ->
     _ = io:setopts('user', [{'encoding', 'unicode'}]),
-    'true' = does_system_has_network_subsystem(),
+    'true' = does_system_have_network_subsystem(),
     {'ok', _Apps} = application:ensure_all_started(?APP).
 
 %% Application callbacks
@@ -39,8 +39,8 @@ stop(_State) ->
     kapps_maintenance:unbind({'migrate', <<"4.0">>}, 'kazoo_voicemail_maintenance', 'migrate'),
     'ok'.
 
--spec does_system_has_network_subsystem() -> boolean().
-does_system_has_network_subsystem() ->
+-spec does_system_have_network_subsystem() -> boolean().
+does_system_have_network_subsystem() ->
     try kz_network_utils:default_binding_ip() of
         _ -> 'true'
     catch

--- a/core/kazoo_apps/src/kazoo_apps_sup.erl
+++ b/core/kazoo_apps/src/kazoo_apps_sup.erl
@@ -36,6 +36,7 @@
                   ,?CACHE_ARGS(?KAPPS_CONFIG_CACHE, ?KAPPS_CONFIG_PROPS)
                   ,?WORKER('kapps_controller')
                   ,?CACHE_ARGS(?KAPPS_GETBY_CACHE, ?KAPPS_GETBY_PROPS)
+                  ,?WORKER('kz_epmd')
                   ]).
 -endif.
 

--- a/core/kazoo_apps/src/kz_epmd.erl
+++ b/core/kazoo_apps/src/kz_epmd.erl
@@ -1,0 +1,104 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2012-2019, 2600Hz
+%%% @doc Monitors EPMD connection and restarts it when necessary
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kz_epmd).
+-behaviour(gen_server).
+
+-export([start_link/0]).
+
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include_lib("kazoo_stdlib/include/kz_types.hrl").
+
+-record(state, {tref :: kz_types:api_reference()
+               ,has_check_failed = 'false' :: boolean()
+               ,name :: string() %% node name of the running node, e.g. kazoo_apps
+               ,host :: string() %% local hostname of the running node
+               ,epmd_mod :: atom() %% in case we're using a custom epmd client module
+               ,port :: inet_address:port() %% node's port to talk disterl
+               }).
+-type state() :: #state{}.
+
+-define(CHECK_EPMD, 'check_epmd').
+
+-spec start_link() -> kz_types:startlink_ret().
+start_link() ->
+    gen_server:start_link({'local', ?MODULE}, ?MODULE, [], []).
+
+-spec init(any()) -> {'ok', state()}.
+init(_) ->
+    lager:info("starting EPMD monitor"),
+    {'match', [Name, Host]} = re:run(atom_to_list(node()), "([^@]+)@(.+)", [{'capture', 'all_but_first', 'list'}]),
+
+    {'ok', check_epmd(#state{name=Name
+                            ,host=Host
+                            ,epmd_mod=net_kernel:epmd_module()
+                            })
+    }.
+
+-spec handle_call(any(), kz_term:pid_ref(), state()) -> kz_types:handle_call_ret_state(state()).
+handle_call(_Call, _From, State) ->
+    {'noreply', State}.
+
+-spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
+handle_cast(_Cast, State) ->
+    {'noreply', State}.
+
+-spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
+handle_info({'timeout', TRef, ?CHECK_EPMD}
+           ,#state{tref=TRef}=State
+           ) ->
+    {'noreply', check_epmd(State)};
+handle_info(_Msg, State) ->
+    lager:debug("unhandled ~p", [_Msg]),
+    {'noreply', State}.
+
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:info("terminating epmd checks: ~p", [_Reason]).
+
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+start_check_timer() ->
+    CheckS = kapps_config:get_integer(<<"epmd">>, <<"check_every_s">>, 60),
+    erlang:start_timer(CheckS * ?MILLISECONDS_IN_SECOND, self(), ?CHECK_EPMD).
+
+check_epmd(#state{name=Name
+                 ,host=Host
+                 ,epmd_mod=Mod
+                 }=State
+          ) ->
+    check_epmd(State, Mod:port_please(Name, Host)).
+
+check_epmd(#state{port=_Port}=State, 'noport') ->
+    lager:error("no EPMD response, re-registering on port ~p", [_Port]),
+    register_with_epmd(State);
+check_epmd(#state{port=Port}=State, {'port', Port, _Vsn}) ->
+    State#state{tref=start_check_timer()};
+check_epmd(#state{port=_OldPort}=State, {'port', Port, _Vsn}) ->
+    lager:info("setting our port to ~p (was ~p)", [Port, _OldPort]),
+    register_with_epmd(State#state{port=Port}).
+
+register_with_epmd(#state{name=Name
+                         ,epmd_mod=Mod
+                         ,port=Port
+                         }=State) ->
+    log_register_result(Mod:register_node(Name, Port)),
+    State#state{tref=start_check_timer()}.
+
+log_register_result({'ok', _Creation}) ->
+    lager:info("created registration: ~p", [_Creation]);
+log_register_result({'error', 'already_registered'}) ->
+    lager:info("already registered with EPMD");
+log_register_result(_Term) ->
+    lager:info("unexpected return from registering: ~p", [_Term]).


### PR DESCRIPTION
Currently no nice way to ensure EPMD is started but this at least lets a node reconnect and re-register when EPMD has gone down and returned.