### PR TITLE
Find where an application's dependencies are stored

### DIFF
--- a/applications/callflow/doc/answer.md
+++ b/applications/callflow/doc/answer.md
@@ -12,4 +12,7 @@ Validator for the answer callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |
+`skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
+
+
+

--- a/applications/callflow/doc/noop.md
+++ b/applications/callflow/doc/noop.md
@@ -12,4 +12,7 @@ Validator for the noop callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |
+`skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
+
+
+

--- a/applications/callflow/doc/wait_for_hangup.md
+++ b/applications/callflow/doc/wait_for_hangup.md
@@ -12,4 +12,7 @@ Validator for the wait_for_hangup callflow data object
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |
+`skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
+
+
+

--- a/scripts/calculate-dep-targets.escript
+++ b/scripts/calculate-dep-targets.escript
@@ -66,7 +66,5 @@ consult_for_app_deps(KazooRoot, App) ->
     proplists:get_value('applications', Config, []).
 
 core_or_app(KazooRoot, AppL) ->
-    case filelib:is_dir(filename:join([KazooRoot, "core", AppL])) of
-        'true' -> "core";
-        'false' -> "applications"
-    end.
+    [Path] = filelib:wildcard(KazooRoot ++ "/{core,applications,deps}/" ++ AppL),
+    filename:basename(filename:dirname(Path)).


### PR DESCRIPTION
Since KAZOO apps list their dependent apps in the .app.src file, it is
imperitive that we search deps/ core/ and applications/ to find the
dependent app.