### PR TITLE
PISTON-680: remove unused X-KAZOO-PUSHER-Invite-Format, extra_headers

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -602,7 +602,6 @@
     "pusher.User-Agents": "pusher User-Agents",
     "pusher.apple.apns_topic": "APNs topic for push notifications payload",
     "pusher.apple.certificate": "PEM-encoded certificate and private key for communicating with APNs",
-    "pusher.apple.extra_headers": "Additional headers for INVITEs sent to push devices in the UA",
     "pusher.apple.host": "APNs host to connect to",
     "pusher.google": "pusher google",
     "pusher.modules": "pusher modules",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -33945,22 +33945,6 @@
                             "description": "PEM-encoded key and certificate",
                             "type": "string"
                         },
-                        "extra_headers": {
-                            "default": {},
-                            "description": "Additional headers for INVITEs sent to push devices in the UA",
-                            "properties": {
-                                "Invite-Format": {
-                                    "description": "When set to push_and_invite, sets the X-KAZOO-PUSHER-Invite-Format header to push_and_invite, resulting in both a push notification and a SIP INVITE being sent to the endpoint.",
-                                    "enum": [
-                                        "invite",
-                                        "push",
-                                        "push_and_invite"
-                                    ],
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
                         "host": {
                             "default": "api.push.apple.com",
                             "description": "APNs server host",
@@ -33976,22 +33960,6 @@
                         "api_key": {
                             "description": "API Key for firebase",
                             "type": "string"
-                        },
-                        "extra_headers": {
-                            "default": {},
-                            "description": "Additional headers for INVITEs sent to push devices in the UA",
-                            "properties": {
-                                "Invite-Format": {
-                                    "description": "When set to push_and_invite, sets the X-KAZOO-PUSHER-Invite-Format header to push_and_invite, resulting in both a push notification and a SIP INVITE being sent to the endpoint.",
-                                    "enum": [
-                                        "invite",
-                                        "push",
-                                        "push_and_invite"
-                                    ],
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
                         }
                     },
                     "type": "object"
@@ -34003,22 +33971,6 @@
                         "api_key": {
                             "description": "API Key for gcm",
                             "type": "string"
-                        },
-                        "extra_headers": {
-                            "default": {},
-                            "description": "Additional headers for INVITEs sent to push devices in the UA",
-                            "properties": {
-                                "Invite-Format": {
-                                    "description": "When set to push_and_invite, sets the X-KAZOO-PUSHER-Invite-Format header to push_and_invite, resulting in both a push notification and a SIP INVITE being sent to the endpoint.",
-                                    "enum": [
-                                        "invite",
-                                        "push",
-                                        "push_and_invite"
-                                    ],
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
                         }
                     },
                     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.pusher.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.pusher.json
@@ -20,22 +20,6 @@
                     "description": "PEM-encoded key and certificate",
                     "type": "string"
                 },
-                "extra_headers": {
-                    "default": {},
-                    "description": "Additional headers for INVITEs sent to push devices in the UA",
-                    "properties": {
-                        "Invite-Format": {
-                            "description": "When set to push_and_invite, sets the X-KAZOO-PUSHER-Invite-Format header to push_and_invite, resulting in both a push notification and a SIP INVITE being sent to the endpoint.",
-                            "enum": [
-                                "invite",
-                                "push",
-                                "push_and_invite"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
                 "host": {
                     "default": "api.push.apple.com",
                     "description": "APNs server host",
@@ -51,22 +35,6 @@
                 "api_key": {
                     "description": "API Key for firebase",
                     "type": "string"
-                },
-                "extra_headers": {
-                    "default": {},
-                    "description": "Additional headers for INVITEs sent to push devices in the UA",
-                    "properties": {
-                        "Invite-Format": {
-                            "description": "When set to push_and_invite, sets the X-KAZOO-PUSHER-Invite-Format header to push_and_invite, resulting in both a push notification and a SIP INVITE being sent to the endpoint.",
-                            "enum": [
-                                "invite",
-                                "push",
-                                "push_and_invite"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
                 }
             },
             "type": "object"
@@ -78,22 +46,6 @@
                 "api_key": {
                     "description": "API Key for gcm",
                     "type": "string"
-                },
-                "extra_headers": {
-                    "default": {},
-                    "description": "Additional headers for INVITEs sent to push devices in the UA",
-                    "properties": {
-                        "Invite-Format": {
-                            "description": "When set to push_and_invite, sets the X-KAZOO-PUSHER-Invite-Format header to push_and_invite, resulting in both a push notification and a SIP INVITE being sent to the endpoint.",
-                            "enum": [
-                                "invite",
-                                "push",
-                                "push_and_invite"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
                 }
             },
             "type": "object"

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -1267,13 +1267,11 @@ push_properties(Endpoint, Call) ->
     PushJObj = kz_json:get_json_value(<<"push">>, Endpoint, kz_json:new()),
     case kz_json:get_ne_binary_value(<<"Token-Type">>, PushJObj) of
         'undefined' -> PushJObj;
-        TokenType ->
-            TokenApp = kz_json:get_ne_binary_value(<<"Token-App">>, PushJObj),
-            Headers = [{<<"Endpoint-ID">>, kz_doc:id(Endpoint)}
-                      ,{<<"Account-ID">>, kapps_call:account_id(Call)}
-                      ],
-            ExtraHeaders = kapps_config:get_json(<<"pusher">>, [TokenType, <<"extra_headers">>], kz_json:new(), TokenApp),
-            kz_json:merge(PushJObj, kz_json:set_values(Headers, ExtraHeaders))
+        _ ->
+            Headers = kz_json:from_list([{<<"Endpoint-ID">>, kz_doc:id(Endpoint)}
+                                        ,{<<"Account-ID">>, kapps_call:account_id(Call)}
+                                        ]),
+            kz_json:merge(PushJObj, Headers)
     end.
 
 -spec push_headers(kz_json:object()) -> kz_json:object().


### PR DESCRIPTION
`extra_headers` and `X-KAZOO-PUSHER-INVITE-FORMAT` were used in a prior version of the Kamailio configs but are no longer used