### PR TITLE
FORUM-10598: validate using parent account's media in sub accounts

### DIFF
--- a/applications/crossbar/src/modules/cb_menus.erl
+++ b/applications/crossbar/src/modules/cb_menus.erl
@@ -37,7 +37,7 @@
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec init() -> ok.
+-spec init() -> 'ok'.
 init() ->
     _ = crossbar_bindings:bind(<<"*.allowed_methods.menus">>, ?MODULE, 'allowed_methods'),
     _ = crossbar_bindings:bind(<<"*.resource_exists.menus">>, ?MODULE, 'resource_exists'),
@@ -46,7 +46,7 @@ init() ->
     _ = crossbar_bindings:bind(<<"*.execute.post.menus">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"*.execute.patch.menus">>, ?MODULE, 'patch'),
     _ = crossbar_bindings:bind(<<"*.execute.delete.menus">>, ?MODULE, 'delete'),
-    ok.
+    'ok'.
 
 %%------------------------------------------------------------------------------
 %% @doc This function determines the verbs that are appropriate for the
@@ -142,7 +142,7 @@ load_menu_summary(Context) ->
 -spec create_menu(cb_context:context()) -> cb_context:context().
 create_menu(Context) ->
     OnSuccess = fun(C) -> on_successful_validation('undefined', C) end,
-    cb_context:validate_request_data(<<"menus">>, Context, OnSuccess).
+    cb_context:validate_request_data(kzd_menus:schema_name(), Context, OnSuccess).
 
 %%------------------------------------------------------------------------------
 %% @doc Load a menu document from the database
