### PR TITLE
bputtick - ledger view unique list_by_source key

### DIFF
--- a/core/kazoo_modb/priv/couchdb/views/ledgers.json
+++ b/core/kazoo_modb/priv/couchdb/views/ledgers.json
@@ -18,7 +18,7 @@
                 "  if (doc.pvt_ledger_type === 'debit')",
                 "    amount *= -1;",
                 "  var result = {'amount': amount, 'source': doc.source, 'usage': doc.usage, 'metadata': doc.metadata || {}, 'executor': doc.executor || {}};",
-                "  emit([doc.source.service, doc.pvt_created], result);",
+                "  emit([doc.source.service, doc.pvt_created, doc._id], result);",
                 "}"
             ]
         },


### PR DESCRIPTION
cb_ledger uses the "list_by_source" view to iterate through the records which has the "key" defined as [{service}, {pvt_created}] - however if there are 2 or more service entries that were created at the same time (multiple legs) this key is no longer unique and when this falls on a chunked boundary, crossbar misinterprets this as EOF returning an incomplete result.

The fix for this is to emit doc._id as the 3rd field to the key so that it remains unique and will still be sorted correctly.