### PR TITLE
[master] fix removing comments when rejected->submitted

### DIFF
--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -1470,7 +1470,8 @@ send_port_comment_notifications(Context, Id, NewComments) ->
     _ = lists:foldl(fun send_port_comment_notification/2, {Context, Id, length(NewComments), 1}, NewComments),
     'ok'.
 
--spec send_port_comment_notification(kz_json:object(), {cb_context:context(), kz_term:ne_binary(), non_neg_integer(), non_neg_integer()}) -> 'ok'.
+-spec send_port_comment_notification(kz_json:object(), {cb_context:context(), kz_term:ne_binary(), non_neg_integer(), non_neg_integer()}) ->
+                                            {cb_context:context(), kz_term:ne_binary(), non_neg_integer(), non_neg_integer()}.
 send_port_comment_notification(NewComment, {Context, Id, TotalNew, Index}) ->
     Setters = [{fun kzd_comment:set_user_id/2, kzd_comment:user_id(NewComment, cb_context:auth_user_id(Context))}
               ,{fun kzd_comment:set_account_id/2, kzd_comment:account_id(NewComment, cb_context:auth_account_id(Context))}

--- a/applications/teletype/priv/templates/port_cancel.html
+++ b/applications/teletype/priv/templates/port_cancel.html
@@ -66,7 +66,7 @@
                             <b>-&nbsp;&nbsp;&nbsp;State:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.port_state}}</span><br>
                             <b>-&nbsp;&nbsp;&nbsp;ID:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.id}}</span><br>{% if port_request.port_scheduled_date %}
                             <b>-&nbsp;&nbsp;&nbsp;Scheduled Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.port_scheduled_date.local|date:"l, F j, Y h:i A"}} ({{port_request.port_scheduled_date.timezone}})</span><br>{% elif port_request.requested_port_date %}
-                            <b>-&nbsp;&nbsp;&nbsp;Requested Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}})</span><br>{% endif %}
+                            <b>-&nbsp;&nbsp;&nbsp;Requested Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}})</span><br>{% endif %}
                             <b>-&nbsp;&nbsp;&nbsp;Numbers:</b><br><span style="font-family:monospace;">{{ port_request.numbers|join:", " }}</span>
                         </p>
                     </td>

--- a/applications/teletype/priv/templates/port_cancel.text
+++ b/applications/teletype/priv/templates/port_cancel.text
@@ -13,7 +13,7 @@ Port Request Information
     State:  {{port_request.port_state}}
     ID:  {{port_request.id}}{% if port_request.port_scheduled_date %}
     Scheduled Date:  {{port_request.port_scheduled_date.local|date:"l, F j, Y h:i A"}} ({{port_request.port_scheduled_date.timezone}}){% elif port_request.requested_port_date %}
-    Requested Transfer Date:  {{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% endif %}
+    Requested Transfer Date:  {{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}}){% endif %}
     Numbers: {{ port_request.numbers|join:", "|stringformat:"s"|wordwrap:40 }}
 
 

--- a/applications/teletype/priv/templates/port_pending.html
+++ b/applications/teletype/priv/templates/port_pending.html
@@ -70,7 +70,7 @@
                             <b>-&nbsp;&nbsp;&nbsp;State:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.port_state}}</span><br>
                             <b>-&nbsp;&nbsp;&nbsp;ID:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.id}}</span><br>{% if port_request.port_scheduled_date %}
                             <b>-&nbsp;&nbsp;&nbsp;Scheduled Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.port_scheduled_date.local|date:"l, F j, Y h:i A"}} ({{port_request.port_scheduled_date.timezone}})</span><br>{% elif port_request.requested_port_date %}
-                            <b>-&nbsp;&nbsp;&nbsp;Requested Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}})</span><br>{% endif %}
+                            <b>-&nbsp;&nbsp;&nbsp;Requested Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}})</span><br>{% endif %}
                             <b>-&nbsp;&nbsp;&nbsp;Numbers:</b><br><span style="font-family:monospace;">{{ port_request.numbers|join:", " }}</span>
                         </p>
                     </td>

--- a/applications/teletype/priv/templates/port_pending.text
+++ b/applications/teletype/priv/templates/port_pending.text
@@ -14,7 +14,7 @@ Port Request Information
     State:  {{port_request.port_state}}
     ID:  {{port_request.id}}{% if port_request.port_scheduled_date %}
     Scheduled Date:  {{port_request.port_scheduled_date.local|date:"l, F j, Y h:i A"}} ({{port_request.port_scheduled_date.timezone}}){% elif port_request.requested_port_date %}
-    Requested Transfer Date:  {{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% endif %}
+    Requested Transfer Date:  {{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}}){% endif %}
     Numbers: {{ port_request.numbers|join:", "|stringformat:"s"|wordwrap:40 }}
 
 

--- a/applications/teletype/priv/templates/port_rejected.html
+++ b/applications/teletype/priv/templates/port_rejected.html
@@ -70,7 +70,7 @@
                             <b>-&nbsp;&nbsp;&nbsp;State:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.port_state}}</span><br>
                             <b>-&nbsp;&nbsp;&nbsp;ID:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.id}}</span><br>{% if port_request.port_scheduled_date %}
                             <b>-&nbsp;&nbsp;&nbsp;Scheduled Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.port_scheduled_date.local|date:"l, F j, Y h:i A"}} ({{port_request.port_scheduled_date.timezone}})</span><br>{% elif port_request.requested_port_date %}
-                            <b>-&nbsp;&nbsp;&nbsp;Requested Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}})</span><br>{% endif %}
+                            <b>-&nbsp;&nbsp;&nbsp;Requested Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}})</span><br>{% endif %}
                             <b>-&nbsp;&nbsp;&nbsp;Numbers:</b><br><span style="font-family:monospace;">{{ port_request.numbers|join:", " }}</span>
                         </p>
                     </td>

