### PR TITLE
[master] KZOO-20 and 21: allow assign rejected portin number and used_by check after completed portin

### DIFF
--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -266,6 +266,9 @@ apply_assignment_updates(Updates, Context) ->
 split_port_requests({DID, Assign, AccountId}, {PRUpdates, NumUpdates}) ->
     Num = knm_converters:normalize(DID),
     case knm_port_request:get_portin_number(AccountId, Num) of
+        {'ok', []} ->
+            %% case of number not_found
+            {PRUpdates, [{DID, Assign}|NumUpdates]};
         {'ok', [JObj|_]} ->
             {[{Num, Assign, JObj}|PRUpdates], NumUpdates};
         {'error', _} ->

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -248,7 +248,8 @@ validate_number_ownership_fold(Number, ReasonJObj, Unauthorized) ->
                                       assignment_updates().
 apply_assignment_updates(Updates, Context) ->
     AccountId = cb_context:account_id(Context),
-    {PRUpdates, NumUpdates} = lists:foldl(fun split_port_requests/2, {[], []}, Updates),
+    AccountUpdates = lists:foldl(fun({Num, App}, X) -> [{Num, App, AccountId} | X] end, [], Updates),
+    {PRUpdates, NumUpdates} = lists:foldl(fun split_port_requests/2, {[], []}, AccountUpdates),
     PortAssignResults = assign_to_port_number(PRUpdates),
     AssignResults = maybe_assign_to_app(NumUpdates, AccountId),
     PortAssignResults ++ AssignResults.
@@ -260,15 +261,15 @@ apply_assignment_updates(Updates, Context) ->
 %%
 %% @end
 %%------------------------------------------------------------------------------
--spec split_port_requests(assignment_to_apply(), {port_req_assignments(), assignments_to_apply()}) ->
+-spec split_port_requests({kz_term:ne_binary(), kz_term:api_binary(), kz_term:ne_binary()}, {port_req_assignments(), assignments_to_apply()}) ->
                                  {port_req_assignments(), assignments_to_apply()}.
-split_port_requests({DID, Assign}=ToApply, {PRUpdates, NumUpdates}) ->
+split_port_requests({DID, Assign, AccountId}, {PRUpdates, NumUpdates}) ->
     Num = knm_converters:normalize(DID),
-    case knm_port_request:get(Num) of
+    case knm_port_request:get_portin_number(AccountId, Num) of
         {'ok', JObj} ->
             {[{Num, Assign, JObj}|PRUpdates], NumUpdates};
         {'error', _} ->
-            {PRUpdates, [ToApply|NumUpdates]}
+            {PRUpdates, [{DID, Assign}|NumUpdates]}
     end.
 
 -spec assign_to_port_number(port_req_assignments()) ->

--- a/applications/crossbar/src/modules/cb_modules_util.erl
+++ b/applications/crossbar/src/modules/cb_modules_util.erl
@@ -266,7 +266,7 @@ apply_assignment_updates(Updates, Context) ->
 split_port_requests({DID, Assign, AccountId}, {PRUpdates, NumUpdates}) ->
     Num = knm_converters:normalize(DID),
     case knm_port_request:get_portin_number(AccountId, Num) of
-        {'ok', JObj} ->
+        {'ok', [JObj|_]} ->
             {[{Num, Assign, JObj}|PRUpdates], NumUpdates};
         {'error', _} ->
             {PRUpdates, [{DID, Assign}|NumUpdates]}

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -1270,7 +1270,7 @@ check_number_portability(PortId, Number, Context) ->
 check_number_portability(_PortId, Number, Context, E164, []) ->
     check_number_existence(E164, Number, Context);
 check_number_portability(PortId, Number, Context, E164, [PortReq]) ->
-    case {kz_json:get_value(<<"value">>, PortReq) =:= cb_context:account_id(Context)
+    case {kz_doc:account_id(PortReq) =:= cb_context:account_id(Context)
          ,kz_doc:id(PortReq) =:= PortId
          }
     of
@@ -1285,7 +1285,7 @@ check_number_portability(PortId, Number, Context, E164, [PortReq]) ->
             number_validation_error(Context, Number, Message);
         {'false', _} ->
             lager:debug("number ~s(~s) is on existing port request for other account(~s)"
-                       ,[E164, Number, kz_json:get_value(<<"value">>, PortReq)]),
+                       ,[E164, Number, kz_doc:account_id(PortReq)]),
             Message = <<"Number is being ported for a different account">>,
             number_validation_error(Context, Number, Message)
     end;

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -50,7 +50,6 @@
                                ]).
 
 -define(ACCOUNTS_BY_SIMPLE_ID, <<"accounts/listing_by_simple_id">>).
