### PR TITLE
HELP-44744: allow chaining children off temporal route actions

### DIFF
--- a/applications/callflow/src/module/cf_temporal_route.erl
+++ b/applications/callflow/src/module/cf_temporal_route.erl
@@ -43,19 +43,19 @@ handle(Data, Call) ->
         <<"menu">> ->
             lager:info("temporal rules main menu"),
             _ = temporal_route_menu(Temporal, rule_ids(Data), Call),
-            cf_exe:stop(Call);
+            cf_exe:continue(Call);
         <<"enable">> ->
             lager:info("force temporal rules to enable"),
             _ = enable_temporal_rules(Temporal, rule_ids(Data), Call),
-            cf_exe:stop(Call);
+            cf_exe:continue(Call);
         <<"disable">> ->
             lager:info("force temporal rules to disable"),
             _ = disable_temporal_rules(Temporal, rule_ids(Data), Call),
-            cf_exe:stop(Call);
+            cf_exe:continue(Call);
         <<"reset">> ->
             lager:info("resume normal temporal rule operation"),
             _ = reset_temporal_rules(Temporal, rule_ids(Data), Call),
-            cf_exe:stop(Call);
+            cf_exe:continue(Call);
         _Action ->
             Rules = get_temporal_rules(Temporal, Call),
             case process_rules(Temporal, Rules, Call) of

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -499,11 +499,7 @@
           'type': object
       'type': object
     'zones':
-      'description': The zone(s) of an account
-      'properties':
-        'home':
-          'description': Which zone is considered the account's home zone
-          'type': string
+      'description': A priority ordered mapping of zones for the account
       'type': object
   'required':
     - name
@@ -9196,6 +9192,10 @@
     'cluster_id':
       'description': provisioner cluster id
       'type': string
+    'zones':
+      'default': {}
+      'description': cluster zones
+      'type': object
   'type': object
 'system_config.conferences':
   'description': Schema for conferences system_config

--- a/doc/mkdocs/commercial.yml
+++ b/doc/mkdocs/commercial.yml
@@ -289,7 +289,7 @@ pages:
     - 'FAQ' : 'doc/appexchange/build_faq.md'
   - 'List Your App':
     - 'Submit Your App': 'doc/appexchange/submit_app.md'
-    - 'Approval Process': 'doc/appexchange/approval_process.md'
+    - 'Approval Process': 'doc/appexchange/states_workflows.md'
     - 'FAQ' : 'doc/appexchange/list_faq.md'
   - 'Sell Your App':
     - 'How to Sell Your App': 'doc/appexchange/how_to_sell.md'


### PR DESCRIPTION
Previously, actions of `menu`, `enable`, `disable`, and `reset` would
terminate the call after processing. Upon discussion, there wasn't a
compelling reason to continue doing this (and restricting the ability
to chain more actions off the action).

The usecase is that when there is an "emergency" a callflow can be
dialed to disable the main temporal route rules and enable the
particular "emergency" temporal route rule.