### PR TITLE
[4.3] fix returning queue_name from gen_listener

### DIFF
--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -469,6 +469,8 @@ handle_call({'add_queue', QueueName, QueueProps, Bindings}, _From, State) ->
     {'reply', {'ok', Q}, S};
 handle_call('other_queues', _From, #state{other_queues=OtherQueues}=State) ->
     {'reply', props:get_keys(OtherQueues), State};
+handle_call('queue_name', _From, #state{queue='undefined', params=Params}=State) ->
+    {'reply', props:get_value('queue_name', Params), State};
 handle_call('queue_name', _From, #state{queue=Q}=State) ->
     {'reply', Q, State};
 handle_call('responders', _From, #state{responders=Rs}=State) ->


### PR DESCRIPTION
 - when the queue_name is requested before it is actually done setting
up it will return 'undefined' instead of the to-be-used name, check for
that condition and return the queue_name that is configured instead