### PR TITLE
PISTON-724: Handled crossbar 'storage' validation when no 'attachment' is supplied in the request body

### DIFF
--- a/applications/crossbar/src/modules/cb_storage.erl
+++ b/applications/crossbar/src/modules/cb_storage.erl
@@ -401,7 +401,7 @@ maybe_check_storage_settings(Context, ReqVerb) when ReqVerb =:= ?HTTP_PUT
     case cb_context:resp_status(Context) of
         'success' when ValidateSettings ->
             lager:debug("validating storage settings"),
-            Attachments = kz_json:get_json_value(<<"attachments">>, cb_context:doc(Context)),
+            Attachments = kz_json:get_json_value(<<"attachments">>, cb_context:doc(Context), kz_json:new()),
             validate_attachments_settings(Attachments, Context);
         'success' when SystemAllowsSkippingValidation ->
             lager:notice("client has explicitly disabled validating attachment settings"),


### PR DESCRIPTION
If a storage object is created through CB without a 'attachment' the request will crash

I have added a case to handle wen no 'attachment' is supplied and skip validation of the attachment settings