### PR TITLE
PISTON-769: do not rely on Hangup-Cause, will be set if transferred to vm

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -546,7 +546,8 @@ record_voicemail(AttachmentName, #mailbox{max_message_length=MaxMessageLength
     case kapps_call_command:b_record(AttachmentName, ?ANY_DIGIT, kz_term:to_binary(MaxMessageLength), Call) of
         {'ok', Msg} ->
             Length = kz_json:get_integer_value(<<"Length">>, Msg, 0),
-            case kz_call_event:hangup_cause(Msg) =:= 'undefined'
+            {Status, _} = kapps_call_command:b_channel_status(Call),
+            case Status =:= 'ok'
                 andalso review_recording(AttachmentName, 'true', Box, Call)
             of
                 'false' ->
@@ -979,7 +980,8 @@ record_forward(AttachmentName, Message, SrcBoxId, #mailbox{media_extension=Ext
     case kapps_call_command:b_record(AttachmentName, ?ANY_DIGIT, kz_term:to_binary(MaxMessageLength), Call) of
         {'ok', Msg} ->
             Length = kz_json:get_integer_value(<<"Length">>, Msg, 0),
-            case kz_call_event:hangup_cause(Msg) =:= 'undefined'
+            {Status, _} = kapps_call_command:b_channel_status(Call),
+            case Status =:= 'ok'
                 andalso review_recording(AttachmentName, 'false', DestBox, Call)
             of
                 'false' ->


### PR DESCRIPTION
We have noticed that when somebody is transferred to a voicemail box, the recording review prompt will not be played if the press a DTMF to save the voicemail. This is because the Hangup-Cause prop is set in the RECORD_STOP call event. It is set due to variable_bridge_hangup_cause being set (it is set when the bridged B leg of the call is down: https://lists.freeswitch.org/pipermail/freeswitch-users/2015-January/110430.html). Switching to kapps_call_command:b_channel_status/1 ensures that we get the true state of the call.