### PR TITLE
Allow generic branching of callflow based on capture group

### DIFF
--- a/applications/callflow/doc/branch_bnumber.md
+++ b/applications/callflow/doc/branch_bnumber.md
@@ -12,7 +12,56 @@ Validator for the branch_bnumber callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
+`hunt` | Should the capture group be used to hunt for a new callflow | `boolean()` | `false` | `false` |  
+`hunt_allow` | A regexp used to match against the capture group to whitelist allowed numbers to hunt | `string()` |   | `false` |  
+`hunt_deny` | A regexp used to match against the capture group to blacklist denied numbers to hunt | `string()` |   | `false` |  
 `skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
 
 
 
+
+
+
+### Branching vs Hunting
+
+#### Branching
+
+With the `hunt` flag set to false, the capture group will be used to lookup a child branch that matches:
+
+```json
+{"patterns":["*55(\\d+)"]
+ ,"flow":{
+   "module":"branch_bnumber"
+   ,"data":{}
+   ,"children":{
+     "_": {...default branch...}
+    ,"{CAPTURE_GROUP}": {...exact match on capture group...}
+   }
+ }
+}
+```
+
+So if the caller dials `*551000` a child key `1000` would need to exist and define the rest of the callflow.
+
+#### Hunting
+
+This isn't particularly useful if you want a more dynamic experience. By setting `hunt` to `true`, the capture group can point to another callflow and branch to its `flow`. This could be used to create specific flows based on feature code that branch to the "normal" flow for the capture group.
+
+For example, enabling per-call call recording could be implemented as:
+
+```json
+{"patterns":["*55(\\d+)"]
+ ,"flow":{
+   "module":"record_call"
+   ,"data":{...}
+   ,"children":{
+     "_":{
+        "module":"branch_bnumber"
+        ,"data":{"hunt":true}
+     }
+   }
+ }
+}
+```
+
+Now, when `*551000` is dialed, call recording is started and then a hunt for `1000` is performed as if the caller had just dialed that to start. If found, the normal callflow for `1000` runs, just with call recording enabled.

--- a/applications/callflow/doc/ref/branch_bnumber.md
+++ b/applications/callflow/doc/ref/branch_bnumber.md
@@ -10,6 +10,9 @@ Validator for the branch_bnumber callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
+`hunt` | Should the capture group be used to hunt for a new callflow | `boolean()` | `false` | `false` |  
+`hunt_allow` | A regexp used to match against the capture group to whitelist allowed numbers to hunt | `string()` |   | `false` |  
+`hunt_deny` | A regexp used to match against the capture group to blacklist denied numbers to hunt | `string()` |   | `false` |  
 `skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
 
 

--- a/applications/callflow/src/cf_route_req.erl
+++ b/applications/callflow/src/cf_route_req.erl
@@ -11,7 +11,9 @@
 %%%-----------------------------------------------------------------------------
 -module(cf_route_req).
 
--export([handle_req/2]).
+-export([handle_req/2
+        ,allow_no_match/1
+        ]).
 
 -include("callflow.hrl").
 

--- a/applications/callflow/src/cf_util.erl
+++ b/applications/callflow/src/cf_util.erl
@@ -778,7 +778,7 @@ normalize_capture_group(<<>>, _) ->
     'undefined';
 normalize_capture_group(CaptureGroup, 'undefined') ->
     knm_converters:normalize(CaptureGroup);
-normalize_capture_group(CaptureGroup, ?NE_BINARY=AccountId) ->
+normalize_capture_group(CaptureGroup, <<AccountId/binary>>) ->
     knm_converters:normalize(CaptureGroup, AccountId);
 normalize_capture_group(CaptureGroup, Call) ->
     normalize_capture_group(CaptureGroup, kapps_call:account_id(Call)).

--- a/applications/callflow/src/module/cf_branch_bnumber.erl
+++ b/applications/callflow/src/module/cf_branch_bnumber.erl
@@ -11,26 +11,86 @@
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(cf_branch_bnumber).
-
 -behaviour(gen_cf_action).
