### PR TITLE
PISTON-780: add max_slot_number to cf_park: continue after >max parked

### DIFF
--- a/applications/callflow/doc/park.md
+++ b/applications/callflow/doc/park.md
@@ -15,6 +15,7 @@ Key | Description | Type | Default | Required | Support
 `default_callback_timeout` | How long, in seconds, to wait before calling back the parker | `integer` |   | `false` | 
 `default_presence_type` | Type of presence to update | `string('early', 'terminated', 'confirmed')` |   | `false` | 
 `default_ringback_timeout` | How long, in milliseconds, before ringing back | `integer` |   | `false` | 
+`max_slot_number` | Continue past this module if the selected slot number exceeds this number. Used to restrict the max number of auto-generated slot numbers | `integer()` |   | `false` | 
 `presence_id` | use this presence_id | `string` |   | `false` | 
 `slot` | Static slot number to use | `string` |   | `false`
 `slots` | Statically define slots and their configuration | `object` | `null` | `false` | 

--- a/applications/callflow/doc/park.md
+++ b/applications/callflow/doc/park.md
@@ -10,7 +10,7 @@ Validator for the park callflow data object
 
 Key | Description | Type | Default | Required | Support
 --- | ----------- | ---- | ------- | -------- | --------
-`action` | Action to take for the caller | `string('park', 'retrieve', 'auto')` | `park` | `false` |
+`action` | Action to take for the caller | `string('direct_park', 'park', 'retrieve', 'auto')` | `park` | `false` |
 `custom_presence_id` | use configured presence_id and fallback to request | `boolean` | `false` | `false` | 
 `default_callback_timeout` | How long, in seconds, to wait before calling back the parker | `integer` |   | `false` | 
 `default_presence_type` | Type of presence to update | `string('early', 'terminated', 'confirmed')` |   | `false` | 

--- a/applications/callflow/doc/ref/park.md
+++ b/applications/callflow/doc/ref/park.md
@@ -15,6 +15,7 @@ Key | Description | Type | Default | Required | Support Level
 `default_callback_timeout` | How long, in seconds, to wait before calling back the parker | `integer()` |   | `false` |  
 `default_presence_type` | Type of presence to update | `string('early' | 'terminated' | 'confirmed')` |   | `false` |  
 `default_ringback_timeout` | How long, in milliseconds, before ringing back | `integer()` |   | `false` |  
+`max_slot_number` | Continue past this module if the selected slot number exceeds this number. Used to restrict the max number of auto-generated slot numbers | `integer()` |   | `false` |  
 `presence_id` | use this presence_id | `string()` |   | `false` |  
 `skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
 `slot` | Static slot number to use | `string()` |   | `false` |  

--- a/applications/callflow/src/module/cf_park.erl
+++ b/applications/callflow/src/module/cf_park.erl
@@ -124,7 +124,7 @@ direct_park(SlotNumber, Slot, ParkedCalls, Data, Call) ->
     case save_slot(SlotNumber, MaxSlotNumber, Slot, ParkedCalls, Call) of
         {'ok', _} -> parked_call(SlotNumber, Slot, Data, Call);
         {'error', ?MAX_SLOT_EXCEEDED} ->
-            cf_exe:continue(kz_term:to_binary(?MAX_SLOT_EXCEEDED), Call);
+            cf_exe:continue(kz_term:to_upper_binary(?MAX_SLOT_EXCEEDED), Call);
         {'error', _Reason} ->
             lager:info("unable to save direct park slot: ~p", [_Reason]),
             cf_exe:stop(Call)

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -3094,6 +3094,10 @@
                     "description": "How long, in milliseconds, before ringing back",
                     "type": "integer"
                 },
+                "max_slot_number": {
+                    "description": "Continue past this module if the selected slot number exceeds this number. Used to restrict the max number of auto-generated slot numbers",
+                    "type": "integer"
+                },
                 "presence_id": {
                     "description": "use this presence_id",
                     "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/callflows.park.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.park.json
@@ -36,6 +36,10 @@
             "description": "How long, in milliseconds, before ringing back",
             "type": "integer"
         },
+        "max_slot_number": {
+            "description": "Continue past this module if the selected slot number exceeds this number. Used to restrict the max number of auto-generated slot numbers",
+            "type": "integer"
+        },
         "presence_id": {
             "description": "use this presence_id",
             "type": "string"


### PR DESCRIPTION
We have a customer who would like the ability to add a callflow module that parks the call traversing the callflow but only allow up to a certain number (in our case 6) parked calls at a time and do something else if they are full. So we are using the direct_park method of parking the call and have created max_slot_number which is the highest slot number that may be parked by the cf mod. If the auto-generated slot number exceeds the max_slot_number, the callflow will continue to the next module.