### PR TITLE
add Rate-ID to cb_rates by number search result

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -21182,6 +21182,9 @@
                 "Rate-Description": {
                     "type": "string"
                 },
+                "Rate-ID": {
+                    "type": "string"
+                },
                 "Rate-Increment": {
                     "type": "integer"
                 },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.rate.resp.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.rate.resp.json
@@ -36,6 +36,9 @@
         "Rate-Description": {
             "type": "string"
         },
+        "Rate-ID": {
+            "type": "string"
+        },
         "Rate-Increment": {
             "type": "integer"
         },

--- a/applications/crossbar/src/modules/cb_rates.erl
+++ b/applications/crossbar/src/modules/cb_rates.erl
@@ -30,6 +30,7 @@
                             ,<<"E164-Number">>
                             ,<<"Prefix">>
                             ,<<"Rate">>
+                            ,<<"Rate-ID">>
                             ,<<"Rate-Description">>
                             ,<<"Rate-Increment">>
                             ,<<"Rate-Minimum">>

--- a/core/kazoo_amqp/src/api/kapi_rate.erl
+++ b/core/kazoo_amqp/src/api/kapi_rate.erl
@@ -71,6 +71,7 @@
                                     ,<<"Prefix">>
                                     ,<<"Pvt-Cost">>
                                     ,<<"Rate">>
+                                    ,<<"Rate-ID">>
                                     ,<<"Rate-Description">>
                                     ,<<"Rate-Increment">>
                                     ,<<"Rate-Minimum">>


### PR DESCRIPTION
It is good to have rate_id in search result in order to able to edit/delete found rate. 