### PR TITLE
[4.3] KZ00-5: move call to cast

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_channels.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channels.erl
@@ -203,10 +203,10 @@ destroy(UUID, Node) ->
 update(UUID, Key, Value) ->
     updates(UUID, [{Key, Value}]).
 
-
 -spec updates(kz_term:ne_binary(), channel_updates()) -> 'ok'.
 updates(UUID, Updates) ->
-    gen_server:call(?SERVER, {'channel_updates', UUID, Updates}).
+    lager:debug("updating channel properties: ~p", [Updates]),
+    gen_server:cast(?SERVER, {'channel_updates', UUID, Updates}).
 
 -spec count() -> non_neg_integer().
 count() -> ets:info(?CHANNELS_TBL, 'size').
@@ -225,13 +225,13 @@ match_presence(PresenceId) ->
 -spec handle_query_auth_id(kz_json:object(), kz_term:proplist()) -> 'ok'.
 handle_query_auth_id(JObj, _Props) ->
     'true' = kapi_call:query_auth_id_req_v(JObj),
-    AuthId = kz_json:get_value(<<"Auth-ID">>, JObj),
+    AuthId = kz_json:get_ne_binary_value(<<"Auth-ID">>, JObj),
     Channels = case find_by_auth_id(AuthId) of
                    {'error', 'not_found'} -> [];
                    {'ok', C} -> C
                end,
     Resp = [{<<"Channels">>, Channels}
-           ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(JObj)}
             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
     ServerId = kz_json:get_value(<<"Server-ID">>, JObj),
@@ -267,7 +267,7 @@ send_user_query_resp(JObj, []) ->
         'false' ->
             lager:debug("no channels, sending empty response"),
             Resp = [{<<"Channels">>, []}
-                   ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
+                   ,{<<"Msg-ID">>, kz_api:msg_id(JObj)}
                     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                    ],
             ServerId = kz_json:get_value(<<"Server-ID">>, JObj),
@@ -276,7 +276,7 @@ send_user_query_resp(JObj, []) ->
     end;
 send_user_query_resp(JObj, Cs) ->
     Resp = [{<<"Channels">>, Cs}
-           ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(JObj)}
             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
     ServerId = kz_json:get_value(<<"Server-ID">>, JObj),
@@ -294,7 +294,7 @@ handle_query_account_channels(JObj, _) ->
 -spec send_account_query_resp(kz_json:object(), kz_json:objects()) -> 'ok'.
 send_account_query_resp(JObj, Cs) ->
     Resp = [{<<"Channels">>, Cs}
-           ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(JObj)}
             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
     ServerId = kz_json:get_value(<<"Server-ID">>, JObj),
@@ -314,7 +314,7 @@ handle_query_channels(JObj, _Props) ->
             lager:debug("not sending query_channels resp due to active-only=true");
         'false' ->
             Resp = [{<<"Channels">>, Channels}
-                   ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
+                   ,{<<"Msg-ID">>, kz_api:msg_id(JObj)}
                     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                    ],
             kapi_call:publish_query_channels_resp(kz_json:get_value(<<"Server-ID">>, JObj), Resp)
@@ -345,7 +345,7 @@ handle_channel_status(JObj, _Props) ->
                   ,{<<"Username">>, kz_json:get_value(<<"username">>, Channel)}
                   ,{<<"Custom-Channel-Vars">>, kz_json:from_list(ecallmgr_fs_channel:channel_ccvs(Channel))}
                   ,{<<"Custom-Application-Vars">>, kz_json:from_list(ecallmgr_fs_channel:channel_cavs(Channel))}
-                  ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
+                  ,{<<"Msg-ID">>, kz_api:msg_id(JObj)}
                    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                   ]
                  ),
@@ -364,7 +364,7 @@ send_empty_channel_resp(CallId, JObj) ->
     Resp = [{<<"Call-ID">>, CallId}
            ,{<<"Status">>, <<"terminated">>}
            ,{<<"Error-Msg">>, <<"no node found with channel">>}
-           ,{<<"Msg-ID">>, kz_json:get_value(<<"Msg-ID">>, JObj)}
+           ,{<<"Msg-ID">>, kz_api:msg_id(JObj)}
             | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
            ],
     kapi_call:publish_channel_status_resp(kz_api:server_id(JObj), Resp).
@@ -416,6 +416,9 @@ handle_call(_, _, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_cast(any(), state()) -> {'noreply', state()}.
+handle_cast({'channel_updates', UUID, Update}, State) ->
+    ets:update_element(?CHANNELS_TBL, UUID, Update),
+    {'noreply', State};
 handle_cast({'destroy_channel', UUID, Node}, State) ->
     kz_util:put_callid(UUID),
     MatchSpec = [{#channel{uuid='$1', node='$2', _ = '_'}


### PR DESCRIPTION
To avoid blocking the calling process when the gen_server is overly
busy, move the channel updates to a cast instead of a call. In
particular, we've observed the authz worker (during route req/resp for
dialplan) getting blocked for 2s while waiting for this update to
occur.

Since the authz worker and dialplan response don't depend on the
channel cache, no sense blocking for the ETS write.