### PR TITLE
Build on macos

### DIFF
--- a/applications/hotornot/test/hon_trie_lru_pqc.erl
+++ b/applications/hotornot/test/hon_trie_lru_pqc.erl
@@ -268,8 +268,6 @@ longest_prefix({Prefix, Rates}
             Acc
     end.
 
--endif.
-
 -spec recreate_parallel(any()) -> any().
 recreate_parallel({Seq, Parallel}) ->
     hon_trie_lru:stop(?KZ_RATES_DB),
@@ -287,3 +285,5 @@ seq([{set, Var, {call, M, F, Args}} | Seq], Vars) ->
 
 parallel(Parallel, Vars) ->
     [spawn(fun() -> seq(Seq, Vars) end) || Seq <- Parallel].
+
+-endif.

--- a/core/kazoo_convert/src/kz_fax_converter.hrl
+++ b/core/kazoo_convert/src/kz_fax_converter.hrl
@@ -4,7 +4,7 @@
 
 -define(TIFF_TO_PDF_CMD, <<"tiff2pdf -o $TO $FROM">>).
 -define(CONVERT_PDF_CMD
-       ,<<"/usr/bin/gs -q "
+       ,<<"gs -q "
           "-r200x200 "
           "-g1728x2200 "
           "-dPDFFitPage "

--- a/core/kazoo_convert/src/kz_openoffice_server.erl
+++ b/core/kazoo_convert/src/kz_openoffice_server.erl
@@ -31,6 +31,7 @@
 -define(TIMEOUT_CANCEL_JOB, 120 * ?MILLISECONDS_IN_SECOND).
 -define(TIMEOUT_DEQUEUE, 'dequeue').
 -define(TIMEOUT_CANCEL, 'cancel_job').
+-define(SERVER_TIMEOUT, 10 * ?MILLISECONDS_IN_SECOND).
 
 -record(state, {queue = queue:new() :: queue:queue()
                ,timer_ref ::  reference()
@@ -60,7 +61,7 @@ start_link() ->
 %%------------------------------------------------------------------------------
 -spec add(kz_term:ne_binary(), map()) -> {'ok', kz_term:ne_binary()}|{'error', kz_term:ne_binary()}.
 add(Source, Options) ->
-    gen_server:call(?MODULE, {'add', Source, Options}).
+    gen_server:call(?MODULE, {'add', Source, Options}, ?SERVER_TIMEOUT).
 
 %%%=============================================================================
 %%% gen_server callbacks

--- a/core/kazoo_convert/test/kz_convert_tests.erl
+++ b/core/kazoo_convert/test/kz_convert_tests.erl
@@ -167,11 +167,11 @@ test_openoffice_to_pdf_binary() ->
     From = read_test_file("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".pdf" >>,
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                                   ,<<"application/pdf">>
-                                                   ,From
-                                                   ,[{<<"job_id">>, JobId}]
-                                                   )
-                  )
+                                                                                 ,<<"application/pdf">>
+                                                                                 ,From
+                                                                                 ,[{<<"job_id">>, JobId}]
+                                                                                 )
+                                                )
     }.
 
 test_openoffice_to_pdf_tuple() ->
@@ -179,11 +179,11 @@ test_openoffice_to_pdf_tuple() ->
     Src = copy_fixture_to_tmp("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".pdf" >>,
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                                   ,<<"application/pdf">>
-                                                   ,{'file', Src}
-                                                   ,[{<<"job_id">>, JobId}]
-                                                   )
-                  )
+                                                                                 ,<<"application/pdf">>
+                                                                                 ,{'file', Src}
+                                                                                 ,[{<<"job_id">>, JobId}]
+                                                                                 )
+                                                )
     }.
 
 test_openoffice_to_tiff_binary() ->
@@ -191,11 +191,11 @@ test_openoffice_to_tiff_binary() ->
     From = read_test_file("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".tiff" >>,
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                                   ,<<"image/tiff">>
-                                                   ,From
-                                                   ,[{<<"job_id">>, JobId}]
-                                                   )
-                  )
+                                                                                 ,<<"image/tiff">>
+                                                                                 ,From
+                                                                                 ,[{<<"job_id">>, JobId}]
+                                                                                 )
+                                                )
     }.
 
 test_openoffice_to_tiff_tuple() ->
