### PR TITLE
Set prefetch to config's value if unnamed queue is used

### DIFF
--- a/core/kazoo_amqp/include/kz_amqp.hrl
+++ b/core/kazoo_amqp/include/kz_amqp.hrl
@@ -237,5 +237,7 @@
 
 -define(AMQP_HIDDEN_TAG, <<"hidden">>).
 
+-define(DEFAULT_PREFETCH, 50).
+
 -define(KZ_AMQP_HRL, 'true').
 -endif.

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -967,15 +967,27 @@ start_amqp(Props, AutoAck) ->
     case kz_amqp_util:new_queue(QueueName, QueueProps) of
         {'error', _}=E -> E;
         Q ->
-            set_qos(props:get_value('basic_qos', Props)),
+            set_qos(QueueName, props:get_value('basic_qos', Props)),
             'ok' = start_consumer(Q, maybe_configure_auto_ack(ConsumeOptions, AutoAck)),
             lager:debug("queue started: ~s", [Q]),
             {'ok', Q}
     end.
 
--spec set_qos('undefined' | non_neg_integer()) -> 'ok'.
-set_qos('undefined') -> 'ok';
-set_qos(N) when is_integer(N), N >= 0 -> kz_amqp_util:basic_qos(N).
+-spec set_qos(binary(), 'undefined' | non_neg_integer()) -> 'ok'.
+set_qos(<<>>, 'undefined') ->
+    case kz_config:get_integer('amqp', 'prefetch') of
+        [N] when is_integer(N) ->
+            lager:debug("random queue getting config.ini QoS settings(~p) applied", [N]),
+            kz_amqp_util:basic_qos(N);
+        _ ->
+            lager:debug("random queue getting default QoS settings(1) applied"),
+            kz_amqp_util:basic_qos(?DEFAULT_PREFETCH)
+    end;
+set_qos(_QueueName, 'undefined') ->
+    lager:debug("named queue has no QoS settings");
+set_qos(_QueueName, N) when is_integer(N), N >= 0 ->
+    lager:debug("applying QoS prefetch of ~p", [N]),
+    kz_amqp_util:basic_qos(N).
 
 -spec start_consumer(kz_term:ne_binary(), kz_term:proplist()) -> 'ok'.
 start_consumer(Q, 'undefined') -> kz_amqp_util:basic_consume(Q, []);

--- a/core/kazoo_amqp/src/kz_amqp_util.erl
+++ b/core/kazoo_amqp/src/kz_amqp_util.erl
@@ -1337,11 +1337,19 @@ is_host_available() -> kz_amqp_connections:is_available().
 
 %%------------------------------------------------------------------------------
 %% @doc Specify quality of service.
+%%
+%%
+%% global: https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.qos.global
+%% global=false applies QoS settings to new consumers on the channel (existing are unaffected).
+%% global=true applies per-channel
 %% @end
 %%------------------------------------------------------------------------------
 -spec basic_qos(non_neg_integer()) -> 'ok'.
 basic_qos(PreFetch) when is_integer(PreFetch) ->
-    kz_amqp_channel:command(#'basic.qos'{prefetch_count = PreFetch}).
+    kz_amqp_channel:command(#'basic.qos'{prefetch_count = PreFetch
+                                        ,prefetch_size = 0
+                                        ,global = 'false'
+                                        }).
 
 %%------------------------------------------------------------------------------
 %% @doc Encode a key so characters like dot won't interfere with routing separator.

--- a/core/kazoo_number_manager/src/knm_search.erl
+++ b/core/kazoo_number_manager/src/knm_search.erl
@@ -127,6 +127,8 @@ handle_call(_Request, _From, State) ->
 -spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
 handle_cast({'gen_listener',{'created_queue', Queue}}, State) ->
     {'noreply', State#{queue => Queue}, ?POLLING_INTERVAL};
+handle_cast({'gen_listener',{'is_consuming',_IsConsuming}}, State) ->
+    {'noreply', State};
 handle_cast({'reset_search',QID}, #{cache := Cache} = State) ->
     lager:debug("resetting query id ~s", [QID]),
     ets:delete(Cache, QID),

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -207,7 +207,10 @@ straight_seq() ->
 
     SummaryResp = summary(API, AccountId),
     ?INFO("summary resp: ~s", [SummaryResp]),
-    'true' = cdrs_exist(CDRs, kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp))),
+    RespCDRs = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
+    ?INFO("Resp CDRs: ~p~n", [lists:usort([kz_doc:id(RespCDR) || RespCDR <- RespCDRs])]),
+    ?INFO("Base CDRs: ~p~n", [lists:usort([kz_doc:id(CDR) || CDR <- CDRs])]),
+    'true' = cdrs_exist(CDRs, RespCDRs),
     ?INFO("all cdrs found in response"),
 
     CSVResp = summary(API, AccountId, <<"text/csv">>),
@@ -281,13 +284,14 @@ cdr_exists(CDR, RespCDRs) ->
 cdrs_exist([], []) -> 'true';
 cdrs_exist([], APIs) ->
     IDs = [kz_doc:id(CDR) || CDR <- APIs],
-    ?INFO("  failed to find API(s) ~s", [kz_binary:join(IDs, <<", ">>)]),
+    ?INFO("  failed to find API results in CDRs: ~s", [kz_binary:join(IDs, <<", ">>)]),
     'false';
 cdrs_exist(CDRs, []) ->
     IDs = [kz_doc:id(CDR) || CDR <- CDRs],
-    ?INFO("  failed to find CDR(s) ~s", [kz_binary:join(IDs, <<", ">>)]),
+    ?INFO("  failed to find CDR(s) in API response: ~s", [kz_binary:join(IDs, <<", ">>)]),
     'false';
 cdrs_exist([_|_]=CDRs, [API|APIs]) ->
+    lager:debug("filtering out ~s", [kz_doc:id(API)]),
     cdrs_exist([CDR || CDR <- CDRs, kz_doc:id(CDR) =/= kz_doc:id(API)]
               ,APIs
               ).
@@ -394,4 +398,10 @@ seed_cdr(AccountId, OwnerId, Year, Month, InteractionId) ->
     kazoo_modb:save_doc(AccountMODb, CDR).
 
 interaction_time(Year, Month, Day) ->
-    calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {1, 2, 3}}).
+    {Today, _} = calendar:universal_time(),
+    interaction_time(Year, Month, Day, Today).
+
+interaction_time(Year, Month, Day, {Year, Month, Day}) ->
+    calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {0, 0, 0}});
+interaction_time(Year, Month, Day, _Today) ->
+    calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {23, 59, 59}}).


### PR DESCRIPTION
When a "random" queue name is used to consume events for a specific
process (vs a "named" queue which generally is for sharing events
among consumers), set the prefetch value to what's in the
config.ini. This setting increases the number of messages in-flight
between the broker and the consumer and speeds up throughput.