### PR TITLE
HELP-43867: rework ledger/modb/services at month's end

### DIFF
--- a/applications/braintree/src/braintree_maintenance.erl
+++ b/applications/braintree/src/braintree_maintenance.erl
@@ -45,7 +45,7 @@ sync_account_services_payments_info(AccountId, Services) ->
                 {'error', _} -> io:format("failed to update service doc~n", [])
             end;
         #bt_api_error{errors = Errors} ->
-            io:format("braintree failed with ~p~n", format_errors(Errors))
+            io:format("braintree failed with ~p~n", [format_errors(Errors)])
     catch
         'throw':{_, ErrJObj} -> io:format("braintree failed with ~s ~n", [kz_json:encode(ErrJObj)])
     end.
@@ -66,7 +66,7 @@ sync_payment_info(AccountId, CardId) ->
         #bt_card{} ->
             io:format("card not found~n");
         #bt_api_error{errors = Errors} ->
-            io:format("braintree failed with ~p~n", format_errors(Errors))
+            io:format("braintree failed with ~p~n", [format_errors(Errors)])
     catch
         'throw':{_, ErrJObj} -> io:format("braintree failed with ~s ~n", [kz_json:encode(ErrJObj)])
     end.

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -35096,6 +35096,33 @@
             },
             "type": "object"
         },
