### PR TITLE
PISTON-923: do not disable trapping exit in acdc_queue_manager

### DIFF
--- a/applications/acdc/src/acdc_queue_manager.erl
+++ b/applications/acdc/src/acdc_queue_manager.erl
@@ -316,8 +316,6 @@ init([Super, AccountId, QueueId]) ->
     init(Super, AccountId, QueueId, QueueJObj).
 
 init(Super, AccountId, QueueId, QueueJObj) ->
-    process_flag('trap_exit', 'false'),
-
     AccountDb = kz_util:format_account_id(AccountId, 'encoded'),
     _ = kz_datamgr:add_to_doc_cache(AccountDb, QueueId, QueueJObj),
 


### PR DESCRIPTION
This would prevent the gen_listener terminate callback from releasing
AMQP channels

This became required as of 65f6b4d3cd7812b25c6d6b1dfff4183736366108 when kz_amqp_history was removed. kz_amqp_history was responsible for capturing the DOWN message for the gen_listener and cleaning up its channels