### PR TITLE
PISTON-867: remove acdc_queue_manager monitor_call

### DIFF
--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -423,13 +423,6 @@ handle_cast({'member_call_cancel', K, JObj}, #state{ignored_member_calls=Dict}=S
 
     'ok' = acdc_stats:call_abandoned(AccountId, QueueId, CallId, Reason),
     {'noreply', State#state{ignored_member_calls=dict:store(K, 'true', Dict)}};
-handle_cast({'monitor_call', Call}, State) ->
-    CallId = kapps_call:call_id(Call),
-    gen_listener:add_binding(self(), 'call', [{'callid', CallId}
-                                             ,{'restrict_to', [<<"CHANNEL_DESTROY">>]}
-                                             ]),
-    lager:debug("bound for call events for ~s", [CallId]),
-    {'noreply', State};
 handle_cast({'start_workers'}, #state{account_id=AccountId
                                      ,queue_id=QueueId
                                      ,supervisor=QueueSup
@@ -566,8 +559,6 @@ handle_cast({'add_queue_member', JObj}, #state{account_id=AccountId
     %% Add call to shared queue
     kapi_acdc_queue:publish_shared_member_call(AccountId, QueueId, JObj),
     lager:debug("put call into shared messaging queue"),
-
-    gen_listener:cast(self(), {'monitor_call', Call}),
 
     acdc_util:presence_update(AccountId, QueueId, ?PRESENCE_RED_FLASH),
 


### PR DESCRIPTION
No longer need to bind to call.CHANNEL_DESTROY.<call_id> for queue
manager. Removal of calls is handled by other events. These bindings
were being leaked and consuming extra AMQP memory over time