### PR TITLE
[master] fallback a default value for pickup_group_feature

### DIFF
--- a/applications/callflow/doc/group_pickup_feature.md
+++ b/applications/callflow/doc/group_pickup_feature.md
@@ -18,7 +18,7 @@ Key | Description | Type | Default | Required | Support Level
 `device_id` | Device to pickup | `string()` |   | `false` |  
 `group_id` | Group in which to find a call to pickup | `string()` |   | `false` |  
 `skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
-`type` | The type of collection to pickup | `string('group' | 'user' | 'device' | 'extension')` |   | `true` |  
+`type` | The type of collection to pickup | `string('group' | 'user' | 'device' | 'extension')` | `extension` | `true` |  
 `user_id` | User in which to find a call to pickup | `string()` |   | `false` |  
 
 

--- a/applications/callflow/doc/ref/group_pickup_feature.md
+++ b/applications/callflow/doc/ref/group_pickup_feature.md
@@ -16,7 +16,7 @@ Key | Description | Type | Default | Required | Support Level
 `device_id` | Device to pickup | `string()` |   | `false` |  
 `group_id` | Group in which to find a call to pickup | `string()` |   | `false` |  
 `skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
-`type` | The type of collection to pickup | `string('group' | 'user' | 'device' | 'extension')` |   | `true` |  
+`type` | The type of collection to pickup | `string('group' | 'user' | 'device' | 'extension')` | `extension` | `true` |  
 `user_id` | User in which to find a call to pickup | `string()` |   | `false` |  
 
 

--- a/applications/callflow/src/module/cf_group_pickup_feature.erl
+++ b/applications/callflow/src/module/cf_group_pickup_feature.erl
@@ -71,7 +71,7 @@
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
     Number = kapps_call:kvs_fetch('cf_capture_group', Call),
-    PickupType = kz_json:get_ne_binary_value(<<"type">>, Data),
+    PickupType = kz_json:get_ne_binary_value(<<"type">>, Data, <<"extension">>),
     case build_pickup_params(Number, PickupType, Call) of
         {'ok', Params} ->
             UpdatedData = kz_json:set_values(Params, Data),
@@ -109,8 +109,6 @@ build_pickup_params(Number, <<"extension">>, Call) ->
             {'error', <<"no callflow with extension ", Number/binary>>};
         {'error', _} = E -> E
     end;
-build_pickup_params(_ ,'undefined', _) ->
-    {'error', <<"parameter 'type' not defined">>};
 build_pickup_params(_, Other, _) ->
     {'error', <<Other/binary," not implemented">>}.
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -2592,6 +2592,7 @@
                     "type": "boolean"
                 },
                 "type": {
+                    "default": "extension",
                     "description": "The type of collection to pickup",
                     "enum": [
                         "group",

--- a/applications/crossbar/priv/couchdb/schemas/callflows.group_pickup_feature.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.group_pickup_feature.json
@@ -28,6 +28,7 @@
             "type": "boolean"
         },
         "type": {
+            "default": "extension",
             "description": "The type of collection to pickup",
             "enum": [
                 "group",

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -2070,6 +2070,7 @@
         When set to true this callflow action is skipped, advancing to the wildcard branch (if any)
       'type': boolean
     'type':
+      'default': extension
       'description': The type of collection to pickup
       'enum':
         - group


### PR DESCRIPTION
To facility legacy documents that still miss `type` for pickup_group_feature callflow doc. This introduces a fallback default value `extension`.