### PR TITLE
[4.3] fix gen_listener terminate to not release channel until after

### DIFF
--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -798,8 +798,8 @@ terminate(Reason, #state{module=Module
                         ,consumer_tags=Tags
                         }) ->
     _ = (catch(lists:foreach(fun kz_amqp_util:basic_cancel/1, Tags))),
-    _ = (catch kz_amqp_channel:release()),
     _Terminated = (catch Module:terminate(Reason, ModuleState)),
+    _ = (catch kz_amqp_channel:release()),
     _ = [listener_federator:stop(F) || {_Broker, F} <- Fs],
     lager:debug("~s terminated cleanly, going down", [Module]).
 


### PR DESCRIPTION
callback terminate
 - allows the callback to still do amqp things in the terminate method