### PR TITLE
[master] check prerequisites for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ JOBS ?= 1
 	validate-swagger \
 	xref xref_release
 
-all: compile
+all: prerequisites compile
 
 changed:
 	@echo "changed: $(CHANGED)"
@@ -58,6 +58,11 @@ changed:
 
 changed_swagger:
 	@echo "$(CHANGED_SWAGGER)"
+
+prerequisites: make-dependency-check
+
+make-dependency-check:
+	$(ROOT)/scripts/make-prerequisite.sh
 
 compile: ACTION = all
 compile: deps kazoo

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -959,6 +959,10 @@ Part of the great rename, converts Whistle-related names to Kazoo-specific names
 
 Generate API clients in multiple languages from the Swagger file.
 
+## `make-prerequisite.sh`
+
+Check make dependency and prerequisite such as git version.
+
 ## `next_version`
 
 returns next release based on branch & tags.

--- a/scripts/make-prerequisite.sh
+++ b/scripts/make-prerequisite.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Prerequisites check for make
+
+# Check git version
+GIT_MAJOR_VERSION=2
+if type git > /dev/null 2>&1; then
+    MajorVersion=`git --version | awk '{print $3}' | awk -F'.' '{print $1}'`
+    if [ $MajorVersion -ne $GIT_MAJOR_VERSION ]
+    then
+        echo "git major version ${GIT_MAJOR_VERSION} is required."
+        exit 1
+    fi
+else
+    echo "git is missing"
+    exit 1
+fi


### PR DESCRIPTION
Introduce pre-check for make dependency like git version. This is motivated by a recent change in mk and erlang.mk upversion that require to parse git output. The older version of git (lower than major version 2) does not match with the output parsing.