### PR TITLE
[4.3] HELP-44667: don't send authz resp on quick hangup

### DIFF
--- a/applications/jonny5/src/j5_hard_limit.erl
+++ b/applications/jonny5/src/j5_hard_limit.erl
@@ -55,7 +55,7 @@ resource_consumption_at_limit(Limits) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec inbound_channels_per_did_at_limit(kz_term:ne_binary(), j5_limits:limits()) -> boolean().
+-spec inbound_channels_per_did_at_limit(j5_request:request(), j5_limits:limits()) -> boolean().
 inbound_channels_per_did_at_limit(Request, Limits) ->
     AccountId = j5_limits:account_id(Limits),
     ToDID = j5_request:number(Request),

--- a/applications/jonny5/src/j5_limits.erl
+++ b/applications/jonny5/src/j5_limits.erl
@@ -242,7 +242,7 @@ create_limits(AccountId, AccountDb, JObj) ->
            ,bundled_twoway_trunks = kzd_limits:bundled_twoway_trunks(JObj, AccountDb)
            ,burst_trunks = kzd_limits:burst_trunks(JObj)
            ,max_postpay_amount = kzd_limits:max_postpay_units(JObj) * -1
-           ,reserve_amount = kzd_limits:reserve_units(JObj, ?DEFAULT_RATE)
+           ,reserve_amount = kzd_limits:reserve_units(JObj, kz_currency:dollars_to_units(?DEFAULT_RATE))
            ,allow_prepay = kzd_limits:allow_prepay(JObj)
            ,allow_postpay = kzd_limits:allow_postpay(JObj)
            ,allotments = kzd_limits:allotments(JObj)

--- a/applications/jonny5/src/j5_request.erl
+++ b/applications/jonny5/src/j5_request.erl
@@ -111,9 +111,10 @@ from_jobj(JObj) ->
     [Num|_] = binary:split(Request, <<"@">>),
     Number = request_number(Num, CCVs),
 
-    #request{account_id = kz_json:get_ne_value(<<"Account-ID">>, CCVs)
+    AccountId = kz_json:get_ne_value(<<"Account-ID">>, CCVs),
+    #request{account_id = AccountId
             ,account_billing = kz_json:get_ne_value(<<"Account-Billing">>, CCVs, <<"limits_enforced">>)
-            ,reseller_id = kz_json:get_ne_value(<<"Reseller-ID">>, CCVs)
+            ,reseller_id = ccv_reseller_id(AccountId, CCVs)
             ,reseller_billing = kz_json:get_ne_value(<<"Reseller-Billing">>, CCVs, <<"limits_enforced">>)
             ,call_id = kz_json:get_ne_value(<<"Call-ID">>, JObj)
             ,call_direction = kz_json:get_value(<<"Call-Direction">>, JObj)
@@ -132,6 +133,13 @@ from_jobj(JObj) ->
             ,request_jobj = JObj
             ,request_ccvs = CCVs
             }.
