### PR TITLE
Voicemail fwd confirmation

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -1132,8 +1132,8 @@ forward_message(AttachmentName, Length, Message, SrcBoxId, #mailbox{mailbox_numb
                     ]
                    ),
     case kvm_message:forward_message(Call, Message, SrcBoxId, NewMsgProps) of
-        {'ok', _NewCall} ->
-            _ = kapps_call_command:b_prompt(<<"vm-forward_confirmed">>, Call),
+        {'ok', NewCall} ->
+            _ = kapps_call_command:b_prompt(<<"vm-forward_confirmed">>, NewCall),
             send_mwi_update(DestBox);
         {'error', _, _Msg} ->
             lager:warning("failed to save forwarded voice mail message recorded media : ~p", [_Msg])

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -1132,7 +1132,9 @@ forward_message(AttachmentName, Length, Message, SrcBoxId, #mailbox{mailbox_numb
                     ]
                    ),
     case kvm_message:forward_message(Call, Message, SrcBoxId, NewMsgProps) of
-        {'ok', _NewCall} -> send_mwi_update(DestBox);
+        {'ok', _NewCall} ->
+            _ = kapps_call_command:b_prompt(<<"vm-forward_confirmed">>, Call),
+            send_mwi_update(DestBox);
         {'error', _, _Msg} ->
             lager:warning("failed to save forwarded voice mail message recorded media : ~p", [_Msg])
     end.


### PR DESCRIPTION
When a user forwards a voicemail there is no interaction with the user confirming the operation. 

This can leave a user confused, we don't want confused users. 

Kazoo-sounds change: https://github.com/2600hz/kazoo-sounds/pull/8