### PR TITLE
Allow larger media files to be uploaded

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/media.json
+++ b/applications/crossbar/priv/couchdb/schemas/media.json
@@ -5,7 +5,7 @@
     "properties": {
         "content_length": {
             "description": "Length, in bytes, of the file",
-            "maximum": 5242880,
+            "maximum": 11534336,
             "minimum": 1,
             "support_level": "supported",
             "type": "integer"


### PR DESCRIPTION
Update the media system schema file to allow media files up to 11Mb to be uploaded