### PR TITLE
PISTON-837: Added transcription to metadata & updated docs

### DIFF
--- a/applications/crossbar/doc/voicemail.md
+++ b/applications/crossbar/doc/voicemail.md
@@ -557,7 +557,11 @@ curl -v -X DELETE \
         "call_id": "79959ZDNmM2I5ZTliMzA0NzA4N2FjNjlmODA5OWVkZjUxZWU",
         "folder": "new",
         "length": 3140,
-        "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba"
+        "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba",
+        "transcription": {
+            "result": "success",
+            "text": "This is a test of the voicemail transcription."
+        }
     },
     "revision": "{REVISION}",
     "request_id": "{REQUEST_ID}",
@@ -592,7 +596,11 @@ curl -v -X GET \
         "call_id": "79959ZDNmM2I5ZTliMzA0NzA4N2FjNjlmODA5OWVkZjUxZWU",
         "folder": "new",
         "length": 3140,
-        "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba"
+        "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba",
+        "transcription": {
+            "result": "success",
+            "text": "This is a test of the voicemail transcription."
+        }
     },
     "revision": "{REVISION}",
     "request_id": "{REQUEST_ID}",
@@ -634,7 +642,11 @@ curl -v -X POST \
         "call_id": "79959ZDNmM2I5ZTliMzA0NzA4N2FjNjlmODA5OWVkZjUxZWU",
         "folder": "saved",
         "length": 3140,
