### PR TITLE
[master] KZOO-15: ensure min value of max_recording_time_limit

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -33044,7 +33044,7 @@
                     "type": "boolean"
                 },
                 "max_recording_time_limit": {
-                    "default": 3600,
+                    "default": 10800,
                     "description": "media maximum recording time limit",
                     "type": "integer"
                 },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.media.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.media.json
@@ -46,7 +46,7 @@
             "type": "boolean"
         },
         "max_recording_time_limit": {
-            "default": 3600,
+            "default": 10800,
             "description": "media maximum recording time limit",
             "type": "integer"
         },

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -11658,7 +11658,7 @@
       'description': media fix media names
       'type': boolean
     'max_recording_time_limit':
-      'default': 3600
+      'default': 10800
       'description': media maximum recording time limit
       'type': integer
     'normalize_destination_args':

--- a/applications/pivot/doc/kazoo/recording.md
+++ b/applications/pivot/doc/kazoo/recording.md
@@ -20,7 +20,7 @@ Recording the caller (or caller and callee in a bridged-call scenario) is straig
 
 This will start the call recording, limiting it to 1200 seconds, and will encode the audio into an MP3 file (alternatively, you can use "wav"). The `url` is where the resulting file will be sent via an HTTP PUT request. It is then up to the receiving server to properly handle the request and store the file for later use.
 
-Note: `time_limit` is constrained by the `system_config/media` doc's `max_recording_time_limit` entry (default is 600 seconds). If your recordings are not long enough, that is the setting that needs increasing.
+Note: `time_limit` is constrained by the `system_config/media` doc's `max_recording_time_limit` entry (default is 10800 seconds). If your recordings are not long enough, that is the setting that needs increasing.
 
 Note: `url` will be used as the base URL for the resulting PUT. The final URL will be `URL/call_recording_CALL_ID.EXT` where `URL` is the supplied URL, `CALL_ID` is the call ID of the A-leg being recorded, and `EXT` is the `format` parameter.
 

--- a/core/kazoo/src/kz_doc.erl
+++ b/core/kazoo/src/kz_doc.erl
@@ -687,7 +687,7 @@ add_pvt_created(Acc, JObj, _, Opts) ->
 
 -spec add_pvt_modified(kz_term:proplist(), doc(), kz_term:api_ne_binary(), kz_term:proplist()) -> kz_term:proplist().
 add_pvt_modified(Acc, _JObj, _, Opts) ->
-    [{?KEY_MODIFIED, props:get_value('now', Opts)} | Acc].
+    [{?KEY_MODIFIED, props:get_value('now', Opts, kz_time:now_s())} | Acc].
 
 -spec add_id(kz_term:proplist(), doc(), any(), kz_term:proplist()) -> kz_term:proplist().
 add_id(Acc, _JObj, _, Opts) ->

--- a/core/kazoo_media/src/kazoo_media_maintenance.erl
+++ b/core/kazoo_media/src/kazoo_media_maintenance.erl
@@ -267,34 +267,52 @@ maybe_migrate_system_config(ConfigId, DeleteAfter) ->
         {'error', 'not_found'} ->
             io:format("  failed to find ~s, not migrating~n", [ConfigId]);
         {'ok', JObj} ->
-            migrate_system_config(kz_doc:public_fields(JObj)),
+            migrate_system_config(kz_doc:public_fields(JObj), DeleteAfter),
             maybe_delete_system_config(ConfigId, DeleteAfter)
     end.
 
 -spec maybe_delete_system_config(kz_term:ne_binary(), boolean()) -> 'ok'.
-maybe_delete_system_config(_ConfigId, 'false') -> 'ok';
 maybe_delete_system_config(ConfigId, 'true') ->
     {'ok', _} = kz_datamgr:del_doc(?KZ_CONFIG_DB, ConfigId),
