### PR TITLE
move fs_dist to core and enable it in kazoo script

### DIFF
--- a/applications/ecallmgr/Makefile
+++ b/applications/ecallmgr/Makefile
@@ -4,11 +4,4 @@ PROJECT = ecallmgr
 
 all: compile
 
-compile: ebin/fs_dist.beam
-
-SOURCES = $(filter-out src/fs_dist.erl, $(wildcard src/*.erl) $(wildcard src/*/*.erl))
-
 include $(ROOT)/make/kz.mk
-
-ebin/fs_dist.beam: src/fs_dist.erl
-	erlc -v -o ebin/ src/fs_dist.erl

--- a/core/kazoo/src/kz_dist.erl
+++ b/core/kazoo/src/kz_dist.erl
@@ -7,14 +7,16 @@
 %%%
 %%% @end
 %%%-----------------------------------------------------------------------------
--module(fs_dist).
+-module(kz_dist).
 
 -export([listen/1, accept/1, accept_connection/5,
          setup/5, close/1, select/1]).
 
+-spec listen(atom()) -> {error, any()} | {ok, term()}.
 listen(Name) ->
     inet_tcp_dist:listen(Name).
 
+-spec select(atom()) -> boolean().
 select(FullNode) ->
     [Node, _Host] = split_node(atom_to_list(FullNode), $@, []),
     case Node =:= "freeswitch" of
@@ -22,20 +24,21 @@ select(FullNode) ->
         false -> false
     end.
 
-accept(_Listen) ->
-    'ok'.
-%% inet_tcp_dist:accept(Listen).
+-spec accept(term()) -> pid().
+accept(Listen) ->
+    inet_tcp_dist:accept(Listen).
 
-accept_connection(_AcceptPid, _Socket, _MyNode, _Allowed, _SetupTime) ->
-    'ok'.
-%% inet_tcp_dist:accept_connection(AcceptPid, Socket, MyNode, Allowed, SetupTime).
+-spec accept_connection(pid(), term(), atom(), term(), term()) -> pid().
+accept_connection(AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
+    inet_tcp_dist:accept_connection(AcceptPid, Socket, MyNode, Allowed, SetupTime).
 
+-spec setup(atom(), term(), atom(), term(), term()) -> pid().
 setup(Node, Type, MyNode, LongOrShortNames, SetupTime) ->
     inet_tcp_dist:setup(Node, Type, MyNode, LongOrShortNames, SetupTime).
 
-close(_Listen) ->
-    ok.
-%% inet_tcp_dist:close(Listen).
+-spec close(term()) -> 'ok'.
+close(Listen) ->
+    inet_tcp_dist:close(Listen).
 
 split_node([Chr|T], Chr, Ack) -> [lists:reverse(Ack)|split_node(T, Chr, [])];
 split_node([H|T], Chr, Ack)   -> split_node(T, Chr, [H|Ack]);

--- a/rel/kazoo
+++ b/rel/kazoo
@@ -552,8 +552,7 @@ case "$1" in
             $NAME_ARG \
             -setcookie $COOKIE \
             -args_file "$VM_ARGS_FILE" \
-            -proto_dist inet_tcp amqp \
-            -start_epmd false
+            -proto_dist kz amqp
 
         # Dump environment info for logging purposes
         echo "Exec: $@" -- ${1+$ARGS}


### PR DESCRIPTION
* change fs_dist to accept connections because of sup & remote_console
* we need to ensure that node only connects outbound thru amqp
   or in the case of ecallmgr to freeswitch with inet_tcp