### PR TITLE
[4.3] correct get_values_and_keys return when duplicate keys exist

### DIFF
--- a/core/kazoo_stdlib/src/props.erl
+++ b/core/kazoo_stdlib/src/props.erl
@@ -259,12 +259,14 @@ get_all_values(Key, Props) -> [V || {K, V} <- Props, K =:= Key].
 
 -spec get_values_and_keys(kz_term:proplist()) -> {[kz_term:proplist_value()], [kz_term:proplist_key()]}.
 get_values_and_keys(Props) ->
-    lists:foldr(fun(Key, {Vs, Ks}) ->
-                        {[get_value(Key, Props)|Vs], [Key|Ks]}
-                end
-               ,{[], []}
-               ,get_keys(Props)
-               ).
+    lists:foldr(fun get_value_and_key/2, {[], []}, Props).
+
+-spec get_value_and_key(kz_term:proplist_property(), {[kz_term:proplist_value()], [kz_term:proplist_key()]}) ->
+                               {[kz_term:proplist_value()], [kz_term:proplist_key()]}.
+get_value_and_key({Key, Value}, {Values, Keys}) ->
+    {[Value | Values], [Key | Keys]};
+get_value_and_key(Key, {Values, Keys}) ->
+    {['true' | Values], [Key | Keys]}.
 
 %%------------------------------------------------------------------------------
 %% @doc Returns the value at Key (or Default) and the (maybe modified) proplist()

--- a/core/kazoo_web/test/kz_http_util_tests.erl
+++ b/core/kazoo_web/test/kz_http_util_tests.erl
@@ -16,17 +16,30 @@ urldecode_test_()->
     ,?_assertEqual(<<"abcd">>, kz_http_util:urldecode(<<"%61%62%63%64">>))
     ].
 
-parse_query_string_test_() ->
-    [?_assertEqual([{<<"foo">>, <<"bar">>}, {<<"baz">>, <<"wibble \r\n">>}, {<<"z">>, <<"1">>}]
-                  ,kz_http_util:parse_query_string(<<"foo=bar&baz=wibble+%0D%0a&z=1">>))
-    ,?_assertEqual([{<<"">>, <<"bar">>}, {<<"baz">>, <<"wibble \r\n">>}, {<<"z">>, <<"">>}]
-                  ,kz_http_util:parse_query_string(<<"=bar&baz=wibble+%0D%0a&z=">>))
-    ,?_assertEqual([{<<"foo">>, <<"bar">>}, {<<"baz">>, <<"wibble \r\n">>}, {<<"z">>, <<"1">>}]
-                  ,kz_http_util:parse_query_string(<<"foo=bar&baz=wibble+%0D%0a&z=1">>))
-    ,?_assertEqual([]
-                  ,kz_http_util:parse_query_string(<<"">>))
-    ,?_assertEqual([{<<"foo">>, <<"">>}, {<<"bar">>, <<"">>}, {<<"baz">>, <<"">>}]
-                  ,kz_http_util:parse_query_string(<<"foo;bar&baz">>))
+query_string_test_() ->
+    Tests = [{[{<<"foo">>, <<"bar">>}, {<<"baz">>, <<"wibble \r\n">>}, {<<"z">>, <<"1">>}]
+             ,<<"foo=bar&baz=wibble+%0D%0A&z=1">>
+             }
+            ,{[{<<"">>, <<"bar">>}, {<<"baz">>, <<"wibble \r\n">>}, {<<"z">>, <<"">>}]
+             ,<<"=bar&baz=wibble+%0D%0A&z=">>
+             }
+            ,{[{<<"foo">>, <<"bar">>}, {<<"baz">>, <<"wibble \r\n">>}, {<<"z">>, <<"1">>}]
+             ,<<"foo=bar&baz=wibble+%0D%0A&z=1">>
+             }
+            ,{[], <<>>}
+            ,{[{<<"via">>, <<"example.org">>}, {<<"via">>, <<"other.example.org">>}]
+             ,<<"via=example.org&via=other.example.org">>
+             }
+            ],
+    [?_assertEqual([{<<"foo">>, <<"">>}, {<<"bar">>, <<"">>}, {<<"baz">>, <<"">>}], kz_http_util:parse_query_string(<<"foo;bar&baz">>))
+     | [encode_decode(Decoded, Encoded)
+        || {Decoded, Encoded} <- Tests
+       ]
+    ].
+
+encode_decode(Decoded, Encoded) ->
+    [?_assertEqual(Decoded, kz_http_util:parse_query_string(Encoded))
+    ,?_assertEqual(Encoded, iolist_to_binary(kz_http_util:props_to_querystring(Decoded)))
     ].
 
 urlsplit_test_() ->


### PR DESCRIPTION
also test encoding/decoding query strings more thoroughly