### PR TITLE
[4.3] FORUM-10598: testing of the media API

### DIFF
--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -996,7 +996,9 @@ is_acceptable_content_type(CTA, CTAs) ->
     ['true' || ModCTA <- CTAs, content_type_matches(CTA, ModCTA)] =/= [].
 
 %% (ReqContentType, ModuleContentType)
--spec content_type_matches(content_type(), content_type()) -> boolean().
+-spec content_type_matches(content_type(), content_type() | [content_type()]) -> boolean().
+content_type_matches(CT, ModCTs) when is_list(ModCTs) ->
+    lists:any(fun(ModCT) -> content_type_matches(CT, ModCT) end, ModCTs);
 content_type_matches({Type, _, _}, {Type, <<"*">>, '*'}) ->
     'true';
 content_type_matches({Type, SubType, _}, {Type, SubType, '*'}) ->
@@ -1006,6 +1008,8 @@ content_type_matches({Type, SubType, Opts}, {Type, SubType, ModOpts}) ->
              ,ModOpts
              );
 content_type_matches(CTA, {CT, SubCT, _}) when is_binary(CTA) ->
+    CTA =:= <<CT/binary, "/", SubCT/binary>>;
+content_type_matches(CTA, {CT, SubCT}) when is_binary(CTA) ->
     CTA =:= <<CT/binary, "/", SubCT/binary>>;
 content_type_matches(CTA, CT) when is_binary(CTA), is_binary(CT) ->
     CTA =:= CT;

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -1009,8 +1009,6 @@ content_type_matches({Type, SubType, Opts}, {Type, SubType, ModOpts}) ->
              );
 content_type_matches(CTA, {CT, SubCT, _}) when is_binary(CTA) ->
     CTA =:= <<CT/binary, "/", SubCT/binary>>;
-content_type_matches(CTA, {CT, SubCT}) when is_binary(CTA) ->
-    CTA =:= <<CT/binary, "/", SubCT/binary>>;
 content_type_matches(CTA, CT) when is_binary(CTA), is_binary(CT) ->
     CTA =:= CT;
 content_type_matches(_CTA, _CTAs) ->

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -270,9 +270,9 @@ load_merge(DocId, DataJObj, Context, Options) ->
                         cb_context:context().
 load_merge(DocId, DataJObj, Context, Options, 'undefined') ->
     Context1 = load(DocId, Context, Options),
-    case success =:= cb_context:resp_status(Context1) of
-        false -> Context1;
-        true ->
+    case 'success' =:= cb_context:resp_status(Context1) of
+        'false' -> Context1;
+        'true' ->
             lager:debug("loaded doc ~s(~s), merging", [DocId, kz_doc:revision(cb_context:doc(Context1))]),
             Merged = kz_json:merge_jobjs(kz_doc:private_fields(cb_context:doc(Context1)), DataJObj),
             handle_datamgr_success(Merged, Context1)
@@ -533,9 +533,13 @@ load_attachment(<<_/binary>>=DocId, AName, Options, Context) ->
             Context1 = load(DocId, Context, Options),
             'success' = cb_context:resp_status(Context1),
 
