### PR TITLE
Vendor all 3rd party dependencies under github/2600hz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ clean-test-core:
 clean-test-apps:
 	@$(MAKE) -j$(JOBS) -C applications/ clean-test
 
+compile-proper: ERLC_OPTS += -DPROPER
+compile-proper: compile-test
+
 compile-test: ERLC_OPTS += +nowarn_missing_spec
 compile-test: deps compile-test-core compile-test-apps
 compile-test-core:

--- a/applications/callflow/src/callflow.app.src
+++ b/applications/callflow/src/callflow.app.src
@@ -1,6 +1,6 @@
 {application,callflow,
-             [{applications,[crypto,erlang_localtime,gproc,kazoo,kazoo_amqp,
-                             kazoo_apps,kazoo_caches,kazoo_call,kazoo_data,
+             [{applications,[crypto,gproc,kazoo,kazoo_amqp,kazoo_apps,
+                             kazoo_caches,kazoo_call,kazoo_data,
                              kazoo_documents,kazoo_edr,kazoo_endpoint,
                              kazoo_globals,kazoo_media,kazoo_number_manager,
                              kazoo_schemas,kazoo_stdlib,kazoo_token_buckets,

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -2156,7 +2156,7 @@ tmp_file(Ext) ->
                             kz_term:ne_binary().
 get_unix_epoch(Epoch, Timezone) ->
     UtcDateTime = calendar:gregorian_seconds_to_datetime(Epoch),
-    LocalDateTime = localtime:utc_to_local(UtcDateTime, Timezone),
+    LocalDateTime = kz_time:adjust_utc_datetime(UtcDateTime, Timezone),
     kz_term:to_binary(calendar:datetime_to_gregorian_seconds(LocalDateTime) - ?UNIX_EPOCH_IN_GREGORIAN).
 
 %%------------------------------------------------------------------------------

--- a/applications/crossbar/doc/rates.md
+++ b/applications/crossbar/doc/rates.md
@@ -12,7 +12,7 @@ Flow is:
   a. Optionally assign a `ratedeck_name` to each row to add rates to different ratedeck databases
 2. Create a service plan for ratedecks
   a. Add the service plan to account(s)
-3. When `{ACCOUNT_ID}` has a rate-able call, Kazoo `hotornot` application  will lookup what ratedeck database to use
+3. When `{ACCOUNT_ID}` has a rate-able call, Kazoo `hotornot` application will lookup what ratedeck database to use
   a. If using the trie algorithm, `hotornot` will find the PID with that ratedeck's trie and query it
   b. Otherwise, use the view of the ratedeck database to query for rates
 
@@ -110,45 +110,9 @@ curl -v -X GET \
 }
 ```
 
-## Upload a Ratedeck CSV
+### Upload a Ratedeck CSV
 
 Uploading CSVs has moved to using the ['tasks'](tasks.md) API, which provides a more generic interface. See the [rates task documentation](/applications/tasks/doc/rates.md) for more details on uploading rates.
-
-### Deprecated version
-
-> POST /v2/rates
-
-For bulk uploading. CSV rows can be formatted in the following ways:
-
-* `Prefix, ISO, Desc, Rate`
-* `Prefix, ISO, Desc, InternalRate, Rate`
-* `Prefix, ISO, Desc, Surcharge, InternalRate, Rate`
-* `Prefix, ISO, Desc, InternalSurcharge, Surcharge, InternalRate, Rate`
-* `Prefix, ISO, Desc, InternalSurcharge, Surcharge, Internal_rate, Rate, Routes, RateIncrement, RateMinimum, Direction`
-
-A US-1 row might look like:
-
-`1, "US-1", "US default rate", 0.01`
-
-This API will return an HTTP 202 and process the CSV in a background process.
-
-```shell
-curl -v -X POST \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -H "Content-Type: text/csv" \
-    --data-binary @/path/to/rates.csv \
-    http://{SERVER}:8000/v2/rates
-```
-
-```json
-{
-    "auth_token": "{AUTH_TOKEN}",
-    "data":"attempting to insert rates from the uploaded document",
-    "request_id": "{REQUEST_ID}",
-    "revision": "{REVISION}",
-    "status": "success"
-}
-```
 
 ### Create a new rate
 

--- a/applications/crossbar/doc/ref/rates.md
+++ b/applications/crossbar/doc/ref/rates.md
@@ -56,16 +56,6 @@ curl -v -X PUT \
     http://{SERVER}:8000/v2/rates
 ```
 
-## Change
-
-> POST /v2/rates
-
-```shell
-curl -v -X POST \
-    -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/rates
-```
-
 ## Fetch
 
 > GET /v2/rates/{RATE_ID}

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -47786,23 +47786,6 @@
                     }
                 }
             },
-            "post": {
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "rates",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/rates"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "request succeeded"
-                    }
-                }
-            },
             "put": {
                 "parameters": [
                     {

--- a/applications/crossbar/priv/oas3/paths/rates.yml
+++ b/applications/crossbar/priv/oas3/paths/rates.yml
@@ -9,20 +9,6 @@ paths:
       summary: Get all rates
       tags:
         - rates
-    post:
-      operationId: PostRates
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '../oas3-schemas.yml#/rates'
-      responses:
-        200:
-          description: Successful operation
-      summary: Update an instance of rates
-      tags:
-        - rates
     put:
       operationId: PutRates
       parameters: []

--- a/applications/crossbar/src/crossbar.app.src
+++ b/applications/crossbar/src/crossbar.app.src
@@ -1,5 +1,5 @@
 {application,crossbar,
-             [{applications,[cowboy,cowlib,crypto,ecsv,erlang_localtime,inets,
+             [{applications,[cowboy,cowlib,crypto,erlang_localtime,inets,
                              kazoo,kazoo_amqp,kazoo_apps,kazoo_attachments,
                              kazoo_auth,kazoo_bindings,kazoo_caches,
                              kazoo_call,kazoo_config,kazoo_csv,kazoo_data,

--- a/applications/crossbar/src/crossbar_view.erl
+++ b/applications/crossbar/src/crossbar_view.erl
@@ -840,7 +840,7 @@ handle_query_result(#{last_key := LastKey
             handle_query_result(LoadMap, Dbs, FilteredJObj, 1, NewLastKey)
     end.
 
--spec handle_query_result(load_params(), kz_term:ne_binaries(), kz_json:objects(), non_neg_integer(), last_key()) -> load_params().
+-spec handle_query_result(load_params(), kz_term:ne_binaries(), kz_json:object() | kz_json:objects(), non_neg_integer(), last_key()) -> load_params().
 handle_query_result(#{is_chunked := 'true'
                      ,context := Context
                      }=LoadMap, [Db|_], FilteredJObjs, FilteredLength, NewLastKey) ->

--- a/applications/notify/src/notify_fax_inbound_error_to_email.erl
+++ b/applications/notify/src/notify_fax_inbound_error_to_email.erl
@@ -111,7 +111,7 @@ create_template_props(Event, Docs, Account) ->
     DateTime = calendar:gregorian_seconds_to_datetime(DateCalled),
 
     Timezone = kz_term:to_list(kz_json:find(<<"fax_timezone">>, Docs, <<"UTC">>)),
-    ClockTimezone = kapps_config:get_string(<<"servers">>, <<"clock_timezone">>, <<"UTC">>),
+    ClockTimezone = kapps_config:get_string(<<"servers">>, <<"clock_timezone">>, "UTC"),
 
     [{<<"account">>, notify_util:json_to_template_props(Account)}
     ,{<<"service">>, notify_util:get_service_props(Event, Account, ?MOD_CONFIG_CAT)}

--- a/applications/notify/src/notify_fax_outbound_error_to_email.erl
+++ b/applications/notify/src/notify_fax_outbound_error_to_email.erl
@@ -112,7 +112,7 @@ create_template_props(Event, Docs, Account) ->
     DateTime = calendar:gregorian_seconds_to_datetime(DateCalled),
 
     Timezone = kz_term:to_list(kz_json:find(<<"timezone">>, Docs, <<"UTC">>)),
-    ClockTimezone = kapps_config:get_string(<<"servers">>, <<"clock_timezone">>, <<"UTC">>),
+    ClockTimezone = kapps_config:get_string(<<"servers">>, <<"clock_timezone">>, "UTC"),
 
     [{<<"account">>, notify_util:json_to_template_props(Account)}
     ,{<<"service">>, notify_util:get_service_props(Event, Account, ?MOD_CONFIG_CAT)}

--- a/applications/notify/src/notify_fax_outbound_to_email.erl
+++ b/applications/notify/src/notify_fax_outbound_to_email.erl
@@ -105,7 +105,7 @@ create_template_props(Event, [FaxDoc | _Others]=_Docs, Account) ->
     DateCalled = kz_json:get_integer_value(<<"Fax-Timestamp">>, Event, Now),
     DateTime = calendar:gregorian_seconds_to_datetime(DateCalled),
     Timezone = kz_term:to_list(kz_json:get_value([<<"tx_result">>,<<"timezone">>], FaxDoc, <<"UTC">>)),
-    ClockTimezone = kapps_config:get_string(<<"servers">>, <<"clock_timezone">>, <<"UTC">>),
+    ClockTimezone = kapps_config:get_string(<<"servers">>, <<"clock_timezone">>, "UTC"),
     [{<<"account">>, notify_util:json_to_template_props(Account)}
     ,{<<"service">>, notify_util:get_service_props(Event, Account, ?MOD_CONFIG_CAT)}
     ,{<<"fax">>, [{<<"caller_id_number">>, knm_util:pretty_print(CIDNum)}

--- a/applications/notify/src/notify_util.erl
+++ b/applications/notify/src/notify_util.erl
@@ -150,7 +150,7 @@ compile_default_subject_template(TemplateModule, Category) ->
 
 -spec compile_default_template(atom(), kz_term:ne_binary(), atom()) -> {'ok', atom()}.
 compile_default_template(TemplateModule, Category, Key) ->
-    Template = case kapps_config:get_ne_binary(Category, Key) of
+    Template = case kapps_config:get_ne_binary(Category, kz_term:to_binary(Key)) of
                    'undefined' -> get_default_template(Category, Key);
                    Else -> Else
                end,

--- a/applications/notify/src/notify_voicemail_to_email.erl
+++ b/applications/notify/src/notify_voicemail_to_email.erl
@@ -121,7 +121,7 @@ create_template_props(Event, Timezone, Account) ->
     DateCalled = kz_json:get_integer_value(<<"Voicemail-Timestamp">>, Event),
     DateTime = calendar:gregorian_seconds_to_datetime(DateCalled),
 
-    ClockTimezone = kapps_config:get_string(<<"servers">>, <<"clock_timezone">>, <<"UTC">>),
+    ClockTimezone = kapps_config:get_string(<<"servers">>, <<"clock_timezone">>, "UTC"),
 
     [{<<"account">>, notify_util:json_to_template_props(Account)}
     ,{<<"service">>, notify_util:get_service_props(Event, Account, ?MOD_CONFIG_CAT)}
@@ -130,7 +130,7 @@ create_template_props(Event, Timezone, Account) ->
                           %% sometimes the name is a number...
                          ,{<<"caller_id_name">>, knm_util:pretty_print(CIDName)}
                          ,{<<"date_called_utc">>, localtime:local_to_utc(DateTime, ClockTimezone)}
-                         ,{<<"date_called">>, localtime:local_to_local(DateTime, ClockTimezone, Timezone)}
+                         ,{<<"date_called">>, localtime:local_to_local(DateTime, ClockTimezone, kz_term:to_list(Timezone))}
                          ,{<<"from_user">>, knm_util:pretty_print(FromE164)}
                          ,{<<"from_realm">>, kz_json:get_value(<<"From-Realm">>, Event)}
                          ,{<<"to_user">>, knm_util:pretty_print(ToE164)}

--- a/core/kazoo_caches/test/kz_cache_pqc.erl
+++ b/core/kazoo_caches/test/kz_cache_pqc.erl
@@ -38,20 +38,20 @@
                ,now_ms = 0 :: pos_integer()
                }).
 
-proper_test_() ->
-    {"Runs kz_cache PropEr tests"
-    ,[
-      {'timeout'
-      ,20 * ?MILLISECONDS_IN_SECOND
-      ,{"sequential testing"
-       ,?_assert(proper:quickcheck(?MODULE:correct(), [{'to_file', 'user'}, 10]))
-       }
-      }
-      %% ,{"parallel testing"
-      %% ,?assert(proper:quickcheck(?MODULE:correct_parallel(), [{'to_file', 'user'}, 50]))
-      %% }
-     ]
-    }.
+%% proper_test_() ->
+%%     {"Runs kz_cache PropEr tests"
+%%     ,[
+%%       {'timeout'
+%%       ,20 * ?MILLISECONDS_IN_SECOND
+%%       ,{"sequential testing"
+%%        ,?_assert(proper:quickcheck(?MODULE:correct(), [{'to_file', 'user'}, 10]))
+%%        }
+%%       }
+%% ,{"parallel testing"
+%% ,?assert(proper:quickcheck(?MODULE:correct_parallel(), [{'to_file', 'user'}, 50]))
+%% }
+%%  ]
+%% }.
 
 run_counterexample() ->
     run_counterexample(proper:counterexample()).

--- a/core/kazoo_convert/doc/README.md
+++ b/core/kazoo_convert/doc/README.md
@@ -10,7 +10,7 @@ The converters used to execute file conversions are modular, modules can be enab
 
 The fax converter module by default use the module `fax_converter`. For a description of how the default fax converter `fax_converter` works, and information about the system commands used in fax file conversions, see [the fax converter documentation.](fax_converter.md)
 
-###Configuration
+### Configuration
 
 The `v2/system_configs/kazoo_convert` configuration parameters are used to enable features and define commands to use for conversion operations.
 
@@ -31,4 +31,3 @@ Key | Description | Type | Default | Required | Support Level
 `fax.validate_tiff_command` | Verifies a TIFF file is valid | `string()` | [see fax_converter doc](fax_converter.md) | `false` |
 `file_cache_path` | The working directory to use when converting files | `string()` | `/tmp/` | `false` |
 `attachment_format` | Format to use for receipt email messages and api responses | `string()` | `pdf` | `false` |
-

--- a/core/kazoo_documents/src/kzd_box_message.erl
+++ b/core/kazoo_documents/src/kzd_box_message.erl
@@ -145,16 +145,15 @@ new(AccountId, Props) ->
 -spec create_message_name(kz_term:ne_binary(), kz_term:api_binary(), kz_time:gregorian_seconds()) -> kz_term:ne_binary().
 create_message_name(BoxNum, 'undefined', UtcSeconds) ->
     create_message_name(BoxNum, kzd_accounts:default_timezone(), UtcSeconds);
-create_message_name(BoxNum, Timezone, UtcSeconds) ->
+create_message_name(BoxNum, <<Timezone/binary>>, UtcSeconds) ->
     UtcDateTime = calendar:gregorian_seconds_to_datetime(kz_term:to_integer(UtcSeconds)),
-    case localtime:utc_to_local(UtcDateTime, Timezone) of
-        {'error', 'unknown_tz'} ->
-            lager:info("unknown timezone: ~s", [Timezone]),
-            message_name(BoxNum, UtcDateTime, " UTC");
-        [LocalDateTime, _DstLocatDateTime] ->
-            message_name(BoxNum, LocalDateTime, "");
-        LocalDateTime ->
+    try kz_time:adjust_utc_datetime(UtcDateTime, Timezone) of
+        {{_,_,_}, {_,_,_}}=LocalDateTime ->
             message_name(BoxNum, LocalDateTime, "")
+    catch
+        'throw':{'error', 'unknown_tz'} ->
+            lager:info("unknown timezone: ~s", [Timezone]),
+            message_name(BoxNum, UtcDateTime, " UTC")
     end.
 
 -spec message_name(kz_term:ne_binary(), kz_time:datetime(), string()) -> kz_term:ne_binary().
@@ -298,7 +297,7 @@ metadata(JObj, Default) ->
     Metadata = kz_json:get_json_value(?KEY_METADATA, JObj, Default),
     maybe_add_transcription(Metadata, JObj).
 
--spec maybe_add_transcription(doc(), doc()) -> doc().
+-spec maybe_add_transcription(doc() | Default, doc()) -> doc() | Default.
 maybe_add_transcription(Metadata, JObj) ->
     case kz_json:get_json_value(?KEY_TRANSCRIPTION, JObj) of
         'undefined' -> Metadata;

--- a/core/kazoo_stdlib/src/kz_date.erl
+++ b/core/kazoo_stdlib/src/kz_date.erl
@@ -39,7 +39,7 @@
 %%------------------------------------------------------------------------------
 -spec from_gregorian_seconds(kz_time:gregorian_seconds(), kz_term:ne_binary()) ->
                                     kz_time:date().
-from_gregorian_seconds(Seconds, <<_/binary>>=TZ) when is_integer(Seconds) ->
+from_gregorian_seconds(Seconds, <<TZ/binary>>) when is_integer(Seconds) ->
     {{_,_,_}, {_,_,_}} = DateTime = calendar:gregorian_seconds_to_datetime(Seconds),
     TZList = kz_term:to_list(TZ),
     {{_,_,_}=Date, {_,_,_}} = localtime:utc_to_local(DateTime, TZList),

--- a/core/kazoo_stdlib/src/kz_time.erl
+++ b/core/kazoo_stdlib/src/kz_time.erl
@@ -157,8 +157,8 @@ rfc2822(Datetime = {Date={Y, Mo, D}, {H, Mi, S}}, TZ) ->
     >>.
 
 -spec tz_offset(calendar:datetime(), kz_term:ne_binary()) -> kz_term:ne_binary().
-tz_offset(Datetime, FromTz) ->
-    case localtime:tz_shift(Datetime, FromTz, <<"UTC">>) of
+tz_offset(Datetime, <<FromTz/binary>>) ->
+    case localtime:tz_shift(Datetime, kz_term:to_list(FromTz), "UTC") of
         0 -> <<"+0000">>;
         {'error', 'unknown_tz'} -> <<"+0000">>;
         {Sign, H, M} ->
@@ -407,8 +407,8 @@ adjust_utc_timestamp(_Timestamp, <<"+", _/binary>>) ->
     throw({'error', 'invalid_offset'});
 adjust_utc_timestamp(_Timestamp, <<"-", _/binary>>) ->
     throw({'error', 'invalid_offset'});
-adjust_utc_timestamp(Timestamp, Timezone) ->
-    try localtime:utc_to_local(calendar:gregorian_seconds_to_datetime(Timestamp), Timezone) of
+adjust_utc_timestamp(Timestamp, <<Timezone/binary>>) when is_integer(Timestamp) ->
+    try localtime:utc_to_local(calendar:gregorian_seconds_to_datetime(Timestamp), kz_term:to_list(Timezone)) of
         {{_, _, _}, {_, _, _}} = Datetime ->
             calendar:datetime_to_gregorian_seconds(Datetime);
         [LocalDatetime, _LocalDstDatetime] ->
@@ -419,7 +419,6 @@ adjust_utc_timestamp(Timestamp, Timezone) ->
         _:_ ->
             throw({'error', 'unknown_tz'})
     end.
-
 
 %%------------------------------------------------------------------------------
 %% @doc Apply the adjustment to the Datetime.

--- a/core/kazoo_stdlib/test/kz_time_tests.erl
+++ b/core/kazoo_stdlib/test/kz_time_tests.erl
@@ -158,7 +158,7 @@ rfc2822_assert({Date, Expected}) ->
 rfc2822_assert({Date, TZ, Expected}) ->
     ?_assertEqual(Expected, kz_time:rfc2822(Date, TZ));
 rfc2822_assert({Date, FromTZ, ToTZ, Expected}) ->
-    NewLocal = localtime:local_to_local(Date, FromTZ, ToTZ),
+    NewLocal = localtime:local_to_local(Date, kz_term:to_list(FromTZ), kz_term:to_list(ToTZ)),
     ?_assertEqual(Expected, kz_time:rfc2822(NewLocal, ToTZ)).
 
 iso8601_test_() ->

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -3,7 +3,6 @@ DEPS = amqp_client \
 	apns \
 	couchbeam \
 	cowboy \
-	ecsv \
 	eflame \
 	erlang_localtime \
 	erlazure \
@@ -46,7 +45,8 @@ ifeq ($(USER),travis)
     DEPS += proper
 endif
 
-dep_amqp_client = hex 3.7.14
+dep_amqp_client = git https://github.com/2600hz/erlang-amqp_client.git v3.7.14
+
 dep_apns = git https://github.com/2600hz/erlang-apns4erl.git aba1fa96a4abbbb2c1628ad5d604f482aad4d12f # latest commit SHA to 2600hz branch
 
 # dep_certifi = hex 0.3.0
@@ -62,14 +62,7 @@ dep_couchbeam = git https://github.com/2600hz/erlang-couchbeam 28fce6c340de83f47
 ### https://github.com/benoitc/couchbeam/pull/166 - no crash when getting body
 ### https://github.com/benoitc/couchbeam/pull/174 - view_cleanup content-type header
 
-dep_cowboy = git https://github.com/ninenines/cowboy 2.6.3
-
-# dep_detergent = git https://github.com/pap/detergent e86dfeded3e4f9f3f9278c6a1aea802079d38b54
-# used by the 'dth' app which is so badly deprecated
-
-dep_ecsv = git https://github.com/2600hz/ecsv 2600hz
-# merged lazedo/ecsv-1 and rcouch/master
-# looks like cb_rates is only user of this, kz_csv may be workable
+dep_cowboy = git https://github.com/2600hz/erlang-cowboy 2.6.3
 
 dep_eflame = git https://github.com/slfritchie/eflame 7b0bb1a7e8c8482a59421a3a50ae69d49af59d52
 # used by kz_tracers
@@ -77,39 +70,40 @@ dep_eflame = git https://github.com/slfritchie/eflame 7b0bb1a7e8c8482a59421a3a50
 # dep_eiconv = git https://github.com/zotonic/eiconv
 # used by gen_smtp
 
-dep_erlang_localtime = git https://github.com/lazedo/erlang_localtime 0bb26016380cd7df5d30aa0ef284ae252b5bae31
+dep_erlang_localtime = git https://github.com/2600hz/erlang-localtime
 # used by kazoo_documents, teletype, notify, crossbar, callflow
 
-dep_erlazure = git https://github.com/lazedo/erlazure.git add-start-link
-# used by kazoo_attachments
+dep_erlazure = git https://github.com/2600hz/erlang-erlazure.git 88e0417251983ab4d8a2a2606c732906eecd5007
+# used by kazoo_attachments, merged in lazedo/erlazure add-start-link changes
 
-dep_erlcloud = git https://github.com/erlcloud/erlcloud 3.2.7
+dep_erlcloud = git https://github.com/2600hz/erlang-erlcloud 3.2.7
 # used by kazoo_attachments and a crossbar test (cb_storage_tests)
 
-dep_escalus = git https://github.com/esl/escalus 0de0463c345a1ade6fccfb9aadad719b58a1cef5
+dep_escalus = git https://github.com/2600hz/erlang-escalus 0de0463c345a1ade6fccfb9aadad719b58a1cef5
 # used by fax cloud printer i think?
 
-dep_exml = git https://github.com/paulgray/exml 2.2.1
+dep_exml = git https://github.com/2600hz/erlang-exml 2.2.1
 # used by fax cloud printer
 
-dep_fcm = git https://github.com/softwarejoint/fcm-erlang.git b2f68a4c6f0f59475597a35e2dc9be13d9ba2910
+dep_fcm = git https://github.com/2600hz/erlang-fcm.git b2f68a4c6f0f59475597a35e2dc9be13d9ba2910
 # Firebase cloud messaging
 # used by pusher
 
-dep_folsom = git https://github.com/boundary/folsom 0.8.2
+dep_folsom = git https://github.com/2600hz/erlang-folsom 0.8.2
 # used by hangups
 
 ## Code reloaders for dev VMs, uncomment if desired
 # dep_fs_event = git https://github.com/jamhed/fs_event 783400da08c2b55c295dbec81df0d926960c0346
 # dep_fs_sync = git https://github.com/jamhed/fs_sync 2cf85cf5861221128f020c453604d509fd37cd53
 
-dep_gen_smtp = hex 0.13.0
+dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp f82a135bf5ce6dc8ca29bd4e30cbdc98cd089ee2
 # used by teletype, notify, and fax
+# SHA fixes spec for gen_smto_client:send/3
 
-dep_getopt = hex 1.0.1
+dep_getopt = git https://github.com/2600hz/erlang-getopt v1.0.1
 # used in some scripts/ and sup
 
-dep_gproc = hex 0.8.0
+dep_gproc = git https://github.com/2600hz/erlang-gproc 0.8.0
 # used by kazoo_events, webseq, konami, acdc, ecallmgr, callflow
 
 dep_hep = git https://github.com/2600hz/hep-erlang a8f62dbc756fd3d4be1e2f0a6cec47a23f6cd18a
@@ -120,7 +114,7 @@ dep_hep = git https://github.com/2600hz/hep-erlang a8f62dbc756fd3d4be1e2f0a6cec4
 # used by kazoo_stdlib in some test modules
 # uncomment if you want to do simple perf testing of code
 
-dep_inet_cidr = git https://github.com/benoitc/inet_cidr.git 1.0.2
+dep_inet_cidr = git https://github.com/2600hz/erlang-inet_cidr.git 1.0.2
 # used by kz_network_utils
 
 dep_jesse = git https://github.com/2600hz/jesse 1.5-rc13
@@ -130,41 +124,42 @@ dep_jiffy = git https://github.com/2600hz/jiffy master  ## utf8 decode
 # includes changes from lazedo/utf8
 # used by kz_json, nklib, jesse, lager, maybe couchbeam if compiled
 
-dep_lager = git https://github.com/erlang-lager/lager 3.6.10
+dep_lager = git https://github.com/2600hz/erlang-lager 3.6.10
 # used everywhere
 
-dep_lager_syslog = git https://github.com/erlang-lager/lager_syslog 3.0.3
+dep_lager_syslog = git https://github.com/2600hz/erlang-lager_syslog 3.0.3
 
-dep_meck = git https://github.com/eproxus/meck 0.8.13
+dep_meck = git https://github.com/2600hz/erlang-meck 0.8.13
 # used in tests for kazoo_voicemail, crossbar, teletype, and other deps
 
-dep_meta = git https://github.com/efcasado/meta 0.1.3
+dep_meta = git https://github.com/2600hz/erlang-meta 0.1.3
 # appears unused
 
-dep_nklib = git https://github.com/NetComposer/nklib v0.4.1
+dep_nklib = git https://github.com/2600hz/erlang-nklib v0.4.1
 # used by kzsip_uri and cb_registrations
 
 # dep_parse_trans = git https://github.com/lazedo/parse_trans
 # appears unused
 
-dep_plists = hex 1.0.0
+dep_plists = git https://github.com/2600hz/erlang-plists 1.0.0
 # used by a handful of core apps
 
-dep_proper = git https://github.com/proper-testing/proper v1.3
+dep_proper = git https://github.com/2600hz/erlang-proper v1.3
 # used by kazoo_proper, knm, kazoo_caches, kazoo_bindings, kz_util_tests, kazoo_token_buckets, kazoo_stdlib
 # used by apps hotornot and callflow
 
-dep_recon = hex 2.4.0
+dep_recon = git https://github.com/2600hz/erlang-recon 2.4.0
 
-dep_ranch = git https://github.com/ninenines/ranch 1.7.1
+dep_ranch = git https://github.com/2600hz/erlang-ranch 1.7.1
 
-dep_reloader = hex 0.1.0
+dep_reloader = git https://github.com/2600hz/erlang-reloader de1e6c74204b61ccf3b3652f05c6a7dec9e8257d
 # Development-related for reloading beam files
 # see rel/dev.vm.args and fixture_shell in make/kz.mk
+# commit adds makefile for compile/clean
 
 dep_syslog = git https://github.com/2600hz/erlang-syslog bbad537a1cb5e4f37e672d2e2665659e850662d0
 
-dep_trie = hex 1.7.5
+dep_trie = git https://github.com/2600hz/erlang-trie v1.7.5
 # used by hotornot
 
 # dep_wsock = git https://github.com/madtrick/wsock 1.1.7
@@ -173,6 +168,6 @@ dep_trie = hex 1.7.5
 dep_yamerl = git https://github.com/2600hz/erlang-yamerl v0.7.0
 # used by kazoo_ast to create OpenAPI 3
 
-dep_zucchini = hex 0.1.0
+dep_zucchini = git https://github.com/2600hz/erlang-zucchini 0.1.0
 # INI file parser
 # used by kazoo_config_init


### PR DESCRIPTION
Moved all fetched dependencies under the 2600Hz orginazation. There
are probably some transitive dependencies that need sorting out but
for a first pass, this should be fine.

Also formally removed the rates CSV upload from the rates API, which
rid us of the ecsv dep.