### PR TITLE
[4.3] don't panic when both schedule date keys are present

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -26296,8 +26296,7 @@
             "type": "object"
         },
         "port_requests.to_scheduled": {
-            "description": "Schema for a port request to be transitioned to the 'scheduled' state",
-            "oneOf": [
+            "anyOf": [
                 {
                     "required": [
                         "scheduled_date"
@@ -26309,6 +26308,7 @@
                     ]
                 }
             ],
+            "description": "Schema for a port request to be transitioned to the 'scheduled' state",
             "properties": {
                 "schedule_on": {
                     "description": "date-time at which to perform the porting",

--- a/applications/crossbar/priv/couchdb/schemas/port_requests.to_scheduled.json.src
+++ b/applications/crossbar/priv/couchdb/schemas/port_requests.to_scheduled.json.src
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "port_requests.to_scheduled",
     "description": "Schema for a port request to be transitioned to the 'scheduled' state",
-    "oneOf": [
+    "anyOf": [
         {
             "required": [
                 "scheduled_date"


### PR DESCRIPTION
If a port request was schedule we use port_requests.to_schedule" schema to validate and on save we convert the date in "schedule_on" to UTC and save it in "schedule_date".

If for some reason the port want to transit to schedule state once again, because the both "schedule_on" and "scheduled_date" are present the above schema won't validate with error `not_one_schema_valid`

master: https://github.com/2600hz/kazoo/pull/5952