### PR TITLE
amqp zones from config are atoms

### DIFF
--- a/core/kazoo_amqp/src/kz_amqp_bootstrap.erl
+++ b/core/kazoo_amqp/src/kz_amqp_bootstrap.erl
@@ -135,30 +135,28 @@ get_zones() ->
         Zones -> Zones
     end.
 
--spec get_from_zone(atom() | kz_term:ne_binary()) -> kz_term:proplist().
-get_from_zone(ZoneAtom) when is_atom(ZoneAtom) ->
-    get_from_zone(kz_term:to_binary(ZoneAtom));
+-spec get_from_zone(atom()) -> kz_term:proplist().
 get_from_zone(ZoneName) ->
     Zones = get_zones(),
     Props = dict:to_list(get_from_zone(ZoneName, Zones, dict:new())),
 
-    case props:get_value(<<"local">>, Props, []) of
-        [] -> [{<<"local">>, kz_config:get(<<"amqp">>, <<"uri">>, [?DEFAULT_AMQP_URI])} | Props];
+    case props:get_value('local', Props, []) of
+        [] -> [{'local', kz_config:get(<<"amqp">>, <<"uri">>, [?DEFAULT_AMQP_URI])} | Props];
         _Else -> Props
     end.
 
--spec get_from_zone(kz_term:ne_binary(), kz_term:proplist(), dict:dict()) -> dict:dict().
+-spec get_from_zone(atom(), kz_term:proplist(), dict:dict()) -> dict:dict().
 get_from_zone(_, [], Dict) -> Dict;
 get_from_zone(ZoneName, [{_, Zone}|Zones], Dict) ->
     case props:get_first_defined([<<"name">>, <<"zone">>], Zone) of
         'undefined' -> get_from_zone(ZoneName, Zones, Dict);
         ZoneName ->
-            get_from_zone(ZoneName, Zones, import_zone(<<"local">>, Zone, Dict));
+            get_from_zone(ZoneName, Zones, import_zone('local', Zone, Dict));
         RemoteZoneName ->
             get_from_zone(ZoneName, Zones, import_zone(RemoteZoneName, Zone, Dict))
     end.
 
--spec import_zone(kz_term:ne_binary(), kz_term:proplist(), dict:dict()) -> dict:dict().
+-spec import_zone(atom(), kz_term:proplist(), dict:dict()) -> dict:dict().
 import_zone(_, [], Dict) -> Dict;
 import_zone(ZoneName, [{<<"amqp_uri">>, URI} | Props], Dict) ->
     case dict:find(ZoneName, Dict) of


### PR DESCRIPTION
```
> kz_config:zone().                        
lx1

> kz_config:get_section(<<"amqp">>).
[{<<"generic">>,
  [{<<"zone">>,lx3},
   {<<"uri">>,<<"amqp://guest:guest@rabbitmq:5676/lx3">>},
   {<<"pool_size">>,50}]},
 {<<"generic">>,
  [{<<"zone">>,lx2},
   {<<"uri">>,<<"amqp://guest:guest@rabbitmq:5676/lx2">>},
   {<<"pool_size">>,50}]},
 {<<"generic">>,
  [{<<"uri">>,<<"amqp://guest:guest@rabbitmq:5676/lx1">>},
   {<<"pool_size">>,50},
   {<<"zone">>,lx1}]}]
```
produces

```
[{lx2,[<<"amqp://guest:guest@rabbitmq:5676/lx2">>]},
 {lx3,[<<"amqp://guest:guest@rabbitmq:5676/lx3">>]},
 {local,[<<"amqp://guest:guest@rabbitmq:5676/lx1">>]}]
```