-    io:format("deleted ~s from ~s", [ConfigId, ?KZ_CONFIG_DB]).
+    io:format("deleted ~s from ~s", [ConfigId, ?KZ_CONFIG_DB]);
+maybe_delete_system_config(_ConfigId, 'false') -> 'ok'.
 
--spec migrate_system_config(kz_json:object()) -> 'ok'.
-migrate_system_config(ConfigJObj) ->
+-spec migrate_system_config(kz_json:object(), boolean()) -> 'ok'.
+migrate_system_config(ConfigJObj, DeleteAfter) ->
     {'ok', MediaJObj} = get_media_config_doc(),
 
     {Updates, _} = kz_json:foldl(fun migrate_system_config_fold/3
                                 ,{[], MediaJObj}
                                 ,ConfigJObj
                                 ),
-    maybe_update_media_config(Updates, MediaJObj).
+    maybe_update_media_config(Updates, MediaJObj),
+    delete_original_config(ConfigJObj, Updates, DeleteAfter).
 
 maybe_update_media_config([], _) ->
     io:format("no changes for that need saving~n");
 maybe_update_media_config(Updates, MediaJObj) ->
     io:format("saving updated media config with:~n~p~n", [Updates]),
+    ensure_save_config_db(Updates, MediaJObj).
+
+%%------------------------------------------------------------------------------
+%% @doc Only delete original attributes when the original doc is NOT deleted.
+%% @end
+%%------------------------------------------------------------------------------
+-spec delete_original_config(kz_json:object(), list(), boolean()) -> 'ok'.
+delete_original_config(_OriginalJObj, _Updates, 'true') -> 'ok';
+delete_original_config(OrigJObj, Updates, 'false') ->
+    Removed = lists:foldl(fun({X, _V}, L) -> [{X, 'null'} | L] end, [], Updates),
+    ensure_save_config_db(Removed, OrigJObj).
+
+-spec ensure_save_config_db(kz_json:flat_proplist(), kz_json:object()) -> 'ok'.
+ensure_save_config_db(Updates, JObj) ->
+    Id = kz_doc:id(JObj),
+    PvtUpdates = [{<<"pvt_modified">>, kz_time:now_s()}],
     Update = [{'update', Updates}
+             ,{'extra_update', PvtUpdates}
              ,{'ensure_saved', 'true'}
              ],
-    {'ok', _} = kz_datamgr:update_doc(?KZ_CONFIG_DB, kz_doc:id(MediaJObj), Update),
+    {'ok', _} = kz_datamgr:update_doc(?KZ_CONFIG_DB, Id, Update),
     'ok'.
 
 -spec get_media_config_doc() -> {'ok', kz_json:object()}.

--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -55,6 +55,7 @@
 
 -define(USE_ACCOUNT_OVERRIDES, kapps_config:get_is_true(?CONFIG_CAT, <<"support_account_overrides">>, 'true')).
 
+-define(DEFAULT_MAX_RECORDING_LIMIT, 3*?SECONDS_IN_HOUR).
 %%------------------------------------------------------------------------------
 %% @doc Normalize audio file to the system default or specified sample rate.
 %% Accepts media file content binary as input.
@@ -370,7 +371,7 @@ recording_url(CallId, Data) ->
 
 -spec max_recording_time_limit() -> ?SECONDS_IN_HOUR.
 max_recording_time_limit() ->
-    kapps_config:get_integer(?CONFIG_CAT, <<"max_recording_time_limit">>, ?SECONDS_IN_HOUR).
+    kapps_config:get_integer(?CONFIG_CAT, <<"max_recording_time_limit">>, ?DEFAULT_MAX_RECORDING_LIMIT).
 
 %% base_url(Host) ->
 %%     Port = kz_couch_connections:get_port(),


### PR DESCRIPTION
max_recording_time_limit can be reset by values from system_config/callflow by kazoo_media_maintenance:migrate(). To prevent reset again, the original callflow (or any originals) data shall be removed after the migration.
    
It's also required that the system-config default should be 10800, as seconds in 3 hours.
 