### PR TITLE
call events getting unnecessary channel

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_call_events.erl
+++ b/applications/ecallmgr/src/ecallmgr_call_events.erl
@@ -1062,7 +1062,8 @@ usurp_other_publishers(#state{node=Node
             ,{<<"Reference">>, Ref}
              | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
             ],
-    kapi_call:publish_usurp_publisher(CallId, Usurp),
+    PublisherFun = fun(P) -> kapi_call:publish_usurp_publisher(CallId, P) end,
+    kz_amqp_worker:cast(Usurp, PublisherFun),
     ecallmgr_usurp_monitor:register('usurp_publisher', CallId, Ref).
 
 -spec get_is_loopback(kz_term:api_binary()) -> atom().


### PR DESCRIPTION
ecallmgr_call_events is now a gen_server, using kapi_call directly assigns a channel which is not properly closed on terminate