### PR TITLE
Kazoo storage fixes for db operations on storage db

### DIFF
--- a/core/kazoo_data/src/kz_dataconnection.erl
+++ b/core/kazoo_data/src/kz_dataconnection.erl
@@ -74,7 +74,7 @@ handle_info('maintain_connection', #data_connection{connected = 'false'}=Connect
             {'noreply', Connection};
         {'ok', C} ->
             self() ! 'maintain_connection',
-            {'noreply', connection_established(C#data_connection{connected='true'})}
+            {'noreply', connection_established(C)}
     end;
 handle_info('maintain_connection', #data_connection{ready=Ready
                                                    ,server=Server

--- a/core/kazoo_data/src/kzs_db.erl
+++ b/core/kazoo_data/src/kzs_db.erl
@@ -57,7 +57,7 @@ db_create_others(#{}=Map, DbName, Options) ->
 do_db_create_others(Map, DbName, Options) ->
     Others = maps:get('others', Map, []),
     lists:all(fun({_Tag, M1}) ->
-                      do_db_create(#{server => M1}, DbName, Options) =/= 'false'
+                      do_db_create(M1, DbName, Options) =/= 'false'
               end, Others).
 
 -spec do_db_create(map(), kz_term:ne_binary(), db_create_options()) -> boolean() | 'exists'.
@@ -85,7 +85,7 @@ db_delete_others(#{}=Map, DbName, Options) ->
 do_db_delete_others(Map, DbName) ->
     Others = maps:get('others', Map, []),
     lists:all(fun({_Tag, M1}) ->
-                      do_db_delete(#{server => M1}, DbName)
+                      do_db_delete(M1, DbName)
               end, Others).
 
 -spec do_db_delete(map(), kz_term:ne_binary()) -> boolean().
@@ -103,7 +103,7 @@ db_view_cleanup(#{}=Map, DbName) ->
     Others = maps:get('others', Map, []),
     do_db_view_cleanup(Map, DbName)
         andalso lists:all(fun({_Tag, M1}) ->
-                                  do_db_view_cleanup(#{server => M1}, DbName)
+                                  do_db_view_cleanup(M1, DbName)
                           end, Others).
 
 -spec do_db_view_cleanup(map(), kz_term:ne_binary()) -> boolean().
@@ -156,7 +156,7 @@ db_exists_all(Map, DbName) ->
 -spec db_exists_others(kz_term:ne_binary(), list()) -> boolean().
 db_exists_others(_, []) -> 'true';
 db_exists_others(DbName, Others) ->
-    lists:all(fun({_Tag, M}) -> db_exists(#{server => M}, DbName) end, Others).
+    lists:all(fun({_Tag, M}) -> db_exists(M, DbName) end, Others).
 
 -spec db_archive(map(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok' | data_error().
 db_archive(#{server := {App, Conn}}=Server, DbName, Filename) ->
@@ -193,7 +193,7 @@ db_view_update(#{}=Map, DbName, Views, Remove) ->
     case do_db_view_update(Map, DbName, Views, Remove) of
         'true' ->
             lists:all(fun({_Tag, M1}) ->
-                              do_db_view_update(#{server => M1}, DbName, Views, Remove) =:= 'true'
+                              do_db_view_update(M1, DbName, Views, Remove) =:= 'true'
                       end
                      ,Others
                      );


### PR DESCRIPTION
You will see in core/kazoo_data/src/kz_dataconnection.erl line 128 that all new connections are stored under the 'server' record on a map.

This can also been seen when you load a data plan for an account:
```
kzs_plan:plan(<<"account%2F08%2Fa5%2F2950bbf979259fefb420bcf486be-201905">>).
#{account_id => <<"08a52950bbf979259fefb420bcf486be">>,
  classification => <<"modb">>,
  others =>
      [{e00f22631e9148bebd941282e26274cb,#{server =>
                                               {kazoo_couch,{server,<<"http://127.0.0.1:5984">>,
                                                                    [{driver_version,couchdb_2},
                                                                     {connection_map,#{host => <<"127.0.0.1">>,
                                                                                       options =>
                                                                                           [{tag,e00f22631e9148bebd941282e26274cb},
                                                                                            {name,<<"Test">>},
                                                                                            {driver,kazoo_couch}],
                                                                                       password => [],port => 5984,username => []}},
                                                                     {recv_timeout,20000},
                                                                     {tag,e00f22631e9148bebd941282e26274cb},
                                                                     {name,<<"Test">>},
                                                                     {driver,kazoo_couch}]}}}}],
  server =>
      {kazoo_couch,{server,<<"http://127.0.0.1:15984">>,
                           [{driver_version,couchdb_2},
                            {connection_map,#{host => "127.0.0.1",
                                              options =>
                                                  [{tag,local},
                                                   {driver,kazoo_couch},
                                                   {cookie,change_me},
                                                   {compact_automatically,true},
                                                   {admin_port,15986}],
                                              password => [],port => 15984,username => []}},
                            {recv_timeout,20000},
                            {tag,local},
                            {driver,kazoo_couch}]}},
  tag => local}```

The ‘others' db connection is stored as a list of {Tag, map(server=>Connection)}

The problem is that when we called 'do_db_create' or the other db operations below we would nest the Server inside a extra map with the key 'server' and this would lead to a crash when no function matching the pattern would match.

I have also added a small change to kz_dataconnection.erl to remove redundant code as i felt it was a very small change and not worth its own ticket.