### PR TITLE
API crash when 'format' JSON schema is triggered

### DIFF
--- a/applications/crossbar/doc/ref/users.md
+++ b/applications/crossbar/doc/ref/users.md
@@ -31,7 +31,7 @@ Key | Description | Type | Default | Required | Support Level
 `directories` | Provides the mappings for what directory the user is a part of (the key), and what callflow (the value) to invoke if the user is selected by the caller. | `object()` |   | `false` |  
 `do_not_disturb.enabled` | Is do-not-disturb enabled for this user? | `boolean()` |   | `false` |  
 `do_not_disturb` | DND Parameters | `object()` |   | `false` |  
-`email` | The email of the user | `string(1..254)` |   | `false` | `supported`
+`email` | The email of the user | `string(3..254)` |   | `false` | `supported`
 `enabled` | Determines if the user is currently enabled | `boolean()` | `true` | `false` | `supported`
 `feature_level` | The user level for assigning feature sets | `string()` |   | `false` |  
 `first_name` | The first name of the user | `string(1..128)` |   | `true` | `supported`

--- a/applications/crossbar/doc/users.md
+++ b/applications/crossbar/doc/users.md
@@ -33,7 +33,7 @@ Key | Description | Type | Default | Required | Support Level
 `directories` | Provides the mappings for what directory the user is a part of (the key), and what callflow (the value) to invoke if the user is selected by the caller. | `object()` |   | `false` |  
 `do_not_disturb.enabled` | Is do-not-disturb enabled for this user? | `boolean()` |   | `false` |  
 `do_not_disturb` | DND Parameters | `object()` |   | `false` |  
-`email` | The email of the user | `string(1..254)` |   | `false` | `supported`
+`email` | The email of the user | `string(3..254)` |   | `false` | `supported`
 `enabled` | Determines if the user is currently enabled | `boolean()` | `true` | `false` | `supported`
 `feature_level` | The user level for assigning feature sets | `string()` |   | `false` |  
 `first_name` | The first name of the user | `string(1..128)` |   | `true` | `supported`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -35960,7 +35960,7 @@
                     "description": "The email of the user",
                     "format": "email",
                     "maxLength": 254,
-                    "minLength": 1,
+                    "minLength": 3,
                     "type": "string"
                 },
                 "enabled": {

--- a/applications/crossbar/priv/couchdb/schemas/users.json
+++ b/applications/crossbar/priv/couchdb/schemas/users.json
@@ -129,7 +129,7 @@
             "description": "The email of the user",
             "format": "email",
             "maxLength": 254,
-            "minLength": 1,
+            "minLength": 3,
             "support_level": "supported",
             "type": "string"
         },

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -974,9 +974,9 @@ failed_error(Error, Context) ->
 
 -spec passed(context()) -> context().
 passed(Context) ->
-    Context1 = case error =:= resp_status(Context) of
-                   true -> Context;
-                   false -> set_resp_status(Context, success)
+    Context1 = case 'error' =:= resp_status(Context) of
+                   'true' -> Context;
+                   'false' -> set_resp_status(Context, 'success')
                end,
     case kz_doc:id(req_data(Context1)) of
         'undefined' -> Context1;

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -920,12 +920,13 @@ format_emergency_caller_id_number(Context, Emergency) ->
     case kz_json:get_ne_binary_value(<<"number">>, Emergency) of
         'undefined' -> Context;
         Number ->
-            NEmergency = kz_json:set_value(<<"number">>, knm_converters:normalize(Number), Emergency),
-            CallerId = cb_context:req_value(Context, <<"caller_id">>),
-            NCallerId = kz_json:set_value(?KEY_EMERGENCY, NEmergency, CallerId),
+            NEmergencyJObj = kz_json:set_value(<<"number">>, knm_converters:normalize(Number), Emergency),
+            CallerIdJObj = cb_context:req_value(Context, <<"caller_id">>),
+            NCallerIdJObj = kz_json:set_value(?KEY_EMERGENCY, NEmergencyJObj, CallerIdJObj),
 
+            lager:debug("setting emergency caller id from ~s to ~s", [Number, knm_converters:normalize(Number)]),
             cb_context:set_req_data(Context
-                                   ,kz_json:set_value(<<"caller_id">>, NCallerId, cb_context:req_data(Context))
+                                   ,kz_json:set_value(<<"caller_id">>, NCallerIdJObj, cb_context:req_data(Context))
                                    )
     end.
 

--- a/core/kazoo_proper/src/kazoo_proper.hrl
+++ b/core/kazoo_proper/src/kazoo_proper.hrl
@@ -28,5 +28,20 @@
        ,_ = data:error(pqc_log:log_info(), Fmt, Args)
        ).
 
+-type expected_codes() :: [response_code()].
+-type expected_header() :: {string(), string() | {'match', string()}}.
+-type expected_headers() :: [expected_header()].
+
+-type response_code() :: 200..600.
+-type response_headers() :: [{string(), string()}].
+-type request_headers() :: [{string(), string()}].
+
+-record(expectation, {response_codes = [] :: expected_codes()
+                     ,response_headers = [] :: expected_headers()
+                     }
+       ).
+-type expectation() :: #expectation{}.
+-type expectations() :: [expectation()].
+
 -define(KAZOO_PROPER_HRL, 'true').
 -endif.

