### PR TITLE
SPHBK-12: [master] rejecting port if port submission is failed due to an external service

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -85,6 +85,11 @@ rest_init(Req, Opts) ->
 
     Path = find_path(Req, Opts),
 
+    MasterId = case kapps_util:get_master_account_id() of
+                   {'ok', Id} -> Id;
+                   {'error', _} -> 'undefined'
+               end,
+
     Setters = [{fun cb_context:set_req_id/2, get_request_id(Req)}
               ,{fun cb_context:set_req_headers/2, cowboy_req:headers(Req)}
               ,{fun host_url/2, Req}
@@ -100,6 +105,7 @@ rest_init(Req, Opts) ->
               ,{fun cb_context:set_api_version/2, find_version(Path, Req)}
               ,{fun cb_context:set_magic_pathed/2, props:is_defined('magic_path', Opts)}
               ,{fun cb_context:store/3, 'metrics', metrics()}
+              ,{fun cb_context:set_master_account_id/2, MasterId}
               ,fun req_nouns/1
               ],
 

--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -189,6 +189,7 @@
                     ,host_url = <<>> :: binary()
                     ,is_superduper_admin = 'undefined' :: kz_term:api_boolean()
                     ,is_account_admin = 'undefined' :: kz_term:api_boolean()
+                    ,master_account_id = 'undefined' :: kz_term:api_ne_binary()
                     }).
 
 -define(MAX_RANGE, kapps_config:get_pos_integer(?CONFIG_CAT

--- a/applications/crossbar/src/modules/cb_comments.erl
+++ b/applications/crossbar/src/modules/cb_comments.erl
@@ -263,7 +263,8 @@ create(Context, {<<"port_requests">>, _}) ->
         {'ok', _} ->
             crossbar_doc:save(Context);
         {'error', _} ->
-            cb_context:add_system_error('datastore_fault', <<"unable to submit comment to carrier">>, Context)
+            Context1 = cb_context:store(Context, 'req_comments', []),
+            cb_context:add_system_error('datastore_fault', <<"unable to submit comment to carrier">>, Context1)
     end;
 create(Context, _Resource) ->
     Doc = cb_context:doc(Context),

--- a/applications/crossbar/src/modules/phonebook.erl
+++ b/applications/crossbar/src/modules/phonebook.erl
@@ -13,7 +13,6 @@
 
 -export([maybe_create_port_in/1
         ,maybe_add_comment/2
-        ,maybe_cancel_port_in/1
 
         ,should_send_to_phonebook/1
         ]).
@@ -23,12 +22,28 @@
 
 -define(MOD_CONFIG_CAT, <<"crossbar.phonebook">>).
 
+-type req_type() :: 'add_comment' | 'port_in'.
+-type reason() :: 'bad_phonebook' | 'bad_http'.
+
+-type errors() :: #{code => non_neg_integer()
+                   ,req_type := req_type()
+                   ,payload := kz_json:object()
+                   ,reason := reason()
+                   }.
+
+-type response() :: {'ok', kz_json:object() | 'disabled'} |
+                    {'error', errors()}.
+
+-export_type([errors/0
+             ,response/0
+             ]).
+
 %%------------------------------------------------------------------------------
 %% @doc exported functions
 %% @end
 %%------------------------------------------------------------------------------
 
--spec maybe_create_port_in(cb_context:context()) -> {'ok', kz_json:object() | 'disabled'} | {'error', kz_term:ne_binary() | {integer(), kz_json:object()}}.
+-spec maybe_create_port_in(cb_context:context()) -> response().
 maybe_create_port_in(Context) ->
     case should_send_to_phonebook(Context) of
         'true' ->
@@ -36,22 +51,11 @@ maybe_create_port_in(Context) ->
         'false' -> {'ok', 'disabled'}
     end.
 
--spec maybe_add_comment(cb_context:context(), kz_json:objects()) -> {'ok', kz_json:object() | 'disabled'} | {'error', kz_term:ne_binary() | {integer(), kz_json:object()}}.
+-spec maybe_add_comment(cb_context:context(), kz_json:objects()) -> response().
 maybe_add_comment(Context, Comment) ->
     case should_send_to_phonebook(Context) of
         'true' ->
             add_comment(cb_context:doc(Context), cb_context:auth_token(Context), Comment);
-        'false' -> {'ok', 'disabled'}
-    end.
-
--spec maybe_cancel_port_in(cb_context:context()) -> {'ok', kz_json:object() | 'disabled'} | {'error', kz_term:ne_binary() | {integer(), kz_json:object()}}.
-maybe_cancel_port_in(Context) ->
-    case should_send_to_phonebook(Context) of
-        'true' ->
-            %%TODO: implement support for this in phonebook
-            %% cancel_port_in(cb_context:doc(Context), cb_context:auth_token(Context));
-            %%UNTIL THEN: just return disabled
-            {'ok', 'disabled'};
         'false' -> {'ok', 'disabled'}
     end.
 
@@ -61,13 +65,8 @@ maybe_cancel_port_in(Context) ->
 %%------------------------------------------------------------------------------
 -spec should_send_to_phonebook(cb_context:context()) -> boolean().
 should_send_to_phonebook(Context) ->
-    MasterId = case kapps_util:get_master_account_id() of
-                   {'ok', Id} -> Id;
-                   {'error', _} ->
-                       cb_context:fetch(Context, 'port_authority_id')
-               end,
     phonebook_enabled()
-        andalso cb_context:fetch(Context, 'port_authority_id', MasterId) =:= MasterId
+        andalso cb_context:fetch(Context, 'port_authority_id') =:= cb_context:master_account_id(Context)
         andalso not req_from_phonebook(Context).
 
 -spec phonebook_enabled() -> boolean().
@@ -85,109 +84,93 @@ req_from_phonebook(Context) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec create_port_in(kz_json:object(), kz_term:ne_binary()) -> {'ok', kz_json:object()} | {'error', kz_term:ne_binary() | {integer(), kz_json:object()}}.
+-spec create_port_in(kz_json:object(), kz_term:ne_binary()) -> response().
 create_port_in(JObj, AuthToken) ->
-    Url = phonebook_uri([<<"accounts">>
-                        ,kz_doc:account_id(JObj)
-                        ,<<"ports">>
-                        ,<<"in">>
-                        ]),
-    Data = kz_json:set_value(<<"data">>, kz_doc:public_fields(JObj), kz_json:new()),
-    lager:debug("creating port in request to phonebook via ~s: ~p", [Url, Data]),
-    Response = kz_http:put(Url, req_headers(AuthToken), kz_json:encode(Data)),
-    handle_resp(Response, JObj, <<"create">>, Url).
+    Url = phonebook_uri([<<"accounts">>, kz_doc:account_id(JObj), <<"ports">>, <<"in">>]),
+    Data = kz_json:from_list([{<<"data">>, kz_doc:public_fields(JObj)}]),
+    make_request('port_in', JObj, AuthToken, Url, Data).
 
--spec add_comment(kz_json:object(), kz_term:ne_binary(), kz_json:objects()) -> {'ok', kz_json:object()} | {'error', kz_term:ne_binary() | {integer(), kz_json:object()}}.
+-spec add_comment(kz_json:object(), kz_term:ne_binary(), kz_json:objects()) -> response().
 add_comment(JObj, AuthToken, Comment) ->
-    Url = phonebook_uri([<<"accounts">>
-                        ,kz_doc:account_id(JObj)
-                        ,<<"ports">>
-                        ,<<"in">>
-                        ,kz_doc:id(JObj)
-                        ,<<"notes">>
-                        ]),
+    Url = phonebook_uri([<<"accounts">>, kz_doc:account_id(JObj), <<"ports">>, <<"in">>, kz_doc:id(JObj), <<"notes">>]),
     Data = kz_json:set_value(<<"data">>, Comment, kz_json:new()),
-    lager:debug("adding comment to phonebook via ~s: ~p", [Url, Data]),
-    Response = kz_http:put(Url, req_headers(AuthToken), kz_json:encode(Data)),
-    handle_resp(Response, JObj, <<"comment">>, Url).
+    make_request('add_comment', JObj, AuthToken, Url, Data).
 
-%% implement support for this in phonebook
-%% -spec cancel_port_in(kz_json:object(), kz_term:ne_binary()) -> {'ok', kz_json:object()} | {'error', kz_term:ne_binary() | kz_json:object()}.
-%% cancel_port_in(JObj, AuthToken) ->
-%%     AccountId = kz_doc:account_id(JObj),
-%%     PortId = kz_doc:id(JObj),
-%%     Url = phonebook_uri([<<"accounts">>, AccountId, <<"ports">>, <<"in">>, PortId]),
-%%     lager:debug("accounts delete via ~s", [Url]),
-%%     Response = kz_http:delete(Url, req_headers(AuthToken)),
-%%     handle_resp(Response, JObj, <<"cancel">>, Url).
+-spec make_request(req_type(), kz_json:object(), kz_term:ne_binary(), string(), kz_json:object()) -> response().
+make_request(Type, JObj, AuthToken, URL, Data) ->
+    log_request(Type, JObj),
+    Response = kz_http:put(URL, req_headers(AuthToken), kz_json:encode(Data)),
+    handle_resp(Type, Response).
 
--spec handle_resp(kz_http:ret(), kz_json:object(), kz_term:ne_binary(), string()) -> {'ok', kz_json:object()} | {'error', kz_term:ne_binary() | {integer(), kz_json:object()}}.
-handle_resp({'ok', 200, _, Resp}, _, _, _) ->
-    RespJObj = kz_json:decode(Resp),
+-spec log_request(req_type(), kz_json:object()) -> 'ok'.
+log_request('port_in', JObj) ->
+    lager:debug("sending request to phonebook for creating/updating port ~s", [kz_doc:id(JObj)]);
+log_request('add_comment', JObj) ->
+    lager:debug("sending request to phonebook to add comment port ~s", [kz_doc:id(JObj)]).
+
+-spec handle_resp(req_type(), kz_http:ret()) -> response().
+handle_resp(Type, {'ok', 200, _, Resp}) ->
+    RespJObj = try kz_json:decode(Resp)
+               catch
+                   _:_ ->
+                       kz_json:from_list(
+                         [{<<"message">>, Resp}
+                         ,{<<"reason">>, <<"phonebook_non_json_repsonse">>}
+                         ]
+                        )
+               end,
     case kz_json:get_ne_binary_value(<<"status">>, RespJObj) of
-        'undefined' -> {'error', <<"invalid response from phonebook">>};
-        <<"error">> -> {'error', RespJObj};
+        'undefined' ->
+            lager:error("phonebook responding without status: ~p", [Resp]),
+            {'error', #{code => 500
+                       ,req_type => Type
+                       ,payload => RespJObj
+                       ,reason => 'bad_phonebook'
+                       }
+            };
+        <<"error">> ->
+            lager:error("phonebook responding 200 with status error: ~p", [Resp]),
+            {'error', #{code => 400
+                       ,req_type => Type
+                       ,payload => RespJObj
+                       ,reason => 'bad_phonebook'
+                       }
+            };
         <<"success">> -> {'ok', RespJObj}
     end;
