### PR TITLE
Do not honor privacy settings for emergency calls

### DIFF
--- a/applications/callflow/src/cf_route_req.erl
+++ b/applications/callflow/src/cf_route_req.erl
@@ -15,6 +15,11 @@
         ,allow_no_match/1
         ]).
 
+-ifdef(TEST).
+-export([avoid_privacy_if_emergency_call/2
+        ]).
+-endif.
+
 -include("callflow.hrl").
 
 -define(DEFAULT_METAFLOWS(AccountId)
@@ -247,20 +252,23 @@ pre_park_action(Call) ->
 -spec update_call(kz_json:object(), boolean(), kz_term:ne_binary(), kapps_call:call()) ->
           kapps_call:call().
 update_call(Flow, NoMatch, ControllerQ, Call) ->
-    Props = [{'cf_flow_id', kz_doc:id(Flow)}
-            ,{'cf_flow_name', kz_json:get_ne_binary_value(<<"name">>, Flow, kapps_call:request_user(Call))}
-            ,{'cf_flow', kz_json:get_value(<<"flow">>, Flow)}
-            ,{'cf_capture_group', kz_json:get_ne_value(<<"capture_group">>, Flow)}
-            ,{'cf_capture_groups', kz_json:get_value(<<"capture_groups">>, Flow, kz_json:new())}
+    FlowId = kz_doc:id(Flow),
+    CaptureGroup = kz_json:get_ne_value(<<"capture_group">>, Flow),
+    NewFlow = avoid_privacy_if_emergency_call(CaptureGroup, Flow),
+    Props = [{'cf_flow_id', FlowId}
+            ,{'cf_flow_name', kz_json:get_ne_binary_value(<<"name">>, NewFlow, kapps_call:request_user(Call))}
+            ,{'cf_flow', kz_json:get_value(<<"flow">>, NewFlow)}
+            ,{'cf_capture_group', CaptureGroup}
+            ,{'cf_capture_groups', kz_json:get_value(<<"capture_groups">>, NewFlow, kz_json:new())}
             ,{'cf_no_match', NoMatch}
-            ,{'cf_metaflow', kz_json:get_value(<<"metaflows">>, Flow, ?DEFAULT_METAFLOWS(kapps_call:account_id(Call)))}
+            ,{'cf_metaflow', kz_json:get_value(<<"metaflows">>, NewFlow, ?DEFAULT_METAFLOWS(kapps_call:account_id(Call)))}
             ],
 
     Updaters = [{fun kapps_call:kvs_store_proplist/2, Props}
                ,{fun kapps_call:set_controller_queue/2, ControllerQ}
                ,{fun kapps_call:set_application_name/2, ?APP_NAME}
                ,{fun kapps_call:set_application_version/2, ?APP_VERSION}
-               ,{fun kapps_call:insert_custom_channel_var/3, <<"CallFlow-ID">>, kz_doc:id(Flow)}
+               ,{fun kapps_call:insert_custom_channel_var/3, <<"CallFlow-ID">>, FlowId}
                ],
     kapps_call:exec(Updaters, Call).
 
@@ -318,4 +326,20 @@ extract_sip_username(Contact) ->
     case catch(re:run(Contact, <<".*sip:(.*)@.*">>, ReOptions)) of
         {'match', [Match]} -> Match;
         _ -> 'undefined'
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc If dialing an emergency number (e.g. 911) using the `*67' feature code, then don't honor privacy settings.
+%% @end
+%%------------------------------------------------------------------------------
+-spec avoid_privacy_if_emergency_call(kz_term:api_binary(), kzd_callflows:doc()) -> kzd_callflows:doc().
+avoid_privacy_if_emergency_call('undefined', Flow) ->
+    Flow;
+avoid_privacy_if_emergency_call(CaptureGroup, Flow) ->
+    case knm_converters:classify(CaptureGroup) of
+        <<"emergency">> ->
+            lager:info("emergency call ongoing, ignoring privacy settings"),
+            kz_json:set_value([<<"flow">>, <<"data">>, <<"mode">>], <<"none">>, Flow);
+        _ ->
+            Flow
     end.

--- a/applications/callflow/test/cf_route_req_tests.erl
+++ b/applications/callflow/test/cf_route_req_tests.erl
@@ -1,0 +1,54 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2011-2019, 2600Hz
+%%% @doc
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(cf_route_req_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+avoid_privacy_if_emergency_call_test_() ->
+    EmergencyFlow = kz_json:set_value(<<"capture_group">>, <<"911">>, star_67_callflow()),
+    NormalFlow = star_67_callflow([<<"+14151234567">>]),
+
+    ModeNoneFlow = kz_json:set_value([<<"flow">>, <<"data">>, <<"mode">>], <<"none">>, EmergencyFlow),
+
+    [{"When dialing emergency number with *67 feature code, ignore privacy settings"
+     ,check_expected(ModeNoneFlow, EmergencyFlow)
+     }
+    ,{"When dialing normal number with *67 feature code, allow privacy settings"
+     ,check_expected(NormalFlow, NormalFlow)
+     }
+    ].
+
+check_expected(Expected, Callflow) ->
+    Resp = cf_route_req:avoid_privacy_if_emergency_call(
+             kz_json:get_ne_value(<<"capture_group">>, Callflow)
+            ,Callflow
+            ),
+    ?_assert(kz_json:are_equal(Expected, Resp)).
+
+star_67_callflow() ->
+    star_67_callflow([]).
+
+star_67_callflow(Numbers) ->
+    Flow = kz_json:from_list_recursive([{<<"children">>, []}
+                                       ,{<<"data">>
+                                        ,[{<<"action">>, <<"full">>}
+                                         ,{<<"endpoint_strategy">>, <<"overwrite">>}
+                                         ,{<<"mode">>, <<"full">>}
+                                         ]
+                                        }
+                                       ,{<<"module">>, <<"privacy">>}
+                                       ]),
+    Routines = [{fun kzd_callflows:set_featurecode_name/2, <<"privacy[mode=full]">>}
+               ,{fun kzd_callflows:set_featurecode_number/2, <<"67">>}
+               ,{fun kzd_callflows:set_flow/2, Flow}
+               ,{fun kzd_callflows:set_patterns/2, [<<"^\\*67([0-9]*)", $$/integer>>]}
+               ,{fun kzd_callflows:set_numbers/2, Numbers}
+               ],
+    kz_json:exec_first(Routines, kzd_callflows:new()).

--- a/applications/stepswitch/test/stepswitch_bridge_tests.erl
+++ b/applications/stepswitch/test/stepswitch_bridge_tests.erl
@@ -1,0 +1,86 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2011-2019, 2600Hz
+%%% @doc
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(stepswitch_bridge_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+avoid_privacy_if_emergency_call_test_() ->
+    EmergencyPrivacy = emergency_endpoint_with_privacy(),
+    EmergencyNotPrivacy = emergency_endpoint_without_privacy(),
+    NotEmergencyPrivacy = not_emergency_endpoint_with_privacy(),
+    NotEmergencyNotPrivacy = not_emergency_endpoint_without_privacy(),
+
+    [{"If emergency endpoint and privacy enabled, don't enforce privacy"
+     ,check_expected(EmergencyNotPrivacy, [EmergencyPrivacy])
+     }
+    ,{"If emergency endpoint and privacy disabled, let it be"
+     ,check_expected(EmergencyNotPrivacy, [EmergencyNotPrivacy])
+     }
+    ,{"If NOT emergency endpoint and privacy enabled, let it be"
+     ,check_expected(NotEmergencyPrivacy, [NotEmergencyPrivacy])
+     }
+    ,{"If NOT emergency endpoint and privacy disabled, let it be"
+     ,check_expected(NotEmergencyNotPrivacy, [NotEmergencyNotPrivacy])
+     }
+    ].
+
+check_expected(Expected, Endpoints) ->
+    Resp = stepswitch_bridge:avoid_privacy_if_emergency_call(
+             stepswitch_bridge:contains_emergency_endpoints(Endpoints)
+            ,Endpoints
+            ),
+    ?_assert(kz_json:are_equal(Expected, hd(Resp))).
+
+emergency_endpoint_with_privacy() ->
+    endpoint(<<"true">>, <<"kazoo">>, 'true', 'true').
+
+emergency_endpoint_without_privacy() ->
+    endpoint(<<"true">>, <<"none">>, 'false', 'false').
+
+not_emergency_endpoint_with_privacy() ->
+    endpoint(<<"false">>, <<"kazoo">>, 'true', 'true').
+
+not_emergency_endpoint_without_privacy() ->
+    endpoint(<<"false">>, <<"none">>, 'false', 'false').
+
+endpoint(IsEmergency, PrivacyMethod, PrivacyHideName, PrivacyHideNumber) ->
+    kz_json:from_list_recursive(
+      [{<<"Route">>, <<"sip:911@testing.zswitch.net">>}
+      ,{<<"Outbound-Callee-ID-Name">>, <<"911">>}
+      ,{<<"Outbound-Callee-ID-Number">>, <<"911">>}
+      ,{<<"To-DID">>, <<"911">>}
+      ,{<<"Invite-Format">>, <<"route">>}
+      ,{<<"Caller-ID-Type">>, <<"external">>}
+      ,{<<"Bypass-Media">>, false}
+      ,{<<"Auth-User">>, <<"user_endpoint">>}
+      ,{<<"Auth-Password">>, <<"password_endpoint">>}
+      ,{<<"Endpoint-Type">>, <<"sip">>}
+      ,{<<"Endpoint-Progress-Timeout">>, <<"8">>}
+      ,{<<"Custom-Channel-Vars">>
+       ,[{<<"Emergency-Resource">>, IsEmergency}
+        ,{<<"Matched-Number">>, <<"911">>}
+        ,{<<"Resource-Type">>, <<"offnet-termination">>}
+        ,{<<"Format-From-URI">>, 'false'}
+        ,{<<"Original-Number">>, <<"911">>}
+        ,{<<"DID-Classifier">>, <<"emergency">>}
+        ,{<<"E164-Destination">>, <<"911">>}
+        ,{<<"Resource-ID">>, <<"eb79c3e4a17518e83307482bf3f2e40b-emergency">>}
+        ,{<<"Global-Resource">>, 'true'}
+        ]
+       }
+      ,{<<"Outbound-Caller-ID-Number">>, <<"+14151234567">>}
+      ,{<<"Outbound-Caller-ID-Name">>, <<"Emergency Caller ID Test">>}
+      ,{<<"Privacy-Method">>, PrivacyMethod}
+      ,{<<"Privacy-Hide-Name">>, PrivacyHideName}
+      ,{<<"Privacy-Hide-Number">>, PrivacyHideNumber}
+      ,{<<"Weight">>, 50}
+      ,{<<"Name">>, <<"E911 Testing Outbound Carrier - emergency">>}
+      ]
+     ).

--- a/core/kazoo_amqp/include/kapi_offnet_resource.hrl
+++ b/core/kazoo_amqp/include/kapi_offnet_resource.hrl
@@ -57,6 +57,7 @@
 -define(KEY_PRIVACY_METHOD, <<"Privacy-Method">>).
 -define(KEY_PRIVACY_HIDE_NAME, <<"Privacy-Hide-Name">>).
 -define(KEY_PRIVACY_HIDE_NUMBER, <<"Privacy-Hide-Number">>).
+-define(KEY_EMERGENCY_RESOURCE, <<"Emergency-Resource">>).
 -define(RESOURCE_TYPE_AUDIO, <<"audio">>).
 -define(RESOURCE_TYPE_ORIGINATE, <<"originate">>).
 -define(RESOURCE_TYPE_SMS, <<"sms">>).


### PR DESCRIPTION
If a user dials to an emergency number and the device, user, account, or carrier has `Caller-ID Privacy` enabled and/or the user uses `*67` feature code to perform the emergency call, disregard the privacy settings and use the configured caller-id for emergency calls.