### PR TITLE
[master] don't panic when both schedule date keys are present

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -26926,8 +26926,7 @@
             "type": "object"
         },
         "port_requests.to_scheduled": {
-            "description": "Schema for a port request to be transitioned to the 'scheduled' state",
-            "oneOf": [
+            "anyOf": [
                 {
                     "required": [
                         "scheduled_date"
@@ -26939,6 +26938,7 @@
                     ]
                 }
             ],
+            "description": "Schema for a port request to be transitioned to the 'scheduled' state",
             "properties": {
                 "schedule_on": {
                     "description": "date-time at which to perform the porting",

--- a/applications/crossbar/priv/couchdb/schemas/port_requests.to_scheduled.json.src
+++ b/applications/crossbar/priv/couchdb/schemas/port_requests.to_scheduled.json.src
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "port_requests.to_scheduled",
     "description": "Schema for a port request to be transitioned to the 'scheduled' state",
-    "oneOf": [
+    "anyOf": [
         {
             "required": [
                 "scheduled_date"

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -6731,12 +6731,12 @@
     - numbers
   'type': object
 'port_requests.to_scheduled':
-  'description': Schema for a port request to be transitioned to the 'scheduled' state
-  'oneOf':
+  'anyOf':
     - 'required':
         - scheduled_date
     - 'required':
         - schedule_on
+  'description': Schema for a port request to be transitioned to the 'scheduled' state
   'properties':
     'schedule_on':
       'description': date-time at which to perform the porting


### PR DESCRIPTION
If a port request was schedule we use port_requests.to_schedule" schema to validate and on save we convert the date in "schedule_on" to UTC and save it in "schedule_date".

If for some reason the port want to transit to schedule state once again, because the both "schedule_on" and "scheduled_date" are present the above schema won't validate with error `not_one_schema_valid`