### PR TITLE
PISTON-953: no need to flush endpoint cache after doc updates

### DIFF
--- a/applications/callflow/src/callflow_maintenance.erl
+++ b/applications/callflow/src/callflow_maintenance.erl
@@ -352,7 +352,8 @@ set_device_classifier_action(Action, Classifier, Uri) ->
     Update = [{[<<"call_restriction">>, Classifier, <<"action">>], Action}],
     UpdateOptions = [{'update', Update}],
 
-    {'ok', _} = kz_datamgr:update_doc(AccountDb, DeviceId, UpdateOptions).
+    {'ok', _} = kz_datamgr:update_doc(AccountDb, DeviceId, UpdateOptions),
+    'ok'.
 
 %%------------------------------------------------------------------------------
 %% @doc Checks if classifier defined in `system_config -> number_manager' doc.

--- a/applications/callflow/src/callflow_maintenance.erl
+++ b/applications/callflow/src/callflow_maintenance.erl
@@ -302,8 +302,6 @@ set_account_classifier_action(Action, Classifier, AccountDb) ->
     Update = [{[<<"call_restriction">>, Classifier, <<"action">>], Action}],
     {'ok', _} = kzd_accounts:update(AccountId, Update),
 
-    kz_endpoint:flush_account(AccountDb),
-
     io:format("  ...  classifier '~s' switched to action '~s'\n", [Classifier, Action]).
 
 -spec all_accounts_set_classifier(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
@@ -354,9 +352,7 @@ set_device_classifier_action(Action, Classifier, Uri) ->
     Update = [{[<<"call_restriction">>, Classifier, <<"action">>], Action}],
     UpdateOptions = [{'update', Update}],
 
-    {'ok', _} = kz_datamgr:update_doc(AccountDb, DeviceId, UpdateOptions),
-
-    kz_endpoint:flush(AccountDb, DeviceId).
+    {'ok', _} = kz_datamgr:update_doc(AccountDb, DeviceId, UpdateOptions).
 
 %%------------------------------------------------------------------------------
 %% @doc Checks if classifier defined in `system_config -> number_manager' doc.

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -699,24 +699,7 @@ flush_account(AccountDb) ->
 
 -spec flush(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 flush(Db, Id) ->
-    kz_cache:erase_local(?CACHE_NAME, {?MODULE, Db, Id}),
-    {'ok', Rev} = kz_datamgr:lookup_doc_rev(Db, Id),
-    Props =
-        [{<<"ID">>, Id}
-        ,{<<"Database">>, Db}
-        ,{<<"Rev">>, Rev}
-        ,{<<"Type">>, kzd_devices:type()}
-         | kz_api:default_headers(<<"configuration">>
-                                 ,?DOC_EDITED
-                                 ,?APP_NAME
-                                 ,?APP_VERSION
-                                 )
-        ],
-    Fun = fun(P) ->
-                  kapi_conf:publish_doc_update('edited', Db, kzd_devices:type(), Id, P)
-          end,
-
-    'ok' = kz_amqp_worker:cast(Props, Fun).
+    kz_cache:erase_local(?CACHE_NAME, {?MODULE, Db, Id}).
 
 %%------------------------------------------------------------------------------
 %% @doc Creates one or more kazoo API endpoints for use in a bridge string.

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -699,7 +699,24 @@ flush_account(AccountDb) ->
 
 -spec flush(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 flush(Db, Id) ->
-    kz_cache:erase_local(?CACHE_NAME, {?MODULE, Db, Id}).
+    kz_cache:erase_local(?CACHE_NAME, {?MODULE, Db, Id}),
+    {'ok', Rev} = kz_datamgr:lookup_doc_rev(Db, Id),
+    Props =
+        [{<<"ID">>, Id}
+        ,{<<"Database">>, Db}
+        ,{<<"Rev">>, Rev}
+        ,{<<"Type">>, kzd_devices:type()}
+         | kz_api:default_headers(<<"configuration">>
+                                 ,?DOC_EDITED
+                                 ,?APP_NAME
+                                 ,?APP_VERSION
+                                 )
+        ],
+    Fun = fun(P) ->
+                  kapi_conf:publish_doc_update('edited', Db, kzd_devices:type(), Id, P)
+          end,
+
+    'ok' = kz_amqp_worker:cast(Props, Fun).
 
 %%------------------------------------------------------------------------------
 %% @doc Creates one or more kazoo API endpoints for use in a bridge string.


### PR DESCRIPTION
Flush should only flush the endpoint cache and callers of the fun do not need to do so as they are performing a doc update anyway. Recent changes to kazoo_caches remove this need.

This also resolves an infinite loop where a listener might act on a doc_{created,deleted,edited} event and request a flush of the endpoint cache before requesting the endpoint via kz_endpoint:get