### PR TITLE
[4.3] KAZOO-6118: strip missing connections off storage plan settings

### DIFF
--- a/core/kazoo_data/test/kzs_plan_tests.erl
+++ b/core/kazoo_data/test/kzs_plan_tests.erl
@@ -7,6 +7,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kazoo_fixturedb/include/kz_fixturedb.hrl").
+-include_lib("kazoo_stdlib/include/kz_types.hrl").
 
 -define(ACCOUNT_DB, <<"account%2Fac%2Fco%2Funt0000000000000000000000003">>).
 -define(ACCOUNT_MODB, <<"account%2Fac%2Fco%2Funt0000000000000000000000003-201710">>).
@@ -39,6 +40,7 @@ render_test_() ->
              ,{"Split account plan test.", ?_test(account_plan_split())}
              ,{"Split modb plan test.", ?_test(modb_plan_split())}
              ,{"Split modb type plan test.", ?_test(match_modb_plan_type_split())}
+             ,{"Handle missing connection.", ?_test(handle_missing_connection())}
              ]
      end
     }.
@@ -110,3 +112,15 @@ match_modb_plan_type_split() ->
     ?assertMatch(#{classification := ?MODB, tag := 'account_4_fax', doc_type := ?FAX_TYPE
                   ,server := {'kazoo_fixturedb', _Conn}}
                 ,kzs_plan:get_dataplan(?ACCOUNT_MODB_SPLIT, ?FAX_TYPE)).
+
+handle_missing_connection() ->
+    AccountId = <<"account0000000000000000000000005">>,
+    Plan = kzs_plan:plan(kz_util:format_account_mod_id(AccountId)),
+    ?assertMatch(#{classification := ?MODB
+                  ,tag := 'local'
+                  ,others := []
+                  ,server := {'kazoo_fixturedb', _}
+                  ,account_id := AccountId
+                  }
+                ,Plan
+                ).

