### PR TITLE
PISTON-772: do not start agents in acdc_queue_manager

### DIFF
--- a/applications/acdc/priv/couchdb/views/queues.json
+++ b/applications/acdc/priv/couchdb/views/queues.json
@@ -10,7 +10,8 @@
     "language": "javascript",
     "views": {
         "agents_listing": {
-            "map": "function(doc) { if (doc.pvt_type !== 'user' || doc.pvt_deleted || typeof doc.queues !== 'object' ) return; for ( i in doc.queues ) { emit(doc.queues[i], doc._id); }}"
+            "map": "function(doc) { if (doc.pvt_type !== 'user' || doc.pvt_deleted || typeof doc.queues !== 'object' ) return; for ( i in doc.queues ) { emit(doc.queues[i], doc._id); }}",
+            "reduce": "_count"
         },
         "crossbar_listing": {
             "map": "function(doc) { if (doc.pvt_type != 'queue' || doc.pvt_deleted) return; emit(doc._id, {'id': doc._id, 'name': doc.name, 'strategy': doc.strategy}); }"

--- a/applications/acdc/src/acdc_init.erl
+++ b/applications/acdc/src/acdc_init.erl
@@ -85,7 +85,8 @@ init_acct_queues(AccountDb, AccountId) ->
 -spec init_acct_agents(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 init_acct_agents(AccountDb, AccountId) ->
     init_agents(AccountId
-               ,kz_datamgr:get_results(AccountDb, <<"queues/agents_listing">>, [])
+               ,kz_datamgr:get_results(AccountDb, <<"queues/agents_listing">>
+                                      ,[{'reduce', 'false'}])
                ).
 
 -spec init_queues(kz_term:ne_binary(), kazoo_data:get_results_return()) -> 'ok'.

--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -438,18 +438,16 @@ handle_cast({'start_workers'}, #state{account_id=AccountId
     case kz_datamgr:get_results(kz_util:format_account_id(AccountId, 'encoded')
                                ,<<"queues/agents_listing">>
                                ,[{'key', QueueId}
-                                ,'include_docs'
+                                ,{'group', 'true'}
+                                ,{'group_level', 1}
                                 ])
     of
         {'ok', []} ->
             lager:debug("no agents yet, but create a worker anyway"),
             acdc_queue_workers_sup:new_worker(WorkersSup, AccountId, QueueId);
-        {'ok', Agents} ->
-            _ = [start_agent_and_worker(WorkersSup, AccountId, QueueId
-                                       ,kz_json:get_value(<<"doc">>, A)
-                                       )
-                 || A <- Agents
-                ],
+        {'ok', [Result]} ->
+            QWC = kz_json:get_integer_value(<<"value">>, Result),
+            acdc_queue_workers_sup:new_workers(WorkersSup, AccountId, QueueId, QWC),
             'ok';
         {'error', _E} ->
             lager:debug("failed to find agent count: ~p", [_E]),
@@ -683,22 +681,6 @@ publish_queue_member_remove(AccountId, QueueId, CallId) ->
            ],
     kapi_acdc_queue:publish_queue_member_remove(Prop).
 
--spec start_agent_and_worker(pid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
-start_agent_and_worker(WorkersSup, AccountId, QueueId, AgentJObj) ->
-    acdc_queue_workers_sup:new_worker(WorkersSup, AccountId, QueueId),
-    AgentId = kz_doc:id(AgentJObj),
-    {'ok', Status} = acdc_agent_util:most_recent_status(AccountId, AgentId),
-    case acdc_agent_util:status_should_auto_start(Status) of
-        'false' -> 'ok';
-        'true' ->
-            lager:debug("maybe starting agent ~s(~s) for queue ~s", [AgentId, Status, QueueId]),
-
-            case acdc_agents_sup:find_agent_supervisor(AccountId, AgentId) of
-                'undefined' -> acdc_agents_sup:new(AgentJObj);
-                P when is_pid(P) -> 'ok'
-            end
-    end.
-
 %% Really sophisticated selection algorithm
 -spec pick_winner(pid(), kz_json:objects(), queue_strategy(), kz_term:api_binary()) ->
                          'undefined' |
@@ -897,7 +879,9 @@ create_strategy_state(Strategy, AcctDb, QueueId) ->
 create_strategy_state('rr', #strategy_state{agents='undefined'}=SS, AcctDb, QueueId) ->
     create_strategy_state('rr', SS#strategy_state{agents=queue:new()}, AcctDb, QueueId);
 create_strategy_state('rr', #strategy_state{agents=AgentQ}=SS, AcctDb, QueueId) ->
-    case kz_datamgr:get_results(AcctDb, <<"queues/agents_listing">>, [{'key', QueueId}]) of
+    case kz_datamgr:get_results(AcctDb, <<"queues/agents_listing">>
+                               ,[{'key', QueueId}, {'reduce', 'false'}])
+    of
         {'ok', []} -> lager:debug("no agents around"), SS;
         {'ok', JObjs} ->
             Q = queue:from_list([Id || JObj <- JObjs,
@@ -914,7 +898,9 @@ create_strategy_state('rr', #strategy_state{agents=AgentQ}=SS, AcctDb, QueueId) 
 create_strategy_state('mi', #strategy_state{agents='undefined'}=SS, AcctDb, QueueId) ->
     create_strategy_state('mi', SS#strategy_state{agents=[]}, AcctDb, QueueId);
 create_strategy_state('mi', #strategy_state{agents=AgentL}=SS, AcctDb, QueueId) ->
-    case kz_datamgr:get_results(AcctDb, <<"queues/agents_listing">>, [{key, QueueId}]) of
+    case kz_datamgr:get_results(AcctDb, <<"queues/agents_listing">>
+                               ,[{'key', QueueId}, {'reduce', 'false'}])
+    of
         {'ok', []} -> lager:debug("no agents around"), SS;
         {'ok', JObjs} ->
             AgentL1 = lists:foldl(fun(JObj, Acc) ->
@@ -935,7 +921,9 @@ create_strategy_state('mi', #strategy_state{agents=AgentL}=SS, AcctDb, QueueId) 
 create_strategy_state('all', #strategy_state{agents='undefined'}=SS, AcctDb, QueueId) ->
     create_strategy_state('all', SS#strategy_state{agents=queue:new()}, AcctDb, QueueId);
 create_strategy_state('all', #strategy_state{agents=AgentQ}=SS, AcctDb, QueueId) ->
-    case kz_datamgr:get_results(AcctDb, <<"queues/agents_listing">>, [{'key', QueueId}]) of
+    case kz_datamgr:get_results(AcctDb, <<"queues/agents_listing">>
+                               ,[{'key', QueueId}, {'reduce', 'false'}])
+    of
         {'ok', []} -> lager:debug("no agents around"), SS;
         {'ok', JObjs} ->
             Q = queue:from_list([Id || JObj <- JObjs,

--- a/applications/acdc/src/acdc_util.erl
+++ b/applications/acdc/src/acdc_util.erl
@@ -82,7 +82,9 @@ send_cdr(Url, JObj, Retries) ->
 %% Returns the list of agents configured for the queue
 -spec agents_in_queue(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_json:path().
 agents_in_queue(AcctDb, QueueId) ->
-    case kz_datamgr:get_results(AcctDb, <<"queues/agents_listing">>, [{'key', QueueId}]) of
+    case kz_datamgr:get_results(AcctDb, <<"queues/agents_listing">>
+                               ,[{'key', QueueId}, {'reduce', 'false'}])
+    of
         {'ok', []} -> [];
         {'error', _E} -> lager:debug("failed to lookup agents for ~s: ~p", [QueueId, _E]), [];
         {'ok', As} -> [kz_json:get_value(<<"value">>, A) || A <- As]

--- a/applications/acdc/src/cb_queues.erl
+++ b/applications/acdc/src/cb_queues.erl
@@ -539,7 +539,7 @@ load_queue_agents(Id, Context) ->
     end.
 
 load_agent_roster(Id, Context) ->
-    crossbar_doc:load_view(?CB_AGENTS_LIST, [{'key', Id}]
+    crossbar_doc:load_view(?CB_AGENTS_LIST, [{'key', Id}, {'reduce', 'false'}]
                           ,Context
                           ,fun normalize_agents_results/2
                           ).


### PR DESCRIPTION
There should not be any situation where the agent needs to be started in
the queue mgr. Running state of the agents should be tied to login state
and is dealt with either on-the-fly when the agent logs in/out or on
acdc boot to resume the previous login state