### PR TITLE
PISTON-709: serialize all agent spawns thru acdc_queues_sup 

### DIFF
--- a/applications/acdc/src/acdc_agent_handler.erl
+++ b/applications/acdc/src/acdc_agent_handler.erl
@@ -390,12 +390,9 @@ handle_agent_change(AccountDb, AccountId, AgentId, ?DOC_EDITED) ->
         P when is_pid(P) -> acdc_agent_fsm:refresh(acdc_agent_sup:fsm(P), JObj)
     end;
 handle_agent_change(_, AccountId, AgentId, ?DOC_DELETED) ->
-    case acdc_agents_sup:find_agent_supervisor(AccountId, AgentId) of
-        'undefined' -> lager:debug("user ~s has left us, but wasn't started", [AgentId]);
-        P when is_pid(P) ->
-            lager:debug("agent ~s(~s) has been deleted, stopping ~p", [AccountId, AgentId, P]),
-            _ = acdc_agent_sup:stop(P),
-            acdc_agent_stats:agent_logged_out(AccountId, AgentId)
+    case acdc_agents_sup:stop_agent(AccountId, AgentId) of
+        'ok' -> acdc_agent_stats:agent_logged_out(AccountId, AgentId);
+        _ -> 'ok'
     end.
 
 -spec handle_presence_probe(kz_json:object(), kz_term:proplist()) -> 'ok'.

--- a/applications/acdc/src/acdc_agent_maintenance.erl
+++ b/applications/acdc/src/acdc_agent_maintenance.erl
@@ -41,31 +41,15 @@ agent_status(AcctId, AgentId) ->
         S -> acdc_agent_sup:status(S)
     end.
 
--spec acct_restart(kz_term:text()) -> 'ok'.
+-spec acct_restart(kz_term:text()) -> [kz_types:sup_startchild_ret()].
 acct_restart(AcctId) when not is_binary(AcctId) ->
     acct_restart(kz_term:to_binary(AcctId));
 acct_restart(AcctId) ->
-    case acdc_agents_sup:find_acct_supervisors(AcctId) of
-        [] -> lager:info("no agents with account id ~s available", [AcctId]);
-        As ->
-            lager:debug("terminating existing agent processes in ~s", [AcctId]),
-            _ = [exit(Sup, 'kill') || Sup <- As],
-            lager:info("restarting agents in ~s", [AcctId]),
-            acdc_init:init_acct_agents(AcctId),
-            'ok'
-    end.
+    acdc_agents_sup:restart_acct(AcctId).
 
--spec agent_restart(kz_term:text(), kz_term:text()) -> 'ok'.
+-spec agent_restart(kz_term:text(), kz_term:text()) -> kz_types:sup_startchild_ret().
 agent_restart(AcctId, AgentId) when not is_binary(AcctId);
                                     not is_binary(AgentId) ->
     agent_restart(kz_term:to_binary(AcctId), kz_term:to_binary(AgentId));
 agent_restart(AcctId, AgentId) ->
-    case acdc_agents_sup:find_agent_supervisor(AcctId, AgentId) of
-        'undefined' -> lager:info("no agent ~s in account ~s available", [AgentId, AcctId]);
-        S ->
-            lager:info("terminating existing agent process ~p", [S]),
-            exit(S, 'kill'),
-            lager:info("restarting agent ~s in ~s", [AgentId, AcctId]),
-            _ = acdc_agents_sup:new(AcctId, AgentId),
-            'ok'
-    end.
+    acdc_agents_sup:restart_agent(AcctId, AgentId).

--- a/applications/acdc/src/acdc_agent_sup.erl
+++ b/applications/acdc/src/acdc_agent_sup.erl
@@ -13,11 +13,9 @@
 -define(SERVER, ?MODULE).
 
 %% API