--- a/applications/teletype/priv/templates/port_rejected.text
+++ b/applications/teletype/priv/templates/port_rejected.text
@@ -13,7 +13,7 @@ Port Request Information
     State:  {{port_request.port_state}}
     ID:  {{port_request.id}}{% if port_request.port_scheduled_date %}
     Scheduled Date:  {{port_request.port_scheduled_date.local|date:"l, F j, Y h:i A"}} ({{port_request.port_scheduled_date.timezone}}){% elif port_request.requested_port_date %}
-    Requested Transfer Date:  {{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% endif %}
+    Requested Transfer Date:  {{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}}){% endif %}
     Numbers: {{ port_request.numbers|join:", "|stringformat:"s"|wordwrap:40 }}
 
 

--- a/applications/teletype/priv/templates/port_request.html
+++ b/applications/teletype/priv/templates/port_request.html
@@ -69,7 +69,7 @@
                             <b>-&nbsp;&nbsp;&nbsp;Name:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.name}}</span><br>
                             <b>-&nbsp;&nbsp;&nbsp;State:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.port_state}}</span><br>
                             <b>-&nbsp;&nbsp;&nbsp;ID:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.id}}</span><br>{% if port_request.requested_port_date %}
-                            <b>-&nbsp;&nbsp;&nbsp;Requested Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}})</span><br>{% endif %}
+                            <b>-&nbsp;&nbsp;&nbsp;Requested Transfer Date:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}})</span><br>{% endif %}
                             <b>-&nbsp;&nbsp;&nbsp;Numbers:</b><br><span style="font-family:monospace;">{{ port_request.numbers|join:", " }}</span>
                         </p>
                     </td>

--- a/applications/teletype/priv/templates/port_request.text
+++ b/applications/teletype/priv/templates/port_request.text
@@ -12,7 +12,7 @@ Port Request Information
     Name:  {{port_request.name}}
     State:  {{port_request.port_state}}
     ID:  {{port_request.id}}{% if port_request.requested_port_date %}
-    Requested Transfer Date:  {{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% endif %}
+    Requested Transfer Date:  {{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}}){% endif %}
     Numbers: {{ port_request.numbers|join:", "|stringformat:"s"|wordwrap:40 }}
 
 

--- a/applications/teletype/priv/templates/port_request_admin.html
+++ b/applications/teletype/priv/templates/port_request_admin.html
@@ -72,7 +72,7 @@
                             </tr>
                             <tr>
                                 <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Requested Port Date</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{% if port_request.requested_port_date %}{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% else %}not scheduled yet{% endif %}</td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{% if port_request.requested_port_date %}{{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}}){% else %}not scheduled yet{% endif %}</td>
                             </tr>
                             <tr>
                                 <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Losing Carrier</b></td>

--- a/applications/teletype/priv/templates/port_request_admin.text
+++ b/applications/teletype/priv/templates/port_request_admin.text
@@ -12,7 +12,7 @@ Request "{{port_request.name}}" to port numbers into account '{{account.name}}' 
     Port ID:  {{port_request.id}}
     State:  {{port_request.port_state}}
     Numbers:  Numbers: {{ port_request.numbers|join:", "|stringformat:"s"|wordwrap:40 }}
-    Requested Port Date:  {% if port_request.requested_port_date %}{{port_request.requested_port_date.local|date:"l, F j, Y h:i A"}} ({{port_request.requested_port_date.timezone}}){% else %}not scheduled yet{% endif %}
+    Requested Port Date:  {% if port_request.requested_port_date %}{{port_request.requested_port_date.local|date:"l, F j, Y"}} ({{port_request.requested_port_date.timezone}}){% else %}not scheduled yet{% endif %}
     Losing Carrier:  {{port_request.losing_carrier}}
     Winning Carrier:  {{port_request.winning_carrier}}
     Carrier Reference Number:  {{port_request.reference_number}}

--- a/core/kazoo_fixturedb/priv/dbs/system_config/docs/665e92549b63fdd67036380d3e68d1ca.att
+++ b/core/kazoo_fixturedb/priv/dbs/system_config/docs/665e92549b63fdd67036380d3e68d1ca.att
@@ -73,7 +73,7 @@
                             </tr>
                             <tr>
                                 <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Requested Port Date</b></td>
-                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.requested_port_date.local|date:"l, F j, Y H:i"}}</td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{port_request.requested_port_date.local|date:"l, F j, Y"}}</td>
                             </tr>
                             <tr>
                                 <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Service Provider</b></td>

--- a/core/kazoo_fixturedb/priv/dbs/system_config/docs/b36216106de3f70f4a034f078c75928d.att
+++ b/core/kazoo_fixturedb/priv/dbs/system_config/docs/b36216106de3f70f4a034f078c75928d.att
@@ -15,7 +15,7 @@ Request "{{port_request.name}}" to port numbers into account '{{account.name}}' 
     Name: {{port_request.name}}
     Port ID: {{port_request.id}}
     State: {{port_request.state}}
-    Requested Port Date: {{port_request.requested_port_date.local|date:"l, F j, Y H:i"}}
+    Requested Port Date: {{port_request.requested_port_date.local|date:"l, F j, Y"}}
     Service Provider: {{port_request.service_provider}}
     Customer Contact: {{port_request.customer_contact}}
     Billing Name: {{port_request.billing_name}}


### PR DESCRIPTION
When transitioning from `rejected` state to `submitted`, empty comments from phonebook response was replacing the comment already in port's document during merging the docs.

Also removing time info from port's templates since the user can't choose the time of desired port date anyway.