### PR TITLE
[master] fix check-dialyzer script to properly fix full path

### DIFF
--- a/scripts/check-dialyzer.escript
+++ b/scripts/check-dialyzer.escript
@@ -89,6 +89,12 @@ is_beam(Path) ->
 is_ebin_dir(Path) ->
     "ebin" == filename:basename(Path).
 
+root_dir("/"++Path) ->
+    filename:join(["/" | lists:takewhile(fun is_not_src/1
+                                        ,string:tokens(Path, "/")
+                                        )
+                  ]
+                 );
 root_dir(Path) ->
     filename:join(lists:takewhile(fun is_not_src/1
                                  ,string:tokens(Path, "/")


### PR DESCRIPTION
For kazoo apps repo, we use the full path as changed file, and pass that to check_dialyzer script. But that script is not properly converting the erl file path (full path) to correct ebin file (dropping the leading "/" from the beginning) causing to not dialyze anything at all.