### PR TITLE
PISTON-701: always publish dereg notif, handler will filter suppression

### DIFF
--- a/applications/blackhole/doc/README.md
+++ b/applications/blackhole/doc/README.md
@@ -176,7 +176,6 @@ Here are a few complete `call.*.*` JSON events:
             "Owner-ID": "699ed7e3d583e2577ac017c575f87262",
             "Realm": "wefwefwefwef.2600hz.com",
             "Register-Overwrite-Notify": "false",
-            "Suppress-Unregister-Notifications": "false",
             "Username": "user_wpxnx7am9w"
         },
         "Custom-SIP-Headers": {
@@ -230,7 +229,6 @@ Here are a few complete `call.*.*` JSON events:
             "Owner-ID": "699ed7e3d583e2577ac017c575f87262",
             "Realm": "wefwefwefwef.2600hz.com",
             "Register-Overwrite-Notify": "false",
-            "Suppress-Unregister-Notifications": "false",
             "Username": "user_wpxnx7am9w"
         },
         "Custom-SIP-Headers": {
@@ -285,7 +283,6 @@ Here are a few complete `call.*.*` JSON events:
             "Owner-ID": "699ed7e3d583e2577ac017c575f87262",
             "Realm": "wefwefwefwef.2600hz.com",
             "Register-Overwrite-Notify": "false",
-            "Suppress-Unregister-Notifications": "false",
             "Username": "user_wpxnx7am9w"
         },
         "Custom-SIP-Headers": {

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -8629,9 +8629,6 @@
                 "Register-Overwrite-Notify": {
                     "type": "string"
                 },
-                "Suppress-Unregister-Notifications": {
-                    "type": "string"
-                },
                 "Tenant-ID": {
                     "type": "string"
                 }

--- a/applications/crossbar/priv/couchdb/schemas/kapi.authn.resp.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.authn.resp.json
@@ -51,9 +51,6 @@
         "Register-Overwrite-Notify": {
             "type": "string"
         },
-        "Suppress-Unregister-Notifications": {
-            "type": "string"
-        },
         "Tenant-ID": {
             "type": "string"
         }

--- a/applications/ecallmgr/src/ecallmgr_registrar.erl
+++ b/applications/ecallmgr/src/ecallmgr_registrar.erl
@@ -92,7 +92,7 @@
                       ,initial_registration = kz_time:now_s() :: kz_time:gregorian_seconds() | '_'
                       ,registrar_node :: kz_term:api_ne_binary() | '_'
                       ,registrar_hostname :: kz_term:api_ne_binary() | '_'
-                      ,suppress_unregister = 'true' :: boolean() | '_'
+                      ,suppress_unregister = 'false' :: boolean() | '_'
                       ,register_overwrite_notify = 'false' :: boolean() | '_'
                       ,account_db :: kz_term:api_binary() | '_'
                       ,account_id :: kz_term:api_binary() | '_'
@@ -853,14 +853,10 @@ augment_registration(Reg, JObj) ->
                             ),
     SuppressUnregister =
         kz_term:is_true(
-          case kz_json:find(<<"Suppress-Unregister-Notifications">>, [JObj, CCVs]) of
-              'undefined' ->
-                  kz_json:find(<<"Suppress-Unregister-Notify">>
-                              ,[JObj, CCVs]
-                              ,Reg#registration.suppress_unregister
-                              );
-              Else -> Else
-          end
+          kz_json:find(<<"Suppress-Unregister-Notify">>
+                      ,[JObj, CCVs]
+                      ,Reg#registration.suppress_unregister
+                      )
          ),
     OverwriteNotify =
         kz_term:is_true(

--- a/applications/registrar/src/reg.hrl
+++ b/applications/registrar/src/reg.hrl
@@ -18,7 +18,6 @@
                    ,authorizing_id :: kz_term:api_binary()
                    ,method :: kz_term:api_binary()
                    ,owner_id :: kz_term:api_binary()
-                   ,suppress_unregister_notifications = 'false' :: boolean()
                    ,register_overwrite_notify = 'false' :: boolean()
                    ,account_realm :: kz_term:api_binary()
                    ,account_normalized_realm :: kz_term:api_binary()

--- a/applications/registrar/src/reg_authn_req.erl
+++ b/applications/registrar/src/reg_authn_req.erl
@@ -51,7 +51,6 @@ send_auth_resp(#auth_user{password=Password
                          ,username=Username
                          ,method=Method
                          ,realm=Realm
-                         ,suppress_unregister_notifications=SupressUnregister
                          ,register_overwrite_notify=RegisterOverwrite
                          ,nonce=Nonce
                          }=AuthUser
@@ -64,7 +63,6 @@ send_auth_resp(#auth_user{password=Password
              ,{<<"Auth-Method">>, get_auth_method(Method)}
              ,{<<"Auth-Nonce">>, Nonce}
              ,{<<"Expires">>, kz_json:get_value(<<"Expires">>,JObj)}
-             ,{<<"Suppress-Unregister-Notifications">>, SupressUnregister}
              ,{<<"Register-Overwrite-Notify">>, RegisterOverwrite}
              ,{<<"Custom-Channel-Vars">>, create_ccvs(AuthUser)}
              ,{<<"Custom-SIP-Headers">>, create_custom_sip_headers(Method, AuthUser)}
@@ -99,7 +97,6 @@ create_ccvs(#auth_user{doc=JObj}=AuthUser) ->
       ,{<<"Account-Realm">>, AuthUser#auth_user.account_normalized_realm}
       ,{<<"Account-Name">>, AuthUser#auth_user.account_name}
       ,{<<"Presence-ID">>, maybe_get_presence_id(AuthUser)}
-      ,{<<"Suppress-Unregister-Notifications">>, AuthUser#auth_user.suppress_unregister_notifications}
       ,{<<"Register-Overwrite-Notify">>, AuthUser#auth_user.register_overwrite_notify}
       ,{<<"Pusher-Application">>, kz_json:get_value([<<"push">>, <<"Token-App">>], JObj)}
        | (create_specific_ccvs(AuthUser, AuthUser#auth_user.method)
@@ -298,7 +295,6 @@ jobj_to_auth_user(JObj, Username, Realm, Req) ->
                          ,authorizing_id = kz_doc:id(JObj)
                          ,method = kz_term:to_lower_binary(Method)
                          ,owner_id = kz_json:get_value(<<"owner_id">>, AuthDoc)
-                         ,suppress_unregister_notifications = kz_json:is_true(<<"suppress_unregister_notifications">>, AuthDoc)
                          ,register_overwrite_notify = kz_json:is_true(<<"register_overwrite_notify">>, AuthDoc)
                          ,doc=AuthDoc
                          ,request=Req

--- a/core/kazoo_amqp/src/api/kapi_authn.erl
+++ b/core/kazoo_amqp/src/api/kapi_authn.erl
@@ -55,7 +55,6 @@
 -define(OPTIONAL_AUTHN_RESP_HEADERS, [<<"Custom-Channel-Vars">>, <<"Custom-SIP-Headers">>
                                      ,<<"Auth-Username">>, <<"Auth-Nonce">>
                                      ,<<"Access-Group">>, <<"Tenant-ID">>, <<"Expires">>
-                                     ,<<"Suppress-Unregister-Notifications">>
                                      ,<<"Register-Overwrite-Notify">>
                                      ]).
 -define(AUTHN_RESP_VALUES, [{<<"Event-Category">>, <<"directory">>}


### PR DESCRIPTION
Context for this change here: https://forums.2600hz.com/forums/topic/10425-tracking-registration-state-events-registerderegister/

Still need to decide on whether this should be opt-in/opt-out/configurable at all. Also, the suppress_unregister record field and the Suppress-Unregister-Notify prop key I don't think are needed anymore nor have a purpose. So I could also remove those.