### PR TITLE
Set prefetch to config's value if unnamed queue is used

### DIFF
--- a/core/kazoo_amqp/include/kz_amqp.hrl
+++ b/core/kazoo_amqp/include/kz_amqp.hrl
@@ -237,5 +237,7 @@
 
 -define(AMQP_HIDDEN_TAG, <<"hidden">>).
 
+-define(DEFAULT_PREFETCH, 50).
+
 -define(KZ_AMQP_HRL, 'true').
 -endif.

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -981,7 +981,7 @@ set_qos(<<>>, 'undefined') ->
             kz_amqp_util:basic_qos(N);
         _ ->
             lager:debug("random queue getting default QoS settings(1) applied"),
-            kz_amqp_util:basic_qos(1)
+            kz_amqp_util:basic_qos(?DEFAULT_PREFETCH)
     end;
 set_qos(_QueueName, 'undefined') ->
     lager:debug("named queue has no QoS settings");

--- a/core/kazoo_amqp/src/kz_amqp_util.erl
+++ b/core/kazoo_amqp/src/kz_amqp_util.erl
@@ -1337,11 +1337,19 @@ is_host_available() -> kz_amqp_connections:is_available().
 
 %%------------------------------------------------------------------------------
 %% @doc Specify quality of service.
+%%
+%%
+%% global: https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.qos.global
+%% global=false applies QoS settings to new consumers on the channel (existing are unaffected).
+%% global=true applies per-channel
 %% @end
 %%------------------------------------------------------------------------------
 -spec basic_qos(non_neg_integer()) -> 'ok'.
 basic_qos(PreFetch) when is_integer(PreFetch) ->
-    kz_amqp_channel:command(#'basic.qos'{prefetch_count = PreFetch}).
+    kz_amqp_channel:command(#'basic.qos'{prefetch_count = PreFetch
+                                        ,prefetch_size = 0
+                                        ,global = 'false'
+                                        }).
 
 %%------------------------------------------------------------------------------
 %% @doc Encode a key so characters like dot won't interfere with routing separator.

--- a/core/kazoo_number_manager/src/knm_search.erl
+++ b/core/kazoo_number_manager/src/knm_search.erl
@@ -127,6 +127,8 @@ handle_call(_Request, _From, State) ->
 -spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
 handle_cast({'gen_listener',{'created_queue', Queue}}, State) ->
     {'noreply', State#{queue => Queue}, ?POLLING_INTERVAL};
+handle_cast({'gen_listener',{'is_consuming',_IsConsuming}}, State) ->
+    {'noreply', State};
 handle_cast({'reset_search',QID}, #{cache := Cache} = State) ->
     lager:debug("resetting query id ~s", [QID]),
     ets:delete(Cache, QID),


### PR DESCRIPTION
When a "random" queue name is used to consume events for a specific process (vs a "named" queue which generally is for sharing events among consumers), set the prefetch value to what's in the config.ini. This setting increases the number of messages in-flight between the broker and the consumer and speeds up throughput.