### PR TITLE
Google ASR mp3 to wav conversion + extra configs

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -34475,18 +34475,43 @@
                     "description": "API key for Google Cloud Speech",
                     "type": "string"
                 },
+                "asr_enable_automatic_punctuation": {
+                    "default": "true",
+                    "description": "speech google asr_enable_automatic_punctuation",
+                    "type": "boolean"
+                },
                 "asr_enable_word_time_offsets": {
                     "description": "top result includes a list of words and the start and end time offsets",
                     "type": "boolean"
+                },
+                "asr_encoding": {
+                    "default": "LINEAR16",
+                    "description": "speech google asr_encoding",
+                    "type": "string"
+                },
+                "asr_model": {
+                    "default": "phone_call",
+                    "description": "speech google asr_model",
+                    "type": "string"
                 },
                 "asr_profanity_filter": {
                     "description": "server will attempt to filter out profanities, replacing all but the initial character in each filtered word with asterisk",
                     "type": "boolean"
                 },
+                "asr_sample_rate_hertz": {
+                    "default": "16000",
+                    "description": "speech google asr_sample_rate_hertz",
+                    "type": "string"
+                },
                 "asr_url": {
                     "default": "https://speech.googleapis.com/v1/speech:recognize",
                     "description": "Google Cloud Speech API url",
                     "type": "string"
+                },
+                "asr_use_enhanced": {
+                    "default": true,
+                    "description": "speech google asr_use_enhanced",
+                    "type": "boolean"
                 },
                 "tts_api_key": {
                     "default": "",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -34476,7 +34476,7 @@
                     "type": "string"
                 },
                 "asr_enable_automatic_punctuation": {
-                    "default": "true",
+                    "default": true,
                     "description": "speech google asr_enable_automatic_punctuation",
                     "type": "boolean"
                 },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.speech.google.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.speech.google.json
@@ -9,7 +9,7 @@
             "type": "string"
         },
         "asr_enable_automatic_punctuation": {
-            "default": "true",
+            "default": true,
             "description": "speech google asr_enable_automatic_punctuation",
             "type": "boolean"
         },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.speech.google.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.speech.google.json
@@ -8,18 +8,43 @@
             "description": "API key for Google Cloud Speech",
             "type": "string"
         },
+        "asr_enable_automatic_punctuation": {
+            "default": "true",
+            "description": "speech google asr_enable_automatic_punctuation",
+            "type": "boolean"
+        },
         "asr_enable_word_time_offsets": {
             "description": "top result includes a list of words and the start and end time offsets",
             "type": "boolean"
+        },
+        "asr_encoding": {
+            "default": "LINEAR16",
+            "description": "speech google asr_encoding",
+            "type": "string"
+        },
+        "asr_model": {
+            "default": "phone_call",
+            "description": "speech google asr_model",
+            "type": "string"
         },
         "asr_profanity_filter": {
             "description": "server will attempt to filter out profanities, replacing all but the initial character in each filtered word with asterisk",
             "type": "boolean"
         },
+        "asr_sample_rate_hertz": {
+            "default": "16000",
+            "description": "speech google asr_sample_rate_hertz",
+            "type": "string"
+        },
         "asr_url": {
             "default": "https://speech.googleapis.com/v1/speech:recognize",
             "description": "Google Cloud Speech API url",
             "type": "string"
+        },
+        "asr_use_enhanced": {
+            "default": true,
+            "description": "speech google asr_use_enhanced",
+            "type": "boolean"
         },
         "tts_api_key": {
             "default": "",

--- a/core/kazoo_speech/src/asr/kazoo_asr_google.erl
+++ b/core/kazoo_speech/src/asr/kazoo_asr_google.erl
@@ -22,7 +22,7 @@
 -define(GOOGLE_ASR_SAMPLE_RATE_HERTZ, kapps_config:get_binary(?GOOGLE_CONFIG_CAT, <<"asr_sample_rate_hertz">>, <<"16000">>)).
 -define(GOOGLE_ASR_MODEL, kapps_config:get_binary(?GOOGLE_CONFIG_CAT, <<"asr_model">>, <<"phone_call">>)).
 -define(GOOGLE_ASR_USE_ENHANCED, kapps_config:get_is_true(?GOOGLE_CONFIG_CAT, <<"asr_use_enhanced">>, 'true')).
--define(GOOGLE_ASR_ENABLE_AUTOMATIC_PUNCTUATION, kapps_config:get_is_true(?GOOGLE_CONFIG_CAT, <<"asr_enable_automatic_punctuation">>, "true")).
+-define(GOOGLE_ASR_ENABLE_AUTOMATIC_PUNCTUATION, kapps_config:get_is_true(?GOOGLE_CONFIG_CAT, <<"asr_enable_automatic_punctuation">>, 'true')).
 
 -define(DEFAULT_ASR_CONTENT_TYPE, <<"application/wav">>).
 -define(SUPPORTED_CONTENT_TYPES, [<<"application/wav">>]).


### PR DESCRIPTION
Google does not support mp3, media should be converted. Additional config options let you get more accurate recognition. Works with v1 and v1p1beta1 of Cloud Speech-to-Text API