### PR TITLE
[4.3] issues with the previous PR left syntax issues in some updated views

### DIFF
--- a/core/kazoo_apps/priv/couchdb/account/groups.json
+++ b/core/kazoo_apps/priv/couchdb/account/groups.json
@@ -32,7 +32,7 @@
                 "    'id': doc._id,",
                 "    'name': doc.name,",
                 "    'features': features,",
-                "    'endpoints': endpoints",
+                "    'endpoints': endpoints,",
                 "    'flags': doc.flags || []",
                 "  });",
                 "}"
@@ -63,7 +63,7 @@
                 "        'id': doc._id,",
                 "        'name': doc.name,",
                 "        'features': features,",
-                "        'endpoints': endpoints",
+                "        'endpoints': endpoints,",
                 "        'flags': doc.flags || []",
                 "      });",
                 "}"

--- a/core/kazoo_documents/src/kzd_accounts.erl
+++ b/core/kazoo_documents/src/kzd_accounts.erl
@@ -19,6 +19,7 @@
 -export([do_not_disturb/1, do_not_disturb/2, set_do_not_disturb/2]).
 -export([do_not_disturb_enabled/1, do_not_disturb_enabled/2, set_do_not_disturb_enabled/2]).
 -export([enabled/1, enabled/2, set_enabled/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([formatters/1, formatters/2, set_formatters/2]).
 -export([language/1, language/2, set_language/2]).
 -export([metaflows/1, metaflows/2, set_metaflows/2]).
@@ -273,6 +274,18 @@ enabled(Doc, Default) ->
 -spec set_enabled(doc(), boolean()) -> doc().
 set_enabled(Doc, Enabled) ->
     kz_json:set_value([<<"enabled">>], Enabled, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec formatters(doc()) -> kz_term:api_object().
 formatters(Doc) ->

--- a/core/kazoo_documents/src/kzd_blacklists.erl
+++ b/core/kazoo_documents/src/kzd_blacklists.erl
@@ -6,6 +6,7 @@
 -module(kzd_blacklists).
 
 -export([new/0]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([name/1, name/2, set_name/2]).
 -export([numbers/1, numbers/2, set_numbers/2]).
 -export([should_block_anonymous/1, should_block_anonymous/2, set_should_block_anonymous/2]).
@@ -21,6 +22,18 @@
 -spec new() -> doc().
 new() ->
     kz_json_schema:default_object(?SCHEMA).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec name(doc()) -> kz_term:api_ne_binary().
 name(Doc) ->

--- a/core/kazoo_documents/src/kzd_callflows.erl
+++ b/core/kazoo_documents/src/kzd_callflows.erl
@@ -9,6 +9,7 @@
 -export([featurecode/1, featurecode/2, set_featurecode/2]).
 -export([featurecode_name/1, featurecode_name/2, set_featurecode_name/2]).
 -export([featurecode_number/1, featurecode_number/2, set_featurecode_number/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([flow/1, flow/2, set_flow/2]).
 -export([metaflow/1, metaflow/2, set_metaflow/2]).
 -export([numbers/1, numbers/2, set_numbers/2]).
@@ -61,6 +62,18 @@ featurecode_number(Doc, Default) ->
 -spec set_featurecode_number(doc(), kz_term:ne_binary()) -> doc().
 set_featurecode_number(Doc, FeaturecodeNumber) ->
     kz_json:set_value([<<"featurecode">>, <<"number">>], FeaturecodeNumber, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec flow(doc()) -> kz_term:api_object().
 flow(Doc) ->

--- a/core/kazoo_documents/src/kzd_conferences.erl
+++ b/core/kazoo_documents/src/kzd_conferences.erl
@@ -12,6 +12,7 @@
 -export([conference_numbers/1, conference_numbers/2, set_conference_numbers/2]).
 -export([controls/1, controls/2, set_controls/2]).
 -export([domain/1, domain/2, set_domain/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([focus/1, focus/2, set_focus/2]).
 -export([language/1, language/2, set_language/2]).
 -export([max_members_media/1, max_members_media/2, set_max_members_media/2]).
@@ -122,6 +123,18 @@ domain(Doc, Default) ->
 -spec set_domain(doc(), binary()) -> doc().
 set_domain(Doc, Domain) ->
     kz_json:set_value([<<"domain">>], Domain, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec focus(doc()) -> kz_term:api_binary().
 focus(Doc) ->

--- a/core/kazoo_documents/src/kzd_devices.erl
+++ b/core/kazoo_documents/src/kzd_devices.erl
@@ -27,6 +27,7 @@
 -export([do_not_disturb_enabled/1, do_not_disturb_enabled/2, set_do_not_disturb_enabled/2]).
 -export([enabled/1, enabled/2, set_enabled/2]).
 -export([exclude_from_queues/1, exclude_from_queues/2, set_exclude_from_queues/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([formatters/1, formatters/2, set_formatters/2]).
 -export([hotdesk/1, hotdesk/2, set_hotdesk/2]).
 -export([language/1, language/2, set_language/2]).
@@ -347,6 +348,18 @@ exclude_from_queues(Doc, Default) ->
 -spec set_exclude_from_queues(doc(), boolean()) -> doc().
 set_exclude_from_queues(Doc, ExcludeFromQueues) ->
     kz_json:set_value([<<"exclude_from_queues">>], ExcludeFromQueues, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec formatters(doc()) -> kz_term:api_object().
 formatters(Doc) ->

--- a/core/kazoo_documents/src/kzd_directories.erl
+++ b/core/kazoo_documents/src/kzd_directories.erl
@@ -7,6 +7,7 @@
 
 -export([new/0]).
 -export([confirm_match/1, confirm_match/2, set_confirm_match/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([max_dtmf/1, max_dtmf/2, set_max_dtmf/2]).
 -export([min_dtmf/1, min_dtmf/2, set_min_dtmf/2]).
 -export([name/1, name/2, set_name/2]).
@@ -36,6 +37,18 @@ confirm_match(Doc, Default) ->
 -spec set_confirm_match(doc(), boolean()) -> doc().
 set_confirm_match(Doc, ConfirmMatch) ->
     kz_json:set_value([<<"confirm_match">>], ConfirmMatch, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec max_dtmf(doc()) -> integer().
 max_dtmf(Doc) ->

--- a/core/kazoo_documents/src/kzd_faxbox.erl
+++ b/core/kazoo_documents/src/kzd_faxbox.erl
@@ -13,6 +13,7 @@
 -export([fax_header/1, fax_header/2, set_fax_header/2]).
 -export([fax_identity/1, fax_identity/2, set_fax_identity/2]).
 -export([fax_timezone/1, fax_timezone/2, set_fax_timezone/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([media/1, media/2, set_media/2]).
 -export([media_fax_option/1, media_fax_option/2, set_media_fax_option/2]).
 -export([name/1, name/2, set_name/2]).
@@ -133,6 +134,18 @@ fax_timezone(Doc, Default) ->
 -spec set_fax_timezone(doc(), binary()) -> doc().
 set_fax_timezone(Doc, FaxTimezone) ->
     kz_json:set_value([<<"fax_timezone">>], FaxTimezone, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec media(doc()) -> kz_json:object().
 media(Doc) ->

--- a/core/kazoo_documents/src/kzd_groups.erl
+++ b/core/kazoo_documents/src/kzd_groups.erl
@@ -8,6 +8,7 @@
 
 -export([new/0]).
 -export([endpoints/1, endpoints/2, set_endpoints/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([music_on_hold/1, music_on_hold/2, set_music_on_hold/2]).
 -export([music_on_hold_media_id/1, music_on_hold_media_id/2, set_music_on_hold_media_id/2]).
 -export([name/1, name/2, set_name/2]).
@@ -35,6 +36,18 @@ endpoints(Doc, Default) ->
 -spec set_endpoints(doc(), kz_json:object()) -> doc().
 set_endpoints(Doc, Endpoints) ->
     kz_json:set_value([<<"endpoints">>], Endpoints, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec music_on_hold(doc()) -> kz_json:object().
 music_on_hold(Doc) ->

--- a/core/kazoo_documents/src/kzd_menus.erl
+++ b/core/kazoo_documents/src/kzd_menus.erl
@@ -7,6 +7,7 @@
 
 -export([new/0]).
 -export([allow_record_from_offnet/1, allow_record_from_offnet/2, set_allow_record_from_offnet/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([hunt/1, hunt/2, set_hunt/2]).
 -export([hunt_allow/1, hunt_allow/2, set_hunt_allow/2]).
 -export([hunt_deny/1, hunt_deny/2, set_hunt_deny/2]).
@@ -45,6 +46,18 @@ allow_record_from_offnet(Doc, Default) ->
 -spec set_allow_record_from_offnet(doc(), boolean()) -> doc().
 set_allow_record_from_offnet(Doc, AllowRecordFromOffnet) ->
     kz_json:set_value([<<"allow_record_from_offnet">>], AllowRecordFromOffnet, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec hunt(doc()) -> boolean().
 hunt(Doc) ->

--- a/core/kazoo_documents/src/kzd_temporal_rules.erl
+++ b/core/kazoo_documents/src/kzd_temporal_rules.erl
@@ -9,6 +9,7 @@
 -export([cycle/1, cycle/2, set_cycle/2]).
 -export([days/1, days/2, set_days/2]).
 -export([enabled/1, enabled/2, set_enabled/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([interval/1, interval/2, set_interval/2]).
 -export([month/1, month/2, set_month/2]).
 -export([name/1, name/2, set_name/2]).
@@ -71,6 +72,18 @@ set_enabled(Doc, Enabled) ->
 -spec delete_enabled(doc()) -> doc().
 delete_enabled(Doc) ->
     kz_json:delete_key([<<"enabled">>], Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec interval(doc()) -> integer().
 interval(Doc) ->

--- a/core/kazoo_documents/src/kzd_temporal_rules_sets.erl
+++ b/core/kazoo_documents/src/kzd_temporal_rules_sets.erl
@@ -6,6 +6,7 @@
 -module(kzd_temporal_rules_sets).
 
 -export([new/0]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([name/1, name/2, set_name/2]).
 -export([temporal_rules/1, temporal_rules/2, set_temporal_rules/2]).
 
@@ -20,6 +21,18 @@
 -spec new() -> doc().
 new() ->
     kz_json_schema:default_object(?SCHEMA).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec name(doc()) -> kz_term:api_ne_binary().
 name(Doc) ->

--- a/core/kazoo_documents/src/kzd_users.erl
+++ b/core/kazoo_documents/src/kzd_users.erl
@@ -29,6 +29,7 @@
 -export([enabled/1, enabled/2, set_enabled/2]).
 -export([feature_level/1, feature_level/2, set_feature_level/2]).
 -export([first_name/1, first_name/2, set_first_name/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([formatters/1, formatters/2, set_formatters/2]).
 -export([hotdesk/1, hotdesk/2, set_hotdesk/2]).
 -export([hotdesk_enabled/1, hotdesk_enabled/2, set_hotdesk_enabled/2]).
@@ -360,6 +361,18 @@ first_name(Doc, Default) ->
 -spec set_first_name(doc(), kz_term:ne_binary()) -> doc().
 set_first_name(Doc, FirstName) ->
     kz_json:set_value([<<"first_name">>], FirstName, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec formatters(doc()) -> kz_term:api_object().
 formatters(Doc) ->

--- a/core/kazoo_documents/src/kzd_vmboxes.erl
+++ b/core/kazoo_documents/src/kzd_vmboxes.erl
@@ -8,6 +8,7 @@
 -export([new/0]).
 -export([check_if_owner/1, check_if_owner/2, set_check_if_owner/2]).
 -export([delete_after_notify/1, delete_after_notify/2, set_delete_after_notify/2]).
+-export([flags/1, flags/2, set_flags/2]).
 -export([is_setup/1, is_setup/2, set_is_setup/2]).
 -export([mailbox/1, mailbox/2, set_mailbox/2]).
 -export([media/1, media/2, set_media/2]).
@@ -63,6 +64,18 @@ delete_after_notify(Doc, Default) ->
 -spec set_delete_after_notify(doc(), boolean()) -> doc().
 set_delete_after_notify(Doc, DeleteAfterNotify) ->
     kz_json:set_value([<<"delete_after_notify">>], DeleteAfterNotify, Doc).
+
+-spec flags(doc()) -> kz_term:api_ne_binaries().
+flags(Doc) ->
+    flags(Doc, 'undefined').
+
+-spec flags(doc(), Default) -> kz_term:ne_binaries() | Default.
+flags(Doc, Default) ->
+    kz_json:get_list_value([<<"flags">>], Doc, Default).
+
+-spec set_flags(doc(), kz_term:ne_binaries()) -> doc().
+set_flags(Doc, Flags) ->
+    kz_json:set_value([<<"flags">>], Flags, Doc).
 
 -spec is_setup(doc()) -> boolean().
 is_setup(Doc) ->


### PR DESCRIPTION
The local branch I have which I used to open the previous PR adding the flags list to the views has some differences with what was actually merged, not sure how that happened yet.  However, here are the missing changes (minus the devices.json update that Luis already issued).

I will also double check the master updates to see if it had a similar issue.