### PR TITLE
Add sparkly-clean command that runs all the clean commands (except test)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,8 @@ changed_swagger:
 compile: ACTION = all
 compile: deps kazoo
 
+sparkly-clean: clean-apps clean-kazoo clean-release clean-deps
+
 clean: clean-kazoo
 	$(if $(wildcard *crash.dump), rm *crash.dump)
 	$(if $(wildcard scripts/log/*), rm -rf scripts/log/*)


### PR DESCRIPTION
Add a make target that includes blowing away the dependencies directory. Useful when somehow you break things really badly.