--- a/core/kazoo_proper/src/pqc_cb_accounts.erl
+++ b/core/kazoo_proper/src/pqc_cb_accounts.erl
@@ -53,7 +53,7 @@ create_account(API, NewAccountName, AccountId) ->
     RequestData = kz_json:from_list([{<<"name">>, NewAccountName}]),
     RequestEnvelope = pqc_cb_api:create_envelope(RequestData),
 
-    Resp = pqc_cb_api:make_request([201, 500]
+    Resp = pqc_cb_api:make_request([#expectation{response_codes=[201, 500]}]
                                   ,fun kz_http:put/3
                                   ,account_url(AccountId)
                                   ,pqc_cb_api:request_headers(API)
@@ -71,7 +71,7 @@ allow_number_additions(AccountId) ->
 
 -spec fetch_account(pqc_cb_api:statE(), kz_term:ne_binary()) -> pqc_cb_api:response().
 fetch_account(API, AccountId) ->
-    pqc_cb_api:make_request([200]
+    pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                            ,fun kz_http:get/2
                            ,account_url(AccountId)
                            ,pqc_cb_api:request_headers(API)
@@ -81,7 +81,7 @@ fetch_account(API, AccountId) ->
 patch_account(API, AccountId, ReqJObj) ->
     RequestEnvelope = pqc_cb_api:create_envelope(ReqJObj),
 
-    pqc_cb_api:make_request([200]
+    pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                            ,fun kz_http:patch/3
                            ,account_url(AccountId)
                            ,pqc_cb_api:request_headers(API)
@@ -90,10 +90,13 @@ patch_account(API, AccountId, ReqJObj) ->
 
 -spec delete_account(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 delete_account(API, AccountId) ->
-    URL = account_url(AccountId),
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    pqc_cb_api:make_request([200], fun kz_http:delete/2, URL, RequestHeaders).
+    pqc_cb_api:make_request([#expectation{response_codes=[200]}]
+                           ,fun kz_http:delete/2
+                           ,account_url(AccountId)
+                           ,RequestHeaders
+                           ).
 
 -spec cleanup_accounts(kz_term:ne_binaries()) -> 'ok'.
 cleanup_accounts(AccountNames) ->
@@ -177,7 +180,7 @@ seq() ->
 enable_and_delete_topup(API) ->
     ?INFO("STARTING ENABLE_AND_DISABLE_TOPUP TEST"),
     %% Make sure everything is clean for the test.
-    cleanup(API),
+    _ = cleanup(API),
 
     AccountResp = create_account(API, hd(?ACCOUNT_NAMES)),
     ?INFO("created account: ~s", [AccountResp]),
@@ -201,14 +204,14 @@ enable_and_delete_topup(API) ->
 
     'undefined' = kz_json:get_ne_value(<<"topup">>, kz_json:decode(Resp1)),
 
-    cleanup(API),
+    _ = cleanup(API),
     ?INFO("FINISHED ENABLE_AND_DISABLE_TOPUP TEST").
 
 -spec enable_and_disable_account_using_patch(pqc_cb_api:state()) -> 'ok'.
 enable_and_disable_account_using_patch(API) ->
     ?INFO("STARTING ENABLE_AND_DISABLE_ACCOUNT_USING_PATCH TEST"),
     %% Make sure everything is clean for the test.
-    cleanup(API),
+    _ = cleanup(API),
 
     AccountResp = create_account(API, hd(?ACCOUNT_NAMES)),
     ?INFO("created account: ~s", [AccountResp]),
@@ -228,7 +231,7 @@ enable_and_disable_account_using_patch(API) ->
     Enabled = pqc_cb_response:data(patch_account(API, AccountId, ReqJObj1)),
     'true' = kz_json:is_true(<<"enabled">>, Enabled, 'true'),
 
-    cleanup(API),
+    _ = cleanup(API),
     ?INFO("FINISHED ENABLE_AND_DISABLE_ACCOUNT_USING_PATCH TEST").
 
 -spec cleanup(pqc_cb_api:state()) -> any().
@@ -239,7 +242,7 @@ cleanup(API) ->
 
 -spec topup_request(pqc_cb_api:state(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
 topup_request(API, AccountId, RequestEnvelope) ->
-    pqc_cb_api:make_request([200]
+    pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                            ,fun kz_http:post/3
                            ,account_url(AccountId)
                            ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_cb_ips.erl
+++ b/core/kazoo_proper/src/pqc_cb_ips.erl
@@ -70,7 +70,7 @@ ip_url(AccountId, IP) ->
                       {'ok', kz_json:objects()} |
                       {'error', 'not_found'}.
 list_ips(API) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ips_url()
                                 ,pqc_cb_api:request_headers(API)
@@ -93,7 +93,7 @@ assign_ips(API, AccountId, Dedicateds) ->
     IPs = [IP || ?DEDICATED(IP, _, _) <- Dedicateds],
     Envelope = pqc_cb_api:create_envelope(IPs),
 
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:post/3
                                 ,ips_url(AccountId)
                                 ,pqc_cb_api:request_headers(API)
@@ -114,7 +114,7 @@ assign_ips(API, AccountId, Dedicateds) ->
 remove_ip(_API, 'undefined', _Dedicated) ->
     {'error', 'not_found'};
 remove_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
-    case pqc_cb_api:make_request([200, 404]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200, 404]}]
                                 ,fun kz_http:delete/2
                                 ,ip_url(AccountId, IP)
                                 ,pqc_cb_api:request_headers(API)
@@ -133,7 +133,7 @@ remove_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
 fetch_ip(_API, 'undefined', _Dedicated) ->
     {'error', 'not_found'};
 fetch_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ip_url(AccountId, IP)
                                 ,pqc_cb_api:request_headers(API)
@@ -153,7 +153,7 @@ assign_ip(_API, 'undefined', _Dedicated) ->
     {'error', 'not_found'};
 assign_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
     Envelope = pqc_cb_api:create_envelope(kz_json:new()),
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:post/3
                                 ,ip_url(AccountId, IP)
                                 ,pqc_cb_api:request_headers(API)
@@ -171,7 +171,7 @@ assign_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
                          {'ok', kz_term:ne_binaries()} |
                          {'error', 'not_found'}.
 fetch_hosts(API) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ip_url("hosts")
                                 ,pqc_cb_api:request_headers(API)
@@ -188,7 +188,7 @@ fetch_hosts(API) ->
                          {'ok', kz_term:ne_binaries()} |
                          {'error', 'not_found'}.
 fetch_zones(API) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ip_url("zones")
                                 ,pqc_cb_api:request_headers(API)
@@ -207,7 +207,7 @@ fetch_zones(API) ->
 fetch_assigned(_API, 'undefined') ->
     {'error', 'not_found'};
 fetch_assigned(API, AccountId) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ip_url(AccountId, "assigned")
                                 ,pqc_cb_api:request_headers(API)
@@ -229,7 +229,7 @@ create_ip(API, ?DEDICATED(IP, Host, Zone)) ->
                              ,{<<"zone">>, Zone}
                              ]),
     Envelope = pqc_cb_api:create_envelope(Data),
-    case pqc_cb_api:make_request([201, 409]
+    case pqc_cb_api:make_request([#expectation{response_codes=[201, 409]}]
                                 ,fun kz_http:put/3
                                 ,ips_url()
                                 ,pqc_cb_api:request_headers(API)
@@ -253,7 +253,7 @@ create_ip(API, ?DEDICATED(IP, Host, Zone)) ->
                        {'ok', kz_json:object()} |
                        {'error', 'not_found'}.
 delete_ip(API, ?DEDICATED(IP, _Host, _Zone)) ->
-    case pqc_cb_api:make_request([200, 404]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200, 404]}]
                                 ,fun kz_http:delete/2
                                 ,ip_url(IP)
                                 ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_cb_ledgers.erl
+++ b/core/kazoo_proper/src/pqc_cb_ledgers.erl
@@ -28,11 +28,12 @@ fetch(API, ?NE_BINARY=AccountId) ->
 -spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 fetch(API, ?NE_BINARY=AccountId, ?NE_BINARY=AcceptType) ->
     LedgersURL = ledgers_url(AccountId),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"accept">>, AcceptType}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{"accept", kz_term:to_list(AcceptType)}]),
 
-    Expectations = #{'response_codes' => [200]
-                    ,'response_headers' => [{<<"content-type">>, AcceptType}]
-                    },
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", kz_term:to_list(AcceptType)}]
+                                }
+                   ],
 
     pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
@@ -49,12 +50,12 @@ fetch_by_source(API, ?NE_BINARY=AccountId, ?NE_BINARY=SourceType) ->
                              pqc_cb_api:response().
 fetch_by_source(API, ?NE_BINARY=AccountId, SourceType, ?NE_BINARY=AcceptType) ->
     LedgersURL = ledgers_source_url(AccountId, SourceType),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"accept">>, AcceptType}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{"accept", kz_term:to_list(AcceptType)}]),
 
