### PR TITLE
[4.3] KAZOO-6122: when fetching the account id by IP, return an error if an…

### DIFF
--- a/applications/crossbar/src/cb_devices_utils.erl
+++ b/applications/crossbar/src/cb_devices_utils.erl
@@ -41,7 +41,8 @@ is_ip_unique(JObj, IP, DeviceId) ->
 is_ip_sip_auth_unique(IP, DeviceId) ->
     case kapps_util:get_ccvs_by_ip(IP) of
         {'ok', CCVs} -> props:get_value(<<"Authorizing-ID">>, CCVs) =:= DeviceId;
-        {'error', 'not_found'} -> 'true'
+        {'error', 'not_found'} -> 'true';
+        {'error', _Reason} -> 'false'
     end.
 
 

--- a/applications/registrar/src/reg_route_req.erl
+++ b/applications/registrar/src/reg_route_req.erl
@@ -38,6 +38,9 @@ maybe_replay_route_req(JObj, CCVs, IP) ->
     case lookup_account_by_ip(IP) of
         {'ok', AccountCCVs} ->
             lager:debug("route req was missing account information, loading from IP ~s and replaying", [IP]),
+            %% NOTE: If this ever comes back empty for any reason it will create a replay loop
+            %%       that will not stop until a restart.
+            ?NE_BINARY = props:get_ne_binary_value(<<"Account-ID">>, AccountCCVs),
             kapi_route:publish_req(
               kz_json:set_value(<<"Custom-Channel-Vars">>
                                ,kz_json:set_values(AccountCCVs, CCVs)

--- a/core/kazoo_documents/src/kzd_accounts.erl
+++ b/core/kazoo_documents/src/kzd_accounts.erl
@@ -269,7 +269,8 @@ enabled(Doc) ->
 
 -spec enabled(doc(), Default) -> boolean() | Default.
 enabled(Doc, Default) ->
-    kz_json:get_boolean_value([<<"enabled">>], Doc, Default).
+    kz_json:get_boolean_value([<<"enabled">>], Doc, Default)
+        andalso kz_json:get_boolean_value([<<"pvt_enabled">>], Doc, Default).
 
 -spec set_enabled(doc(), boolean()) -> doc().
 set_enabled(Doc, Enabled) ->
@@ -779,7 +780,7 @@ is_enabled(?NE_BINARY = Id) ->
         {'error', _} -> 'false'
     end;
 is_enabled(JObj) ->
-    kz_json:is_true([<<"pvt_enabled">>], JObj, 'true').
+    enabled(JObj, 'true').
 
 -spec enable(doc()) -> doc().
 enable(JObj) ->


### PR DESCRIPTION
… object is disabled

In the case of a valid document, that is enabled, and system_config set to use sip_auth, AND the associated user or account disabled kapps_util will return {ok, []}

ie: ok with no additional parameters to add to the CCVs reg_route_req assumed (happy case) that if it was found an account id was associated.  However, in this case no account id is proved leading to a route_req replay with no account id and a loop.

From an admin perspective, setting up an account with ip auth, disabling the device/user/account associated and then calling the number results in a significant spike in CPU and/or memory.