### PR TITLE
HELP-10397 [4.3] Use default value for `type` in group pickup 

### DIFF
--- a/applications/callflow/doc/group_pickup_feature.md
+++ b/applications/callflow/doc/group_pickup_feature.md
@@ -13,7 +13,7 @@ Validator for the group_pickup_feature callflow data object
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
-`type` | The type of collection to pickup | `string('group' | 'user' | 'device' | 'extension')` |   | `true` |  
+`type` | The type of collection to pickup | `string('group' | 'user' | 'device' | 'extension')` | `extension` | `true` |  
 
 
 

--- a/applications/callflow/doc/ref/group_pickup_feature.md
+++ b/applications/callflow/doc/ref/group_pickup_feature.md
@@ -11,7 +11,7 @@ Validator for the group_pickup_feature callflow data object
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
-`type` | The type of collection to pickup | `string('group' | 'user' | 'device' | 'extension')` |   | `true` |  
+`type` | The type of collection to pickup | `string('group' | 'user' | 'device' | 'extension')` | `extension` | `true` |  
 
 
 

--- a/applications/callflow/src/module/cf_group_pickup_feature.erl
+++ b/applications/callflow/src/module/cf_group_pickup_feature.erl
@@ -66,7 +66,7 @@
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
     Number = kapps_call:kvs_fetch('cf_capture_group', Call),
-    PickupType = kz_json:get_ne_binary_value(<<"type">>, Data),
+    PickupType = kz_json:get_ne_binary_value(<<"type">>, Data, <<"extension">>),
     case build_pickup_params(Number, PickupType, Call) of
         {'ok', Params} ->
             cf_group_pickup:handle(kz_json:set_values(Params, Data), Call);
@@ -102,8 +102,6 @@ build_pickup_params(Number, <<"extension">>, Call) ->
             {'error', <<"no callflow with extension ", Number/binary>>};
         {'error', _} = E -> E
     end;
-build_pickup_params(_ ,'undefined', _) ->
-    {'error', <<"parameter 'type' not defined">>};
 build_pickup_params(_, Other, _) ->
     {'error', <<Other/binary," not implemented">>}.
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -2539,6 +2539,7 @@
                     "type": "boolean"
                 },
                 "type": {
+                    "default": "extension",
                     "description": "The type of collection to pickup",
                     "enum": [
                         "group",

--- a/applications/crossbar/priv/couchdb/schemas/callflows.group_pickup_feature.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.group_pickup_feature.json
@@ -8,6 +8,7 @@
             "type": "boolean"
         },
         "type": {
+            "default": "extension",
             "description": "The type of collection to pickup",
             "enum": [
                 "group",


### PR DESCRIPTION
Previously `type` was not required; if not included the action would
essentially be skipped. The schema was then updated to require `type`
but existing feature code callflows still had empty `data` objects
with no `type` defined - thus still "not working".

Default the `type` to `extension` as that is the common `type` used by
SmartPBX-configured feature codes.