### PR TITLE
PISTON-773: rework some acdc_agent_util status code

### DIFF
--- a/applications/acdc/src/acdc_agent_util.erl
+++ b/applications/acdc/src/acdc_agent_util.erl
@@ -39,8 +39,7 @@ update_status(?NE_BINARY = AccountId, AgentId, Status, Options) ->
     kz_amqp_worker:cast(API, fun kapi_acdc_stats:publish_status_update/1).
 
 -spec most_recent_status(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                {'ok', kz_term:ne_binary()} |
-                                {'error', any()}.
+                                {'ok', kz_term:ne_binary()}.
 most_recent_status(AccountId, AgentId) ->
     case most_recent_ets_status(AccountId, AgentId) of
         {'ok', _}=OK -> OK;

--- a/applications/acdc/src/acdc_agent_util.erl
+++ b/applications/acdc/src/acdc_agent_util.erl
@@ -18,6 +18,8 @@
         ,most_recent_db_statuses/1, most_recent_db_statuses/2, most_recent_db_statuses/3
 
         ,changed/2, find_most_recent_fold/3
+
+        ,status_should_auto_start/1
         ]).
 
 -include("acdc.hrl").
@@ -54,26 +56,25 @@ most_recent_status(AccountId, AgentId) ->
                                     {'ok', kz_term:ne_binary()} |
                                     {'error', any()}.
 most_recent_ets_status(AccountId, AgentId) ->
-    API = [{<<"Account-ID">>, AccountId}
-          ,{<<"Agent-ID">>, AgentId}
-           | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
-          ],
-    case kz_amqp_worker:call(API
-                            ,fun kapi_acdc_stats:publish_status_req/1
-                            ,fun kapi_acdc_stats:status_resp_v/1
-                            )
-    of
-        {'error', _E}=E -> E;
-        {'ok', Resp} ->
-            Stats = kz_json:get_value([<<"Agents">>, AgentId], Resp),
-            {_, StatusJObj} = kz_json:foldl(fun find_most_recent_fold/3, {0, kz_json:new()}, Stats),
-            {'ok', kz_json:get_value(<<"status">>, StatusJObj)}
+    case most_recent_ets_statuses(AccountId, AgentId) of
+        {'error', _}=E -> E;
+        {'ok', Statuses} ->
+            most_recent_ets_agent_status(kz_json:get_json_value(AgentId, Statuses))
     end.
+
+-spec most_recent_ets_agent_status(kz_term:api_object()) ->
+                                          {'ok', kz_term:ne_binary()} |
+                                          {'error', 'not_found'}.
+most_recent_ets_agent_status('undefined') -> {'error', 'not_found'};
+most_recent_ets_agent_status(Stats) ->
+    {_, StatusJObj} = kz_json:foldl(fun find_most_recent_fold/3, {0, kz_json:new()}, Stats),
+    {'ok', kz_json:get_value(<<"status">>, StatusJObj)}.
 
 -spec most_recent_db_status(kz_term:ne_binary(), kz_term:ne_binary()) ->
                                    {'ok', kz_term:ne_binary()}.
 most_recent_db_status(AccountId, AgentId) ->
     Opts = [{'startkey', [AgentId, kz_time:now_s()]}
+           ,{'endkey', [AgentId, 0]}
            ,{'limit', 1}
            ,'descending'
            ],
@@ -96,6 +97,7 @@ most_recent_db_status(AccountId, AgentId) ->
                                          {'ok', kz_term:ne_binary()}.
 prev_month_recent_db_status(AccountId, AgentId) ->
     Opts = [{'startkey', [AgentId, kz_time:now_s()]}
+           ,{'endkey', [AgentId, 0]}
            ,{'limit', 1}
            ,'descending'
            ],
@@ -132,79 +134,38 @@ most_recent_statuses(AccountId, Options) when is_list(Options) ->
 -spec most_recent_statuses(kz_term:ne_binary(), kz_term:api_binary(), kz_term:proplist()) ->
                                   statuses_return().
 most_recent_statuses(AccountId, AgentId, Options) ->
-    ETS = kz_util:spawn_monitor(fun async_most_recent_ets_statuses/4, [AccountId, AgentId, Options, self()]),
-    DB = maybe_start_db_lookup('async_most_recent_db_statuses'
-                              ,fun async_most_recent_db_statuses/4
-                              ,AccountId, AgentId, Options, self()
-                              ),
-    {'ok', receive_statuses([ETS, DB])}.
+    ETSStatuses = case most_recent_ets_statuses(AccountId, AgentId, Options) of
+                      {'ok', Statuses} -> Statuses;
+                      {'error', _} -> kz_json:new()
+                  end,
+    DBStatuses = case fetch_db_statuses(AccountId, AgentId, Options) of
+                     {'ok', Statuses2} -> Statuses2;
+                     {'error', _} -> kz_json:new()
+                 end,
+    {'ok', kz_json:merge(DBStatuses, ETSStatuses)}.
 