-    Expectations = [#{'response_codes' => [200]
-                     ,'response_headers' => [{<<"content-type">>, AcceptType}]
-                     }
-                   ,#{'response_codes' => [204]}
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", kz_term:to_list(AcceptType)}]
+                                }
+                   ,#expectation{response_codes = [204]}
                    ],
 
     pqc_cb_api:make_request(Expectations
@@ -69,7 +70,7 @@ credit(API, ?NE_BINARY=AccountId, Ledger) ->
     LedgersURL = ledgers_credit_url(AccountId),
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    Expectations = #{'response_codes' => [201]},
+    Expectations = [#expectation{response_codes = [201]}],
 
     Envelope = pqc_cb_api:create_envelope(Ledger),
 
@@ -86,7 +87,7 @@ debit(API, ?NE_BINARY=AccountId, Ledger) ->
     LedgersURL = ledgers_debit_url(AccountId),
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    Expectations = #{'response_codes' => [201]},
+    Expectations = [#expectation{response_codes = [201]}],
 
     Envelope = pqc_cb_api:create_envelope(Ledger),
 

--- a/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
+++ b/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
@@ -42,7 +42,12 @@ list_number(API, AccountId, Number) ->
     URL = number_url(AccountId, Number),
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    pqc_cb_api:make_request([200, 404], fun kz_http:get/2, URL, RequestHeaders).
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,URL
+                           ,RequestHeaders
+                           ).
 
 -spec add_number(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 add_number(_API, 'undefined', _Number) -> ?FAILED_RESPONSE;
@@ -52,7 +57,8 @@ add_number(API, AccountId, Number) ->
     RequestEnvelope  = pqc_cb_api:create_envelope(kz_json:new()
                                                  ,kz_json:from_list([{<<"accept_charges">>, 'true'}])
                                                  ),
-    pqc_cb_api:make_request([201, 404, 409]
+    Expectations = [#expectation{response_codes = [201, 404, 409]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,URL
                            ,RequestHeaders
@@ -64,7 +70,8 @@ remove_number(_API, 'undefined', _Number) -> ?FAILED_RESPONSE;
 remove_number(API, AccountId, Number) ->
     URL = number_url(AccountId, Number),
     RequestHeaders = pqc_cb_api:request_headers(API),
-    pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:delete/2
                            ,URL
                            ,RequestHeaders
@@ -76,7 +83,9 @@ activate_number(API, AccountId, Number) ->
     URL = number_url(AccountId, Number, "activate"),
     RequestHeaders = pqc_cb_api:request_headers(API),
     RequestEnvelope  = pqc_cb_api:create_envelope(kz_json:new(), kz_json:from_list([{<<"accept_charges">>, 'true'}])),
-    pqc_cb_api:make_request([201, 404, 500]
+
+    Expectations = [#expectation{response_codes = [201, 404, 500]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,URL
                            ,RequestHeaders

--- a/core/kazoo_proper/src/pqc_cb_rates.erl
+++ b/core/kazoo_proper/src/pqc_cb_rates.erl
@@ -109,7 +109,7 @@ create_service_plan(API, RatedeckId) ->
             'ok'
     end.
 
--spec assign_service_plan(pqc_cb_api:state(), kz_term:ne_binary() | proper_types:type(), kz_term:ne_binary()) ->
+-spec assign_service_plan(pqc_cb_api:state(), kz_term:api_ne_binary() | proper_types:type(), kz_term:ne_binary()) ->
                                  pqc_cb_api:response().
 assign_service_plan(_API, 'undefined', _RatedeckId) ->
     ?INFO("no account to assign ~s to", [_RatedeckId]),
@@ -119,8 +119,8 @@ assign_service_plan(API, AccountId, RatedeckId) ->
     ServicePlanId = service_plan_id(RatedeckId),
     pqc_cb_services:assign_service_plan(API, AccountId, ServicePlanId).
 
--spec rate_account_did(pqc_cb_api:state(), kz_term:ne_binary() | proper_types:type(), kz_term:ne_binary()) ->
-                              kz_term:api_integer().
+-spec rate_account_did(pqc_cb_api:state(), kz_term:api_ne_binary() | proper_types:type(), kz_term:ne_binary()) ->
+                              kz_term:api_number().
 rate_account_did(_API, 'undefined', _DID) ->
     ?INFO("account doesn't exist to rate DID ~p", [_DID]),
     ?FAILED_RESPONSE;
@@ -189,7 +189,8 @@ delete_rate(API, ID, <<_/binary>>=RatedeckId) ->
     ?INFO("deleting rate ~s from ~s", [ID, RatedeckId]),
 
     URL = rate_url(ID, RatedeckId),
-    pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:delete/2
                            ,URL ++ "&should_soft_delete=false"
                            ,pqc_cb_api:request_headers(API)
@@ -202,7 +203,8 @@ get_rate(API, RateDoc) ->
     ?INFO("getting rate info for ~s in ~s", [ID, kzd_rates:ratedeck_id(RateDoc)]),
 
     URL = rate_url(ID, kzd_rates:ratedeck_id(RateDoc)),
-    pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,URL
                            ,pqc_cb_api:request_headers(API)
@@ -215,7 +217,8 @@ get_rates(API) ->
 -spec get_rates(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 get_rates(API, RatedeckId) ->
     ?INFO("getting rates for ratedeck ~s", [RatedeckId]),
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,rates_url() ++ "?ratedeck_id=" ++ kz_term:to_list(RatedeckId)
                            ,pqc_cb_api:request_headers(API)
@@ -228,7 +231,8 @@ get_rates_by_prefix(API, Prefix) ->
 -spec get_rates_by_prefix(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 get_rates_by_prefix(API, Prefix, RatedeckId) ->
     ?INFO("getting rates for ratedeck ~s by prefix ~s", [RatedeckId, Prefix]),
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,rates_url()
                             ++ "?ratedeck_id=" ++ kz_term:to_list(RatedeckId)
@@ -236,7 +240,7 @@ get_rates_by_prefix(API, Prefix, RatedeckId) ->
                            ,pqc_cb_api:request_headers(API)
                            ).
 
--spec rate_did(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_integer().
+-spec rate_did(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_number().
 rate_did(API, RatedeckId, DID) ->
     ?INFO("rating DID ~s using ~s", [DID, RatedeckId]),
     URL = rate_number_url(RatedeckId, DID),
@@ -247,7 +251,8 @@ rate_did(API, RatedeckId, DID) ->
 make_rating_request(API, URL) ->
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    Resp = pqc_cb_api:make_request([200, 500]
+    Expectations = [#expectation{response_codes = [200, 500]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,RequestHeaders

--- a/core/kazoo_proper/src/pqc_cb_recordings.erl
+++ b/core/kazoo_proper/src/pqc_cb_recordings.erl
@@ -28,7 +28,8 @@
                              {'error', 'not_found'} |
                              {'ok', kz_json:objects()}.
 list_recordings(API, AccountId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200]}
+    Expectations = [#expectation{response_codes = [200]}],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:get/2
                                 ,recordings_url(AccountId)
                                 ,pqc_cb_api:request_headers(API)
@@ -46,7 +47,8 @@ list_recordings(API, AccountId) ->
                              {'ok', kz_json:object()} |
                              {'error', 'not_found'}.
 fetch_recording(API, AccountId, RecordingId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200]}
+    Expectations = [#expectation{response_codes = [200]}],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:get/2
                                 ,recordings_url(AccountId, RecordingId)
                                 ,pqc_cb_api:request_headers(API)
@@ -64,13 +66,13 @@ fetch_recording(API, AccountId, RecordingId) ->
                                     {'ok', kz_term:ne_binary()} |
                                     {'error', 'not_found'}.
 fetch_recording_binary(API, AccountId, RecordingId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200]
-                                  ,'response_headers' =>
-                                       [{"content-type", "audio/mpeg"}]
-                                  }
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "audio/mpeg"}]
+                                }],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:get/2
                                 ,recordings_url(AccountId, RecordingId)
-                                ,pqc_cb_api:request_headers(API, [{<<"accept">>, "audio/mpeg"}])
+                                ,pqc_cb_api:request_headers(API, [{"accept", "audio/mpeg"}])
                                 )
     of
         {'error', _E} ->
@@ -84,10 +86,10 @@ fetch_recording_binary(API, AccountId, RecordingId) ->
                                       {'ok', kz_term:ne_binary()} |
                                       {'error', 'not_found'}.
 fetch_recording_tunneled(API, AccountId, RecordingId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200]
-                                  ,'response_headers' =>
-                                       [{"content-type", "audio/mpeg"}]
-                                  }
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "audio/mpeg"}]
+                                }],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:get/2
                                 ,recordings_url(AccountId, RecordingId) ++ "?accept=audio/mpeg"
                                 ,pqc_cb_api:request_headers(API)
@@ -134,7 +136,8 @@ create_attachment(MODB, DocId) ->
                               {'ok', kz_json:object()} |
                               {'error', 'not_found'}.
 delete_recording(API, AccountId, RecordingId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200, 404]}
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:delete/2
                                 ,recordings_url(AccountId, RecordingId)
                                 ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_cb_search.erl