-handle_resp({'ok', Code, _, Resp}, JObj, Type, Url) ->
-    lager:warning("phonebook error ~b response: ~p", [Code, Resp]),
-    Response = kz_json:decode(Resp),
-    Message = kz_json:get_ne_binary_value(<<"message">>, Response, <<"unknown error">>),
-    Data = kz_json:get_json_value(<<"data">>, Response, kz_json:new()),
-    Prop = props:filter_empty(
-             [{<<"http_code">>, Code}
-             ,{<<"error_message">>, Message}
-             ,{<<"request_id">>, kz_json:get_value(<<"request_id">>, Response)}
-             ,{<<"response_code">>, kz_json:get_value(<<"code">>, Response)}
-             ,{<<"phonebook_url">>, kz_term:to_binary(Url)}
-              | kz_json:recursive_to_proplist(Data)
-             ]),
-    create_alert(Prop, JObj, Type),
-    {'error', {Code, Response}};
-handle_resp({'error', {'connect_failed', _}}, JObj, Type, Url) ->
-    lager:error("connection failed to phonebook url ~s", [Url]),
-    Prop = [{<<"error_message">>, <<"connection failed to phonebook">>}
-           ,{<<"phonebook_url">>, kz_term:to_binary(Url)}
-           ],
-    create_alert(Prop, JObj, Type),
-    {'error', <<"failed to connect to phonebook">>};
-handle_resp({'error', {'malformed_url', _}}, JObj, Type, Url) ->
-    lager:error("phonebook fatal error malformed_url ~s", [Url]),
-    Prop = [{<<"error_message">>, <<"malformed_url">>}
-           ,{<<"phonebook_url">>, kz_term:to_binary(Url)}
-           ],
-    create_alert(Prop, JObj, Type),
-    {'error', <<"malformed_url">>};
-handle_resp(Error, JObj, Type, Url) ->
-    lager:error("phonebook unknown error ~p", [Error]),
-    Message = kz_term:to_binary(io_lib:format("~p", [Error])),
-    Prop = [{<<"error_message">>, Message}
-           ,{<<"phonebook_url">>, kz_term:to_binary(Url)}
-           ],
-    create_alert(Prop, JObj, Type),
-    {'error', Message}.
-
+handle_resp(Type, {'ok', Code, _, Resp}) ->
+    lager:warning("phonebook responding with code ~b and response: ~p", [Code, Resp]),
+    RespJObj = try kz_json:decode(Resp)
+               catch
+                   _:_ ->
+                       kz_json:from_list(
+                         [{<<"message">>, Resp}
+                         ,{<<"reason">>, <<"phonebook_non_json_repsonse">>}
+                         ]
+                        )
+               end,
+    {'error', #{code => Code
+               ,req_type => Type
+               ,payload => RespJObj
+               ,reason => 'bad_phonebook'
+               }
+    };
+handle_resp(Type, Error) ->
+    lager:debug("failed to make http request to phonebook server: ~p", [Error]),
+    {'error', #{code => 500
+               ,req_type => Type
+               ,payload => kz_json:from_list([{<<"message">>, <<"failed to connect to port automation system">>}
+                                             ,{<<"reason">>, kz_term:to_binary(io_lib:format("~p", [Error]))}
+                                             ])
+               ,reason => 'bad_http'
+               }
+    }.
 
 -spec phonebook_uri(iolist()) -> string().
 phonebook_uri(ExplodedPath) ->
     Url = kapps_config:get_binary(?MOD_CONFIG_CAT, <<"phonebook_url">>),
     Uri = kz_util:uri(Url, ExplodedPath),
     kz_term:to_list(Uri).
