### PR TITLE
FORUM-10598: testing of the media api

### DIFF
--- a/applications/crossbar/doc/media.md
+++ b/applications/crossbar/doc/media.md
@@ -87,7 +87,7 @@ Key | Description | Type | Default | Required | Support Level
 `language` | The language of the media file or text | `string()` | `en-us` | `false` | `supported`
 `media_source` | Defines the source of the media | `string('recording' | 'upload' | 'tts')` | `upload` | `true` | `supported`
 `name` | A friendly name for the media | `string(1..128)` |   | `true` | `supported`
-`prompt_id` | The prompt this media file represents | `string()` |   | `false` |
+`prompt_id` | The prompt this media file represents | `string()` |   | `false` |  
 `source_id` | If the media was generated from a callflow module, this is ID of the properties | `string(32)` |   | `false` | `beta`
 `source_type` | If the media was generated from a callflow module, this is the module name | `string()` |   | `false` | `beta`
 `streamable` | Determines if the media can be streamed | `boolean()` | `true` | `false` | `supported`

--- a/applications/crossbar/doc/media.md
+++ b/applications/crossbar/doc/media.md
@@ -87,7 +87,7 @@ Key | Description | Type | Default | Required | Support Level
 `language` | The language of the media file or text | `string()` | `en-us` | `false` | `supported`
 `media_source` | Defines the source of the media | `string('recording' | 'upload' | 'tts')` | `upload` | `true` | `supported`
 `name` | A friendly name for the media | `string(1..128)` |   | `true` | `supported`
-`prompt_id` | The prompt this media file represents | `string()` |   | `false` |  
+`prompt_id` | The prompt this media file represents | `string()` |   | `false` |
 `source_id` | If the media was generated from a callflow module, this is ID of the properties | `string(32)` |   | `false` | `beta`
 `source_type` | If the media was generated from a callflow module, this is the module name | `string()` |   | `false` | `beta`
 `streamable` | Determines if the media can be streamed | `boolean()` | `true` | `false` | `supported`