@@ -203,11 +203,11 @@ test_openoffice_to_tiff_tuple() ->
     Src = copy_fixture_to_tmp("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".tiff" >>,
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                                   ,<<"image/tiff">>
-                                                   ,{'file', Src}
-                                                   ,[{<<"job_id">>, JobId}]
-                                                   )
-                  )
+                                                                                 ,<<"image/tiff">>
+                                                                                 ,{'file', Src}
+                                                                                 ,[{<<"job_id">>, JobId}]
+                                                                                 )
+                                                )
     }.
 
 test_tiff_to_pdf_binary_output_binary() ->
@@ -281,47 +281,47 @@ test_openoffice_to_pdf_binary_output_binary() ->
     JobId = kz_binary:rand_hex(16),
     From = read_test_file("valid.docx"),
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', _}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                            ,<<"application/pdf">>
-                                            ,From
-                                            ,[{<<"job_id">>, JobId},{<<"output_type">>, 'binary'}]
-                                            )
-                  )
+                                                                          ,<<"application/pdf">>
+                                                                          ,From
+                                                                          ,[{<<"job_id">>, JobId},{<<"output_type">>, 'binary'}]
+                                                                          )
+                                                )
     }.
 
 test_openoffice_to_pdf_tuple_output_binary() ->
     JobId = kz_binary:rand_hex(16),
     Src = copy_fixture_to_tmp("valid.docx"),
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', _}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                            ,<<"application/pdf">>
-                                            ,{'file', Src}
-                                            ,[{<<"job_id">>, JobId}
-                                             ,{<<"output_type">>, 'binary'}]
-                                            )
-                  )
+                                                                          ,<<"application/pdf">>
+                                                                          ,{'file', Src}
+                                                                          ,[{<<"job_id">>, JobId}
+                                                                           ,{<<"output_type">>, 'binary'}]
+                                                                          )
+                                                )
     }.
 
 test_openoffice_to_tiff_binary_output_binary() ->
     JobId = kz_binary:rand_hex(16),
     From = read_test_file("valid.docx"),
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', _}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                            ,<<"image/tiff">>
-                                            ,From
-                                            ,[{<<"job_id">>, JobId}
-                                             ,{<<"output_type">>, 'binary'}]
-                                            )
-                  )
+                                                                          ,<<"image/tiff">>
+                                                                          ,From
+                                                                          ,[{<<"job_id">>, JobId}
+                                                                           ,{<<"output_type">>, 'binary'}]
+                                                                          )
+                                                )
     }.
 
 test_openoffice_to_tiff_tuple_output_binary() ->
     JobId = kz_binary:rand_hex(16),
     Src = copy_fixture_to_tmp("valid.docx"),
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', _}
-                  ,kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                 ,<<"image/tiff">>
-                                 ,{'file', Src}
-                                 ,[{<<"job_id">>, JobId}]
-                                 )
-                  )
+                                                ,kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+                                                               ,<<"image/tiff">>
+                                                               ,{'file', Src}
+                                                               ,[{<<"job_id">>, JobId}]
+                                                               )
+                                                )
     }.
 
 test_tiff_to_pdf_binary_invalid() ->
@@ -499,14 +499,14 @@ test_openoffice_to_tiff_to_filename() ->
     From = read_test_file("valid.docx"),
     Expected = <<"/tmp/", (kz_binary:rand_hex(16))/binary, ".tiff" >>,
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}
-                  ,kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                 ,<<"image/tiff">>
-                                 ,From
-                                 ,[{<<"job_id">>, JobId}
-                                  ,{<<"to_filename">>, Expected}
-                                  ]
-                                 )
-                  )
+                                                ,kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+                                                               ,<<"image/tiff">>
+                                                               ,From
+                                                               ,[{<<"job_id">>, JobId}
+                                                                ,{<<"to_filename">>, Expected}
+                                                                ]
+                                                               )
+                                                )
     }.
 
 test_tiff_to_tiff_read_metadata() ->
@@ -576,22 +576,22 @@ test_openoffice_to_tiff_read_metadata() ->
     JobId = kz_binary:rand_hex(16),
     From = read_test_file("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".tiff">>,
-    
+
     {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected
-                   ,[{<<"page_count">>, 1}
-                    ,{<<"size">>, _}
-                    ,{<<"mimetype">>, <<"image/tiff">>}
-                    ,{<<"filetype">>, <<"tiff">>}
-                    ]
-                   }
-                  ,kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
-                                 ,<<"image/tiff">>
-                                 ,From
-                                 ,[{<<"job_id">>, JobId}
-                                  ,{<<"read_metadata">>, true}
-                                  ]
-                                 )
-                  )
+                                                 ,[{<<"page_count">>, 1}
+                                                  ,{<<"size">>, _}
+                                                  ,{<<"mimetype">>, <<"image/tiff">>}
+                                                  ,{<<"filetype">>, <<"tiff">>}
+                                                  ]
+                                                 }
+                                                ,kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+                                                               ,<<"image/tiff">>
+                                                               ,From
+                                                               ,[{<<"job_id">>, JobId}
+                                                                ,{<<"read_metadata">>, true}
+                                                                ]
+                                                               )
+                                                )
     }.
 
 test_read_metadata() ->