+++ b/core/kazoo_proper/src/pqc_cb_search.erl
@@ -20,7 +20,12 @@ search_account_by_name(API, Name) ->
                     ,{<<"v">>, Name}
                     ]
                    ),
-    pqc_cb_api:make_request([200], fun kz_http:get/2, URL ++ [$? | Querystring], RequestHeaders).
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,URL ++ [$? | Querystring]
+                           ,RequestHeaders
+                           ).
 
 -spec search_url(pqc_cb_api:state()) -> string().
 search_url(API) ->

--- a/core/kazoo_proper/src/pqc_cb_services.erl
+++ b/core/kazoo_proper/src/pqc_cb_services.erl
@@ -42,7 +42,8 @@ assign_service_plan(API, AccountId, ServicePlanId) ->
     RequestData = kz_json:from_list([{<<"add">>, [ServicePlanId]}]),
     RequestEnvelope = pqc_cb_api:create_envelope(RequestData),
 
-    pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:post/3
                            ,URL
                            ,RequestHeaders
@@ -54,7 +55,8 @@ assign_service_plan(API, AccountId, ServicePlanId) ->
 available_service_plans(API, AccountId) ->
     URL = string:join([account_service_plan_url(AccountId), "available"], "/"),
     RequestHeaders = pqc_cb_api:request_headers(API),
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,URL
                            ,RequestHeaders