-
--spec create_alert(kz_term:proplist(), kz_json:object(), kz_term:ne_binary()) -> 'ok'.
-create_alert(Response, JObj, Type) ->
-    Subject = <<"Phonebook request failed">>,
-    Msg = kz_term:to_binary(io_lib:format("Unable to submit port update to phonebook for port: ~s"
-                                         ,[kzd_port_requests:name(JObj)])
-                           ),
-    Props = [{<<"request_type">>, Type}
-            ,{<<"port_id">>, kz_doc:id(JObj)}
-            ,{<<"phone_numbers">>, kz_json:get_keys(kzd_port_requests:numbers(JObj))}
-            ,{<<"account_id">>, kz_doc:account_id(JObj)}
-            ,{<<"port_state">>, kz_json:get_ne_binary_value(?PORT_PVT_STATE, JObj)}
-             | Response
-            ],
-    kz_notify:detailed_alert(Subject, Msg, Props, []).
 
 -spec req_headers(kz_term:ne_binary()) -> kz_term:proplist().
 req_headers(Token) ->
@@ -197,4 +180,3 @@ req_headers(Token) ->
       ,{"X-Kazoo-Cluster-ID", kzd_cluster:id()}
       ,{"User-Agent", kz_term:to_list(erlang:node())}
       ]).
