### PR TITLE
PISTON-711: start_key off by one, resulting in missed records paginating

### DIFF
--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -366,7 +366,8 @@ get_view_options([{<<"cdrs">>, [?PATH_INTERACTION]}, {<<"users">>, [OwnerId]}|_]
     {?CB_INTERACTION_LIST_BY_USER
     ,props:filter_undefined(
        [{'range_start_keymap', [OwnerId]}
-       ,{'range_end_keymap', fun(Ts) -> [OwnerId, Ts, kz_json:new()] end}
+       ,{'range_end_keymap', [OwnerId]}
+       ,{'key_min_length', 4}
        ,{'group', 'true'}
        ,{'group_level', 3}
        ,{'reduce', 'true'}


### PR DESCRIPTION
When a query is made through a CouchDB view, the supplied start_key and end_key must have the same length as those in the result set (note: with no grouping applied!). If this is not the case, some results may be filtered out as they are sorted outside the selected range. In Kazoo’s case, this can mean that the next_start_key produced by viewing the last result’s key can be wrong when the group level is not equal to the length of the view key in the underlying view definition.

The following is an example of what can happen here:

GET https://{{baseURL}}/v2/accounts/{{account_id}}/users/{{user_id}}/cdrs/interaction?page_size=10

The view backing this query (interactions/interaction_listing_by_owner) has keys of length 4 (owner_id, interaction_time, interaction_key, channel_created_time). cb_cdrs however uses a group_level of 3. This means that the result set will have keys of length 3. Now assume our last result has a key of `["0a1fde86ac5e801b57ae58510710b31f", 63719832457, "98fe29cc"]` (these are owner_id, interaction_time, and interaction_key, omitting the channel_created_time due to the group_level). This will be returned as the next_start_key. It is one element beyond the page_size of the original req. One would assume in the next query:

GET http://{{baseURL}}/v2/accounts/{{account_id}}/users/{{user_id}}/cdrs/interaction?page_size=10&start_key={{start_key}}

that the result set begins with the result specified with the start_key. It does not. It begins at the record one after the start_key record, causing lost results.

This is because the sort order is descending for this request, and therefore results with keys that sort greater than the start_key will be filtered out. By submitting a start_key of `length(ViewKeys)-1`, CouchDB interprets the 4th missing element as `null` which sorts low (https://docs.couchdb.org/en/stable/ddocs/views/collation.html#collation-specification). This means that any records that have the first 3 elements of their key matching the start_key but have _anything_ other than null/false/true as their 4th element of their key will be filtered out.

In the interaction example, since the last element of the key is an integer (channel_created_time), the record that should have been returned by the next_start_key is going to be skipped.

The solution in this PR addresses this by padding the length of the start_key used for the query to a specific length. This must be set on the query options ahead of time, by knowing what the definition of the view is (what length keys are emitted). The change will automatically detect the sort order: ascending sorts mean the end_key should be padded with the "high sort" option of an empty JSON object, and the start_key should be padded with the "low sort" option of false (I used false because there is currently nothing in Kazoo for representing `null` in JSON). Descending sorts do the opposite, to ensure the start_key is padded as high as possible and the end_key is padded as low as possible.

There are likely to be other Crossbar requests that are subject to the issue, but I am not going to be finding them as part of this PR.
