### PR TITLE
[master] More circleci updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,12 +62,9 @@ jobs:
             if [ x"$(cat .git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum make/deps.mk | cut -d" " -f1) > ".git/.kz_deps_hash"
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum make/deps.mk
+            ls -al make
       - run:
           name: Making dependencies
           command : make deps
@@ -124,10 +121,10 @@ jobs:
           name: Running code checks
           command: make code_checks
       - run:
-          name: Making app applications
+          name: Checking app source file
           command: make app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make sup_completion
       - run:
           name: Running xref check
@@ -159,7 +156,7 @@ jobs:
           name: Checking doc states
           command: scripts/state-of-docs.sh || true
       - run:
-          name: Checking EDoc states
+          name: Validating EDoc states
           command: scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
@@ -173,8 +170,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: make build-plt dialyze-changed
+          command: make dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -195,7 +195,7 @@ jobs:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS
       - run:
-          name: Making CI release
+          name: Building CI release
           command: make build-ci-release
       - run:
           name: Running Kazoo release
@@ -209,9 +209,12 @@ jobs:
       - store_artifacts:
           path: /tmp/circleci-artifacts
       - run:
-          name: Checking for errors
+          name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi

--- a/applications/acdc/.circleci/config.yml
+++ b/applications/acdc/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/ananke/.circleci/config.yml
+++ b/applications/ananke/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/blackhole/.circleci/config.yml
+++ b/applications/blackhole/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/braintree/.circleci/config.yml
+++ b/applications/braintree/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/call_inspector/.circleci/config.yml
+++ b/applications/call_inspector/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/callflow/.circleci/config.yml
+++ b/applications/callflow/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/camper/.circleci/config.yml
+++ b/applications/camper/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/cccp/.circleci/config.yml
+++ b/applications/cccp/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/cdr/.circleci/config.yml
+++ b/applications/cdr/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/conference/.circleci/config.yml
+++ b/applications/conference/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/crossbar/.circleci/config.yml
+++ b/applications/crossbar/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/doodle/.circleci/config.yml
+++ b/applications/doodle/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/ecallmgr/.circleci/config.yml
+++ b/applications/ecallmgr/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/edr/.circleci/config.yml
+++ b/applications/edr/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/fax/.circleci/config.yml
+++ b/applications/fax/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/frontier/.circleci/config.yml
+++ b/applications/frontier/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/hangups/.circleci/config.yml
+++ b/applications/hangups/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/hotornot/.circleci/config.yml
+++ b/applications/hotornot/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/jonny5/.circleci/config.yml
+++ b/applications/jonny5/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/konami/.circleci/config.yml
+++ b/applications/konami/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/media_mgr/.circleci/config.yml
+++ b/applications/media_mgr/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/milliwatt/.circleci/config.yml
+++ b/applications/milliwatt/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/notify/.circleci/config.yml
+++ b/applications/notify/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/omnipresence/.circleci/config.yml
+++ b/applications/omnipresence/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/pivot/.circleci/config.yml
+++ b/applications/pivot/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/pusher/.circleci/config.yml
+++ b/applications/pusher/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/registrar/.circleci/config.yml
+++ b/applications/registrar/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/reorder/.circleci/config.yml
+++ b/applications/reorder/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/skel/.circleci/config.yml
+++ b/applications/skel/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/spyvsspy/.circleci/config.yml
+++ b/applications/spyvsspy/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/stats/.circleci/config.yml
+++ b/applications/stats/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/stepswitch/.circleci/config.yml
+++ b/applications/stepswitch/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/sysconf/.circleci/config.yml
+++ b/applications/sysconf/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/tasks/.circleci/config.yml
+++ b/applications/tasks/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/teletype/.circleci/config.yml
+++ b/applications/teletype/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/trunkstore/.circleci/config.yml
+++ b/applications/trunkstore/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/applications/webhooks/.circleci/config.yml
+++ b/applications/webhooks/.circleci/config.yml
@@ -135,26 +135,31 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
             fi
       - run:
-          name: Exporting build environment variables
+          name: Generating build environment variables
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
             echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
+            if [ -z "$KAZOO_APP" ] || [ -z "$KAZOO_ROOT" ] || [ -z "$BASE_BRANCH" ] ; then
+              echo ":: eniroment variable are not set"
+              exit 1
+            fi
       - run:
           name: Creating artifacts directory
           command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -162,17 +167,22 @@ jobs:
           name: Cloning core repository
           command : |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
           command: ${KAZOO_ROOT}/scripts/circleci.bash
       - run:
-          name: Generating change list for application
-          command: echo -e 'export CHANGED="$(for file in `find ${KAZOO_ROOT}/applications/${KAZOO_APP} -name "*.[e|h]rl"`; do readlink -e $file; done | xargs echo)"' >> $BASH_ENV
-      - run:
-          name: Displaying changed files
-          command: echo $CHANGED
+          name: Export changed files
+          command: |
+            cd "$KAZOO_ROOT/$APP_PATH"
+            for file in $(git --no-pager diff --name-only HEAD $BASE_BRANCH); do
+              CHANGED+=" $KAZOO_ROOT/$APP_PATH/$file"
+            done
+            printf 'export CHANGED="%s"\n' "$CHANGED" | tee -a $BASH_ENV
       - persist_to_workspace:
           root: ~/
           paths:
@@ -193,14 +203,9 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Show dependency hash
-          command: |
-            md5sum make/deps.mk || true
-            ls -al make || true
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making deps
           command: make -C ${KAZOO_ROOT} deps
@@ -239,16 +244,14 @@ jobs:
           keys:
             - deps-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
-          name: Displaying deps hash
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-      - run:
-          name: Compiling for unit test environment
+          name: Compiling Kazoo core for unit test environment
           command: ERLC_OPTS='-DPROPER' make -C ${KAZOO_ROOT}/core compile-test
       - run:
           name: Running Eunit tests
           command: make -C "$KAZOO_ROOT/$APP_PATH" eunit
+      - run:
+          name: Uploading Coverage Report
+          command: make coverage-report
 
   checks:
     <<: *defaults
@@ -257,7 +260,7 @@ jobs:
           at: ~/
       - run:
           name: Running code formatter
-          command: make -C ${KAZOO_ROOT} fmt
+          command: TO_FMT="$CHANGED" make -C ${KAZOO_ROOT} fmt
       - run:
           name: Running code checks
           command: make -C ${KAZOO_ROOT} code_checks
@@ -265,7 +268,7 @@ jobs:
           name: Checking app source file
           command: make -C ${KAZOO_ROOT} app_applications
       - run:
-          name: Generating sup bash completion file
+          name: Generating sup bash completion files
           command: make -C ${KAZOO_ROOT} sup_completion
       - run:
           name: Running xref check
@@ -275,7 +278,9 @@ jobs:
           command: make -C ${KAZOO_ROOT} elvis
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   docs:
     <<: *defaults
@@ -302,7 +307,9 @@ jobs:
           command: ${KAZOO_ROOT}/scripts/state-of-edoc.escript
       - run:
           name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
+          command: |
+            cd $KAZOO_ROOT/$APP_PATH
+            $KAZOO_ROOT/scripts/check-unstaged.bash
 
   analyze:
     <<: *defaults
@@ -313,8 +320,11 @@ jobs:
           keys:
             - plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
       - run:
+          name: Building plt file
+          command: make -C ${KAZOO_ROOT} build-plt
+      - run:
           name: Dailyzing changed Erlang files
-          command: TO_DIALYZE="$(echo $CHANGED)" make -C ${KAZOO_ROOT} build-plt dialyze
+          command: make -C ${KAZOO_ROOT} dialyze-changed
       - save_cache:
           key: plt-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -333,9 +343,6 @@ jobs:
           name: Building CI release
           command: make -C ${KAZOO_ROOT} build-ci-release
       - run:
-          name: Checking for unstaged files
-          command: ${KAZOO_ROOT}/scripts/check-unstaged.bash
-      - run:
           name: Running Kazoo release
           command: KAZOO_CONFIG=${KAZOO_ROOT}/rel/ci.config.ini REL="kazoo_apps" ACT="console" NODE_NAME_TYPE="-sname" make -C ${KAZOO_ROOT} release
       - run:
@@ -350,8 +357,11 @@ jobs:
           name: Checking for errors in artifacts
           command: |
             if [[ $(grep -c -v -F 'exit with reason shutdown' ${CIRCLE_ARTIFACTS}/log/error.log) -gt 0 ]]; then
+              printf ":: some errors are detected during running release\n\n"
               cat ${CIRCLE_ARTIFACTS}/log/error.log
               exit 1
+            else
+              printf ":: no errors are found in release\n\n"
             fi
 
   build_centos7:
@@ -376,7 +386,7 @@ jobs:
           command: |
             BAZE="$(cat "${HOME}/2600hz/the_app/.base_branch")"
             if [ -n "$BAZE" ]; then
-              echo -e "\n\nexport BASE_BRANCH=$BAZE" >> $BASH_ENV
+              printf "\n\nexport BASE_BRANCH=$BAZE\n" | tee -a $BASH_ENV
             else
               echo "add base branch name of main Kazoo repo (like origin/master) to '.base_branch' in your application root directory"
               exit 1
@@ -386,13 +396,14 @@ jobs:
           command: |
             APP_DASH=${CIRCLE_PROJECT_REPONAME#kazoo-}
             APP=${APP_DASH/-/_}
-            echo -e "export KAZOO_APP=${APP}\n" >> $BASH_ENV
-            echo -e "export KAZOO_ROOT=${HOME}/2600hz/kazoo" >> $BASH_ENV
-            echo -e "export APP_PATH=applications/${APP}\n\n" >> $BASH_ENV
+            printf "export KAZOO_APP=${APP}\n" | tee -a $BASH_ENV
+            printf "export KAZOO_ROOT=${HOME}/2600hz/kazoo\n" | tee -a $BASH_ENV
+            printf "export APP_PATH=applications/${APP}\n\n" | tee -a $BASH_ENV
       - run:
           name: Displaying environment information
           command: |
-            echo ":: behold, running ci tests for application: $KAZOO_APP"
+            echo ":: behold, running build step for application: $KAZOO_APP"
+            echo "KAZOO_APP: $KAZOO_APP"
             echo "KAZOO_ROOT: $KAZOO_ROOT"
             echo "APP_PATH: $APP_PATH"
             echo "BASE_BRANCH: $BASE_BRANCH"
@@ -400,7 +411,10 @@ jobs:
           name: Cloning core repository
           command: |
             if [ ! -d ${KAZOO_ROOT} ]; then
+              echo ":: Cloning core repository to $KAZOO_ROOT"
               git clone https://github.com/2600hz/kazoo $KAZOO_ROOT
+            else
+              echo ":: Core repository is already cloned"
             fi
       - run:
           name: Running core setup script
@@ -415,13 +429,12 @@ jobs:
             if [ x"$(cat $KAZOO_ROOT/.git/.kz_deps_hash)" = x"$deps_hash" ]; then
               touch "$KAZOO_ROOT/make/.deps.mk.$deps_hash"
             fi
-            echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) > "$KAZOO_ROOT/.git/.kz_deps_hash"
+            (echo -n $(md5sum $KAZOO_ROOT/make/deps.mk | cut -d" " -f1) | tee "$KAZOO_ROOT/.git/.kz_deps_hash") && echo
+            md5sum $KAZOO_ROOT/make/deps.mk
+            ls -al $KAZOO_ROOT/make
       - run:
           name: Making dependencies
-          command: |
-            md5sum $KAZOO_ROOT/make/deps.mk || true
-            ls -al $KAZOO_ROOT/make || true
-            make -C ${KAZOO_ROOT} deps
+          command: make -C ${KAZOO_ROOT} deps
       - save_cache:
           key: deps-centos-v1-{{ checksum "~/2600hz/kazoo/make/deps.mk" }}-{{ checksum "/usr/local/lib/erlang/releases/RELEASES" }}
           paths:
@@ -434,11 +447,9 @@ jobs:
             VERSION=$(./version)
             RELEASE=$(./release)
             PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
-            echo "export VERSION=${VERSION}" >> $BASH_ENV
-            echo "export RELEASE=${RELEASE}" >> $BASH_ENV
-            PACKAGE_NAME=$(./package_name)
-            echo "export PACKAGE_NAME=${PACKAGE_NAME}" >> $BASH_ENV
+            echo "export PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $BASH_ENV
+            echo "export VERSION=${VERSION}" | tee -a $BASH_ENV
+            echo "export RELEASE=${RELEASE}" | tee -a $BASH_ENV
             echo "build version for ${PACKAGE_NAME} version: ${VERSION} release: ${RELEASE}"
       - run:
           name: Building release

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -35,7 +35,7 @@ DEPS ?= amqp_client \
 # BUILD_DEPS = parse_trans
 IGNORE_DEPS = hamcrest
 
-ifeq ($(USER),travis)
+ifeq ($(CIRCLECI),true)
     DEPS += coveralls
     dep_coveralls = git https://github.com/markusn/coveralls-erl 1.4.0
     DEPS += proper

--- a/scripts/cover.escript
+++ b/scripts/cover.escript
@@ -19,4 +19,4 @@ main(_) ->
 get_ci_job_id("true", _) ->
     {"travis-ci", os:getenv("TRAVIS_JOB_ID")};
 get_ci_job_id(_, "true") ->
-    {"circleci", os:getenv("CIRCLE_BUILD_NUM")}.
+    {"circle-ci", os:getenv("CIRCLE_BUILD_NUM")}.


### PR DESCRIPTION
This is the latest fixes for application's CircleCI config file:

We found out the `CHANGED` variable are not passed to some of the targets, so they won't actually runs against the the app report and no won't report any error/warnings at all.

* fix check_unstaged step show it shows the changes in the app folder
* fix dialyzer so it actually dialyzes the *changed* files in the app folder
* fix code_checks so it runs on changed files in the app folder
* fix fmt
* add coverage report step (I think it need per repo activation in coveralls.com site)
* fix deps.mk so it adds coveralls as dependency in circleci env
* Use `tee` as much as possible and print important variables