--spec maybe_start_db_lookup(atom(), fun(), kz_term:ne_binary(), kz_term:api_binary(), list(), pid()) ->
-                                   kz_term:pid_ref() | 'undefined'.
-maybe_start_db_lookup(F, Fun, AccountId, AgentId, Options, Self) ->
-    case kz_cache:fetch_local(?CACHE_NAME, db_fetch_key(F, AccountId, AgentId)) of
-        {'ok', _} -> 'undefined';
-        {'error', 'not_found'} ->
-            kz_util:spawn_monitor(Fun, [AccountId, AgentId, Options, Self])
+fetch_db_statuses(AccountId, AgentId, Options) ->
+    case kz_cache:fetch_local(?CACHE_NAME, db_fetch_key(AccountId)) of
+        {'ok', Statuses} -> {'ok', filter_agent_statuses(Statuses, AgentId)};
+        {'error', 'not_found'} -> maybe_db_lookup(AccountId, AgentId, Options)
     end.
 
-db_fetch_key(F, AccountId, AgentId) -> {F, AccountId, AgentId}.
-
--type receive_info() :: [{pid(), reference()} | 'undefined'].
-
--spec receive_statuses(receive_info()) ->
-                              kz_json:object().
-receive_statuses(Reqs) -> receive_statuses(Reqs, kz_json:new()).
-
--spec receive_statuses(receive_info(), kz_json:object()) ->
-                              kz_json:object().
-receive_statuses([], AccJObj) -> AccJObj;
-receive_statuses(['undefined' | Reqs], AccJObj) ->
-    receive_statuses(Reqs, AccJObj);
-receive_statuses([{Pid, Ref} | Reqs], AccJObj) ->
-    receive
-        {'statuses', Statuses, Pid} ->
-            clear_monitor(Ref),
-            receive_statuses(Reqs, kz_json:merge(Statuses, AccJObj));
-        {'DOWN', Ref, 'process', Pid, _R} ->
-            lager:debug("req in ~p died: ~p", [Pid, _R]),
-            clear_monitor(Ref),
-            receive_statuses(Reqs, AccJObj)
-    after 3000 ->
-            lager:debug("timed out waiting for ~p to respond", [Pid]),
-            receive_statuses(Reqs, AccJObj)
-    end.
-
--spec clear_monitor(reference()) -> 'ok'.
-clear_monitor(Ref) ->
-    erlang:demonitor(Ref, ['flush']),
-    receive
-        {'DOWN', Ref, 'process', _, _} -> clear_monitor(Ref)
-    after 0 -> 'ok'
-    end.
-
--spec async_most_recent_ets_statuses(kz_term:ne_binary(), kz_term:api_binary(), kz_term:proplist(), pid()) -> 'ok'.
-async_most_recent_ets_statuses(AccountId, AgentId, Options, Pid) ->
-    case most_recent_ets_statuses(AccountId, AgentId, Options) of
+-spec maybe_db_lookup(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
+                             statuses_return() | {'error', any()}.
+maybe_db_lookup(AccountId, AgentId, Options) ->
+    case most_recent_db_statuses(AccountId, Options) of
         {'ok', Statuses} ->
-            Pid ! {'statuses', Statuses, self()},
-            'ok';
-        {'error', _E} ->
-            Pid ! {'statuses', kz_json:new(), self()},
-            'ok'
+            kz_cache:store_local(?CACHE_NAME, db_fetch_key(AccountId), Statuses),
+            {'ok', filter_agent_statuses(Statuses, AgentId)};
+        {'error', _}=E -> E
     end.
 
--spec async_most_recent_db_statuses(kz_term:ne_binary(), kz_term:api_binary(), kz_term:proplist(), pid()) -> 'ok'.
-async_most_recent_db_statuses(AccountId, AgentId, Options, Pid) ->
-    case most_recent_db_statuses(AccountId, AgentId, Options) of
-        {'ok', Statuses} ->
-            Pid ! {'statuses', Statuses, self()},
-            kz_cache:store_local(?CACHE_NAME, db_fetch_key('async_most_recent_db_statuses', AccountId, AgentId), 'true'),
-            'ok';
-        {'error', _E} ->
-            Pid ! {'statuses', kz_json:new(), self()},
-            'ok'
-    end.
+-spec db_fetch_key(AccountId) -> {'async_most_recent_db_statuses', AccountId}.
+db_fetch_key(AccountId) -> {'async_most_recent_db_statuses', AccountId}.
+
+filter_agent_statuses(Statuses, 'undefined') -> Statuses;
+filter_agent_statuses(Statuses, KeepAgentId) ->
+    kz_json:filter(fun({AgentId, _}) -> AgentId =:= KeepAgentId end, Statuses).
 
 -spec most_recent_ets_statuses(kz_term:ne_binary()) ->
                                       statuses_return() |
@@ -229,14 +190,20 @@ most_recent_ets_statuses(AccountId, AgentId, Options) ->
             ,{<<"Agent-ID">>, AgentId}
              | kz_api:default_headers(?APP_NAME, ?APP_VERSION) ++ Options
             ]),