--define(PORT_REQ_NUMBERS, <<"port_requests/port_in_numbers">>).
 -define(ALL_PORT_REQ_NUMBERS, <<"port_requests/all_port_in_numbers">>).
 -define(LISTING_BY_STATE, <<"port_requests/listing_by_state">>).
 -define(LISTING_BY_NUMBER, <<"port_requests/listing_by_number">>).
@@ -1249,15 +1248,6 @@ successful_validation(Context, _Id) ->
     Normalized = knm_port_request:normalize_numbers(cb_context:doc(Context)),
     cb_context:set_doc(Context, Normalized).
 
--spec fetch_by_number(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
-fetch_by_number(Context, Number) ->
-    Options = [{'keymap', Number}
-              ,{'databases', [?KZ_PORT_REQUESTS_DB]}
-              ,{'unchunkable', 'true'}
-              ,{'should_paginate', 'false'}
-              ],
-    crossbar_view:load(Context, ?PORT_REQ_NUMBERS, Options).
-
 %%------------------------------------------------------------------------------
 %% @doc
 %% @end
@@ -1267,12 +1257,12 @@ fetch_by_number(Context, Number) ->
 check_number_portability(PortId, Number, Context) ->
     E164 = knm_converters:normalize(Number),
     lager:debug("checking ~s(~s) for portability", [E164, Number]),
-    Context1 = fetch_by_number(Context, E164),
-    case cb_context:resp_status(Context1) of
-        'success' ->
-            DataResp = cb_context:resp_data(Context1),
-            check_number_portability(PortId, Number, Context1, E164, DataResp);
-        _ -> Context1
+    case knm_port_request:get_portin_number(cb_context:account_id(Context), E164) of
+        {'error', Reason}->
+            lager:debug("failed to check ports for number portability: ~p", [Reason]),
+            crossbar_doc:handle_datamgr_errors(Reason, PortId, Context);
+        {'ok', Result} ->
+            check_number_portability(PortId, Number, Context, E164, Result)
     end.
 
 -spec check_number_portability(kz_term:api_binary(), kz_term:ne_binary(), cb_context:context(), kz_term:ne_binary(), kz_json:objects()) ->

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -597,7 +597,7 @@ transition_numbers(PortReq) ->
 %% This may not be a reliable source of used_by comparing to the callflow doc.
 %% @end
 %%------------------------------------------------------------------------------
--spec app_used_by_portin(kz_term:ne_binary(), kz_json:object()) -> 'undefined' | list().
+-spec app_used_by_portin(kz_term:ne_binary(), kz_json:object()) -> kz_term:proplist().
 app_used_by_portin(Numbers, JObj) ->
     NumbersObj = kzd_port_requests:numbers(JObj),
     [{Num, kz_json:get_value([Num, ?USED_BY_KEY], NumbersObj)}

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -143,14 +143,15 @@ get(DID=?NE_BINARY) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec get_portin_number(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kz_json:object()} |
+-spec get_portin_number(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kz_json:objects()} |
                                                                      {'error', any()}.
 get_portin_number(AccountId, DID=?NE_BINARY) ->
-    ViewOptions = [{'key', [AccountId, DID]}, 'include_docs'],
-    Result = kz_datamgr:get_single_result(?KZ_PORT_REQUESTS_DB, ?PORT_NUM_LISTING, ViewOptions),
-    case Result of
-        {'ok', Docs} ->
-            {'ok', kz_json:get_value(<<"doc">>, Docs)};
+    ViewOptions = [{'key', [AccountId, DID]}
+                  ,'include_docs'
+                  ],
+    case kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB, ?PORT_NUM_LISTING, ViewOptions) of
+        {'ok', JObjs} ->
+            {'ok', [kz_json:get_value(<<"doc">>, JObj) || JObj <- JObjs]};
         {'error', _E}=Error ->
             lager:debug("failed to find portin number '~s': ~p", [DID, _E]),
             Error

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -533,9 +533,9 @@ migrate() ->
 completed_port(PortReq) ->
     Numbers = kz_json:get_keys(kzd_port_requests:numbers(PortReq)),
     case transition_numbers(PortReq) of
-        {ok, Save} ->
+        {'ok', Save} ->
             reconcile_app_used_by(Numbers, PortReq),
-            {ok, Save};
+            {'ok', Save};
         Error -> Error
     end.
 
@@ -604,7 +604,7 @@ app_used_by_portin(Numbers, JObj) ->
         kz_term:is_not_empty(kz_json:get_value([Num, ?USED_BY_KEY], NumbersObj))
     ].
 