@@ -112,7 +112,7 @@ curl -v -X GET \
     "auth_token": "{AUTH_TOKEN}",
     "data": [
         {
-            "id": "0c347bba3754056caad610bb8a337342",
+            "id": "{MEDIA_ID}",
             "is_prompt": false,
             "language": "en-us",
             "media_source": "tts",
@@ -215,7 +215,7 @@ curl -v -X DELETE \
 ```shell
 curl -v -X GET \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/media/0c347bba3754056caad610bb8a337342
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}
 ```
 
 ```json
@@ -223,7 +223,7 @@ curl -v -X GET \
     "auth_token": "{AUTH_TOKEN}",
     "data": {
         "description": "tts file",
-        "id": "0c347bba3754056caad610bb8a337342",
+        "id": "{MEDIA_ID}",
         "language": "en-us",
         "media_source": "tts",
         "name": "Main AA BG",
@@ -331,38 +331,64 @@ curl -v -X GET \
 
 ## Get the raw media file
 
-> GET /v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/raw
+Streams back an the uploaded media.
+
+> GET /v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/
 
 ```shell
 curl -v -X GET \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     -H 'Accept: audio/mp3' \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/raw
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/
 ```
 
-Streams back an MP3-encoded media.
+!!! note
+    There is a deprecated but maintained URL, `GET /v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/raw`, as well.
 
 ## Add the media binary file to the media meta data
 
-> POST /v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/raw
+> POST /v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/
 
 ```shell
 curl -v -X POST \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     -H 'Content-Type: audio/mp3' \
     --data-binary @/path/to/file.mp3 \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/raw
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/
+```
+```json
+{
+  "auth_token": "{AUTH_TOKEN}",
+  "data": {
+    "id": "{MEDIA_ID}",
+    "language": "{LANG}",
+    "media_source": "upload",
+    "name": "{FRIENDLY_NAME}",
+    "streamable": true,
+    "tts": {
+      "voice": "female/en-US"
+    }
+  },
+  "node": "{NODENAME}",
+  "request_id": "{REQUEST_ID}",
+  "revision": "{REVISION}",
+  "status": "success",
+  "timestamp": "{TIMESTAMP}"
+}
 ```
 
 ```shell
 curl -v -X POST \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    -H 'Content-Type: audio/x-wav \
+    -H 'Content-Type: audio/x-wav' \
     --data-binary @/path/to/file.wav \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/raw
 ```
 
 Only one of the above; any subsequent POSTs will overwrite the existing binary data.
+
+!!! note
+    There is a deprecated but maintained URL, `GET /v2/accounts/{ACCOUNT_ID}/media/{MEDIA_ID}/raw`, as well.
 
 ## List all translations of a given prompt
 

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -533,9 +533,13 @@ load_attachment(<<_/binary>>=DocId, AName, Options, Context) ->
             Context1 = load(DocId, Context, Options),
             'success' = cb_context:resp_status(Context1),
 
+            CT = kz_doc:attachment_content_type(cb_context:doc(Context1), AName, <<"application/octet-stream">>),
+            lager:debug("adding content type ~s from attachment ~s", [CT, AName]),
+
             cb_context:setters(Context1
                               ,[{fun cb_context:set_resp_data/2, AttachBin}
                                ,{fun cb_context:set_resp_etag/2, rev_to_etag(cb_context:doc(Context1))}
+                               ,{fun cb_context:add_resp_headers/2, #{<<"content-type">> => CT}}
                                ])
     end;
 load_attachment(Doc, AName, Options, Context) ->
@@ -713,13 +717,7 @@ save_attachment(DocId, Name, Contents, Context, Options) ->
     end.
 
 handle_saved_attachment(Context, DocId) ->
-    {'ok', Rev1} = kz_datamgr:lookup_doc_rev(cb_context:account_db(Context), DocId),
-    cb_context:setters(Context
-                      ,[{fun cb_context:set_doc/2, kz_json:new()}
-                       ,{fun cb_context:set_resp_status/2, 'success'}
-                       ,{fun cb_context:set_resp_data/2, kz_json:new()}
-                       ,{fun cb_context:set_resp_etag/2, rev_to_etag(Rev1)}
-                       ]).
+    load(DocId, Context).
 
 -spec maybe_delete_doc(cb_context:context(), kz_term:ne_binary()) ->
                               {'ok', _} |

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -176,7 +176,7 @@ maybe_open_cache_docs(DbName, DocIds, Options) ->
 %%------------------------------------------------------------------------------
 -spec check_document_type(cb_context:context(), kz_json:object() | kz_json:objects(), kz_term:proplist()) ->
                                  boolean().
-check_document_type(_Context, [], _Options) -> true;
+check_document_type(_Context, [], _Options) -> 'true';
 check_document_type(Context, [_|_]=JObjs, Options) ->
     F = fun(JObj) -> check_document_type(Context, JObj, Options) end,
     lists:all(F, JObjs);
@@ -192,6 +192,7 @@ document_type_match('undefined', _ExpectedType, _ReqType) ->
     lager:debug("document doesn't have type, requested type is ~p", [_ReqType]),
     'true';
 document_type_match(_JObjType, <<"any">>, _) -> 'true';
+document_type_match(_JObjType, 'undefined', _) -> 'true';
 document_type_match(ExpectedType, ExpectedTypes, _)
   when is_list(ExpectedTypes) ->
     lists:member(ExpectedType, ExpectedTypes);

--- a/applications/crossbar/src/modules/cb_media.erl
+++ b/applications/crossbar/src/modules/cb_media.erl
@@ -415,7 +415,7 @@ post_media_doc(Context, MediaId, _AccountId) ->
 -spec post_media_doc_or_binary(cb_context:context(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> cb_context:context().
 post_media_doc_or_binary(Context, MediaId, ContentType) ->
     case api_util:content_type_matches(ContentType, acceptable_content_types()) of
-        'false' -> cb_context:save(Context);
+        'false' -> crossbar_doc:save(Context);
         'true' -> post(Context, MediaId, ?BIN_DATA)
     end.
 

--- a/applications/crossbar/src/modules/cb_media.erl
+++ b/applications/crossbar/src/modules/cb_media.erl
@@ -14,10 +14,9 @@
         ,resource_exists/0, resource_exists/1, resource_exists/2
         ,authorize/1
         ,validate/1, validate/2, validate/3
-        ,content_types_provided/3
-        ,content_types_accepted/3
+        ,content_types_provided/2, content_types_provided/3
+        ,content_types_accepted/2, content_types_accepted/3
         ,languages_provided/1, languages_provided/2, languages_provided/3
-        ,get/3
         ,put/1
         ,post/2, post/3
         ,delete/2, delete/3
@@ -71,7 +70,6 @@ init() ->
     _ = crossbar_bindings:bind(<<"*.resource_exists.media">>, ?MODULE, 'resource_exists'),
     _ = crossbar_bindings:bind(<<"*.languages_provided.media">>, ?MODULE, 'languages_provided'),
     _ = crossbar_bindings:bind(<<"*.validate.media">>, ?MODULE, 'validate'),
-    _ = crossbar_bindings:bind(<<"*.execute.get.media">>, ?MODULE, 'get'),
     _ = crossbar_bindings:bind(<<"*.execute.put.media">>, ?MODULE, 'put'),
     _ = crossbar_bindings:bind(<<"*.execute.post.media">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"*.execute.delete.media">>, ?MODULE, 'delete'),
@@ -167,6 +165,19 @@ authorize_media(_Context, _Nouns, _AccountId) ->
 acceptable_content_types() ->
     ?MEDIA_MIME_TYPES.
 
+-spec content_types_provided(cb_context:context(), path_token()) ->
+                                    cb_context:context().
+content_types_provided(Context, MediaId) ->
+    Verb = cb_context:req_verb(Context),
+    ContentType = cb_context:req_header(Context, <<"accept">>),
+    case ?HTTP_GET =:= Verb
+        andalso api_util:content_type_matches(ContentType, acceptable_content_types())
+    of
+        'false' -> Context;
+        'true' ->
+            content_types_provided_for_media(Context, MediaId, ?BIN_DATA, ?HTTP_GET)
+    end.
+
 -spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
                                     cb_context:context().
 content_types_provided(Context, MediaId, ?BIN_DATA) ->
@@ -191,6 +202,19 @@ content_types_provided_for_media(Context, MediaId, ?BIN_DATA, ?HTTP_GET) ->
 content_types_provided_for_media(Context, _MediaId, ?BIN_DATA, _Verb) ->
     Context.
 
+-spec content_types_accepted(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
+content_types_accepted(Context, _MediaId) ->
+    Verb = cb_context:req_verb(Context),
+    ContentType = cb_context:req_header(Context, <<"content-type">>),
+    case ?HTTP_POST =:= Verb
+        andalso api_util:content_type_matches(ContentType, acceptable_content_types())
+    of
+        'false' -> Context;
+        'true' ->
+            CTA = [{'from_binary', acceptable_content_types()}],
+            cb_context:set_content_types_accepted(Context, CTA)
+    end.
+
 -spec content_types_accepted(cb_context:context(), path_token(), path_token()) ->
                                     cb_context:context().
 content_types_accepted(Context, _MediaId, ?BIN_DATA) ->
@@ -199,7 +223,7 @@ content_types_accepted(Context, _MediaId, ?BIN_DATA) ->
 -spec content_types_accepted_for_upload(cb_context:context(), http_method()) ->
                                                cb_context:context().
 content_types_accepted_for_upload(Context, ?HTTP_POST) ->
-    CTA = [{'from_binary', ?MEDIA_MIME_TYPES}],
+    CTA = [{'from_binary', acceptable_content_types()}],
     cb_context:set_content_types_accepted(Context, CTA);
 content_types_accepted_for_upload(Context, _Verb) ->
     Context.
@@ -260,11 +284,25 @@ validate_media_docs(Context, ?HTTP_PUT) ->
 
 -spec validate_media_doc(cb_context:context(), kz_term:ne_binary(), http_method()) -> cb_context:context().
 validate_media_doc(Context, MediaId, ?HTTP_GET) ->
-    load_media_meta(Context, MediaId);
+    case api_util:content_type_matches(cb_context:req_header(Context, <<"accept">>)
+                                      ,acceptable_content_types()
+                                      )
+    of
+        'false' -> load_media_meta(Context, MediaId);
+        'true' -> validate_media_binary(Context, MediaId, ?HTTP_GET, [])
+    end;
 validate_media_doc(Context, MediaId, ?HTTP_POST) ->
-    validate_request(MediaId, Context);
+    validate_media_doc_update(Context, MediaId, cb_context:req_header(Context, <<"content-type">>));
 validate_media_doc(Context, MediaId, ?HTTP_DELETE) ->
     load_media_meta(Context, MediaId).
+
+-spec validate_media_doc_update(cb_context:context(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> cb_context:context().
+validate_media_doc_update(Context, MediaId, ContentType) ->
+    lager:debug("trying to update doc with content ~s", [ContentType]),
+    case api_util:content_type_matches(ContentType, acceptable_content_types()) of
+        'false' -> validate_request(MediaId, Context);
+        'true' -> validate_media_binary(Context, MediaId, ?HTTP_POST, cb_context:req_files(Context))
+    end.
 
 -spec validate_media_binary(cb_context:context(), kz_term:ne_binary(), http_method(), kz_term:proplist()) -> cb_context:context().
 validate_media_binary(Context, MediaId, ?HTTP_GET, _Files) ->
@@ -348,11 +386,6 @@ validate_upload(Context, MediaId, FileJObj) ->
                                             )
                     ).
 
--spec get(cb_context:context(), path_token(), path_token()) -> cb_context:context().
-get(Context, _MediaId, ?BIN_DATA) ->
-    CT = kz_json:get_value(<<"content-type">>, cb_context:doc(Context), <<"application/octet-stream">>),
-    cb_context:add_resp_headers(Context, #{<<"content-type">> => CT}).
-
 -spec put(cb_context:context()) -> cb_context:context().
 put(Context) ->
     put_media(Context, cb_context:account_id(Context)).
@@ -373,10 +406,17 @@ post(Context, MediaId) ->
 -spec post_media_doc(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 post_media_doc(Context, MediaId, 'undefined') ->
     post_media_doc(cb_context:set_account_db(Context, ?KZ_MEDIA_DB), MediaId, <<"ignore">>);
-post_media_doc(Context, _MediaId, _AccountId) ->
+post_media_doc(Context, MediaId, _AccountId) ->
     case is_tts(cb_context:doc(Context)) of
         'true' -> create_update_tts(Context, <<"update">>);
-        'false' -> crossbar_doc:save(remove_tts_keys(Context))
+        'false' -> post_media_doc_or_binary(remove_tts_keys(Context), MediaId, cb_context:req_header(Context, <<"content-type">>))
+    end.
+
+-spec post_media_doc_or_binary(cb_context:context(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> cb_context:context().
+post_media_doc_or_binary(Context, MediaId, ContentType) ->
+    case api_util:content_type_matches(ContentType, acceptable_content_types()) of
+        'false' -> cb_context:save(Context);
+        'true' -> post(Context, MediaId, ?BIN_DATA)
     end.
 
 -spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().

--- a/core/kazoo_proper/src/kazoo_proper.hrl
+++ b/core/kazoo_proper/src/kazoo_proper.hrl
@@ -36,8 +36,9 @@
 -type expected_headers() :: [expected_header()].
 
 -type response_code() :: 200..600.
--type response_headers() :: [{string(), string()}].
--type request_headers() :: [{string(), string()}].
+-type response_headers() :: kz_http:headers().
+
+-type request_headers() :: [{kz_term:ne_binary(), string()}].
 
 -record(expectation, {response_codes = [] :: expected_codes()
                      ,response_headers = [] :: expected_headers()

--- a/core/kazoo_proper/src/kazoo_proper.hrl
+++ b/core/kazoo_proper/src/kazoo_proper.hrl
@@ -2,6 +2,9 @@
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
 -include_lib("kazoo_stdlib/include/kz_databases.hrl").
 
+-define(APP_NAME, <<"kazoo_proper">>).
+-define(APP_VERSION, <<"5.0">>).
+
 -define(FAILED_RESPONSE, <<"{}">>).
 
 -define(DEBUG(Fmt)

--- a/core/kazoo_proper/src/pqc_cb_api.erl
+++ b/core/kazoo_proper/src/pqc_cb_api.erl
@@ -153,14 +153,14 @@ auth_account_id(#{'account_id' := AccountId}) -> AccountId.
 request_headers(API) ->
     request_headers(API, []).
 
--spec request_headers(state(), kz_http:headers()) -> kz_http:headers().
+-spec request_headers(state(), request_headers()) -> kz_http:headers().
 request_headers(#{'auth_token' := AuthToken
                  ,'request_id' := RequestId
                  }
                ,RequestHeaders
                ) ->
     lager:md([{'request_id', RequestId}]),
-    Defaults = [{"x-auth-token", kz_term:to_list(AuthToken)}
+    Defaults = [{<<"x-auth-token">>, kz_term:to_list(AuthToken)}
                 | default_request_headers(RequestId)
                ],
     [{kz_term:to_list(K), V}
@@ -168,28 +168,28 @@ request_headers(#{'auth_token' := AuthToken
     ].
 
 %% Need binary keys to avoid props assuming "foo" is [102, 111, 111] as a nested key
--spec default_request_headers() -> kz_http:headers().
+-spec default_request_headers() -> request_headers().
 default_request_headers() ->
     [{<<"content-type">>, "application/json"}
     ,{<<"accept">>, "application/json"}
     ].
 
--spec default_request_headers(kz_term:ne_binary()) -> kz_http:headers().
+-spec default_request_headers(kz_term:ne_binary()) -> request_headers().
 default_request_headers(RequestId) ->
     NowMS = kz_time:now_ms(),
     APIRequestID = kz_term:to_list(RequestId) ++ "-" ++ integer_to_list(NowMS),
     lager:debug("request id ~s", [APIRequestID]),
-    [{"x-request-id", APIRequestID}
+    [{<<"x-request-id">>, APIRequestID}
      | default_request_headers()
     ].
 
--spec make_request(expectations(), fun_2(), string(), kz_http:headers()) ->
+-spec make_request(expectations(), fun_2(), string(), request_headers()) ->
                           response().
 make_request(Expectations, HTTP, URL, RequestHeaders) ->
     ?INFO("~p(~s, ~p)", [HTTP, URL, RequestHeaders]),
     handle_response(Expectations, HTTP(URL, RequestHeaders)).
 
--spec make_request(expectations(), fun_3(), string(), kz_http:headers(), iodata()) ->
+-spec make_request(expectations(), fun_3(), string(), request_headers(), iodata()) ->
                           response().
 make_request(Expectations, HTTP, URL, RequestHeaders, RequestBody) ->
     ?INFO("~p: ~s", [HTTP, URL]),

--- a/core/kazoo_proper/src/pqc_cb_api.erl
+++ b/core/kazoo_proper/src/pqc_cb_api.erl
@@ -170,8 +170,8 @@ request_headers(#{'auth_token' := AuthToken
 %% Need binary keys to avoid props assuming "foo" is [102, 111, 111] as a nested key
 -spec default_request_headers() -> kz_http:headers().
 default_request_headers() ->
-    [{"content-type", "application/json"}
-    ,{"accept", "application/json"}
+    [{<<"content-type">>, "application/json"}
+    ,{<<"accept">>, "application/json"}
     ].
 
 -spec default_request_headers(kz_term:ne_binary()) -> kz_http:headers().

--- a/core/kazoo_proper/src/pqc_cb_media.erl
+++ b/core/kazoo_proper/src/pqc_cb_media.erl
@@ -1,0 +1,275 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_media).
+
+%% API requests
+-export([summary/2
+        ,create/3
+        ,fetch/3, fetch/4
+        ,fetch_binary/3
+        ,update/3, update/4
+        ,update_binary/4
+        ,patch/4
+        ,delete/3
+        ]).
+
+-export([seq/0
+        ,cleanup/0
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
+
+-spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+summary(API, AccountId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,media_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec create(pqc_cb_api:state(), kz_term:ne_binary(), kzd_media:doc()) -> pqc_cb_api:response().
+create(API, AccountId, MediaJObj) ->
+    URL = media_url(AccountId),
+
+    Expectations = [#expectation{response_codes = [201]
+                                ,response_headers = [{"content-type", "application/json"}
+                                                    ,{"location", {'match', expected_location_value(URL)}}
+                                                    ]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(MediaJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:put/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch(API, AccountId, MediaId) ->
+    fetch(API, AccountId, MediaId, <<"application/json">>).
+
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch(API, AccountId, MediaId, AcceptType) ->
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", kz_term:to_list(AcceptType)}]
+                                }],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,media_url(AccountId, MediaId)
+                           ,pqc_cb_api:request_headers(API, [{<<"accept">>, kz_term:to_list(AcceptType)}])
+                           ).
+
+-spec fetch_binary(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch_binary(API, AccountId, MediaId) ->
+    AcceptType = "audio/mp3",
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", AcceptType}]
+                                }],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,media_bin_url(AccountId, MediaId)
+                           ,pqc_cb_api:request_headers(API, [{<<"accept">>, AcceptType}])
+                           ).
+
+-spec update(pqc_cb_api:state(), kz_term:ne_binary(), kzd_media:doc()) -> pqc_cb_api:response().
+update(API, AccountId, MediaJObj) ->
+    URL = media_url(AccountId, kz_doc:id(MediaJObj)),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(MediaJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec update(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), iodata()) -> pqc_cb_api:response().
+update(API, AccountId, MediaId, Data) ->
+    URL = media_url(AccountId, MediaId),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API, [{<<"content-type">>, "audio/mp3"}])
+                           ,Data
+                           ).
+
+-spec update_binary(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), iodata()) -> pqc_cb_api:response().
+update_binary(API, AccountId, MediaId, Data) ->
+    URL = media_bin_url(AccountId, MediaId),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API, [{<<"content-type">>, "audio/mp3"}])
+                           ,Data
+                           ).
+
+-spec patch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
+patch(API, AccountId, MediaId, PatchJObj) ->
+    URL = media_url(AccountId, MediaId),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(PatchJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:patch/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec delete(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+delete(API, AccountId, MediaId) ->
+    URL = media_url(AccountId, MediaId),
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:delete/2
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec media_url(kz_term:ne_binary()) -> string().
+media_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "media"], "/").
+
+-spec media_bin_url(kz_term:ne_binary(), kz_term:ne_binaryy()) -> string().
+media_bin_url(AccountId, MediaId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "media", kz_term:to_list(MediaId), "raw"], "/").
+
+-spec media_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
+media_url(AccountId, MediaId) ->
+    string:join([media_url(AccountId), kz_term:to_list(MediaId)], "/").
+
+
+-spec seq() -> 'ok'.
+seq() ->
+    Fs = [fun seq_media_file/0],
+    run_funs(Fs).
+
+run_funs([]) -> 'ok';
+run_funs([F|Fs]) ->
+    F(),
+    cleanup(),
+    run_funs(Fs).
+
+seq_media_file() ->
+    API = pqc_cb_api:init_api(['crossbar', 'media_mgr'], ['cb_media']),
+    AccountId = create_account(API),
+
+    EmptySummaryResp = summary(API, AccountId),
+    lager:info("empty summary resp: ~s", [EmptySummaryResp]),
+    [] = kz_json:get_list_value([<<"data">>], kz_json:decode(EmptySummaryResp)),
+
+    CreateMetaResp = create(API, AccountId, new_media_doc()),
+    lager:info("created media meta: ~s", [CreateMetaResp]),
+    CreatedMeta = kz_json:get_json_value([<<"data">>], kz_json:decode(CreateMetaResp)),
+    MediaId = kz_doc:id(CreatedMeta),
+
+    SummaryResp = summary(API, AccountId),
+    lager:info("summary resp: ~s", [SummaryResp]),
+    [MediaSummary] = kz_json:get_list_value([<<"data">>], kz_json:decode(SummaryResp)),
+    'true' = kz_doc:id(CreatedMeta) =:= kz_doc:id(MediaSummary),
+
+    {'ok', MP3} = file:read_file(filename:join([code:priv_dir('kazoo_proper'), "mp3.mp3"])),
+
+    UploadResp = update_binary(API, AccountId, MediaId, MP3),
+    lager:info("upload resp: ~s", [UploadResp]),
+    UploadedMediaMeta = kz_json:get_json_value([<<"data">>], kz_json:decode(UploadResp)),
+    MediaId = kz_doc:id(UploadedMediaMeta),
+
+    UpdateResp = update(API, AccountId, MediaId, MP3),
+    lager:info("update resp: ~s", [UploadResp]),
+    UpdatedMediaMeta = kz_json:get_json_value([<<"data">>], kz_json:decode(UpdateResp)),
+    MediaId = kz_doc:id(UpdatedMediaMeta),
+
+    FetchedMedia = fetch_binary(API, AccountId, MediaId),
+    lager:info("fetched binary: ~p", [FetchedMedia]),
+    MP3 = FetchedMedia,
+
+    FetchedMediaAgain = fetch(API, AccountId, MediaId, <<"audio/mp3">>),
+    lager:info("fetched binary again: ~p", [FetchedMediaAgain]),
+    MP3 = FetchedMediaAgain,
+
+    MediaName = <<"/", AccountId/binary, "/", MediaId/binary>>,
+    {'ok', [AMQPResp|_]} = pqc_media_mgr:request_media_url(MediaName, <<"new">>),
+    lager:info("fetched URL for ~s: ~p", [MediaName, AMQPResp]),
+    StreamURL = kz_json:get_ne_binary_value(<<"Stream-URL">>, AMQPResp),
+    lager:info("streaming from ~s", [StreamURL]),
+    {'ok', 200, _, FetchedMP3} = kz_http:get(kz_term:to_list(StreamURL)),
+    lager:info("streamed: ~p", [FetchedMP3]),
+    MP3 = FetchedMP3,
+
+    DeleteResp = delete(API, AccountId, MediaId),
+    lager:info("delete resp: ~s", [DeleteResp]),
+
+    EmptySummaryAgain = summary(API, AccountId),
+    lager:info("empty summary again: ~s", [EmptySummaryAgain]),
+    [] = kz_json:get_list_value([<<"data">>], kz_json:decode(EmptySummaryAgain)),
+
+    cleanup(API),
+    lager:info("FINISHED MEDIA SEQ").
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
+    cleanup_system().
+
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _ = pqc_cb_api:cleanup(API),
+    cleanup_system().
+
+cleanup_system() -> 'ok'.
+
+-spec create_account(pqc_cb_api:state()) -> kz_term:ne_binary().
+create_account(API) ->
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    lager:info("created account: ~s", [AccountResp]),
+
+    kz_json:get_ne_binary_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
+
+%% take http://whatever:port/v2/... and get /v2/.../{regex}
+expected_location_value(URL) ->
+    expected_location_value(URL, "(\\w{32})").
+
+expected_location_value(URL, Id) ->
+    {'match', [_Host, Path]} = re:run(URL, "^(.+)(/v2/.+$)", [{'capture','all_but_first', 'list'}]),
+    Path ++ [$/ | kz_term:to_list(Id)].
+
+new_media_doc() ->
+    Set = [{fun kzd_media:set_name/2, kz_binary:rand_hex(6)}],
+    kz_doc:public_fields(kz_json:exec_first(Set, kzd_media:new())).

--- a/core/kazoo_proper/src/pqc_cb_media.erl
+++ b/core/kazoo_proper/src/pqc_cb_media.erl
@@ -181,7 +181,7 @@ seq() ->
 
 run_funs([]) -> 'ok';
 run_funs([F|Fs]) ->
-    F(),
+    _ = F(),
     cleanup(),
     run_funs(Fs).
 

--- a/core/kazoo_proper/src/pqc_cb_media.erl
+++ b/core/kazoo_proper/src/pqc_cb_media.erl
@@ -223,7 +223,9 @@ seq_media_file() ->
     lager:info("fetched binary again: ~p", [FetchedMediaAgain]),
     MP3 = FetchedMediaAgain,
 
-    MediaName = <<"/", AccountId/binary, "/", MediaId/binary>>,
+    MediaName = kz_media_util:media_path(<<"/", AccountId/binary, "/", MediaId/binary>>, kz_binary:rand_hex(16)),
+
+    lager:info("fetching URL for ~s", [MediaName]),
     {'ok', [AMQPResp|_]} = pqc_media_mgr:request_media_url(MediaName, <<"new">>),
     lager:info("fetched URL for ~s: ~p", [MediaName, AMQPResp]),
     StreamURL = kz_json:get_ne_binary_value(<<"Stream-URL">>, AMQPResp),

--- a/core/kazoo_proper/src/pqc_cb_users.erl
+++ b/core/kazoo_proper/src/pqc_cb_users.erl
@@ -21,7 +21,7 @@
 
 -include("kazoo_proper.hrl").
 
--define(ACCOUNT_NAMES, [<<"account_for_users">>]).
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
 
 -spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 summary(API, AccountId) ->

--- a/core/kazoo_proper/src/pqc_media_mgr.erl
+++ b/core/kazoo_proper/src/pqc_media_mgr.erl
@@ -1,0 +1,29 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_media_mgr).
+
+-export([request_media_url/1, request_media_url/2]).
+
+-include("kazoo_proper.hrl").
+
+-spec request_media_url(kz_term:ne_binary()) -> kz_amqp_worker:request_return().
+request_media_url(MediaName) ->
+    request_media_url(MediaName, <<"new">>).
+
+-spec request_media_url(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_amqp_worker:request_return().
+request_media_url(MediaName, Type) ->
+    MsgProps = props:filter_undefined(
+                 [{<<"Media-Name">>, MediaName}
+                 ,{<<"Stream-Type">>, Type}
+                 ,{<<"Call-ID">>, kz_binary:rand_hex(8)}
+                 ,{<<"Msg-ID">>, kz_binary:rand_hex(8)}
+                  | kz_api:default_headers(<<"media">>, <<"media_req">>, ?APP_NAME, ?APP_VERSION)
+                 ]),
+    kz_amqp_worker:call_collect(MsgProps
+                               ,fun kapi_media:publish_req/1
+                               ,{'media_mgr', fun kapi_media:resp_v/1}
+                               ).


### PR DESCRIPTION
Testing the CRUDy parts of the media API endpoint, including
uploading/fetching the media binary data.

Removes the need to use /raw to specify the binary data vs JSON
metadata.

Adds a test to query media_mgr for the streaming URL and fetching the
media via AMQP query.