--- a/core/kazoo_fixturedb/priv/dbs/system_data/docs/account0000000000000000000000005.json
+++ b/core/kazoo_fixturedb/priv/dbs/system_data/docs/account0000000000000000000000005.json
@@ -1,0 +1,60 @@
+{
+    "_id": "account0000000000000000000000005",
+    "_rev": "2-52a85bb635459a40a21a071718886bb4",
+    "attachments": {
+        "5fa1f134417927ae200fb12879acec71": {
+            "handler": "google_drive",
+            "name": "mydrive",
+            "settings": {
+                "oauth_doc_id": "{OAUTH_DOC_ID}"
+            }
+        },
+        "fb45659e12a9b8fca1bf6a0e4a95b220": {
+            "handler": "s3",
+            "name": "mys3",
+            "settings": {
+                "bucket": "kazoo",
+                "key": "{KEY}",
+                "secret": "{SECRET}+"
+            }
+        }
+    },
+    "plan": {
+        "modb": {
+            "types": {
+                "call_recording": {
+                    "attachments": {
+                        "handler": "fb45659e12a9b8fca1bf6a0e4a95b220",
+                        "params": {
+                            "acl": "myacl",
+                            "bucket": "sandbox",
+                            "path": "recordings"
+                        }
+                    }
+                },
+                "fax": {
+                    "attachments": {
+                        "handler": "fb45659e12a9b8fca1bf6a0e4a95b220",
+                        "params": {
+                            "acl": "myacl",
+                            "bucket": "sandbox",
+                            "path": "faxes"
+                        }
+                    },
+                    "connection": "09ee9fb9714bd6dfe5ce457da9adf897"
+                },
+                "mailbox_message": {
+                    "attachments": {
+                        "handler": "5fa1f134417927ae200fb12879acec71",
+                        "params": {
+                            "folder_id": "{FOLDER_ID}",
+                            "folder_name": "kazoo"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "pvt_account_id": "account0000000000000000000000005",
+    "pvt_type": "storage"
+}

--- a/core/kazoo_fixturedb/priv/dbs/system_data/views/storage+accounts.json
+++ b/core/kazoo_fixturedb/priv/dbs/system_data/views/storage+accounts.json
@@ -5,6 +5,11 @@
         "value": null
     },
     {
+        "id": "account0000000000000000000000005",
+        "key": "account0000000000000000000000005",
+        "value": null
+    },
+    {
         "id": "system",
         "key": "system",
         "value": null

--- a/core/kazoo_proper/src/pqc_cb_storage.erl
+++ b/core/kazoo_proper/src/pqc_cb_storage.erl
@@ -50,7 +50,7 @@ create(API, AccountId, ?NE_BINARY=UUID, ValidateSettings) ->
 create(API, AccountId, StorageDoc, ValidateSettings) ->
     StorageURL = storage_url(AccountId, ValidateSettings),
     RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, <<"application/json">>}]),
-    pqc_cb_api:make_request([201, 400]
+    pqc_cb_api:make_request([201]
                            ,fun kz_http:put/3
                            ,StorageURL
                            ,RequestHeaders
@@ -92,11 +92,15 @@ init_system() ->
 
 -spec seq() -> 'ok'.
 seq() ->
-    _ = base_test(),
-    cleanup(),
-    _ = skip_validation_test(),
-    cleanup(),
-    _ = global_test(),
+    Tests = [fun base_test/0
+            ,fun skip_validation_test/0
+            ,fun global_test/0
+            ,fun missing_ref_test/0
+            ],
+    lists:foreach(fun run_test/1, Tests).
+
+run_test(TestFun) ->
+    TestFun(),
     cleanup().
 
 skip_validation_test() ->
@@ -107,7 +111,7 @@ skip_validation_test() ->
     AccountId = create_account(API),
 
     StorageDoc = storage_doc(kz_binary:rand_hex(16)),
-    ShouldFailToCreate = create(API, AccountId, StorageDoc, 'false'),
+    {'error', ShouldFailToCreate} = create(API, AccountId, StorageDoc, 'false'),
     ?INFO("should fail: ~s", [ShouldFailToCreate]),
 
     check_if_allowed(kz_json:decode(ShouldFailToCreate), 'false'),
@@ -125,7 +129,7 @@ skip_validation_test() ->
     kzs_plan:disallow_validation_overrides(),
     ?INFO("dis-allowing validation overrides"),
 
-    ShouldAgainFailToCreate = create(API, AccountId, StorageDoc, 'false'),
+    {'error', ShouldAgainFailToCreate} = create(API, AccountId, StorageDoc, 'false'),
     ?INFO("should fail again: ~s", [ShouldAgainFailToCreate]),
     check_if_allowed(kz_json:decode(ShouldAgainFailToCreate), 'false'),
 
@@ -324,14 +328,36 @@ http_handler_settings() ->
                       ]).
 
 storage_plan(UUID) ->
-    kz_json:from_list([{<<"modb">>, modb_plan(UUID)}]).
+    storage_plan(UUID, 'undefined').
 
-modb_plan(UUID) ->
-    kz_json:from_list([{<<"types">>, modb_types(UUID)}]).
+storage_plan(AttUUID, ConnUUID) ->
+    kz_json:from_list([{<<"modb">>, modb_plan(AttUUID, ConnUUID)}]).
 
-modb_types(UUID) ->
-    kz_json:from_list([{<<"mailbox_message">>, mailbox_handler(UUID)}]).
+modb_plan(AttUUID, ConnUUID) ->
+    kz_json:from_list([{<<"types">>, modb_types(AttUUID, ConnUUID)}]).
 
-mailbox_handler(UUID) ->
-    Handler = kz_json:from_list([{<<"handler">>, UUID}]),
-    kz_json:from_list([{<<"attachments">>, Handler}]).
+modb_types(AttUUID, ConnUUID) ->
+    kz_json:from_list([{<<"mailbox_message">>, mailbox_handler(AttUUID, ConnUUID)}]).
+
+mailbox_handler(AttUUID, ConnUUID) ->
+    Handler = kz_json:from_list([{<<"handler">>, AttUUID}]),
+    kz_json:from_list([{<<"attachments">>, Handler}
+                      ,{<<"connection">>, ConnUUID}
+                      ]).
+
+storage_doc_missing_conn(AttUUID, ConnUUID) ->
+    kz_json:from_list([{<<"attachments">>, storage_attachments(AttUUID)}
+                      ,{<<"plan">>, storage_plan(AttUUID, ConnUUID)}
+                      ]).
+
+-spec missing_ref_test() -> 'ok'.
+missing_ref_test() ->
+    ?INFO("GLOBAL TEST"),
+
+    API = init_api(),
+
+    AccountId = create_account(API),
+
+    MissingConnDoc = storage_doc_missing_conn(kz_binary:rand_hex(16), kz_binary:rand_hex(16)),
+    {'error', ErrMsg} = create(API, AccountId, MissingConnDoc),
+    ?INFO("failed to create storage: ~s", [ErrMsg]).

--- a/core/kazoo_proper/src/pqc_cb_storage.erl
+++ b/core/kazoo_proper/src/pqc_cb_storage.erl
@@ -262,9 +262,6 @@ handle_multipart_contents(MediaId, MP3, [_Part | Parts]) ->
     ?DEBUG("skipping part ~s", [_Part]),
     handle_multipart_contents(MediaId, MP3, Parts).
 
-handle_mp3_contents(MP3, MP3, 'false') ->
-    ?INFO("got expected mp3 data"),
-    'true';
 handle_mp3_contents(MP3, Base64MP3, 'true') ->
     ?INFO("checking base64-encoded data"),
     case base64:decode(Base64MP3) of


### PR DESCRIPTION
Given a storage plan with "plan".Classification."types".Type:
If Type."connection" is defined, check that the value (the connection
ID) is also defined on the root level's "connections" object. If not,
remove the connection from the Type.

Adds tests for crossbar rejection of undefined connections and checks
that kzs_plan:plan/1 returns an appropriately filtered plan.