### PR TITLE
Password reset tokens will now expire 1 hour after creation

### DIFF
--- a/applications/crossbar/src/modules/cb_user_auth.erl
+++ b/applications/crossbar/src/modules/cb_user_auth.erl
@@ -39,7 +39,7 @@
             Ok -> Ok
         end).
 -define(RESET_PVT_TYPE, <<"password_reset">>).
--define(RESET_TIMEOUT, 3600).
+-define(RESET_TIMEOUT, kapps_config:get_pos_integer(<<"crossbar.auth">>, <<"password_reset_expiry_s">>, ?SECONDS_IN_HOUR)).
 
 %%%=============================================================================
 %%% API

--- a/applications/crossbar/src/modules_v1/cb_users_v1.erl
+++ b/applications/crossbar/src/modules_v1/cb_users_v1.erl
@@ -615,7 +615,9 @@ maybe_validate_username(UserId, Context) ->
         orelse username_doc_id(NewUsername, Context)
     of
         %% user name is unchanged
-        'true' -> maybe_rehash_creds(UserId, NewUsername, Context);
+        'true' ->
+            _ = cb_user_auth:maybe_remove_old_reset_ids(kazoo_modb:get_modb(cb_context:account_db(Context)), UserId),
+            maybe_rehash_creds(UserId, NewUsername, Context);
         %% updated user name that doesn't exist
         'undefined' ->
             manditory_rehash_creds(UserId, NewUsername, Context);

--- a/applications/teletype/priv/templates/password_recovery.html
+++ b/applications/teletype/priv/templates/password_recovery.html
@@ -39,7 +39,7 @@
                     </td>
                 </tr>
                     <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
-                        <p style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;">We received a request to change the password of your VoIP services of account <b>{{account.name}}</b>.<br><br>If you did not make this request, just ignore this email. Otherwise, please <a href="{{link}}">use this link</a> to change your password.</p>
+                        <p style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;">We received a request to change the password of your VoIP services of account <b>{{account.name}}</b>.<br><br>If you did not make this request, just ignore this email. Otherwise, please <a href="{{link}}">use this link</a> to change your password. This link will be valid for <b>1 hour</b>.</p>
                     </td>
                 </tr>
             </table>

--- a/applications/teletype/priv/templates/password_recovery.text
+++ b/applications/teletype/priv/templates/password_recovery.text
@@ -7,3 +7,5 @@ We received a request to change the password of your VoIP services of account "{
 If you did not make this request, just ignore this email. Otherwise, please click the link below to change your password:
 
 {{link}}
+
+This link will be valid for 1 hour.

--- a/core/kazoo_fixturedb/priv/dbs/system_config/docs/2ce1fbf27e98babc5709efd9d295c847.att
+++ b/core/kazoo_fixturedb/priv/dbs/system_config/docs/2ce1fbf27e98babc5709efd9d295c847.att
@@ -39,7 +39,7 @@
                     </td>
                 </tr>
                     <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
-                        <p style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;">We received a request to change the password of your VoIP services of account <b>{{account.name}}</b>.<br><br>If you did not make this request, just ignore this email. Otherwise, please <a href="{{link}}">use this link</a> to change your password.</p>
+                        <p style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;">We received a request to change the password of your VoIP services of account <b>{{account.name}}</b>.<br><br>If you did not make this request, just ignore this email. Otherwise, please <a href="{{link}}">use this link</a> to change your password. This link will be valid for <b>1 hour</b>.</p>
                     </td>
                 </tr>
             </table>

--- a/core/kazoo_fixturedb/priv/dbs/system_config/docs/7c5cd1485f81668f4a347466e977372c.att
+++ b/core/kazoo_fixturedb/priv/dbs/system_config/docs/7c5cd1485f81668f4a347466e977372c.att
@@ -7,3 +7,5 @@ We received a request to change the password of your VoIP services of account "{
 If you did not make this request, just ignore this email. Otherwise, please click the link below to change your password:
 
 {{link}}
+
+This link will be valid for 1 hour.

--- a/core/kazoo_modb/priv/couchdb/views/auth.json
+++ b/core/kazoo_modb/priv/couchdb/views/auth.json
@@ -76,6 +76,19 @@
                 "  });",
                 "}"
             ]
+        },
+        "password_reset_requests_by_userid": {
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'password_reset' || doc.pvt_deleted)",
+                "    return;",
+                "  emit(doc.pvt_userid, {",
+                "    'id': doc._id,",
+                "    'userid': doc.pvt_userid,",
+                "    'created': doc.pvt_created",
+                "  });",
+                "}"
+            ]
         }
     }
 }


### PR DESCRIPTION
Previously, password reset tokens would always be valid and would never be cleaned up. 

This work is for cleaning up previous password reset tokens when a new one is requested. Also with this work a password reset token that was requested over an hour ago will be invalidated. 