### PR TITLE
[master] service changes summary per account followup

### DIFF
--- a/applications/crossbar/src/modules/cb_services.erl
+++ b/applications/crossbar/src/modules/cb_services.erl
@@ -230,6 +230,7 @@ validate(Context, ?AUDIT) ->
 validate(Context, ?AUDIT_SUMMARY) ->
     ViewOptions = [{'group_level', 1}
                   ,{'mapper', fun normalize_day_summary_by_date/2}
+                  ,{'max_range', ?SECONDS_IN_YEAR}
                   ,{'range_start_keymap', fun audit_summary_range_key/1}
                   ,{'range_end_keymap', fun audit_summary_range_key/1}
                   ],
@@ -265,6 +266,7 @@ validate(Context, ?AUDIT_SUMMARY, SourceService) ->
     RangeKeyFun = fun(Timestamp) -> audit_summary_range_key(SourceService, Timestamp) end,
     ViewOptions = [{'group_level', 2}
                   ,{'mapper', fun normalize_day_summary_by_source/2}
+                  ,{'max_range', ?SECONDS_IN_YEAR}
                   ,{'range_start_keymap', RangeKeyFun}
                   ,{'range_end_keymap', RangeKeyFun}
                   ],

--- a/applications/crossbar/src/modules/cb_services.erl
+++ b/applications/crossbar/src/modules/cb_services.erl
@@ -230,7 +230,6 @@ validate(Context, ?AUDIT) ->
 validate(Context, ?AUDIT_SUMMARY) ->
     ViewOptions = [{'group_level', 1}
                   ,{'mapper', fun normalize_day_summary_by_date/2}
-                  ,{'max_range', ?SECONDS_IN_YEAR}
                   ,{'range_start_keymap', fun audit_summary_range_key/1}
                   ,{'range_end_keymap', fun audit_summary_range_key/1}
                   ],
@@ -266,7 +265,6 @@ validate(Context, ?AUDIT_SUMMARY, SourceService) ->
     RangeKeyFun = fun(Timestamp) -> audit_summary_range_key(SourceService, Timestamp) end,
     ViewOptions = [{'group_level', 2}
                   ,{'mapper', fun normalize_day_summary_by_source/2}
-                  ,{'max_range', ?SECONDS_IN_YEAR}
                   ,{'range_start_keymap', RangeKeyFun}
                   ,{'range_end_keymap', RangeKeyFun}
                   ],

--- a/applications/crossbar/src/modules/cb_services.erl
+++ b/applications/crossbar/src/modules/cb_services.erl
@@ -573,7 +573,10 @@ list_resellers_editable(Context, AccountId) ->
 %%------------------------------------------------------------------------------
 -spec load_audit_logs(cb_context:context()) -> cb_context:context().
 load_audit_logs(Context) ->
-    Options = [{'mapper', fun normalize_audit_view_results/2}],
+    Options = [{'mapper', fun normalize_audit_view_results/2}
+              ,{'range_start_keymap', []}
+              ,{'range_end_keymap', crossbar_view:suffix_key_fun([kz_json:new()])}
+              ],
     crossbar_view:load_modb(Context, ?AUDIT_LOG_LIST, Options).
 
 %%------------------------------------------------------------------------------

--- a/core/kazoo_modb/priv/couchdb/views/services.json
+++ b/core/kazoo_modb/priv/couchdb/views/services.json
@@ -13,7 +13,7 @@
             "map": [
                 "function(doc) {",
                 "  if ( doc.pvt_deleted || doc.pvt_type != 'audit_log') return;",
-                "  emit(doc.pvt_created, {",
+                "  emit([doc.pvt_created, doc._id], {",
                 "    'id': doc._id,",
                 "    'status': doc.status,",
                 "    'reason': doc.reason,",

--- a/core/kazoo_services/src/kz_services_plan.erl
+++ b/core/kazoo_services/src/kz_services_plan.erl
@@ -358,7 +358,6 @@ assign(Services, JObj, Options) ->
                      [{<<"contract">>, Contract}
                      ,{<<"vendor_id">>, VendorId}
                      ,{<<"overrides">>, Overrides}
-                     ,{<<"contract">>, Contract}
                      ]
                     ),
             assign(Services, PlanId, Plan, Options)

--- a/core/kazoo_services/src/kz_services_plan.erl
+++ b/core/kazoo_services/src/kz_services_plan.erl
@@ -348,18 +348,19 @@ assign(Services, PlanId, Options) when is_binary(PlanId) ->
 assign(Services, JObj, Options) ->
     ResellerId = kz_services_reseller:get_id(Services),
     VendorId = kz_json:get_ne_binary_value(<<"vendor_id">>, JObj, ResellerId),
-    Overrides = kz_json:get_json_value(<<"overrides">>, JObj, kz_json:new()),
-    Contract = kz_json:get_json_value(<<"contract">>, JObj, kz_json:new()),
+    Overrides = kz_json:get_json_value(<<"overrides">>, JObj),
+    Contract = kz_json:get_json_value(<<"contract">>, JObj),
 
     case kz_doc:id(JObj) of
         'undefined' -> Services;
         PlanId ->
-            Props = [{<<"contract">>, Contract}
-                    ,{<<"vendor_id">>, VendorId}
-                    ,{<<"overrides">>, Overrides}
-                    ,{<<"contract">>, Contract}
-                    ],
-            Plan = kz_json:from_list(Props),
+            Plan = kz_json:from_list(
+                     [{<<"contract">>, Contract}
+                     ,{<<"vendor_id">>, VendorId}
+                     ,{<<"overrides">>, Overrides}
+                     ,{<<"contract">>, Contract}
+                     ]
+                    ),
             assign(Services, PlanId, Plan, Options)
     end.
 


### PR DESCRIPTION
* ~Increasing max allowed date range for service change summary per account~
* Reverting changes made by https://github.com/2600hz/kazoo/pull/5822 . It seems https://github.com/2600hz/kazoo/commit/4d131905639052bbad9e6dc13dba64940881fd42 removes override and contract defaults values from assign.
* Using composite key in for per request in https://github.com/2600hz/kazoo/pull/5822#discussion_r300799463