### PR TITLE
[4.3] back ported fix of broken rabbitmq redurdancy

### DIFF
--- a/core/kazoo/include/kz_api_literals.hrl
+++ b/core/kazoo/include/kz_api_literals.hrl
@@ -27,6 +27,7 @@
 
 -define(KEY_REQUEST_FROM_PID, <<"Request-From-PID">>).
 -define(KEY_REPLY_TO_PID, <<"Reply-To-PID">>).
+-define(KEY_DELIVER_TO_PID, <<"Deliver-To-PID">>).
 
 -define(KZ_API_LITERALS_HRL, 'true').
 -endif.

--- a/core/kazoo_amqp/include/kz_amqp.hrl
+++ b/core/kazoo_amqp/include/kz_amqp.hrl
@@ -7,6 +7,7 @@
 -ifndef(KZ_AMQP_HRL).
 
 -include_lib("amqp_client/include/amqp_client.hrl").
+-include("kz_api.hrl").
 
 -define(KEY_ORGN_RESOURCE_REQ, <<"orginate.resource.req">>). %% corresponds to originate_resource_req/1 api call
 -define(RESOURCE_QUEUE_NAME, <<"resource.provider">>).

--- a/core/kazoo_amqp/include/kz_api.hrl
+++ b/core/kazoo_amqp/include/kz_api.hrl
@@ -82,6 +82,7 @@
         ,?KEY_REPLY_TO_PID
         ,?KEY_AMQP_BROKER
         ,?KEY_AMQP_ZONE
