### PR TITLE
[4.3] Conference related updates

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_conference_control.erl
+++ b/applications/ecallmgr/src/ecallmgr_conference_control.erl
@@ -99,16 +99,16 @@ init([Node, ConferenceId, InstanceId]) ->
 %%------------------------------------------------------------------------------
 -spec handle_call(any(), kz_term:pid_ref(), state()) -> kz_types:handle_call_ret_state(state()).
 handle_call(_Request, _From, State) ->
-    {reply, ok, State}.
+    {'reply', 'ok', State}.
 
 %%------------------------------------------------------------------------------
 %% @doc Handling cast messages.
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
-handle_cast({'gen_listener',{'created_queue',_QueueName}}, State) ->
+handle_cast({'gen_listener', {'created_queue', _QueueName}}, State) ->
     {'noreply', State};
-handle_cast({'gen_listener',{'is_consuming',_IsConsuming}}, State) ->
+handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
     {'noreply', State};
 handle_cast(_Msg, State) ->
     {'noreply', State}.

--- a/core/kazoo_amqp/src/listener_federator.erl
+++ b/core/kazoo_amqp/src/listener_federator.erl
@@ -43,7 +43,8 @@
 %%------------------------------------------------------------------------------
 -spec start_link(pid(), kz_term:ne_binary(), kz_term:proplist()) -> kz_types:startlink_ret().
 start_link(Parent, Broker, Params) ->
-    gen_listener:start_link(?SERVER, Params, [Parent, Broker]).
+    ParentCallId = kz_util:get_callid(),
+    gen_listener:start_link(?SERVER, Params, [Parent, ParentCallId, Broker]).
 
 -spec broker(kz_types:server_ref()) -> kz_term:ne_binary().
 broker(Pid) ->
@@ -62,10 +63,14 @@ stop(Pid) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec init([pid() | kz_term:ne_binary()]) -> {'ok', state()}.
-init([Parent, Broker]=L) ->
-    lager:debug("federating listener ~p on broker ~s", L),
+init([Parent, ParentCallId, Broker]=L) ->
+    lager:debug("federating listener ~p(~s) on broker ~s", L),
     _ = kz_amqp_channel:consumer_broker(Broker),
     Zone = kz_term:to_binary(kz_amqp_connections:broker_zone(Broker)),
+
+    CallId = kz_binary:join([ParentCallId, Zone], <<"-">>),
+    kz_util:put_callid(CallId),
+
     {'ok', #state{parent=Parent
                  ,broker=Broker
                  ,zone=Zone


### PR DESCRIPTION
If ecallmgrs don't respond, conference API requests could crash due to unhandled timeout clause.

Improve logging around federated listeners.