### PR TITLE
Prevent infinite loops when undefined is passed to flush_cache_doc or…

### DIFF
--- a/core/kazoo_data/src/kzs_cache.erl
+++ b/core/kazoo_data/src/kzs_cache.erl
@@ -303,6 +303,8 @@ flush_cache_doc(Db, Doc) when is_binary(Db) ->
     flush_cache_doc(Db, Doc, []).
 
 -spec flush_cache_doc(kz_term:ne_binary() | db(), kz_term:ne_binary() | kz_json:object(), kz_term:proplist()) -> 'ok'.
+flush_cache_doc(_, 'undefined', _) ->
+    lager:error("Invalid doc"), 'ok';
 flush_cache_doc(#db{name=Name}, Doc, Options) ->
     flush_cache_doc(kz_term:to_binary(Name), Doc, Options);
 flush_cache_doc(DbName, DocId, _Options) when is_binary(DocId) ->


### PR DESCRIPTION
… when doc doesn't have ID

Every now and then it happens that when you create a new doc it may not have an id yet and if you hit a DB error such as conflict flush_cache_doc is called in an infinite loop. Very difficult to notice it, so I added a guard to detect it and print an error so people can be aware.