-        "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba"
+        "media_id": "201605-6aadef09f6fcf5fd8bcdfca312e923ba",
+        "transcription": {
+            "result": "success",
+            "text": "This is a test of the voicemail transcription."
+        }
     },
     "revision": "{REVISION}",
     "request_id": "{REQUEST_ID}",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -25355,6 +25355,24 @@
                 "to": {
                     "description": "The SIP to header",
                     "type": "string"
+                },
+                "transcription": {
+                    "description": "The transcription data object",
+                    "properties": {
+                        "result": {
+                            "description": "The status of the transcription",
+                            "enum": [
+                                "success",
+                                "error"
+                            ],
+                            "type": "string"
+                        },
+                        "text": {
+                            "description": "The text of the transcription",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "required": [

--- a/applications/crossbar/priv/couchdb/schemas/mailbox_message.json
+++ b/applications/crossbar/priv/couchdb/schemas/mailbox_message.json
@@ -46,6 +46,24 @@
         "to": {
             "description": "The SIP to header",
             "type": "string"
+        },
+        "transcription": {
+            "description": "The transcription data object",
+            "properties": {
+                "result": {
+                    "description": "The status of the transcription",
+                    "enum": [
+                        "success",
+                        "error"
+                    ],
+                    "type": "string"
+                },
+                "text": {
+                    "description": "The text of the transcription",
+                    "type": "string"
+                }
+            },
+            "type": "object"
         }
     },
     "required": [

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -5454,6 +5454,19 @@
     'to':
       'description': The SIP to header
       'type': string
+    'transcription':
+      'description': The transcription data object
+      'properties':
+        'result':
+          'description': The status of the transcription
+          'enum':
+            - success
+            - error
+          'type': string
+        'text':
+          'description': The transcribed text
+          'type': string
+      'type': object
   'required':
     - media_id
   'type': object

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -5464,7 +5464,7 @@
             - error
           'type': string
         'text':
-          'description': The transcribed text
+          'description': The text of the transcription
           'type': string
       'type': object
   'required':

--- a/core/kazoo_documents/src/kzd_box_message.erl
+++ b/core/kazoo_documents/src/kzd_box_message.erl
@@ -50,6 +50,7 @@
 -define(KEY_VOICEMAIL, <<"voicemail">>).
 
 -define(KEY_METADATA, <<"metadata">>).
+-define(KEY_TRANSCRIPTION, <<"transcription">>).
 -define(KEY_META_CALL_ID, <<"call_id">>).
 -define(KEY_META_CID_NAME, <<"caller_id_name">>).
 -define(KEY_META_CID_NUMBER, <<"caller_id_number">>).
@@ -294,7 +295,15 @@ metadata(JObj) ->
 
 -spec metadata(doc(), Default) -> doc() | Default.
 metadata(JObj, Default) ->
-    kz_json:get_value(?KEY_METADATA, JObj, Default).
+    Metadata = kz_json:get_json_value(?KEY_METADATA, JObj, Default),
+    maybe_add_transcription(Metadata, JObj).
+
+-spec maybe_add_transcription(doc(), doc()) -> doc().
+maybe_add_transcription(Metadata, JObj) ->
+    case kz_json:get_json_value(?KEY_TRANSCRIPTION, JObj) of
+        'undefined' -> Metadata;
+        Transcription -> kz_json:insert_value(?KEY_TRANSCRIPTION, Transcription, Metadata)
+    end.
 
 -spec set_metadata(kz_json:object(), doc()) -> doc().
 set_metadata(Metadata, JObj) ->

--- a/core/kazoo_documents/src/kzd_mailbox_message.erl
+++ b/core/kazoo_documents/src/kzd_mailbox_message.erl
@@ -1,6 +1,6 @@
 %%%-----------------------------------------------------------------------------
 %%% @copyright (C) 2010-2019, 2600Hz
-%%% @doc
+%%% @doc Accessors for `mailbox_message' document.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kzd_mailbox_message).
@@ -15,6 +15,9 @@
 -export([media_id/1, media_id/2, set_media_id/2]).
 -export([timestamp/1, timestamp/2, set_timestamp/2]).
 -export([to/1, to/2, set_to/2]).
+-export([transcription/1, transcription/2, set_transcription/2]).
+-export([transcription_result/1, transcription_result/2, set_transcription_result/2]).
+-export([transcription_text/1, transcription_text/2, set_transcription_text/2]).
 
 
 -include("kz_documents.hrl").
@@ -135,3 +138,39 @@ to(Doc, Default) ->
 -spec set_to(doc(), binary()) -> doc().
 set_to(Doc, To) ->
     kz_json:set_value([<<"to">>], To, Doc).
+
+-spec transcription(doc()) -> kz_term:api_object().
+transcription(Doc) ->
+    transcription(Doc, 'undefined').
+
+-spec transcription(doc(), Default) -> kz_json:object() | Default.
+transcription(Doc, Default) ->
+    kz_json:get_json_value([<<"transcription">>], Doc, Default).
+
+-spec set_transcription(doc(), kz_json:object()) -> doc().
+set_transcription(Doc, Transcription) ->
+    kz_json:set_value([<<"transcription">>], Transcription, Doc).
+
+-spec transcription_result(doc()) -> kz_term:api_binary().
+transcription_result(Doc) ->
+    transcription_result(Doc, 'undefined').
+
+-spec transcription_result(doc(), Default) -> binary() | Default.
+transcription_result(Doc, Default) ->
+    kz_json:get_binary_value([<<"transcription">>, <<"result">>], Doc, Default).
+
+-spec set_transcription_result(doc(), binary()) -> doc().
+set_transcription_result(Doc, TranscriptionResult) ->
+    kz_json:set_value([<<"transcription">>, <<"result">>], TranscriptionResult, Doc).
+
+-spec transcription_text(doc()) -> kz_term:api_binary().
+transcription_text(Doc) ->
+    transcription_text(Doc, 'undefined').
+
+-spec transcription_text(doc(), Default) -> binary() | Default.
+transcription_text(Doc, Default) ->
+    kz_json:get_binary_value([<<"transcription">>, <<"text">>], Doc, Default).
+
+-spec set_transcription_text(doc(), binary()) -> doc().
+set_transcription_text(Doc, TranscriptionText) ->
+    kz_json:set_value([<<"transcription">>, <<"text">>], TranscriptionText, Doc).

--- a/core/kazoo_documents/src/kzd_mailbox_message.erl.src
+++ b/core/kazoo_documents/src/kzd_mailbox_message.erl.src
@@ -15,6 +15,9 @@
 -export([media_id/1, media_id/2, set_media_id/2]).
 -export([timestamp/1, timestamp/2, set_timestamp/2]).
 -export([to/1, to/2, set_to/2]).
+-export([transcription/1, transcription/2, set_transcription/2]).
+-export([transcription_result/1, transcription_result/2, set_transcription_result/2]).
+-export([transcription_text/1, transcription_text/2, set_transcription_text/2]).
 
 
 -include("kz_documents.hrl").
@@ -135,3 +138,39 @@ to(Doc, Default) ->
 -spec set_to(doc(), binary()) -> doc().
 set_to(Doc, To) ->
     kz_json:set_value([<<"to">>], To, Doc).
+
+-spec transcription(doc()) -> kz_term:api_object().
+transcription(Doc) ->
+    transcription(Doc, 'undefined').
+
+-spec transcription(doc(), Default) -> kz_json:object() | Default.
+transcription(Doc, Default) ->
+    kz_json:get_json_value([<<"transcription">>], Doc, Default).
+
+-spec set_transcription(doc(), kz_json:object()) -> doc().
+set_transcription(Doc, Transcription) ->
+    kz_json:set_value([<<"transcription">>], Transcription, Doc).
+
+-spec transcription_result(doc()) -> kz_term:api_binary().
+transcription_result(Doc) ->
+    transcription_result(Doc, 'undefined').
+
+-spec transcription_result(doc(), Default) -> binary() | Default.
+transcription_result(Doc, Default) ->
+    kz_json:get_binary_value([<<"transcription">>, <<"result">>], Doc, Default).
+
+-spec set_transcription_result(doc(), binary()) -> doc().
+set_transcription_result(Doc, TranscriptionResult) ->
+    kz_json:set_value([<<"transcription">>, <<"result">>], TranscriptionResult, Doc).
+
+-spec transcription_text(doc()) -> kz_term:api_binary().
+transcription_text(Doc) ->
+    transcription_text(Doc, 'undefined').
+
+-spec transcription_text(doc(), Default) -> binary() | Default.
+transcription_text(Doc, Default) ->
+    kz_json:get_binary_value([<<"transcription">>, <<"text">>], Doc, Default).
+
+-spec set_transcription_text(doc(), binary()) -> doc().
+set_transcription_text(Doc, TranscriptionText) ->
+    kz_json:set_value([<<"transcription">>, <<"text">>], TranscriptionText, Doc).

--- a/core/kazoo_modb/priv/couchdb/views/mailbox_messages.json
+++ b/core/kazoo_modb/priv/couchdb/views/mailbox_messages.json
@@ -41,7 +41,8 @@
                 "    'call_id': doc.metadata.call_id,",
                 "    'folder': doc.metadata.folder,",
                 "    'length': doc.metadata.length,",
-                "    'media_id': doc.metadata.media_id",
+                "    'media_id': doc.metadata.media_id,",
+                "    'transcribed': doc.transcription && doc.transcription.result && doc.transcription.result === 'success'",
                 "   });",
                 "}"
             ]
@@ -60,7 +61,8 @@
                 "    'call_id': doc.metadata.call_id,",
                 "    'folder': doc.metadata.folder,",
                 "    'length': doc.metadata.length,",
-                "    'media_id': doc.metadata.media_id",
+                "    'media_id': doc.metadata.media_id,",
+                "    'transcribed': doc.transcription && doc.transcription.result && doc.transcription.result === 'success'",
                 "   });",
                 "}"
             ]


### PR DESCRIPTION
Transcriptions are being saved outside of the metadata key which is what is returned when information about a voicemail is pulled from crossbar. I had originally considered changing the way transcriptions are saved to move them into metadata but decided on the approach of adding it to the return data upon request so that this will work with pre-existing transcriptions. I’ve updated the crossbar api doc also because now this data will be returned when applicable.