--spec reconcile_app_used_by(list(), kz_json:object()) -> 'ok'.
+-spec reconcile_app_used_by(kz_term:ne_binaries(), kz_json:object()) -> 'ok'.
 reconcile_app_used_by(Numbers, JObj) ->
     AccountId = kz_doc:account_id(JObj),
     AccountDb = kz_util:format_account_db(AccountId),
@@ -613,24 +613,23 @@ reconcile_app_used_by(Numbers, JObj) ->
     lager:debug("transitioning numbers ~p to active used by apps ~p portin usage ~p"
                ,[Numbers, AppUsedBy, PortInUsedBy]
                ),
-    _Ok=[log_wrong_app_in_portin(proplists:get_value(N, PortInUsedBy), App, N) || {N, App} <- AppUsedBy],
+    _ = [log_wrong_app_in_portin(proplists:get_value(N, PortInUsedBy), App, N) || {N, App} <- AppUsedBy],
 
     %% app used_by carried over to phone_number document
     lists:foreach(
       fun({App, Nums}) ->
               case Nums of
-                  [] -> ok;
+                  [] -> 'ok';
                   Nums -> knm_numbers:assign_to_app(Nums, App)
               end
       end
      , NumAppUsage
      ).
 
--spec log_wrong_app_in_portin(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok' | {'ok', kz_term:ne_binary()}.
+-spec log_wrong_app_in_portin(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 log_wrong_app_in_portin(App, App, _Num) -> 'ok';
 log_wrong_app_in_portin(PortInApp, App, Num) ->
-    lager:error("port in number ~p has an incorrect app ~p, the correct app is ~p", [Num, PortInApp, App]),
-    {'ok', App}.
+    lager:debug("port in number ~p has an incorrect app ~p, the correct app is ~p", [Num, PortInApp, App]).
 
 %%------------------------------------------------------------------------------
 %% @doc Get numbers' app used_by from app's database in different format
@@ -638,14 +637,15 @@ log_wrong_app_in_portin(PortInApp, App, Num) ->
 %% 2) ensure app used_by carried to phone_number when port in is completed
 %% @end
 %%------------------------------------------------------------------------------
--spec get_dids_for_app(kz_term:ne_binary(), list()) -> {list(), list()}.
+-spec get_dids_for_app(kz_term:ne_binary(), kz_term:ne_binaries()) -> {kz_term:proplist(), kz_term:proplist()}.
 get_dids_for_app(AccountDb, Numbers) ->
     CfDIDs = get_dids_for_app(AccountDb, Numbers, ?CALLFLOW_LIST),
     TsDIDs = get_dids_for_app(AccountDb, Numbers, ?TRUNKSTORE_LIST),
     NumApps = [{N, <<"callflow">>} || N <- CfDIDs] ++ [{N, <<"trunkstore">>} || N <- TsDIDs],
     {NumApps, [{<<"callflow">>, CfDIDs}, {<<"trunkstore">>, TsDIDs}]}.
 
--spec get_dids_for_app(kz_term:ne_binary(), list(), kz_term:ne_binary()) -> list().
+-spec get_dids_for_app(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary()) ->
+                              kz_term:ne_binaries().
 get_dids_for_app(AccountDb, Numbers, View) ->
     case kz_datamgr:get_result_keys(AccountDb, View, [{'keys', Numbers}]) of
         {'ok', DIDs} -> DIDs;

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -604,35 +604,51 @@ app_used_by_portin(Numbers, JObj) ->
         kz_term:is_not_empty(kz_json:get_value([Num, ?USED_BY_KEY], NumbersObj))
     ].
 