--- a/core/kazoo_convert/test/kz_convert_tests.erl
+++ b/core/kazoo_convert/test/kz_convert_tests.erl
@@ -9,6 +9,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kazoo_convert/include/kz_convert.hrl").
 
+-define(OPENOFFICE_TIMEOUT, 15).
+
 fax_test_() ->
     {setup
     ,fun setup/0
@@ -164,49 +166,49 @@ test_openoffice_to_pdf_binary() ->
     JobId = kz_binary:rand_hex(16),
     From = read_test_file("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".pdf" >>,
-    [?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
                                                    ,<<"application/pdf">>
                                                    ,From
                                                    ,[{<<"job_id">>, JobId}]
                                                    )
                   )
-    ].
+    }.
 
 test_openoffice_to_pdf_tuple() ->
     JobId = kz_binary:rand_hex(16),
     Src = copy_fixture_to_tmp("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".pdf" >>,
-    [?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
                                                    ,<<"application/pdf">>
                                                    ,{'file', Src}
                                                    ,[{<<"job_id">>, JobId}]
                                                    )
                   )
-    ].
+    }.
 
 test_openoffice_to_tiff_binary() ->
     JobId = kz_binary:rand_hex(16),
     From = read_test_file("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".tiff" >>,
-    [?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
                                                    ,<<"image/tiff">>
                                                    ,From
                                                    ,[{<<"job_id">>, JobId}]
                                                    )
                   )
-    ].
+    }.
 
 test_openoffice_to_tiff_tuple() ->
     JobId = kz_binary:rand_hex(16),
     Src = copy_fixture_to_tmp("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".tiff" >>,
-    [?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
                                                    ,<<"image/tiff">>
                                                    ,{'file', Src}
                                                    ,[{<<"job_id">>, JobId}]
                                                    )
                   )
-    ].
+    }.
 
 test_tiff_to_pdf_binary_output_binary() ->
     JobId = kz_binary:rand_hex(16),
@@ -278,49 +280,49 @@ test_pdf_to_tiff_tuple_output_binary() ->
 test_openoffice_to_pdf_binary_output_binary() ->
     JobId = kz_binary:rand_hex(16),
     From = read_test_file("valid.docx"),
-    [?_assertMatch({'ok', _}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', _}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
                                             ,<<"application/pdf">>
                                             ,From
                                             ,[{<<"job_id">>, JobId},{<<"output_type">>, 'binary'}]
                                             )
                   )
-    ].
+    }.
 
 test_openoffice_to_pdf_tuple_output_binary() ->
     JobId = kz_binary:rand_hex(16),
     Src = copy_fixture_to_tmp("valid.docx"),
-    [?_assertMatch({'ok', _}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', _}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
                                             ,<<"application/pdf">>
                                             ,{'file', Src}
                                             ,[{<<"job_id">>, JobId}
                                              ,{<<"output_type">>, 'binary'}]
                                             )
                   )
-    ].
+    }.
 
 test_openoffice_to_tiff_binary_output_binary() ->
     JobId = kz_binary:rand_hex(16),
     From = read_test_file("valid.docx"),
-    [?_assertMatch({'ok', _}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', _}, kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
                                             ,<<"image/tiff">>
                                             ,From
                                             ,[{<<"job_id">>, JobId}
                                              ,{<<"output_type">>, 'binary'}]
                                             )
                   )
-    ].
+    }.
 
 test_openoffice_to_tiff_tuple_output_binary() ->
     JobId = kz_binary:rand_hex(16),
     Src = copy_fixture_to_tmp("valid.docx"),
-    [?_assertMatch({'ok', _}
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', _}
                   ,kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
                                  ,<<"image/tiff">>
                                  ,{'file', Src}
                                  ,[{<<"job_id">>, JobId}]
                                  )
                   )
-    ].
+    }.
 
 test_tiff_to_pdf_binary_invalid() ->
     JobId = kz_binary:rand_hex(16),
@@ -496,7 +498,7 @@ test_openoffice_to_tiff_to_filename() ->
     JobId = kz_binary:rand_hex(16),
     From = read_test_file("valid.docx"),
     Expected = <<"/tmp/", (kz_binary:rand_hex(16))/binary, ".tiff" >>,
