### PR TITLE
PISTON-745: Added shared convert function to phone_numbers endpoints

### DIFF
--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -29,6 +29,8 @@
 
         ,get_request_action/1
         ,normalize_alphanum_name/1
+
+        ,maybe_convert_numbers_to_list/1
         ]).
 
 -include("crossbar.hrl").
@@ -380,3 +382,19 @@ normalize_alphanum_name(Context) ->
     Doc = cb_context:doc(Context),
     Name = kz_json:get_ne_binary_value(<<"name">>, Doc),
     cb_context:set_doc(Context, kz_json:set_value(<<"pvt_alphanum_name">>, normalize_alphanum_name(Name), Doc)).
+
+-spec maybe_convert_numbers_to_list(cb_context:context()) -> cb_context:context().
+maybe_convert_numbers_to_list(Context) ->
+    case cb_context:req_header(Context, <<"accept">>) of
+        <<"text/csv">> ->
+            Numbers = kz_json:get_json_value(<<"numbers">>, cb_context:resp_data(Context)),
+            NewRespData = kz_json:foldl(fun convert_numbers_to_list/3, [], Numbers),
+            cb_context:set_resp_data(Context, NewRespData);
+        _ -> Context
+    end.
+
+-spec convert_numbers_to_list(kz_term:ne_binary(), kz_json:object(), kz_json:object()) -> kz_json:object().
+convert_numbers_to_list(Key, Value, JObj) ->
+    [kz_json:from_list([{<<"number">>, Key} | kz_json:recursive_to_proplist(Value)])
+     | JObj
+    ].

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -397,7 +397,7 @@ maybe_convert_numbers_to_list(Context) ->
 maybe_requesting_csv(Context) ->
     case cb_context:req_header(Context, <<"accept">>) of
         <<"text/csv">> -> 'true';
-        _ -> <<"csv">> == cb_context:req_param(Context, <<"accept">>)
+        _ -> <<"csv">> =:= cb_context:req_param(Context, <<"accept">>)
     end.
 
 -spec convert_numbers_to_list(kz_term:ne_binary(), kz_json:object(), kz_json:object()) -> kz_json:object().

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -385,12 +385,19 @@ normalize_alphanum_name(Context) ->
 
 -spec maybe_convert_numbers_to_list(cb_context:context()) -> cb_context:context().
 maybe_convert_numbers_to_list(Context) ->
-    case cb_context:req_header(Context, <<"accept">>) of
-        <<"text/csv">> ->
+    case maybe_requesting_csv(Context) of
+        'true' ->
             Numbers = kz_json:get_json_value(<<"numbers">>, cb_context:resp_data(Context)),
             NewRespData = kz_json:foldl(fun convert_numbers_to_list/3, [], Numbers),
             cb_context:set_resp_data(Context, NewRespData);
-        _ -> Context
+        'false' -> Context
+    end.
+
+-spec maybe_requesting_csv(cb_context:context()) -> boolean().
+maybe_requesting_csv(Context) ->
+    case cb_context:req_header(Context, <<"accept">>) of
+        <<"text/csv">> -> 'true';
+        _ -> <<"csv">> == cb_context:req_param(Context, <<"accept">>)
     end.
 
 -spec convert_numbers_to_list(kz_term:ne_binary(), kz_json:object(), kz_json:object()) -> kz_json:object().

--- a/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_phone_numbers_v1.erl
@@ -163,7 +163,7 @@ validate(Context) ->
 validate_1(Context, ?HTTP_GET) ->
     case cb_context:account_id(Context) of
         'undefined' -> find_numbers(Context);
-        _ -> summary(Context)
+        _ -> cb_modules_util:maybe_convert_numbers_to_list(summary(Context))
     end.
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().

--- a/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_phone_numbers_v2.erl
@@ -222,7 +222,7 @@ validate_phone_numbers(Context, ?HTTP_GET, 'undefined') ->
     maybe_find_numbers(Context);
 validate_phone_numbers(Context, ?HTTP_GET, _AccountId) ->
     case kz_json:get_ne_value(?PREFIX, cb_context:query_string(Context)) of
-        'undefined' -> summary(Context);
+        'undefined' -> cb_modules_util:maybe_convert_numbers_to_list(summary(Context));
         _Prefix -> maybe_find_numbers(Context)
     end.
 


### PR DESCRIPTION
The purpose of this PR is to send different data to crossbar from the phone_numbers module. The way it was before this change is it would send the data as a nested JSON object which kz_csv was having trouble formatting into a proper csv. The kz_csv module currently works best with an array of objects which is why I added a check in the phone numbers module to send an array instead of an object, I also added the number to the object properties instead of having it be the key.