-

--- a/core/kazoo_documents/src/kzd_port_requests.erl
+++ b/core/kazoo_documents/src/kzd_port_requests.erl
@@ -39,13 +39,14 @@
 
 %% Private fields
 -export([pvt_account_name/1, pvt_account_name/2, set_pvt_account_name/2]).
+-export([pvt_last_phonebook_error/1, pvt_last_phonebook_error/2, set_pvt_last_phonebook_error/2]).
 -export([pvt_port_authority/1, pvt_port_authority/2, set_pvt_port_authority/2]).
 -export([pvt_port_authority_name/1, pvt_port_authority_name/2, set_pvt_port_authority_name/2]).
 -export([pvt_port_state/1, pvt_port_state/2, set_pvt_port_state/2]).
 -export([pvt_ported_numbers/1, pvt_ported_numbers/2, set_pvt_ported_numbers/2]).
 -export([pvt_sent/1, pvt_sent/2, set_pvt_sent/2]).
--export([pvt_tree/1, pvt_tree/2, set_pvt_tree/2]).
 -export([pvt_transitions/1, pvt_transitions/2, set_pvt_tranisitions/2]).
+-export([pvt_tree/1, pvt_tree/2, set_pvt_tree/2]).
 
 %% Utilities
 -export([get_transition/2]).