+
+-spec ccv_reseller_id(kz_term:ne_binary(), kz_json:object()) -> kz_term:api_ne_binary().
+ccv_reseller_id(AccountId, CCVs) ->
+    case kz_json:get_ne_value(<<"Reseller-ID">>, CCVs) of
+        'undefined' -> kzd_accounts:reseller_id(AccountId);
+        ResellerId -> ResellerId
+    end.
 
 -spec from_ccvs(request(), kz_term:proplist()) -> request().
 from_ccvs(#request{request_ccvs=ReqCCVs

--- a/core/kazoo_documents/src/kzd_accounts.erl
+++ b/core/kazoo_documents/src/kzd_accounts.erl
@@ -927,9 +927,12 @@ demote(JObj) ->
 path_reseller() ->
     [<<"pvt_reseller">>].
 
--spec reseller_id(doc()) -> doc().
-reseller_id(JObj) ->
-    kz_json:get_value([<<"pvt_reseller_id">>], JObj).
+-spec reseller_id(kz_term:ne_binary() | doc()) -> doc().
+reseller_id(<<AccountId/binary>>) ->
+    {'ok', AccountDoc} = fetch(AccountId),
+    reseller_id(AccountDoc);
+reseller_id(AccountDoc) ->
+    kz_json:get_value([<<"pvt_reseller_id">>], AccountDoc).
 
 -spec set_reseller_id(doc(), kz_term:ne_binary()) -> doc().
 set_reseller_id(JObj, ResellerId) ->

--- a/core/kazoo_proper/src/pqc_cb_limits.erl
+++ b/core/kazoo_proper/src/pqc_cb_limits.erl
@@ -1,0 +1,41 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2019-, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_limits).
+
+-export([fetch/2
+        ,update/3
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch(API, <<AccountId/binary>>) ->
+    URL = limits_url(AccountId),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+
+    Expectations = [#{'response_codes' => [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,URL
+                           ,RequestHeaders
+                           ).
+
+-spec update(pqc_cb_api:state(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
+update(API, <<AccountId/binary>>, JObj) ->
+    URL = limits_url(AccountId),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+    RequestEnvelope = pqc_cb_api:create_envelope(JObj),
+
+    Expectations = [#{'response_codes' => [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,RequestHeaders
+                           ,kz_json:encode(RequestEnvelope)
+                           ).
+
+limits_url(<<AccountId/binary>>) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "limits"], "/").

--- a/core/kazoo_proper/src/pqc_j5_channels.erl
+++ b/core/kazoo_proper/src/pqc_j5_channels.erl
@@ -1,0 +1,98 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2019-, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_j5_channels).
+
+-export([seq/0
+        ,cleanup/0
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
+
+-spec seq() -> 'ok'.
+seq() ->
+    API = pqc_cb_api:init_api(['crossbar', 'jonny5']
+                             ,['cb_accounts', 'cb_limits_v2']
+                             ),
+    AccountId = create_account(API),
+    _ = update_limits(API, pqc_cb_api:auth_account_id(API)),
+    _ = update_limits(API, AccountId),
+
+    j5_channels:flush(),
+
+    CallId = kz_binary:rand_hex(5),
+
+    %% We expect a channel destroy processed before an authz response
+    %% to cause the authz response to not be sent
+
+    _ = send_channel_destroy(AccountId, CallId),
+    {'error', 'timeout'} = send_authz_req(AccountId, CallId),
+    0 = query_limits(AccountId),
+    cleanup(API).
+
+create_account(API) ->
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    ?INFO("created account: ~s", [AccountResp]),
+
+    kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
+
+send_authz_req(AccountId, CallId) ->
+    Req = [{<<"Call-Direction">>, <<"inbound">>}
+          ,{<<"Call-ID">>, CallId}
+          ,{<<"Caller-ID-Name">>, <<?MODULE_STRING>>}
+          ,{<<"Caller-ID-Number">>, <<"19998887777">>}
+          ,{<<"From">>, <<?MODULE_STRING>>}
+          ,{<<"Request">>, <<"12223334444@realm.com">>}
+          ,{<<"To">>, <<"12223334444@realm.com">>}
+          ,{<<"Custom-Channel-Vars">>, kz_json:from_list([{<<"Account-ID">>, AccountId}])}
+           | kz_api:default_headers(<<?MODULE_STRING>>, <<"5.0">>)
+          ],
+    kz_amqp_worker:call(Req
+                       ,fun kapi_authz:publish_authz_req/1
+                       ,fun kapi_authz:authz_resp_v/1
+                       ,3 * ?MILLISECONDS_IN_SECOND
+                       ).
+
+send_channel_destroy(AccountId, CallId) ->
+    Event = [{<<"Call-Direction">>, <<"inbound">>}
+            ,{<<"Call-ID">>, CallId}
+            ,{<<"Caller-ID-Name">>, <<?MODULE_STRING>>}
+            ,{<<"Caller-ID-Number">>, <<"19998887777">>}
+            ,{<<"From">>, <<?MODULE_STRING>>}
+            ,{<<"Request">>, <<"12223334444@realm.com">>}
+            ,{<<"To">>, <<"12223334444@realm.com">>}
+            ,{<<"Timestamp">>, kz_time:now_s()}
+            ,{<<"Custom-Channel-Vars">>, kz_json:from_list([{<<"Account-ID">>, AccountId}])}
+             | kz_api:default_headers(<<"call_event">>, <<"CHANNEL_DESTROY">>, <<?MODULE_STRING>>, <<"5.0">>)
+            ],
+    kz_amqp_worker:cast(Event, fun kapi_call:publish_event/1).
+
+query_limits(AccountId) ->
+    j5_channels:total_calls(AccountId).
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
+    cleanup_system().
+
+cleanup(API) ->
+    ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _ = pqc_cb_api:cleanup(API),
+    cleanup_system().
+
+cleanup_system() -> 'ok'.
+
+update_limits(API, AccountId) ->
+    _Update = pqc_cb_limits:update(API
+                                  ,AccountId
+                                  ,kz_json:from_list([{<<"twoway_trunks">>, 2}
+                                                     ,{<<"accept_charges">>, 'true'}
+                                                     ]
+                                                    )
+                                  ),
+    ?INFO("update limits: ~s", [_Update]).

--- a/core/kazoo_services/src/kz_services_bookkeeper.erl
+++ b/core/kazoo_services/src/kz_services_bookkeeper.erl
@@ -130,7 +130,7 @@ store_audit_log(Services, Invoice) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec update_audit_log(kz_services:services(), kz_term:api_object(), kz_amqp_worker:request_return()) ->
+-spec update_audit_log(kz_services:services(), kz_term:api_object(), kz_amqp_worker:request_return() | kz_term:proplist()) ->
                               kz_term:api_object().
 update_audit_log(_Services, 'undefined', _Result) -> 'undefined';
 update_audit_log(Services, AuditJObj, {'error', 'timeout'}) ->


### PR DESCRIPTION
Processing the authz request can take longer than processing the
subsequent CHANNEL_DESTROY. This causes the flushing in j5_channels to
occur before the storing of the authorization payload. Since the
channel is gone, the authorization payload isn't flushed and counts
against the account/reseller limits.

Instead, check the j5_channels ETS table for the authorization
payload on CHANNEL_DESTROY; if none, store an entry with a
destroyed:true flag. If a subsequent authz response is attempted
to be stored, this check will keep it from happening.

Introduce a test for sending CHANNEL_DESTROY followed by authz_req and
ensuring totals remain 0 and no authz_resp is generated.