### PR TITLE
HELP-41363: Add HotDesk-Current-ID CCV when device is hotdesked (#5600)

### DIFF
--- a/applications/registrar/src/reg_authn_req.erl
+++ b/applications/registrar/src/reg_authn_req.erl
@@ -103,7 +103,8 @@ create_ccvs(#auth_user{doc=JObj}=AuthUser) ->
       ,{<<"Register-Overwrite-Notify">>, AuthUser#auth_user.register_overwrite_notify}
       ,{<<"Pusher-Application">>, kz_json:get_value([<<"push">>, <<"Token-App">>], JObj)}
        | (create_specific_ccvs(AuthUser, AuthUser#auth_user.method)
-          ++ generate_security_ccvs(AuthUser))
+          ++ generate_security_ccvs(AuthUser)
+          ++ maybe_add_hotdesk_current_id(AuthUser))
       ]).
 
 -spec maybe_get_presence_id(auth_user()) -> kz_term:api_binary().
@@ -502,3 +503,10 @@ maybe_enforce_security({#auth_user{doc=JObj}=User, Acc}) ->
 -spec maybe_set_encryption_flags({auth_user(), kz_term:proplist()}) -> {auth_user(), kz_term:proplist()}.
 maybe_set_encryption_flags({#auth_user{doc=JObj}=User, Acc}) ->
     {User, encryption_method_map(Acc, JObj)}.
+
+-spec maybe_add_hotdesk_current_id(auth_user()) -> kz_term:proplist().
+maybe_add_hotdesk_current_id(#auth_user{doc=JObj}) ->
+    case kzd_devices:hotdesk_ids(JObj, []) of
+        [] -> [];
+        [Id | _] -> [{<<"Hotdesk-Current-ID">>, Id}]
+    end.


### PR DESCRIPTION
Master counterpart:  #5600
HELP-41363: Rename ccv HotDesk-Current-ID to Hotdesk-Current-ID

HELP-41363: Improve code according to PR review comments

HELP-41363: Improve code according to PR review comments

just pattern-match the list