### PR TITLE
PISTON-731: Changed duration_seconds in cdr to int from string to match all other 'seconds' value types

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -707,7 +707,7 @@ specific_call_event_props(<<"CHANNEL_DESTROY">>, _, Props) ->
     ,{<<"From-Uri">>, props:get_value(<<"variable_sip_from_uri">>, Props)}
     ,{<<"Remote-SDP">>, props:get_value(<<"variable_switch_r_sdp">>, Props)}
     ,{<<"Local-SDP">>, props:get_value(<<"variable_rtp_local_sdp_str">>, Props)}
-    ,{<<"Duration-Seconds">>, props:get_value(<<"variable_duration">>, Props)}
+    ,{<<"Duration-Seconds">>, props:get_integer_value(<<"variable_duration">>, Props)}
     ,{<<"Billing-Seconds">>, get_billing_seconds(Props)}
     ,{<<"Ringing-Seconds">>, get_ringing_seconds(Props)}
     ,{<<"User-Agent">>, props:get_value(<<"variable_sip_user_agent">>, Props)}


### PR DESCRIPTION
duration_seconds in a cdr doc is stored as a string value when billing_seconds is stored as an int. 

As a result every time a cdr is loaded through CB, the string value must be converted to an int. 

Converting it to a int before saving also helps follow consistency.