### PR TITLE
HELP-44744: allow chaining children off temporal route actions

### DIFF
--- a/applications/callflow/src/module/cf_temporal_route.erl
+++ b/applications/callflow/src/module/cf_temporal_route.erl
@@ -43,19 +43,19 @@ handle(Data, Call) ->
         <<"menu">> ->
             lager:info("temporal rules main menu"),
             _ = temporal_route_menu(Temporal, rule_ids(Data), Call),
-            cf_exe:stop(Call);
+            cf_exe:continue(Call);
         <<"enable">> ->
             lager:info("force temporal rules to enable"),
             _ = enable_temporal_rules(Temporal, rule_ids(Data), Call),
-            cf_exe:stop(Call);
+            cf_exe:continue(Call);
         <<"disable">> ->
             lager:info("force temporal rules to disable"),
             _ = disable_temporal_rules(Temporal, rule_ids(Data), Call),
-            cf_exe:stop(Call);
+            cf_exe:continue(Call);
         <<"reset">> ->
             lager:info("resume normal temporal rule operation"),
             _ = reset_temporal_rules(Temporal, rule_ids(Data), Call),
-            cf_exe:stop(Call);
+            cf_exe:continue(Call);
         _Action ->
             Rules = get_temporal_rules(Temporal, Call),
             case process_rules(Temporal, Rules, Call) of


### PR DESCRIPTION
Previously, actions of `menu`, `enable`, `disable`, and `reset` would
terminate the call after processing. Upon discussion, there wasn't a
compelling reason to continue doing this (and restricting the ability
to chain more actions off the action).

The usecase is that when there is an "emergency" a callflow can be
dialed to disable the main temporal route rules and enable the
particular "emergency" temporal route rule.