### PR TITLE
[master] remove used_by under port_in number when its callflow is deleted

### DIFF
--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -446,28 +446,27 @@ get_user_name(AuthAccountId, UserId) ->
                            {'error', any()}.
 assign_to_app(Number, NewApp, JObj) ->
     Numbers = kzd_port_requests:numbers(JObj),
-    NumObj = kz_json:get_json_value(Number, Numbers),
     lager:debug("assigning number ~s in port request ~s from ~p to ~s"
-               ,[Number, kz_doc:id(JObj), NumObj, NewApp]
+               ,[Number, kz_doc:id(JObj), Numbers, NewApp]
                ),
-    assign_to_app(Number, NewApp, NumObj, JObj).
+    assign_to_app(Number, NewApp, Numbers, JObj).
 
+-spec assign_to_app(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_json:object()|'undefined', kz_json:object()) ->
+                           {'ok', kz_json:object()} |
+                           {'error', any()}.
 assign_to_app(_Number, _NewApp, 'undefined', _JObj) ->
     {'error', 'not_found'};
-assign_to_app(Number, NewApp, NumObj, JObj) ->
-    case kz_json:get_value(?USED_BY_KEY, NumObj) of
+assign_to_app(Number, NewApp, Numbers, JObj) ->
+    case kz_json:get_value([Number, ?USED_BY_KEY], Numbers) of
         NewApp -> {'ok', JObj};
         _OldApp ->
-            NewNumJObj = kz_json:set_value(Number, build_number_used_by(NewApp, NumObj), kz_json:new()),
+            NewNumJObj = kz_json:set_value([Number, ?USED_BY_KEY]
+                                          ,NewApp
+                                          ,kz_json:delete_key([Number, ?USED_BY_KEY], Numbers)
+                                          ),
             lager:debug("set new number app ~p", [NewNumJObj]),
             save_doc(kzd_port_requests:set_numbers(JObj, NewNumJObj))
     end.
-
--spec build_number_used_by(kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
-build_number_used_by('undefined', NumberObj) ->
-    kz_json:delete_key(?USED_BY_KEY, NumberObj);
-build_number_used_by(NewApp, NumberObj) ->
-    kz_json:set_value(?USED_BY_KEY, NewApp, NumberObj).
 
 %%------------------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
1. Remove used_by json object under a port_in number when the associated callflow is deleted.