--- a/core/kazoo_proper/src/pqc_cb_storage.erl
+++ b/core/kazoo_proper/src/pqc_cb_storage.erl
@@ -49,8 +49,9 @@ create(API, AccountId, ?NE_BINARY=UUID, ValidateSettings) ->
     create(API, AccountId, storage_doc(UUID), ValidateSettings);
 create(API, AccountId, StorageDoc, ValidateSettings) ->
     StorageURL = storage_url(AccountId, ValidateSettings),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, <<"application/json">>}]),
-    pqc_cb_api:make_request([201, 400]
+    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "application/json"}]),
+    Expectations = [#expectation{response_codes = [201, 400]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,StorageURL
                            ,RequestHeaders

--- a/core/kazoo_proper/src/pqc_cb_system_configs.erl
+++ b/core/kazoo_proper/src/pqc_cb_system_configs.erl
@@ -74,7 +74,8 @@ config_url(Id, NodeId) ->
 -spec list_configs(pqc_cb_api:api()) -> kz_term:ne_binaries().
 list_configs(API) ->
     URL = configs_url(),
-    Resp = pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -84,7 +85,8 @@ list_configs(API) ->
 -spec get_config(pqc_cb_api:api(), kz_term:ne_binary()) -> kzd_system_configs:doc().
 get_config(API, Id) ->
     URL = config_url(Id),
-    Resp = pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -94,7 +96,8 @@ get_config(API, Id) ->
 -spec get_default_config(pqc_cb_api:api(), kz_term:ne_binary()) -> kzd_system_configs:doc().
 get_default_config(API, Id) ->
     URL = config_url(Id) ++ "?with_defaults=true",
-    Resp = pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -104,7 +107,8 @@ get_default_config(API, Id) ->
 -spec get_node_config(pqc_cb_api:api(), kz_term:ne_binary(), kz_term:ne_binary()) -> kzd_system_configs:doc().
 get_node_config(API, Id, NodeId) ->
     URL = config_url(Id, NodeId) ++ "?with_defaults=true",
-    Resp = pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -117,8 +121,9 @@ set_default_config(API, Config) ->
     ?INFO("setting default config for ~p", [Config]),
     URL = config_url(kz_doc:id(Config)),
     Data = pqc_cb_api:create_envelope(Config),
+    Expectations = [#expectation{response_codes = [200]}],
 
-    Resp = pqc_cb_api:make_request([200]
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:post/3
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -131,8 +136,9 @@ patch_default_config(API, Id, Config) ->
     ?INFO("patching default config for ~p", [Config]),
     URL = config_url(Id),
     Data = pqc_cb_api:create_envelope(Config),
+    Expectations = [#expectation{response_codes = [200]}],
 
-    Resp = pqc_cb_api:make_request([200]
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:patch/3
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -143,7 +149,8 @@ patch_default_config(API, Id, Config) ->
 -spec delete_config(pqc_cb_api:api(), kz_term:ne_binary()) -> kz_json:object().
 delete_config(API, Id) ->
     URL = config_url(Id),
-    Resp = pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:delete/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_cb_tasks.erl
+++ b/core/kazoo_proper/src/pqc_cb_tasks.erl
@@ -18,9 +18,10 @@
 -spec create(pqc_cb_api:state(), string(), iolist()) -> pqc_cb_api:response().
 create(API, QueryString, CSV) ->
     TaskURL = tasks_url(QueryString),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, <<"text/csv">>}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "text/csv"}]),
+    Expectations = [#expectation{response_codes = [201, 404, 409]}],
 
-    pqc_cb_api:make_request([201, 404, 409]
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,TaskURL
                            ,RequestHeaders
@@ -29,7 +30,8 @@ create(API, QueryString, CSV) ->
 
 -spec execute(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 execute(API, TaskId) ->
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:patch/3
                            ,task_url(TaskId)
                            ,pqc_cb_api:request_headers(API)
@@ -38,7 +40,8 @@ execute(API, TaskId) ->
 
 -spec fetch(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 fetch(API, TaskId) ->
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,task_url(TaskId)
                            ,pqc_cb_api:request_headers(API)
@@ -46,20 +49,21 @@ fetch(API, TaskId) ->
 
 -spec fetch_csv(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 fetch_csv(API, TaskId, CSV) ->
-    Expectations = [#{'response_codes' => [200]
-                     ,'response_headers' => [{"content-type", "text/csv"}]
-                     }
-                   ,#{'response_codes' => [204]}
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "text/csv"}]
+                                }
+                   ,#expectation{response_codes = [204]}
                    ],
     pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,task_csv_url(TaskId, CSV)
-                           ,pqc_cb_api:request_headers(API, [{<<"accept">>, <<"text/csv">>}])
+                           ,pqc_cb_api:request_headers(API, [{"accept", "text/csv"}])
                            ).
 
 -spec delete(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 delete(API, TaskId) ->
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:delete/2
                            ,task_url(TaskId)
                            ,pqc_cb_api:request_headers(API)
@@ -71,8 +75,9 @@ query(API, Category, Action) ->
                         ,"&action=", kz_term:to_list(Action)
                         ]
                        ),