+-spec reconcile_app_used_by(list(), kz_json:object()) -> 'ok'.
 reconcile_app_used_by(Numbers, JObj) ->
     AccountId = kz_doc:account_id(JObj),
     AccountDb = kz_util:format_account_db(AccountId),
     PortInUsedBy = app_used_by_portin(Numbers, JObj),
-    AppUsedBy = get_dids_for_app(AccountDb, Numbers),
-    lager:debug("transitioning numbers ~p to active used by apps ~p", [Numbers, AppUsedBy]),
+    {AppUsedBy, NumAppUsage} = get_dids_for_app(AccountDb, Numbers),
+    lager:debug("transitioning numbers ~p to active used by apps ~p portin usage ~p"
+               ,[Numbers, AppUsedBy, PortInUsedBy]
+               ),
     _Ok=[log_wrong_app_in_portin(proplists:get_value(N, PortInUsedBy), App, N) || {N, App} <- AppUsedBy],
 
     %% app used_by carried over to phone_number document
-    lists:foreach(fun({Num, App}) -> knm_number:assign_to_app(Num, App) end, AppUsedBy).
+    lists:foreach(
+      fun({App, Nums}) ->
+              case Nums of
+                  [] -> ok;
+                  Nums -> knm_numbers:assign_to_app(Nums, App)
+              end
+      end
+     , NumAppUsage
+     ).
 
+-spec log_wrong_app_in_portin(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok' | {'ok', kz_term:ne_binary()}.
 log_wrong_app_in_portin(App, App, _Num) -> 'ok';
 log_wrong_app_in_portin(PortInApp, App, Num) ->
     lager:error("port in number ~p has an incorrect app ~p, the correct app is ~p", [Num, PortInApp, App]),
     {'ok', App}.
 
 %%------------------------------------------------------------------------------
-%% @doc Get numbers' app used_by for app's database
+%% @doc Get numbers' app used_by from app's database in different format
+%% to be processed 1) detect missing apps in port in number
+%% 2) ensure app used_by carried to phone_number when port in is completed
 %% @end
 %%------------------------------------------------------------------------------
--spec get_dids_for_app(kz_term:ne_binary(), list()) -> list().
+-spec get_dids_for_app(kz_term:ne_binary(), list()) -> {list(), list()}.
 get_dids_for_app(AccountDb, Numbers) ->
-    get_dids_for_app(AccountDb, Numbers, ?CALLFLOW_LIST, <<"callflow">>)
-        ++ get_dids_for_app(AccountDb, Numbers, ?TRUNKSTORE_LIST, <<"trunkstore">>).
+    CfDIDs = get_dids_for_app(AccountDb, Numbers, ?CALLFLOW_LIST),
+    TsDIDs = get_dids_for_app(AccountDb, Numbers, ?TRUNKSTORE_LIST),
+    NumApps = [{N, <<"callflow">>} || N <- CfDIDs] ++ [{N, <<"trunkstore">>} || N <- TsDIDs],
+    {NumApps, [{<<"callflow">>, CfDIDs}, {<<"trunkstore">>, TsDIDs}]}.
 
--spec get_dids_for_app(kz_term:ne_binary(), list(), kz_term:ne_binary(), kz_term:ne_binary()) -> list().
-get_dids_for_app(AccountDb, Numbers, View, App) ->
+-spec get_dids_for_app(kz_term:ne_binary(), list(), kz_term:ne_binary()) -> list().
+get_dids_for_app(AccountDb, Numbers, View) ->
     case kz_datamgr:get_result_keys(AccountDb, View, [{'keys', Numbers}]) of
-        {'ok', DIDs} -> [{DID, App} || DID <- DIDs];
+        {'ok', DIDs} -> DIDs;
         {'error', _} -> []
     end.
 

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -599,7 +599,10 @@ transition_numbers(PortReq) ->
 -spec app_used_by_portin(kz_term:ne_binary(), kz_json:object()) -> 'undefined' | list().
 app_used_by_portin(Numbers, JObj) ->
     NumbersObj = kzd_port_requests:numbers(JObj),