-    [?_assertMatch({'ok', Expected}
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected}
                   ,kz_convert:fax(<<"application/vnd.openxmlformats-officedocument.wordprocessingml.document">>
                                  ,<<"image/tiff">>
                                  ,From
@@ -505,7 +507,7 @@ test_openoffice_to_tiff_to_filename() ->
                                   ]
                                  )
                   )
-    ].
+    }.
 
 test_tiff_to_tiff_read_metadata() ->
     JobId = kz_binary:rand_hex(16),
@@ -574,7 +576,8 @@ test_openoffice_to_tiff_read_metadata() ->
     JobId = kz_binary:rand_hex(16),
     From = read_test_file("valid.docx"),
     Expected = <<"/tmp/", JobId/binary, ".tiff">>,
-    [?_assertMatch({'ok', Expected
+    
+    {timeout, ?OPENOFFICE_TIMEOUT, ?_assertMatch({'ok', Expected
                    ,[{<<"page_count">>, 1}
                     ,{<<"size">>, _}
                     ,{<<"mimetype">>, <<"image/tiff">>}
@@ -589,7 +592,7 @@ test_openoffice_to_tiff_read_metadata() ->
                                   ]
                                  )
                   )
-    ].
+    }.
 
 test_read_metadata() ->
     Src = copy_fixture_to_tmp("valid.tiff"),

--- a/doc/engineering/installing-on-mac.md
+++ b/doc/engineering/installing-on-mac.md
@@ -7,7 +7,7 @@ install these dependencies is via `brew` so [install brew](https://brew.sh/) if 
 
 Run the brew install command below to install dependencies:
 
-```brew install libxslt openssl ncurses expat htmldoc```
+```brew install python@2 libxslt openssl ncurses expat imagemagick ghostscript htmldoc```
 
 And you can skip installing these (they are included via the Apple command line tools or the brew packages):
 

--- a/doc/engineering/installing-on-mac.md
+++ b/doc/engineering/installing-on-mac.md
@@ -1,14 +1,20 @@
 # Installing on Mac (for development)
 
+Make sure you've run `xcode-select --install` to install various build tools that are available(such as zlib.
+
 Some additional dependencies are required to get things up and running on Mac. The easiest way to
 install these dependencies is via `brew` so [install brew](https://brew.sh/) if you haven't already.
 
-Now install the dependencies listed in the installation.md file using `brew install <dependency name>`.
-Some have different names on mac, such as:
+Run the brew install command below to install dependencies:
 
-* build-essential 
-* zlib1g-dev 
-* libssl-dev
+```brew install libxslt openssl ncurses expat htmldoc```
+
+And you can skip installing these (they are included via the Apple command line tools or the brew packages):
+
+* build-essential
+* zlib1g-dev
+* git-core
+* libexpat1-dev
 
 ## Additional Dependencies
 
@@ -21,6 +27,9 @@ to your path(brew will tell you about it after install completes)
 * md5sha1sum
 * make
 
+You can install all of the above with:
+```brew install gnu-sed md5sha1sum make```
+
 Next install libreoffice, which can be done via `brew cask install libreoffice`.
 
 ### Fix executable paths
@@ -31,4 +40,4 @@ them via brew they give you the instructions on what to add.
 You will also want to add a symlink for libreoffice somewhere in your path because the default 
 executable name is `soffice` but kazoo expects it to be `libreoffice`. Something like:
 
-```$ ln -s /usr/local/bin/soffice /usr/local/bin/libreoffice```
+```ln -s /usr/local/bin/soffice /usr/local/bin/libreoffice```

--- a/doc/engineering/installing-on-mac.md
+++ b/doc/engineering/installing-on-mac.md
@@ -49,7 +49,7 @@ from `/usr/local/bin/bash` and symlinking the brew bash into its place:
 ```ln -s /usr/local/Cellar/bash/5.0.7/bin/bash /usr/local/bin/bash```
 You may also want to do this for `/bin/bash` for consistency but it is not required.
 
-### Fix executable paths
+## Fix executable paths
 
 gnu-sed, md5 etc need their executables added to your path. When you install 
 them via brew they give you the instructions on what to add.

--- a/doc/engineering/installing-on-mac.md
+++ b/doc/engineering/installing-on-mac.md
@@ -1,9 +1,9 @@
 # Installing on Mac (for development)
 
-Make sure you've run `xcode-select --install` to install various build tools that are available(such as zlib.
+Make sure you have run `xcode-select --install` to install various build tools that are available(such as zlib.
 
 Some additional dependencies are required to get things up and running on Mac. The easiest way to
-install these dependencies is via `brew` so [install brew](https://brew.sh/) if you haven't already.
+install these dependencies is via `brew` so [install brew](https://brew.sh/) if you have not already.
 
 Run the brew install command below to install dependencies:
 
@@ -42,6 +42,12 @@ Again, make sure to follow the instructions to add them to your path with their 
 The version of emacs that comes with MacOS is very out of date, and you will need it for running
 the auto formatting command. Install a newer version via brew:
 ```brew cask install emacs```
+
+To build the docs you will need to upgrade bash to version 5. You can do this through:
+```brew install bash``` and then removing (Perhaps just rename it) your existing bash 
+from `/usr/local/bin/bash` and symlinking the brew bash into its place:
+```ln -s /usr/local/Cellar/bash/5.0.7/bin/bash /usr/local/bin/bash```
+You may also want to do this for `/bin/bash` for consistency but it is not required.
 
 ### Fix executable paths
 

--- a/doc/engineering/installing-on-mac.md
+++ b/doc/engineering/installing-on-mac.md
@@ -32,6 +32,17 @@ You can install all of the above with:
 
 Next install libreoffice, which can be done via `brew cask install libreoffice`.
 
+## Tooling Dependencies
+
+Several build commands require the gnu version of utilities. For simplicity you can install
+the `coreutils` bundle from brew to get the gnu version of utility applications:
+```brew install coreutils```
+Again, make sure to follow the instructions to add them to your path with their default names.
+
+The version of emacs that comes with MacOS is very out of date, and you will need it for running
+the auto formatting command. Install a newer version via brew:
+```brew cask install emacs```
+
 ### Fix executable paths
 
 gnu-sed, md5 etc need their executables added to your path. When you install 

--- a/doc/engineering/installing-on-mac.md
+++ b/doc/engineering/installing-on-mac.md
@@ -1,0 +1,34 @@
+# Installing on Mac (for development)
+
+Some additional dependencies are required to get things up and running on Mac. The easiest way to
+install these dependencies is via `brew` so install [brew|https://brew.sh/] if you haven't already.
+
+Now install the dependencies listed in the installation.md file using `brew install <dependency name>`.
+Some have different names on mac, such as:
+
+* build-essential 
+* zlib1g-dev 
+* libssl-dev
+
+## Additional Dependencies
+
+Some applications are very old or configured differently in Mac OS, so use brew 
+to install these to bring them up to date:
+Note: Make sure to follow the directions on symlinking executables or adding executables 
+to your path(brew will tell you about it after install completes)
+
+* gnu-sed
+* md5sha1sum
+* make
+
+Next install libreoffice, which can be done via `brew cask install libreoffice`.
+
+### Fix executable paths
+
+gnu-sed, md5 etc need their executables added to your path. When you install 
+them via brew they give you the instructions on what to add.
+
+You will also want to add a symlink for libreoffice somewhere in your path because the default 
+executable name is `soffice` but kazoo expects it to be `libreoffice`. Something like:
+
+```$ ln -s /usr/local/bin/soffice /usr/local/bin/libreoffice```

--- a/doc/engineering/installing-on-mac.md
+++ b/doc/engineering/installing-on-mac.md
@@ -1,7 +1,7 @@
 # Installing on Mac (for development)
 
 Some additional dependencies are required to get things up and running on Mac. The easiest way to
-install these dependencies is via `brew` so install [brew|https://brew.sh/] if you haven't already.
+install these dependencies is via `brew` so [install brew](https://brew.sh/) if you haven't already.
 
 Now install the dependencies listed in the installation.md file using `brew install <dependency name>`.
 Some have different names on mac, such as:

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -483,6 +483,7 @@ pages:
   - 'Erlang VM Tracing': 'doc/engineering/tracing.md'
   - 'Flame Graphs': 'doc/engineering/flame_graphs.md'
   - 'Install/Build Kazoo': 'doc/installation.md'
+  - 'Install/Build Kazoo on MacOS': 'doc/engineering/installing-on-mac.md'
   - 'Kazoo Globals Registry': 'doc/engineering/kz_globals.md'
   - 'Kazoo Scripts': 'scripts/README.md'
   - 'Loopback Channels': 'doc/engineering/loopback.md'


### PR DESCRIPTION
Add documentation for building kazoo on mac osx (for development). Add a configurable timeout around file conversion (default 10 seconds). Move an endif to fix some missing macro definitions.