### PR TITLE
For group pickup feature. Seek pickup target down the callflow tree u…

### DIFF
--- a/applications/callflow/doc/group_pickup_feature.md
+++ b/applications/callflow/doc/group_pickup_feature.md
@@ -21,7 +21,7 @@ Key | Description | Type | Default | Required | Support Level
 
 ### Usage
 
-Currently the feature code for group pickup will lookup a device by SIP username or an extension that has a first child in the `flow` of `user`, `device`, `ring_group`, or `page_group`.
+The feature code for group pickup will lookup a device by SIP username or an extension. The callflow for that extention is searched in a depth-first order until a targetable module is found (one of `user`, `device`, `ring_group`, or `page_group`). Once a suitable module is found, if there is an unanswered call ringing a targeted device it will be picked up.
 
 #### Extension callflow
 

--- a/applications/callflow/src/module/cf_group_pickup_feature.erl
+++ b/applications/callflow/src/module/cf_group_pickup_feature.erl
@@ -97,7 +97,7 @@ build_pickup_params(Number, <<"extension">>, Call) ->
         {'ok', FlowDoc, 'false'} ->
             Data = kz_json:get_json_value([<<"flow">>, <<"data">>], FlowDoc),
             Module = kz_json:get_ne_binary_value([<<"flow">>, <<"module">>], FlowDoc),
-            ChildFlow = wh_json:get_value([<<"flow">>, <<"children">>, <<"_">>], FlowDoc),
+            ChildFlow = kz_json:get_value([<<"flow">>, <<"children">>, <<"_">>], FlowDoc),
             params_from_data(Module, Data, ChildFlow);
         {'ok', _FlowDoc, 'true'} ->
             {'error', <<"no callflow with extension ", Number/binary>>};
@@ -127,7 +127,7 @@ params_from_data('undefined', _, _) ->
     {'error',<<"module not defined in callflow">>};
 params_from_data(_Other, _, Flow) ->
     lager:debug("skipping module ~p, looking at children", [_Other]),
-    Child = wh_json:get_value([<<"children">>, <<"_">>], Flow),
-    Data = wh_json:get_value([<<"data">>], Child),
-    Module = wh_json:get_value([<<"module">>], Child),
+    Child = kz_json:get_value([<<"children">>, <<"_">>], Flow),
+    Data = kz_json:get_value([<<"data">>], Child),
+    Module = kz_json:get_value([<<"module">>], Child),
     params_from_data(Module, Data, Child).

--- a/applications/callflow/src/module/cf_group_pickup_feature.erl
+++ b/applications/callflow/src/module/cf_group_pickup_feature.erl
@@ -97,7 +97,7 @@ build_pickup_params(Number, <<"extension">>, Call) ->
         {'ok', FlowDoc, 'false'} ->
             Data = kz_json:get_json_value([<<"flow">>, <<"data">>], FlowDoc),
             Module = kz_json:get_ne_binary_value([<<"flow">>, <<"module">>], FlowDoc),
-            ChildFlow = kz_json:get_value([<<"flow">>, <<"children">>, <<"_">>], FlowDoc),
+            ChildFlow = kz_json:get_json_value([<<"flow">>, <<"children">>, <<"_">>], FlowDoc),
             params_from_data(Module, Data, ChildFlow);
         {'ok', _FlowDoc, 'true'} ->
             {'error', <<"no callflow with extension ", Number/binary>>};
@@ -108,9 +108,11 @@ build_pickup_params(_ ,'undefined', _) ->
 build_pickup_params(_, Other, _) ->
     {'error', <<Other/binary," not implemented">>}.
 
--spec params_from_data(kz_term:ne_binary(), kz_json:object(), kz_json:object()) ->
+-spec params_from_data(kz_term:api_ne_binary(), kz_json:object(), kz_term:api_object()) ->
                               {'ok', kz_term:proplist()} |
                               {'error', kz_term:ne_binary()}.
+params_from_data(_, _, 'undefined') ->
+    {'error',<<"callflow not defined">>};
 params_from_data(<<"user">>, Data, _Flow) ->
     EndpointId = kz_json:get_ne_binary_value(<<"id">>, Data),
     {'ok', [{<<"user_id">>, EndpointId}]};