@@ -390,6 +391,22 @@ pvt_account_name(Doc, Default) ->
 -spec set_pvt_account_name(doc(), kz_term:ne_binary()) -> doc().
 set_pvt_account_name(Doc, Name) ->
     kz_json:set_value([<<"pvt_account_name">>], Name, Doc).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec pvt_last_phonebook_error(doc()) -> kz_term:api_ne_binary().
+pvt_last_phonebook_error(Doc) ->
+    pvt_last_phonebook_error(Doc, 'undefined').
+
+-spec pvt_last_phonebook_error(doc(), Default) -> kz_term:ne_binary() | Default.
+pvt_last_phonebook_error(Doc, Default) ->
+    kz_json:get_ne_binary_value([<<"pvt_last_phonebook_error">>], Doc, Default).
+
+-spec set_pvt_last_phonebook_error(doc(), kz_term:ne_binary()) -> doc().
+set_pvt_last_phonebook_error(Doc, Name) ->
+    kz_json:set_value([<<"pvt_last_phonebook_error">>], Name, Doc).
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -28,7 +28,7 @@
         ,migrate/0
         ]).
 
--export([transition_metadata/2, transition_metadata/3]).
+-export([transition_metadata/2, transition_metadata/3, transition_metadata/4]).
 -export_type([transition_metadata/0]).
 
 -compile({'no_auto_import', [get/1]}).
@@ -43,6 +43,7 @@
                                 ,user_last_name => kz_term:api_ne_binary()
                                 ,user_full_name => kz_term:api_ne_binary()
                                 ,optional_reason => kz_term:api_ne_binary()
+                                ,timestamp => kz_time:gregorian_seconds()
                                 }.
 
 -define(VIEW_LISTING_SUBMITTED, <<"port_requests/listing_submitted">>).
