### PR TITLE
[master] update ledger summary normalizer

### DIFF
--- a/applications/crossbar/src/modules/cb_ledgers.erl
+++ b/applications/crossbar/src/modules/cb_ledgers.erl
@@ -470,7 +470,7 @@ normalize_view_result(LedgerJObj) ->
 %%------------------------------------------------------------------------------
 -spec normalize_summary_by_account(kz_json:objects(), kz_json:objects()) -> kz_json:objects().
 normalize_summary_by_account(JObj, Acc) ->
-    [AccountId, _PeriodStartTS, _DocId] = kz_json:get_value(<<"key">>, JObj),
+    [AccountId|_] = kz_json:get_value(<<"key">>, JObj),
     Ledger = normalize_ledger_jobj(AccountId, kz_json:get_value(<<"value">>, JObj)),
     [kz_json:sum_jobjs([Ledger | Acc])].
 


### PR DESCRIPTION
Fix normalizer for ledgers summary API so it extract account ID from view's key correctly.

In previous [PR](https://github.com/2600hz/kazoo/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+PROD-30) for PRDO-30 the ledgers account summary was change to have account_id, timestamp and doc._id as view's compound key, but the normalizer in crossbar module didn't updated accordingly.