-    case kz_amqp_worker:call(API
-                            ,fun kapi_acdc_stats:publish_status_req/1
-                            ,fun kapi_acdc_stats:status_resp_v/1
-                            )
+    case kz_amqp_worker:call_collect(API
+                                    ,fun kapi_acdc_stats:publish_status_req/1
+                                    ,'acdc'
+                                    ,3 * ?MILLISECONDS_IN_SECOND
+                                    )
     of
         {'error', _}=E -> E;
-        {'ok', Resp} ->
-            {'ok', kz_json:get_value([<<"Agents">>], Resp, kz_json:new())}
+        {'ok', Resps} ->
+            OKResps = lists:filter(fun kapi_acdc_stats:status_resp_v/1, Resps),
+            Statuses = lists:foldl(fun(Resp, AccJObj) ->
+                                           AgentsStatuses = kz_json:get_json_value(<<"Agents">>, Resp),
+                                           kz_json:merge(AgentsStatuses, AccJObj)
+                                   end, kz_json:new(), OKResps),
+            {'ok', Statuses}
     end.
 
 -spec most_recent_db_statuses(kz_term:ne_binary()) ->
@@ -408,3 +375,8 @@ changed([F|From], To, Add, Rm) ->
         'true' -> changed(From, lists:delete(F, To), Add, Rm);
         'false' -> changed(From, To, Add, [F|Rm])
     end.
+
+-spec status_should_auto_start(kz_term:ne_binary()) -> boolean().
+status_should_auto_start(<<"logged_out">>) -> 'false';
+status_should_auto_start(<<"unknown">>) -> 'false';
+status_should_auto_start(_) -> 'true'.

--- a/applications/acdc/src/acdc_handlers.erl
+++ b/applications/acdc/src/acdc_handlers.erl
@@ -97,7 +97,7 @@ update_acdc_actor(Call, AgentId, <<"user">>) ->
     AcctId = kapps_call:account_id(Call),
 
     case acdc_agent_util:most_recent_status(AcctId, AgentId) of
-        {'ok', <<"logout">>} ->
+        {'ok', <<"logged_out">>} ->
             update_acdc_agent(Call, AcctId, AgentId, <<"login">>, fun kapi_acdc_agent:publish_login/1);
         {'ok', <<"pause">>} ->
             update_acdc_agent(Call, AcctId, AgentId, <<"resume">>, fun kapi_acdc_agent:publish_resume/1);

--- a/applications/acdc/src/acdc_init.erl
+++ b/applications/acdc/src/acdc_init.erl
@@ -94,7 +94,8 @@ init_queues(AccountId, {'error', 'gateway_timeout'}) ->
     wait_a_bit(),
     'ok';
 init_queues(AccountId, {'error', 'not_found'}) ->
-    lager:error("the queues view for ~s appears to be missing; you should probably fix that", [AccountId]);
+    lager:error("the queues view for ~s appears to be missing; you should probably fix that", [AccountId]),
+    'ok';
 init_queues(AccountId, {'error', _E}) ->
     lager:debug("error fetching queues: ~p", [_E]),
     try_queues_again(AccountId),
@@ -102,7 +103,8 @@ init_queues(AccountId, {'error', _E}) ->
     'ok';
 init_queues(AccountId, {'ok', Qs}) ->
     acdc_stats:init_db(AccountId),