+    Expectations = [#expectation{response_codes = [200]}],
 
-    pqc_cb_api:make_request([200]
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,TaskURL
                            ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_cb_users.erl
+++ b/core/kazoo_proper/src/pqc_cb_users.erl
@@ -1,0 +1,228 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_users).
+
+%% API requests
+-export([summary/2
+        ,create/3
+        ,fetch/3
+        ,update/3
+        ,patch/4
+        ,delete/3
+        ]).
+
+-export([seq/0
+        ,cleanup/0
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<"account_for_users">>]).
+
+-spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+summary(API, AccountId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,users_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec create(pqc_cb_api:state(), kz_term:ne_binary(), kzd_users:doc()) -> pqc_cb_api:response().
+create(API, AccountId, UserJObj) ->
+    URL = users_url(AccountId),
+
+    Expectations = [#expectation{response_codes = [201]
+                                ,response_headers = [{"content-type", "application/json"}
+                                                    ,{"location", {'match', expected_location_value(URL)}}
+                                                    ]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(UserJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:put/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch(API, AccountId, UserId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,user_url(AccountId, UserId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec update(pqc_cb_api:state(), kz_term:ne_binary(), kzd_users:doc()) -> pqc_cb_api:response().
+update(API, AccountId, UserJObj) ->
+    URL = user_url(AccountId, kz_doc:id(UserJObj)),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(UserJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec patch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
+patch(API, AccountId, UserId, PatchJObj) ->
+    URL = user_url(AccountId, UserId),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(PatchJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:patch/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec delete(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+delete(API, AccountId, UserId) ->
+    URL = user_url(AccountId, UserId),
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:delete/2
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec users_url(kz_term:ne_binary()) -> string().
+users_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "users"], "/").
+
+-spec user_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
+user_url(AccountId, UserId) ->
+    string:join([users_url(AccountId), kz_term:to_list(UserId)], "/").
+
+-spec seq() -> 'ok'.
+seq() ->
+    API = pqc_cb_api:init_api(['crossbar'], ['cb_users_v2']),
+    AccountId = create_account(API),
+
+    'ok' = create_simple_user(API, AccountId),
+    wrong_format_check(API, AccountId),
+
+    cleanup(API),
+    ?INFO("FINISHED USERS SEQ").
+
+create_simple_user(API, AccountId) ->
+    EmptySummaryResp = summary(API, AccountId),
+    ?INFO("empty summary resp: ~s", [EmptySummaryResp]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
+
+    UserJObj = new_user(),
+    CreateResp = create(API, AccountId, UserJObj),
+    ?INFO("created user ~s", [CreateResp]),
+    CreatedUser = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
+    UserId = kz_doc:id(CreatedUser),
+    'true' = user_docs_match(UserJObj, CreatedUser),
+
+    UserWithEmail = kzd_users:set_email(CreatedUser, <<(kz_binary:rand_hex(4))/binary, "@2600hz.com">>),
+    UpdateResp = update(API, AccountId, UserWithEmail),
+    ?INFO("updated to ~s", [UpdateResp]),
+    'true' = user_docs_match(UserWithEmail, kz_json:get_json_value(<<"data">>, kz_json:decode(UpdateResp))),
+
+    Patch = kz_json:from_list([{<<"custom">>, <<"value">>}]),
+    PatchedUser = kz_json:merge(UserWithEmail, Patch),
+
+    PatchResp = patch(API, AccountId, UserId, Patch),
+    ?INFO("patched to ~s", [PatchResp]),
+    'true' = user_docs_match(PatchedUser, kz_json:get_json_value(<<"data">>, kz_json:decode(PatchResp))),
+
+    SummaryResp = summary(API, AccountId),
+    ?INFO("summary resp: ~s", [SummaryResp]),
+    [SummaryUser] = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
+    UserId = kz_doc:id(SummaryUser),
+
+    DeleteResp = delete(API, AccountId, UserId),
+    ?INFO("delete resp: ~s", [DeleteResp]),
+
+    EmptyAgain = summary(API, AccountId),
+    ?INFO("empty summary resp: ~s", [EmptyAgain]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptyAgain)),
+    ?INFO("FINISHED SIMPLE USER").
+
+wrong_format_check(API, AccountId) ->
+    ShortEmail = kzd_users:set_email(new_user(), <<"e">>),
+    {'error', ShortEmailError} = create(API, AccountId, ShortEmail),
+    lager:info("validation failed creating empty email: ~s", [ShortEmailError]),
+
+    WrongFormat = kzd_users:set_email(new_user(), kz_binary:rand_hex(4)),
+    {'error', WrongFormatError} = create(API, AccountId, WrongFormat),
+    lager:info("validation failed creating user: ~s", [WrongFormatError]),
+    'true' = kzd_users:email(WrongFormat) =:= kz_json:get_ne_binary_value([<<"data">>, <<"email">>, <<"wrong_format">>, <<"value">>]
+                                                                         ,kz_json:decode(WrongFormatError)
+                                                                         ),
+    lager:info("FINISHED WRONG FORMAT CHECK").
+
+user_docs_match(Model, RespJObj) ->
+    kz_json:all(fun({ModelKey, ModelValue}) -> user_setting_matches(ModelKey, ModelValue, RespJObj) end
+               ,Model
+               ).
+
+user_setting_matches(ModelKey, ModelValue, RespJObj) ->
+    case kz_json:get_value(ModelKey, RespJObj) of
+        ModelValue -> 'true';
+        _V ->
+            ?INFO("key ~s is ~p instead of ~p", [ModelKey, _V, ModelValue]),
+            'false'
+    end.
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
+    cleanup_system().
+
+cleanup(API) ->
+    ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _ = pqc_cb_api:cleanup(API),
+    cleanup_system().
+
+cleanup_system() -> 'ok'.
+
+-spec create_account(pqc_cb_api:state()) -> kz_term:ne_binary().
+create_account(API) ->
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    ?INFO("created account: ~s", [AccountResp]),
+
+    kz_json:get_ne_binary_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
+
+-spec new_user() -> kzd_users:doc().
+new_user() ->
+    kz_doc:public_fields(
+      kz_json:exec_first([{fun kzd_users:set_first_name/2, kz_binary:rand_hex(4)}
+                         ,{fun kzd_users:set_last_name/2, kz_binary:rand_hex(4)}
+                         ]
+                        ,kzd_users:new()
+                        )
+     ).
+
+%% take http://whatever:port/v2/... and get /v2/.../{regex}
+expected_location_value(URL) ->
+    expected_location_value(URL, "(\\w{32})").
+
+expected_location_value(URL, Id) ->
+    {'match', [_Host, Path]} = re:run(URL, "^(.+)(/v2/.+$)", [{'capture','all_but_first', 'list'}]),
+    Path ++ [$/ | kz_term:to_list(Id)].

--- a/core/kazoo_proper/src/pqc_cb_whitelabel.erl
+++ b/core/kazoo_proper/src/pqc_cb_whitelabel.erl
@@ -15,7 +15,8 @@
 -spec create_whitelabel(pqc_cb_api:state(), kz_doc:setter_funs()) -> pqc_cb_api:response().
 create_whitelabel(API, Setters) ->
     Envelope = pqc_cb_api:create_envelope(kz_doc:setters(kz_json:new(), Setters)),
-    pqc_cb_api:make_request([201]
+    Expectations = [#expectation{response_codes = [201]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,whitelabel_url(pqc_cb_api:auth_account_id(API))
                            ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_kazoo_model.erl
+++ b/core/kazoo_proper/src/pqc_kazoo_model.erl
@@ -173,7 +173,9 @@ has_rate_matching(#kazoo_model{}=Model, RatedeckId, DID) ->
     Ratedeck = ratedeck(Model, RatedeckId),
     has_rate_matching(Ratedeck, DID).
 
--spec has_service_plan_rate_matching(model(), kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
+-spec has_service_plan_rate_matching(model(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                                            'false' |
+                                            {'true', number()}.
 has_service_plan_rate_matching(#kazoo_model{'accounts'=Accounts
                                            ,'service_plans'=SPs
                                            }=Model
@@ -196,7 +198,9 @@ has_service_plan_rate_matching(#kazoo_model{'accounts'=Accounts
             end
     end.
 
--spec has_rate_matching(rate_data(), kz_term:ne_binary()) -> boolean().
+-spec has_rate_matching(rate_data(), kz_term:ne_binary()) ->
+                               'false' |
+                               {'true', number()}.
 has_rate_matching(Ratedeck, <<"+", Number/binary>>) ->
     has_rate_matching(Ratedeck, Number);
 has_rate_matching(Ratedeck, Number) ->

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -49,7 +49,7 @@
         ,find_value/3, find_value/4
         ,foreach/2
         ,all/2, any/2
-        ,exec/2
+        ,exec/2, exec_first/2
         ]).
 
 -export([get_ne_value/2, get_ne_value/3]).
@@ -1545,9 +1545,24 @@ exec(Funs, ?JSON_WRAPPER(_)=JObj) ->
     lists:foldl(fun exec_fold/2, JObj, Funs).
 
 -spec exec_fold(exec_fun(), object()) -> object().
-exec_fold({F, K, V}, C) when is_function(F, 3) -> F(K, V, C);
-exec_fold({F, V}, C) when is_function(F, 2) -> F(V, C);
-exec_fold(F, C) when is_function(F, 1) -> F(C).
+exec_fold({F, K, V}, JObj) when is_function(F, 3) -> F(K, V, JObj);
+exec_fold({F, V}, JObj) when is_function(F, 2) -> F(V, JObj);
+exec_fold(F, JObj) when is_function(F, 1) -> F(JObj).
+
+-type exec_first_fun_1() :: fun((object()) -> object()).
+-type exec_first_fun_2() :: {fun((_, object()) -> object()), _}.
+-type exec_first_fun_3() :: {fun((_, _, object()) -> object()), _, _}.
+-type exec_first_fun() :: exec_first_fun_1() | exec_first_fun_2() | exec_first_fun_3().
+-type exec_first_funs() :: [exec_first_fun(),...].
+
+-spec exec_first(exec_first_funs(), object()) -> object().
+exec_first(Funs, ?JSON_WRAPPER(_)=JObj) ->
+    lists:foldl(fun exec_first_fold/2, JObj, Funs).
+
+-spec exec_first_fold(exec_first_fun(), object()) -> object().
+exec_first_fold({F, K, V}, JObj) when is_function(F, 3) -> F(JObj, K, V);
+exec_first_fold({F, V}, JObj) when is_function(F, 2) -> F(JObj, V);
+exec_first_fold(F, JObj) when is_function(F, 1) -> F(JObj).
 
 -spec utf8_binary(json_term()) -> json_term().
 utf8_binary(<<V/binary>>) -> kz_binary:to_utf8(V);

--- a/core/kazoo_web/src/kz_http.erl
+++ b/core/kazoo_web/src/kz_http.erl
@@ -30,7 +30,7 @@
                   'trace'.
 
 -type field() :: string().
--type value() :: string().
+-type value() :: string() | integer().
 -type header() :: {field(), value()}.
 -type headers() :: [header()].
 

--- a/core/kazoo_web/src/kz_http_util.erl
+++ b/core/kazoo_web/src/kz_http_util.erl
@@ -405,7 +405,6 @@ get_resp_header(RespHeader, RespHeaders, Default) ->
         'false' -> Default
     end.
 
-
 -type part() :: {binary(), kz_term:proplist()}.
 -type parts() :: [part()].
 


### PR DESCRIPTION
In this case, a user was created with an empty (`""`) email address. It failed both the `minLength` and `format` requirements but kz_json_schema was not ready to handle the `wrong_format` error from jesse and the API request crashed.

This PR adds wrong_format handling as well as introduces user API CRUD testing in kazoo_proper. Also increases minLength for emails to 3 (1 makes no sense).

Additionally, crashes occurred during user validation if schema validation failed. The functions that tried to modify the user doc (loaded after successful validation) failed because failed validation did not set a doc in cb_context and thus kz_json operations occurred against `'undefined'`. This PR sets those apart and checks that validation of the request was successful before running the updates.

Lastly, introduced a complement to `kz_json:exec/2`: `kz_json:exec_first/2` which runs the functions with the JObj accumulator in the first position of the supplied functions (versus in the last position as in `exec/2`.