@@ -105,7 +106,8 @@ public_fields(JObj) ->
 -spec read_only_public_fields(kz_json:object()) -> kz_term:api_object().
 read_only_public_fields(Doc) ->
     JObj = kz_json:from_list(
-             [{<<"account_name">>, kzd_port_requests:pvt_account_name(Doc)}
+             [{<<"account_id">>, kz_doc:account_id(Doc)}
+             ,{<<"account_name">>, kzd_port_requests:pvt_account_name(Doc)}
              ,{<<"port_authority">>, kzd_port_requests:pvt_port_authority(Doc)}
              ,{<<"port_authority_name">>, kzd_port_requests:pvt_port_authority_name(Doc)}
              ,{<<"ported_numbers">>, kzd_port_requests:pvt_ported_numbers(Doc)}
@@ -367,9 +369,10 @@ successful_transition(JObj, FromState, ToState, Metadata) ->
 transition_metadata_jobj(FromState, ToState, #{auth_account_id := AuthAccountId
                                               ,auth_account_name := AuthAccountName
                                               ,optional_reason := OptionalReason
+                                              ,timestamp := Timestamp
                                               }=Metadata) ->
     kz_json:from_list_recursive(
-      [{?TRANSITION_TIMESTAMP, kz_time:now_s()}
+      [{?TRANSITION_TIMESTAMP, Timestamp}
       ,{?TRANSITION_TYPE, ?PORT_TRANSITION}
       ,{?TRANSITION_REASON, OptionalReason}
       ,{<<"transition">>, [{<<"new">>, ToState}
@@ -399,10 +402,14 @@ maybe_user(#{auth_user_id := UserId
 
 -spec transition_metadata(kz_term:ne_binary(), kz_term:api_ne_binary()) -> transition_metadata().
 transition_metadata(AuthAccountId, AuthUserId) ->
-    transition_metadata(AuthAccountId, AuthUserId, 'undefined').
+    transition_metadata(AuthAccountId, AuthUserId, 'undefined', 'undefined').
 
 -spec transition_metadata(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> transition_metadata().
-transition_metadata(?MATCH_ACCOUNT_RAW(AuthAccountId), UserId, Reason) ->
+transition_metadata(AuthAccountId, AuthUserId, Reason) ->
+    transition_metadata(AuthAccountId, AuthUserId, Reason, 'undefined').
+
+-spec transition_metadata(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), kz_term:api_seconds()) -> transition_metadata().
+transition_metadata(?MATCH_ACCOUNT_RAW(AuthAccountId), UserId, Reason, RequestedTimestamp) ->
     OptionalUserId = case UserId of
                          ?NE_BINARY -> UserId;
                          _ -> 'undefined'
@@ -412,6 +419,10 @@ transition_metadata(?MATCH_ACCOUNT_RAW(AuthAccountId), UserId, Reason) ->
                          ?NE_BINARY -> Reason;
                          _ -> 'undefined'
                      end,
+    Timestamp = case RequestedTimestamp of
+                    'undefined' -> kz_time:now_s();
+                    Time -> Time
+                end,
     #{auth_account_id => AuthAccountId
      ,auth_account_name => kzd_accounts:fetch_name(AuthAccountId)
      ,auth_user_id => OptionalUserId
@@ -419,6 +430,7 @@ transition_metadata(?MATCH_ACCOUNT_RAW(AuthAccountId), UserId, Reason) ->
      ,user_last_name => kzd_users:last_name(UserJObj)
      ,user_full_name => kzd_users:full_name(UserJObj, kzd_users:username(UserJObj, kzd_users:email(UserJObj)))
      ,optional_reason => OptionalReason
+     ,timestamp => Timestamp
      }.
 
 -spec get_user_name(kz_term:ne_binary(), kz_term:api_ne_binary()) -> kz_json:object().


### PR DESCRIPTION
* Rejecting the port if the external service (port automation) is failing to submit the port
* Also saving the port automation failure as a private comment and as a field inside port's document.
* Adding master account id to `cb_context` to easy access to master id in crossbar modules.