### PR TITLE
PISTON-846: check HTTP method for cb_users_v2 CTPs

### DIFF
--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -113,10 +113,14 @@ content_types_provided(Context, _, ?VCARD) ->
                                                                   ]}
                                                    ]);
 content_types_provided(Context, _, ?PHOTO) ->
-    cb_context:set_content_types_provided(Context, [{'to_binary', [{<<"application">>, <<"octet-stream">>}
-                                                                  ,{<<"application">>, <<"base64">>}
-                                                                  ]}
-                                                   ]);
+    case cb_context:method(Context) of
+        ?HTTP_GET -> cb_context:set_content_types_provided(
+                       Context, [{'to_binary', [{<<"application">>, <<"octet-stream">>}
+                                               ,{<<"application">>, <<"base64">>}
+                                               ]}
+                                ]);
+        _ -> Context
+    end;
 content_types_provided(Context, _, _) ->
     Context.
 


### PR DESCRIPTION
- issue cropped up due to https://github.com/2600hz/kazoo/commit/733a53560815b3ea52ecc987278d6ea9fbc91323

The expected type provided by the POST/DELETE (save/delete attachment) for the /photo endpoint is JSON, but that causes a crash like this when the CTPs are binary:
```
Jul  4 00:01:40 kazoo41-1 2600hz[29473]: |0000000000|cowboy_req:684(<0.3874.0>) CRASH REPORT Process <0.3874.0> with 0 neighbours exited with reason: bad argument in call to erlang:iolist_size({[]}) in cowboy_req:has_resp_body/1 line 684
Jul  4 00:01:40 kazoo41-1 2600hz[29473]: |0000000000|Undefined:Undefined(<0.148.0>) Lager event handler error_logger_lager_h exited with reason {'EXIT',{{case_clause,[api_resource,<0.3870.0>,2,<0.3874.0>,badarg,[{erlang,iolist_size,[{[]}],[]},{cowboy_req,has_resp_body,1,[{file,"src/cowboy_req.erl"},{line,684}]},{cowboy_rest,has_resp_body,2,[{file,"src/cowboy_rest.erl"},{line,1025}]},{cowboy_rest,process_content_type,3,[{file,"src/cowboy_rest.erl"},{line,993}]},{cowboy_rest,upgrade,4,[{file,"src/cowboy_rest.erl"},{line,260}]},{cowboy_stream_h,execute,3,[{file,"src/cowboy_stream_h.erl"},{line,249}]},{cowboy_stream_h,request_process,3,...},...]]},...}}
```