@@ -150,7 +150,7 @@ create_menu(Context) ->
 %%------------------------------------------------------------------------------
 -spec load_menu(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
 load_menu(DocId, Context) ->
-    crossbar_doc:load(DocId, Context, ?TYPE_CHECK_OPTION(<<"menu">>)).
+    crossbar_doc:load(DocId, Context, ?TYPE_CHECK_OPTION(kzd_menus:type())).
 
 %%------------------------------------------------------------------------------
 %% @doc Update an existing menu document with the data provided, if it is
@@ -160,7 +160,7 @@ load_menu(DocId, Context) ->
 -spec update_menu(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
 update_menu(DocId, Context) ->
     OnSuccess = fun(C) -> on_successful_validation(DocId, C) end,
-    cb_context:validate_request_data(<<"menus">>, Context, OnSuccess).
+    cb_context:validate_request_data(kzd_menus:schema_name(), Context, OnSuccess).
 
 %%------------------------------------------------------------------------------
 %% @doc Update-merge an existing menu document with the data provided, if it is
@@ -178,13 +178,11 @@ validate_patch(DocId, Context) ->
 -spec on_successful_validation(kz_term:api_binary(), cb_context:context()) ->
                                       cb_context:context().
 on_successful_validation('undefined', Context) ->
-    cb_context:set_doc(Context, kz_json:set_values([{<<"pvt_type">>, <<"menu">>}
-                                                   ,{<<"pvt_vsn">>, <<"2">>}
-                                                   ]
-                                                  ,cb_context:doc(Context)
-                                                  ));
+    MenuReq = cb_context:doc(Context),
+    MenuDoc = kz_doc:set_vsn(kz_doc:set_type(MenuReq, kzd_menus:type()), <<"2">>),
+    cb_context:set_doc(Context, MenuDoc);
 on_successful_validation(DocId, Context) ->
-    crossbar_doc:load_merge(DocId, Context, ?TYPE_CHECK_OPTION(<<"menu">>)).
+    crossbar_doc:load_merge(DocId, Context, ?TYPE_CHECK_OPTION(kzd_menus:type())).
 
 %%------------------------------------------------------------------------------
 %% @doc Normalizes the results of a view.

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -40,6 +40,7 @@
 -export([create_masquerade_event/2, create_masquerade_event/3]).
 -export([media_path/1, media_path/2, media_path/3, media_path/4
         ,lookup_media/4
+        ,request_media_url/4
         ]).
 -export([unserialize_fs_array/1, unserialize_fs_props/1]).
 -export([convert_fs_evt_name/1, convert_kazoo_app_name/1]).
@@ -1352,11 +1353,11 @@ maybe_cache_media_response(MediaName, MediaResp) ->
             {'error', 'not_found'};
         MediaUrl ->
             CacheProps = media_url_cache_props(MediaName),
-            _ = kz_cache:store_local(?ECALLMGR_UTIL_CACHE
-                                    ,?ECALLMGR_PLAYBACK_MEDIA_KEY(MediaName)
-                                    ,MediaUrl
-                                    ,CacheProps
-                                    ),
+            catch kz_cache:store_local(?ECALLMGR_UTIL_CACHE
+                                      ,?ECALLMGR_PLAYBACK_MEDIA_KEY(MediaName)
+                                      ,MediaUrl
+                                      ,CacheProps
+                                      ),
             lager:debug("media ~s stored to playback cache : ~s", [MediaName, MediaUrl]),
             {'ok', MediaUrl}
     end.

--- a/core/kazoo_documents/src/kzd_menus.erl
+++ b/core/kazoo_documents/src/kzd_menus.erl
@@ -27,6 +27,9 @@
 -export([retries/1, retries/2, set_retries/2]).
 -export([timeout/1, timeout/2, set_timeout/2]).
 
+-export([schema_name/0
+        ,type/0
+        ]).
 
 -include("kz_documents.hrl").
 
@@ -34,10 +37,11 @@
 -export_type([doc/0]).
 
 -define(SCHEMA, <<"menus">>).
+-define(TYPE, <<"menu">>).
 
 -spec new() -> doc().
 new() ->
-    kz_json_schema:default_object(?SCHEMA).
+    kz_doc:set_type(kz_json_schema:default_object(?SCHEMA), type()).
 
 -spec allow_record_from_offnet(doc()) -> boolean().
 allow_record_from_offnet(Doc) ->
@@ -230,3 +234,9 @@ timeout(Doc, Default) ->
 -spec set_timeout(doc(), integer()) -> doc().
 set_timeout(Doc, Timeout) ->
     kz_json:set_value([<<"timeout">>], Timeout, Doc).
+
+-spec schema_name() -> kz_term:ne_binary().
+schema_name() -> ?SCHEMA.
+
+-spec type() -> kz_term:ne_binary().
+type() -> ?TYPE.

--- a/core/kazoo_proper/src/pqc_cb_media.erl
+++ b/core/kazoo_proper/src/pqc_cb_media.erl
@@ -24,6 +24,7 @@
 
 -export([seq/0
         ,cleanup/0
+        ,new_media_doc/0
         ]).
 
 -include("kazoo_proper.hrl").
@@ -277,6 +278,7 @@ expected_location_value(URL, Id) ->
     {'match', [_Host, Path]} = re:run(URL, "^(.+)(/v2/.+$)", [{'capture','all_but_first', 'list'}]),
     Path ++ [$/ | kz_term:to_list(Id)].
 
+-spec new_media_doc() -> kzd_media:doc().
 new_media_doc() ->
     Set = [{fun kzd_media:set_name/2, kz_binary:rand_hex(6)}],
     kz_doc:public_fields(kz_json:exec_first(Set, kzd_media:new())).

--- a/core/kazoo_proper/src/pqc_cb_menus.erl
+++ b/core/kazoo_proper/src/pqc_cb_menus.erl
@@ -1,0 +1,180 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%%
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_menus).
+
+%% API requests
+-export([summary/2
+        ,create/3
+        ,fetch/3
+        ,update/3
+        ,patch/4
+        ,delete/3
+        ]).
+
+-export([seq/0
+        ,cleanup/0
+        ,new_menu/0
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
+
+-spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+summary(API, AccountId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,menus_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec create(pqc_cb_api:state(), kz_term:ne_binary(), kzd_menus:doc()) -> pqc_cb_api:response().
+create(API, AccountId, MenuJObj) ->
+    URL = menus_url(AccountId),
+
+    Expectations = [#expectation{response_codes = [201]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(MenuJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:put/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+fetch(API, AccountId, MenuId) ->
+    Expectations = [#expectation{response_codes = [200]}],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,menu_url(AccountId, MenuId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec update(pqc_cb_api:state(), kz_term:ne_binary(), kzd_menu:doc()) -> pqc_cb_api:response().
+update(API, AccountId, MenuJObj) ->
+    URL = menu_url(AccountId, kz_doc:id(MenuJObj)),
+
+    Expectations = [#expectation{response_codes = [200]
+                                ,response_headers = [{"content-type", "application/json"}]
+                                }
+                   ],
+
+    Envelope = pqc_cb_api:create_envelope(MenuJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec patch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
+patch(API, AccountId, MenuId, PatchJObj) ->
+    URL = menu_url(AccountId, MenuId),
+
+    Expectations = [#expectation{response_codes = [200]}],
+
+    Envelope = pqc_cb_api:create_envelope(PatchJObj),
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:patch/3
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ,kz_json:encode(Envelope)
+                           ).
+
+-spec delete(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+delete(API, AccountId, MenuId) ->
+    URL = menu_url(AccountId, MenuId),
+    Expectations = [#expectation{response_codes = [200]}],
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:delete/2
+                           ,URL
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec menus_url(kz_term:ne_binary()) -> string().
+menus_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "menus"], "/").
+
+-spec menu_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
+menu_url(AccountId, MenuId) ->
+    string:join([menus_url(AccountId), kz_term:to_list(MenuId)], "/").
+
+-spec seq() -> 'ok'.
+seq() ->
+    API = pqc_cb_api:init_api(['crossbar'], ['cb_menus']),
+    AccountId = create_account(API),
+
+    EmptySummaryResp = summary(API, AccountId),
+    ?INFO("empty summary resp: ~s", [EmptySummaryResp]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
+
+    MenuJObj = new_menu(),
+    CreateResp = create(API, AccountId, MenuJObj),
+    ?INFO("created menu ~s", [CreateResp]),
+    CreatedMenu = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
+    MenuId = kz_doc:id(CreatedMenu),
+
+    Patch = kz_json:from_list([{<<"custom">>, <<"value">>}]),
+    PatchResp = patch(API, AccountId, MenuId, Patch),
+    ?INFO("patched to ~s", [PatchResp]),
+
+    SummaryResp = summary(API, AccountId),
+    ?INFO("summary resp: ~s", [SummaryResp]),
+    [SummaryMenu] = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
+    MenuId = kz_doc:id(SummaryMenu),
+
+    DeleteResp = delete(API, AccountId, MenuId),
+    ?INFO("delete resp: ~s", [DeleteResp]),
+
+    EmptyAgain = summary(API, AccountId),
+    ?INFO("empty summary resp: ~s", [EmptyAgain]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptyAgain)),
+
+    cleanup(API),
+    lager:info("FINISHED MENU SEQ").
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
+    cleanup_system().
+
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _ = pqc_cb_api:cleanup(API),
+    cleanup_system().
+
+cleanup_system() -> 'ok'.
+
+-spec create_account(pqc_cb_api:state()) -> kz_term:ne_binary().
+create_account(API) ->
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    lager:info("created account: ~s", [AccountResp]),
+
+    kz_json:get_ne_binary_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
+
+-spec new_menu() -> kzd_menus:doc().
+new_menu() ->
+    kz_doc:public_fields(
+      kz_json:exec_first([{fun kzd_menus:set_name/2, kz_binary:rand_hex(4)}]
+                        ,kzd_menus:new()
+                        )
+     ).

--- a/core/kazoo_proper/src/pqc_forum_10598.erl
+++ b/core/kazoo_proper/src/pqc_forum_10598.erl
@@ -1,0 +1,84 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2011-2019, 2600Hz
+%%% @doc menu greeting media when referencing other account's media
+%%%
+%%% 1. create media in account 1
+%%% 2. create menu callflow in account 2
+%%%   a. set "greeting" to "/{ACCOUNT_1}/{MEDIA_ID}"
+%%% 3. fetch media path as ecallmgr would
+%%%
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_forum_10598).
+
+-export([seq/0
+        ,cleanup/0, cleanup/1
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-spec seq() -> 'ok'.
+seq() ->
+    API = pqc_cb_api:init_api(['crossbar', 'media_mgr']
+                             ,['cb_media']
+                             ),
+    ParentAccountId = create_account(API, <<?MODULE_STRING, "_parent">>),
+    ChildAccountId = create_account(API, <<?MODULE_STRING, "_child">>),
+
+    CreateMetaResp = pqc_cb_media:create(API, ParentAccountId, pqc_cb_media:new_media_doc()),
+    lager:info("created media meta: ~s", [CreateMetaResp]),
+    MediaId = kz_json:get_ne_binary_value([<<"data">>, <<"id">>], kz_json:decode(CreateMetaResp)),
+
+    {'ok', MP3} = file:read_file(filename:join([code:priv_dir('kazoo_proper'), "mp3.mp3"])),
+    _UploadResp = pqc_cb_media:update_binary(API, ParentAccountId, MediaId, MP3),
+    lager:info("uploaded mp3 to media: ~s", [_UploadResp]),
+
+    CreatedMenuResp = pqc_cb_menus:create(API, ChildAccountId, new_menu(ParentAccountId, MediaId)),
+    lager:info("created menu: ~s", [CreatedMenuResp]),
+    Menu = kz_json:get_json_value([<<"data">>], kz_json:decode(CreatedMenuResp)),
+
+    GreetingPrompt = kz_media_util:media_path(kzd_menus:media_greeting(Menu), ChildAccountId),
+    lager:info("greeting prompt: ~s", [GreetingPrompt]),
+
+    CallId = kz_binary:rand_hex(3),
+    PlayCommand = kapps_call_command:play_command(GreetingPrompt, CallId),
+    lager:info("play command: ~p", [PlayCommand]),
+
+    MediaName = kz_json:get_ne_binary_value(<<"Media-Name">>, PlayCommand),
+    {'ok', MediaPath} = ecallmgr_util:request_media_url(MediaName, 'new', CallId, PlayCommand),
+    lager:info("media path for ~s: ~s", [MediaName, MediaPath]),
+
+    {'ok', 200, _, MP3} = kz_http:get(MediaPath),
+    lager:info("got mp3 from ~s", [MediaPath]),
+
+    cleanup(API).
+
+-spec new_menu(kz_term:ne_binary(), kz_term:ne_binary()) -> kzd_menus:doc().
+new_menu(AccountId, MediaId) ->
+    Greeting = <<"/", AccountId/binary, "/", MediaId/binary>>,
+    kzd_menus:set_media_greeting(pqc_cb_menus:new_menu(), Greeting).
+
+-spec create_account(pqc_cb_api:state(), kz_term:ne_binary()) -> kz_term:ne_binary().
+create_account(API, Name) ->
+    AccountResp = pqc_cb_accounts:create_account(API, Name),
+    lager:info("created account: ~s", [AccountResp]),
+
+    kz_json:get_ne_binary_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    _ = pqc_cb_accounts:cleanup_accounts([<<?MODULE_STRING, "_parent">>, <<?MODULE_STRING, "_child">>]),
+    cleanup_system().
+
+-spec cleanup(pqc_cb_api:state()) -> 'ok'.
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts([<<?MODULE_STRING, "_parent">>, <<?MODULE_STRING, "_child">>]),
+    _ = pqc_cb_api:cleanup(API),
+    cleanup_system().
+
+cleanup_system() -> 'ok'.


### PR DESCRIPTION
Specifically the ask was to use a parent account's media in a child
account's menu greeting. pqc_forum_10598.erl effectively follows the
path of creating a media file in a parent account, creating a menu in
a child account, and following the path of that
media path (/parent_account/media_id) until it is resolved to a couch
URL by ecallmgr via media_mgr.

Also added a CRUD seq test for the menu API.