-    [acdc_queues_sup:new(AccountId, kz_doc:id(Q)) || Q <- Qs].
+    _ = [acdc_queues_sup:new(AccountId, kz_doc:id(Q)) || Q <- Qs],
+    'ok'.
 
 -spec init_agents(kz_term:ne_binary(), kazoo_data:get_results_return()) -> any().
 init_agents(_, {'ok', []}) -> 'ok';

--- a/applications/acdc/src/acdc_init.erl
+++ b/applications/acdc/src/acdc_init.erl
@@ -140,9 +140,10 @@ try_again(AccountId, F) ->
 spawn_previously_logged_in_agent(AccountId, AgentId) ->
     kz_util:spawn(
       fun() ->
-              case acdc_agent_util:most_recent_status(AccountId, AgentId) of
-                  {'ok', <<"logged_out">>} -> lager:debug("agent ~s in ~s is logged out, not starting", [AgentId, AccountId]);
-                  {'ok', _Status} -> acdc_agents_sup:new(AccountId, AgentId)
+              {'ok', Status} = acdc_agent_util:most_recent_status(AccountId, AgentId),
+              case acdc_agent_util:status_should_auto_start(Status) of
+                  'false' -> lager:debug("agent ~s in ~s is ~s, not starting", [AgentId, AccountId, Status]);
+                  'true' -> acdc_agents_sup:new(AccountId, AgentId)
               end
       end).
 

--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -526,11 +526,10 @@ handle_cast({'reject_member_call', Call, JObj}, #state{account_id=AccountId
     {'noreply', State};
 
 handle_cast({'sync_with_agent', A}, #state{account_id=AccountId}=State) ->
-    case acdc_agent_util:most_recent_status(AccountId, A) of
-        {'ok', Status} ->
-            not acdc_agent_util:status_should_auto_start(Status)
-                andalso gen_listener:cast(self(), {'agent_unavailable', A});
-        _ -> gen_listener:cast(self(), {'agent_available', A})
+    {'ok', Status} = acdc_agent_util:most_recent_status(AccountId, A),
+    case acdc_agent_util:status_should_auto_start(Status) of
+        'true' -> 'ok';
+        'false' -> gen_listener:cast(self(), {'agent_unavailable', A})
     end,
     {'noreply', State};
 

--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -527,7 +527,9 @@ handle_cast({'reject_member_call', Call, JObj}, #state{account_id=AccountId
 
 handle_cast({'sync_with_agent', A}, #state{account_id=AccountId}=State) ->
     case acdc_agent_util:most_recent_status(AccountId, A) of
-        {'ok', <<"logged_out">>} -> gen_listener:cast(self(), {'agent_unavailable', A});
+        {'ok', Status} ->
+            not acdc_agent_util:status_should_auto_start(Status)
+                andalso gen_listener:cast(self(), {'agent_unavailable', A});
         _ -> gen_listener:cast(self(), {'agent_available', A})
     end,
     {'noreply', State};
@@ -686,11 +688,11 @@ publish_queue_member_remove(AccountId, QueueId, CallId) ->
 start_agent_and_worker(WorkersSup, AccountId, QueueId, AgentJObj) ->
     acdc_queue_workers_sup:new_worker(WorkersSup, AccountId, QueueId),
     AgentId = kz_doc:id(AgentJObj),
-    case acdc_agent_util:most_recent_status(AccountId, AgentId) of
-        {'ok', <<"logout">>} -> 'ok';
-        {'ok', <<"logged_out">>} -> 'ok';
-        {'ok', _Status} ->
-            lager:debug("maybe starting agent ~s(~s) for queue ~s", [AgentId, _Status, QueueId]),
+    {'ok', Status} = acdc_agent_util:most_recent_status(AccountId, AgentId),
+    case acdc_agent_util:status_should_auto_start(Status) of
+        'false' -> 'ok';
+        'true' ->
+            lager:debug("maybe starting agent ~s(~s) for queue ~s", [AgentId, Status, QueueId]),
 
             case acdc_agents_sup:find_agent_supervisor(AccountId, AgentId) of
                 'undefined' -> acdc_agents_sup:new(AgentJObj);


### PR DESCRIPTION
- consider <<"unknown">> same as <<"logged_out">> for recent statuses
- use most_recent_ets_statuses/2 for most_recent_ets_status/2, just
  filter afterwards
- set endkey for most_recent_db_status/2 so other agents don't count for
  prev status of a new agent
- reintroduce db statuses, but cache them at the account level since ETS
  can be trusted after start
- most_recent_ets_statuses/2 will pull from _all_ acdc nodes instead of
  just the first to reply. Sorting omitted - we'll trust whichever node
  is first to answer for each agent