### PR TITLE
preserve bindings (#5986)

### DIFF
--- a/core/kazoo_amqp/src/kz_amqp_assignments.erl
+++ b/core/kazoo_amqp/src/kz_amqp_assignments.erl
@@ -425,6 +425,7 @@ move_channel_to_consumer(#kz_amqp_assignment{timestamp=Timestamp
     Assignment =
         ConsumerAssignment#kz_amqp_assignment{channel=Channel
                                              ,channel_ref=ChannelRef
+                                             ,broker=Broker
                                              ,connection=Connection
                                              ,assigned=kz_time:start_time()
                                              },
@@ -468,7 +469,7 @@ add_consumer_to_channel(#kz_amqp_assignment{channel=Channel
                                                   ,watchers=sets:new()
                                                   }),
     lager:debug("assigned existing channel ~p on ~s(~p) to new consumer ~p"
-               ,[Channel, _Broker, Consumer, Connection]
+               ,[Channel, _Broker, Connection, Consumer]
                ),
 
     register_channel_handlers(Channel, Consumer),
@@ -570,6 +571,7 @@ assign_channel(#kz_amqp_assignment{channel=CurrentChannel
                ),
 
     _ = (catch kz_amqp_channel:close(CurrentChannel)),
+    Consumer ! {'kz_amqp_assignment', 'lost_channel'},
     assign_channel(Assignment#kz_amqp_assignment{channel='undefined'
                                                 ,reconnect='true'
                                                 }


### PR DESCRIPTION
if there's an error before the start consume
we can potentially have initial Params
set to empty array and therefore loose the bindings

also, since we're folding the Params into bindings
the return is the list of bindings that we preserve in state,
so we still need to add the existing binding to the acumulator.

we need to set the broker when assigning existing to consumer

we need to send 'channel_lost' if we're moving the channel
to the primary broker