### PR TITLE
improve shutdown and DOWN signal handling in kz_amqp

### DIFF
--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -63,6 +63,8 @@
 
 -export([kz_log_md_clear/0, kz_log_md_put/2]).
 
+-export([vm_status/0]).
+
 -ifdef(TEST).
 -export([resolve_uri_path/2]).
 -endif.
@@ -777,6 +779,15 @@ application_version(Application) ->
         {'ok', Vsn} -> kz_term:to_binary(Vsn);
         'undefined' -> <<"unknown">>
     end.
+
+-spec vm_status() -> 'starting' | 'stopping' | 'started_stable' | 'unknown'.
+vm_status() ->
+    vm_status(init:get_status()).
+
+vm_status({'starting', _ProvidedStatus}) -> 'starting';
+vm_status({'stopping', _ProvidedStatus}) -> 'stopping';
+vm_status({'started', 'started'}) -> 'started_stable';
+vm_status(_) -> 'unknown_state'.
 
 %%------------------------------------------------------------------------------
 %% @doc Like `lists:usort/1' but preserves original ordering.

--- a/core/kazoo_amqp/src/kz_amqp_connection_sup.erl
+++ b/core/kazoo_amqp/src/kz_amqp_connection_sup.erl
@@ -40,6 +40,7 @@ add(#kz_amqp_connection{}=Connection) ->
 
 -spec remove(pid()) -> 'ok' | {'error', any()}.
 remove(Connection) when is_pid(Connection) ->
+    lager:debug("remove connection pid ~p", [Connection]),
     supervisor:terminate_child(?SERVER, Connection).
 
 %%==============================================================================

--- a/core/kazoo_amqp/src/kz_amqp_connections.erl
+++ b/core/kazoo_amqp/src/kz_amqp_connections.erl
@@ -357,7 +357,7 @@ handle_cast({'connection_available', Connection}, State) ->
     _ = ets:update_element(?TAB, Connection, Props),
     {'noreply', notify_watchers(State), 'hibernate'};
 handle_cast({'connection_unavailable', Connection}, State) ->
-    lager:warning("connection ~p is no longer available", [Connection]),
+    lager:info("connection ~p is no longer available", [Connection]),
     Props = [{#kz_amqp_connections.available, 'false'}],
     _ = ets:update_element(?TAB, Connection, Props),
     {'noreply', State, 'hibernate'};
@@ -376,7 +376,9 @@ handle_cast(_Msg, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
-handle_info({'DOWN', _Ref, 'process', _Connection, shutdown}, State) ->
+handle_info({'DOWN', _Ref, 'process', _Connection, 'shutdown'}, State) ->
+    {'noreply', State, 'hibernate'};
+handle_info({'DOWN', _Ref, 'process', _Connection, 'killed'}, State) ->
     {'noreply', State, 'hibernate'};
 handle_info({'DOWN', Ref, 'process', Connection, _Reason}, State) ->
     lager:warning("connection ~p went down: ~p", [Connection, _Reason]),

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -116,7 +116,6 @@
         ]).
 
 -export([check_release/0]).
--export([graceful_shutdown/0]).
 
 -include("kazoo_apps.hrl").
 


### PR DESCRIPTION
Capture the shutdown signal and handle it differently than other EXIT. The shutdown sequence is based on init:stop() from kz_maintenance test.