### PR TITLE
Added the ability for parent call-restrictions to be inherited

### DIFF
--- a/core/kazoo_documents/src/kzd_accounts.erl
+++ b/core/kazoo_documents/src/kzd_accounts.erl
@@ -24,6 +24,7 @@
 -export([metaflows/1, metaflows/2, set_metaflows/2]).
 -export([music_on_hold/1, music_on_hold/2, set_music_on_hold/2]).
 -export([music_on_hold_media_id/1, music_on_hold_media_id/2, set_music_on_hold_media_id/2]).
+-export([id/1]).
 -export([name/1, name/2, set_name/2]).
 -export([notifications/1, notifications/2, set_notifications/2]).
 -export([notifications_first_occurrence/1, notifications_first_occurrence/2, set_notifications_first_occurrence/2]).
@@ -369,6 +370,10 @@ music_on_hold_media_id(Doc, Default) ->
 -spec set_music_on_hold_media_id(doc(), binary()) -> doc().
 set_music_on_hold_media_id(Doc, MusicOnHoldMediaId) ->
     kz_json:set_value([<<"music_on_hold">>, <<"media_id">>], MusicOnHoldMediaId, Doc).
+
+-spec id(doc()) -> kz_term:api_binary().
+id(Doc) ->
+    kz_doc:id(Doc).
 
 -spec name(doc()) -> kz_term:api_ne_binary().
 name(Doc) ->

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -250,7 +250,7 @@ merge_attributes(Device, <<"device">>, Keys) ->
     Owner = get_user(kz_doc:account_db(Device), Device),
     Endpoint = kz_json:set_value(<<"owner_id">>, kz_doc:id(Owner), Device),
     case kzd_accounts:fetch(kz_doc:account_id(Device)) of
-        {'ok', Account} -> merge_attributes(Keys, Account, Endpoint, Owner);
+        {'ok', Account} -> merge_attributes(Keys, merge_parent_call_restrictions(Account), Endpoint, Owner);
         {'error', _} -> merge_attributes(Keys, kz_json:new(), Endpoint, Owner)
     end;
 merge_attributes(Account, <<"account">>, Keys) ->
@@ -508,6 +508,17 @@ merge_call_restrictions([Classifier|Classifiers], Account, Endpoint, Owner) ->
             %% user inherit or no user, either way use the device restrictions
             merge_call_restrictions(Classifiers, Account, Endpoint, Owner)
     end.
+
+-spec merge_parent_call_restrictions(kz_json:object()) -> kz_json:object().
+merge_parent_call_restrictions(Account) ->
+    Fun = fun(Parent, Acc) ->
+                  case kzd_accounts:fetch(Parent) of
+                      {'ok', ParentAccount} ->
+                          merge_attributes([<<"call_restriction">>], ParentAccount, Acc, kz_json:new());
+                      {'error', _} -> Acc
+                  end
+          end,
+    lists:foldl(Fun, kz_json:new(), [kzd_accounts:id(Account) | kzd_accounts:tree(Account)]).
 
 -spec get_user(kz_term:ne_binary(), kz_term:api_binary() | kz_json:object()) -> kz_json:object().
 get_user(_AccountDb, 'undefined') -> kz_json:new();


### PR DESCRIPTION
When a child account sets their call-restrictions to `inherit`, this change will allow that restriction to be inherited from their parent accounts. 

A child call-restriction can be inherited from any parent account in the account hierarchy. 