-    [{Num, kz_json:get_value([Num, ?USED_BY_KEY], NumbersObj)} || Num <- Numbers].
+    [{Num, kz_json:get_value([Num, ?USED_BY_KEY], NumbersObj)}
+     || Num <- Numbers,
+        kz_term:is_not_empty(kz_json:get_value([Num, ?USED_BY_KEY], NumbersObj))
+    ].
 
 reconcile_app_used_by(Numbers, JObj) ->
     AccountId = kz_doc:account_id(JObj),
@@ -624,7 +627,7 @@ log_wrong_app_in_portin(PortInApp, App, Num) ->
 -spec get_dids_for_app(kz_term:ne_binary(), list()) -> list().
 get_dids_for_app(AccountDb, Numbers) ->
     get_dids_for_app(AccountDb, Numbers, ?CALLFLOW_LIST, <<"callflow">>)
-    ++ get_dids_for_app(AccountDb, Numbers, ?TRUNKSTORE_LIST, <<"trunkstore">>).
+        ++ get_dids_for_app(AccountDb, Numbers, ?TRUNKSTORE_LIST, <<"trunkstore">>).
 
 -spec get_dids_for_app(kz_term:ne_binary(), list(), kz_term:ne_binary(), kz_term:ne_binary()) -> list().
 get_dids_for_app(AccountDb, Numbers, View, App) ->

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -14,6 +14,7 @@
         ,public_fields/0
         ,public_fields/1
         ,get/1
+        ,get_portin_number/2
         ,new/2
         ,account_active_ports/1
         ,descendant_active_ports/1
@@ -29,6 +30,7 @@
         ]).
 
 -export([transition_metadata/2, transition_metadata/3, transition_metadata/4]).
+-export([app_used_by_portin/2,used_by_which_app/2]).
 -export_type([transition_metadata/0]).
 
 -compile({'no_auto_import', [get/1]}).
@@ -50,6 +52,9 @@
 -define(ACTIVE_PORT_LISTING, <<"port_requests/active_port_request">>).
 -define(DESCENDANT_ACTIVE_PORT_LISTING, <<"port_requests/listing_by_descendant_state">>).
 -define(ACTIVE_PORT_IN_NUMBERS, <<"port_requests/port_in_numbers">>).
+-define(PORT_NUM_LISTING, <<"port_requests/phone_numbers_listing">>).
+-define(CALLFLOW_LIST, <<"callflows/listing_by_number">>).
+-define(TRUNKSTORE_LIST, <<"trunkstore/lookup_did">>).
 
 -type transition_response() :: {'ok', kz_json:object()} |
                                {'error', 'invalid_state_transition' | 'user_not_allowed' | kz_json:object()}.
@@ -131,6 +136,23 @@ get(DID=?NE_BINARY) ->
         {'ok', Port} -> {'ok', kz_json:get_value(<<"doc">>, Port)};
         {'error', _E}=Error ->
             lager:debug("failed to query for port number '~s': ~p", [DID, _E]),
+            Error
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec get_portin_number(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kz_json:object()} |
+                                                                     {'error', any()}.
+get_portin_number(AccountId, DID=?NE_BINARY) ->
+    ViewOptions = [{'key', [AccountId, DID]}, 'include_docs'],
+    Result = kz_datamgr:get_single_result(?KZ_PORT_REQUESTS_DB, ?PORT_NUM_LISTING, ViewOptions),
+    case Result of
+        {'ok', Docs} ->
+            {'ok', kz_json:get_value(<<"doc">>, Docs)};
+        {'error', _E}=Error ->
+            lager:debug("failed to find portin number '~s': ~p", [DID, _E]),
             Error
     end.
 
@@ -262,7 +284,8 @@ states_to_scheduled(_AllowFromSubmitted='true') ->
 transition_to_complete(JObj, Metadata) ->
     case transition(JObj, Metadata, [?PORT_PENDING, ?PORT_SCHEDULED, ?PORT_REJECTED], ?PORT_COMPLETED) of
         {'error', _}=E -> E;