--export([start_link/1, start_link/2, start_link/4
-        ,restart/1
+-export([start_link/2, start_link/3, start_link/4
         ,listener/1
         ,fsm/1
-        ,stop/1
         ,status/1
         ]).
 
@@ -36,27 +34,17 @@
 %% @doc Starts the supervisor.
 %% @end
 %%------------------------------------------------------------------------------
-
--spec start_link(kz_json:object()) -> kz_types:startlink_ret().
-start_link(AgentJObj) ->
-    supervisor:start_link(?SERVER, [AgentJObj]).
-
 -spec start_link(kapps_call:call(), kz_term:ne_binary()) -> kz_types:startlink_ret().
 start_link(ThiefCall, QueueId) ->
     supervisor:start_link(?SERVER, [ThiefCall, QueueId]).
 
+-spec start_link(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> kz_types:startlink_ret().
+start_link(AcctId, AgentId, AgentJObj) ->
+    supervisor:start_link(?SERVER, [AcctId, AgentId, AgentJObj]).
+
 -spec start_link(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), kz_term:ne_binaries()) -> kz_types:startlink_ret().
 start_link(AcctId, AgentId, AgentJObj, Queues) ->
     supervisor:start_link(?SERVER, [AcctId, AgentId, AgentJObj, Queues]).
-
--spec stop(pid()) -> 'ok' | {'error', 'not_found'}.
-stop(Supervisor) ->
-    supervisor:terminate_child('acdc_agents_sup', Supervisor).
-
--spec restart(pid()) -> kz_types:sup_startchild_ret().
-restart(Supervisor) ->
-    _ = stop(Supervisor),
-    supervisor:restart_child('acdc_agents_sup', Supervisor).
 
 -spec status(pid()) -> 'ok'.
 status(Supervisor) ->
@@ -71,8 +59,7 @@ status(Supervisor) ->
             ?PRINT("  FSM: ~p", [FSM]),
             print_status(augment_status(Status, LPid));
         _ ->
-            ?PRINT("Agent Supervisor ~p is dead, stopping", [Supervisor]),
-            stop(Supervisor)
+            ?PRINT("Agent Supervisor ~p is dead", [Supervisor])
     end.
 
 -define(AGENT_INFO_FIELDS, kapps_config:get(?CONFIG_CAT, <<"agent_info_fields">>

--- a/applications/acdc/src/acdc_agents_sup.erl
+++ b/applications/acdc/src/acdc_agents_sup.erl
@@ -31,6 +31,7 @@
 -export([init/1]).
 
 -define(CHILD_ID(AccountId, AgentId), <<AccountId/binary, "-", AgentId/binary>>).
+-define(THIEF_ID(AccountId, QueueId, CallId), <<"thief-", AccountId/binary, "-", QueueId/binary, "-", CallId/binary>>).
 -define(CHILD(Id, Args), ?SUPER_NAME_ARGS_TYPE(Id, 'acdc_agent_sup', Args, 'transient')).
 -define(INITIAL_CHILDREN, []).
 
@@ -69,7 +70,11 @@ new(AcctId, AgentId, AgentJObj, Queues) ->
     start_agent(AcctId, AgentId, AgentJObj, [Queues]).
 
 -spec new_thief(kapps_call:call(), kz_term:ne_binary()) -> kz_types:sup_startchild_ret().
-new_thief(Call, QueueId) -> supervisor:start_child(?SERVER, [Call, QueueId]).
+new_thief(Call, QueueId) ->
+    AccountId = kapps_call:account_id(Call),
+    CallId = kapps_call:call_id(Call),
+    Id = ?THIEF_ID(AccountId, QueueId, CallId),
+    supervisor:start_child(?MODULE, ?CHILD(Id, [Call, QueueId])).
 
 -spec stop_agent(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_types:sup_deletechild_ret().
 stop_agent(AcctId, AgentId) ->

--- a/core/kazoo_stdlib/src/kz_types.erl
+++ b/core/kazoo_stdlib/src/kz_types.erl
@@ -31,6 +31,9 @@
 -type sup_startchild_ret() :: {'ok', sup_child_id()} |
                               {'ok', sup_child_id(), any()} |
                               {'error', sup_startchild_err()}.
+-type sup_deletechild_err() :: 'running' | 'restarting' | 'not_found' |
+                               'simple_one_for_one'.
+-type sup_deletechild_ret() :: 'ok' | {'error', sup_deletechild_err()}.
 
 %% Recreate the non-exported types defined in the Erlang gen_server source
 -type startlink_err() :: {'already_started', pid()} |
@@ -135,6 +138,8 @@
              ,sup_child_id/0
              ,sup_startchild_err/0
              ,sup_startchild_ret/0
+             ,sup_deletechild_err/0
+             ,sup_deletechild_ret/0
              ,startlink_err/0
              ,startlink_ret/0
              ,startapp_ret/0


### PR DESCRIPTION
Prevent multiple acdc_agent_sup procs from being spawned for a single agent unless they are thief procs. 