### PR TITLE
PORT-21: [4.3] remove enum from post/pre street direction

### DIFF
--- a/applications/crossbar/doc/port_requests.md
+++ b/applications/crossbar/doc/port_requests.md
@@ -97,8 +97,8 @@ Key | Description | Type | Default | Required | Support Level
 `bill.region` | The region (state) of the billing address the losing carrier has on record | `string()` |   | `false` |
 `bill.street_address` | The street name of the billing address the losing carrier has on record | `string()` |   | `false` |
 `bill.street_number` | The street number of the billing address the losing carrier has on record | `string()` |   | `false` |
-`bill.street_post_dir` | Street Post-Direction | `string('E' | 'N' | 'NE' | 'NW' | 'S' | 'SE' | 'SW' | 'W')` |   | `false` |
-`bill.street_pre_dir` | Street Pre-Direction | `string('E' | 'N' | 'NE' | 'NW' | 'S' | 'SE' | 'SW' | 'W')` |   | `false` |
+`bill.street_post_dir` | Street Post-Direction | `string()` |   | `false` |
+`bill.street_pre_dir` | Street Pre-Direction | `string()` |   | `false` |
 `bill.street_type` | The street type of the billing address the losing carrier has on record | `string()` |   | `false` |
 `bill` | Billing information of the losing carrier | `object()` |   | `false` |
 `comments` | The history of comments made on a port request | `["array(", "[#/definitions/comment](#comment)", ")"]` |   | `false` |

--- a/applications/crossbar/doc/ref/port_requests.md
+++ b/applications/crossbar/doc/ref/port_requests.md
@@ -20,8 +20,8 @@ Key | Description | Type | Default | Required | Support Level
 `bill.region` | The region (state) of the billing address the losing carrier has on record | `string()` |   | `false` |  
 `bill.street_address` | The street name of the billing address the losing carrier has on record | `string()` |   | `false` |  
 `bill.street_number` | The street number of the billing address the losing carrier has on record | `string()` |   | `false` |  
-`bill.street_post_dir` | Street Post-Direction | `string('E' | 'N' | 'NE' | 'NW' | 'S' | 'SE' | 'SW' | 'W')` |   | `false` |  
-`bill.street_pre_dir` | Street Pre-Direction | `string('E' | 'N' | 'NE' | 'NW' | 'S' | 'SE' | 'SW' | 'W')` |   | `false` |  
+`bill.street_post_dir` | Street Post-Direction | `string()` |   | `false` |  
+`bill.street_pre_dir` | Street Pre-Direction | `string()` |   | `false` |  
 `bill.street_type` | The street type of the billing address the losing carrier has on record | `string()` |   | `false` |  
 `bill` | Billing information of the losing carrier | `object()` |   | `false` |  
 `comments` | The history of comments made on a port request | `["array(", "[#/definitions/comment](#comment)", ")"]` |   | `false` |  

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -26154,30 +26154,10 @@
                         },
                         "street_post_dir": {
                             "description": "Street Post-Direction",
-                            "enum": [
-                                "E",
-                                "N",
-                                "NE",
-                                "NW",
-                                "S",
-                                "SE",
-                                "SW",
-                                "W"
-                            ],
                             "type": "string"
                         },
                         "street_pre_dir": {
                             "description": "Street Pre-Direction",
-                            "enum": [
-                                "E",
-                                "N",
-                                "NE",
-                                "NW",
-                                "S",
-                                "SE",
-                                "SW",
-                                "W"
-                            ],
                             "type": "string"
                         },
                         "street_type": {

--- a/applications/crossbar/priv/couchdb/schemas/port_requests.json
+++ b/applications/crossbar/priv/couchdb/schemas/port_requests.json
@@ -48,30 +48,10 @@
                 },
                 "street_post_dir": {
                     "description": "Street Post-Direction",
-                    "enum": [
-                        "E",
-                        "N",
-                        "NE",
-                        "NW",
-                        "S",
-                        "SE",
-                        "SW",
-                        "W"
-                    ],
                     "type": "string"
                 },
                 "street_pre_dir": {
                     "description": "Street Pre-Direction",
-                    "enum": [
-                        "E",
-                        "N",
-                        "NE",
-                        "NW",
-                        "S",
-                        "SE",
-                        "SW",
-                        "W"
-                    ],
                     "type": "string"
                 },
                 "street_type": {


### PR DESCRIPTION
Removing enum from post/pre street direction. Old port docs still has empty post/pre and it causing issue for updating the port request.

master: https://github.com/2600hz/kazoo/pull/5702