-        {'ok', Transitioned} -> completed_port(Transitioned)
+        {'ok', Transitioned} ->
+            completed_port(Transitioned)
     end.
 
 -spec transition_to_rejected(kz_json:object(), transition_metadata()) -> transition_response().
@@ -508,8 +531,16 @@ migrate() ->
 %%------------------------------------------------------------------------------
 -spec completed_port(kz_json:object()) -> transition_response().
 completed_port(PortReq) ->
-    lager:debug("transitioning numbers to active"),
-    transition_numbers(PortReq).
+    AccountId = kz_doc:account_id(PortReq),
+    Numbers = kz_json:get_keys(kzd_port_requests:numbers(PortReq)),
+    AppUsedBy = maybe_reconcile_app_used_by(Numbers, AccountId, PortReq),
+    lager:debug("transitioning numbers ~p to active used by apps ~p", [Numbers, AppUsedBy]),
+    case transition_numbers(PortReq) of
+        {ok, Save} ->
+            update_used_by(Numbers, AppUsedBy),
+            {ok, Save};
+        _E -> _E
+    end.
 
 -spec completed_portin(kz_term:ne_binary(), kz_term:ne_binary(), transition_metadata()) -> 'ok' | {'error', any()}.
 completed_portin(Num, AccountId, #{optional_reason := OptionalReason}) ->
@@ -544,7 +575,7 @@ transition_numbers(PortReq) ->
               ,{'ported_in', 'true'}
               ,{'public_fields', kz_json:from_list([{<<"port_id">>, PortReqId}])}
               ],
-    lager:debug("creating local numbers for port ~s", [PortReqId]),
+    lager:debug("account ~p creating local numbers for port ~s", [AccountId, PortReqId]),
     Numbers = kz_json:get_keys(kzd_port_requests:numbers(PortReq)),
     case knm_numbers:create(Numbers, Options) of
         #{ko := KOs} when map_size(KOs) =:= 0 ->
@@ -562,6 +593,66 @@ transition_numbers(PortReq) ->
                     {'error', PortReq}
             end
     end.
+
+-spec update_used_by(list(), 'undefined' | kz_term:ne_binary()) -> 'ok'.
+update_used_by(_Numbers, 'undefined') -> 'ok';
+update_used_by(Numbers, App) ->
+    lager:debug("update number ~p with used_by ~p", [Numbers, App]),
+    _Ok = knm_numbers:assign_to_app(Numbers, App),
+    'ok'.
+
+%%------------------------------------------------------------------------------
+%% @doc Apps used by in the port in document.
+%% This may not be a reliable source of used_by comparing to the callflow doc.
+%% @end
+%%------------------------------------------------------------------------------
+-spec app_used_by_portin(kz_term:ne_binary(), kz_json:object()) -> 'undefined' | list().
+app_used_by_portin(Numbers, JObj) ->
+    NumbersObj = kzd_port_requests:numbers(JObj),
+    [{Num, kz_json:get_value([Num, ?USED_BY_KEY], NumbersObj)} || Num <- Numbers].
+
+maybe_reconcile_app_used_by(Numbers, AccountId, JObj) ->
+    AccountDb = kz_util:format_account_db(AccountId),
+    PortInUsedBy = app_used_by_portin(Numbers, JObj),
+    AppUsedBy = used_by_which_app(AccountDb, Numbers),
+    _Ok=[maybe_reconcile_app(proplists:get_value(N, PortInUsedBy), App, N, JObj) || {N, App} <- AppUsedBy],
+    app_used_by(AppUsedBy).
+
+maybe_reconcile_app(App, App, _Num, _JObj) ->
+    {'ok', App};
+maybe_reconcile_app(_PortInApp, App, Num, JObj) ->
+    lager:warning("port in number ~p app ~p replaced by correct app ~p", [Num, _PortInApp, App]),
+    _Ok = assign_to_app(Num, App, JObj),
+    {'ok', App}.
+
+app_used_by([]) -> 'undefined';
+app_used_by([{_Num, App}|_T]) -> App.
+
+query_app_view(AccountDb, View, Num, App) ->
+    Options = [{'keys', Num}],
+    Result = kz_datamgr:get_results(AccountDb, View, Options),
+    case Result of
+        {'ok', DocsObj} ->
+            Docs = kz_json:to_proplist(DocsObj),
+            [{proplists:get_value(<<"key">>, Doc), App} || Doc <- Docs];
+        E ->
+            lager:debug("error find number ~p document view ~p error ~p", [Num, View, E]),
+            []
+    end.
+
+used_by_app(AccountDb, Numbers, 'callflow') ->
+    query_app_view(AccountDb, ?CALLFLOW_LIST, Numbers, <<"callflow">>);
+used_by_app(AccountDb, Numbers, 'trunkstore') ->
+    query_app_view(AccountDb, ?TRUNKSTORE_LIST, Numbers, <<"trunkstore">>).
+
+%%------------------------------------------------------------------------------
+%% @doc Apps used by phe number based on callflow or trunkstore docs.
+%% This is considered as a reliable source about used_by.
+%% @end
+%%------------------------------------------------------------------------------
+-spec used_by_which_app(kz_term:ne_binary(), kz_term:ne_binary()) -> list().
+used_by_which_app(AccountDb, Num) ->
+    used_by_app(AccountDb, Num, 'callflow') ++ used_by_app(AccountDb, Num, 'trunkstore').
 
 numbers_not_in_account_nor_in_service(AccountId, Nums) ->
     #{ko := KOs, ok := Ns} = knm_numbers:get(Nums),

