### PR TITLE
PISTON-892: avoid race condition btwn agent sup delete/restart child

### DIFF
--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -1523,8 +1523,6 @@ terminate(Reason, _StateName, #state{account_id=AccountId
 
 maybe_stop_agent('normal', AccountId, AgentId) ->
     stop_agent(AccountId, AgentId);
-maybe_stop_agent('shutdown', AccountId, AgentId) ->
-    stop_agent(AccountId, AgentId);
 maybe_stop_agent(_Reason, _AccountId, _AgentId) ->
     'ok'.
 


### PR DESCRIPTION
When the parent supervisor is shutting down the supervisor of this process with supervisor:terminate_child/2 during a restart, the reason will be 'shutdown'. acdc_agents_sup:stop_agent/2 should not be called as it will try to delete the supervisor child before it is restarted and the restart will do nothing, leaving the agent stopped