### PR TITLE
PISTON-835:Posible fix for kz_json:to_map/1 for kz_json:objects() with the same keys

### DIFF
--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -685,9 +685,9 @@ recursive_to_proplist(Else) -> Else.
 %% @end
 %%------------------------------------------------------------------------------
 
--spec to_map(object() | objects()) -> map().
+-spec to_map(object() | objects()) -> map() | list(map()).
 to_map(JObjs) when is_list(JObjs) ->
-    lists:foldl(fun to_map_fold/2, #{}, JObjs);
+    lists:map(fun(JObj) -> to_map(JObj) end, JObjs);
 to_map(JObj) ->
     recursive_to_map(JObj).
 
@@ -696,9 +696,6 @@ to_map(JObj) ->
 -spec to_map(get_key(), object() | objects()) -> map().
 to_map(Key, JObj) ->
     recursive_to_map(get_json_value(Key, JObj, new())).
-
-to_map_fold(JObj, #{}=Map) ->
-    maps:merge(Map, recursive_to_map(JObj)).
 
 -spec recursive_to_map(object() | objects() | kz_term:proplist()) -> map().
 recursive_to_map(?JSON_WRAPPER(Props)) ->

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -687,7 +687,7 @@ recursive_to_proplist(Else) -> Else.
 
 -spec to_map(object() | objects()) -> map() | list(map()).
 to_map(JObjs) when is_list(JObjs) ->
-    jiffy:decode(kz_json:encode(JObjs), [return_maps]);
+    jiffy:decode(encode(JObjs), [return_maps]);
 to_map(JObj) ->
     recursive_to_map(JObj).
 

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -687,7 +687,7 @@ recursive_to_proplist(Else) -> Else.
 
 -spec to_map(object() | objects()) -> map() | list(map()).
 to_map(JObjs) when is_list(JObjs) ->
-    lists:map(fun(JObj) -> to_map(JObj) end, JObjs);
+    jiffy:decode(kz_json:encode(JObjs), [return_maps]);
 to_map(JObj) ->
     recursive_to_map(JObj).
 


### PR DESCRIPTION
There is a issue with to_map in kz_json.

```kz_json:to_map([{[{<<"A">>, 1}, {<<"B">>, 2}]}, {[{<<"A">>, 8}, {<<"B">>, 9}]}])```

Will return:

```#{<<"A">> => 8,<<"B">> => 9}```

Possible solution is to return:

```[#{<<"A">> => 8,<<"B">> => 9},#{<<"A">> => 1,<<"B">> => 2}]```

But im open to suggestions. Other option is to just remove the case that deals with lists and cause a crash. 