+
+-export([handle/2]).
 
 -include("callflow.hrl").
 
-%% API
--export([handle/2]).
-
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
-handle(_Data, Call) ->
-    Number = kapps_call:kvs_fetch('cf_capture_group', Call),
-    NumberToBranch = case kz_term:is_empty(Number) of
-                         'true' -> kapps_call:request_user(Call);
-                         'false' -> cf_util:normalize_capture_group(Number)
-                     end,
-    case NumberToBranch of
-        'undefined' ->
-            lager:debug("capture group is empty and can not be set as destination."),
-            cf_exe:continue(Call);
-        _ ->
-            lager:debug("trying to branch to ~p", [NumberToBranch]),
-            cf_exe:continue(NumberToBranch, Call)
+handle(Data, Call) ->
+    CaptureGroup = kapps_call:kvs_fetch('cf_capture_group', Call),
+    handle(Data, Call, cf_util:normalize_capture_group(CaptureGroup, Call)).
+
+handle(_Data, Call, 'undefined') ->
+    lager:info("no capture group value to use, skipping"),
+    cf_exe:continue(Call);
+handle(_Data, Call, <<>>) ->
+    lager:info("no capture group value to use, skipping"),
+    cf_exe:continue(Call);
+handle(Data, Call, CaptureGroup) ->
+    handle(Data, Call, CaptureGroup, kz_json:is_true(<<"hunt">>, Data)).
+
+handle(_Data, Call, CaptureGroup, 'false') ->
+    lager:info("trying to branch to child ~s", [CaptureGroup]),
+    cf_exe:continue(CaptureGroup, Call);
+handle(Data, Call, CaptureGroup, 'true') ->
+    maybe_hunt(Data, Call, CaptureGroup).
+
+maybe_hunt(Data, Call, CaptureGroup) ->
+    HuntDeny = kz_json:get_ne_binary_value(<<"hunt_deny">>, Data),
+    HuntAllow = kz_json:get_ne_binary_value(<<"hunt_allow">>, Data),
+
+    maybe_hunt(Data, Call, CaptureGroup, is_hunt_allowed(CaptureGroup, HuntDeny, HuntAllow)).
+
+is_hunt_allowed(CaptureGroup, HuntDeny, HuntAllow) ->
+    is_allowed(CaptureGroup, HuntAllow)
+        andalso not is_denied(CaptureGroup, HuntDeny).
+
+is_allowed(_CaptureGroup, 'undefined') -> 'true';
+is_allowed(_CaptureGroup, <<>>) -> 'true';
+is_allowed(CaptureGroup, Regex) ->
+    try re:run(CaptureGroup, Regex) of
+        {'match', _} -> 'true';
+        'nomatch' ->
+            lager:info("capture group ~s does not match allowed regex ~s", [CaptureGroup, Regex]),
+            'false'
+    catch
+        _:_ ->
+            lager:info("regex ~s is invalid, not allowing", [Regex]),
+            'false'
+    end.
+
+is_denied(_CaptureGroup, 'undefined') -> 'false';
+is_denied(_CaptureGroup, <<>>) -> 'false';
+is_denied(CaptureGroup, Regex) ->
+    try re:run(CaptureGroup, Regex) of
+        'nomatch' -> 'false';
+        {'match', _} ->
+            lager:info("capture group ~s does matches denied regex ~s, not allowing hunt", [CaptureGroup, Regex]),
+            'true'
+    catch
+        _:_ ->
+            lager:info("regex ~s is invalid, allowing hunt", [Regex]),
+            'false'
+    end.
+
+maybe_hunt(_Data, Call, CaptureGroup, 'true') ->
+    AccountId = kapps_call:account_id(Call),
+    lager:info("hunting for ~s in account ~s", [CaptureGroup, AccountId]),
+
+    AllowNoMatch = cf_route_req:allow_no_match(Call),
+    case cf_flow:lookup(CaptureGroup, AccountId) of
+        {'ok', Flow, NoMatch} when (not NoMatch)
+                                   orelse AllowNoMatch ->
+            Props = [{'cf_capture_group', kz_json:get_ne_value(<<"capture_group">>, Flow)}
+                    ,{'cf_capture_groups', kz_json:get_value(<<"capture_groups">>, Flow, kz_json:new())}
+                    ],
+            UpdatedCall = kapps_call:kvs_store_proplist(Props, Call),
+            cf_exe:set_call(UpdatedCall),
+            lager:info("branching to ~s", [kz_doc:id(Flow)]),
+            cf_exe:branch(kzd_callflows:flow(Flow, kz_json:new()), UpdatedCall);
+        _Else ->
+            lager:info("hunt failed to find a callflow"),
+            cf_exe:continue(Call)
     end.