+        ,?KEY_DELIVER_TO_PID
         ]).
 -define(DEFAULT_VALUES, [{?KEY_NODE, kz_term:to_binary(node())}
                         ,{?KEY_MSG_ID, kz_binary:rand_hex(16)}

--- a/core/kazoo_amqp/src/api/kapi.erl
+++ b/core/kazoo_amqp/src/api/kapi.erl
@@ -1,0 +1,47 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc Kazoo API Helpers.
+%%% Most API functions take a proplist, filter it against required headers
+%%% and optional headers, and return either the JSON string if all
+%%% required headers (default AND API-call-specific) are present, or an
+%%% error if some headers are missing.
+%%%
+%%% To only check the validity, use the API call's corresponding *_v/1 function.
+%%% This will parse the proplist and return a boolean()if the proplist is valid
+%%% for creating a JSON message.
+%%%
+%%%
+%%% @author James Aimonetti
+%%% @author Karl Anderson
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kapi).
+
+%% API
+-export([delivery_message/2
+        ,encode_pid/1, encode_pid/2
+        ]).
+
+-include_lib("kz_amqp_util.hrl").
+
+-spec event_category(kz_json:object()) -> atom().
+event_category(JObj) ->
+    kz_term:to_atom(kz_api:event_category(JObj), 'true').
+
+-spec event_name(kz_json:object()) -> atom().
+event_name(JObj) ->
+    kz_term:to_atom(kz_api:event_name(JObj), 'true').
+
+-spec delivery_message(kz_json:object(), kz_term:proplist()) -> term().
+delivery_message(JObj, Props) ->
+    Basic = props:get_value('basic', Props),
+    Deliver = #'basic.deliver'{exchange=Exchange, routing_key=RK} = props:get_value('deliver', Props),
+    {{Exchange, RK, {Basic, Deliver}}, {event_category(JObj), event_name(JObj)}, JObj}.
+
+-spec encode_pid(kz_term:ne_binary()) -> kz_term:ne_binary().
+encode_pid(Queue) ->
+    encode_pid(Queue, self()).
+
+-spec encode_pid(kz_term:ne_binary(), pid()) -> kz_term:ne_binary().
+encode_pid(Queue, Pid) ->
+    list_to_binary(["pid://", kz_term:to_binary(Pid), "/", Queue]).

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -188,19 +188,19 @@
 
 -type handle_event_return() :: 'ignore' |
                                {'ignore', module_state()} |
+                               {'ignore', module_state(), timeout() | 'hibernate'} |
                                {'reply', kz_term:proplist()} |
                                {'reply', kz_term:proplist(), module_state()}.
 
 -callback handle_event(kz_json:object(), module_state()) -> handle_event_return().
--callback handle_event(kz_json:object(), basic_deliver(), module_state()) -> handle_event_return().
--callback handle_event(kz_json:object(), basic_deliver(), amqp_basic(), module_state()) -> handle_event_return().
+-callback handle_event(kz_json:object(), kz_term:proplist(), module_state()) -> handle_event_return().
 
 -callback terminate('normal' | 'shutdown' | {'shutdown', any()} | any(), module_state()) ->
     any().
 -callback code_change(any() | {'down', any()}, module_state(), any()) ->
     {'ok', module_state()} | {'error', any()}.
 
--optional_callbacks([handle_event/2, handle_event/3, handle_event/4]).
+-optional_callbacks([handle_event/2, handle_event/3]).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -884,7 +884,7 @@ distribute_event(JObj, {Deliver, #'P_basic'{headers=Headers}=Basic}=BasicDeliver
             end
     end.
 
--spec distribute_event(callback_data(), kz_json:object(), deliver(), state()) -> state().
+-spec distribute_event(callback_data(), kz_json:object(), deliver(), state()) -> {'noreply', state()}.
 distribute_event(CallbackData, JObj, Deliver, #state{responders=Responders
                                                     ,consumer_key=ConsumerKey
                                                     }=State) ->
@@ -939,6 +939,7 @@ client_handle_event(JObj, {Module, Fun, 2}, CallbackData, _Deliver) ->
 -spec callback_handle_event(kz_json:object(), deliver(), state()) ->
                                    'ignore' |
                                    {'ignore', module_state()} |
+                                   {'ignore', module_state(), 'hibernate' | timeout()} |
                                    callback_data() |
                                    {callback_data(), module_state()}.
 callback_handle_event(_JObj
@@ -976,7 +977,7 @@ callback_handle_event(JObj
     case callback_handle_event(JObj, Props, MFA, ModuleState) of
         'ignore' -> 'ignore';
         {'ignore', _NewModuleState} = Reply -> Reply;
-        {'ignore', _NewModuleState, 'hibernate'} = Reply -> Reply;
+        {'ignore', _NewModuleState, _TimeoutOrHibernate} = Reply -> Reply;
         {'reply', NewProps} when is_list(NewProps) ->
             [{'server', Self}
             ,{'queue', Queue}

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -101,7 +101,7 @@
         ,execute/2
         ]).
 
--export([federated_event/4]).
+-export([federated_event/3]).
 -export([delayed_cast/3
         ]).
 -export([distribute_event/3]).
@@ -380,9 +380,9 @@ rm_binding(Srv, {Binding, Props}) ->
 rm_binding(Srv, Binding, Props) ->
     gen_server:cast(Srv, {'rm_binding', kz_term:to_binary(Binding), Props}).
 
--spec federated_event(kz_types:server_ref(), kz_json:object(), basic_deliver(), amqp_basic()) -> 'ok'.
-federated_event(Srv, JObj, BasicDeliver, BasicData) ->
-    gen_server:cast(Srv, {'federated_event', JObj, BasicDeliver, BasicData}).
+-spec federated_event(kz_types:server_ref(), kz_json:object(), kz_term:proplist()) -> 'ok'.
+federated_event(Srv, JObj, Props) ->
+    gen_server:cast(Srv, {'federated_event', JObj, Props}).
 
 -spec execute(kz_types:server_ref(), module(), atom(), [any()]) -> 'ok'.
 execute(Srv, Module, Function, Args) ->
@@ -515,11 +515,13 @@ handle_cast({'add_binding', Binding, Props}, State) ->
     {'noreply', handle_add_binding(Binding, Props, State)};
 handle_cast({'rm_binding', Binding, Props}, State) ->
     {'noreply', handle_rm_binding(Binding, Props, State)};
-handle_cast({'federated_event', JObj, BasicDeliver, BasicData}, #state{params=Params}=State) ->
+handle_cast({'federated_event', JObj, Props}, #state{params=Params}=State) ->
+    Deliver = props:get_value('deliver', Props),
+    Basic = props:get_value('basic', Props),
     case props:is_true('spawn_handle_event', Params, 'false') of
-        'true'  -> kz_util:spawn(fun distribute_event/3, [JObj, {BasicDeliver, BasicData}, State]),
+        'true'  -> kz_util:spawn(fun distribute_event/3, [JObj, {Deliver, Basic}, State]),
                    {'noreply', State};
-        'false' -> {'noreply', distribute_event(JObj, {BasicDeliver, BasicData}, State)}
+        'false' -> distribute_event(JObj, {Deliver, Basic}, State)
     end;
 handle_cast({'$execute', Module, Function, Args}
            ,#state{federators=[]}=State
@@ -656,10 +658,9 @@ handle_info({#'basic.deliver'{}=BD
             'false' -> 'ok'
         end,
     case props:is_true('spawn_handle_event', Params, 'false') of
-        'false' -> {'noreply', handle_event(Payload, CT, {BD, Basic}, State)};
-        'true'  ->
-            kz_util:spawn(fun handle_event/4, [Payload, CT, {BD, Basic}, State]),
-            {'noreply', State}
+        'false' -> handle_event(Payload, CT, {BD, Basic}, State);
+        'true'  -> kz_util:spawn(fun handle_event/4, [Payload, CT, {BD, Basic}, State]),
+                   {'noreply', State}
     end;
 handle_info({#'basic.return'{}=BR
             ,#amqp_msg{props=#'P_basic'{content_type=CT}
@@ -731,7 +732,7 @@ handle_info(Message, State) ->
 %% Allows listeners to pass options to handlers.
 %% @end
 %%------------------------------------------------------------------------------
--spec handle_event(kz_term:ne_binary(), kz_term:ne_binary(), deliver(), state()) ->  state().
+-spec handle_event(kz_term:ne_binary(), kz_term:ne_binary(), deliver(), state()) ->  kz_types:handle_info_ret().
 handle_event(Payload, <<"application/json">>, Deliver, State) ->
     JObj = kz_json:decode(Payload),
     _ = kz_util:put_callid(JObj),
@@ -854,44 +855,67 @@ format_status(_Opt
              }]
     end.
 
--spec distribute_event(kz_json:object(), deliver(), state()) -> state().
-distribute_event(JObj, Deliver, State) ->
-    case callback_handle_event(JObj, Deliver, State) of
-        'ignore' -> State;
-        {'ignore', ModuleState} -> State#state{module_state=ModuleState};
-        {CallbackData, ModuleState} -> distribute_event(CallbackData, JObj, Deliver, State#state{module_state=ModuleState});
-        CallbackData -> distribute_event(CallbackData, JObj, Deliver, State)
+-spec distribute_event(kz_json:object(), deliver(), state()) ->  kz_types:handle_info_ret().
+distribute_event(JObj, {_ , #'P_basic'{headers='undefined'}}=BasicDeliver, State) ->
+    case callback_handle_event(JObj, BasicDeliver, State) of
+        'ignore' -> {'noreply', State};
+        {'ignore', ModuleState} -> {'noreply', State#state{module_state=ModuleState}};
+        {'ignore', ModuleState, 'hibernate'} -> {'noreply', State#state{module_state=ModuleState}, 'hibernate'};
+        {'ignore', ModuleState, Timeout} -> {'noreply', State#state{module_state=ModuleState}, Timeout};
+        {CallbackData, ModuleState} -> distribute_event(CallbackData, JObj, BasicDeliver, State#state{module_state=ModuleState});
+        CallbackData -> distribute_event(CallbackData, JObj, BasicDeliver, State)
+    end;
+distribute_event(JObj, {Deliver, #'P_basic'{headers=Headers}=Basic}=BasicDeliver, State) ->
+    case lists:keyfind(?KEY_DELIVER_TO_PID, 1, Headers) of
+        {?KEY_DELIVER_TO_PID, _, Pid} ->
+            Props = [{'basic', Basic}
+                    ,{'deliver', Deliver}
+                    ],
+            kz_term:to_pid(Pid) ! {'kapi', kapi:delivery_message(JObj, Props)},
+            {'noreply', State};
+        'false' ->
+            case callback_handle_event(JObj, BasicDeliver, State) of
+                'ignore' -> {'noreply', State};
+                {'ignore', ModuleState} -> {'noreply', State#state{module_state=ModuleState}};
+                {'ignore', ModuleState, 'hibernate'} -> {'noreply', State#state{module_state=ModuleState}, 'hibernate'};
+                {'ignore', ModuleState, Timeout} -> {'noreply', State#state{module_state=ModuleState}, Timeout};
+                {CallbackData, ModuleState} -> distribute_event(CallbackData, JObj, BasicDeliver, State#state{module_state=ModuleState});
+                CallbackData -> distribute_event(CallbackData, JObj, BasicDeliver, State)
+            end
     end.
 
 -spec distribute_event(callback_data(), kz_json:object(), deliver(), state()) -> state().
-distribute_event(CallbackData
-                ,JObj
-                ,Deliver
-                ,#state{responders=Responders
-                       ,consumer_key=ConsumerKey
-                       }=State
-                ) ->
+distribute_event(CallbackData, JObj, Deliver, #state{responders=Responders
+                                                    ,consumer_key=ConsumerKey
+                                                    }=State) ->
     Key = kz_util:get_event_type(JObj),
     Channel = kz_amqp_channel:consumer_channel(),
-    _ = [kz_util:spawn(fun client_handle_event/6
-                      ,[JObj
-                       ,Channel
-                       ,ConsumerKey
-                       ,Callback
-                       ,CallbackData
-                       ,Deliver
-                       ])
+    _ = [kz_util:spawn(fun client_handle_event/6, [JObj
+                                                  ,Channel
+                                                  ,ConsumerKey
+                                                  ,Callback
+                                                  ,CallbackData
+                                                  ,Deliver
+                                                  ])
          || {Evt, Callback} <- Responders,
             maybe_event_matches_key(Key, Evt)
         ],
-    State.
+    {'noreply', State}.
 
 -spec client_handle_event(kz_json:object(), kz_amqp_channel:consumer_channel(), kz_amqp_channel:consumer_pid(), responder_mfa(), callback_data(), deliver()) -> any().
 client_handle_event(JObj, 'undefined', ConsumerKey, Callback, CallbackData, Deliver) ->
     _ = kz_util:put_callid(JObj),
     _ = kz_amqp_channel:consumer_pid(ConsumerKey),
     client_handle_event(JObj, Callback, CallbackData, Deliver);
-client_handle_event(JObj, Channel, ConsumerKey, Callback, CallbackData, Deliver) ->
+client_handle_event(JObj, #kz_amqp_assignment{channel=Channel}, ConsumerKey, Callback, CallbackData, Deliver)
+  when is_pid(Channel)->
+    _ = kz_util:put_callid(JObj),
+    _ = kz_amqp_channel:consumer_pid(ConsumerKey),
+    _ = is_process_alive(Channel)
+        andalso kz_amqp_channel:consumer_channel(Channel),
+    client_handle_event(JObj, Callback, CallbackData, Deliver);
+client_handle_event(JObj, Channel, ConsumerKey, Callback, CallbackData, Deliver)
+  when is_pid(Channel) ->
     _ = kz_util:put_callid(JObj),
     _ = kz_amqp_channel:consumer_pid(ConsumerKey),
     _ = is_process_alive(Channel)
@@ -918,7 +942,7 @@ client_handle_event(JObj, {Module, Fun, 2}, CallbackData, _Deliver) ->
                                    callback_data() |
                                    {callback_data(), module_state()}.
 callback_handle_event(_JObj
-                     ,{BasicDeliver, Basic}
+                     ,{Deliver, Basic}
                      ,#state{module_state=ModuleState
                             ,queue=Queue
                             ,other_queues=OtherQueues
@@ -929,61 +953,66 @@ callback_handle_event(_JObj
     [{'server', Self}
     ,{'queue', Queue}
     ,{'basic', Basic}
-    ,{'deliver', BasicDeliver}
+    ,{'deliver', Deliver}
     ,{'other_queues', props:get_keys(OtherQueues)}
     ,{'state', ModuleState}
     ];
 
 callback_handle_event(JObj
-                     ,{BasicDeliver, Basic}=Deliver
+                     ,{Deliver, Basic}
                      ,#state{module_state=ModuleState
                             ,queue=Queue
                             ,other_queues=OtherQueues
                             ,self=Self
                             ,handle_event_mfa=MFA
-                            }
+                            }=_State
                      ) ->
-    case callback_handle_event(JObj, Deliver, MFA, ModuleState) of
+    Props = [{'queue', Queue}
+            ,{'basic', Basic}
+            ,{'deliver', Deliver}
+            ,{'other_queues', props:get_keys(OtherQueues)}
+            ],
+
+    case callback_handle_event(JObj, Props, MFA, ModuleState) of
         'ignore' -> 'ignore';
         {'ignore', _NewModuleState} = Reply -> Reply;
-        {'reply', Props} when is_list(Props) ->
+        {'ignore', _NewModuleState, 'hibernate'} = Reply -> Reply;
+        {'reply', NewProps} when is_list(NewProps) ->
             [{'server', Self}
             ,{'queue', Queue}
             ,{'basic', Basic}
-            ,{'deliver', BasicDeliver}
+            ,{'deliver', Deliver}
             ,{'other_queues', props:get_keys(OtherQueues)}
-             | Props
+             | NewProps
             ];
-        {'reply', Props, NewModuleState} when is_list(Props) ->
+        {'reply', NewProps, NewModuleState} when is_list(Props) ->
             {[{'server', Self}
              ,{'queue', Queue}
              ,{'basic', Basic}
-             ,{'deliver', BasicDeliver}
+             ,{'deliver', Deliver}
              ,{'other_queues', props:get_keys(OtherQueues)}
-              | Props
+              | NewProps
              ]
             ,NewModuleState
             };
         {'EXIT', Why} ->
-            lager:error("CRASH in handle_event ~p", [Why]),
+            lager:error("CRASH in handle_event ~p : ~p", [Why, _State]),
             [{'server', Self}
             ,{'queue', Queue}
             ,{'basic', Basic}
-            ,{'deliver', BasicDeliver}
+            ,{'deliver', Deliver}
             ,{'other_queues', props:get_keys(OtherQueues)}
             ,{'state', ModuleState}
             ]
     end.
 
--spec callback_handle_event(kz_json:object(), deliver(), mfa(), module_state()) ->
+-spec callback_handle_event(kz_json:object(), kz_term:proplist(), mfa(), module_state()) ->
                                    handle_event_return() |
                                    {'EXIT', any()}.
 callback_handle_event(JObj, _, {Module, Fun, 2}, ModuleState) ->
     catch Module:Fun(JObj, ModuleState);
-callback_handle_event(JObj, {BasicDeliver, _}, {Module, Fun, 3}, ModuleState) ->
-    catch Module:Fun(JObj, BasicDeliver, ModuleState);
-callback_handle_event(JObj, {BasicDeliver, Basic}, {Module, Fun, 4}, ModuleState) ->
-    catch Module:Fun(JObj, BasicDeliver, Basic, ModuleState);
+callback_handle_event(JObj, Props, {Module, Fun, 3}, ModuleState) ->
+    catch Module:Fun(JObj, Props, ModuleState);
 callback_handle_event(_, _, _, _) ->
     {'EXIT', 'not_exported'}.
 

--- a/core/kazoo_amqp/src/listener_federator.erl
+++ b/core/kazoo_amqp/src/listener_federator.erl
@@ -15,7 +15,7 @@
         ,handle_call/3
         ,handle_cast/2
         ,handle_info/2
-        ,handle_event/4
+        ,handle_event/3
         ,terminate/2
         ,code_change/3
         ]).
@@ -106,12 +106,12 @@ handle_info(_Info, State) ->
     lager:info("unhandled message: ~p", [_Info]),
     {'noreply', State}.
 
--spec handle_event(kz_json:object(), gen_listener:basic_deliver(), amqp_basic(), state()) -> gen_listener:handle_event_return().
-handle_event(JObj, BasicDeliver, BasicData, #state{parent=Parent
-                                                  ,broker=Broker
-                                                  ,self_binary=Self
-                                                  ,zone=Zone
-                                                  }) ->
+-spec handle_event(kz_json:object(), kz_term:proplist(), state()) -> gen_listener:handle_event_return().
+handle_event(JObj, Props, #state{parent=Parent
+                                ,broker=Broker
+                                ,self_binary=Self
+                                ,zone=Zone
+                                }) ->
     lager:debug("relaying federated ~s event (~p) ~s from ~s to ~p with consumer pid ~p",
                 [kz_api:event_category(JObj), kz_api:msg_id(JObj), kz_api:event_name(JObj), Zone, Parent, Self]
                ),
@@ -126,8 +126,7 @@ handle_event(JObj, BasicDeliver, BasicData, #state{parent=Parent
                                                     ]
                                                    ,JObj
                                                    )
-                                ,BasicDeliver
-                                ,BasicData
+                                ,Props
                                 ),
     'ignore'.
 

--- a/core/kazoo_amqp/src/listener_utils.erl
+++ b/core/kazoo_amqp/src/listener_utils.erl
@@ -108,8 +108,7 @@ responder({Module, Fun}) when is_atom(Module), is_atom(Fun) ->
     responder_mfa(Module, Fun);
 responder(CallbackFun)
   when is_function(CallbackFun, 2);
-       is_function(CallbackFun, 3);
-       is_function(CallbackFun, 4) ->
+       is_function(CallbackFun, 3) ->
     {'arity', Arity} = erlang:fun_info(CallbackFun, 'arity'),
     {CallbackFun, Arity};
 responder(_) -> 'undefined'.


### PR DESCRIPTION
After [PR 5712](https://github.com/2600hz/kazoo/pull/5712) (for 4.3 branch after [PR 5742](https://github.com/2600hz/kazoo/pull/5742)) rabbimq redundancy is broken.

For master this fixed at [PR5747](https://github.com/2600hz/kazoo/pull/5747) but not back ported into 4.3 branch.

you can reproduce issue by
*joining two rabbitmq daemon into cluster*
```
/ # rabbitmqctl cluster_status
Cluster status of node 'rabbit@rmq1.kazoo' ...
[{nodes,[{disc,['rabbit@rmq1.kazoo','rabbit@rmq2.kazoo']}]},
 {running_nodes,['rabbit@rmq2.kazoo','rabbit@rmq1.kazoo']},
 {cluster_name,<<"rabbit@rmq2.kazoo">>},
 {partitions,[]},
 {alarms,[{'rabbit@rmq2.kazoo',[]},{'rabbit@rmq1.kazoo',[]}]}]
```

*setting two amq connections in kazoo config.ini*
```sh
[safarov@safarov-dell tmp]$ head /etc/kazoo/core/config.ini 
; section are between [] = [section]
; key = value
; to comment add ";" in front of the line
[amqp]
uri = "amqp://kazoo:change_me@127.0.0.1:15672"
uri = "amqp://kazoo:change_me@127.0.0.1:25672"

[bigcouch]
compact_automatically = true
```

Starting "./scripts/dev-start-apps.sh" and "./scripts/dev-start-ecallmgr.sh" and then checking node status.
all will be as expected.

Then stop one rabbimq and check nodes status.

kapps not not able to see ecallmgr node.
