### PR TITLE
KZ00-5: move call to cast

### DIFF
--- a/applications/ecallmgr/src/fetch/ecallmgr_fs_fetch_dialplan.erl
+++ b/applications/ecallmgr/src/fetch/ecallmgr_fs_fetch_dialplan.erl
@@ -232,7 +232,7 @@ activate_call_control(#{call_id := CallId, winner := #{payload := JObj}} = Map) 
     kz_util:put_callid(CallId),
     CCVs = kzd_fetch:ccvs(JObj),
     ControllerQ = kzd_fetch:controller_queue(JObj),
-    ecallmgr_fs_channels:deferred_update(CallId, #channel.handling_locally, 'true'),
+    ecallmgr_fs_channels:update(CallId, #channel.handling_locally, 'true'),
     Args = Map#{controller_q => ControllerQ
                ,initial_ccvs => CCVs
                },


### PR DESCRIPTION
To avoid blocking the calling process when the gen_server is overly
busy, move the channel updates to a cast instead of a call. In
particular, we've observed the authz worker (during route req/resp for
dialplan) getting blocked for 2s while waiting for this update to
occur.

Since the authz worker and dialplan response don't depend on the
channel cache, no sense blocking for the ETS write.