### PR TITLE
change to use kz_time for UTC conversion

### DIFF
--- a/applications/callflow/src/module/cf_temporal_route.erl
+++ b/applications/callflow/src/module/cf_temporal_route.erl
@@ -165,7 +165,7 @@ get_temporal_rules(#temporal{local_sec=LSec
 
 -spec get_temporal_rules(kz_json:path(), non_neg_integer(), kz_term:ne_binary(), kz_term:ne_binary(), rules()) -> rules().
 get_temporal_rules(Routes, LSec, AccountDb, TZ, Rules) when is_binary(TZ) ->
-    Now = localtime:utc_to_local(calendar:universal_time(), kz_term:to_list(TZ)),
+    Now = kz_time:adjust_utc_timestamp(calendar:universal_time(), kz_term:to_list(TZ)),
     get_temporal_rules(Routes, LSec, AccountDb, TZ, Now, Rules).
 
 -spec get_temporal_rules(routes(), non_neg_integer(), kz_term:ne_binary(), kz_term:ne_binary(), kz_time:datetime(), rules()) -> rules().
@@ -435,7 +435,7 @@ enable_temporal_rules(Temporal, [RuleId|T]=Rules, Call) ->
 %%------------------------------------------------------------------------------
 -spec load_current_time(temporal()) -> temporal().
 load_current_time(#temporal{timezone=Timezone}=Temporal)->
-    {LocalDate, LocalTime} = localtime:utc_to_local(calendar:universal_time()
+    {LocalDate, LocalTime} = kz_time:adjust_utc_timestamp(calendar:universal_time()
                                                    ,kz_term:to_list(Timezone)
                                                    ),
     lager:info("local time for ~s is {~w,~w}", [Timezone, LocalDate, LocalTime]),

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -2092,7 +2092,7 @@ tmp_file(Ext) ->
                             kz_term:ne_binary().
 get_unix_epoch(Epoch, Timezone) ->
     UtcDateTime = calendar:gregorian_seconds_to_datetime(Epoch),
-    LocalDateTime = localtime:utc_to_local(UtcDateTime, Timezone),
+    LocalDateTime = kz_time:adjust_utc_timestamp(UtcDateTime, Timezone),
     kz_term:to_binary(calendar:datetime_to_gregorian_seconds(LocalDateTime) - ?UNIX_EPOCH_IN_GREGORIAN).
 
 %%------------------------------------------------------------------------------

--- a/applications/crossbar/src/modules/cb_faxes.erl
+++ b/applications/crossbar/src/modules/cb_faxes.erl
@@ -654,7 +654,7 @@ get_file_name(Context, Doc, ContentType) ->
 -spec get_timestamp(cb_context:context(), kz_time:datetime()) -> kz_term:ne_binary().
 get_timestamp(Context, UtcTime) ->
     Timezone = get_timezone(Context),
-    LocalTime = case localtime:utc_to_local(UtcTime, kz_term:to_list(Timezone)) of
+    LocalTime = case kz_time:adjust_utc_timestamp(UtcTime, kz_term:to_list(Timezone)) of
                     {{_,_,_},{_,_,_}}=LT ->
                         lager:debug("converted to TZ: ~s", [Timezone]),
                         LT;

--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -1127,7 +1127,7 @@ generate_media_name('undefined', GregorianSeconds, Ext, Timezone) ->
     generate_media_name(<<"unknown">>, GregorianSeconds, Ext, Timezone);
 generate_media_name(CallerId, GregorianSeconds, Ext, Timezone) ->
     UTCDateTime = calendar:gregorian_seconds_to_datetime(kz_term:to_integer(GregorianSeconds)),
-    LocalTime = case localtime:utc_to_local(UTCDateTime, kz_term:to_list(Timezone)) of
+    LocalTime = case kz_time:adjust_utc_timestamp(UTCDateTime, kz_term:to_list(Timezone)) of
                     {{_,_,_},{_,_,_}}=LT ->
                         lager:debug("converted to TZ: ~s", [Timezone]),
                         LT;


### PR DESCRIPTION
 - this will prevent crashes or undefined behavior during "magic hour"
the time during a DST switch