+        "system_config.tasks.ledger_rollover": {
+            "description": "Schema for tasks.ledger_rollover system_config",
+            "properties": {
+                "rollover_in_parallel": {
+                    "default": 10,
+                    "description": "How many accounts to rollover per-pass (in parallel)",
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.tasks.modb_creation": {
+            "description": "Schema for tasks.modb_creation system_config",
+            "properties": {
+                "create_in_parallel": {
+                    "default": 1,
+                    "description": "How many accounts to process per pass (in parallel).",
+                    "type": "integer"
+                },
+                "creation_day": {
+                    "default": 28,
+                    "description": "Which day of the month (of current month) to create next month's MODBs on",
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
         "system_config.tasks.notify_resend": {
             "description": "Schema for tasks.notify_resend system_config",
             "properties": {

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -35201,6 +35201,17 @@
             },
             "type": "object"
         },
+        "system_config.tasks.services_rollover": {
+            "description": "Schema for tasks.services_rollover system_config",
+            "properties": {
+                "rollover_in_parallel": {
+                    "default": 10,
+                    "description": "How many accounts to rollover services for per pass (in parallel)",
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
         "system_config.teletype": {
             "description": "Schema for teletype system_config",
             "properties": {

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -35099,6 +35099,16 @@
         "system_config.tasks.ledger_rollover": {
             "description": "Schema for tasks.ledger_rollover system_config",
             "properties": {
+                "refresh_in_parallel": {
+                    "default": 50,
+                    "description": "tasks ledger_rollover refresh_in_parallel",
+                    "type": "integer"
+                },
+                "refresh_view_enabled": {
+                    "default": false,
+                    "description": "tasks ledger_rollover refresh_view_enabled",
+                    "type": "boolean"
+                },
                 "rollover_in_parallel": {
                     "default": 10,
                     "description": "How many accounts to rollover per-pass (in parallel)",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.tasks.ledger_rollover.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.tasks.ledger_rollover.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.tasks.ledger_rollover",
+    "description": "Schema for tasks.ledger_rollover system_config",
+    "properties": {
+        "rollover_in_parallel": {
+            "default": 10,
+            "description": "How many accounts to rollover per-pass (in parallel)",
+            "type": "integer"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/system_config.tasks.ledger_rollover.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.tasks.ledger_rollover.json
@@ -3,6 +3,16 @@
     "_id": "system_config.tasks.ledger_rollover",
     "description": "Schema for tasks.ledger_rollover system_config",
     "properties": {
+        "refresh_in_parallel": {
+            "default": 50,
+            "description": "tasks ledger_rollover refresh_in_parallel",
+            "type": "integer"
+        },
+        "refresh_view_enabled": {
+            "default": false,
+            "description": "tasks ledger_rollover refresh_view_enabled",
+            "type": "boolean"
+        },
         "rollover_in_parallel": {
             "default": 10,
             "description": "How many accounts to rollover per-pass (in parallel)",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.tasks.modb_creation.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.tasks.modb_creation.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.tasks.modb_creation",
+    "description": "Schema for tasks.modb_creation system_config",
+    "properties": {
+        "create_in_parallel": {
+            "default": 1,
+            "description": "How many accounts to process per pass (in parallel).",
+            "type": "integer"
+        },
+        "creation_day": {
+            "default": 28,
+            "description": "Which day of the month (of current month) to create next month's MODBs on",
+            "type": "integer"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/system_config.tasks.services_rollover.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.tasks.services_rollover.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.tasks.services_rollover",
+    "description": "Schema for tasks.services_rollover system_config",
+    "properties": {
+        "rollover_in_parallel": {
+            "default": 10,
+            "description": "How many accounts to rollover services for per pass (in parallel)",
+            "type": "integer"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/src/crossbar_services.erl
+++ b/applications/crossbar/src/crossbar_services.erl
@@ -44,8 +44,8 @@ maybe_dry_run(Context, CurrentJObj, ProposedJObj) ->
     Services = kz_services:fetch(AuthAccountId),
     Updated = kz_services:set_updates(Services
                                      ,AccountId
-                                     ,[CurrentJObj]
-                                     ,[ProposedJObj]
+                                     ,kz_services:to_billables(CurrentJObj)
+                                     ,kz_services:to_billables(ProposedJObj)
                                      ),
     Quotes = kz_services_invoices:create(Updated),
     HasAdditions = kz_services_invoices:has_billable_additions(Quotes),
@@ -135,7 +135,11 @@ update_subscriptions(_Context, _CurrentJObj, _ProposedJObj, 'undefined') ->
 update_subscriptions(Context, CurrentJObj, ProposedJObj, AccountId) ->
     AuditLog = audit_log(Context),
     lager:info("committing updates to ~s", [AccountId]),
-    _ = kz_services:commit_updates(AccountId, CurrentJObj, ProposedJObj, AuditLog),
+    _ = kz_services:commit_updates(AccountId
+                                  ,CurrentJObj
+                                  ,ProposedJObj
+                                  ,AuditLog
+                                  ),
     'ok'.
 
 %%------------------------------------------------------------------------------

--- a/applications/crossbar/src/crossbar_services.erl
+++ b/applications/crossbar/src/crossbar_services.erl
@@ -44,8 +44,8 @@ maybe_dry_run(Context, CurrentJObj, ProposedJObj) ->
     Services = kz_services:fetch(AuthAccountId),
     Updated = kz_services:set_updates(Services
                                      ,AccountId
-                                     ,CurrentJObj
-                                     ,ProposedJObj
+                                     ,[CurrentJObj]
+                                     ,[ProposedJObj]
                                      ),
     Quotes = kz_services_invoices:create(Updated),
     HasAdditions = kz_services_invoices:has_billable_additions(Quotes),

--- a/applications/crossbar/src/modules/cb_services.erl
+++ b/applications/crossbar/src/modules/cb_services.erl
@@ -463,7 +463,7 @@ load_audit_logs(Context) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec override_plans(cb_context:context(), kz_services:serivces()) -> kz_services:services().
+-spec override_plans(cb_context:context(), kz_services:services()) -> kz_services:services().
 override_plans(Context, Services) ->
     case kz_json:get_ne_json_value(<<"overrides">>, cb_context:req_data(Context)) of
         'undefined' -> Services;

--- a/applications/ecallmgr/src/call_control/ecallmgr_call_control.erl
+++ b/applications/ecallmgr/src/call_control/ecallmgr_call_control.erl
@@ -92,7 +92,7 @@
                ,controller_q :: kz_term:api_ne_binary()
                ,controller_p :: kz_term:api_pid()
                ,control_q :: kz_term:api_ne_binary()
-               ,initial_ccvs :: kz_json:api_object()
+               ,initial_ccvs :: kz_term:api_object()
                ,node_down_tref :: kz_term:api_reference()
                ,current_cmd_uuid :: kz_term:api_binary()
                ,event_uuids = [] :: kz_term:ne_binaries()
@@ -915,7 +915,7 @@ queue_insert_fun(Position, QueueFun) when is_function(QueueFun, 2) ->
 %% @end
 %%------------------------------------------------------------------------------
 %% See Noop documentation for Filter-Applications to get an idea of this function's purpose
--spec maybe_filter_queue(kz_json:api_objects(), queue:queue()) -> queue:queue().
+-spec maybe_filter_queue(kz_term:api_objects(), queue:queue()) -> queue:queue().
 maybe_filter_queue('undefined', CommandQ) -> CommandQ;
 maybe_filter_queue([], CommandQ) -> CommandQ;
 maybe_filter_queue([AppName|T]=Apps, CommandQ) when is_binary(AppName) ->

--- a/applications/tasks/doc/ledger_rollover.md
+++ b/applications/tasks/doc/ledger_rollover.md
@@ -1,0 +1,21 @@
+# Ledger Rollover Task
+
+The ledger rollover task, at the start of the month, walks the accounts and rolls over their ledger amount from the previous month to the new MODB.
+
+There is also a task to refresh the primary ledgers view, `totals_by_source`, to make sure the index isn't too far behind when the monthly rollover task occurs.
+
+## Rollover
+
+Rollover sums up the ledgers of the previous month's MODB and creates a new ledger in the now-current MODB for that amount.
+
+Set `tasks.ledger_rollover`'s `rollover_in_parallel` to control how many accounts to roll over at a time.
+
+## Refresh
+
+Refresh the view index for the `ledgers/totals_by_source` view to process any docs.
+
+For reference, running the rollover on an unindexed MODB with 12,000 docs (318 of which are ledger docs) took ~6 seconds. Running the same view on an up-to-date index took 70 milliseconds. Similar to CDRs, this is a good one to enable.
+
+Set `tasks.ledger_rollover`'s `refresh_view_enabled` to `true` to enable the job (performed daily).
+
+Set `tasks.ledger_rollover`'s `refresh_in_parallel` to control how many MODBs to refresh at a time.

--- a/applications/tasks/doc/modb_creation.md
+++ b/applications/tasks/doc/modb_creation.md
@@ -1,0 +1,42 @@
+# MODB Creation Task
+
+Create account MODBs ahead of time.
+
+## Metered creation
+
+On the configured day of the month (the 28th by default), the task will calculate the seconds left until the start of the next month. Based on that time range and the number of accounts, MODB creation will be spaced across that time period.
+
+For instance:
+
+```
+% May 28 2019 = 63726220800
+% June 1 2019 = 63726566400
+
+DiffS = (63726566400 - 63726220800) = 345600s
+
+Accounts = 1000
+
+DelayPerAccount = (DiffS / Accounts) = 345600 / 1000 = 345s
+```
+
+An MODB will be created every 345s until the end of the month.
+
+## Manually run
+
+If you need to manually run the task, you can use SUP to accomplish it:
+
+```
+sup kt_modb_creation create_modbs
+```
+
+This will spawn a worker and return immediately with the PID of that worker.
+
+## System Config
+
+### Date of starting creation
+
+System admins can select which day of the month to start MODB creation for the next month. Set `tasks.modb_creation` doc's `creation_day` to a number in `1..28` to ensure each month will trigger creation.
+
+### Parallel Creation
+
+System admins can speed this up by increasing the `tasks.modb_creation` doc's `create_in_parallel` (default is 1). If set to `10` for instance, the delay becomes `(DiffS / InParallel) / Accounts` or `34s` - 10 MODBs created every 34 seconds.

--- a/applications/tasks/doc/services_rollover.md
+++ b/applications/tasks/doc/services_rollover.md
@@ -1,0 +1,5 @@
+# Services Rollover Task
+
+Handles rolling over service totals to the new MODB.
+
+Set `tasks.services_rollover`'s `rollover_in_parallel` to control how many accounts to process at the same time.

--- a/applications/tasks/src/kz_tasks_trigger.erl
+++ b/applications/tasks/src/kz_tasks_trigger.erl
@@ -20,6 +20,13 @@
         ,terminate/2
         ]).
 
+-ifdef(TEST).
+-export([seconds_until_next_day/1
+        ,seconds_until_next_hour/1
+        ,seconds_until_next_minute/1
+        ]).
+-endif.
+
 -include("tasks.hrl").
 
 -define(SERVER, {'via', 'kz_globals', ?MODULE}).
@@ -33,7 +40,8 @@
 -type state() :: #state{}.
 
 -define(CLEANUP_TIMER
-       ,kapps_config:get_pos_integer(?CONFIG_CAT, <<"browse_dbs_interval_s">>, ?SECONDS_IN_DAY)).
+       ,kapps_config:get_pos_integer(?CONFIG_CAT, <<"browse_dbs_interval_s">>, ?SECONDS_IN_DAY)
+       ).
 
 %%%=============================================================================
 %%% API
@@ -115,26 +123,26 @@ handle_cast(_Msg, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
-handle_info({'EXIT', _Pid, normal}, State) ->
+handle_info({'EXIT', _Pid, 'normal'}, State) ->
     lager:debug("job ~p terminated normally", [_Pid]),
-    {noreply, State};
+    {'noreply', State};
 handle_info({'EXIT', _Pid, _Reason}, State) ->
     lager:error("job ~p crashed: ~p", [_Pid, _Reason]),
-    {noreply, State};
+    {'noreply', State};
 
-handle_info({timeout, Ref, _Msg}, #state{minute_ref = Ref}=State) ->
+handle_info({'timeout', Ref, _Msg}, #state{minute_ref = Ref}=State) ->
     spawn_jobs(Ref, ?TRIGGER_MINUTELY),
     {'noreply', State#state{minute_ref = minute_timer()}};
 
-handle_info({timeout, Ref, _Msg}, #state{hour_ref = Ref}=State) ->
+handle_info({'timeout', Ref, _Msg}, #state{hour_ref = Ref}=State) ->
     spawn_jobs(Ref, ?TRIGGER_HOURLY),
     {'noreply', State#state{hour_ref = hour_timer()}};
 
-handle_info({timeout, Ref, _Msg}, #state{day_ref = Ref}=State) ->
+handle_info({'timeout', Ref, _Msg}, #state{day_ref = Ref}=State) ->
     spawn_jobs(Ref, ?TRIGGER_DAILY),
     {'noreply', State#state{day_ref = day_timer()}};
 
-handle_info({timeout, Ref, _Msg}, #state{browse_dbs_ref = Ref}=State) ->
+handle_info({'timeout', Ref, _Msg}, #state{browse_dbs_ref = Ref}=State) ->
     _Pid = kz_util:spawn(fun browse_dbs_for_triggers/1, [Ref]),
     lager:debug("cleaning up in ~p(~p)", [_Pid, Ref]),
     {'noreply', State};
@@ -172,30 +180,51 @@ code_change(_OldVsn, State, _Extra) ->
 %%------------------------------------------------------------------------------
 -spec minute_timer() -> reference().
 minute_timer() ->
-    erlang:start_timer(?MILLISECONDS_IN_MINUTE, self(), ok).
+    erlang:start_timer(seconds_until_next_minute() * ?MILLISECONDS_IN_SECOND, self(), 'ok').
+
+-spec seconds_until_next_minute() -> 0..?SECONDS_IN_MINUTE.
+seconds_until_next_minute() ->
+    seconds_until_next_minute(calendar:universal_time()).
+
+-spec seconds_until_next_minute(kz_time:datetime()) -> 0..?SECONDS_IN_MINUTE.
+seconds_until_next_minute({_, {_H, _M, S}}) ->
+    ?SECONDS_IN_MINUTE - S.
 
 -spec hour_timer() -> reference().
 hour_timer() ->
-    erlang:start_timer(?MILLISECONDS_IN_HOUR, self(), ok).
+    erlang:start_timer(seconds_until_next_hour() * ?MILLISECONDS_IN_SECOND, self(), 'ok').
+
+-spec seconds_until_next_hour() -> 0..?SECONDS_IN_HOUR.
+seconds_until_next_hour() ->
+    seconds_until_next_hour(calendar:universal_time()).
+
+-spec seconds_until_next_hour(kz_time:datetime()) -> 0..?SECONDS_IN_HOUR.
+seconds_until_next_hour({_, {_H, M, S}}) ->
+    ((?MINUTES_IN_HOUR - M) * ?SECONDS_IN_MINUTE) - S.
 
 -spec day_timer() -> reference().
 day_timer() ->
-    erlang:start_timer(?MILLISECONDS_IN_DAY, self(), ok).
+    erlang:start_timer(seconds_until_next_day() * ?MILLISECONDS_IN_SECOND, self(), 'ok').
+
+-spec seconds_until_next_day() -> 0..?SECONDS_IN_DAY.
+seconds_until_next_day() ->
+    seconds_until_next_day(calendar:universal_time()).
+
+-spec seconds_until_next_day(kz_time:datetime()) -> 0..?SECONDS_IN_DAY.
+seconds_until_next_day({_, {H, M, S}}) ->
+    ((?HOURS_IN_DAY - H) * ?SECONDS_IN_HOUR) - (M * ?SECONDS_IN_MINUTE) - S.
 
 -spec browse_dbs_timer() -> reference().
 browse_dbs_timer() ->
     Expiry = ?CLEANUP_TIMER,
     lager:debug("starting cleanup timer for ~b s", [Expiry]),
-    erlang:start_timer(Expiry * ?MILLISECONDS_IN_SECOND, self(), ok).
+    erlang:start_timer(Expiry * ?MILLISECONDS_IN_SECOND, self(), 'ok').
 
-
--spec spawn_jobs(reference(), kz_term:ne_binary()) -> ok.
+-spec spawn_jobs(reference(), kz_term:ne_binary()) -> 'ok'.
 spawn_jobs(Ref, Binding) ->
-    CallId = make_callid(Ref, Binding),
-    _Pid = erlang:spawn_link(fun () ->
-                                     _ = kz_util:put_callid(CallId),
-                                     tasks_bindings:map(Binding, [])
-                             end),
+    kz_util:put_callid(make_callid(Ref, Binding)),
+    _Pid = kz_util:spawn_link(fun tasks_bindings:map/2, [Binding, []]),
+    kz_util:put_callid(?MODULE),
     lager:debug("binding ~s triggered ~p via ~p", [Binding, _Pid, Ref]).
 
 -spec make_callid(reference(), kz_term:ne_binary()) -> kz_term:ne_binary().
@@ -204,6 +233,7 @@ make_callid(Ref, Binding) ->
     Id = ref_to_id(Ref),
     <<"task_", Key/binary, "_", Id/binary>>.
 
+-spec ref_to_id(reference()) -> kz_term:ne_binary().
 ref_to_id(Ref) ->
     Bin = list_to_binary(io_lib:format("~p", [Ref])),
     Start = <<"#Ref<">>,

--- a/applications/tasks/src/kz_tasks_trigger.erl
+++ b/applications/tasks/src/kz_tasks_trigger.erl
@@ -229,7 +229,7 @@ spawn_jobs(Ref, Binding) ->
 
 -spec make_callid(reference(), kz_term:ne_binary()) -> kz_term:ne_binary().
 make_callid(Ref, Binding) ->
-    Key = lists:last(binary:split(Binding, <<$.>>, [global])),
+    Key = lists:last(binary:split(Binding, <<$.>>, ['global'])),
     Id = ref_to_id(Ref),
     <<"task_", Key/binary, "_", Id/binary>>.
 
@@ -263,7 +263,8 @@ browse_dbs_for_triggers(Ref) ->
     'ok' = kt_compaction_reporter:start_tracking_job(self(), node(), CallId, Sorted),
     F = fun({Db, _Sizes}, Ctr) ->
                 lager:debug("compacting ~p out of ~p dbs (~p remaining)",
-                            [Ctr, TotalSorted, (TotalSorted - Ctr)]),
+                            [Ctr, TotalSorted, (TotalSorted - Ctr)]
+                           ),
                 cleanup_pass(Db),
                 Ctr + 1
         end,

--- a/applications/tasks/src/modules/kt_ledger_rollover.erl
+++ b/applications/tasks/src/modules/kt_ledger_rollover.erl
@@ -12,6 +12,8 @@
 %% Triggerables
 -export([handle_req/0]).
 
+-export([rollover_accounts/2]).
+
 -include("tasks.hrl").
 
 -define(MOD_CAT, <<(?CONFIG_CAT)/binary, ".ledger_rollover">>).

--- a/applications/tasks/src/modules/kt_ledger_rollover.erl
+++ b/applications/tasks/src/modules/kt_ledger_rollover.erl
@@ -1,0 +1,47 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2013-2019, 2600Hz
+%%% @doc Handle rolling over ledgers at the start of the month
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kt_ledger_rollover).
+
+%% behaviour: tasks_provider
+
+-export([init/0]).
+
+%% Triggerables
+-export([handle_req/0]).
+
+-include("tasks.hrl").
+
+-define(MOD_CAT, <<(?CONFIG_CAT)/binary, ".ledger_rollover">>).
+
+-spec init() -> 'ok'.
+init() ->
+    _ = tasks_bindings:bind(?TRIGGER_DAILY, ?MODULE, 'handle_req').
+
+-spec handle_req() -> 'ok'.
+handle_req() ->
+    handle_req(erlang:date()).
+
+-spec handle_req(kz_time:date()) -> 'ok'.
+handle_req({Year, Month, 1}) ->
+    lager:info("its a new month ~p-~p", [Year, Month]),
+    rollover_accounts(Year, Month);
+handle_req({_Year, _Month, _Day}) -> 'ok'.
+
+-spec rollover_accounts(kz_time:year(), kz_time:month()) -> 'ok'.
+rollover_accounts(Year, Month) ->
+    rollover_accounts(Year, Month, kz_datamgr:paginate_results(?KZ_ACCOUNTS_DB, <<"accounts/listing_by_id">>, [])).
+
+-spec rollover_accounts(kz_time:year(), kz_time:month(), {'ok', kz_json:objects(), kz_json:api_json_term()} | kz_datamgr:data_error()) -> 'ok'.
+rollover_accounts(Year, Month, {'ok', Accounts, 'undefined'}) ->
+    _ = [kz_ledgers:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
+    lager:info("finished rolling over ~p accounts", [length(Accounts)]);
+rollover_accounts(Year, Month, {'ok', Accounts, NextPageKey}) ->
+    _ = [kz_ledgers:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
+    rollover_accounts(Year, Month
+                     ,kz_datamgr:paginate_results(?KZ_ACCOUNTS_DB, <<"accounts/listing_by_id">>, [{'startkey', NextPageKey}])
+                     );
+rollover_accounts(_Year, _Month, {'error', _E}) ->
+    lager:error("failed to query account listing during rollover: ~p", [_E]).

--- a/applications/tasks/src/modules/kt_ledger_rollover.erl
+++ b/applications/tasks/src/modules/kt_ledger_rollover.erl
@@ -30,7 +30,28 @@ handle_req() ->
 handle_req({Year, Month, 1}) ->
     _P = kz_util:spawn(fun rollover_accounts/2, [Year, Month]),
     lager:info("its a new month ~p-~p, rolling over ledgers in ~p", [Year, Month, _P]);
-handle_req({_Year, _Month, _Day}) -> 'ok'.
+handle_req({Year, Month, _Day}) ->
+    case kapps_config:is_true(?MOD_CAT, <<"refresh_view_enabled">>, 'false') of
+        'true' ->
+            _P = kz_util:spawn(fun refresh_ledger_view/2, [Year, Month]),
+            lager:debug("refreshing ledger totals in ~p", [_P]);
+        'false' -> 'ok'
+    end.
+
+refresh_ledger_view(Year, Month) ->
+    PerPage = kapps_config:get_integer(?MOD_CAT, <<"refresh_in_parallel">>, 50),
+    refresh_ledger_view(Year, Month, PerPage, get_page('undefined', PerPage)).
+
+refresh_ledger_view(Year, Month, _PerPage, {'ok', Accounts, 'undefined'}) ->
+    _ = [refresh_ledger(Year, Month, kz_doc:id(Account)) || Account <- Accounts],
+    lager:debug("finished refreshing ledgers view");
+refresh_ledger_view(Year, Month, PerPage, {'ok', Accounts, NextStartKey}) ->
+    _ = [refresh_ledger(Year, Month, kz_doc:id(Account)) || Account <- Accounts],
+    refresh_ledger_view(Year, Month, PerPage, get_page(NextStartKey, PerPage)).
+
+refresh_ledger(Year, Month, AccountId) ->
+    MODB = kz_util:format_account_id(AccountId, Year, Month),
+    _ = kazoo_modb:get_results(MODB, <<"ledgers/totals_by_source">>, [{'limit', 1}]).
 
 -spec rollover_accounts(kz_time:year(), kz_time:month()) -> 'ok'.
 rollover_accounts(Year, Month) ->
@@ -39,7 +60,7 @@ rollover_accounts(Year, Month) ->
 -spec rollover_accounts(kz_time:year(), kz_time:month(), kz_datamgr:paginated_results()) -> 'ok'.
 rollover_accounts(Year, Month, {'ok', Accounts, 'undefined'}) ->
     _ = [kz_ledgers:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
-    lager:info("finished rolling over ~p accounts", [length(Accounts)]);
+    lager:info("finished rolling over accounts");
 rollover_accounts(Year, Month, {'ok', Accounts, NextPageKey}) ->
     _ = [kz_ledgers:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
     rollover_accounts(Year, Month, get_page(NextPageKey));
@@ -47,15 +68,20 @@ rollover_accounts(_Year, _Month, {'error', _E}) ->
     lager:error("failed to query account listing during rollover: ~p", [_E]).
 
 -spec get_page(kz_json:api_json_term()) -> kz_datamgr:paginated_results().
-get_page('undefined') ->
-    query([]);
 get_page(NextStartKey) ->
-    query([{'startkey', NextStartKey}]).
+    get_page(NextStartKey, kapps_config:get_integer(?MOD_CAT, <<"rollover_in_parallel">>, 10)).
+
+-spec get_page(kz_json:api_json_term(), pos_integer()) -> kz_datamgr:paginated_results().
+get_page('undefined', PageSize) ->
+    query([{'page_size', PageSize}]);
+get_page(NextStartKey, PageSize) ->
+    query([{'startkey', NextStartKey}
+          ,{'page_size', PageSize}
+          ]).
 
 -spec query(kz_datamgr:view_options()) -> kz_datamgr:paginated_results().
 query(ViewOptions) ->
-    AccountsPerPass = kapps_config:get_integer(?MOD_CAT, <<"rollover_in_parallel">>, 10),
     kz_datamgr:paginate_results(?KZ_ACCOUNTS_DB
                                ,<<"accounts/listing_by_id">>
-                               ,[{'page_size', AccountsPerPass} | ViewOptions]
+                               ,ViewOptions
                                ).

--- a/applications/tasks/src/modules/kt_ledger_rollover.erl
+++ b/applications/tasks/src/modules/kt_ledger_rollover.erl
@@ -12,7 +12,9 @@
 %% Triggerables
 -export([handle_req/0]).
 
--export([rollover_accounts/2]).
+-export([rollover_accounts/2
+        ,refresh_ledger_view/2
+        ]).
 
 -include("tasks.hrl").
 
@@ -38,6 +40,7 @@ handle_req({Year, Month, _Day}) ->
         'false' -> 'ok'
     end.
 
+-spec refresh_ledger_view(kz_time:year(), kz_time:month()) -> 'ok'.
 refresh_ledger_view(Year, Month) ->
     PerPage = kapps_config:get_integer(?MOD_CAT, <<"refresh_in_parallel">>, 50),
     refresh_ledger_view(Year, Month, PerPage, get_page('undefined', PerPage)).

--- a/applications/tasks/src/modules/kt_ledger_rollover.erl
+++ b/applications/tasks/src/modules/kt_ledger_rollover.erl
@@ -34,16 +34,23 @@ handle_req({_Year, _Month, _Day}) -> 'ok'.
 
 -spec rollover_accounts(kz_time:year(), kz_time:month()) -> 'ok'.
 rollover_accounts(Year, Month) ->
-    rollover_accounts(Year, Month, kz_datamgr:paginate_results(?KZ_ACCOUNTS_DB, <<"accounts/listing_by_id">>, [])).
+    rollover_accounts(Year, Month, get_page('undefined')).
 
--spec rollover_accounts(kz_time:year(), kz_time:month(), {'ok', kz_json:objects(), kz_json:api_json_term()} | kz_datamgr:data_error()) -> 'ok'.
+-spec rollover_accounts(kz_time:year(), kz_time:month(), paginate_results()) -> 'ok'.
 rollover_accounts(Year, Month, {'ok', Accounts, 'undefined'}) ->
-    _ = [kz_ledgers:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
+    _ = [kz_services_modb:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
     lager:info("finished rolling over ~p accounts", [length(Accounts)]);
 rollover_accounts(Year, Month, {'ok', Accounts, NextPageKey}) ->
-    _ = [kz_ledgers:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
-    rollover_accounts(Year, Month
-                     ,kz_datamgr:paginate_results(?KZ_ACCOUNTS_DB, <<"accounts/listing_by_id">>, [{'startkey', NextPageKey}])
-                     );
+    _ = [kz_services_modb:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
+    rollover_accounts(Year, Month, get_page(NextPageKey));
 rollover_accounts(_Year, _Month, {'error', _E}) ->
     lager:error("failed to query account listing during rollover: ~p", [_E]).
+
+-type paginate_results() :: {'ok', kz_json:objects(), kz_json:api_json_term()} |
+                            kz_datamgr:data_error().
+-spec get_page(kz_json:api_json_term()) -> paginate_results().
+get_page(NextStartKey) ->
+    kz_datamgr:paginate_results(?KZ_ACCOUNTS_DB
+                               ,<<"accounts/listing_by_id">>
+                               ,[{'startkey', NextStartKey}]
+                               ).

--- a/applications/tasks/src/modules/kt_ledger_rollover.erl
+++ b/applications/tasks/src/modules/kt_ledger_rollover.erl
@@ -54,7 +54,8 @@ get_page(NextStartKey) ->
 
 -spec query(kz_datamgr:view_options()) -> kz_datamgr:paginated_results().
 query(ViewOptions) ->
+    AccountsPerPass = kapps_config:get_integer(?MOD_CAT, <<"rollover_in_parallel">>, 10),
     kz_datamgr:paginate_results(?KZ_ACCOUNTS_DB
                                ,<<"accounts/listing_by_id">>
-                               ,ViewOptions
+                               ,[{'page_size', AccountsPerPass} | ViewOptions]
                                ).

--- a/applications/tasks/src/modules/kt_modb.erl
+++ b/applications/tasks/src/modules/kt_modb.erl
@@ -10,17 +10,16 @@
 
 %% behaviour: tasks_provider
 
--export([init/0
-        ]).
+-export([init/0]).
 
 %% Triggerables
--export([clean_modb/1
-        ]).
+-export([clean_modb/1]).
 
 -include("tasks.hrl").
 
--define(SHOULD_ARCHIVE_MODBS,
-        kapps_config:get_is_true(?CONFIG_CAT, <<"should_archive_modbs">>, 'false')).
+-define(SHOULD_ARCHIVE_MODBS
+       ,kapps_config:get_is_true(?CONFIG_CAT, <<"should_archive_modbs">>, 'false')
+       ).
 
 %%%=============================================================================
 %%% API

--- a/applications/tasks/src/modules/kt_modb_creation.erl
+++ b/applications/tasks/src/modules/kt_modb_creation.erl
@@ -39,7 +39,7 @@ create_modbs(Year, Month) ->
 
 -spec create_modbs(kz_time:year(), kz_time:month(), {'ok', non_neg_integer()} | kz_datamgr:data_error()) -> 'ok'.
 create_modbs(Year, Month, {'ok', NumAccounts}) ->
-    NextMonthS = calendar:datetime_to_gregorian_seconds({{Year, Month+1, 1}, {0,0,0}}),
+    NextMonthS = calendar:datetime_to_gregorian_seconds({kz_date:normalize({Year, Month+1, 1}), {0,0,0}}),
     NowS = kz_time:now_s(),
     SecondsLeft = NextMonthS - NowS,
 

--- a/applications/tasks/src/modules/kt_modb_creation.erl
+++ b/applications/tasks/src/modules/kt_modb_creation.erl
@@ -1,0 +1,92 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2013-2019, 2600Hz
+%%% @doc Handle creating MODBs ahead of time
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kt_modb_creation).
+
+%% behaviour: tasks_provider
+
+-export([init/0]).
+
+%% Triggerables
+-export([handle_req/0]).
+
+-export([create_modbs/2]).
+
+-include("tasks.hrl").
+
+-define(MOD_CAT, <<(?CONFIG_CAT)/binary, ".modb_creation">>).
+
+-spec init() -> 'ok'.
+init() ->
+    _ = tasks_bindings:bind(?TRIGGER_DAILY, ?MODULE, 'handle_req').
+
+-spec handle_req() -> 'ok'.
+handle_req() ->
+    {'ok', CreateOnDay} = kapps_config:get_integer(?MOD_CAT, <<"creation_day">>, 28),
+    handle_req(CreateOnDay, erlang:date()).
+
+-spec handle_req(kz_time:day(), kz_time:date()) -> 'ok'.
+handle_req(Day, {Year, Month, Day}) ->
+    _P = kz_util:spawn(fun create_modbs/2, [Year, Month]),
+    lager:info("it is modb creation day! creating in ~p", [_P]);
+handle_req(_CreateOnDay, {_Year, _Month, _Day}) -> 'ok'.
+
+-spec create_modbs(kz_time:year(), kz_time:month()) -> 'ok'.
+create_modbs(Year, Month) ->
+    create_modbs(Year, Month, kz_datamgr:get_results_count(?KZ_ACCOUNTS_DB, <<"accounts/listing_by_id">>, [])).
+
+-spec create_modbs(kz_time:year(), kz_time:month(), {'ok', non_neg_integer()} | kz_datamgr:data_error()) -> 'ok'.
+create_modbs(Year, Month, {'ok', NumAccounts}) ->
+    NextMonthS = calendar:datetime_to_gregorian_seconds({{Year, Month+1, 1}, {0,0,0}}),
+    NowS = kz_time:now_s(),
+    SecondsLeft = NextMonthS - NowS,
+
+    %% Conservatively create 1 MODB per time unit
+    {'ok', AccountsPerPass} = kapps_config:get_integer(?MOD_CAT, <<"create_in_parallel">>, 1),
+
+    SecondsPerPass = (SecondsLeft div AccountsPerPass) div NumAccounts,
+
+    lager:info("creating ~p modbs (~p per pass), ~p seconds delay between passes"
+              ,[NumAccounts, AccountsPerPass, SecondsPerPass]
+              ),
+    create_modbs_metered(Year, Month, AccountsPerPass, SecondsPerPass).
+
+create_modbs_metered(Year, Month, AccountsPerPass, SecondsPerPass) ->
+    create_modbs_metered(Year, Month, AccountsPerPass, SecondsPerPass
+                        ,get_page(AccountsPerPass, 'undefined')
+                        ).
+
+create_modbs_metered(Year, Month, _AccountsPerPass, _SecondsPerPass, {'ok', Accounts, 'undefined'}) ->
+    _ = [create_modb(Year, Month, Account) || Account <- Accounts],
+    lager:info("finished creating account MODBs");
+create_modbs_metered(Year, Month, AccountsPerPass, SecondsPerPass, {'ok', Accounts, NextPageKey}) ->
+    NowS = kz_time:now_s(),
+    _ = [create_modb(Year, Month, Account) || Account <- Accounts],
+    ElapsedS = kz_time:elapsed_s(NowS),
+    WaitS = SecondsPerPass - ElapsedS,
+    lager:info("created ~p modb(s), waiting ~ps for next pass", [length(Accounts), WaitS]),
+    timer:sleep(WaitS * ?MILLISECONDS_IN_SECOND),
+    create_modbs_metered(Year, Month, AccountsPerPass, SecondsPerPass
+                        ,get_page(AccountsPerPass, NextPageKey)
+                        );
+create_modbs_metered(_Year, _Month, _AccountsPerPass, _SecondsPerPass, {'error', _E}) ->
+    lager:info("error paginating accounts: ~p", [_E]).
+
+-spec create_modb(kz_time:year(), kz_time:month(), kz_json:object()) -> boolean().
+create_modb(Year, Month, AccountView) ->
+    AccountId = kz_doc:id(AccountView),
+    AccountMODB = kz_util:format_account_id(AccountId, Year, Month),
+    kazoo_modb:maybe_create(AccountMODB).
+
+-spec get_page(pos_integer(), kz_json:api_json_term()) ->
+                      {'ok', kz_json:objects(), kz_json:api_json_term()} |
+                      kz_datamgr:data_error().
+get_page(AccountsPerPass, NextStartKey) ->
+    kz_datamgr:paginate_results(?KZ_ACCOUNTS_DB
+                               ,<<"accounts/listing_by_id">>
+                               ,[{'page_size', AccountsPerPass}
+                                ,{'startkey', NextStartKey}
+                                ]
+                               ).

--- a/applications/tasks/src/modules/kt_modb_creation.erl
+++ b/applications/tasks/src/modules/kt_modb_creation.erl
@@ -24,7 +24,7 @@ init() ->
 
 -spec handle_req() -> 'ok'.
 handle_req() ->
-    {'ok', CreateOnDay} = kapps_config:get_integer(?MOD_CAT, <<"creation_day">>, 28),
+    CreateOnDay = kapps_config:get_integer(?MOD_CAT, <<"creation_day">>, 28),
     handle_req(CreateOnDay, erlang:date()).
 
 -spec handle_req(kz_time:day(), kz_time:date()) -> 'ok'.
@@ -80,13 +80,17 @@ create_modb(Year, Month, AccountView) ->
     AccountMODB = kz_util:format_account_id(AccountId, Year, Month),
     kazoo_modb:maybe_create(AccountMODB).
 
--spec get_page(pos_integer(), kz_json:api_json_term()) ->
-                      {'ok', kz_json:objects(), kz_json:api_json_term()} |
-                      kz_datamgr:data_error().
+-spec get_page(pos_integer(), kz_json:api_json_term()) -> kz_datamgr:paginated_results().
+get_page(AccountsPerPass, 'undefined') ->
+    query([{'page_size', AccountsPerPass}]);
 get_page(AccountsPerPass, NextStartKey) ->
+    query([{'page_size', AccountsPerPass}
+          ,{'startkey', NextStartKey}
+          ]).
+
+-spec query(kz_datamgr:view_options()) -> kz_datamgr:paginated_results().
+query(ViewOptions) ->
     kz_datamgr:paginate_results(?KZ_ACCOUNTS_DB
                                ,<<"accounts/listing_by_id">>
-                               ,[{'page_size', AccountsPerPass}
-                                ,{'startkey', NextStartKey}
-                                ]
+                               ,ViewOptions
                                ).

--- a/applications/tasks/src/modules/kt_modb_creation.erl
+++ b/applications/tasks/src/modules/kt_modb_creation.erl
@@ -12,7 +12,7 @@
 %% Triggerables
 -export([handle_req/0]).
 
--export([create_modbs/2]).
+-export([create_modbs/0, create_modbs/2]).
 
 -include("tasks.hrl").
 
@@ -32,6 +32,12 @@ handle_req(Day, {Year, Month, Day}) ->
     _P = kz_util:spawn(fun create_modbs/2, [Year, Month]),
     lager:info("it is modb creation day! creating in ~p", [_P]);
 handle_req(_CreateOnDay, {_Year, _Month, _Day}) -> 'ok'.
+
+-spec create_modbs() -> 'ok'.
+create_modbs() ->
+    {Year, Month, _D} = erlang:date(),
+    _P = kz_util:spawn(fun create_modbs/2, [Year, Month]),
+    io:format("creating modbs in ~p~n", [_P]).
 
 -spec create_modbs(kz_time:year(), kz_time:month()) -> 'ok'.
 create_modbs(Year, Month) ->

--- a/applications/tasks/src/modules/kt_modb_creation.erl
+++ b/applications/tasks/src/modules/kt_modb_creation.erl
@@ -44,7 +44,7 @@ create_modbs(Year, Month, {'ok', NumAccounts}) ->
     SecondsLeft = NextMonthS - NowS,
 
     %% Conservatively create 1 MODB per time unit
-    {'ok', AccountsPerPass} = kapps_config:get_integer(?MOD_CAT, <<"create_in_parallel">>, 1),
+    AccountsPerPass = kapps_config:get_integer(?MOD_CAT, <<"create_in_parallel">>, 1),
 
     SecondsPerPass = (SecondsLeft div AccountsPerPass) div NumAccounts,
 

--- a/applications/tasks/src/modules/kt_services.erl
+++ b/applications/tasks/src/modules/kt_services.erl
@@ -14,16 +14,13 @@
         ]).
 
 %% Verifiers
--export([
-        ]).
+-export([]).
 
 %% Appliers
--export([descendant_quantities/2
-        ]).
+-export([descendant_quantities/2]).
 
 %% Triggerables
--export([cleanup/1
-        ]).
+-export([cleanup/1]).
 
 -include("tasks.hrl").
 -include_lib("kazoo_services/include/kazoo_services.hrl").
@@ -46,11 +43,10 @@
 %%------------------------------------------------------------------------------
 -spec init() -> 'ok'.
 init() ->
-    _ = tasks_bindings:bind(?TRIGGER_SYSTEM, ?MODULE, cleanup),
+    _ = tasks_bindings:bind(?TRIGGER_SYSTEM, ?MODULE, 'cleanup'),
     _ = tasks_bindings:bind(<<"tasks.help">>, ?MODULE, 'help'),
     _ = tasks_bindings:bind(<<"tasks."?CATEGORY".output_header">>, ?MODULE, 'output_header'),
     tasks_bindings:bind_actions(<<"tasks."?CATEGORY>>, ?MODULE, ?ACTIONS).
-
 
 -spec output_header(kz_term:ne_binary()) -> kz_tasks:output_header().
 output_header(<<"descendant_quantities">>) ->
@@ -99,13 +95,14 @@ action(<<"descendant_quantities">>) ->
 %%% Appliers
 
 -spec descendant_quantities(kz_tasks:extra_args(), kz_tasks:iterator()) -> kz_tasks:iterator().
-descendant_quantities(#{account_id := AccountId}, init) ->
+descendant_quantities(#{account_id := AccountId}, 'init') ->
     Descendants = kapps_util:account_descendants(AccountId),
     DescendantsMoDBs = lists:flatmap(fun kapps_util:get_account_mods/1, Descendants),
     lager:debug("found ~p descendants & ~p MoDBs in total"
-               ,[length(Descendants), length(DescendantsMoDBs)]),
-    {ok, DescendantsMoDBs};
-descendant_quantities(_, []) -> stop;
+               ,[length(Descendants), length(DescendantsMoDBs)]
+               ),
+    {'ok', DescendantsMoDBs};
+descendant_quantities(_, []) -> 'stop';
 descendant_quantities(_, [SubAccountMoDB | DescendantsMoDBs]) ->
     ?MATCH_MODB_SUFFIX_ENCODED(A, B, Rest, YYYY, MM) = SubAccountMoDB,
     AccountId = ?MATCH_ACCOUNT_RAW(A, B, Rest),
@@ -114,19 +111,17 @@ descendant_quantities(_, [SubAccountMoDB | DescendantsMoDBs]) ->
     case rows_for_quantities(AccountId, YYYY, MM, BoM, EoM) of
         [] ->
             %% No rows generated: ask worker to skip writing for this step.
-            {ok, DescendantsMoDBs};
+            {'ok', DescendantsMoDBs};
         Rows -> {Rows, DescendantsMoDBs}
     end.
 
-
 %%% Triggerables
 
--spec cleanup(kz_term:ne_binary()) -> ok.
+-spec cleanup(kz_term:ne_binary()) -> 'ok'.
 cleanup(?KZ_SERVICES_DB) ->
     lager:debug("checking ~s for abandoned accounts", [?KZ_SERVICES_DB]),
     cleanup_orphaned_services_docs();
-cleanup(_SystemDb) -> ok.
-
+cleanup(_SystemDb) -> 'ok'.
 
 %%%=============================================================================
 %%% Internal functions
@@ -182,7 +177,6 @@ maybe_integer_to_binary(Item, JObj) ->
         'undefined' -> 'undefined';
         Quantity -> integer_to_binary(Quantity)
     end.
-
 
 -spec cleanup_orphaned_services_docs() -> 'ok'.
 cleanup_orphaned_services_docs() ->

--- a/applications/tasks/src/modules/kt_services.erl
+++ b/applications/tasks/src/modules/kt_services.erl
@@ -199,7 +199,7 @@ cleanup_orphaned_services_doc(AccountId=?NE_BINARY) ->
         'true' -> 'ok';
         'false' ->
             lager:info("account ~s no longer exists but has a services doc", [AccountId]),
-            kz_datamgr:del_doc(?KZ_SERVICES_DB, AccountId),
+            _ = kz_datamgr:del_doc(?KZ_SERVICES_DB, AccountId),
             timer:sleep(5 * ?MILLISECONDS_IN_SECOND)
     end;
 cleanup_orphaned_services_doc(View) ->

--- a/applications/tasks/src/modules/kt_services_rollover.erl
+++ b/applications/tasks/src/modules/kt_services_rollover.erl
@@ -1,9 +1,9 @@
 %%%-----------------------------------------------------------------------------
 %%% @copyright (C) 2013-2019, 2600Hz
-%%% @doc Handle rolling over ledgers at the start of the month
+%%% @doc Handle rolling over services at the start of the month
 %%% @end
 %%%-----------------------------------------------------------------------------
--module(kt_ledger_rollover).
+-module(kt_services_rollover).
 
 %% behaviour: tasks_provider
 
@@ -16,7 +16,7 @@
 
 -include("tasks.hrl").
 
--define(MOD_CAT, <<(?CONFIG_CAT)/binary, ".ledger_rollover">>).
+-define(MOD_CAT, <<(?CONFIG_CAT)/binary, ".services_rollover">>).
 
 -spec init() -> 'ok'.
 init() ->
@@ -29,7 +29,7 @@ handle_req() ->
 -spec handle_req(kz_time:date()) -> 'ok'.
 handle_req({Year, Month, 1}) ->
     _P = kz_util:spawn(fun rollover_accounts/2, [Year, Month]),
-    lager:info("its a new month ~p-~p, rolling over ledgers in ~p", [Year, Month, _P]);
+    lager:info("its a new month ~p-~p, rolling over services in ~p", [Year, Month, _P]);
 handle_req({_Year, _Month, _Day}) -> 'ok'.
 
 -spec rollover_accounts(kz_time:year(), kz_time:month()) -> 'ok'.
@@ -38,10 +38,10 @@ rollover_accounts(Year, Month) ->
 
 -spec rollover_accounts(kz_time:year(), kz_time:month(), kz_datamgr:paginated_results()) -> 'ok'.
 rollover_accounts(Year, Month, {'ok', Accounts, 'undefined'}) ->
-    _ = [kz_ledgers:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
+    _ = [kz_services_modb:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
     lager:info("finished rolling over ~p accounts", [length(Accounts)]);
 rollover_accounts(Year, Month, {'ok', Accounts, NextPageKey}) ->
-    _ = [kz_ledgers:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
+    _ = [kz_services_modb:rollover(kz_doc:id(Account), Year, Month) || Account <- Accounts],
     rollover_accounts(Year, Month, get_page(NextPageKey));
 rollover_accounts(_Year, _Month, {'error', _E}) ->
     lager:error("failed to query account listing during rollover: ~p", [_E]).

--- a/applications/tasks/test/kt_tasks_trigger_tests.erl
+++ b/applications/tasks/test/kt_tasks_trigger_tests.erl
@@ -1,0 +1,40 @@
+-module(kt_tasks_trigger_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DATE, {2600, 10, 10}).
+
+next_minute_test_() ->
+    [?_assertEqual(60, kz_tasks_trigger:seconds_until_next_minute({?DATE, {1, 2, 0}}))
+    ,?_assertEqual(59, kz_tasks_trigger:seconds_until_next_minute({?DATE, {1, 2, 1}}))
+    ,?_assertEqual(30, kz_tasks_trigger:seconds_until_next_minute({?DATE, {1, 2, 30}}))
+    ,?_assertEqual(2, kz_tasks_trigger:seconds_until_next_minute({?DATE, {1, 2, 58}}))
+    ,?_assertEqual(1, kz_tasks_trigger:seconds_until_next_minute({?DATE, {1, 2, 59}}))
+    ,?_assertEqual(0, kz_tasks_trigger:seconds_until_next_minute({?DATE, {1, 2, 60}}))
+    ].
+
+next_hour_test_() ->
+    [?_assertEqual(3600, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 0, 0}}))
+    ,?_assertEqual(3599, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 0, 1}}))
+    ,?_assertEqual(3540, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 1, 0}}))
+    ,?_assertEqual(3539, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 1, 1}}))
+
+    ,?_assertEqual(1800, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 30, 0}}))
+    ,?_assertEqual(1770, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 30, 30}}))
+    ,?_assertEqual(1741, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 30, 59}}))
+
+    ,?_assertEqual(60, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 59, 0}}))
+    ,?_assertEqual(59, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 59, 1}}))
+    ,?_assertEqual(1, kz_tasks_trigger:seconds_until_next_hour({?DATE, {1, 59, 59}}))
+    ].
+
+next_day_test_() ->
+    [?_assertEqual(86400, kz_tasks_trigger:seconds_until_next_day({?DATE, {0, 0, 0}}))
+
+    ,?_assertEqual(61, kz_tasks_trigger:seconds_until_next_day({?DATE, {23, 58, 59}}))
+    ,?_assertEqual(60, kz_tasks_trigger:seconds_until_next_day({?DATE, {23, 59, 0}}))
+
+    ,?_assertEqual(3, kz_tasks_trigger:seconds_until_next_day({?DATE, {23, 59, 57}}))
+    ,?_assertEqual(2, kz_tasks_trigger:seconds_until_next_day({?DATE, {23, 59, 58}}))
+    ,?_assertEqual(1, kz_tasks_trigger:seconds_until_next_day({?DATE, {23, 59, 59}}))
+    ].

--- a/core/kazoo/src/kz_doc.erl
+++ b/core/kazoo/src/kz_doc.erl
@@ -598,7 +598,6 @@ update_pvt_parameters(JObj0, DBName) ->
                                    doc().
 update_pvt_parameters(JObj, DbName, Options) ->
     Opts = props:insert_value('now', kz_time:now_s(), Options),
-
     Updates = get_pvt_updates(JObj, DbName, Opts),
     kz_json:set_values(Updates, JObj).
 

--- a/core/kazoo_apps/src/kapps_config.erl
+++ b/core/kazoo_apps/src/kapps_config.erl
@@ -1128,7 +1128,6 @@ fetch_category(Category, 'false') ->
         ,{{<<"provisioner">>, <<"cluster_id">>}
          ,{<<"cluster">>, <<"cluster_id">>}
          }
-
         ,{{<<"services">>, <<"master_account_bookkeeper">>}
          ,fun(_FromId, _Node, _FromSetting, <<"kz_bookkeeper_braintree">>) ->
                   {<<"services">>

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -691,7 +691,7 @@ ensure_aggregate_account(Account) ->
             update_or_add_to_accounts_db(AccountId, JObj)
     end.
 
--spec update_or_add_to_accounts_db(kz_term:ne_bianry(), kz_json:object()) -> 'ok'.
+-spec update_or_add_to_accounts_db(kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 update_or_add_to_accounts_db(AccountId, JObj) ->
     <<"account">> = kz_doc:type(JObj),
     case kz_datamgr:lookup_doc_rev(?KZ_ACCOUNTS_DB, AccountId) of
@@ -1033,9 +1033,7 @@ fix_services_tree(AccountId, Tree) ->
     Services = kz_services:fetch(AccountId),
     fix_services_tree(Services, Tree, kz_services:services_jobj(Services)).
 
--spec fix_services_tree(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:api_object()) -> 'ok'.
-fix_services_tree(_, _, 'undefined') ->
-    io:format("    !!! can't fix pvt_tree in service doc, account_db does not exists~n");
+-spec fix_services_tree(kz_term:ne_binary(), kz_term:ne_binaries(), kzd_services:doc()) -> 'ok'.
 fix_services_tree(Services, Tree, ServicesJObj) ->
     case kzd_services:tree(ServicesJObj) =:= Tree of
         'true' -> 'ok';
@@ -1187,7 +1185,7 @@ import_account(Account, Parent) ->
 -spec import_account(kz_term:ne_binary()
                     ,kz_term:ne_binary()
                     ,{'ok', kz_json:object()} | kazoo_data:data_error()
-                    ,{'ok', kz_json:object()} | kazoo_dat:data_error()
+                    ,{'ok', kz_json:object()} | kazoo_data:data_error()
                     ) -> 'ok'.
 import_account(_AccountId, _ParentId, {'error', _Reason1}, {'error', _Reason2}) ->
     io:format("can not open account '~s' (~p) and parent '~s' (~p)~n"
@@ -1211,14 +1209,14 @@ import_account(AccountId, ParentId, {'ok', AccountJObj}, {'ok', ParentJObj}) ->
         {'ok', SavedJObj} ->
             io:format("account saved, updating services and import account's numbers to number dbs~n"),
             update_or_add_to_accounts_db(AccountId, SavedJObj),
-            remove_and_reconcile_services(AccountId),
+            _ = remove_and_reconcile_services(AccountId),
             _ = kazoo_number_manager_maintenance:copy_single_account_to_number_dbs(AccountId),
             'ok';
         {'error', _Reason} ->
             io:format("failed to update account '~s' definition in accountdb: ~p~n", [AccountId, _Reason])
     end.
 
--spec remove_and_reconcile_services(kz_term:ne_binary()) -> 'ok'.
+-spec remove_and_reconcile_services(kz_term:ne_binary()) -> kz_services:services().
 remove_and_reconcile_services(AccountId) ->
     io:format("ensuring services doc for '~s'~n", [AccountId]),
     _ = kz_datamgr:del_doc(?KZ_SERVICES_DB, AccountId),

--- a/core/kazoo_couch/src/kazoo_couch.erl
+++ b/core/kazoo_couch/src/kazoo_couch.erl
@@ -77,7 +77,7 @@ format_error(Error) ->
     kz_couch_util:format_error(Error).
 
 %% Connection operations
--spec get_db(kz_data:connection(), kz_term:ne_binary()) -> db().
+-spec get_db(server(), kz_term:ne_binary()) -> db().
 get_db(Server, DbName) ->
     kz_couch_util:get_db(Server, DbName).
 
@@ -292,7 +292,7 @@ all_docs(Server, DbName, Options) ->
 
 -spec server_version(server()) -> couch_version().
 server_version(#server{options=Options}) ->
-    props:get_value('driver_version', Options).
+    props:get_value('driver_version', Options, 'bigcouch').
 
 -spec db_local_filter(kz_term:ne_binaries(), kz_data:options()) -> kz_term:ne_binaries().
 db_local_filter(List, Options) ->

--- a/core/kazoo_couch/src/kazoo_couch_sup.erl
+++ b/core/kazoo_couch/src/kazoo_couch_sup.erl
@@ -40,7 +40,7 @@ start_link() ->
 %% specifications.
 %% @end
 %%------------------------------------------------------------------------------
--spec init(any()) -> kz_types:sup_init_ret().
+-spec init([]) -> kz_types:sup_init_ret().
 init([]) ->
     RestartStrategy = 'one_for_one',
     MaxRestarts = 5,

--- a/core/kazoo_couch/src/kz_couch_db.erl
+++ b/core/kazoo_couch/src/kz_couch_db.erl
@@ -146,6 +146,7 @@ archive(#db{}=Db, DbName, File, MaxDocs, N, Pos) when N =< MaxDocs ->
     case kz_couch_view:all_docs(Db, ViewOptions) of
         {'ok', []} -> io:format("    no docs left after pos ~p~n", [Pos]);
         {'ok', Docs} ->
+            'ok' = maybe_add_comma(File, Pos),
             'ok' = archive_docs(File, Docs),
             io:format("    archived ~p docs~n", [N]);
         {'error', _E} ->
@@ -161,6 +162,7 @@ archive(Db, DbName, File, MaxDocs, N, Pos) ->
     case kz_couch_view:all_docs(Db, ViewOptions) of
         {'ok', []} -> io:format("    no docs left after pos ~p~n", [Pos]);
         {'ok', Docs} ->
+            'ok' = maybe_add_comma(File, Pos),
             'ok' = archive_docs(File, Docs),
             io:format("    archived ~p docs~n", [MaxDocs]),
             archive(Db, DbName, File, MaxDocs, N - MaxDocs, Pos + MaxDocs);
@@ -169,6 +171,18 @@ archive(Db, DbName, File, MaxDocs, N, Pos) ->
             timer:sleep(500),
             archive(Db, DbName, File, MaxDocs, N, Pos)
     end.
+
+%% when writing 2nd+ page of results, the previous page's last JObj will not have a comma after it
+%% so you would get files like
+%% [Pass1JObj,
+%%  Pass1JObj
+%%  Pass2JObj,
+%%  Pass2JObj
+%% Which is invalid JSON
+-spec maybe_add_comma(file:io_device(), non_neg_integer()) -> 'ok'.
+maybe_add_comma(_File, 0) -> 'ok';
+maybe_add_comma(File, _Pos) ->
+    'ok' = file:write(File, [$,]).
 
 -spec archive_docs(file:io_device(), kz_json:objects()) -> 'ok'.
 archive_docs(_, []) -> 'ok';
@@ -191,9 +205,15 @@ db_import(#server{}=Conn, DbName, Filename) ->
                           'ok' |
                           couchbeam_error().
 do_db_import(#server{}=Conn, DbName, Docs) ->
-    JObjs0 = [kz_json:delete_keys([<<"_rev">>, <<"_attachments">>], kz_json:get_value(<<"doc">>, Doc)) || Doc <- Docs],
-    JObjs = [JObj || JObj <- JObjs0, filter_views(kz_json:get_value(<<"_id">>, JObj))],
+    JObjs = [cleanup_for_import(Doc)
+             || Doc <- Docs,
+                filter_views(kz_doc:id(Doc))
+            ],
     kz_couch_doc:save_docs(Conn, DbName, JObjs, []).
+
+cleanup_for_import(Doc) ->
+    JObj = kz_json:get_json_value(<<"doc">>, Doc),
+    kz_json:delete_keys([<<"_rev">>, <<"_attachments">>], JObj).
 
 filter_views(<<"_design", _/binary>>) -> 'false';
 filter_views(_Id) -> 'true'.

--- a/core/kazoo_couch/src/kz_couch_db.erl
+++ b/core/kazoo_couch/src/kz_couch_db.erl
@@ -226,6 +226,9 @@ do_db_compact(#db{}=Db) ->
         'ok' ->
             lager:debug("compaction has started"),
             'true';
+        {'ok', _OK} ->
+            lager:debug("compaction has started: ~p", [_OK]),
+            'true';
         {'error', {'conn_failed', {'error', 'timeout'}}} ->
             lager:warning("connection timed out"),
             'false';

--- a/core/kazoo_couch/src/kz_couch_doc.erl
+++ b/core/kazoo_couch/src/kz_couch_doc.erl
@@ -161,7 +161,9 @@ do_save_docs(#db{}=Db, Docs, Options, Acc) ->
         {Save, Cont} ->
             case perform_save_docs(Db, Save, Options) of
                 {'error', _}=E -> E;
-                {'ok', JObjs} -> do_save_docs(Db, Cont, Options, JObjs ++ Acc)
+                {'ok', JObjs} ->
+                    timer:sleep(?COUCH_MAX_BULK_INSERT), %% let slow dbs catch up
+                    do_save_docs(Db, Cont, Options, JObjs ++ Acc)
             end
     catch
         'error':'badarg' ->

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -1474,7 +1474,7 @@ get_result_docs(DbName, DesignDoc, Keys) ->
 %%------------------------------------------------------------------------------
 -type paginate_options() :: [{'page_size', pos_integer()}] | view_options().
 -type paginated_results() :: {'ok', kz_json:objects(), kz_json:api_json_term()} |
-                             kz_datamgr:data_error().
+                             data_error().
 
 -spec paginate_results(kz_term:ne_binary(), kz_term:ne_binary(), paginate_options()) ->
                               {'ok', kz_json:objects(), kz_json:api_json_term()} |

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -109,6 +109,7 @@
              ,db_classification/0
              ,update_option/0, update_options/0
              ,get_results_return/0
+             ,paginated_results/0
              ]).
 
 -deprecated({'ensure_saved', '_', 'eventually'}).
@@ -1472,6 +1473,9 @@ get_result_docs(DbName, DesignDoc, Keys) ->
 %% @end
 %%------------------------------------------------------------------------------
 -type paginate_options() :: [{'page_size', pos_integer()}] | view_options().
+-type paginated_results() :: {'ok', kz_json:objects(), kz_json:api_json_term()} |
+                             kz_datamgr:data_error().
+
 -spec paginate_results(kz_term:ne_binary(), kz_term:ne_binary(), paginate_options()) ->
                               {'ok', kz_json:objects(), kz_json:api_json_term()} |
                               data_error().

--- a/core/kazoo_data/src/kzs_db.erl
+++ b/core/kazoo_data/src/kzs_db.erl
@@ -182,7 +182,10 @@ db_archive(#{server := {App, Conn}}=Server, DbName, Filename) ->
 db_import(#{server := {App, Conn}}=Server, DbName, Filename) ->
     case db_exists(Server, DbName) of
         'true' -> App:db_import(Conn, DbName, Filename);
-        'false' -> 'ok'
+        'false' ->
+            io:format("db ~s doesn't exist, creating~n", [DbName]),
+            'true' = db_create(Server, DbName),
+            App:db_import(Conn, DbName, Filename)
     end.
 
 -spec db_list(map(), view_options()) -> {'ok', kz_term:ne_binaries()} | data_error().

--- a/core/kazoo_data/src/kzs_db.erl
+++ b/core/kazoo_data/src/kzs_db.erl
@@ -145,6 +145,19 @@ maybe_cache_db_exists('true', #{server := {App, Conn}}, DbName) ->
     kz_cache:store_local(?KAZOO_DATA_PLAN_CACHE, {'database', {App, Conn}, DbName}, 'true', Props),
     'true'.
 
+%%------------------------------------------------------------------------------
+%% @doc Makes sure databases exist across all configured connections
+%%
+%% Since KAZOO can store different doc types using different connections, the database
+%% itself must exist on all connections; it is the doc being saved that will determine
+%% which connection will be used to save the doc.
+%%
+%% For example, you may wish KAZOO to store CDRs in Couch cluster A
+%% You may also wish to store call recordings in Couch cluster B
+%% The MODB for those docs must exist on both connections, which is what this function
+%% is ensuring.
+%% @end
+%%------------------------------------------------------------------------------
 -spec db_exists_all(map(), kz_term:ne_binary()) -> boolean().
 db_exists_all(Map, DbName) ->
     case kz_cache:fetch_local(?KAZOO_DATA_PLAN_CACHE, {'database', DbName}) of

--- a/core/kazoo_globals/src/kz_globals.erl
+++ b/core/kazoo_globals/src/kz_globals.erl
@@ -885,7 +885,7 @@ amqp_call_scope() ->
 -spec amqp_call_scope(integer(), integer()) -> fun() | 'undefined'.
 amqp_call_scope(_N, Seconds)
   when Seconds < ?MILLISECONDS_IN_MINUTE * 2 ->
-    lager:debug("system running for less than 2 minutes, attempting to collect 10 responses from kazoo_globals"),
+    lager:debug("system running for less than 2 minutes, attempting to collect 10 (instead of ~p) responses from kazoo_globals", [_N]),
     amqp_call_scope_fun(10);
 amqp_call_scope(N, _Seconds) ->
     amqp_call_scope_fun(N).
@@ -903,6 +903,7 @@ is_ready() ->
     try
         gen_listener:call(?MODULE, 'is_ready')
     catch
-        _T:_E -> lager:info("globals is_ready returned ~p : ~p", [_T,_E]),
-                 false
+        _T:_E ->
+            lager:info("globals is_ready returned ~p : ~p", [_T,_E]),
+            'false'
     end.

--- a/core/kazoo_ledgers/src/kz_currency.erl
+++ b/core/kazoo_ledgers/src/kz_currency.erl
@@ -194,7 +194,7 @@ rollover(Account, Year, Month, Units) ->
     kz_ledgers:rollover(Account, Year, Month, Units).
 
 %%------------------------------------------------------------------------------
-%% @doc
+%% @doc Callback to handle rolling over ledgers to the new MODB
 %% @end
 %%------------------------------------------------------------------------------
 -spec modb(kz_term:ne_binary()) -> available_units_return().

--- a/core/kazoo_ledgers/src/kz_currency.erl
+++ b/core/kazoo_ledgers/src/kz_currency.erl
@@ -28,7 +28,6 @@
         ,rollover/3
         ,rollover/4
         ]).
--export([modb/1]).
 
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
 
@@ -192,12 +191,3 @@ rollover(Account, Year, Month) ->
                       available_units_return().
 rollover(Account, Year, Month, Units) ->
     kz_ledgers:rollover(Account, Year, Month, Units).
-
-%%------------------------------------------------------------------------------
-%% @doc Callback to handle rolling over ledgers to the new MODB
-%% @end
-%%------------------------------------------------------------------------------
--spec modb(kz_term:ne_binary()) -> available_units_return().
-modb(MODb) ->
-    {Account, Year, Month} = kazoo_modb_util:split_account_mod(MODb),
-    rollover(Account, Year, Month).

--- a/core/kazoo_ledgers/src/kz_ledger.erl
+++ b/core/kazoo_ledgers/src/kz_ledger.erl
@@ -594,7 +594,7 @@ to_json(#ledger{private_fields=PrivateFields}=Ledger) ->
             ],
     kz_json:set_values(Props, LedgerJObj).
 
--spec get_created_timestamp(kzd_ledgers:doc()) -> kz_term:integer().
+-spec get_created_timestamp(kzd_ledgers:doc()) -> integer().
 get_created_timestamp(LedgerJObj) ->
     kz_doc:created(LedgerJObj, kz_time:now_s()).
 

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -100,7 +100,7 @@ total_sources_from_previous(Account) ->
 -spec get_sources_total(kz_term:ne_binary(), kazoo_modb:view_options()) ->
                                kz_currency:available_units_return().
 get_sources_total(Account, Options) ->
-    View = <<"ledgers/total_by_source">>,
+    View = ?TOTAL_BY_SOURCE,
     ViewOptions = ['reduce'
                   ,{'group_level', 1}
                   ,'missing_as_error'
@@ -384,7 +384,7 @@ rollover_past_available_units(Account, Year, Month) ->
     {PreviousYear, PreviousMonth} =
         kazoo_modb_util:prev_year_month(Year, Month),
 
-    lager:info("rolling over past y/m ~p:~p", [PreviousYear, PreviousMonth]),
+    lager:info("rolling over previous month ~p:~p", [PreviousYear, PreviousMonth]),
 
     case kz_currency:past_available_units(Account, PreviousYear, PreviousMonth) of
         {'error', 'db_not_found'} ->
@@ -432,8 +432,8 @@ rollover(Account, Year, Month, Total) ->
                           ],
             get_sources_total(Account, ViewOptions);
         {'error', 'conflict'} ->
-            lager:info("ledger rollover for ~s ~p-~p exists already"
-                      ,[Account, Year, Month]
+            lager:info("ledger rollover ~s for ~s ~p-~p exists already"
+                      ,[kz_doc:id(LedgerJObj), Account, Year, Month]
                       ),
             ViewOptions = [{'year', Year}
                           ,{'month', Month}

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -109,7 +109,7 @@ get_sources_total(Account, Options) ->
     case kazoo_modb:get_results(Account, View, ViewOptions) of
         {'ok', []} ->
             lager:info("missing ledgers from ~s: ~p/~p"
-                      ,[Account, props:get_value('year', ViewOptions), props:get_value('month', View)]
+                      ,[Account, props:get_value('year', ViewOptions), props:get_value('month', ViewOptions)]
                       ),
             {'error', 'missing_ledgers'};
         {'ok', JObjs} ->

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -369,7 +369,7 @@ rollover(Account, Year, Month) ->
     case should_rollover_monthly_balance() of
         'true' -> rollover_past_available_units(Account, Year, Month);
         'false' ->
-            lager:debug("monthly balance rollover is disabled, assuming previous balance was 0", []),
+            lager:debug("monthly balance rollover is disabled, assuming previous balance was 0"),
             rollover(Account, Year, Month, 0)
     end.
 

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -361,7 +361,7 @@ migrate_legacy_rollover(Account, Options, Year, Month) ->
     end.
 
 %%------------------------------------------------------------------------------
-%% @doc
+%% @doc given the current Year/Month, rollover last month's ledgers
 %% @end
 %%------------------------------------------------------------------------------
 -spec rollover(kz_term:ne_binary()) -> {'ok', kz_ledger:ledger()} |
@@ -370,15 +370,22 @@ rollover(Account) ->
     {Year, Month, _} = erlang:date(),
     rollover(Account, Year, Month).
 
+%%------------------------------------------------------------------------------
+%% @doc rollover the previous MODBs ledgers into the given year/month
+%% @end
+%%------------------------------------------------------------------------------
 -spec rollover(kz_term:ne_binary(),  kz_time:year(), kz_time:month()) ->
                       {'ok', kz_ledger:ledger()} |
                       {'error', any()}.
 rollover(Account, Year, Month) ->
+    MODB = kz_util:format_account_id(Account, Year, Month),
+
     case should_rollover_monthly_balance() of
-        'true' -> rollover_past_available_units(Account, Year, Month);
+        'true' ->
+            rollover_past_available_units(MODB, Year, Month);
         'false' ->
             lager:debug("monthly balance rollover is disabled, assuming previous balance was 0"),
-            rollover(Account, Year, Month, 0)
+            rollover(MODB, Year, Month, 0)
     end.
 
 -spec rollover_past_available_units(kz_term:ne_binary(),  kz_time:year(), kz_time:month()) ->

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -384,7 +384,7 @@ rollover_past_available_units(Account, Year, Month) ->
     {PreviousYear, PreviousMonth} =
         kazoo_modb_util:prev_year_month(Year, Month),
 
-    lager:info("past y/m ~p:~p", [PreviousYear, PreviousMonth]),
+    lager:info("rolling over past y/m ~p:~p", [PreviousYear, PreviousMonth]),
 
     case kz_currency:past_available_units(Account, PreviousYear, PreviousMonth) of
         {'error', 'db_not_found'} ->
@@ -414,7 +414,7 @@ rollover(Account, Year, Month, Total) ->
           ,{fun kz_ledger:set_period_start/2, kz_time:now_s()}
           ,{fun kz_ledger:set_metadata/2, Metadata}
           ,{fun kz_ledger:set_unit_amount/2, Total}
-          ,{fun kz_ledger:set_id/2, ?ROLLOVER_ID(Year,Month)}
+          ,{fun kz_ledger:set_id/2, ?ROLLOVER_ID(Year, Month)}
           ,{fun kz_ledger:set_ledger_type/2, ledger_type(Total)}
           ,{fun kz_ledger:set_executor_trigger/2, <<"automatic">>}
           ,{fun kz_ledger:set_executor_module/2, ?MODULE}

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -94,7 +94,11 @@ total_sources_from_previous(Account) ->
     total_sources(Account, PreviousYear, PreviousMonth).
 
 %%------------------------------------------------------------------------------
-%% @doc
+%% @doc Fetch total units for the MODB
+%%
+%% On an un-indexed MODB with 12,000 documents (381 of which are ledger docs)
+%% it took about 6s to index and return the view results. On the same database
+%% after indexing, 70ms.
 %% @end
 %%------------------------------------------------------------------------------
 -spec get_sources_total(kz_term:ne_binary(), kazoo_modb:view_options()) ->

--- a/core/kazoo_modb/doc/README.md
+++ b/core/kazoo_modb/doc/README.md
@@ -1,1 +1,7 @@
 # Kazoo Month Only DB *Manages Monthly Databases*
+
+Month-only databases are used to separate account configuration settings (like users, devices, callflows, etc) and temporal data like call recordings, faxes, voicemails, etc. This allows the account database to stay pretty small in size while the MODBs can grow based on usage but once a new month rolls around, cap the database's size and allow it to be archived and removed from the DB cluster after a certain time.
+
+## Intialization
+
+MODBs are loaded with the appropriate views then a series of routines are run. These are set in the `system_config/modb` document under the `routines` key.

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -527,7 +527,7 @@ add_routine(Module) ->
 
 -spec add_migrate_routines(kz_term:ne_binaries(), kz_term:ne_binary()) -> kz_term:ne_binaries().
 add_migrate_routines(Routines, Module) ->
-    lists:usort([Module | migrate_routines(Routines, [])] ++ [<<"kz_currency">>]).
+    lists:usort([Module | migrate_routines(Routines, [])] -- [<<"kz_currency">>]).
 
 -spec migrate_routines(kz_term:ne_binaries(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
 migrate_routines([], Acc) -> Acc;

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -486,7 +486,10 @@ run_routines(AccountMODb) ->
            ],
     wait_for_runs(Runs, kz_time:now()).
 
--spec wait_for_runs([{kz_term:ne_binary(), kz_term:pid_ref()}], kz_time:now()) -> 'ok'.
+-type run() :: {kz_term:ne_binary(), kz_term:pid_ref()}.
+-type runs() :: [run()].
+
+-spec wait_for_runs(runs(), kz_time:now()) -> 'ok'.
 wait_for_runs([], _Start) -> 'ok';
 wait_for_runs(Runs, Start) ->
     receive
@@ -497,6 +500,7 @@ wait_for_runs(Runs, Start) ->
             lager:info("runs haven't finished yet, moving on: ~p", [Runs])
     end.
 
+-spec handle_finished_run(runs(), kz_time:now(), kz_term:pid_ref(), any()) -> 'ok'.
 handle_finished_run(Runs, Start, PidRef, Reason) ->
     case lists:keytake(PidRef, 2, Runs) of
         'false' ->

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -444,13 +444,13 @@ create(AccountMODb) ->
 
 -spec do_create(kz_term:ne_binary(), boolean()) -> boolean().
 do_create(AccountMODb, 'true') ->
-    lager:info("modb ~p is exists, just refreshing views...", [AccountMODb]),
+    lager:info("modb '~s' exists, just refreshing views and running routines...", [AccountMODb]),
     EncodedMODb = kz_util:format_account_modb(AccountMODb, 'encoded'),
     _ = refresh_views(EncodedMODb),
     run_routines(AccountMODb),
     'true';
 do_create(AccountMODb, 'false') ->
-    lager:debug("creating modb ~p", [AccountMODb]),
+    lager:debug("creating modb '~s'", [AccountMODb]),
     EncodedMODb = kz_util:format_account_modb(AccountMODb, 'encoded'),
     case kz_datamgr:db_create(EncodedMODb) of
         'true' ->
@@ -480,17 +480,34 @@ refresh_views(AccountMODb) ->
 -spec run_routines(kz_term:ne_binary()) -> 'ok'.
 run_routines(AccountMODb) ->
     Routines = kapps_config:get_ne_binaries(?CONFIG_CAT, <<"routines">>, []),
-    _ = [run_routine(AccountMODb, Routine) || Routine <- Routines],
-    'ok'.
+    Runs = [{Routine, kz_util:spawn_monitor(kz_term:to_atom(Routine), 'modb', [AccountMODb])}
+            || Routine <- Routines,
+               kz_module:is_exported(Routine, 'modb', 1)
+           ],
+    wait_for_runs(Runs, kz_time:now()).
 
--spec run_routine(kz_term:ne_binary(), kz_term:ne_binary()) -> any().
-run_routine(AccountMODb, Routine) ->
-    case kz_module:is_exported(Routine, 'modb', 1) of
+-spec wait_for_runs([{kz_term:ne_binary(), kz_term:pid_ref()}], kz_time:now()) -> 'ok'.
+wait_for_runs([], _Start) -> 'ok';
+wait_for_runs(Runs, Start) ->
+    receive
+        {'DOWN', Ref, 'process', Pid, Reason} ->
+            handle_finished_run(Runs, Start, {Pid, Ref}, Reason)
+    after
+        ?MILLISECONDS_IN_MINUTE ->
+            lager:info("runs haven't finished yet, moving on: ~p", [Runs])
+    end.
+
+handle_finished_run(Runs, Start, PidRef, Reason) ->
+    case lists:keytake(PidRef, 2, Runs) of
         'false' ->
-            lager:info("skipping routine ~s, doesn't export modb/1", [Routine]);
-        'true' ->
-            Module = kz_term:to_atom(Routine),
-            _ = Module:modb(AccountMODb)
+            lager:debug("ignoring unknown pid/ref ~p: ~p", [PidRef, Reason]),
+            wait_for_runs(Runs, Start);
+        {'value', {Routine, PidRef}, RestRuns} when Reason =:= 'normal' ->
+            lager:debug("routine ~s(~p) finished after ~pms", [Routine, element(1, PidRef), kz_time:elapsed_ms(Start)]),
+            wait_for_runs(RestRuns, Start);
+        {'value', {Routine, PidRef}, RestRuns} ->
+            lager:info("routine ~s(~p) crashed after ~pms: ~p", [Routine, element(1, PidRef), kz_time:elapsed_ms(Start), Reason]),
+            wait_for_runs(RestRuns, Start)
     end.
 
 -spec add_routine(kz_term:ne_binary() | atom()) -> 'ok'.

--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -836,12 +836,14 @@ check_app_usage(#{todo := JObjs}=State, AccountDb) ->
     check_app_usage_fold(State#{todo => []}, [{AccountDb, JObjs}]).
 
 %% @private see note above
--spec check_app_usage_fold(loop_state(), kz_json:objects()) -> loop_state().
+-spec check_app_usage_fold(loop_state(), [{kz_term:ne_binary(), kz_json:objects()}]) -> loop_state().
 check_app_usage_fold(State, []) ->
     State;
 check_app_usage_fold(#{todo := Todo
                       ,apps_fixers := Fixers
-                      }=State, [{AccountDbForEver, JObjs}|Rest]) ->
+                      }=State
+                    ,[{AccountDbForEver, JObjs}|Rest]
+                    ) ->
     Ids = [kz_doc:id(JObj) || JObj <- JObjs],
     AppsUsing = get_account_dids_apps(AccountDbForEver, Ids),
 
@@ -1461,7 +1463,7 @@ fix_unassign_doc(DIDs) ->
               ,{'batch_run', 'true'}
               ],
     case knm_numbers:update(DIDs, Setters, Options) of
-        #{ko := []} -> 'ok';
+        #{ko := Map} when map_size(Map) =:= 0 -> 'ok';
         #{ko := KOs} ->
             ?SUP_LOG_DEBUG("failed fixing ~b unassigned numbers.", [maps:size(KOs)])
     end.

--- a/core/kazoo_number_manager/src/knm_numbers.erl
+++ b/core/kazoo_number_manager/src/knm_numbers.erl
@@ -662,7 +662,7 @@ run_services(T=#{todo := Numbers}) ->
             ko(Numbers, Reason, T)
     end.
 
--spec run_services(kz_term:ne_binaries(), kz_json:object(), kz_services:services()) -> 'ok'.
+-spec run_services(kz_term:ne_binaries(), kz_json:object(), [kz_services:services()]) -> 'ok'.
 run_services([], _Updates, UpdatedServicesAcc) ->
     _ = [kz_services:commit(UpdatedServices) || UpdatedServices <- lists:reverse(UpdatedServicesAcc)],
     'ok';

--- a/core/kazoo_proper/src/pqc_kazoo_model.erl
+++ b/core/kazoo_proper/src/pqc_kazoo_model.erl
@@ -52,7 +52,7 @@
 
 %% #{"prefix" => cost}
 -type rate_data() :: #{kz_term:ne_binary() => non_neg_integer()}.
--type service_plans() :: [{kz_term:ne_binary(), kzd_service_plan:plan()}].
+-type service_plans() :: [{kz_term:ne_binary(), kzd_service_plan:doc()}].
 
 -type account_data() :: #{'name' => kz_term:ne_binary()
                          ,'service_plans' => service_plans()

--- a/core/kazoo_services/src/kazoo_services_sup.erl
+++ b/core/kazoo_services/src/kazoo_services_sup.erl
@@ -14,21 +14,15 @@
 
 -define(SERVER, ?MODULE).
 
--define(ORIGIN_BINDINGS, [[{'db', ?KZ_SERVICES_DB}, {'type', kzd_services:type()}]
-                         ]).
+-define(ORIGIN_BINDINGS, [[{'db', ?KZ_SERVICES_DB}, {'type', kzd_services:type()}]]).
 
--define(CACHE_PROPS, [{'origin_bindings', ?ORIGIN_BINDINGS}
-                     ]).
+-define(CACHE_PROPS, [{'origin_bindings', ?ORIGIN_BINDINGS}]).
 
 %% Helper macro for declaring children of supervisor
 -ifdef(TEST).
--define(CHILDREN, [?CACHE_ARGS(?CACHE_NAME, [])
-                  ,?WORKER('kz_services_modb')
-                  ]).
+-define(CHILDREN, [?CACHE_ARGS(?CACHE_NAME, [])]).
 -else.
--define(CHILDREN, [?CACHE_ARGS(?CACHE_NAME, ?CACHE_PROPS)
-                  ,?WORKER('kz_services_modb')
-                  ]).
+-define(CHILDREN, [?CACHE_ARGS(?CACHE_NAME, ?CACHE_PROPS)]).
 -endif.
 
 %%==============================================================================

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -945,7 +945,7 @@ commit_updates(Account, Current, Proposed) ->
                     ) -> services().
 commit_updates(Account, Current, Proposed, AuditLog) ->
     AccountId = kz_util:format_account_id(Account),
-    FetchOptions = [{'updates', AccountId, Current, Proposed}
+    FetchOptions = [{'updates', AccountId, to_billables(Current), to_billables(Proposed)}
                    ,{'audit_log', add_audit_log_changes_account(AccountId, AuditLog)}
                    ],
     Services = fetch(AccountId, FetchOptions),
@@ -957,6 +957,11 @@ commit_updates(Account, Current, Proposed, AuditLog) ->
         'false' ->
             commit_updates(Services, FetchOptions)
     end.
+
+-spec to_billables(kz_services_quantities:billables() | kz_services_quantities:billable()) -> kz_services_quantities:billables().
+to_billables('undefined') -> [];
+to_billables(Bs) when is_list(Bs) -> Bs;
+to_billables(B) -> [B].
 
 -spec should_skip_updates(services()) -> boolean().
 should_skip_updates(Services) ->

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -261,7 +261,7 @@ remove_plans(Services) ->
     reset_plans(set_services_jobj(Services, ServicesJObj)).
 
 -spec find_object_plans(kz_services_quantities:billables(), kz_services_quantities:billables()) -> kz_json:objects().
-find_object_plans(JObjsA, JObjsB) ->
+find_object_plans(JObjsA, JObjsB) when is_list(JObjsA), is_list(JObjsB) ->
     FilterFun = find_object_plans_filter(
                   find_object_plans(JObjsB)
                  ),
@@ -438,7 +438,7 @@ account_proposed_billables(#kz_services{account_proposed_billables=Proposed}) ->
     Proposed.
 
 -spec set_account_updates(services(), kz_services_quantities:billables(), kz_services_quantities:billables()) -> services().
-set_account_updates(#kz_services{}=Services, Current, Proposed) ->
+set_account_updates(#kz_services{}=Services, Current, Proposed) when is_list(Current), is_list(Proposed) ->
     Updates = kz_services_quantities:calculate_updates(Services, Current, Proposed),
     Services#kz_services{account_updates=Updates
                         ,account_current_billables=Current

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -194,10 +194,10 @@ current_plans(Services) ->
     UpdatedObjectPlans = find_object_plans(CurrentBillables, ProposedBillables),
 
     Routines = [{kz_json:are_equal(CurrentPlans, ProposedPlans)
-                ,{services_jobj, current_services_jobj(Services)}
+                ,{'services_jobj', current_services_jobj(Services)}
                 }
                ,{kz_term:is_empty(UpdatedObjectPlans)
-                ,{modified_object_plans, UpdatedObjectPlans}
+                ,{'modified_object_plans', UpdatedObjectPlans}
                 }
                ],
     maybe_fetch_plans(Services, Routines).
@@ -212,10 +212,10 @@ proposed_plans(Services) ->
     UpdatedObjectPlans = find_object_plans(ProposedBillables, CurrentBillables),
 
     Routines = [{kz_json:are_equal(CurrentPlans, ProposedPlans)
-                ,{services_jobj, services_jobj(Services)}
+                ,{'services_jobj', services_jobj(Services)}
                 }
                ,{kz_term:is_empty(UpdatedObjectPlans)
-                ,{modified_object_plans, UpdatedObjectPlans}
+                ,{'modified_object_plans', UpdatedObjectPlans}
                 }
                ],
     maybe_fetch_plans(Services, Routines).
@@ -281,15 +281,11 @@ find_object_plans_filter(ObjectPlans) ->
     end.
 
 -spec find_object_plans(kz_services_quantities:billables()) -> kz_json:objects().
-find_object_plans('undefined') ->
-    [];
 find_object_plans(JObjs) when is_list(JObjs) ->
     lists:foldl(fun find_object_plans_fold/2
                ,[]
                ,JObjs
-               );
-find_object_plans(JObj) ->
-    find_object_plans([JObj]).
+               ).
 
 -spec find_object_plans_fold(kz_json:object(), kz_json:objects()) -> kz_json:objects().
 find_object_plans_fold(JObj, Plans) ->

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -105,8 +105,8 @@
 -record(kz_services, {account_id :: kz_term:api_ne_binary()
                      ,account_quantities = 'undefined' :: kz_term:api_object()
                      ,account_updates = kz_json:new() :: kz_json:object()
-                     ,account_current_billables = [] :: kz_json:objects()
-                     ,account_proposed_billables = [] :: kz_json:objects()
+                     ,account_current_billables = [] :: kz_services_quantities:billables()
+                     ,account_proposed_billables = [] :: kz_services_quantities:billables()
                      ,audit_log = kz_json:new() :: kz_json:object()
                      ,cascade_quantities = 'undefined' :: kz_term:api_object()
                      ,cascade_updates = kz_json:new() :: kz_json:object()
@@ -267,7 +267,7 @@ find_object_plans(JObjsA, JObjsB) ->
                  ),
     lists:filter(FilterFun, find_object_plans(JObjsA)).
 
--spec find_object_plans_filter(kz_json:objects()) -> fun((kz_json:object()) -> boolean()).
+-spec find_object_plans_filter(kz_services_quantities:billables()) -> fun((kz_services_quantities:billable()) -> boolean()).
 find_object_plans_filter(ObjectPlans) ->
     Plans = [{kz_doc:id(Plan), Plan}
              || Plan <- ObjectPlans
@@ -282,10 +282,7 @@ find_object_plans_filter(ObjectPlans) ->
 
 -spec find_object_plans(kz_services_quantities:billables()) -> kz_json:objects().
 find_object_plans(JObjs) when is_list(JObjs) ->
-    lists:foldl(fun find_object_plans_fold/2
-               ,[]
-               ,JObjs
-               ).
+    lists:foldl(fun find_object_plans_fold/2, [], JObjs).
 
 -spec find_object_plans_fold(kz_json:object(), kz_json:objects()) -> kz_json:objects().
 find_object_plans_fold(JObj, Plans) ->
@@ -432,11 +429,11 @@ reset_updates(Services) ->
 account_updates(#kz_services{account_updates=Updates}) ->
     Updates.
 
--spec account_current_billables(services()) -> kz_json:objects().
+-spec account_current_billables(services()) -> kz_services_quantities:billables().
 account_current_billables(#kz_services{account_current_billables=Current}) ->
     Current.
 
--spec account_proposed_billables(services()) -> kz_json:objects().
+-spec account_proposed_billables(services()) -> kz_services_quantities:billables().
 account_proposed_billables(#kz_services{account_proposed_billables=Proposed}) ->
     Proposed.
 

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -95,6 +95,7 @@
 -export([reconcile/1
         ,reconcile/2
         ]).
+-export([to_billables/1]).
 
 -export([is_services/1]).
 

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -291,7 +291,7 @@ find_object_plans_fold(JObj, Plans) ->
         Plan -> [Plan|Plans]
     end.
 
--spec create_services_object_plans(kz_json:object()) -> kz_json:api_object().
+-spec create_services_object_plans(kz_json:object()) -> kz_term:api_object().
 create_services_object_plans(JObj) ->
     case kz_json:get_ne_json_value([<<"service">>, <<"plans">>], JObj) of
         'undefined' -> 'undefined';

--- a/core/kazoo_services/src/kz_services_bookkeeper.erl
+++ b/core/kazoo_services/src/kz_services_bookkeeper.erl
@@ -130,7 +130,7 @@ store_audit_log(Services, Invoice) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec update_audit_log(kz_services:services(), kz_term:api_object(), kz_amqp_worker:request_result()) ->
+-spec update_audit_log(kz_services:services(), kz_term:api_object(), kz_amqp_worker:request_return()) ->
                               kz_term:api_object().
 update_audit_log(_Services, 'undefined', _Result) -> 'undefined';
 update_audit_log(Services, AuditJObj, {'error', 'timeout'}) ->

--- a/core/kazoo_services/src/kz_services_item.erl
+++ b/core/kazoo_services/src/kz_services_item.erl
@@ -779,7 +779,7 @@ has_billable_additions(Item) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec hash(item()) -> kz_term:binary().
+-spec hash(item()) -> binary().
 hash(Item) ->
     kz_binary:md5(
       <<(category_name(Item))/binary

--- a/core/kazoo_services/src/kz_services_items.erl
+++ b/core/kazoo_services/src/kz_services_items.erl
@@ -213,7 +213,7 @@ annotate(CurrentItems, ProposedItems, Reason) ->
     do_annotate([Items || {_ItemHash, Items} <- TentativeItems], Reason, []).
 
 -type tentative_items() :: [{kz_services_item:item() | 'undefined', kz_services_item:item() | 'undefined'}].
--spec do_annotate(tentative_items(), kz_term:api_bianry(), items()) -> items().
+-spec do_annotate(tentative_items(), kz_term:api_binary(), items()) -> items().
 do_annotate([], _Reason, Items) ->
     Items;
 do_annotate([{CurrentItem, 'undefined'}|TentativeItems], Reason, Items) ->

--- a/core/kazoo_services/src/kz_services_modb.erl
+++ b/core/kazoo_services/src/kz_services_modb.erl
@@ -45,9 +45,11 @@ save_services_to_modb(AccountMODb, ServicesJObj, Id) ->
             lager:debug("saved services snapshot as ~s in ~s"
                        ,[kz_doc:id(JObj), AccountMODb]
                        );
+        {'error', 'conflict'} ->
+            lager:info("conflict when saving services snapshot ~s in ~s", [Id, AccountMODb]);
         {'error', _R} ->
-            lager:warning("failed to store services snapshot in ~s: ~p"
-                         ,[AccountMODb, _R]
+            lager:warning("failed to store services snapshot ~s in ~s: ~p"
+                         ,[Id, AccountMODb, _R]
                          )
     end.
 
@@ -69,11 +71,11 @@ maybe_save_to_previous_modb(NewMODb, ServicesJObj) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec update_pvts(kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
-update_pvts(?MATCH_MODB_SUFFIX_RAW(AccountId, _Year, _Month) = AccountMODb, ServicesJObj) ->
+update_pvts(AccountMODb, ServicesJObj) ->
     WithoutRev = kz_doc:delete_revision(ServicesJObj),
     kz_doc:update_pvt_parameters(WithoutRev
                                 ,AccountMODb
                                 ,[{'account_db', AccountMODb}
-                                 ,{'account_id', AccountId}
+                                 ,{'account_id', kz_util:format_account_id(AccountMODb)}
                                  ]
                                 ).

--- a/core/kazoo_services/src/kz_services_modb.erl
+++ b/core/kazoo_services/src/kz_services_modb.erl
@@ -28,18 +28,10 @@ start_link() ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec modb(kz_term:ne_binary()) -> pid().
-modb(AccountMODb) ->
-    kz_util:spawn(fun run/1, [AccountMODb]).
-
-%%------------------------------------------------------------------------------
-%% @doc
-%% @end
-%%------------------------------------------------------------------------------
--spec run(kz_term:ne_binary()) -> 'ok'.
-run(?MATCH_MODB_SUFFIX_ENCODED(_AccountId, _Year, _Month) = AccountMODb) ->
-    run(kz_util:format_account_modb(AccountMODb, 'raw'));
-run(?MATCH_MODB_SUFFIX_RAW(AccountId, _Year, _Month) = AccountMODb) ->
+-spec modb(kz_term:ne_binary()) -> 'ok'.
+modb(?MATCH_MODB_SUFFIX_ENCODED(_AccountId, _Year, _Month) = AccountMODb) ->
+    modb(kz_util:format_account_modb(AccountMODb, 'raw'));
+modb(?MATCH_MODB_SUFFIX_RAW(AccountId, _Year, _Month) = AccountMODb) ->
     lager:debug("creating snapshot for account ~s services in month ~s-~s"
                ,[AccountId
                 ,_Year
@@ -56,9 +48,9 @@ run(?MATCH_MODB_SUFFIX_RAW(AccountId, _Year, _Month) = AccountMODb) ->
                     ),
     save_services_to_modb(AccountMODb, ServicesJObj, ?SERVICES_BOM),
     maybe_save_to_previous_modb(AccountMODb, ServicesJObj);
-run(Account) ->
+modb(Account) ->
     AccountId = kz_util:format_account_id(Account),
-    run(kazoo_modb:get_modb(AccountId)).
+    modb(kazoo_modb:get_modb(AccountId)).
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/core/kazoo_services/src/kz_services_modb.erl
+++ b/core/kazoo_services/src/kz_services_modb.erl
@@ -15,7 +15,7 @@
 -include_lib("kazoo_services/include/kazoo_services.hrl").
 
 %%------------------------------------------------------------------------------
-%% @doc
+%% @doc Adds this module as a callback for when MODBs are created
 %% @end
 %%------------------------------------------------------------------------------
 -spec start_link() -> kz_types:startlink_ret().

--- a/core/kazoo_services/src/kz_services_plans.erl
+++ b/core/kazoo_services/src/kz_services_plans.erl
@@ -125,7 +125,7 @@ get_services_plan_overrides(Services, PlanId) ->
     PlanOverrides = kzd_services:plan_overrides(ServicesJObj, PlanId),
     kz_json:merge_recursive(PlansOverrides, PlanOverrides).
 
--spec get_object_plans(kzd_services:services(), fetch_context(), fetch_options()) -> fetch_context().
+-spec get_object_plans(kz_services:services(), fetch_context(), fetch_options()) -> fetch_context().
 get_object_plans(Services, FetchContext, Options) ->
     AccountId = kz_services:account_id(Services),
     AccountDb = kz_util:format_account_db(AccountId),
@@ -293,7 +293,7 @@ overrides(Services) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec override(kz_services:services(), kz_json:object()) -> kz_serivces:services().
+-spec override(kz_services:services(), kz_json:object()) -> kz_services:services().
 override(Services, Overrides) ->
     override(Services, Overrides, []).
 
@@ -442,7 +442,7 @@ merge_plans_sort({A, _}, {B, _}) ->
 cumulative_merge_keys(Root, Key) ->
     lists:flatten([Root, Key]).
 
--spec simple_merge_plans(merge_strategy_plans()) -> kz_json:objcet().
+-spec simple_merge_plans(merge_strategy_plans()) -> kz_json:object().
 simple_merge_plans([]) ->
     kz_json:new();
 simple_merge_plans([{_, Head}|Tail]) ->
@@ -452,7 +452,7 @@ simple_merge_plans([{_, Head}|Tail]) ->
 simple_merge_plans({_, PlanJObj}, Merged) ->
     kz_json:merge(Merged, PlanJObj).
 
--spec recursive_merge_plans(merge_strategy_plans()) -> kz_json:objcet().
+-spec recursive_merge_plans(merge_strategy_plans()) -> kz_json:object().
 recursive_merge_plans([]) ->
     kz_json:new();
 recursive_merge_plans([{_, Head}|Tail]) ->

--- a/core/kazoo_services/src/kz_services_quantities.erl
+++ b/core/kazoo_services/src/kz_services_quantities.erl
@@ -27,6 +27,7 @@
 -type quantities_prop() :: [quantity_kv()].
 -export_type([quantities_prop/0
              ,billables/0
+             ,billable/0
              ]).
 
 %%------------------------------------------------------------------------------

--- a/core/kazoo_services/src/modules/kz_services_payment_tokens.erl
+++ b/core/kazoo_services/src/modules/kz_services_payment_tokens.erl
@@ -69,7 +69,7 @@ default(Thing, Bookkeeper) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec update(kz_services:service() | kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
+-spec update(kz_services:services() | kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
                     kz_services:services().
 update(?NE_BINARY = AccountId, Bookkeeper, Token) ->
     update(kz_services:fetch(AccountId), Bookkeeper, Token);
@@ -86,7 +86,7 @@ update(Services, Bookkeeper, Token) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec updates(kz_servics:services() | kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects()) ->
+-spec updates(kz_services:services() | kz_term:ne_binary(), kz_term:ne_binary(), kz_json:objects()) ->
                      kz_services:services().
 updates(?NE_BINARY = AccountId, Bookkeeper, ProposedTokens) ->
     updates(kz_services:fetch(AccountId), Bookkeeper, ProposedTokens);
@@ -112,7 +112,7 @@ updates(Services, Bookkeeper, ProposedTokens) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec delete(kz_services:service() | kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object() | kz_term:ne_binary()) ->
+-spec delete(kz_services:services() | kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object() | kz_term:ne_binary()) ->
                     kz_services:services().
 delete(<<AccountId/binary>>, Bookkeeper, Token) ->
     delete(kz_services:fetch(AccountId), Bookkeeper, Token);

--- a/core/kazoo_stdlib/include/kz_types.hrl
+++ b/core/kazoo_stdlib/include/kz_types.hrl
@@ -15,6 +15,9 @@
 -define(SECONDS_IN_WEEK,   604800).
 -define(SECONDS_IN_YEAR, 31540000).
 
+-define(MINUTES_IN_HOUR, 60).
+-define(HOURS_IN_DAY, 24).
+
 -define(BYTES_K,          1024).
 -define(BYTES_M,       1048576).
 -define(BYTES_G,    1073741824).

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -171,7 +171,7 @@ decode(JSON, <<"application/json">>) ->
     try unsafe_decode(JSON)
     catch
         _:{'invalid_json', {'error', {_Loc, _Msg}}, _JSON} ->
-            lager:error_unsafe("decode error ~s near char # ~b => ~s", [_Msg, _Loc, JSON]),
+            lager:error_unsafe("decode error ~s near char # ~b => ~s", [_Msg, _Loc, binary:part(JSON, _Loc-5, 25)]),
             new()
     end.
 

--- a/core/kazoo_transactions/src/kz_transaction.erl
+++ b/core/kazoo_transactions/src/kz_transaction.erl
@@ -586,7 +586,7 @@ to_json(#transaction{private_fields=PrivateFields}=Transaction) ->
             ],
     kz_json:set_values(Props, TransactionJObj).
 
--spec get_created_timestamp(kzd_transactions:doc()) -> kz_term:integer().
+-spec get_created_timestamp(kzd_transactions:doc()) -> integer().
 get_created_timestamp(TransactionJObj) ->
     kz_json:get_integer_value(<<"pvt_created">>, TransactionJObj, kz_time:now_s()).
 
@@ -855,7 +855,7 @@ send_notification(Transaction) ->
         ],
     kz_amqp_worker:cast(Notification, fun kapi_notifications:publish_transaction/1).
 
--spec card_last_four(transaction(), kz_json:object()) -> kz_term:api_ne_bianry().
+-spec card_last_four(transaction(), kz_json:object()) -> kz_term:api_ne_binary().
 card_last_four(Transaction, BookkeeperDetails) ->
     case kz_json:get_ne_binary_value([<<"card">>, <<"last_four">>], BookkeeperDetails) of
         'undefined' -> default_card_last_four(Transaction);

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -354,6 +354,7 @@ pages:
     - 'applications/tasks/doc/kazoo_bill_early_task.md'
     - 'applications/tasks/doc/kz_notify_resender.md'
     - 'applications/tasks/doc/maintenance.md'
+    - 'applications/tasks/doc/modb_creation.md'
     - 'applications/tasks/doc/notify_resend_maintenance.md'
     - 'applications/tasks/doc/rates.md'
   - 'Teletype':

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -353,10 +353,12 @@ pages:
     - 'applications/tasks/doc/fax_cleanup.md'
     - 'applications/tasks/doc/kazoo_bill_early_task.md'
     - 'applications/tasks/doc/kz_notify_resender.md'
+    - 'applications/tasks/doc/ledger_rollover.md'
     - 'applications/tasks/doc/maintenance.md'
     - 'applications/tasks/doc/modb_creation.md'
     - 'applications/tasks/doc/notify_resend_maintenance.md'
     - 'applications/tasks/doc/rates.md'
+    - 'applications/tasks/doc/services_rollover.md'
   - 'Teletype':
     - 'applications/teletype/doc/README.md'
     - 'applications/teletype/doc/maintenance.md'

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -54,7 +54,7 @@ dep_apns = git https://github.com/inaka/apns4erl.git 2.3.0
 # dep_chatterbox = hex 0.7.0
 # used by apns4erl
 
-dep_couchbeam = git https://github.com/2600hz/couchbeam 2600hz #bumped to match upstream 1.4.2
+dep_couchbeam = git https://github.com/2600hz/erlang-couchbeam 28fce6c340de83f4792d45224c29ec729b8e264d # latest commit SHA to 2600hz branch
 ### https://github.com/benoitc/couchbeam/pull/158 - _list functions fix
 ### https://github.com/benoitc/couchbeam/pull/164 - allow 202 in put_attachment
 ### https://github.com/benoitc/couchbeam/pull/165 - fetch couchdb config


### PR DESCRIPTION
Separates ledger/services rollover from modb creation. This allows modbs to be created ahead of time (potentially removing contention on the database cluster at the beginning of the month).

3 task modules are introduced:

- `kt_modb_creation` - given a day of the month (defaults to the 28th), when the current month reaches that day, start creating MODBs for the next month. This work is distributed across the time left in the month and by how many accounts to process per pass (in parallel).
- `kt_ledger_rollover` - on the first of the month, rollover all accounts' ledgers to the new MODB. Can control how many are processed in parallel as well.
- `kt_services_rollover` - on the first of the month, create the SERVICES_BOM (and optionally the SERVICES_EOM in the previous month's modb) for each account.

Other changes include starting the task app's temporal timers to track the actual minute/hour/day times vs a minute/hour/day's worth of seconds. So if the tasks app is started at 04:33:22, the minute timer will first wait 38s, the hour timer will wait 26:38, and the day timer will wait 19:26:38.

