### PR TITLE
add tokens consumed and remaining stats to crossbar response

### DIFF
--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -1569,6 +1569,11 @@ maybe_set_pull_response_stream({FileLength, TransportFun}, Req, Context)
 maybe_set_pull_response_stream(Other, Req, Context) ->
     {Other, Req, Context}.
 
+-spec get_token_obj(cb_context:context()) -> kz_json:object().
+get_token_obj(Context) ->
+    kz_json:from_list([{<<"consumed">>, cb_modules_util:token_cost(Context)}
+                      ,{<<"remaining">>, cb_modules_util:tokens_remaining(Context)}
+                      ]).
 %%------------------------------------------------------------------------------
 %% @doc This function extracts the response fields and puts them in a proplist.
 %% @end
@@ -1582,8 +1587,7 @@ do_create_resp_envelope(Context) ->
     Resp = case cb_context:response(Context) of
                {'ok', RespData} ->
                    [{<<"auth_token">>, cb_context:auth_token(Context)}
-                   ,{<<"crossbar_tokens_remaining">>, cb_modules_util:tokens_remaining(Context)}
-                   ,{<<"crossbar_tokens_consumed">>, cb_modules_util:token_cost(Context)}
+                   ,{<<"tokens">>, get_token_obj(Context)}
                    ,{<<"status">>, <<"success">>}
                    ,{<<"request_id">>, cb_context:req_id(Context)}
                    ,{<<"node">>, kz_nodes:node_encoded()}
@@ -1595,8 +1599,7 @@ do_create_resp_envelope(Context) ->
                {'error', {ErrorCode, ErrorMsg, RespData}} ->
                    lager:debug("generating error ~b ~s response", [ErrorCode, ErrorMsg]),
                    [{<<"auth_token">>, kz_term:to_binary(cb_context:auth_token(Context))}
-                   ,{<<"crossbar_tokens_remaining">>, cb_modules_util:tokens_remaining(Context)}
-                   ,{<<"crossbar_tokens_consumed">>, cb_modules_util:token_cost(Context)}
+                   ,{<<"tokens">>, get_token_obj(Context)}
                    ,{<<"request_id">>, cb_context:req_id(Context)}
                    ,{<<"node">>, kz_nodes:node_encoded()}
                    ,{<<"version">>, kz_util:kazoo_version()}

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -1582,6 +1582,8 @@ do_create_resp_envelope(Context) ->
     Resp = case cb_context:response(Context) of
                {'ok', RespData} ->
                    [{<<"auth_token">>, cb_context:auth_token(Context)}
+                   ,{<<"crossbar_tokens_remaining">>, cb_modules_util:tokens_remaining(Context)}
+                   ,{<<"crossbar_tokens_consumed">>, cb_modules_util:token_cost(Context)}
                    ,{<<"status">>, <<"success">>}
                    ,{<<"request_id">>, cb_context:req_id(Context)}
                    ,{<<"node">>, kz_nodes:node_encoded()}
@@ -1593,6 +1595,8 @@ do_create_resp_envelope(Context) ->
                {'error', {ErrorCode, ErrorMsg, RespData}} ->
                    lager:debug("generating error ~b ~s response", [ErrorCode, ErrorMsg]),
                    [{<<"auth_token">>, kz_term:to_binary(cb_context:auth_token(Context))}
+                   ,{<<"crossbar_tokens_remaining">>, cb_modules_util:tokens_remaining(Context)}
+                   ,{<<"crossbar_tokens_consumed">>, cb_modules_util:token_cost(Context)}
                    ,{<<"request_id">>, cb_context:req_id(Context)}
                    ,{<<"node">>, kz_nodes:node_encoded()}
                    ,{<<"version">>, kz_util:kazoo_version()}

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -15,6 +15,7 @@
 
         ,bucket_name/1
         ,token_cost/1, token_cost/2, token_cost/3
+        ,tokens_remaining/1
         ,bind/2
 
         ,take_sync_field/1
@@ -125,6 +126,10 @@ bucket_name('undefined', AccountId) ->
     <<"no_ip/", AccountId/binary>>;
 bucket_name(IP, AccountId) ->
     <<IP/binary, "/", AccountId/binary>>.
+
+-spec tokens_remaining(cb_context:context()) -> non_neg_integer().
+tokens_remaining(Context) ->
+    kz_buckets:tokens_remaining(<<"crossbar">>, bucket_name(Context)).
 
 -spec token_cost(cb_context:context()) -> non_neg_integer().
 token_cost(Context) ->

--- a/core/kazoo_token_buckets/src/kz_buckets.erl
+++ b/core/kazoo_token_buckets/src/kz_buckets.erl
@@ -18,6 +18,7 @@
         ,start_bucket/1, start_bucket/2, start_bucket/3, start_bucket/4, start_bucket/5
         ,exists/1, exists/2
         ,tokens/0
+        ,tokens_remaining/2
 
         ,get_bucket/2, get_bucket/3
         ]).
@@ -254,6 +255,15 @@ print_bucket_info(#bucket{key={App, _}}=Bucket, _OldApp) ->
              ,[App, "", "", "" ,""]
              ),
     print_bucket_info(Bucket, App).
+
+-spec tokens_remaining(kz_term:ne_binary(), kz_term:ne_binary()) -> non_neg_integer().
+tokens_remaining(App, Key) ->
+    case ets:lookup(table_id(), {App, Key}) of
+            [] ->
+                ?MAX_TOKENS(App);
+            [#bucket{srv=P}] ->
+                kz_token_bucket:tokens(P)
+    end.
 
 %%%=============================================================================
 %%% ETS

--- a/core/kazoo_token_buckets/src/kz_buckets.erl
+++ b/core/kazoo_token_buckets/src/kz_buckets.erl
@@ -259,10 +259,10 @@ print_bucket_info(#bucket{key={App, _}}=Bucket, _OldApp) ->
 -spec tokens_remaining(kz_term:ne_binary(), kz_term:ne_binary()) -> non_neg_integer().
 tokens_remaining(App, Key) ->
     case ets:lookup(table_id(), {App, Key}) of
-            [] ->
-                ?MAX_TOKENS(App);
-            [#bucket{srv=P}] ->
-                kz_token_bucket:tokens(P)
+        [] ->
+            ?MAX_TOKENS(App);
+        [#bucket{srv=P}] ->
+            kz_token_bucket:tokens(P)
     end.
 
 %%%=============================================================================


### PR DESCRIPTION
Adds new fields to crossbar response envelope fields for debugging:

`crossbar_tokens_consumed`: the token cost of the request
`crossbar_tokens_remaining`: remaining tokens for this client