+            CT = kz_doc:attachment_content_type(cb_context:doc(Context1), AName, <<"application/octet-stream">>),
+            lager:debug("adding content type ~s from attachment ~s", [CT, AName]),
+
             cb_context:setters(Context1
                               ,[{fun cb_context:set_resp_data/2, AttachBin}
                                ,{fun cb_context:set_resp_etag/2, rev_to_etag(cb_context:doc(Context1))}
+                               ,{fun cb_context:add_resp_headers/2, #{<<"content-type">> => CT}}
                                ])
     end;
 load_attachment(Doc, AName, Options, Context) ->
@@ -698,13 +702,7 @@ save_attachment(DocId, Name, Contents, Context, Options) ->
     end.
 
 handle_saved_attachment(Context, DocId) ->
-    {'ok', Rev1} = kz_datamgr:lookup_doc_rev(cb_context:account_db(Context), DocId),
-    cb_context:setters(Context
-                      ,[{fun cb_context:set_doc/2, kz_json:new()}
-                       ,{fun cb_context:set_resp_status/2, 'success'}
-                       ,{fun cb_context:set_resp_data/2, kz_json:new()}
-                       ,{fun cb_context:set_resp_etag/2, rev_to_etag(Rev1)}
-                       ]).
+    load(DocId, Context).
 
 -spec maybe_delete_doc(cb_context:context(), kz_term:ne_binary()) ->
                               {'ok', _} |

--- a/applications/crossbar/src/modules/cb_media.erl
+++ b/applications/crossbar/src/modules/cb_media.erl
@@ -14,10 +14,9 @@
         ,resource_exists/0, resource_exists/1, resource_exists/2
         ,authorize/1
         ,validate/1, validate/2, validate/3
-        ,content_types_provided/3
-        ,content_types_accepted/3
+        ,content_types_provided/2, content_types_provided/3
+        ,content_types_accepted/2, content_types_accepted/3
         ,languages_provided/1, languages_provided/2, languages_provided/3
-        ,get/3
         ,put/1
         ,post/2, post/3
         ,delete/2, delete/3
@@ -71,7 +70,6 @@ init() ->
     _ = crossbar_bindings:bind(<<"*.resource_exists.media">>, ?MODULE, 'resource_exists'),
     _ = crossbar_bindings:bind(<<"*.languages_provided.media">>, ?MODULE, 'languages_provided'),
     _ = crossbar_bindings:bind(<<"*.validate.media">>, ?MODULE, 'validate'),
-    _ = crossbar_bindings:bind(<<"*.execute.get.media">>, ?MODULE, 'get'),
     _ = crossbar_bindings:bind(<<"*.execute.put.media">>, ?MODULE, 'put'),
     _ = crossbar_bindings:bind(<<"*.execute.post.media">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"*.execute.delete.media">>, ?MODULE, 'delete'),
@@ -167,6 +165,19 @@ authorize_media(_Context, _Nouns, _AccountId) ->
 acceptable_content_types() ->
     ?MEDIA_MIME_TYPES.
 
+-spec content_types_provided(cb_context:context(), path_token()) ->
+                                    cb_context:context().
+content_types_provided(Context, MediaId) ->
+    Verb = cb_context:req_verb(Context),
+    ContentType = cb_context:req_header(Context, <<"accept">>),
+    case ?HTTP_GET =:= Verb
+        andalso api_util:content_type_matches(ContentType, acceptable_content_types())
+    of
+        'false' -> Context;
+        'true' ->
+            content_types_provided_for_media(Context, MediaId, ?BIN_DATA, ?HTTP_GET)
+    end.
+
 -spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
                                     cb_context:context().
 content_types_provided(Context, MediaId, ?BIN_DATA) ->
@@ -191,6 +202,19 @@ content_types_provided_for_media(Context, MediaId, ?BIN_DATA, ?HTTP_GET) ->
 content_types_provided_for_media(Context, _MediaId, ?BIN_DATA, _Verb) ->
     Context.
 
+-spec content_types_accepted(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
+content_types_accepted(Context, _MediaId) ->
+    Verb = cb_context:req_verb(Context),
+    ContentType = cb_context:req_header(Context, <<"content-type">>),
+    case ?HTTP_POST =:= Verb
+        andalso api_util:content_type_matches(ContentType, acceptable_content_types())
+    of
+        'false' -> Context;
+        'true' ->
+            CTA = [{'from_binary', acceptable_content_types()}],
+            cb_context:set_content_types_accepted(Context, CTA)
+    end.
+
 -spec content_types_accepted(cb_context:context(), path_token(), path_token()) ->
                                     cb_context:context().
 content_types_accepted(Context, _MediaId, ?BIN_DATA) ->
@@ -199,7 +223,7 @@ content_types_accepted(Context, _MediaId, ?BIN_DATA) ->
 -spec content_types_accepted_for_upload(cb_context:context(), http_method()) ->
                                                cb_context:context().
 content_types_accepted_for_upload(Context, ?HTTP_POST) ->
-    CTA = [{'from_binary', ?MEDIA_MIME_TYPES}],
+    CTA = [{'from_binary', acceptable_content_types()}],
     cb_context:set_content_types_accepted(Context, CTA);
 content_types_accepted_for_upload(Context, _Verb) ->
     Context.
@@ -260,11 +284,25 @@ validate_media_docs(Context, ?HTTP_PUT) ->
 
 -spec validate_media_doc(cb_context:context(), kz_term:ne_binary(), http_method()) -> cb_context:context().
 validate_media_doc(Context, MediaId, ?HTTP_GET) ->
-    load_media_meta(Context, MediaId);
+    case api_util:content_type_matches(cb_context:req_header(Context, <<"accept">>)
+                                      ,acceptable_content_types()
+                                      )
+    of
+        'false' -> load_media_meta(Context, MediaId);
+        'true' -> validate_media_binary(Context, MediaId, ?HTTP_GET, [])
+    end;
 validate_media_doc(Context, MediaId, ?HTTP_POST) ->
-    validate_request(MediaId, Context);
+    validate_media_doc_update(Context, MediaId, cb_context:req_header(Context, <<"content-type">>));
 validate_media_doc(Context, MediaId, ?HTTP_DELETE) ->
     load_media_meta(Context, MediaId).
+
+-spec validate_media_doc_update(cb_context:context(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> cb_context:context().
+validate_media_doc_update(Context, MediaId, ContentType) ->
+    lager:debug("trying to update doc with content ~s", [ContentType]),
+    case api_util:content_type_matches(ContentType, acceptable_content_types()) of
+        'false' -> validate_request(MediaId, Context);
+        'true' -> validate_media_binary(Context, MediaId, ?HTTP_POST, cb_context:req_files(Context))
+    end.
 
 -spec validate_media_binary(cb_context:context(), kz_term:ne_binary(), http_method(), kz_term:proplist()) -> cb_context:context().
 validate_media_binary(Context, MediaId, ?HTTP_GET, _Files) ->
@@ -348,11 +386,6 @@ validate_upload(Context, MediaId, FileJObj) ->
                                             )
                     ).
 
--spec get(cb_context:context(), path_token(), path_token()) -> cb_context:context().
-get(Context, _MediaId, ?BIN_DATA) ->
-    CT = kz_json:get_value(<<"content-type">>, cb_context:doc(Context), <<"application/octet-stream">>),
-    cb_context:add_resp_headers(Context, #{<<"content-type">> => CT}).
-
 -spec put(cb_context:context()) -> cb_context:context().
 put(Context) ->
     put_media(Context, cb_context:account_id(Context)).
@@ -373,10 +406,17 @@ post(Context, MediaId) ->
 -spec post_media_doc(cb_context:context(), kz_term:ne_binary(), kz_term:api_binary()) -> cb_context:context().
 post_media_doc(Context, MediaId, 'undefined') ->
     post_media_doc(cb_context:set_account_db(Context, ?KZ_MEDIA_DB), MediaId, <<"ignore">>);
-post_media_doc(Context, _MediaId, _AccountId) ->
+post_media_doc(Context, MediaId, _AccountId) ->
     case is_tts(cb_context:doc(Context)) of
         'true' -> create_update_tts(Context, <<"update">>);
-        'false' -> crossbar_doc:save(remove_tts_keys(Context))
+        'false' -> post_media_doc_or_binary(remove_tts_keys(Context), MediaId, cb_context:req_header(Context, <<"content-type">>))
+    end.
+
+-spec post_media_doc_or_binary(cb_context:context(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> cb_context:context().
+post_media_doc_or_binary(Context, MediaId, ContentType) ->
+    case api_util:content_type_matches(ContentType, acceptable_content_types()) of
+        'false' -> crossbar_doc:save(Context);
+        'true' -> post(Context, MediaId, ?BIN_DATA)
     end.
 
 -spec post(cb_context:context(), path_token(), path_token()) -> cb_context:context().
@@ -675,7 +715,7 @@ load_media_docs_by_prompt(Context, PromptId, 'undefined') ->
                             ,[{'startkey_fun', fun(Ctx) -> prompt_start_key(Ctx, PromptId) end}
                              ,{'endkey', [PromptId, kz_json:new()]}
                              ,{'reduce', 'false'}
-                             ,{'include_docs', 'false'}
+                             ,'include_docs'
                              ]
                             ,cb_context:set_account_db(Context, ?KZ_MEDIA_DB)
                             ,fun normalize_prompt_results/2
@@ -687,7 +727,7 @@ load_media_docs_by_prompt(Context, PromptId, _AccountId) ->
                             ,[{'startkey_fun', fun(Ctx) -> prompt_start_key(Ctx, PromptId) end}
                              ,{'endkey', [PromptId, kz_json:new()]}
                              ,{'reduce', 'false'}
-                             ,{'include_docs', 'false'}
+                             ,'include_docs'
                              ]
                             ,Context
                             ,fun normalize_prompt_results/2

--- a/applications/crossbar/src/modules/cb_media.erl
+++ b/applications/crossbar/src/modules/cb_media.erl
@@ -161,9 +161,9 @@ authorize_media(_Context, _Nouns, _AccountId) ->
 %% @doc Add content types accepted and provided by this module
 %% @end
 %%------------------------------------------------------------------------------
--spec acceptable_content_types() -> kz_term:proplist().
+-spec acceptable_content_types() -> [content_type()].
 acceptable_content_types() ->
-    ?MEDIA_MIME_TYPES.
+    [{M, N, '*'} || {M, N} <- ?MEDIA_MIME_TYPES].
 
 -spec content_types_provided(cb_context:context(), path_token()) ->
                                     cb_context:context().

--- a/core/kazoo_proper/src/kazoo_proper.app.src
+++ b/core/kazoo_proper/src/kazoo_proper.app.src
@@ -1,10 +1,11 @@
-{application, kazoo_proper,
- [
-  {description, "Kazoo Proper - Proper Statem and FSM testing"},
-  {vsn, "4.0.0"},
-  {modules, []},
-  {registered, []},
-  {applications, [ kernel
-                 , stdlib
-                 ]}
- ]}.
+{application,kazoo_proper,
+ [{applications,[cowboy,cowlib,crypto,eunit,goldrush,
+                 kazoo,kazoo_amqp,
+                 kazoo_csv,kazoo_data,kazoo_documents,
+                 kazoo_ledgers,kazoo_modb,
+                 kazoo_services,kazoo_stdlib,kazoo_web,kernel,
+                 lager,proper,ranch,stdlib]},
+  {description,"Kazoo Proper - Proper Statem and FSM testing"},
+  {vsn,"4.0.0"},
+  {modules,[]},
+  {registered,[]}]}.

--- a/core/kazoo_proper/src/kazoo_proper.hrl
+++ b/core/kazoo_proper/src/kazoo_proper.hrl
@@ -2,6 +2,9 @@
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
 -include_lib("kazoo_stdlib/include/kz_databases.hrl").
 
+-define(APP_NAME, <<"kazoo_proper">>).
+-define(APP_VERSION, <<"5.0">>).
+
 -define(FAILED_RESPONSE, <<"{}">>).
 
 -define(DEBUG(Fmt)
@@ -27,6 +30,22 @@
 -define(ERROR(Fmt, Args)
        ,_ = data:error(pqc_log:log_info(), Fmt, Args)
        ).
+
+-type expected_codes() :: [response_code()].
+-type expected_header() :: {string(), string() | {'match', string()}}.
+-type expected_headers() :: [expected_header()].
+
+-type response_code() :: 200..600.
+-type response_headers() :: kz_http:headers().
+
+-type request_headers() :: [{kz_term:ne_binary(), string()}].
+
+-record(expectation, {response_codes = [] :: expected_codes()
+                     ,response_headers = [] :: expected_headers()
+                     }
+       ).
+-type expectation() :: #expectation{}.
+-type expectations() :: [expectation()].
 
 -define(KAZOO_PROPER_HRL, 'true').
 -endif.

--- a/core/kazoo_proper/src/pqc_cb_accounts.erl
+++ b/core/kazoo_proper/src/pqc_cb_accounts.erl
@@ -9,6 +9,9 @@
 -export([create_account/2, create_account/3
         ,update_account/3
         ,delete_account/2
+        ,patch_account/3
+        ,fetch_account/2
+
         ,cleanup/0, cleanup_accounts/1, cleanup_accounts/2
 
         ,command/2
@@ -51,7 +54,7 @@ create_account(API, NewAccountName, AccountId) ->
     RequestData = kz_json:from_list([{<<"name">>, NewAccountName}]),
     RequestEnvelope = pqc_cb_api:create_envelope(RequestData),
 
-    Resp = pqc_cb_api:make_request([201, 500]
+    Resp = pqc_cb_api:make_request([#expectation{response_codes=[201, 500]}]
                                   ,fun kz_http:put/3
                                   ,account_url(AccountId)
                                   ,pqc_cb_api:request_headers(API)
@@ -65,7 +68,7 @@ create_account(API, NewAccountName, AccountId) ->
 update_account(API, AccountId, ReqData) ->
     RequestEnvelope = pqc_cb_api:create_envelope(ReqData),
 
-    pqc_cb_api:make_request([200]
+    pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                            ,fun kz_http:post/3
                            ,account_url(AccountId)
                            ,pqc_cb_api:request_headers(API)
@@ -79,12 +82,34 @@ allow_number_additions(AccountId) ->
                                           ),
     ?INFO("updated ~s (~s) to allow number additions", [AccountId, kz_doc:revision(_Account)]).
 
+-spec fetch_account(pqc_cb_api:statE(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch_account(API, AccountId) ->
+    pqc_cb_api:make_request([#expectation{response_codes=[200]}]
+                           ,fun kz_http:get/2
+                           ,account_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec patch_account(pqc_cb_api:state(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
+patch_account(API, AccountId, ReqJObj) ->
+    RequestEnvelope = pqc_cb_api:create_envelope(ReqJObj),
+
+    pqc_cb_api:make_request([#expectation{response_codes=[200]}]
+                           ,fun kz_http:patch/3
+                           ,account_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(RequestEnvelope)
+                           ).
+
 -spec delete_account(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 delete_account(API, AccountId) ->
-    URL = account_url(AccountId),
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    pqc_cb_api:make_request([200], fun kz_http:delete/2, URL, RequestHeaders).
+    pqc_cb_api:make_request([#expectation{response_codes=[200]}]
+                           ,fun kz_http:delete/2
+                           ,account_url(AccountId)
+                           ,RequestHeaders
+                           ).
 
 -spec cleanup_accounts(kz_term:ne_binaries()) -> 'ok'.
 cleanup_accounts(AccountNames) ->
@@ -160,7 +185,8 @@ postcondition(Model
 
 -spec seq() -> 'ok'.
 seq() ->
-    enable_and_delete_topup(),
+    _ = enable_and_delete_topup(),
+    _ = enable_and_disable_account_using_patch(),
     seq_44832().
 
 -spec seq_44832() -> 'ok'.
@@ -185,7 +211,7 @@ seq_44832() ->
                  ,lists:seq(1, 4)
                  ),
 
-    cleanup(API),
+    _ = cleanup(API),
     ?INFO("finished double-POST check").
 
 -spec enable_and_delete_topup() -> 'ok'.
@@ -214,18 +240,48 @@ enable_and_delete_topup() ->
 
     'undefined' = kz_json:get_ne_value(<<"topup">>, kz_json:decode(Resp1)),
 
-    cleanup(API),
-    ?INFO("FINISHED ENABLE AND DISABLE TOPUP CHECKS").
+    _ = cleanup(API),
+    ?INFO("FINISHED ENABLE_AND_DISABLE_TOPUP TEST").
+
+-spec enable_and_disable_account_using_patch() -> 'ok'.
+enable_and_disable_account_using_patch() ->
+    ?INFO("STARTING ENABLE_AND_DISABLE_ACCOUNT_USING_PATCH TEST"),
+    API = pqc_cb_api:init_api(['crossbar'], ['cb_accounts']),
+
+    %% Make sure everything is clean for the test.
+    _ = cleanup(API),
+
+    AccountResp = create_account(API, hd(?ACCOUNT_NAMES)),
+    ?INFO("created account: ~s", [AccountResp]),
+
+    AccountId = kz_json:get_binary_value(<<"id">>, pqc_cb_response:data(AccountResp)),
+
+    Fetched = pqc_cb_response:data(fetch_account(API, AccountId)),
+    'true' = kz_json:is_true(<<"enabled">>, Fetched, 'true'),
+
+    ?INFO("disabling account"),
+    ReqJObj = kz_json:from_list([{<<"enabled">>, 'false'}]),
+    Disabled = pqc_cb_response:data(patch_account(API, AccountId, ReqJObj)),
+    'false' = kz_json:is_true(<<"enabled">>, Disabled, 'true'),
+
+    ?INFO("enabling account"),
+    ReqJObj1 = kz_json:from_list([{<<"enabled">>, 'true'}]),
+    Enabled = pqc_cb_response:data(patch_account(API, AccountId, ReqJObj1)),
+    'true' = kz_json:is_true(<<"enabled">>, Enabled, 'true'),
+
+    _ = cleanup(API),
+    ?INFO("FINISHED ENABLE_AND_DISABLE_ACCOUNT_USING_PATCH TEST").
 
 -spec cleanup(pqc_cb_api:state()) -> any().
 cleanup(API) ->
     ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
     _ = cleanup_accounts(API, ?ACCOUNT_NAMES),
-    _ = pqc_cb_api:cleanup(API).
+    _ = pqc_cb_api:cleanup(API),
+    'ok'.
 
 -spec topup_request(pqc_cb_api:state(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
 topup_request(API, AccountId, RequestEnvelope) ->
-    pqc_cb_api:make_request([200]
+    pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                            ,fun kz_http:post/3
                            ,account_url(AccountId)
                            ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_cb_api.erl
+++ b/core/kazoo_proper/src/pqc_cb_api.erl
@@ -32,17 +32,6 @@
         ]
        ).
 
--type expected_code() :: 200..600.
--type expected_codes() :: [expected_code()].
--type expected_headers() :: [{string(), string()}].
--type expectation() :: #{'response_codes' := expected_codes()
-                        ,'response_headers' => expected_headers()
-                        }.
--type expectations() :: [expectation()].
-
--type response_code() :: 200..600.
--type response_headers() :: [{string(), string()}].
-
 -type response() :: binary() |
                     kz_http:ret() |
                     {'error', binary()}.
@@ -54,7 +43,7 @@
                   ,'account_id' => kz_term:ne_binary()
                   ,'request_id' => kz_term:ne_binary()
                   ,'trace_file' => kz_data_tracing:trace_ref()
-                  ,'start' => kz_time:now()
+                  ,'start' => kz_time:start_time()
                   }.
 
 -export_type([state/0
@@ -88,7 +77,7 @@ authenticate() ->
 
     {'ok', Trace} = start_trace(),
 
-    Resp = make_request([201]
+    Resp = make_request([#expectation{response_codes = [201]}]
                        ,fun kz_http:put/3
                        ,URL
                        ,default_request_headers(kz_util:get_callid())
@@ -107,7 +96,7 @@ authenticate(AccountName, Username, Password) ->
 
     {'ok', Trace} = start_trace(),
 
-    Resp = make_request([201]
+    Resp = make_request([#expectation{response_codes = [201]}]
                        ,fun kz_http:put/3
                        ,URL
                        ,default_request_headers(kz_util:get_callid())
@@ -151,7 +140,7 @@ create_api_state(<<_/binary>> = RespJSON, Trace) ->
      ,'account_id' => kz_json:get_ne_binary_value([<<"data">>, <<"account_id">>], RespEnvelope)
      ,'request_id' => kz_util:get_callid()
      ,'trace_file' => Trace
-     ,'start' => get('now')
+     ,'start' => get('start_time')
      }.
 
 -spec v2_base_url() -> string().
@@ -160,30 +149,32 @@ v2_base_url() -> api_base().
 -spec auth_account_id(state()) -> kz_term:ne_binary().
 auth_account_id(#{'account_id' := AccountId}) -> AccountId.
 
--spec request_headers(state()) -> kz_term:proplist().
+-spec request_headers(state()) -> kz_http:headers().
 request_headers(API) ->
     request_headers(API, []).
 
--spec request_headers(state(), kz_term:proplist()) -> kz_term:proplist().
+-spec request_headers(state(), request_headers()) -> kz_http:headers().
 request_headers(#{'auth_token' := AuthToken
                  ,'request_id' := RequestId
                  }
                ,RequestHeaders
                ) ->
     lager:md([{'request_id', RequestId}]),
-    props:set_values(RequestHeaders
-                    ,[{<<"x-auth-token">>, kz_term:to_list(AuthToken)}
-                      | default_request_headers(RequestId)
-                     ]
-                    ).
-
--spec default_request_headers() -> kz_term:proplist().
-default_request_headers() ->
-    [{<<"content-type">>, <<"application/json">>}
-    ,{<<"accept">>, <<"application/json">>}
+    Defaults = [{<<"x-auth-token">>, kz_term:to_list(AuthToken)}
+                | default_request_headers(RequestId)
+               ],
+    [{kz_term:to_list(K), V}
+     || {K, V} <- props:unique([{kz_term:to_binary(K), V} || {K, V} <- RequestHeaders ++ Defaults])
     ].
 
--spec default_request_headers(kz_term:ne_binary()) -> kz_term:proplist().
+%% Need binary keys to avoid props assuming "foo" is [102, 111, 111] as a nested key
+-spec default_request_headers() -> request_headers().
+default_request_headers() ->
+    [{<<"content-type">>, "application/json"}
+    ,{<<"accept">>, "application/json"}
+    ].
+
+-spec default_request_headers(kz_term:ne_binary()) -> request_headers().
 default_request_headers(RequestId) ->
     NowMS = kz_time:now_ms(),
     APIRequestID = kz_term:to_list(RequestId) ++ "-" ++ integer_to_list(NowMS),
@@ -192,35 +183,21 @@ default_request_headers(RequestId) ->
      | default_request_headers()
     ].
 
--spec make_request(expectations() | expectation() | expected_code() | expected_codes(), fun_2(), string(), kz_term:proplist()) ->
+-spec make_request(expectations(), fun_2(), string(), request_headers()) ->
                           response().
-make_request(Code, HTTP, URL, RequestHeaders) when is_integer(Code) ->
-    make_request([#{'response_codes' => [Code]}], HTTP, URL, RequestHeaders);
-make_request([Code|_]=Codes, HTTP, URL, RequestHeaders) when is_integer(Code) ->
-    make_request([#{'response_codes' => Codes}], HTTP, URL, RequestHeaders);
-make_request(#{'response_codes' := _}=Expectation, HTTP, URL, RequestHeaders) ->
-    make_request([Expectation], HTTP, URL, RequestHeaders);
-make_request([#{}|_]=Expectations, HTTP, URL, RequestHeaders) ->
-    ?INFO("~p(~p, ~p)", [HTTP, URL, RequestHeaders]),
-
+make_request(Expectations, HTTP, URL, RequestHeaders) ->
+    ?INFO("~p(~s, ~p)", [HTTP, URL, RequestHeaders]),
     handle_response(Expectations, HTTP(URL, RequestHeaders)).
 
--spec make_request(expectations() | expectation() | expected_code() | expected_codes(), fun_3(), string(), kz_term:proplist(), iodata()) ->
+-spec make_request(expectations(), fun_3(), string(), request_headers(), iodata()) ->
                           response().
-make_request(Code, HTTP, URL, RequestHeaders, RequestBody) when is_integer(Code) ->
-    make_request([#{'response_codes' => [Code]}], HTTP, URL, RequestHeaders, RequestBody);
-make_request([Code|_]=Codes, HTTP, URL, RequestHeaders, RequestBody) when is_integer(Code) ->
-    make_request([#{'response_codes' => Codes}], HTTP, URL, RequestHeaders, RequestBody);
-make_request(#{'response_codes' := _}=Expectation, HTTP, URL, RequestHeaders, RequestBody) ->
-    make_request([Expectation], HTTP, URL, RequestHeaders, RequestBody);
-make_request([#{}|_]=Expectations, HTTP, URL, RequestHeaders, RequestBody) ->
+make_request(Expectations, HTTP, URL, RequestHeaders, RequestBody) ->
     ?INFO("~p: ~s", [HTTP, URL]),
     ?DEBUG("headers: ~p", [RequestHeaders]),
     ?DEBUG("body: ~s", [RequestBody]),
     handle_response(Expectations, HTTP(URL, RequestHeaders, iolist_to_binary(RequestBody))).
 
--spec create_envelope(kz_json:json_term()) ->
-                             kz_json:object().
+-spec create_envelope(kz_json:json_term()) -> kz_json:object().
 create_envelope(Data) ->
     create_envelope(Data, kz_json:new()).
 
@@ -230,55 +207,69 @@ create_envelope(Data, Envelope) ->
     kz_json:set_value(<<"data">>, Data, Envelope).
 
 -spec handle_response(expectations(), kz_http:ret()) -> response().
-handle_response([#{}|_]=Expectations, {'ok', ActualCode, RespHeaders, RespBody}) ->
-    case expectations_met(Expectations, ActualCode, [{"resp_code", ActualCode} | RespHeaders]) of
+handle_response(Expectations, {'ok', ActualCode, RespHeaders, RespBody}) ->
+    ?INFO("checking expectations against ~p: ~p", [ActualCode, RespHeaders]),
+    case expectations_met(Expectations, ActualCode, RespHeaders) of
         'true' -> RespBody;
         'false' ->
-            lager:info("expectations not met: ~w", [Expectations]),
-            lager:debug("~p: ~p", [ActualCode, RespHeaders]),
+            lager:info("expectations not met: ~p", [Expectations]),
+            lager:info("~p: ~p", [ActualCode, RespHeaders]),
             {'error', RespBody}
     end;
 handle_response(_Expectations, {'error','socket_closed_remotely'}=E) ->
-    lager:error("~nwe broke crossbar!"),
+    lager:error("we broke crossbar!"),
     throw(E);
 handle_response(_ExpectedCode, {'error', _}=E) ->
     lager:error("broken req: ~p", [E]),
     E.
 
 -spec expectations_met(expectations(), response_code(), response_headers()) -> boolean().
-expectations_met(Expectations, RespCode, RespHeaders) ->
-    ?INFO("checking expectations against ~p: ~p", [RespCode, RespHeaders]),
-    lists:any(fun(E) -> expectation_met(E, RespCode, RespHeaders) end
-             ,Expectations
-             ).
+expectations_met([], _RespCode, _RespHeaders) -> 'false';
+expectations_met([Expectation|Expectations], RespCode, RespHeaders) ->
+    case expectation_met(Expectation, RespCode, RespHeaders) of
+        'true' -> 'true';
+        'false' -> expectations_met(Expectations, RespCode, RespHeaders)
+    end.
 
 -spec expectation_met(expectation(), response_code(), response_headers()) -> boolean().
-expectation_met(#{}=Expectation, RespCode, RespHeaders) ->
-    response_code_matches(Expectation, RespCode)
-        andalso response_headers_match(Expectation, RespHeaders).
+expectation_met(#expectation{response_codes = ExpectedCodes
+                            ,response_headers = ExpectedHeaders
+                            }
+               ,RespCode
+               ,RespHeaders
+               ) ->
+    response_code_matches(ExpectedCodes, RespCode)
+        andalso response_headers_match(ExpectedHeaders, RespHeaders).
 
--spec response_code_matches(expectation(), response_code()) -> boolean().
-response_code_matches(#{'response_codes' := ExpectedCodes}, ResponseCode) ->
-    case lists:member(ResponseCode, ExpectedCodes) of
-        'true' -> 'true';
-        'false' ->
-            ?INFO("failed expectation: code ~w but expected ~w"
-                 ,[ResponseCode, ExpectedCodes]
-                 ),
-            'false'
-    end;
-response_code_matches(_Expectation, _Code) -> 'true'.
+-spec response_code_matches(expected_codes(), response_code()) -> boolean().
+response_code_matches([Code | _], Code) -> 'true';
+response_code_matches([_Code | Codes], ResponseCode) -> response_code_matches(Codes, ResponseCode);
+response_code_matches([], _ResponseCode) ->
+    lager:info("failed expectation: response code ~w didn't match", [_ResponseCode]),
+    'false'.
 
--spec response_headers_match(expectation(), response_headers()) -> boolean().
-response_headers_match(#{'response_headers' := ExpectedHeaders}, RespHeaders) ->
+-spec response_headers_match(expected_headers(), response_headers()) -> boolean().
+response_headers_match(ExpectedHeaders, RespHeaders) ->
     lists:all(fun(ExpectedHeader) -> response_header_matches(ExpectedHeader, RespHeaders) end
              ,ExpectedHeaders
-             );
-response_headers_match(_Expectation, _RespHeaders) -> 'true'.
+             ).
 
--spec response_header_matches({string(), string()}, response_headers()) -> boolean().
+-spec response_header_matches(expected_header(), response_headers()) -> boolean().
+response_header_matches({ExpectedHeader, {'match', Match}}, RespHeaders) ->
+    RespHeaderValue = kz_http_util:get_resp_header(ExpectedHeader, RespHeaders),
+    case re:run(RespHeaderValue, Match) of
+        {'match', _} -> 'true';
+        'nomatch' ->
+            lager:info("~p:~p ~/~ ~p", [ExpectedHeader, Match, RespHeaderValue]),
+            'false'
+    end;
 response_header_matches({ExpectedHeader, ExpectedValue}, RespHeaders) ->
-    kz_term:to_list(ExpectedValue) =:= kz_http_util:get_resp_header(kz_term:to_list(ExpectedHeader), RespHeaders).
+    case kz_http_util:get_resp_header(ExpectedHeader, RespHeaders) of
+        ExpectedValue -> 'true';
+        _RespHeaderValue ->
+            lager:info("~p:~p =/= ~p", [ExpectedHeader, ExpectedValue, _RespHeaderValue]),
+            'false'
+    end.
 
 -spec start_trace() -> {'ok', kz_data_tracing:trace_ref()}.
 start_trace() ->
@@ -290,7 +281,7 @@ start_trace() ->
                     RID -> RID
                 end,
     lager:md([{'request_id', RequestId}]),
-    put('now', kz_time:now()),
+    put('start_time', kz_time:start_time()),
 
     TracePath = trace_path(),
 

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -34,7 +34,7 @@ summary(API, AccountId) ->
 -spec summary(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 summary(API, AccountId, Accept) ->
     URL = cdrs_url(AccountId),
-    Headers = [{"accept", kz_term:to_list(Accept)}],
+    Headers = [{<<"accept">>, kz_term:to_list(Accept)}],
     RequestHeaders = pqc_cb_api:request_headers(API, Headers),
 
     Expectations = [#expectation{response_codes = [200]
@@ -99,7 +99,7 @@ update_request_id(RequestHeaders) ->
                        [Id, Now] -> iolist_to_binary([Id, "-", Now, "-", "1"]);
                        [Id, Now, Nth] -> iolist_to_binary([Id, "-", Now, "-", incr_nth(Nth)])
                    end,
-    [{"x-request-id", kz_term:to_list(NewRequestId)} | RequestHeaders].
+    props:set_value(<<"x-request-id">>, kz_term:to_list(NewRequestId), RequestHeaders).
 
 incr_nth(Nth) ->
     kz_term:to_integer(Nth) + 1 + $0.

--- a/core/kazoo_proper/src/pqc_cb_ips.erl
+++ b/core/kazoo_proper/src/pqc_cb_ips.erl
@@ -70,7 +70,7 @@ ip_url(AccountId, IP) ->
                       {'ok', kz_json:objects()} |
                       {'error', 'not_found'}.
 list_ips(API) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ips_url()
                                 ,pqc_cb_api:request_headers(API)
@@ -93,7 +93,7 @@ assign_ips(API, AccountId, Dedicateds) ->
     IPs = [IP || ?DEDICATED(IP, _, _) <- Dedicateds],
     Envelope = pqc_cb_api:create_envelope(IPs),
 
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:post/3
                                 ,ips_url(AccountId)
                                 ,pqc_cb_api:request_headers(API)
@@ -114,7 +114,7 @@ assign_ips(API, AccountId, Dedicateds) ->
 remove_ip(_API, 'undefined', _Dedicated) ->
     {'error', 'not_found'};
 remove_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
-    case pqc_cb_api:make_request([200, 404]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200, 404]}]
                                 ,fun kz_http:delete/2
                                 ,ip_url(AccountId, IP)
                                 ,pqc_cb_api:request_headers(API)
@@ -133,7 +133,7 @@ remove_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
 fetch_ip(_API, 'undefined', _Dedicated) ->
     {'error', 'not_found'};
 fetch_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ip_url(AccountId, IP)
                                 ,pqc_cb_api:request_headers(API)
@@ -153,7 +153,7 @@ assign_ip(_API, 'undefined', _Dedicated) ->
     {'error', 'not_found'};
 assign_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
     Envelope = pqc_cb_api:create_envelope(kz_json:new()),
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:post/3
                                 ,ip_url(AccountId, IP)
                                 ,pqc_cb_api:request_headers(API)
@@ -171,7 +171,7 @@ assign_ip(API, AccountId, ?DEDICATED(IP, _, _)) ->
                          {'ok', kz_term:ne_binaries()} |
                          {'error', 'not_found'}.
 fetch_hosts(API) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ip_url("hosts")
                                 ,pqc_cb_api:request_headers(API)
@@ -188,7 +188,7 @@ fetch_hosts(API) ->
                          {'ok', kz_term:ne_binaries()} |
                          {'error', 'not_found'}.
 fetch_zones(API) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ip_url("zones")
                                 ,pqc_cb_api:request_headers(API)
@@ -207,7 +207,7 @@ fetch_zones(API) ->
 fetch_assigned(_API, 'undefined') ->
     {'error', 'not_found'};
 fetch_assigned(API, AccountId) ->
-    case pqc_cb_api:make_request([200]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200]}]
                                 ,fun kz_http:get/2
                                 ,ip_url(AccountId, "assigned")
                                 ,pqc_cb_api:request_headers(API)
@@ -229,7 +229,7 @@ create_ip(API, ?DEDICATED(IP, Host, Zone)) ->
                              ,{<<"zone">>, Zone}
                              ]),
     Envelope = pqc_cb_api:create_envelope(Data),
-    case pqc_cb_api:make_request([201, 409]
+    case pqc_cb_api:make_request([#expectation{response_codes=[201, 409]}]
                                 ,fun kz_http:put/3
                                 ,ips_url()
                                 ,pqc_cb_api:request_headers(API)
@@ -253,7 +253,7 @@ create_ip(API, ?DEDICATED(IP, Host, Zone)) ->
                        {'ok', kz_json:object()} |
                        {'error', 'not_found'}.
 delete_ip(API, ?DEDICATED(IP, _Host, _Zone)) ->
-    case pqc_cb_api:make_request([200, 404]
+    case pqc_cb_api:make_request([#expectation{response_codes=[200, 404]}]
                                 ,fun kz_http:delete/2
                                 ,ip_url(IP)
                                 ,pqc_cb_api:request_headers(API)
@@ -335,9 +335,7 @@ seq() ->
 
         catch
             _E:_R ->
-                ST = erlang:get_stacktrace(),
-                ?INFO("failed ~s: ~p", [_E, _R]),
-                [?INFO("st: ~p", [S]) || S <- ST]
+                ?INFO("failed ~s: ~p", [_E, _R])
         after
             pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
             _ = delete_ip(API, IP),
@@ -526,9 +524,7 @@ correct() ->
                                     )
                    catch
                        _E:_R ->
-                           ST = erlang:get_stacktrace(),
                            io:format("exception running commands: ~s:~p~n", [_E, _R]),
-                           [io:format("~p~n", [S]) || S <- ST],
                            _ = cleanup(),
                            'false'
                    end

--- a/core/kazoo_proper/src/pqc_cb_ledgers.erl
+++ b/core/kazoo_proper/src/pqc_cb_ledgers.erl
@@ -28,7 +28,7 @@ fetch(API, ?NE_BINARY=AccountId) ->
 -spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 fetch(API, ?NE_BINARY=AccountId, ?NE_BINARY=AcceptType) ->
     LedgersURL = ledgers_url(AccountId),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{"accept", kz_term:to_list(AcceptType)}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"accept">>, kz_term:to_list(AcceptType)}]),
 
     Expectations = [#expectation{response_codes = [200]
                                 ,response_headers = [{"content-type", kz_term:to_list(AcceptType)}]
@@ -50,7 +50,7 @@ fetch_by_source(API, ?NE_BINARY=AccountId, ?NE_BINARY=SourceType) ->
                              pqc_cb_api:response().
 fetch_by_source(API, ?NE_BINARY=AccountId, SourceType, ?NE_BINARY=AcceptType) ->
     LedgersURL = ledgers_source_url(AccountId, SourceType),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{"accept", kz_term:to_list(AcceptType)}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"accept">>, kz_term:to_list(AcceptType)}]),
 
     Expectations = [#expectation{response_codes = [200]
                                 ,response_headers = [{"content-type", kz_term:to_list(AcceptType)}]

--- a/core/kazoo_proper/src/pqc_cb_limits.erl
+++ b/core/kazoo_proper/src/pqc_cb_limits.erl
@@ -16,7 +16,7 @@ fetch(API, <<AccountId/binary>>) ->
     URL = limits_url(AccountId),
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    Expectations = [#{'response_codes' => [200]}],
+    Expectations = [#expectation{response_codes = [200]}],
     pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,URL
@@ -29,7 +29,7 @@ update(API, <<AccountId/binary>>, JObj) ->
     RequestHeaders = pqc_cb_api:request_headers(API),
     RequestEnvelope = pqc_cb_api:create_envelope(JObj),
 
-    Expectations = [#{'response_codes' => [200]}],
+    Expectations = [#expectation{response_codes = [200]}],
     pqc_cb_api:make_request(Expectations
                            ,fun kz_http:post/3
                            ,URL

--- a/core/kazoo_proper/src/pqc_cb_media.erl
+++ b/core/kazoo_proper/src/pqc_cb_media.erl
@@ -1,0 +1,277 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_media).
+
+%% API requests
+-export([summary/2
+        ,create/3
+        ,fetch/3, fetch/4
+        ,fetch_binary/3
+        ,update/3, update/4
+        ,update_binary/4
+        ,patch/4
+        ,delete/3
+        ]).
+
+-export([seq/0
+        ,cleanup/0
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
+
+-spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+summary(API, AccountId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,media_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec create(pqc_cb_api:state(), kz_term:ne_binary(), kzd_media:doc()) -> pqc_cb_api:response().
+create(API, AccountId, MediaJObj) ->
+    URL = media_url(AccountId),
+
+    Expectations = [#expectation{response_codes = [201]
+                                ,response_headers = [{"content-type", "application/json"}
+                                                    ,{"location", {'match', expected_location_value(URL)}}
+                                                    ]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(MediaJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:put/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch(API, AccountId, MediaId) ->
+    fetch(API, AccountId, MediaId, <<"application/json">>).
+
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch(API, AccountId, MediaId, AcceptType) ->
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", kz_term:to_list(AcceptType)}]
+                                }],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,media_url(AccountId, MediaId)
+                           ,pqc_cb_api:request_headers(API, [{<<"accept">>, kz_term:to_list(AcceptType)}])
+                           ).
+
+-spec fetch_binary(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch_binary(API, AccountId, MediaId) ->
+    AcceptType = "audio/mp3",
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", AcceptType}]
+                                }],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,media_bin_url(AccountId, MediaId)
+                           ,pqc_cb_api:request_headers(API, [{<<"accept">>, AcceptType}])
+                           ).
+
+-spec update(pqc_cb_api:state(), kz_term:ne_binary(), kzd_media:doc()) -> pqc_cb_api:response().
+update(API, AccountId, MediaJObj) ->
+    URL = media_url(AccountId, kz_doc:id(MediaJObj)),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(MediaJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec update(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), iodata()) -> pqc_cb_api:response().
+update(API, AccountId, MediaId, Data) ->
+    URL = media_url(AccountId, MediaId),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API, [{<<"content-type">>, "audio/mp3"}])
+                           ,Data
+                           ).
+
+-spec update_binary(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), iodata()) -> pqc_cb_api:response().
+update_binary(API, AccountId, MediaId, Data) ->
+    URL = media_bin_url(AccountId, MediaId),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API, [{<<"content-type">>, "audio/mp3"}])
+                           ,Data
+                           ).
+
+-spec patch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
+patch(API, AccountId, MediaId, PatchJObj) ->
+    URL = media_url(AccountId, MediaId),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(PatchJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:patch/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec delete(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+delete(API, AccountId, MediaId) ->
+    URL = media_url(AccountId, MediaId),
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:delete/2
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec media_url(kz_term:ne_binary()) -> string().
+media_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "media"], "/").
+
+-spec media_bin_url(kz_term:ne_binary(), kz_term:ne_binaryy()) -> string().
+media_bin_url(AccountId, MediaId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "media", kz_term:to_list(MediaId), "raw"], "/").
+
+-spec media_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
+media_url(AccountId, MediaId) ->
+    string:join([media_url(AccountId), kz_term:to_list(MediaId)], "/").
+
+
+-spec seq() -> 'ok'.
+seq() ->
+    Fs = [fun seq_media_file/0],
+    run_funs(Fs).
+
+run_funs([]) -> 'ok';
+run_funs([F|Fs]) ->
+    _ = F(),
+    cleanup(),
+    run_funs(Fs).
+
+seq_media_file() ->
+    API = pqc_cb_api:init_api(['crossbar', 'media_mgr'], ['cb_media']),
+    AccountId = create_account(API),
+
+    EmptySummaryResp = summary(API, AccountId),
+    lager:info("empty summary resp: ~s", [EmptySummaryResp]),
+    [] = kz_json:get_list_value([<<"data">>], kz_json:decode(EmptySummaryResp)),
+
+    CreateMetaResp = create(API, AccountId, new_media_doc()),
+    lager:info("created media meta: ~s", [CreateMetaResp]),
+    CreatedMeta = kz_json:get_json_value([<<"data">>], kz_json:decode(CreateMetaResp)),
+    MediaId = kz_doc:id(CreatedMeta),
+
+    SummaryResp = summary(API, AccountId),
+    lager:info("summary resp: ~s", [SummaryResp]),
+    [MediaSummary] = kz_json:get_list_value([<<"data">>], kz_json:decode(SummaryResp)),
+    'true' = kz_doc:id(CreatedMeta) =:= kz_doc:id(MediaSummary),
+
+    {'ok', MP3} = file:read_file(filename:join([code:priv_dir('kazoo_proper'), "mp3.mp3"])),
+
+    UploadResp = update_binary(API, AccountId, MediaId, MP3),
+    lager:info("upload resp: ~s", [UploadResp]),
+    UploadedMediaMeta = kz_json:get_json_value([<<"data">>], kz_json:decode(UploadResp)),
+    MediaId = kz_doc:id(UploadedMediaMeta),
+
+    UpdateResp = update(API, AccountId, MediaId, MP3),
+    lager:info("update resp: ~s", [UpdateResp]),
+    UpdatedMediaMeta = kz_json:get_json_value([<<"data">>], kz_json:decode(UpdateResp)),
+    MediaId = kz_doc:id(UpdatedMediaMeta),
+
+    FetchedMedia = fetch_binary(API, AccountId, MediaId),
+    lager:info("fetched binary: ~p", [FetchedMedia]),
+    MP3 = FetchedMedia,
+
+    FetchedMediaAgain = fetch(API, AccountId, MediaId, <<"audio/mp3">>),
+    lager:info("fetched binary again: ~p", [FetchedMediaAgain]),
+    MP3 = FetchedMediaAgain,
+
+    MediaName = kz_media_util:media_path(<<"/", AccountId/binary, "/", MediaId/binary>>, kz_binary:rand_hex(16)),
+
+    lager:info("fetching URL for ~s", [MediaName]),
+    {'ok', [AMQPResp|_]} = pqc_media_mgr:request_media_url(MediaName, <<"new">>),
+    lager:info("fetched URL for ~s: ~p", [MediaName, AMQPResp]),
+    StreamURL = kz_json:get_ne_binary_value(<<"Stream-URL">>, AMQPResp),
+    lager:info("streaming from ~s", [StreamURL]),
+    {'ok', 200, _, FetchedMP3} = kz_http:get(kz_term:to_list(StreamURL)),
+    lager:info("streamed: ~p", [FetchedMP3]),
+    MP3 = FetchedMP3,
+
+    DeleteResp = delete(API, AccountId, MediaId),
+    lager:info("delete resp: ~s", [DeleteResp]),
+
+    EmptySummaryAgain = summary(API, AccountId),
+    lager:info("empty summary again: ~s", [EmptySummaryAgain]),
+    [] = kz_json:get_list_value([<<"data">>], kz_json:decode(EmptySummaryAgain)),
+
+    cleanup(API),
+    lager:info("FINISHED MEDIA SEQ").
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
+    cleanup_system().
+
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _ = pqc_cb_api:cleanup(API),
+    cleanup_system().
+
+cleanup_system() -> 'ok'.
+
+-spec create_account(pqc_cb_api:state()) -> kz_term:ne_binary().
+create_account(API) ->
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    lager:info("created account: ~s", [AccountResp]),
+
+    kz_json:get_ne_binary_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
+
+%% take http://whatever:port/v2/... and get /v2/.../{regex}
+expected_location_value(URL) ->
+    expected_location_value(URL, "(\\w{32})").
+
+expected_location_value(URL, Id) ->
+    {'match', [_Host, Path]} = re:run(URL, "^(.+)(/v2/.+$)", [{'capture','all_but_first', 'list'}]),
+    Path ++ [$/ | kz_term:to_list(Id)].
+
+new_media_doc() ->
+    Set = [{fun kzd_media:set_name/2, kz_binary:rand_hex(6)}],
+    kz_doc:public_fields(kz_json:exec_first(Set, kzd_media:new())).

--- a/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
+++ b/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
@@ -42,7 +42,12 @@ list_number(API, AccountId, Number) ->
     URL = number_url(AccountId, Number),
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    pqc_cb_api:make_request([200, 404], fun kz_http:get/2, URL, RequestHeaders).
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,URL
+                           ,RequestHeaders
+                           ).
 
 -spec add_number(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 add_number(_API, 'undefined', _Number) -> ?FAILED_RESPONSE;
@@ -52,7 +57,8 @@ add_number(API, AccountId, Number) ->
     RequestEnvelope  = pqc_cb_api:create_envelope(kz_json:new()
                                                  ,kz_json:from_list([{<<"accept_charges">>, 'true'}])
                                                  ),
-    pqc_cb_api:make_request([201, 404, 409]
+    Expectations = [#expectation{response_codes = [201, 404, 409]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,URL
                            ,RequestHeaders
@@ -64,7 +70,8 @@ remove_number(_API, 'undefined', _Number) -> ?FAILED_RESPONSE;
 remove_number(API, AccountId, Number) ->
     URL = number_url(AccountId, Number),
     RequestHeaders = pqc_cb_api:request_headers(API),
-    pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:delete/2
                            ,URL
                            ,RequestHeaders
@@ -76,7 +83,9 @@ activate_number(API, AccountId, Number) ->
     URL = number_url(AccountId, Number, "activate"),
     RequestHeaders = pqc_cb_api:request_headers(API),
     RequestEnvelope  = pqc_cb_api:create_envelope(kz_json:new(), kz_json:from_list([{<<"accept_charges">>, 'true'}])),
-    pqc_cb_api:make_request([201, 404, 500]
+
+    Expectations = [#expectation{response_codes = [201, 404, 500]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,URL
                            ,RequestHeaders

--- a/core/kazoo_proper/src/pqc_cb_port_requests.erl
+++ b/core/kazoo_proper/src/pqc_cb_port_requests.erl
@@ -108,17 +108,16 @@ initial_state() ->
                    ,lists:reverse(?ACCOUNT_NAMES)
                    )
     catch
-        _R:_T ->
-            ?debugFmt("exception ~p:~p", [_R, _T]),
-            kz_util:log_stacktrace(),
+        _E:_R ->
+            ?debugFmt("exception ~p:~p", [_E, _R]),
             cleanup(State),
-            throw(failed)
+            throw('failed')
     end.
 
 -spec initialize_account(pqc_cb_api:state(), kz_term:ne_binary(), state()) -> state().
 initialize_account(API, AccountName, StateAcc) ->
     Account = create_account(API, AccountName, StateAcc),
-    true = kz_term:is_ne_binary(Account),
+    'true' = kz_term:is_ne_binary(Account),
 
     AccountJObj = pqc_cb_response:data(Account),
     AccountId = kz_doc:id(AccountJObj),
@@ -127,7 +126,7 @@ initialize_account(API, AccountName, StateAcc) ->
     _ = timer:sleep(1000), %% too fast for kazoo
 
     UserResp = create_admin_user(API, AccountId, AccountName),
-    true = kz_term:is_ne_binary(UserResp),
+    'true' = kz_term:is_ne_binary(UserResp),
     User = pqc_cb_response:data(UserResp),
 
     AccountApi = pqc_cb_api:authenticate(kzd_accounts:name(AccountJObj)
@@ -137,9 +136,9 @@ initialize_account(API, AccountName, StateAcc) ->
 
     _ = timer:sleep(1000), %% too fast for kazoo
 
-    IsAuthority = maps:get(<<"is_port_authority">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS), false),
+    IsAuthority = maps:get(<<"is_port_authority">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS), 'false'),
     Whitelabel = create_whitelabel(AccountApi, AccountId, AccountName, IsAuthority),
-    true = kz_term:is_ne_binary(Whitelabel),
+    'true' = kz_term:is_ne_binary(Whitelabel),
 
     StateAcc#{AccountName => #{model => pqc_kazoo_model:new(AccountApi)
                               ,account_id => AccountId
@@ -173,7 +172,8 @@ create_admin_user(API, AccountId, AccountName) ->
          ),
 
     Url = string:join([pqc_cb_accounts:account_url(AccountId), "users"], "/"),
-    pqc_cb_api:make_request([201]
+    Expectations = [#expectation{response_codes = [201]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,Url
                            ,pqc_cb_api:request_headers(API)
@@ -239,7 +239,7 @@ create_ports_seq(State) ->
 
 -spec create_ports_seq(state(), kz_term:ne_binary()) -> term().
 create_ports_seq(State, AccountName) ->
-    Model = maps:get(model, maps:get(AccountName, State)),
+    Model = maps:get('model', maps:get(AccountName, State)),
     API = pqc_kazoo_model:api(Model),
 
     Created = create_port(API, AccountName),
@@ -252,8 +252,8 @@ create_ports_seq(State, AccountName) ->
 -spec create_ports_seq(state(), kz_term:ne_binary(), pqc_cb_api:response()) -> term().
 create_ports_seq(State, AccountName, Resp) ->
     WhoIsPortAuthority = maps:get(<<"port_authority">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS)),
-    AuthorityId = maps:get(account_id, maps:get(WhoIsPortAuthority, State)),
-    AuthorityName = maps:get(account_name, maps:get(WhoIsPortAuthority, State)),
+    AuthorityId = maps:get('account_id', maps:get(WhoIsPortAuthority, State)),
+    AuthorityName = maps:get('account_name', maps:get(WhoIsPortAuthority, State)),
 
     JObj = pqc_cb_response:data(Resp),
     ReadOnly = kz_json:get_json_value(<<"_read_only">>, JObj, kz_json:new()),
@@ -278,8 +278,7 @@ create_ports_seq(State, AccountName, Resp) ->
 
 -spec port_agent_seq(state()) -> term().
 port_agent_seq(State) ->
-    [{"listing test", port_agent_list_seq(State)}
-    ].
+    [{"listing test", port_agent_list_seq(State)}].
 
 -spec port_agent_list_seq(state()) -> term().
 port_agent_list_seq(State) ->
@@ -289,7 +288,7 @@ port_agent_list_seq(State) ->
 self_list_seq(State, AccountName) ->
     [{'setup'
      ,fun() ->
-              #{model := Model} = maps:get(AccountName, State),
+              #{'model' := Model} = maps:get(AccountName, State),
               list_account_ports(pqc_kazoo_model:api(Model))
       end
      ,fun(Fetched) ->
@@ -306,8 +305,8 @@ self_list_seq(State, AccountName) ->
 -spec self_list_seq(state(), kz_term:ne_binary(), pqc_cb_api:response()) -> term().
 self_list_seq(State, AccountName, Resp) ->
     WhoIsPortAuthority = maps:get(<<"port_authority">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS)),
-    AuthorityId = maps:get(account_id, maps:get(WhoIsPortAuthority, State)),
-    AuthorityName = maps:get(account_name, maps:get(WhoIsPortAuthority, State)),
+    AuthorityId = maps:get('account_id', maps:get(WhoIsPortAuthority, State)),
+    AuthorityName = maps:get('account_name', maps:get(WhoIsPortAuthority, State)),
 
     PortNumbers = maps:get(<<"numbers">>, maps:get(AccountName, ?ACCOUNTS_SETTINGS)),
 
@@ -345,7 +344,7 @@ self_list_seq(State, AccountName, Resp) ->
 port_account_seq(#{master := #{model := Model}}) ->
     API = pqc_kazoo_model:api(Model),
     [{"get master's account ports"
-     ,?_assertEqual(true, have_ports(list_account_ports(API)))
+     ,?_assertEqual('true', have_ports(list_account_ports(API)))
      }
     ].
 
@@ -353,14 +352,14 @@ port_account_seq(#{master := #{model := Model}}) ->
 port_descendants_seq(#{master := #{model := Model}}) ->
     API = pqc_kazoo_model:api(Model),
     [{"get all master account descendants's ports"
-     ,?_assertEqual(true, have_ports(list_descendants_ports(API)))
+     ,?_assertEqual('true', have_ports(list_descendants_ports(API)))
      }
     ].
 
 -spec have_ports(pqc_cb_api:response()) -> boolean().
-have_ports({error, Error}) ->
+have_ports({'error', Error}) ->
     ?debugFmt("we have some rror:~n~p~n", [Error]),
-    false;
+    'false';
 have_ports(Resp) ->
     JObj = kz_json:decode(Resp),
     kz_json:get_ne_binary_value(<<"status">>, JObj, <<"error">>) =/= <<"error">>
@@ -383,7 +382,8 @@ create_port(API, AccountName) ->
     AccountId = pqc_cb_api:auth_account_id(API),
     Envelope = pqc_cb_api:create_envelope(seed_ports(AccountName)),
 
-    pqc_cb_api:make_request([201]
+    Expectations = [#expectation{response_codes = [201]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,ports_account_url(AccountId)
                            ,pqc_cb_api:request_headers(API)
@@ -400,7 +400,8 @@ create_port(API, AccountName) ->
 
 -spec list_account_ports(pqc_cb_api:state()) -> pqc_cb_api:response().
 list_account_ports(API) ->
-    pqc_cb_api:make_request([#{'response_codes' => [200]}]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,ports_account_url(pqc_cb_api:auth_account_id(API))
                            ,pqc_cb_api:request_headers(API)
@@ -408,7 +409,8 @@ list_account_ports(API) ->
 
 -spec list_descendants_ports(pqc_cb_api:state()) -> pqc_cb_api:response().
 list_descendants_ports(API) ->
-    pqc_cb_api:make_request([#{'response_codes' => [200]}]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,ports_descendants_url(pqc_cb_api:auth_account_id(API))
                            ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_cb_rates.erl
+++ b/core/kazoo_proper/src/pqc_cb_rates.erl
@@ -12,10 +12,12 @@
         ]).
 
 -export([upload_rate/2, upload_csv/2
+        ,upload_rates/2
         ,rate_did/3
         ,delete_rate/2
         ,get_rate/2
         ,get_rates/1, get_rates/2
+        ,get_rates_by_prefix/2, get_rates_by_prefix/3
 
         ,create_service_plan/2
         ,assign_service_plan/3
@@ -44,27 +46,45 @@
 -spec rate_doc(kz_term:ne_binary() | proper_types:type(), number() | proper_types:type()) ->
                       kzd_rates:doc().
 rate_doc(RatedeckId, Cost) ->
-    kzd_rates:from_map(#{<<"prefix">> => <<"1222">>
+    kzd_rates:from_map(#{<<"prefix">> => 1222
                         ,<<"rate_cost">> => Cost
                         ,<<"ratedeck_id">> => RatedeckId
                         ,<<"direction">> => <<"inbound">>
                         }
                       ).
 
+rate_doc_with_route(RatedeckId, Cost) ->
+    kzd_rates:from_map(#{<<"prefix">> => 1333
+                        ,<<"rate_cost">> => Cost
+                        ,<<"ratedeck_id">> => RatedeckId
+                        ,<<"direction">> => <<"inbound">>
+                        ,<<"routes">> => <<"^\\+?1333.+\$">>
+                        }
+                      ).
+
+rate_doc_with_routes(RatedeckId, Cost) ->
+    kzd_rates:from_map(#{<<"prefix">> => 1444
+                        ,<<"rate_cost">> => Cost
+                        ,<<"ratedeck_id">> => RatedeckId
+                        ,<<"direction">> => <<"inbound">>
+                        ,<<"routes">> => kz_json:encode([<<"^\\+?1444.+\$">>]) % json encoded array for upload
+                        }
+                      ).
+
 -spec upload_rate(pqc_cb_api:state(), kzd_rates:doc()) -> {'ok', kz_term:api_ne_binary()}.
 upload_rate(API, RateDoc) ->
-    ?INFO("uploading rate ~p", [RateDoc]),
-    CSV = kz_csv:from_jobjs([RateDoc]),
-    upload_csv(API, CSV, kzd_rates:ratedeck_id(RateDoc)).
+    upload_rates(API, [RateDoc]).
+
+-spec upload_rates(pqc_cb_api:state(), [kzd_rates:doc()]) -> {'ok', kz_term:api_ne_binary()}.
+upload_rates(API, RateDocs) when is_list(RateDocs) ->
+    ?INFO("uploading rates ~p", [RateDocs]),
+    CSV = kz_csv:from_jobjs(RateDocs),
+
+    upload_csv(API, CSV).
 
 -spec upload_csv(pqc_cb_api:state(), iodata()) ->
                         {'ok', kz_term:api_ne_binary()}.
 upload_csv(API, CSV) ->
-    upload_csv(API, CSV, 'undefined').
-
--spec upload_csv(pqc_cb_api:state(), iodata(), kz_term:api_ne_binary()) ->
-                        {'ok', kz_term:api_ne_binary()}.
-upload_csv(API, CSV, _RatedeckId) ->
     CreateResp = pqc_cb_tasks:create(API, "category=rates&action=import", CSV),
     TaskId = kz_json:get_ne_binary_value([<<"data">>, <<"_read_only">>, <<"id">>]
                                         ,kz_json:decode(CreateResp)
@@ -89,7 +109,7 @@ create_service_plan(API, RatedeckId) ->
             'ok'
     end.
 
--spec assign_service_plan(pqc_cb_api:state(), kz_term:ne_binary() | proper_types:type(), kz_term:ne_binary()) ->
+-spec assign_service_plan(pqc_cb_api:state(), kz_term:api_ne_binary() | proper_types:type(), kz_term:ne_binary()) ->
                                  pqc_cb_api:response().
 assign_service_plan(_API, 'undefined', _RatedeckId) ->
     ?INFO("no account to assign ~s to", [_RatedeckId]),
@@ -99,8 +119,8 @@ assign_service_plan(API, AccountId, RatedeckId) ->
     ServicePlanId = service_plan_id(RatedeckId),
     pqc_cb_services:assign_service_plan(API, AccountId, ServicePlanId).
 
--spec rate_account_did(pqc_cb_api:state(), kz_term:ne_binary() | proper_types:type(), kz_term:ne_binary()) ->
-                              kz_term:api_integer().
+-spec rate_account_did(pqc_cb_api:state(), kz_term:api_ne_binary() | proper_types:type(), kz_term:ne_binary()) ->
+                              kz_term:api_number().
 rate_account_did(_API, 'undefined', _DID) ->
     ?INFO("account doesn't exist to rate DID ~p", [_DID]),
     ?FAILED_RESPONSE;
@@ -151,7 +171,7 @@ wait_for_task(API, TaskId) ->
 
 get_csvs(_API, _TaskId, []) -> 'ok';
 get_csvs(API, TaskId, [CSV|CSVs]) ->
-    get_csv(API, TaskId, CSV),
+    _ = get_csv(API, TaskId, CSV),
     get_csvs(API, TaskId, CSVs).
 
 get_csv(API, TaskId, CSV) ->
@@ -169,7 +189,8 @@ delete_rate(API, ID, <<_/binary>>=RatedeckId) ->
     ?INFO("deleting rate ~s from ~s", [ID, RatedeckId]),
 
     URL = rate_url(ID, RatedeckId),
-    pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:delete/2
                            ,URL ++ "&should_soft_delete=false"
                            ,pqc_cb_api:request_headers(API)
@@ -182,7 +203,8 @@ get_rate(API, RateDoc) ->
     ?INFO("getting rate info for ~s in ~s", [ID, kzd_rates:ratedeck_id(RateDoc)]),
 
     URL = rate_url(ID, kzd_rates:ratedeck_id(RateDoc)),
-    pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,URL
                            ,pqc_cb_api:request_headers(API)
@@ -195,13 +217,30 @@ get_rates(API) ->
 -spec get_rates(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 get_rates(API, RatedeckId) ->
     ?INFO("getting rates for ratedeck ~s", [RatedeckId]),
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,rates_url() ++ "?ratedeck_id=" ++ kz_term:to_list(RatedeckId)
                            ,pqc_cb_api:request_headers(API)
                            ).
 
--spec rate_did(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_integer().
+-spec get_rates_by_prefix(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+get_rates_by_prefix(API, Prefix) ->
+    get_rates_by_prefix(API, Prefix, ?KZ_RATES_DB).
+
+-spec get_rates_by_prefix(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+get_rates_by_prefix(API, Prefix, RatedeckId) ->
+    ?INFO("getting rates for ratedeck ~s by prefix ~s", [RatedeckId, Prefix]),
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,rates_url()
+                            ++ "?ratedeck_id=" ++ kz_term:to_list(RatedeckId)
+                            ++ "&prefix=" ++ kz_term:to_list(Prefix)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec rate_did(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_number().
 rate_did(API, RatedeckId, DID) ->
     ?INFO("rating DID ~s using ~s", [DID, RatedeckId]),
     URL = rate_number_url(RatedeckId, DID),
@@ -212,7 +251,8 @@ rate_did(API, RatedeckId, DID) ->
 make_rating_request(API, URL) ->
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    Resp = pqc_cb_api:make_request([200, 500]
+    Expectations = [#expectation{response_codes = [200, 500]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,RequestHeaders
@@ -256,9 +296,7 @@ correct() ->
                                     )
                    catch
                        _E:_R ->
-                           ST = erlang:get_stacktrace(),
                            io:format("exception running commands: ~s:~p~n", [_E, _R]),
-                           [io:format("~p~n", [S]) || S <- ST],
                            _ = cleanup(),
                            'false'
                    end
@@ -324,7 +362,9 @@ seq() ->
     Model = initial_state(),
     API = pqc_kazoo_model:api(Model),
 
-    RateDoc = rate_doc(<<"custom">>, 1.0),
+    RatedeckId = <<"custom">>,
+
+    RateDoc = rate_doc(RatedeckId, 1.0),
 
     RateCost = kz_currency:units_to_dollars(
                  kapps_call_util:base_call_cost(kzd_rates:rate_cost(RateDoc)
@@ -334,14 +374,18 @@ seq() ->
                 ),
     ?INFO("rate cost from doc: ~p", [RateCost]),
 
-    {'ok', TaskId} = ?MODULE:upload_rate(API, RateDoc),
+    RateDocWithRoute = rate_doc_with_route(RatedeckId, 2.0),
+    RateDocWithRoutes = rate_doc_with_routes(RatedeckId, 3.0),
+
+    {'ok', TaskId} = ?MODULE:upload_rates(API, [RateDoc, RateDocWithRoute, RateDocWithRoutes]),
     ?INFO("uploaded task: ~s~n", [TaskId]),
 
-    GetResp = ?MODULE:get_rate(API, RateDoc),
-    GetJObj = kz_json:decode(GetResp),
-    RateJObj = kz_json:get_json_value(<<"data">>, GetJObj),
-    ?INFO("get rate: ~p~n", [RateJObj]),
-    'true' = kz_doc:id(RateDoc) =:= kz_doc:id(RateJObj),
+    'true' = lists:all(fun(D) -> validate_rate_upload(D, API) end, [RateDoc, RateDocWithRoute, RateDocWithRoutes]),
+
+    ListByPrefixResp = get_rates_by_prefix(API, hd(?PHONE_NUMBERS), RatedeckId),
+    ?INFO("listed by prefix: ~s", [ListByPrefixResp]),
+    [Listed] = kz_json:get_value(<<"data">>, kz_json:decode(ListByPrefixResp)),
+    'true' = kz_doc:id(Listed) =:= kz_doc:id(RateDoc),
 
     RateCost = ?MODULE:rate_did(API, kzd_rates:ratedeck_id(RateDoc), hd(?PHONE_NUMBERS)),
     ?INFO("successfully rated ~p using global ratedeck", [hd(?PHONE_NUMBERS)]),
@@ -386,6 +430,29 @@ seq() ->
     ?INFO("COMPLETED SUCCESSFULLY!"),
     _ = cleanup(API),
     io:format("done: ~p~n", [API]).
+
+validate_rate_upload(RateDoc, API) ->
+    GetResp = ?MODULE:get_rate(API, RateDoc),
+    GetJObj = kz_json:decode(GetResp),
+    RateJObj = kz_json:get_json_value(<<"data">>, GetJObj),
+    kz_doc:id(RateDoc) =:= kz_doc:id(RateJObj)
+        andalso are_equal(RateDoc, RateJObj).
+
+are_equal(RateDoc, RateJObj) ->
+    lists:all(fun(<<"routes">>) ->
+                      case kz_json:get_value(<<"routes">>, RateDoc) of
+                          'undefined' ->
+                              kzd_rates:default_routes(RateDoc) =:= kzd_rates:routes(RateJObj);
+                          <<"[", _/binary>>=JSON ->
+                              kz_json:decode(JSON) =:= kzd_rates:routes(RateJObj);
+                          <<Route/binary>> ->
+                              [Route] =:= kzd_rates:routes(RateJObj)
+                      end;
+                 (Key) ->
+                      kz_json:get_value(Key, RateDoc) =:= kz_json:get_value(Key, RateJObj)
+              end
+             ,kz_json:get_keys(kz_doc:public_fields(RateDoc, 'false'))
+             ).
 
 -spec command(any()) -> proper_types:type().
 command(Model) ->

--- a/core/kazoo_proper/src/pqc_cb_recordings.erl
+++ b/core/kazoo_proper/src/pqc_cb_recordings.erl
@@ -72,7 +72,7 @@ fetch_recording_binary(API, AccountId, RecordingId) ->
     case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:get/2
                                 ,recordings_url(AccountId, RecordingId)
-                                ,pqc_cb_api:request_headers(API, [{"accept", "audio/mpeg"}])
+                                ,pqc_cb_api:request_headers(API, [{<<"accept">>, "audio/mpeg"}])
                                 )
     of
         {'error', _E} ->

--- a/core/kazoo_proper/src/pqc_cb_recordings.erl
+++ b/core/kazoo_proper/src/pqc_cb_recordings.erl
@@ -28,7 +28,8 @@
                              {'error', 'not_found'} |
                              {'ok', kz_json:objects()}.
 list_recordings(API, AccountId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200]}
+    Expectations = [#expectation{response_codes = [200]}],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:get/2
                                 ,recordings_url(AccountId)
                                 ,pqc_cb_api:request_headers(API)
@@ -46,7 +47,8 @@ list_recordings(API, AccountId) ->
                              {'ok', kz_json:object()} |
                              {'error', 'not_found'}.
 fetch_recording(API, AccountId, RecordingId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200]}
+    Expectations = [#expectation{response_codes = [200]}],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:get/2
                                 ,recordings_url(AccountId, RecordingId)
                                 ,pqc_cb_api:request_headers(API)
@@ -61,16 +63,16 @@ fetch_recording(API, AccountId, RecordingId) ->
     end.
 
 -spec fetch_recording_binary(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
-                                    {'ok', kz_json:object()} |
+                                    {'ok', kz_term:ne_binary()} |
                                     {'error', 'not_found'}.
 fetch_recording_binary(API, AccountId, RecordingId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200]
-                                  ,'response_headers' =>
-                                       [{"content-type", "audio/mpeg"}]
-                                  }
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "audio/mpeg"}]
+                                }],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:get/2
                                 ,recordings_url(AccountId, RecordingId)
-                                ,pqc_cb_api:request_headers(API, [{<<"accept">>, "audio/mpeg"}])
+                                ,pqc_cb_api:request_headers(API, [{"accept", "audio/mpeg"}])
                                 )
     of
         {'error', _E} ->
@@ -81,13 +83,13 @@ fetch_recording_binary(API, AccountId, RecordingId) ->
     end.
 
 -spec fetch_recording_tunneled(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
-                                      {'ok', kz_json:object()} |
+                                      {'ok', kz_term:ne_binary()} |
                                       {'error', 'not_found'}.
 fetch_recording_tunneled(API, AccountId, RecordingId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200]
-                                  ,'response_headers' =>
-                                       [{"content-type", "audio/mpeg"}]
-                                  }
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "audio/mpeg"}]
+                                }],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:get/2
                                 ,recordings_url(AccountId, RecordingId) ++ "?accept=audio/mpeg"
                                 ,pqc_cb_api:request_headers(API)
@@ -134,7 +136,8 @@ create_attachment(MODB, DocId) ->
                               {'ok', kz_json:object()} |
                               {'error', 'not_found'}.
 delete_recording(API, AccountId, RecordingId) ->
-    case pqc_cb_api:make_request(#{'response_codes' => [200, 404]}
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    case pqc_cb_api:make_request(Expectations
                                 ,fun kz_http:delete/2
                                 ,recordings_url(AccountId, RecordingId)
                                 ,pqc_cb_api:request_headers(API)
@@ -200,9 +203,7 @@ seq() ->
         io:format(?MODULE_STRING":seq/0 was successful~n")
     catch
         _E:_R ->
-            ST = erlang:get_stacktrace(),
             ?INFO(?MODULE_STRING ":seq/0 failed ~s: ~p", [_E, _R]),
-            _ = [?INFO("st: ~p", [S]) || S <- ST],
             io:format(?MODULE_STRING ":seq/0 failed: ~s: ~p", [_E, _R])
     after
         pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),

--- a/core/kazoo_proper/src/pqc_cb_search.erl
+++ b/core/kazoo_proper/src/pqc_cb_search.erl
@@ -20,7 +20,12 @@ search_account_by_name(API, Name) ->
                     ,{<<"v">>, Name}
                     ]
                    ),
-    pqc_cb_api:make_request([200], fun kz_http:get/2, URL ++ [$? | Querystring], RequestHeaders).
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,URL ++ [$? | Querystring]
+                           ,RequestHeaders
+                           ).
 
 -spec search_url(pqc_cb_api:state()) -> string().
 search_url(API) ->

--- a/core/kazoo_proper/src/pqc_cb_services.erl
+++ b/core/kazoo_proper/src/pqc_cb_services.erl
@@ -42,7 +42,8 @@ assign_service_plan(API, AccountId, ServicePlanId) ->
     RequestData = kz_json:from_list([{<<"add">>, [ServicePlanId]}]),
     RequestEnvelope = pqc_cb_api:create_envelope(RequestData),
 
-    pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:post/3
                            ,URL
                            ,RequestHeaders
@@ -54,7 +55,8 @@ assign_service_plan(API, AccountId, ServicePlanId) ->
 available_service_plans(API, AccountId) ->
     URL = string:join([account_service_plan_url(AccountId), "available"], "/"),
     RequestHeaders = pqc_cb_api:request_headers(API),
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,URL
                            ,RequestHeaders

--- a/core/kazoo_proper/src/pqc_cb_storage.erl
+++ b/core/kazoo_proper/src/pqc_cb_storage.erl
@@ -49,8 +49,9 @@ create(API, AccountId, ?NE_BINARY=UUID, ValidateSettings) ->
     create(API, AccountId, storage_doc(UUID), ValidateSettings);
 create(API, AccountId, StorageDoc, ValidateSettings) ->
     StorageURL = storage_url(AccountId, ValidateSettings),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, <<"application/json">>}]),
-    pqc_cb_api:make_request([201]
+    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "application/json"}]),
+    Expectations = [#expectation{response_codes = [201]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,StorageURL
                            ,RequestHeaders
@@ -276,7 +277,8 @@ handle_mp3_contents(MP3, Base64MP3, 'true') ->
 -spec cleanup() -> 'ok'.
 cleanup() ->
     _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
-    cleanup_system().
+    cleanup_system(),
+    timer:sleep(500).
 
 cleanup(API) ->
     ?INFO("CLEANUP TIME, EVERYBODY HELPS"),

--- a/core/kazoo_proper/src/pqc_cb_storage.erl
+++ b/core/kazoo_proper/src/pqc_cb_storage.erl
@@ -49,7 +49,7 @@ create(API, AccountId, ?NE_BINARY=UUID, ValidateSettings) ->
     create(API, AccountId, storage_doc(UUID), ValidateSettings);
 create(API, AccountId, StorageDoc, ValidateSettings) ->
     StorageURL = storage_url(AccountId, ValidateSettings),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "application/json"}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, "application/json"}]),
     Expectations = [#expectation{response_codes = [201]}],
     pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3

--- a/core/kazoo_proper/src/pqc_cb_system_configs.erl
+++ b/core/kazoo_proper/src/pqc_cb_system_configs.erl
@@ -1,3 +1,8 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2018-2019, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
 -module(pqc_cb_system_configs).
 
 -export([seq/0
@@ -69,7 +74,8 @@ config_url(Id, NodeId) ->
 -spec list_configs(pqc_cb_api:api()) -> kz_term:ne_binaries().
 list_configs(API) ->
     URL = configs_url(),
-    Resp = pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -79,7 +85,8 @@ list_configs(API) ->
 -spec get_config(pqc_cb_api:api(), kz_term:ne_binary()) -> kzd_system_configs:doc().
 get_config(API, Id) ->
     URL = config_url(Id),
-    Resp = pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -89,7 +96,8 @@ get_config(API, Id) ->
 -spec get_default_config(pqc_cb_api:api(), kz_term:ne_binary()) -> kzd_system_configs:doc().
 get_default_config(API, Id) ->
     URL = config_url(Id) ++ "?with_defaults=true",
-    Resp = pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -99,7 +107,8 @@ get_default_config(API, Id) ->
 -spec get_node_config(pqc_cb_api:api(), kz_term:ne_binary(), kz_term:ne_binary()) -> kzd_system_configs:doc().
 get_node_config(API, Id, NodeId) ->
     URL = config_url(Id, NodeId) ++ "?with_defaults=true",
-    Resp = pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:get/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -112,8 +121,9 @@ set_default_config(API, Config) ->
     ?INFO("setting default config for ~p", [Config]),
     URL = config_url(kz_doc:id(Config)),
     Data = pqc_cb_api:create_envelope(Config),
+    Expectations = [#expectation{response_codes = [200]}],
 
-    Resp = pqc_cb_api:make_request([200]
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:post/3
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -121,13 +131,14 @@ set_default_config(API, Config) ->
                                   ),
     pqc_cb_response:data(Resp).
 
--spec patch_default_config(pqc_cb_api:api(), kz_tern:ne_binary(), kz_json:object()) -> kzd_system_configs:doc().
+-spec patch_default_config(pqc_cb_api:api(), kz_term:ne_binary(), kz_json:object()) -> kzd_system_configs:doc().
 patch_default_config(API, Id, Config) ->
     ?INFO("patching default config for ~p", [Config]),
     URL = config_url(Id),
     Data = pqc_cb_api:create_envelope(Config),
+    Expectations = [#expectation{response_codes = [200]}],
 
-    Resp = pqc_cb_api:make_request([200]
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:patch/3
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)
@@ -138,7 +149,8 @@ patch_default_config(API, Id, Config) ->
 -spec delete_config(pqc_cb_api:api(), kz_term:ne_binary()) -> kz_json:object().
 delete_config(API, Id) ->
     URL = config_url(Id),
-    Resp = pqc_cb_api:make_request([200, 404]
+    Expectations = [#expectation{response_codes = [200, 404]}],
+    Resp = pqc_cb_api:make_request(Expectations
                                   ,fun kz_http:delete/2
                                   ,URL
                                   ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_cb_tasks.erl
+++ b/core/kazoo_proper/src/pqc_cb_tasks.erl
@@ -6,21 +6,79 @@
 %%%-----------------------------------------------------------------------------
 -module(pqc_cb_tasks).
 
--export([create/3
-        ,execute/2
-        ,fetch/2, fetch_csv/3
-        ,delete/2
+-export([create/2, create/3
+        ,create_account/3, create_account/4
+        ,execute/2, execute/3
+        ,fetch/2, fetch/3
+        ,fetch_csv/3, fetch_csv/4
+        ,delete/2, delete/3
         ,query/3
         ]).
 
 -include("kazoo_proper.hrl").
 
+%%------------------------------------------------------------------------------
+%% @doc Craete a noinput task
+%% @end
+%%------------------------------------------------------------------------------
+-spec create(pqc_cb_api:state(), string()) -> pqc_cb_api:response().
+create(API, QueryString) ->
+    TaskURL = tasks_url(QueryString),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+    Expectations = [#expectation{response_codes = [201, 404, 409]}],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:put/3
+                           ,TaskURL
+                           ,RequestHeaders
+                           ,<<>>
+                           ).
+
+%%------------------------------------------------------------------------------
+%% @doc Craete an input task with CSV request body
+%% @end
+%%------------------------------------------------------------------------------
 -spec create(pqc_cb_api:state(), string(), iolist()) -> pqc_cb_api:response().
 create(API, QueryString, CSV) ->
     TaskURL = tasks_url(QueryString),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, <<"text/csv">>}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "text/csv"}]),
+    Expectations = [#expectation{response_codes = [201, 404, 409]}],
 
-    pqc_cb_api:make_request([201, 404, 409]
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:put/3
+                           ,TaskURL
+                           ,RequestHeaders
+                           ,CSV
+                           ).
+
+%%------------------------------------------------------------------------------
+%% @doc Craete a noinput task for an account
+%% @end
+%%------------------------------------------------------------------------------
+-spec create_account(pqc_cb_api:state(), kz_term:ne_binary(), string()) -> pqc_cb_api:response().
+create_account(API, AccountId, QueryString) ->
+    TaskURL = tasks_url(AccountId, QueryString),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+    Expectations = [#expectation{response_codes = [201, 404, 409]}],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:put/3
+                           ,TaskURL
+                           ,RequestHeaders
+                           ,<<>>
+                           ).
+
+%%------------------------------------------------------------------------------
+%% @doc Craete an input task with CSV request body for an account
+%% @end
+%%------------------------------------------------------------------------------
+-spec create_account(pqc_cb_api:state(), kz_term:ne_binary(), string(), iolist()) -> pqc_cb_api:response().
+create_account(API, AccountId, QueryString, CSV) ->
+    TaskURL = tasks_url(AccountId, QueryString),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "text/csv"}]),
+    Expectations = [#expectation{response_codes = [201, 404, 409]}],
+
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,TaskURL
                            ,RequestHeaders
@@ -29,39 +87,83 @@ create(API, QueryString, CSV) ->
 
 -spec execute(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 execute(API, TaskId) ->
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:patch/3
                            ,task_url(TaskId)
                            ,pqc_cb_api:request_headers(API)
                            ,<<>>
                            ).
 
+-spec execute(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+execute(API, AccountId, TaskId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:patch/3
+                           ,task_url(AccountId, TaskId)
+                           ,pqc_cb_api:request_headers(API)
+                           ,<<>>
+                           ).
+
 -spec fetch(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 fetch(API, TaskId) ->
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,task_url(TaskId)
                            ,pqc_cb_api:request_headers(API)
                            ).
 
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch(API, AccountId, TaskId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,task_url(AccountId, TaskId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
 -spec fetch_csv(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 fetch_csv(API, TaskId, CSV) ->
-    Expectations = [#{'response_codes' => [200]
-                     ,'response_headers' => [{"content-type", "text/csv"}]
-                     }
-                   ,#{'response_codes' => [204]}
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "text/csv"}]
+                                }
+                   ,#expectation{response_codes = [204]}
                    ],
     pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,task_csv_url(TaskId, CSV)
-                           ,pqc_cb_api:request_headers(API, [{<<"accept">>, <<"text/csv">>}])
+                           ,pqc_cb_api:request_headers(API, [{"accept", "text/csv"}])
+                           ).
+
+-spec fetch_csv(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch_csv(API, AccountId, TaskId, CSV) ->
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "text/csv"}]
+                                }
+                   ,#expectation{response_codes = [204]}
+                   ],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,task_csv_url(AccountId, TaskId, CSV)
+                           ,pqc_cb_api:request_headers(API, [{"accept", "text/csv"}])
                            ).
 
 -spec delete(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
 delete(API, TaskId) ->
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:delete/2
                            ,task_url(TaskId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec delete(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+delete(API, AccountId, TaskId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:delete/2
+                           ,task_url(AccountId, TaskId)
                            ,pqc_cb_api:request_headers(API)
                            ).
 
@@ -71,8 +173,9 @@ query(API, Category, Action) ->
                         ,"&action=", kz_term:to_list(Action)
                         ]
                        ),
+    Expectations = [#expectation{response_codes = [200]}],
 
-    pqc_cb_api:make_request([200]
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,TaskURL
                            ,pqc_cb_api:request_headers(API)
@@ -82,10 +185,22 @@ query(API, Category, Action) ->
 task_csv_url(TaskId, CSV) ->
     task_url(TaskId) ++ "?csv_name=" ++ kz_term:to_list(CSV).
 
+-spec task_csv_url(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> string().
+task_csv_url(AccountId, TaskId, CSV) ->
+    task_url(AccountId, TaskId) ++ "?csv_name=" ++ kz_term:to_list(CSV).
+
 -spec task_url(kz_term:ne_binary()) -> string().
 task_url(TaskId) ->
     string:join([pqc_cb_api:v2_base_url(), "tasks", kz_term:to_list(TaskId)], "/").
 
+-spec task_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
+task_url(AccountId, TaskId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "tasks", kz_term:to_list(TaskId)], "/").
+
 -spec tasks_url(iolist()) -> iolist().
 tasks_url(QueryString) ->
     string:join([pqc_cb_api:v2_base_url(), "tasks"], "/") ++ [$? | QueryString].
+
+-spec tasks_url(kz_term:ne_binary(), iolist()) -> iolist().
+tasks_url(AccountId, QueryString) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "tasks"], "/") ++ [$? | QueryString].

--- a/core/kazoo_proper/src/pqc_cb_tasks.erl
+++ b/core/kazoo_proper/src/pqc_cb_tasks.erl
@@ -41,7 +41,7 @@ create(API, QueryString) ->
 -spec create(pqc_cb_api:state(), string(), iolist()) -> pqc_cb_api:response().
 create(API, QueryString, CSV) ->
     TaskURL = tasks_url(QueryString),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "text/csv"}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, "text/csv"}]),
     Expectations = [#expectation{response_codes = [201, 404, 409]}],
 
     pqc_cb_api:make_request(Expectations
@@ -75,7 +75,7 @@ create_account(API, AccountId, QueryString) ->
 -spec create_account(pqc_cb_api:state(), kz_term:ne_binary(), string(), iolist()) -> pqc_cb_api:response().
 create_account(API, AccountId, QueryString, CSV) ->
     TaskURL = tasks_url(AccountId, QueryString),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "text/csv"}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, "text/csv"}]),
     Expectations = [#expectation{response_codes = [201, 404, 409]}],
 
     pqc_cb_api:make_request(Expectations
@@ -133,7 +133,7 @@ fetch_csv(API, TaskId, CSV) ->
     pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,task_csv_url(TaskId, CSV)
-                           ,pqc_cb_api:request_headers(API, [{"accept", "text/csv"}])
+                           ,pqc_cb_api:request_headers(API, [{<<"accept">>, "text/csv"}])
                            ).
 
 -spec fetch_csv(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
@@ -146,7 +146,7 @@ fetch_csv(API, AccountId, TaskId, CSV) ->
     pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,task_csv_url(AccountId, TaskId, CSV)
-                           ,pqc_cb_api:request_headers(API, [{"accept", "text/csv"}])
+                           ,pqc_cb_api:request_headers(API, [{<<"accept">>, "text/csv"}])
                            ).
 
 -spec delete(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().

--- a/core/kazoo_proper/src/pqc_cb_users.erl
+++ b/core/kazoo_proper/src/pqc_cb_users.erl
@@ -1,0 +1,228 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_users).
+
+%% API requests
+-export([summary/2
+        ,create/3
+        ,fetch/3
+        ,update/3
+        ,patch/4
+        ,delete/3
+        ]).
+
+-export([seq/0
+        ,cleanup/0
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
+
+-spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+summary(API, AccountId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,users_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec create(pqc_cb_api:state(), kz_term:ne_binary(), kzd_users:doc()) -> pqc_cb_api:response().
+create(API, AccountId, UserJObj) ->
+    URL = users_url(AccountId),
+
+    Expectations = [#expectation{response_codes = [201]
+                                ,response_headers = [{"content-type", "application/json"}
+                                                    ,{"location", {'match', expected_location_value(URL)}}
+                                                    ]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(UserJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:put/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch(API, AccountId, UserId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,user_url(AccountId, UserId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec update(pqc_cb_api:state(), kz_term:ne_binary(), kzd_users:doc()) -> pqc_cb_api:response().
+update(API, AccountId, UserJObj) ->
+    URL = user_url(AccountId, kz_doc:id(UserJObj)),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(UserJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec patch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
+patch(API, AccountId, UserId, PatchJObj) ->
+    URL = user_url(AccountId, UserId),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(PatchJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:patch/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec delete(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+delete(API, AccountId, UserId) ->
+    URL = user_url(AccountId, UserId),
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:delete/2
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec users_url(kz_term:ne_binary()) -> string().
+users_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "users"], "/").
+
+-spec user_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
+user_url(AccountId, UserId) ->
+    string:join([users_url(AccountId), kz_term:to_list(UserId)], "/").
+
+-spec seq() -> 'ok'.
+seq() ->
+    API = pqc_cb_api:init_api(['crossbar'], ['cb_users_v2']),
+    AccountId = create_account(API),
+
+    'ok' = create_simple_user(API, AccountId),
+    wrong_format_check(API, AccountId),
+
+    cleanup(API),
+    ?INFO("FINISHED USERS SEQ").
+
+create_simple_user(API, AccountId) ->
+    EmptySummaryResp = summary(API, AccountId),
+    ?INFO("empty summary resp: ~s", [EmptySummaryResp]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
+
+    UserJObj = new_user(),
+    CreateResp = create(API, AccountId, UserJObj),
+    ?INFO("created user ~s", [CreateResp]),
+    CreatedUser = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
+    UserId = kz_doc:id(CreatedUser),
+    'true' = user_docs_match(UserJObj, CreatedUser),
+
+    UserWithEmail = kzd_users:set_email(CreatedUser, <<(kz_binary:rand_hex(4))/binary, "@2600hz.com">>),
+    UpdateResp = update(API, AccountId, UserWithEmail),
+    ?INFO("updated to ~s", [UpdateResp]),
+    'true' = user_docs_match(UserWithEmail, kz_json:get_json_value(<<"data">>, kz_json:decode(UpdateResp))),
+
+    Patch = kz_json:from_list([{<<"custom">>, <<"value">>}]),
+    PatchedUser = kz_json:merge(UserWithEmail, Patch),
+
+    PatchResp = patch(API, AccountId, UserId, Patch),
+    ?INFO("patched to ~s", [PatchResp]),
+    'true' = user_docs_match(PatchedUser, kz_json:get_json_value(<<"data">>, kz_json:decode(PatchResp))),
+
+    SummaryResp = summary(API, AccountId),
+    ?INFO("summary resp: ~s", [SummaryResp]),
+    [SummaryUser] = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
+    UserId = kz_doc:id(SummaryUser),
+
+    DeleteResp = delete(API, AccountId, UserId),
+    ?INFO("delete resp: ~s", [DeleteResp]),
+
+    EmptyAgain = summary(API, AccountId),
+    ?INFO("empty summary resp: ~s", [EmptyAgain]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptyAgain)),
+    ?INFO("FINISHED SIMPLE USER").
+
+wrong_format_check(API, AccountId) ->
+    ShortEmail = kzd_users:set_email(new_user(), <<"e">>),
+    {'error', ShortEmailError} = create(API, AccountId, ShortEmail),
+    lager:info("validation failed creating empty email: ~s", [ShortEmailError]),
+
+    WrongFormat = kzd_users:set_email(new_user(), kz_binary:rand_hex(4)),
+    {'error', WrongFormatError} = create(API, AccountId, WrongFormat),
+    lager:info("validation failed creating user: ~s", [WrongFormatError]),
+    'true' = kzd_users:email(WrongFormat) =:= kz_json:get_ne_binary_value([<<"data">>, <<"email">>, <<"wrong_format">>, <<"value">>]
+                                                                         ,kz_json:decode(WrongFormatError)
+                                                                         ),
+    lager:info("FINISHED WRONG FORMAT CHECK").
+
+user_docs_match(Model, RespJObj) ->
+    kz_json:all(fun({ModelKey, ModelValue}) -> user_setting_matches(ModelKey, ModelValue, RespJObj) end
+               ,Model
+               ).
+
+user_setting_matches(ModelKey, ModelValue, RespJObj) ->
+    case kz_json:get_value(ModelKey, RespJObj) of
+        ModelValue -> 'true';
+        _V ->
+            ?INFO("key ~s is ~p instead of ~p", [ModelKey, _V, ModelValue]),
+            'false'
+    end.
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
+    cleanup_system().
+
+cleanup(API) ->
+    ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _ = pqc_cb_api:cleanup(API),
+    cleanup_system().
+
+cleanup_system() -> 'ok'.
+
+-spec create_account(pqc_cb_api:state()) -> kz_term:ne_binary().
+create_account(API) ->
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    ?INFO("created account: ~s", [AccountResp]),
+
+    kz_json:get_ne_binary_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
+
+-spec new_user() -> kzd_users:doc().
+new_user() ->
+    kz_doc:public_fields(
+      kz_json:exec_first([{fun kzd_users:set_first_name/2, kz_binary:rand_hex(4)}
+                         ,{fun kzd_users:set_last_name/2, kz_binary:rand_hex(4)}
+                         ]
+                        ,kzd_users:new()
+                        )
+     ).
+
+%% take http://whatever:port/v2/... and get /v2/.../{regex}
+expected_location_value(URL) ->
+    expected_location_value(URL, "(\\w{32})").
+
+expected_location_value(URL, Id) ->
+    {'match', [_Host, Path]} = re:run(URL, "^(.+)(/v2/.+$)", [{'capture','all_but_first', 'list'}]),
+    Path ++ [$/ | kz_term:to_list(Id)].

--- a/core/kazoo_proper/src/pqc_cb_vmboxes.erl
+++ b/core/kazoo_proper/src/pqc_cb_vmboxes.erl
@@ -30,8 +30,8 @@ new_message(API, AccountId, BoxId, MessageJObj, MessageBin) ->
                                         ),
 
     RequestHeaders = pqc_cb_api:request_headers(API
-                                               ,[{"content-type", "multipart/mixed; boundary=" ++ kz_term:to_list(Boundary)}
-                                                ,{"content-length", iolist_size(Body)}
+                                               ,[{<<"content-type">>, "multipart/mixed; boundary=" ++ kz_term:to_list(Boundary)}
+                                                ,{<<"content-length">>, iolist_size(Body)}
                                                 ]
                                                ),
 
@@ -60,7 +60,7 @@ fetch_message_metadata(API, AccountId, BoxId, MessageId) ->
 fetch_message_binary(API, AccountId, BoxId, MessageId) ->
     MessageURL = message_bin_url(AccountId, BoxId, MessageId),
 
-    RequestHeaders = pqc_cb_api:request_headers(API, [{"accept", "audio/mp3"}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"accept">>, "audio/mp3"}]),
 
     Expectations = [#expectation{response_codes = [200]}],
     pqc_cb_api:make_request(Expectations
@@ -72,7 +72,7 @@ fetch_message_binary(API, AccountId, BoxId, MessageId) ->
 -spec create_box(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 create_box(API, AccountId, BoxName) ->
     BoxesURL = boxes_url(AccountId),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "application/json"}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, "application/json"}]),
 
     Data = kz_json:from_list([{<<"name">>, BoxName}
                              ,{<<"mailbox">>, BoxName}

--- a/core/kazoo_proper/src/pqc_cb_vmboxes.erl
+++ b/core/kazoo_proper/src/pqc_cb_vmboxes.erl
@@ -1,3 +1,8 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2018-2019, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
 -module(pqc_cb_vmboxes).
 
 -export([new_message/5
@@ -5,6 +10,8 @@
         ,fetch_message_binary/4
         ,create_box/3
         ]).
+
+-include("kazoo_proper.hrl").
 
 -spec new_message(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), binary()) ->
                          pqc_cb_api:response().
@@ -23,12 +30,13 @@ new_message(API, AccountId, BoxId, MessageJObj, MessageBin) ->
                                         ),
 
     RequestHeaders = pqc_cb_api:request_headers(API
-                                               ,[{<<"content-type">>, <<"multipart/mixed; boundary=", Boundary/binary>>}
-                                                ,{<<"content-length">>, iolist_size(Body)}
+                                               ,[{"content-type", "multipart/mixed; boundary=" ++ kz_term:to_list(Boundary)}
+                                                ,{"content-length", iolist_size(Body)}
                                                 ]
                                                ),
 
-    pqc_cb_api:make_request([201]
+    Expectations = [#expectation{response_codes = [201]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,MessagesURL
                            ,RequestHeaders
@@ -41,7 +49,8 @@ fetch_message_metadata(API, AccountId, BoxId, MessageId) ->
 
     RequestHeaders = pqc_cb_api:request_headers(API),
 
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,MessageURL
                            ,RequestHeaders
@@ -51,9 +60,10 @@ fetch_message_metadata(API, AccountId, BoxId, MessageId) ->
 fetch_message_binary(API, AccountId, BoxId, MessageId) ->
     MessageURL = message_bin_url(AccountId, BoxId, MessageId),
 
-    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"accept">>, <<"audio/mp3">>}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{"accept", "audio/mp3"}]),
 
-    pqc_cb_api:make_request([200]
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:get/2
                            ,MessageURL
                            ,RequestHeaders
@@ -62,14 +72,15 @@ fetch_message_binary(API, AccountId, BoxId, MessageId) ->
 -spec create_box(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 create_box(API, AccountId, BoxName) ->
     BoxesURL = boxes_url(AccountId),
-    RequestHeaders = pqc_cb_api:request_headers(API, [{<<"content-type">>, <<"application/json">>}]),
+    RequestHeaders = pqc_cb_api:request_headers(API, [{"content-type", "application/json"}]),
 
     Data = kz_json:from_list([{<<"name">>, BoxName}
                              ,{<<"mailbox">>, BoxName}
                              ]),
     Req = pqc_cb_api:create_envelope(Data),
+    Expectations = [#expectation{response_codes = [201]}],
 
-    pqc_cb_api:make_request([201]
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,BoxesURL
                            ,RequestHeaders

--- a/core/kazoo_proper/src/pqc_cb_webhooks.erl
+++ b/core/kazoo_proper/src/pqc_cb_webhooks.erl
@@ -1,0 +1,159 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2019-, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_webhooks).
+
+%% API functions
+-export([list_available/1
+        ,samples/1, sample/2
+
+         %% Account operations
+        ,summary/2
+        ]).
+
+%% Manual test functions
+-export([seq/0
+        ,cleanup/0
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<"account_for_webhooks">>]).
+
+-spec list_available(pqc_cb_api:state()) -> pqc_cb_api:response().
+list_available(API) ->
+    URL = base_webhooks_url(),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+
+    Expectations = [#expectation{response_codes = [200]}],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,URL
+                           ,RequestHeaders
+                           ).
+
+-spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+summary(API, AccountId) ->
+    WebhooksURL = webhooks_url(AccountId),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+
+    Expectations = [#expectation{response_codes = [200]}],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,WebhooksURL
+                           ,RequestHeaders
+                           ).
+
+-spec samples(pqc_cb_api:state()) -> pqc_cb_api:response().
+samples(API) ->
+    URL = samples_url(),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+
+    Expectations = [#expectation{response_codes = [200]}],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,URL
+                           ,RequestHeaders
+                           ).
+
+-spec sample(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+sample(API, SampleId) ->
+    URL = sample_url(SampleId),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+
+    Expectations = [#expectation{response_codes = [200]}],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,URL
+                           ,RequestHeaders
+                           ).
+
+-spec base_webhooks_url() -> string().
+base_webhooks_url() ->
+    string:join([pqc_cb_api:v2_base_url(), "webhooks"], "/").
+
+-spec webhooks_url(kz_term:ne_binary()) -> string().
+webhooks_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "webhooks"], "/").
+
+%% -spec webhook_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
+%% webhook_url(AccountId, WebhookId) ->
+%%     string:join([pqc_cb_accounts:account_url(AccountId), "webhooks", kz_term:to_list(WebhookId)], "/").
+
+-spec samples_url() -> string().
+samples_url() ->
+    string:join([base_webhooks_url(), "samples"], "/").
+
+-spec sample_url(kz_term:ne_binary()) -> string().
+sample_url(SampleId) ->
+    string:join([base_webhooks_url(), "samples", kz_term:to_list(SampleId)], "/").
+
+-spec seq() -> 'ok'.
+seq() ->
+    Model = initial_state(),
+    API = pqc_kazoo_model:api(Model),
+
+    AvailableResp = list_available(API),
+    lager:info("available: ~s", [AvailableResp]),
+    Available = kz_json:get_list_value(<<"data">>, kz_json:decode(AvailableResp)),
+    'true' = ([] =/= Available),
+
+    SamplesResp = samples(API),
+    lager:info("samples: ~s", [SamplesResp]),
+    Samples = [_|_] = kz_json:get_list_value(<<"data">>, kz_json:decode(SamplesResp)),
+
+    lists:all(fun(SampleId) -> can_fetch_sample(API, SampleId) end, Samples),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    lager:info("created account: ~s", [AccountResp]),
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+
+    SummaryResp = summary(API, AccountId),
+    lager:info("summary: ~s", [SummaryResp]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
+
+    cleanup(API),
+    lager:info("FINISHED").
+
+-spec initial_state() -> pqc_kazoo_model:model().
+initial_state() ->
+    _ = init_system(),
+    API = pqc_cb_api:authenticate(),
+    pqc_kazoo_model:new(API).
+
+init_system() ->
+    TestId = kz_binary:rand_hex(5),
+    kz_util:put_callid(TestId),
+
+    _ = kz_data_tracing:clear_all_traces(),
+    _ = [kapps_controller:start_app(App) ||
+            App <- ['crossbar', 'webhooks']
+        ],
+    _ = [crossbar_maintenance:start_module(Mod) ||
+            Mod <- ['cb_webhooks']
+        ],
+    lager:info("INIT FINISHED").
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
+    cleanup_system().
+
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _ = pqc_cb_api:cleanup(API),
+    cleanup_system().
+
+cleanup_system() -> 'ok'.
+
+can_fetch_sample(API, SampleId) ->
+    SampleResp = sample(API, SampleId),
+    lager:info("sample for ~s: ~s", [SampleId, SampleResp]),
+    [] =/= kz_json:get_list_value(<<"data">>, kz_json:decode(SampleResp)).

--- a/core/kazoo_proper/src/pqc_cb_whitelabel.erl
+++ b/core/kazoo_proper/src/pqc_cb_whitelabel.erl
@@ -15,7 +15,8 @@
 -spec create_whitelabel(pqc_cb_api:state(), kz_doc:setter_funs()) -> pqc_cb_api:response().
 create_whitelabel(API, Setters) ->
     Envelope = pqc_cb_api:create_envelope(kz_doc:setters(kz_json:new(), Setters)),
-    pqc_cb_api:make_request([201]
+    Expectations = [#expectation{response_codes = [201]}],
+    pqc_cb_api:make_request(Expectations
                            ,fun kz_http:put/3
                            ,whitelabel_url(pqc_cb_api:auth_account_id(API))
                            ,pqc_cb_api:request_headers(API)

--- a/core/kazoo_proper/src/pqc_httpd.erl
+++ b/core/kazoo_proper/src/pqc_httpd.erl
@@ -1,3 +1,8 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2018-2019, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
 -module(pqc_httpd).
 -behaviour(cowboy_handler).
 -behaviour(gen_server).
@@ -95,7 +100,7 @@ update_req(Path, <<_/binary>>=Content) ->
 log_meta(LogId) ->
     kz_util:put_callid(LogId),
     lager:md([{'request_id', LogId}]),
-    put('now', kz_time:now()),
+    put('start_time', kz_time:start_time()),
     'ok'.
 
 -spec init(list()) -> {'ok', state()}.
@@ -137,7 +142,7 @@ init(Req, HandlerOpts) ->
 
 -spec handle(cowboy_req:req(), State) -> {'ok', cowboy_req:req(), State}.
 handle(Req, State) ->
-    put('now', kz_time:now()),
+    put('start_time', kz_time:start_time()),
     handle(Req, State, cowboy_req:method(Req)).
 
 handle(Req, State, <<"POST">>) ->
@@ -183,7 +188,7 @@ add_req_to_state(Req, State) ->
 
 -spec read_body({'ok', binary(), cowboy_req:req()} |
                 {'more', binary(), cowboy_req:req()}
-               ) -> {cowbow_req:req(), iodata()}.
+               ) -> {cowboy_req:req(), iodata()}.
 read_body({'ok', BodyPart, Req}) ->
     {Req, BodyPart};
 read_body({'more', BodyPart, Req}) ->
@@ -230,7 +235,7 @@ handle_part_headers(Req, Headers) ->
 
 -spec terminate(any(), cowboy_req:req(), any()) -> 'ok'.
 terminate(_Reason, _Req, _State) ->
-    ?INFO("finished req ~p", [kz_time:elapsed_ms(get('now'))]).
+    ?INFO("finished req ~p", [kz_time:elapsed_ms(get('start_time'))]).
 
 -spec terminate(any(), state()) -> 'ok'.
 terminate(_Reason, _State) ->

--- a/core/kazoo_proper/src/pqc_kazoo_model.erl
+++ b/core/kazoo_proper/src/pqc_kazoo_model.erl
@@ -173,7 +173,9 @@ has_rate_matching(#kazoo_model{}=Model, RatedeckId, DID) ->
     Ratedeck = ratedeck(Model, RatedeckId),
     has_rate_matching(Ratedeck, DID).
 
--spec has_service_plan_rate_matching(model(), kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
+-spec has_service_plan_rate_matching(model(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                                            'false' |
+                                            {'true', number()}.
 has_service_plan_rate_matching(#kazoo_model{'accounts'=Accounts
                                            ,'service_plans'=SPs
                                            }=Model
@@ -196,7 +198,9 @@ has_service_plan_rate_matching(#kazoo_model{'accounts'=Accounts
             end
     end.
 
--spec has_rate_matching(rate_data(), kz_term:ne_binary()) -> boolean().
+-spec has_rate_matching(rate_data(), kz_term:ne_binary()) ->
+                               'false' |
+                               {'true', number()}.
 has_rate_matching(Ratedeck, <<"+", Number/binary>>) ->
     has_rate_matching(Ratedeck, Number);
 has_rate_matching(Ratedeck, Number) ->

--- a/core/kazoo_proper/src/pqc_kzs_cache.erl
+++ b/core/kazoo_proper/src/pqc_kzs_cache.erl
@@ -172,7 +172,7 @@ doc(Rev) ->
 
 doc_updates(Rev) ->
     [{<<"_rev">>, Rev}
-     | [{kz_term:to_binary(Key), kz_binary:rand_hex(16)} || Key <- lists:seq(1,50)]
+     | [{[kz_term:to_binary(Key)], kz_binary:rand_hex(16)} || Key <- lists:seq(1,50)]
     ].
 
 -spec initial_state() -> 'undefined'.

--- a/core/kazoo_proper/src/pqc_log.erl
+++ b/core/kazoo_proper/src/pqc_log.erl
@@ -10,8 +10,8 @@
 
 -spec log_info() -> [{atom(), iolist()}].
 log_info() ->
-    log_info(get('now')).
+    log_info(get('start_time')).
 log_info('undefined') ->
     [];
-log_info(Now) ->
-    [{'elapsed', kz_term:to_list(kz_time:elapsed_ms(Now))}].
+log_info(StartTime) ->
+    [{'elapsed', kz_term:to_list(kz_time:elapsed_ms(StartTime))}].

--- a/core/kazoo_proper/src/pqc_media_mgr.erl
+++ b/core/kazoo_proper/src/pqc_media_mgr.erl
@@ -1,0 +1,29 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_media_mgr).
+
+-export([request_media_url/1, request_media_url/2]).
+
+-include("kazoo_proper.hrl").
+
+-spec request_media_url(kz_term:ne_binary()) -> kz_amqp_worker:request_return().
+request_media_url(MediaName) ->
+    request_media_url(MediaName, <<"new">>).
+
+-spec request_media_url(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_amqp_worker:request_return().
+request_media_url(MediaName, Type) ->
+    MsgProps = props:filter_undefined(
+                 [{<<"Media-Name">>, MediaName}
+                 ,{<<"Stream-Type">>, Type}
+                 ,{<<"Call-ID">>, kz_binary:rand_hex(8)}
+                 ,{<<"Msg-ID">>, kz_binary:rand_hex(8)}
+                  | kz_api:default_headers(<<"media">>, <<"media_req">>, ?APP_NAME, ?APP_VERSION)
+                 ]),
+    kz_amqp_worker:call_collect(MsgProps
+                               ,fun kapi_media:publish_req/1
+                               ,{'media_mgr', fun kapi_media:resp_v/1}
+                               ).

--- a/core/kazoo_proper/src/pqc_util.erl
+++ b/core/kazoo_proper/src/pqc_util.erl
@@ -37,22 +37,23 @@ simple_counterexample() ->
 
 -spec simple_counterexample('undefined' | list()) -> [{module(), function(), list()}].
 simple_counterexample('undefined') ->
-    {error, no_counterexample};
+    {'error', 'no_counterexample'};
 simple_counterexample([Seq]) ->
     [{M, F, ['{API}'|cleanup_args(Args)]}
-     || {set, _Var, {call, M, F, [_|Args]}} <- Seq
+     || {'set', _Var, {'call', M, F, [_|Args]}} <- Seq
     ].
 
 cleanup_args(Args) ->
     [cleanup_arg(Arg) || Arg <- Args].
-cleanup_arg({call, M, F, Args}) ->
+cleanup_arg({'call', M, F, Args}) ->
     {M,F, length(Args)};
 cleanup_arg(Arg) -> Arg.
 
-
+%% {M, F, Args/Arity, [{file, Filename}, {line, LineNo}]}
+-type stack_item() :: {module(), atom(), arity() | [term()], [{'file', string()} | {'line', integer()}]}.
 -spec run_counterexample(module()) ->
                                 {kz_term:ne_binary(), 'postcondition_failed'} |
-                                {kz_term:ne_binary(), atom(), any(), [erlang:stack_item()]} |
+                                {kz_term:ne_binary(), atom(), any(), [stack_item()]} |
                                 {'ok', kz_term:ne_binary()}.
 run_counterexample(PQC) ->
     PQC:cleanup(),
@@ -79,7 +80,7 @@ run_counterexample(PQC) ->
             {RequestId, 'postcondition_failed'};
         E:R ->
             #{'request_id' := RequestId} = pqc_kazoo_model:api(InitialState),
-            {RequestId, E, R, erlang:get_stacktrace()}
+            {RequestId, E, R}
     after
         PQC:cleanup()
     end.

--- a/core/kazoo_stdlib/src/kz_time.erl
+++ b/core/kazoo_stdlib/src/kz_time.erl
@@ -11,6 +11,7 @@
         ,to_gregorian_seconds/2
         ,pretty_print_datetime/1
         ,rfc1036/1, rfc1036/2
+        ,rfc2822/1, rfc2822/2
         ,iso8601/1, iso8601/2
         ,iso8601_time/1
         ,from_iso8601/1
@@ -29,6 +30,8 @@
         ,weekday/1, month/1
         ,unitfy_seconds/1
         ,adjust_utc_timestamp/2, adjust_utc_datetime/2
+
+        ,start_time/0
         ]).
 
 -ifdef(TEST).
@@ -52,11 +55,14 @@
 -type date() :: calendar:date(). %%{year(), month(), day()}.
 -type time() :: calendar:time(). %%{hour(), minute(), second()}.
 -type datetime() :: calendar:datetime(). %%{date(), time()}.
--type iso_week() :: calendar:yearweeknum(). %%{year(), weeknum()}.
+-type iso_week() :: {year(), weeknum()}.
 -type gregorian_seconds() :: pos_integer().
 -type unix_seconds() :: pos_integer().
 -type api_seconds() :: 'undefined' | gregorian_seconds().
 -type ordinal() :: kz_term:ne_binary(). % "every" | "first" | "second" | "third" | "fourth" | "fifth" | "last".
+
+%% {'start_time', erlang:monotonic_time()}
+-type start_time() :: {'start_time', integer()}.
 
 -export_type([api_seconds/0
              ,date/0
@@ -113,7 +119,7 @@ to_gregorian_seconds({{_,_,_},{_,_,_}}=Datetime, ?NE_BINARY=FromTimezone) ->
 pretty_print_datetime(Timestamp) when is_integer(Timestamp) ->
     pretty_print_datetime(calendar:gregorian_seconds_to_datetime(Timestamp));
 pretty_print_datetime({{Y,Mo,D},{H,Mi,S}}) ->
-    iolist_to_binary(io_lib:format("~4..0w-~2..0w-~2..0w_~2..0w-~2..0w-~2..0w"
+    iolist_to_binary(io_lib:format("~4..0w-~2..0w-~2..0w_~2..0w:~2..0w:~2..0w"
                                   ,[Y, Mo, D, H, Mi, S]
                                   )).
 
@@ -135,6 +141,37 @@ rfc1036({Date = {Y, Mo, D}, {H, Mi, S}}, TZ) ->
     >>;
 rfc1036(Timestamp, TZ) when is_integer(Timestamp) ->
     rfc1036(calendar:gregorian_seconds_to_datetime(Timestamp), TZ).
+
+-spec rfc2822(calendar:datetime() | gregorian_seconds()) -> kz_term:ne_binary().
+rfc2822(Timestamp) ->
+    rfc2822(Timestamp, <<"GMT">>).
+
+-spec rfc2822(calendar:datetime() | gregorian_seconds(), kz_term:ne_binary()) -> kz_term:ne_binary().
+rfc2822(Timestamp, TZ) when is_integer(Timestamp) ->
+    rfc2822(calendar:gregorian_seconds_to_datetime(Timestamp), TZ);
+rfc2822(Datetime = {Date={Y, Mo, D}, {H, Mi, S}}, TZ) ->
+    Wday = calendar:day_of_the_week(Date),
+    <<(weekday(Wday))/binary, ", ",
+      (kz_binary:pad_left(kz_term:to_binary(D), 2, <<"0">>))/binary, " ",
+      (month(Mo))/binary, " ",
+      (kz_term:to_binary(Y))/binary, " ",
+      (kz_binary:pad_left(kz_term:to_binary(H), 2, <<"0">>))/binary, ":",
+      (kz_binary:pad_left(kz_term:to_binary(Mi), 2, <<"0">>))/binary, ":",
+      (kz_binary:pad_left(kz_term:to_binary(S), 2, <<"0">>))/binary,
+      " ", (tz_offset(Datetime, TZ))/binary
+    >>.
+
+-spec tz_offset(calendar:datetime(), kz_term:ne_binary()) -> kz_term:ne_binary().
+tz_offset(Datetime, <<FromTz/binary>>) ->
+    case localtime:tz_shift(Datetime, kz_term:to_list(FromTz), "UTC") of
+        0 -> <<"+0000">>;
+        {'error', 'unknown_tz'} -> <<"+0000">>;
+        {Sign, H, M} ->
+            list_to_binary([kz_term:to_binary(Sign)
+                           ,kz_binary:pad_left(kz_term:to_binary(H), 2, <<"0">>)
+                           ,kz_binary:pad_left(kz_term:to_binary(M), 2, <<"0">>)
+                           ])
+    end.
 
 %%------------------------------------------------------------------------------
 %% @doc Format time part of ISO 8601.
@@ -375,8 +412,8 @@ adjust_utc_timestamp(_Timestamp, <<"+", _/binary>>) ->
     throw({'error', 'invalid_offset'});
 adjust_utc_timestamp(_Timestamp, <<"-", _/binary>>) ->
     throw({'error', 'invalid_offset'});
-adjust_utc_timestamp(Timestamp, Timezone) ->
-    try localtime:utc_to_local(calendar:gregorian_seconds_to_datetime(Timestamp), Timezone) of
+adjust_utc_timestamp(Timestamp, <<Timezone/binary>>) when is_integer(Timestamp) ->
+    try localtime:utc_to_local(calendar:gregorian_seconds_to_datetime(Timestamp), kz_term:to_list(Timezone)) of
         {{_, _, _}, {_, _, _}} = Datetime ->
             calendar:datetime_to_gregorian_seconds(Datetime);
         [LocalDatetime, _LocalDstDatetime] ->
@@ -387,7 +424,6 @@ adjust_utc_timestamp(Timestamp, Timezone) ->
         _:_ ->
             throw({'error', 'unknown_tz'})
     end.
-
 
 %%------------------------------------------------------------------------------
 %% @doc Apply the adjustment to the Datetime.
@@ -438,7 +474,7 @@ month(12) -> <<"Dec">>.
 
 -spec pretty_print_elapsed_s(non_neg_integer()) -> kz_term:ne_binary().
 pretty_print_elapsed_s(0) -> <<"0s">>;
-pretty_print_elapsed_s(Seconds) ->
+pretty_print_elapsed_s(Seconds) when is_integer(Seconds), Seconds > 0 ->
     iolist_to_binary(unitfy_seconds(Seconds)).
 
 -spec unitfy_seconds(non_neg_integer()) -> iolist().
@@ -455,16 +491,18 @@ unitfy_seconds(Seconds) ->
     D = Seconds div ?SECONDS_IN_DAY,
     [kz_term:to_binary(D), "d", unitfy_seconds(Seconds - (D * ?SECONDS_IN_DAY))].
 
--spec decr_timeout(timeout(), now() | gregorian_seconds()) -> timeout().
+-spec decr_timeout(timeout(), now() | gregorian_seconds() | start_time()) -> timeout().
 decr_timeout('infinity', _) -> 'infinity';
 decr_timeout(Timeout, {_Mega, _S, _Micro}=Start) when is_integer(Timeout) ->
     decr_timeout(Timeout, Start, now());
 decr_timeout(Timeout, StartS) when is_integer(Timeout),
                                    is_integer(StartS),
                                    ?UNIX_EPOCH_IN_GREGORIAN < StartS ->
-    decr_timeout(Timeout, StartS, now_s()).
+    decr_timeout(Timeout, StartS, now_s());
+decr_timeout(Timeout, {'start_time', _}=StartTime) ->
+    decr_timeout(Timeout, StartTime, start_time()).
 
--spec decr_timeout(timeout(), now() | gregorian_seconds(), now() | gregorian_seconds()) -> timeout().
+-spec decr_timeout(timeout(), now() | gregorian_seconds() | start_time(), now() | gregorian_seconds() | start_time()) -> timeout().
 decr_timeout('infinity', _Start, _Future) -> 'infinity';
 decr_timeout(Timeout, Start, {_Mega, _S, _Micro}=Now) ->
     decr_timeout_elapsed(Timeout, elapsed_s(Start, Now));
@@ -473,7 +511,9 @@ decr_timeout(Timeout, StartS, Now) when is_integer(Timeout),
                                         ?UNIX_EPOCH_IN_GREGORIAN < StartS,
                                         is_integer(Now),
                                         ?UNIX_EPOCH_IN_GREGORIAN < Now ->
-    decr_timeout_elapsed(Timeout, elapsed_s(StartS, Now)).
+    decr_timeout_elapsed(Timeout, elapsed_s(StartS, Now));
+decr_timeout(Timeout, {'start_time', _}=Start, {'start_time', _}=End) ->
+    decr_timeout_elapsed(Timeout, elapsed_s(Start, End)).
 
 -spec decr_timeout_elapsed(non_neg_integer(), non_neg_integer()) -> non_neg_integer().
 decr_timeout_elapsed(Timeout, Elapsed) ->
@@ -489,19 +529,24 @@ microseconds_to_seconds(Microseconds) -> kz_term:to_integer(Microseconds) div ?M
 -spec milliseconds_to_seconds(float() | integer() | string() | binary()) -> non_neg_integer().
 milliseconds_to_seconds(Milliseconds) -> kz_term:to_integer(Milliseconds) div ?MILLISECONDS_IN_SECOND.
 
--spec elapsed_s(now() | pos_integer()) -> pos_integer().
+-spec elapsed_s(now() | pos_integer() | start_time()) -> non_neg_integer().
 elapsed_s({_,_,_}=Start) -> elapsed_s(Start, now());
-elapsed_s(Start) when is_integer(Start) -> elapsed_s(Start, now_s()).
+elapsed_s(Start) when is_integer(Start) -> elapsed_s(Start, now_s());
+elapsed_s({'start_time', _}=Start) -> elapsed_s(Start, start_time()).
 
--spec elapsed_ms(now() | pos_integer()) -> pos_integer().
+-spec elapsed_ms(now() | pos_integer() | start_time()) -> non_neg_integer().
 elapsed_ms({_,_,_}=Start) -> elapsed_ms(Start, now());
-elapsed_ms(Start) when is_integer(Start) -> elapsed_ms(Start, now_ms()).
+elapsed_ms(Start) when is_integer(Start) -> elapsed_ms(Start, now_ms());
+elapsed_ms({'start_time', _}=Start) -> elapsed_ms(Start, start_time()).
 
--spec elapsed_us(now() | pos_integer()) -> pos_integer().
+-spec elapsed_us(now() | pos_integer() | start_time()) -> non_neg_integer().
 elapsed_us({_,_,_}=Start) -> elapsed_us(Start, now());
-elapsed_us(Start) when is_integer(Start) -> elapsed_us(Start, now_us()).
+elapsed_us(Start) when is_integer(Start) -> elapsed_us(Start, now_us());
+elapsed_us({'start_time', _}=Start) -> elapsed_us(Start, start_time()).
 
--spec elapsed_s(now() | pos_integer(), now() | pos_integer()) -> pos_integer().
+-spec elapsed_s(now() | pos_integer() | start_time(), now() | pos_integer() | start_time()) -> non_neg_integer().
+elapsed_s({'start_time', Start}, {'start_time', End}) ->
+    erlang:convert_time_unit(End-Start, 'native', 'second');
 elapsed_s({_,_,_}=Start, {_,_,_}=Now) ->
     timer:now_diff(Now, Start) div ?MICROSECONDS_IN_SECOND;
 elapsed_s({_,_,_}=Start, Now) -> elapsed_s(now_s(Start), Now);
@@ -511,7 +556,9 @@ elapsed_s(Start, Now)
        is_integer(Now) ->
     Now - Start.
 
--spec elapsed_ms(now() | pos_integer(), now() | pos_integer()) -> pos_integer().
+-spec elapsed_ms(now() | pos_integer() | start_time(), now() | pos_integer() | start_time()) -> non_neg_integer().
+elapsed_ms({'start_time', Start}, {'start_time', End}) ->
+    erlang:convert_time_unit(End-Start, 'native', 'millisecond');
 elapsed_ms({_,_,_}=Start, {_,_,_}=Now) ->
     timer:now_diff(Now, Start) div ?MILLISECONDS_IN_SECOND;
 elapsed_ms({_,_,_}=Start, Now) -> elapsed_ms(now_ms(Start), Now);
@@ -527,7 +574,9 @@ elapsed_ms(Start, Now)
        is_integer(Now) ->
     (Now - Start) * ?MILLISECONDS_IN_SECOND.
 
--spec elapsed_us(now() | pos_integer(), now() | pos_integer()) -> pos_integer().
+-spec elapsed_us(now() | pos_integer() | start_time(), now() | pos_integer() | start_time()) -> non_neg_integer().
+elapsed_us({'start_time', Start}, {'start_time', End}) ->
+    erlang:convert_time_unit(End-Start, 'native', 'microsecond');
 elapsed_us({_,_,_}=Start, {_,_,_}=Now) ->
     timer:now_diff(Now, Start);
 elapsed_us({_,_,_}=Start, Now) -> elapsed_us(now_us(Start), Now);
@@ -545,7 +594,6 @@ elapsed_us(Start, Now)
 
 -spec now() -> now().
 now() -> os:timestamp().
-
 
 -spec now_s() -> gregorian_seconds().
 now_s() ->  erlang:system_time('seconds') + ?UNIX_EPOCH_IN_GREGORIAN.
@@ -570,7 +618,6 @@ now_s({_,_,_}=Now) ->
 
 unix_us_to_gregorian_us(UnixUS) ->
     UnixUS + (?UNIX_EPOCH_IN_GREGORIAN * ?MICROSECONDS_IN_SECOND).
-
 
 -spec format_date() -> binary().
 format_date() ->
@@ -597,3 +644,7 @@ format_datetime() ->
 -spec format_datetime(gregorian_seconds()) -> binary().
 format_datetime(Timestamp) when is_integer(Timestamp) ->
     list_to_binary([format_date(Timestamp), " ", format_time(Timestamp)]).
+
+-spec start_time() -> start_time().
+start_time() ->
+    {'start_time', erlang:monotonic_time()}.


### PR DESCRIPTION
Testing the CRUDy parts of the media API endpoint, including
uploading/fetching the media binary data.

Removes the need to use /raw to specify the binary data vs JSON
metadata.

Adds a test to query media_mgr for the streaming URL and fetching the
media via AMQP query.

Also backport more of the kazoo_proper tests