--- a/core/kazoo_number_manager/src/knm_port_request.erl
+++ b/core/kazoo_number_manager/src/knm_port_request.erl
@@ -30,7 +30,7 @@
         ]).
 
 -export([transition_metadata/2, transition_metadata/3, transition_metadata/4]).
--export([app_used_by_portin/2,used_by_which_app/2]).
+-export([app_used_by_portin/2, get_dids_for_app/2]).
 -export_type([transition_metadata/0]).
 
 -compile({'no_auto_import', [get/1]}).
@@ -531,15 +531,12 @@ migrate() ->
 %%------------------------------------------------------------------------------
 -spec completed_port(kz_json:object()) -> transition_response().
 completed_port(PortReq) ->
-    AccountId = kz_doc:account_id(PortReq),
     Numbers = kz_json:get_keys(kzd_port_requests:numbers(PortReq)),
-    AppUsedBy = maybe_reconcile_app_used_by(Numbers, AccountId, PortReq),
-    lager:debug("transitioning numbers ~p to active used by apps ~p", [Numbers, AppUsedBy]),
     case transition_numbers(PortReq) of
         {ok, Save} ->
-            update_used_by(Numbers, AppUsedBy),
+            reconcile_app_used_by(Numbers, PortReq),
             {ok, Save};
-        _E -> _E
+        Error -> Error
     end.
 
 -spec completed_portin(kz_term:ne_binary(), kz_term:ne_binary(), transition_metadata()) -> 'ok' | {'error', any()}.
@@ -594,13 +591,6 @@ transition_numbers(PortReq) ->
             end
     end.
 
--spec update_used_by(list(), 'undefined' | kz_term:ne_binary()) -> 'ok'.
-update_used_by(_Numbers, 'undefined') -> 'ok';
-update_used_by(Numbers, App) ->
-    lager:debug("update number ~p with used_by ~p", [Numbers, App]),
-    _Ok = knm_numbers:assign_to_app(Numbers, App),
-    'ok'.
-
 %%------------------------------------------------------------------------------
 %% @doc Apps used by in the port in document.
 %% This may not be a reliable source of used_by comparing to the callflow doc.
@@ -611,48 +601,37 @@ app_used_by_portin(Numbers, JObj) ->
     NumbersObj = kzd_port_requests:numbers(JObj),
     [{Num, kz_json:get_value([Num, ?USED_BY_KEY], NumbersObj)} || Num <- Numbers].
 
-maybe_reconcile_app_used_by(Numbers, AccountId, JObj) ->
+reconcile_app_used_by(Numbers, JObj) ->
+    AccountId = kz_doc:account_id(JObj),
     AccountDb = kz_util:format_account_db(AccountId),
     PortInUsedBy = app_used_by_portin(Numbers, JObj),