--- a/applications/callflow/src/module/cf_menu.erl
+++ b/applications/callflow/src/module/cf_menu.erl
@@ -243,7 +243,7 @@ hunt_for_callflow(Digits, Menu, Call) ->
                     ],
             UpdatedCall = kapps_call:kvs_store_proplist(Props, Call),
             cf_exe:set_call(UpdatedCall),
-            cf_exe:branch(kz_json:get_value(<<"flow">>, Flow, kz_json:new()), UpdatedCall),
+            cf_exe:branch(kzd_callflows:flow(Flow, kz_json:new()), UpdatedCall),
             'true';
         _ ->
             lager:info("callflow hunt failed"),

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1809,6 +1809,19 @@
         "callflows.branch_bnumber": {
             "description": "Validator for the branch_bnumber callflow data object",
             "properties": {
+                "hunt": {
+                    "default": false,
+                    "description": "Should the capture group be used to hunt for a new callflow",
+                    "type": "boolean"
+                },
+                "hunt_allow": {
+                    "description": "A regexp used to match against the capture group to whitelist allowed numbers to hunt",
+                    "type": "string"
+                },
+                "hunt_deny": {
+                    "description": "A regexp used to match against the capture group to blacklist denied numbers to hunt",
+                    "type": "string"
+                },
                 "skip_module": {
                     "description": "When set to true this callflow action is skipped, advancing to the wildcard branch (if any)",
                     "type": "boolean"

--- a/applications/crossbar/priv/couchdb/schemas/callflows.branch_bnumber.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.branch_bnumber.json
@@ -3,6 +3,19 @@
     "_id": "callflows.branch_bnumber",
     "description": "Validator for the branch_bnumber callflow data object",
     "properties": {
+        "hunt": {
+            "default": false,
+            "description": "Should the capture group be used to hunt for a new callflow",
+            "type": "boolean"
+        },
+        "hunt_allow": {
+            "description": "A regexp used to match against the capture group to whitelist allowed numbers to hunt",
+            "type": "string"
+        },
+        "hunt_deny": {
+            "description": "A regexp used to match against the capture group to blacklist denied numbers to hunt",
+            "type": "string"
+        },
         "skip_module": {
             "description": "When set to true this callflow action is skipped, advancing to the wildcard branch (if any)",
             "type": "boolean"

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -1462,6 +1462,18 @@
 'callflows.branch_bnumber':
   'description': Validator for the branch_bnumber callflow data object
   'properties':
+    'hunt':
+      'default': false
+      'description': Should the capture group be used to hunt for a new callflow
+      'type': boolean
+    'hunt_allow':
+      'description': |-
+        A regexp used to match against the capture group to whitelist allowed numbers to hunt
+      'type': string
+    'hunt_deny':
+      'description': |-
+        A regexp used to match against the capture group to blacklist denied numbers to hunt
+      'type': string
     'skip_module':
       'description': |-
         When set to true this callflow action is skipped, advancing to the wildcard branch (if any)


### PR DESCRIPTION
Most callflow actions that include a feature code option have a
separate module for handling the capture group portion, and a main
action module for the feature.

Rather than require all actions wanting to be feature-code-able to
create a corresponding feature code module, when the action only wants
to use the capture group to re-hunt and branch to the found callflow,
this callflow action branch_bnumber can be put at the end to perform
the hunt.