@@ -127,7 +129,7 @@ params_from_data('undefined', _, _) ->
     {'error',<<"module not defined in callflow">>};
 params_from_data(_Other, _, Flow) ->
     lager:debug("skipping module ~p, looking at children", [_Other]),
-    Child = kz_json:get_value([<<"children">>, <<"_">>], Flow),
-    Data = kz_json:get_value([<<"data">>], Child),
-    Module = kz_json:get_value([<<"module">>], Child),
+    Child = kz_json:get_json_value([<<"children">>, <<"_">>], Flow),
+    Data = kz_json:get_json_value([<<"data">>], Child),
+    Module = kz_json:get_ne_binary_value([<<"module">>], Child),
     params_from_data(Module, Data, Child).

--- a/applications/callflow/src/module/cf_group_pickup_feature.erl
+++ b/applications/callflow/src/module/cf_group_pickup_feature.erl
@@ -97,7 +97,8 @@ build_pickup_params(Number, <<"extension">>, Call) ->
         {'ok', FlowDoc, 'false'} ->
             Data = kz_json:get_json_value([<<"flow">>, <<"data">>], FlowDoc),
             Module = kz_json:get_ne_binary_value([<<"flow">>, <<"module">>], FlowDoc),
-            params_from_data(Module, Data, Call);
+            ChildFlow = wh_json:get_value([<<"flow">>, <<"children">>, <<"_">>], FlowDoc),
+            params_from_data(Module, Data, ChildFlow);
         {'ok', _FlowDoc, 'true'} ->
             {'error', <<"no callflow with extension ", Number/binary>>};
         {'error', _} = E -> E
@@ -107,22 +108,26 @@ build_pickup_params(_ ,'undefined', _) ->
 build_pickup_params(_, Other, _) ->
     {'error', <<Other/binary," not implemented">>}.
 
--spec params_from_data(kz_term:ne_binary(), kz_json:object(), kapps_call:call()) ->
+-spec params_from_data(kz_term:ne_binary(), kz_json:object(), kz_json:object()) ->
                               {'ok', kz_term:proplist()} |
                               {'error', kz_term:ne_binary()}.
-params_from_data(<<"user">>, Data, _Call) ->
+params_from_data(<<"user">>, Data, _Flow) ->
     EndpointId = kz_json:get_ne_binary_value(<<"id">>, Data),
     {'ok', [{<<"user_id">>, EndpointId}]};
-params_from_data(<<"device">>, Data, _Call) ->
+params_from_data(<<"device">>, Data, _Flow) ->
     EndpointId = kz_json:get_ne_binary_value(<<"id">>, Data),
     {'ok', [{<<"device_id">>, EndpointId}]};
-params_from_data(<<"ring_group">>, Data, _Call) ->
+params_from_data(<<"ring_group">>, Data, _Flow) ->
     [Endpoint |_Endpoints] = kz_json:get_list_value(<<"endpoints">>, Data, []),
     EndpointType = kz_json:get_ne_binary_value(<<"endpoint_type">>, Endpoint),
     {'ok', [{<<EndpointType/binary, "_id">>, kz_doc:id(Endpoint)}]};
-params_from_data(<<"page_group">>, Data, _Call) ->
-    params_from_data(<<"ring_group">>, Data, _Call);
+params_from_data(<<"page_group">>, Data, _Flow) ->
+    params_from_data(<<"ring_group">>, Data, _Flow);
 params_from_data('undefined', _, _) ->
     {'error',<<"module not defined in callflow">>};
-params_from_data(Other, _, _) ->
-    {'error',<<"module ", Other/binary, " not implemented">>}.
+params_from_data(_Other, _, Flow) ->
+    lager:debug("skipping module ~p, looking at children", [_Other]),
+    Child = wh_json:get_value([<<"children">>, <<"_">>], Flow),
+    Data = wh_json:get_value([<<"data">>], Child),
+    Module = wh_json:get_value([<<"module">>], Child),
+    params_from_data(Module, Data, Child).


### PR DESCRIPTION
…ntil some known module is reached, instead of failing for trivial modules that don't make a difference.

Make it more like the eavesdrop feature which traverses the tree already. Here I took advantage of `_Call` being unused and just replaced it with the subflow `Flow` arg.