-    AppUsedBy = used_by_which_app(AccountDb, Numbers),
-    _Ok=[maybe_reconcile_app(proplists:get_value(N, PortInUsedBy), App, N, JObj) || {N, App} <- AppUsedBy],
-    app_used_by(AppUsedBy).
+    AppUsedBy = get_dids_for_app(AccountDb, Numbers),
+    lager:debug("transitioning numbers ~p to active used by apps ~p", [Numbers, AppUsedBy]),
+    _Ok=[log_wrong_app_in_portin(proplists:get_value(N, PortInUsedBy), App, N) || {N, App} <- AppUsedBy],
 
-maybe_reconcile_app(App, App, _Num, _JObj) ->
-    {'ok', App};
-maybe_reconcile_app(_PortInApp, App, Num, JObj) ->
-    lager:warning("port in number ~p app ~p replaced by correct app ~p", [Num, _PortInApp, App]),
-    _Ok = assign_to_app(Num, App, JObj),
+    %% app used_by carried over to phone_number document
+    lists:foreach(fun({Num, App}) -> knm_number:assign_to_app(Num, App) end, AppUsedBy).
+
+log_wrong_app_in_portin(App, App, _Num) -> 'ok';
+log_wrong_app_in_portin(PortInApp, App, Num) ->
+    lager:error("port in number ~p has an incorrect app ~p, the correct app is ~p", [Num, PortInApp, App]),
     {'ok', App}.
 
-app_used_by([]) -> 'undefined';
-app_used_by([{_Num, App}|_T]) -> App.
-
-query_app_view(AccountDb, View, Num, App) ->
-    Options = [{'keys', Num}],
-    Result = kz_datamgr:get_results(AccountDb, View, Options),
-    case Result of
-        {'ok', DocsObj} ->
-            Docs = kz_json:to_proplist(DocsObj),
-            [{proplists:get_value(<<"key">>, Doc), App} || Doc <- Docs];
-        E ->
-            lager:debug("error find number ~p document view ~p error ~p", [Num, View, E]),
-            []
-    end.
-
-used_by_app(AccountDb, Numbers, 'callflow') ->
-    query_app_view(AccountDb, ?CALLFLOW_LIST, Numbers, <<"callflow">>);
-used_by_app(AccountDb, Numbers, 'trunkstore') ->
-    query_app_view(AccountDb, ?TRUNKSTORE_LIST, Numbers, <<"trunkstore">>).
-
 %%------------------------------------------------------------------------------
-%% @doc Apps used by phe number based on callflow or trunkstore docs.
-%% This is considered as a reliable source about used_by.
+%% @doc Get numbers' app used_by for app's database
 %% @end
 %%------------------------------------------------------------------------------
--spec used_by_which_app(kz_term:ne_binary(), kz_term:ne_binary()) -> list().
-used_by_which_app(AccountDb, Num) ->
-    used_by_app(AccountDb, Num, 'callflow') ++ used_by_app(AccountDb, Num, 'trunkstore').
+-spec get_dids_for_app(kz_term:ne_binary(), list()) -> list().
+get_dids_for_app(AccountDb, Numbers) ->
+    get_dids_for_app(AccountDb, Numbers, ?CALLFLOW_LIST, <<"callflow">>)
+    ++ get_dids_for_app(AccountDb, Numbers, ?TRUNKSTORE_LIST, <<"trunkstore">>).
+
+-spec get_dids_for_app(kz_term:ne_binary(), list(), kz_term:ne_binary(), kz_term:ne_binary()) -> list().
+get_dids_for_app(AccountDb, Numbers, View, App) ->
+    case kz_datamgr:get_result_keys(AccountDb, View, [{'keys', Numbers}]) of
+        {'ok', DIDs} -> [{DID, App} || DID <- DIDs];
+        {'error', _} -> []
+    end.
 
 numbers_not_in_account_nor_in_service(AccountId, Nums) ->
     #{ko := KOs, ok := Ns} = knm_numbers:get(Nums),


### PR DESCRIPTION
1. use 'phone_numbers_listing' view to get port in number assignment
2. the change applies to cb_callflow/cb_connectivity via cb_module_utils:apply_assigment_updates

3. Reconcile legacy used_by in the port-in document and trunkstore/callflow usage
4. Update portin database with the correct used_by when port is completed
5. Preserve used_by value in the new number database when a port in is completed.
