### PR TITLE
PISTON-859: always update acdc_queue_listener my_q

### DIFF
--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -242,7 +242,7 @@ handle_cast({'get_friends', WorkerSup}, State) ->
     {'noreply', State#state{fsm_pid=FSMPid
                            ,shared_pid=SharedPid
                            }};
-handle_cast({'gen_listener', {'created_queue', Q}}, #state{my_q='undefined'}=State) ->
+handle_cast({'gen_listener', {'created_queue', Q}}, State) ->
     {'noreply', State#state{my_q=Q}, 'hibernate'};
 
 handle_cast({'member_connect_req', MemberCallJObj, Delivery, _Url}


### PR DESCRIPTION
Handles channel being lost - new queue may be provided to gen_listener