### PR TITLE
couch creds - 4.3

### DIFF
--- a/core/kazoo_couch/src/kz_couch_util.erl
+++ b/core/kazoo_couch/src/kz_couch_util.erl
@@ -93,10 +93,10 @@ retry504s(Fun, Cnt) ->
 new_connection(#{}=Map) ->
     connect(maps:fold(fun connection_parse/3, #kz_couch_connection{}, Map)).
 
--spec maybe_add_auth(string(), string(), kz_term:proplist()) -> kz_term:proplist().
-maybe_add_auth("", _Pass, Options) -> Options;
-maybe_add_auth(User, Pass, Options) ->
-    [{'basic_auth', {User, Pass}} | Options].
+-spec maybe_add_auth(string(), string(), string()) -> string() | binary().
+maybe_add_auth("", _Pass, Host) -> Host;
+maybe_add_auth(User, Pass, Host) ->
+    list_to_binary([kz_term:to_binary(User), ":", kz_term:to_binary(Pass), "@", Host]).
 
 check_options(Options) ->
     Routines = [fun convert_options/1
@@ -166,8 +166,8 @@ connect(#kz_couch_connection{host=Host
                ,password => Pass
                ,options => Options
                },
-    Opts = [{'connection_map', ConnMap} | maybe_add_auth(User, Pass, check_options(Options))],
-    Conn = couchbeam:server_connection(kz_term:to_list(Host), Port, <<>>, Opts),
+    Opts = [{'connection_map', ConnMap} | check_options(Options)],
+    Conn = couchbeam:server_connection(kz_term:to_list(maybe_add_auth(User, Pass, Host)), Port, <<>>, Opts),
     lager:debug("new connection to host ~s:~b, testing: ~p", [Host, Port, Conn]),
     connection_info(Conn).
 


### PR DESCRIPTION
currently when using creds to access couch, the library creates a {basic_auth, User, Pass} to pass as options to couchbeam. couchbeam doesn't do anything with this and pass it along to hackney request.
hackney adds the authorization header to the request.

the problem with this comes when freeswitch tries to access media files (attachments) directly from couch. the attachment url does not contain the credentials because kazoo_couch defers the server_url to couchbeam which knows nothing (or adds) the credentials.

creating the Host with User:Pass@Host seems to fix it, according to mkbusy which now runs couch with creds
