### PR TITLE
PISTON-928:Added the ability to delete a doc id to kz_doc

### DIFF
--- a/core/kazoo/src/kz_doc.erl
+++ b/core/kazoo/src/kz_doc.erl
@@ -16,6 +16,7 @@
 
 -export([id/1, id/2
         ,set_id/2
+        ,delete_id/1
         ,path_id/0
         ]).
 -export([revision/1
@@ -189,6 +190,10 @@ id(JObj, Default) ->
 -spec set_id(doc(), kz_term:ne_binary()) -> doc().
 set_id(JObj, Id) ->
     kz_json:set_value(?KEY_ID, Id, JObj).
+
+-spec delete_id(doc()) -> doc().
+delete_id(JObj) ->
+    kz_json:delete_key(?KEY_ID, JObj).
 
 -spec path_id() -> kz_json:path().
 path_id() ->


### PR DESCRIPTION
I know its rare that this is needed to be done but in the PostgreSQL driver im developing for MODB data i have a use case where i want to store the doc id in a column and the rest of the data without the doc id in another column so i need to delete the doc id. For that reason i feel this is worth adding. 