### PR TITLE
Notifications for Voicemail Delete Actions

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -866,7 +866,7 @@ play_messages(Messages, Count, Box, Call) ->
 
 -spec play_messages(kz_json:objects(), kz_json:objects(), non_neg_integer(), mailbox(), kapps_call:call()) ->
           'ok' | 'complete'.
-play_messages([H|T]=Messages, PrevMessages, Count, #mailbox{seek_duration=SeekDuration}=Box, Call) ->
+play_messages([H|T]=Messages, PrevMessages, Count, #mailbox{seek_duration=SeekDuration, mailbox_id=BoxId}=Box, Call) ->
     AccountId = kapps_call:account_id(Call),
     Message = kvm_message:media_url(AccountId, H),
     lager:info("playing mailbox message ~p (~s)", [Count, Message]),
@@ -890,6 +890,9 @@ play_messages([H|T]=Messages, PrevMessages, Count, #mailbox{seek_duration=SeekDu
             lager:info("caller chose to delete the message"),
             _ = kapps_call_command:flush(Call),
             _ = kapps_call_command:b_prompt(<<"vm-deleted">>, Call),
+            MessageId = kz_json:get_ne_binary_value(<<"media_id">>, H),
+            JObj = hd(kz_json:get_list_value(<<"succeeded">>, kvm_messages:fetch(AccountId, [MessageId], BoxId))),
+            kvm_util:publish_voicemail_deleted(BoxId, JObj, 'dtmf'),
             _ = kvm_message:set_folder({?VM_FOLDER_DELETED, 'false'}, H, AccountId),
             play_messages(T, PrevMessages, Count, Box, Call);
         {'ok', 'return'} ->

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -19633,6 +19633,115 @@
             ],
             "type": "object"
         },
+        "kapi.notifications.voicemail_deleted": {
+            "description": "AMQP API for notifications.voicemail_deleted",
+            "properties": {
+                "Account-DB": {
+                    "type": "string"
+                },
+                "Account-ID": {
+                    "type": "string"
+                },
+                "Attachment-URL": {
+                    "type": "string"
+                },
+                "Bcc": {
+                    "type": "string"
+                },
+                "Call-ID": {
+                    "type": "string"
+                },
+                "Caller-ID-Name": {
+                    "type": "string"
+                },
+                "Caller-ID-Number": {
+                    "type": "string"
+                },
+                "Cc": {
+                    "type": "string"
+                },
+                "Event-Category": {
+                    "enum": [
+                        "notification"
+                    ],
+                    "type": "string"
+                },
+                "Event-Name": {
+                    "enum": [
+                        "voicemail_deleted"
+                    ],
+                    "type": "string"
+                },
+                "From": {
+                    "type": "string"
+                },
+                "From-Realm": {
+                    "type": "string"
+                },
+                "From-User": {
+                    "type": "string"
+                },
+                "HTML": {
+                    "type": "string"
+                },
+                "Preview": {
+                    "type": "string"
+                },
+                "Reason": {
+                    "enum": [
+                        "dtmf",
+                        "delete_after_notify",
+                        "crossbar_action"
+                    ],
+                    "type": "string"
+                },
+                "Reply-To": {
+                    "type": "string"
+                },
+                "Subject": {
+                    "type": "string"
+                },
+                "Text": {
+                    "type": "string"
+                },
+                "To": {
+                    "type": "string"
+                },
+                "To-Realm": {
+                    "type": "string"
+                },
+                "To-User": {
+                    "type": "string"
+                },
+                "Voicemail-Box": {
+                    "type": "string"
+                },
+                "Voicemail-ID": {
+                    "type": "string"
+                },
+                "Voicemail-Length": {
+                    "type": "string"
+                },
+                "Voicemail-Timestamp": {
+                    "type": "string"
+                },
+                "Voicemail-Transcription": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Account-ID",
+                "From-Realm",
+                "From-User",
+                "Reason",
+                "To-Realm",
+                "To-User",
+                "Voicemail-Box",
+                "Voicemail-ID",
+                "Voicemail-Timestamp"
+            ],
+            "type": "object"
+        },
         "kapi.notifications.voicemail_full": {
             "description": "AMQP API for notifications.voicemail_full",
             "properties": {
@@ -19756,6 +19865,9 @@
                 "Preview": {
                     "type": "string"
                 },
+                "Reason": {
+                    "type": "string"
+                },
                 "Reply-To": {
                     "type": "string"
                 },
@@ -19854,6 +19966,9 @@
                     "type": "string"
                 },
                 "Preview": {
+                    "type": "string"
+                },
+                "Reason": {
                     "type": "string"
                 },
                 "Reply-To": {
@@ -29273,6 +29388,11 @@
                     "description": "callflow singular call hook url",
                     "type": "string"
                 },
+                "vm_delete_amqp": {
+                    "default": false,
+                    "description": "callflow vm_delete_amqp",
+                    "type": "boolean"
+                },
                 "voicemail": {
                     "properties": {
                         "delete_after_notify": {
@@ -29355,6 +29475,11 @@
                             "description": "callflow fastforward and rewind seek duration",
                             "minimum": 0,
                             "type": "integer"
+                        },
+                        "vm_delete_amqp": {
+                            "default": false,
+                            "description": "send ampq message to notify about voicemail deletion",
+                            "type": "boolean"
                         },
                         "vm_message_forward_type": {
                             "default": "only_forward",
@@ -32794,6 +32919,7 @@
                         "teletype_transaction",
                         "teletype_voicemail_full",
                         "teletype_voicemail_to_email",
+                        "teletype_voicemail_deleted",
                         "teletype_webhook_disabled"
                     ],
                     "description": "teletype modules to start when teletype is started",
@@ -33181,6 +33307,22 @@
                 "text_content_transfer_encoding": {
                     "default": "7BIT",
                     "description": "notify.transaction text content transfer encoding",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.notify.voicemail_deleted": {
+            "description": "Schema for notify.voicemail_deleted system_config",
+            "properties": {
+                "html_content_transfer_encoding": {
+                    "default": "7BIT",
+                    "description": "notify.voicemail_deleted html content transfer encoding",
+                    "type": "string"
+                },
+                "text_content_transfer_encoding": {
+                    "default": "7BIT",
+                    "description": "notify.voicemail_deleted text content transfer encoding",
                     "type": "string"
                 }
             },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.voicemail_deleted.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.voicemail_deleted.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "_id": "kapi.notifications.voicemail_saved",
-    "description": "AMQP API for notifications.voicemail_saved",
+    "_id": "kapi.notifications.voicemail_deleted",
+    "description": "AMQP API for notifications.voicemail_deleted",
     "properties": {
         "Account-DB": {
             "type": "string"
@@ -35,7 +35,7 @@
         },
         "Event-Name": {
             "enum": [
-                "voicemail_saved"
+                "voicemail_deleted"
             ],
             "type": "string"
         },
@@ -55,6 +55,11 @@
             "type": "string"
         },
         "Reason": {
+            "enum": [
+                "dtmf",
+                "delete_after_notify",
+                "crossbar_action"
+            ],
             "type": "string"
         },
         "Reply-To": {
@@ -95,6 +100,7 @@
         "Account-ID",
         "From-Realm",
         "From-User",
+        "Reason",
         "To-Realm",
         "To-User",
         "Voicemail-Box",

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.voicemail_new.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.voicemail_new.json
@@ -54,6 +54,9 @@
         "Preview": {
             "type": "string"
         },
+        "Reason": {
+            "type": "string"
+        },
         "Reply-To": {
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
@@ -100,6 +100,11 @@
             "description": "callflow singular call hook url",
             "type": "string"
         },
+        "vm_delete_amqp": {
+            "default": false,
+            "description": "callflow vm_delete_amqp",
+            "type": "boolean"
+        },
         "voicemail": {
             "properties": {
                 "delete_after_notify": {
@@ -182,6 +187,11 @@
                     "description": "callflow fastforward and rewind seek duration",
                     "minimum": 0,
                     "type": "integer"
+                },
+                "vm_delete_amqp": {
+                    "default": false,
+                    "description": "send ampq message to notify about voicemail deletion",
+                    "type": "boolean"
                 },
                 "vm_message_forward_type": {
                     "default": "only_forward",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.json
@@ -36,6 +36,7 @@
                 "teletype_transaction",
                 "teletype_voicemail_full",
                 "teletype_voicemail_to_email",
+                "teletype_voicemail_deleted",
                 "teletype_webhook_disabled"
             ],
             "description": "teletype modules to start when teletype is started",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.voicemail_deleted.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.voicemail_deleted.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.notify.voicemail_deleted",
+    "description": "Schema for notify.voicemail_deleted system_config",
+    "properties": {
+        "html_content_transfer_encoding": {
+            "default": "7BIT",
+            "description": "notify.voicemail_deleted html content transfer encoding",
+            "type": "string"
+        },
+        "text_content_transfer_encoding": {
+            "default": "7BIT",
+            "description": "notify.voicemail_deleted text content transfer encoding",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -417,6 +417,7 @@ delete(Context, BoxId) ->
     AccountId = cb_context:account_id(Context),
     Msgs = kvm_messages:get(AccountId, BoxId),
     MsgIds = [kzd_box_message:media_id(M) || M <- Msgs],
+    'ok' = publish_voicemail_deleted(AccountId, BoxId, MsgIds),
     _ = kvm_messages:change_folder(?VM_FOLDER_DELETED, MsgIds, AccountId, BoxId, add_pvt_auth_funs(Context)),
     C = crossbar_doc:delete(Context),
     update_mwi(C, BoxId).
@@ -425,6 +426,7 @@ delete(Context, BoxId) ->
 delete(Context, BoxId, ?MESSAGES_RESOURCE) ->
     AccountId = cb_context:account_id(Context),
     MsgIds = cb_context:resp_data(Context),
+    'ok' = publish_voicemail_deleted(AccountId, BoxId, MsgIds),
     Result = kvm_messages:change_folder({?VM_FOLDER_DELETED, 'true'}, MsgIds, AccountId, BoxId, add_pvt_auth_funs(Context)),
     C = crossbar_util:response(Result, Context),
     update_mwi(C, BoxId).
@@ -432,6 +434,7 @@ delete(Context, BoxId, ?MESSAGES_RESOURCE) ->
 -spec delete(cb_context:context(), path_token(), path_token(), path_token()) -> cb_context:context().
 delete(Context, BoxId, ?MESSAGES_RESOURCE, MediaId) ->
     AccountId = cb_context:account_id(Context),
+    'ok' = publish_voicemail_deleted(AccountId, BoxId, [MediaId]),
     case kvm_message:change_folder({?VM_FOLDER_DELETED, 'true'}, MediaId, AccountId, BoxId, add_pvt_auth_funs(Context)) of
         {'ok', Message} ->
             C = crossbar_util:response(Message, Context),
@@ -469,6 +472,19 @@ add_pvt_auth_funs(Context) ->
 add_pvt_auth(JObj, Context) ->
     AuthUpdates = crossbar_doc:add_pvt_auth(JObj, [], Context),
     kz_json:set_values(AuthUpdates, JObj).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec publish_voicemail_deleted(kz_term:ne_binary(), path_token(), path_tokens()) -> 'ok'.
+publish_voicemail_deleted(AccountId, BoxId, MessageIds) ->
+    JObjs = kz_json:get_list_value(<<"succeeded">>, kvm_messages:fetch(AccountId, MessageIds, BoxId)),
+    lists:foreach(
+      fun(JObj) ->
+              kvm_util:publish_voicemail_deleted(BoxId, JObj, 'crossbar_action')
+      end,
+      JObjs).
 
 %%------------------------------------------------------------------------------
 %% @doc disallow vmbox messages array changing.

--- a/applications/teletype/priv/templates/voicemail_deleted.html
+++ b/applications/teletype/priv/templates/voicemail_deleted.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="x-apple-disable-message-reformatting">
+    <title>Voicemail Message Was Deleted</title>
+    <!--[if !mso]><link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'><![endif]-->
+    <style>
+        /* CSS Reset */
+        html,body{margin:0 auto !important;padding:0 !important;height:100% !important;width:100% !important;} *{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;}div[style*="margin:16px 0"]{margin:0 !important;}table,td{mso-table-lspace:0pt !important;mso-table-rspace:0pt !important;}table{border-spacing:0 !important;border-collapse:collapse !important;table-layout:fixed !important;margin:0 auto !important;}table table table{table-layout:auto;}img{-ms-interpolation-mode:bicubic;}*[x-apple-data-detectors]{color:inherit !important;text-decoration:none !important;}.x-gmail-data-detectors,.x-gmail-data-detectors *,.aBn{border-bottom:0 !important;cursor:default !important;}.a6S{display:none !important;opacity:0.01 !important;}img.g-img + div{display:none !important;}.button-link{text-decoration:none !important;}@media only screen and (min-device-width:375px) and (max-device-width:413px){.email-container{min-width:375px !important;}}
+        /* Progressive Enhancements */
+        *{font-family:'Open Sans',Arial,sans-serif;}
+        html,body{font-size:15px;line-height:20px;}
+    </style>
+</head>
+<body width="100%" bgcolor="#eaeaea" style="margin:0;mso-line-height-rule:exactly;background-color:#eaeaea">
+    <center style="padding:40px 0;width:100%;background:#eaeaea;text-align:left;">
+        <div style="display:none;font-size:1px;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;mso-hide:all;font-family:sans-serif;">
+            Voicemail Message Was Deleted from {{caller_id.number}} -
+        </div>
+        <div style="max-width:600px;margin:auto;" class="email-container">
+            <!--[if mso]>
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" align="center">
+            <tr>
+            <td>
+            <![endif]-->
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#5995f7" align="center" width="100%" style="background-color:#5995f7;border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <tr><td height="10" style="font-size:10px;line-height:10px;">&nbsp;</td></tr>
+            </table>
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:40px;text-align:center;">
+                        <h2 style="margin:0;padding:0;text-align:center;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">Voicemail Deleted</h2>
+                    </td>
+                </tr>
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">
+                        <h3 style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">Hi{% if user.first_name %} {{user.first_name}}{% endif %},</h3>
+                    </td>
+                </tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
+                        <p style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;">The voicemail from <b>{{caller_id.name_number}}</b> for your voicemail box at <b>{{voicemail.vmbox_name}} ({{voicemail.vmbox_number}})</b> was deleted.<br><br>Please find the message audio file in the attachment.</p>
+                    </td>
+            </tr>
+            <tr>
+                <td bgcolor="#ffffff" style="padding:20px;">
+                    <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%">
+                        <tr>
+                            <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Deletion reason</b></td>
+                            <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{reason}}</td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            </table>
+            {% if voicemail.transcription %}
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">
+                        <h3 style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">Transcription</h3>
+                    </td>
+                </tr>
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;">
+                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" bgcolor="#eaeaea" width="80%" style="background-color:#eaeaea;border-radius:5px;">
+                            <tr>
+                                <td style="padding:13px;font-family:'Open Sans',sans-serif;font-size:13px;color:#555555;line-height:20px;border-radius:5px;">
+                                    <p style="margin:0;padding:0">{{voicemail.transcription}}</p>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+            {% endif %}
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">
+                        <h3 style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">Voicemail Message Details</h3>
+                    </td>
+                </tr>
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;">
+                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%">
+                            <tr>
+                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Caller</b></td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{caller_id.name_number}}</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Callee</b></td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{to.user}} (originally dialed number)</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Received</b></td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{date_called.local|date:"l,F j,Y \\a\\t H:i"}}</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>Length</b></td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{voicemail.length|default:"00:00:00"}}</td>
+                            </tr>
+                        </table>
+                        {% if voicemail.file_name %}
+                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%">
+                            <tr>
+                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>File Name</b></td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{voicemail.file_name}}</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>File Type</b></td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{voicemail.file_type|upper}}</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:10px;background-color:#f5f5f5;text-align:right;font-family:'Open Sans',sans-serif;color:#555555;font-size:13px;font-weight:400;line-height:20px;border-size:3px;border-color:#ffffff;border-right-style:solid;border-bottom-style:solid;" width="30%"><b>File Size</b></td>
+                                <td style="padding:10px;background-color:#eaeaea;font-size:13px;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;border-size:3px;border-color:#ffffff;border-bottom-style:solid;" width="70%">{{voicemail.file_size|filesizeformat}}</td>
+                            </tr>
+                        </table>
+                        {% endif %}
+                    </td>
+                </tr>
+            </table>
+            <!-- Pre-Footer -->
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <!-- Clear Spacer -->
+                <tr><td height="50" style="background-color:#ffffff;font-size:50px;line-height:50px;">&nbsp;</td></tr>
+                <tr><!-- #6a59f7 -->
+                    <td bgcolor="#e2e2e2" style="padding:0 20px;background-color:#e2e2e2;color:#555555;">
+                        <h4 style="font-weight:100;line-height:20px;margin:13px 0;font-family:'Open Sans',sans-serif;color:#555555;">Account Information</h4>
+                        <p style="margin:13px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;font-size:11px;line-height:18px;">
+                            <b>-&nbsp;&nbsp;&nbsp;Account ID:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{account.id}}</span><br>
+                            <b>-&nbsp;&nbsp;&nbsp;Account Name:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{account.name}}</span><br>
+                            <b>-&nbsp;&nbsp;&nbsp;Account Realm:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{account.realm}}</span>
+                        </p>
+                    </td>
+                </tr>
+            </table>
+            <!-- Email Footer -->
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
+            </table>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
+            <!--[if mso]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+        </div>
+    </center>
+</body>
+</html>

--- a/applications/teletype/priv/templates/voicemail_deleted.text
+++ b/applications/teletype/priv/templates/voicemail_deleted.text
@@ -1,0 +1,38 @@
+                Voicemail Deleted
+
+
+Hi{% if user.first_name %} {{user.first_name}}{% endif %},
+
+A voicemail from {{caller_id.name_number}} for
+your voicemail box at {{voicemail.vmbox_name}} (number: {{voicemail.vmbox_number}}) was deleted.
+Please find the message audio file in the attachment.
+{% if voicemail.transcription %}
+
+Deletion reason: {{reason}}
+
+=== Transcription ===
+
+{{voicemail.transcription}}
+{% endif %}
+
+=== Voicemail Message Details ===
+
+    Caller: {{caller_id.name_number}}
+    Callee: {{to.user}} (originally dialed number)
+    Received: {{date_called.local|date:"l, F j, Y \\a\\t H:i"}}
+    Length: {{voicemail.length}}{% if voicemail.file_name %}
+    File Name: {{voicemail.file_name}}
+    File Type: {{voicemail.file_type|upper}}
+    File Size: {{voicemail.file_size|filesizeformat}}{% endif %}
+
+
+
+Account Information
+
+    Account ID: {{account.id}}
+    Account Name: {{account.name}}
+    Account Realm: {{account.realm}}
+
+
+
+Sent from {{system.encoded_node}}

--- a/applications/teletype/src/templates/teletype_voicemail_deleted.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_deleted.erl
@@ -1,0 +1,320 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2014-2020, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(teletype_voicemail_deleted).
+-behaviour(teletype_gen_email_template).
+
+-export([id/0
+        ,init/0
+        ,macros/0, macros/1
+        ,subject/0
+        ,category/0
+        ,friendly_name/0
+        ,to/0, from/0, cc/0, bcc/0, reply_to/0
+        ]).
+-export([handle_req/1]).
+
+-include("teletype.hrl").
+
+-spec id() -> kz_term:ne_binary().
+id() ->
+    <<"voicemail_deleted">>.
+
+-spec macros() -> kz_json:object().
+macros() ->
+    kz_json:from_list(
+      [?MACRO_VALUE(<<"voicemail.vmbox_id">>, <<"voicemail_vmbox_id">>, <<"Voicemail Box Id">>, <<"Which voicemail box was the message left in">>)
+      ,?MACRO_VALUE(<<"voicemail.msg_id">>, <<"voicemail_msg_id">>, <<"Voicemail Message ID">>, <<"Message Id of the voicemail">>)
+      ,?MACRO_VALUE(<<"voicemail.transcription">>, <<"voicemail_transcription">>, <<"Voicemail Message Transcription">>, <<"Voicemail Message Transcription">>)
+      ,?MACRO_VALUE(<<"voicemail.length">>, <<"voicemail_length">>, <<"Voicemail Length">>, <<"Length of the voicemail file (formatted in HH:MM:SS)">>)
+      ,?MACRO_VALUE(<<"voicemail.file_name">>, <<"voicemail_file_name">>, <<"Voicemail File Name">>, <<"Name of the voicemail file">>)
+      ,?MACRO_VALUE(<<"voicemail.file_type">>, <<"voicemail_file_type">>, <<"Voicemail File Type">>, <<"Type of the voicemail file">>)
+      ,?MACRO_VALUE(<<"voicemail.file_size">>, <<"voicemail_file_size">>, <<"Voicemail File Size">>, <<"Size of the voicemail file in bytes">>)
+      ,?MACRO_VALUE(<<"reason">>, <<"voicemail_delete_reason">>, <<"Voicemail Delete Reason">>, <<"Why the voicemail was deleted">>)
+       | ?DEFAULT_CALL_MACROS
+       ++ ?USER_MACROS
+       ++ ?COMMON_TEMPLATE_MACROS
+      ]).
+
+-spec subject() -> kz_term:ne_binary().
+subject() -> <<"Voicemail from {{caller_id.name_number}} was deleted">>.
+
+-spec category() -> kz_term:ne_binary().
+category() -> <<"voicemail">>.
+
+-spec friendly_name() -> kz_term:ne_binary().
+friendly_name() -> <<"Deleted Voicemail To Email">>.
+
+-spec to() -> kz_json:object().
+to() -> ?CONFIGURED_EMAILS(?EMAIL_ORIGINAL).
+
+-spec from() -> kz_term:api_ne_binary().
+from() -> teletype_util:default_from_address().
+
+-spec cc() -> kz_json:object().
+cc() -> ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, []).
+
+-spec bcc() -> kz_json:object().
+bcc() -> ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, []).
+
+-spec reply_to() -> kz_term:api_ne_binary().
+reply_to() -> teletype_util:default_reply_to().
+
+-spec init() -> 'ok'.
+init() ->
+    kz_util:put_callid(?MODULE),
+    teletype_templates:init(?MODULE),
+    teletype_bindings:bind(<<"voicemail_deleted">>, ?MODULE, 'handle_req').
+
+-spec handle_req(kz_json:object()) -> template_response().
+handle_req(JObj) ->
+    handle_req(JObj, kapi_notifications:voicemail_deleted_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> template_response().
+handle_req(_, 'false') ->
+    lager:debug("invalid data for ~s", [id()]),
+    teletype_util:notification_failed(id(), <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [id()]),
+
+    %% Gather data for template
+    DataJObj = kz_json:normalize(JObj),
+    AccountId = kz_json:get_value(<<"account_id">>, DataJObj),
+
+    case is_notice_enabled(AccountId, JObj) of
+        'false' -> teletype_util:notification_disabled(DataJObj, id());
+        'true' -> process_req(DataJObj)
+    end.
+
+-spec is_notice_enabled(kz_term:ne_binary(), kz_json:object()) -> boolean().
+is_notice_enabled(AccountId, JObj) ->
+    case teletype_util:is_notice_enabled(AccountId, JObj, id()) of
+        'false' -> 'false';
+        'true' ->
+            teletype_util:template_system_value(id(), <<"is_enabled">>, 'false')
+    end.
+
+-spec process_req(kz_json:object()) -> template_response().
+process_req(DataJObj) ->
+    VMBoxJObj = get_vmbox(DataJObj),
+    UserJObj = get_owner(VMBoxJObj, DataJObj),
+    BoxEmails = kzd_voicemail_box:notification_emails(VMBoxJObj),
+    Emails = maybe_add_user_email(BoxEmails, kzd_user:email(UserJObj), kzd_user:voicemail_notification_enabled(UserJObj)),
+    Values = [{<<"vmbox_doc">>, VMBoxJObj}
+             ,{<<"user">>, UserJObj}
+             ,{<<"to">>, Emails}
+             ],
+    ReqData = kz_json:set_values(Values, DataJObj),
+
+    case teletype_util:is_preview(DataJObj) of
+        'false' -> maybe_process_req(ReqData);
+        'true' ->
+            maybe_process_req(kz_json:merge_jobjs(DataJObj, ReqData))
+    end.
+
+-spec get_vmbox(kz_json:object()) -> kz_json:object().
+get_vmbox(DataJObj) ->
+    VMBoxId = kz_json:get_value(<<"voicemail_box">>, DataJObj),
+    case teletype_util:open_doc(<<"vmbox">>, VMBoxId, DataJObj) of
+        {'ok', JObj} -> JObj;
+        {'error', _Reason} ->
+            lager:debug("failed to open vmbox ~s: ~p", [VMBoxId, _Reason]),
+            kz_json:new()
+    end.
+
+-spec get_owner(kzd_voicemail_box:doc(), kz_json:object()) -> kz_json:object().
+get_owner(VMBoxJObj, DataJObj) ->
+    OwnerId = kzd_voicemail_box:owner_id(VMBoxJObj),
+    case teletype_util:open_doc(<<"user">>, OwnerId, DataJObj) of
+        {'ok', JObj} -> JObj;
+        {'error', _Reason} ->
+            lager:debug("failed to open user ~s: ~p", [OwnerId, _Reason]),
+            kz_json:new()
+    end.
+
+-spec maybe_add_user_email(kz_term:ne_binaries(), kz_term:api_binary(), boolean()) -> kz_term:ne_binaries().
+maybe_add_user_email(BoxEmails, 'undefined', _) -> BoxEmails;
+maybe_add_user_email(BoxEmails, UserEmail, 'false') -> lists:delete(UserEmail, BoxEmails);
+maybe_add_user_email(BoxEmails, UserEmail, 'true') -> [UserEmail | BoxEmails].
+
+
+-spec maybe_process_req(kz_json:object()) -> template_response().
+maybe_process_req(DataJObj) ->
+    HasEmail = kz_term:is_not_empty(kz_json:get_value(<<"to">>, DataJObj)),
+    maybe_process_req(DataJObj, HasEmail).
+
+-spec maybe_process_req(kz_json:object(), boolean()) -> template_response().
+maybe_process_req(DataJObj, false) ->
+    Msg = io_lib:format("requestor or box ~s has no emails or owner doesn't want emails"
+                       ,[kz_json:get_value(<<"voicemail_box">>, DataJObj)]
+                       ),
+    lager:debug(Msg),
+    teletype_util:notification_ignored(id());
+maybe_process_req(DataJObj, true) ->
+    do_process_req(DataJObj).
+
+-spec do_process_req(kz_json:object()) -> template_response().
+do_process_req(DataJObj) ->
+    teletype_util:send_update(DataJObj, <<"pending">>),
+    Macros0 = macros(DataJObj),
+    Macros = props:delete(<<"attachments">>, Macros0),
+
+    %% Load templates
+    RenderedTemplates = teletype_templates:render(id(), Macros, DataJObj),
+
+    AccountId = kz_json:get_value(<<"account_id">>, DataJObj),
+    {'ok', TemplateMetaJObj} = teletype_templates:fetch_notification(id(), AccountId),
+    Subject0 = kz_json:find(<<"subject">>, [DataJObj, TemplateMetaJObj], subject()),
+    Subject = teletype_util:render_subject(Subject0, Macros),
+    Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, id()),
+
+    case teletype_util:send_email(Emails, Subject, RenderedTemplates, props:get_value(<<"attachments">>, Macros0)) of
+        'ok' -> teletype_util:notification_completed(id());
+        {'error', Reason} -> teletype_util:notification_failed(id(), Reason)
+    end.
+
+-spec macros(kz_json:object()) -> kz_term:proplist().
+macros(DataJObj) ->
+    TemplateData = template_data(DataJObj),
+    EmailAttachements = email_attachments(DataJObj, TemplateData),
+    Macros = maybe_add_file_data(TemplateData, EmailAttachements),
+    props:set_value(<<"attachments">>, EmailAttachements, Macros).
+
+-spec template_data(kz_json:object()) -> kz_term:proplist().
+template_data(DataJObj) ->
+    [{<<"system">>, teletype_util:system_params()}
+     | build_template_data(DataJObj)
+    ].
+
+-spec email_attachments(kz_json:object(), kz_term:proplist()) -> attachments().
+email_attachments(DataJObj, Macros) ->
+    email_attachments(DataJObj, Macros, teletype_util:is_preview(DataJObj)).
+
+-spec email_attachments(kz_json:object(), kz_term:proplist(), boolean()) -> attachments().
+email_attachments(_DataJObj, _Macros, 'true') -> [];
+email_attachments(DataJObj, Macros, 'false') ->
+    VMId = kz_json:get_value(<<"voicemail_id">>, DataJObj),
+    AccountId = kz_json:get_value(<<"account_id">>, DataJObj),
+    Db = kvm_util:get_db(AccountId, VMId),
+    VMJObj = case kvm_message:fetch(AccountId, VMId) of
+                 {'ok', JObj} -> JObj;
+                 {'error', _} ->
+                     throw({'error', 'no_attachment'})
+             end,
+
+    maybe_fetch_attachments(DataJObj, Db, VMId, get_file_name(VMJObj, Macros), kz_doc:attachments(VMJObj)).
+
+-spec maybe_fetch_attachments(kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_object()) -> attachments().
+maybe_fetch_attachments(_, _, _, _, 'undefined') ->
+    throw({'error', 'no_attachment'});
+maybe_fetch_attachments(DataJObj, Db, VMId, FileName, Attachments) ->
+    case kz_json:is_empty(Attachments) of
+        'true' -> throw({'error', 'no_attachment'});
+        'false' ->
+            teletype_util:send_update(DataJObj, <<"pending">>),
+            fetch_attachments(Db, VMId, FileName, Attachments)
+    end.
+
+-spec fetch_attachments(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> attachments().
+fetch_attachments(Db, VMId, FileName, Attachments) ->
+    {[AttachmentMeta], [AttachmentId]} = kz_json:get_values(Attachments),
+    ContentType = kz_json:get_value(<<"content_type">>, AttachmentMeta),
+
+    lager:debug("accessing voicemail attachment ~s at ~s / ~s", [AttachmentId, Db, VMId]),
+
+    case kz_datamgr:fetch_attachment(Db, {kzd_box_message:type(), VMId}, AttachmentId) of
+        {'ok', Bin} -> [{ContentType, FileName, Bin}];
+        {'error', _E} ->
+            lager:debug("failed to fetch attachment ~s: ~p", [AttachmentId, _E]),
+            throw({'error', 'no_attachment'})
+    end.
+
+-spec get_file_name(kz_json:object(), kz_term:proplist()) -> kz_term:ne_binary().
+get_file_name(MediaJObj, Macros) ->
+    %% CallerID_Date_Time.mp3
+    CallerID =
+        case {props:get_value([<<"caller_id">>, <<"name">>], Macros)
+             ,props:get_value([<<"caller_id">>, <<"number">>], Macros)
+             }
+        of
+            {'undefined', 'undefined'} -> props:get_value([<<"from">>, <<"user">>], Macros, <<"Unknown">>);
+            {'undefined', Num} -> Num;
+            {Name, _} -> Name
+        end,
+
+    LocalDateTime = props:get_value([<<"date_called">>, <<"local">>], Macros),
+
+    Extension = get_extension(MediaJObj),
+    FileName = iolist_to_binary([CallerID, $_, kz_time:pretty_print_datetime(LocalDateTime), $., Extension]),
+
+    kz_http_util:urlencode(
+      binary:replace(kz_term:to_lower_binary(FileName), <<$\s>>, <<$_>>)
+     ).
+
+-spec get_extension(kz_json:object()) -> kz_term:ne_binary().
+get_extension(MediaJObj) ->
+    kz_mime:to_extension(kz_doc:attachment_content_type(MediaJObj)).
+
+-spec build_template_data(kz_json:object()) -> kz_term:proplist().
+build_template_data(DataJObj) ->
+    Timezone = kzd_voicemail_box:timezone(kz_json:get_value(<<"vmbox_doc">>, DataJObj)),
+    [{<<"voicemail">>, build_voicemail_data(DataJObj)}
+    ,{<<"account">>, teletype_util:account_params(DataJObj)}
+    ,{<<"user">>, teletype_util:user_params(kz_json:get_value(<<"user">>, DataJObj))}
+    ,{<<"owner">>, teletype_util:user_params(kz_json:get_value(<<"user">>, DataJObj))}
+    ,{<<"reason">>, render_vm_delete_reason(DataJObj)}
+     | teletype_util:build_call_data(DataJObj, Timezone)
+    ].
+
+-spec build_voicemail_data(kz_json:object()) -> kz_term:proplist().
+build_voicemail_data(DataJObj) ->
+    props:filter_undefined(
+      [{<<"vmbox_id">>, kz_json:get_value(<<"voicemail_box">>, DataJObj)}
+      ,{<<"box">>, kz_json:get_value(<<"voicemail_box">>, DataJObj)} %% backward compatibility
+      ,{<<"vmbox_name">>, kz_json:get_value([<<"vmbox_doc">>, <<"name">>], DataJObj)}
+      ,{<<"vmbox_number">>, kz_json:get_value([<<"vmbox_doc">>, <<"mailbox">>], DataJObj)}
+      ,{<<"msg_id">>, kz_json:get_value(<<"voicemail_id">>, DataJObj)}
+      ,{<<"name">>, kz_json:get_value(<<"voicemail_id">>, DataJObj)} %% backward compatibility
+      ,{<<"transcription">>, get_transcription(DataJObj)}
+      ,{<<"length">>, pretty_print_length(DataJObj)}
+      ]).
+
+-spec render_vm_delete_reason(kz_json:object()) -> kz_term:api_ne_binary().
+render_vm_delete_reason(DataJObj) ->
+    case kz_json:get_atom_value(<<"reason">>, DataJObj) of
+        'dtmf' -> <<"user pressed DTMF key">>;
+        'delete_after_notify' -> <<"due to 'Deleted after notify'">>;
+        'crossbar_action' -> <<"due to crossbar action (webhook)">>
+    end.
+
+-spec get_transcription(kz_json:object()) -> kz_term:api_ne_binary().
+get_transcription(DataJObj) ->
+    case kz_json:get_value(<<"voicemail_transcription">>, DataJObj) of
+        'undefined' -> 'undefined';
+        ?NE_BINARY=Bin -> Bin;
+        JObj -> kz_json:get_ne_binary_value(<<"text">>, JObj)
+    end.
+
+-spec pretty_print_length(kz_term:api_object() | pos_integer()) -> kz_term:ne_binary().
+pretty_print_length('undefined') -> <<"00:00:00">>;
+pretty_print_length(Ms) when is_integer(Ms) ->
+    MilliSeconds = kz_time:milliseconds_to_seconds(Ms),
+    Us = kz_time:unix_seconds_to_gregorian_seconds(MilliSeconds),
+    {_, {H, M, S}} = calendar:gregorian_seconds_to_datetime(Us),
+    kz_term:to_binary(io_lib:format("~2..0w:~2..0w:~2..0w", [H, M, S]));
+pretty_print_length(JObj) ->
+    pretty_print_length(kz_json:get_integer_value(<<"voicemail_length">>, JObj)).
+
+-spec maybe_add_file_data(kz_term:proplist(), attachments()) -> kz_term:proplist().
+maybe_add_file_data(Macros, []) -> Macros;
+maybe_add_file_data(Macros, [{ContentType, FileName, Bin}]) ->
+    Props = props:filter_undefined(
+              [{<<"file_name">>, FileName}
+              ,{<<"file_type">>, kz_mime:to_extension(ContentType)}
+              ,{<<"file_size">>, erlang:size(Bin)}
+              ]),
+    VMF = props:set_values(Props, props:get_value(<<"voicemail">>, Macros, [])),
+    props:set_value(<<"voicemail">>, VMF, Macros).

--- a/applications/teletype/test/teletype_render_tests.erl
+++ b/applications/teletype/test/teletype_render_tests.erl
@@ -18,7 +18,7 @@ render_test_() ->
     ,fun setup/0
     ,fun cleanup/1
     ,fun(_ReturnOfSetup) ->
-             [?_assertEqual(36, length(?DEFAULT_MODULES))
+             [?_assertEqual(37, length(?DEFAULT_MODULES))
               %% ,test_rendering(teletype_account_zone_change)
              ,test_rendering(teletype_bill_reminder)
               %% ,test_rendering(teletype_cnam_request)

--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -238,8 +238,10 @@ set_folder(Folder, Message, AccountId) ->
         {'error', _} -> {'error', Message}
     end.
 
--spec maybe_set_folder(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> db_ret().
-maybe_set_folder(_, ?VM_FOLDER_DELETED = ToFolder, MessageId, AccountId, _Msg) ->
+-spec maybe_set_folder(kz_term:ne_binary(), vm_folder(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> db_ret().
+maybe_set_folder(_, ToFolder, MessageId, AccountId, _Msg) when ToFolder == ?VM_FOLDER_DELETED;
+                                                               ToFolder == {?VM_FOLDER_DELETED, 'true'};
+                                                               ToFolder == {?VM_FOLDER_DELETED, 'false'} ->
     %% ensuring that message is really deleted
     change_folder(ToFolder, MessageId, AccountId, 'undefined');
 maybe_set_folder(FromFolder, FromFolder, _MessageId, _AccountId, Msg) ->
@@ -884,6 +886,7 @@ maybe_update_meta(Length, Action, Call, MediaId, BoxId) ->
         'delete' ->
             lager:debug("attachment was sent out via notification, set folder to delete"),
             Fun = [fun(JObj) ->
+                           'ok' = kvm_util:publish_voicemail_deleted(BoxId, JObj, 'delete_after_notify'),
                            kzd_box_message:apply_folder({?VM_FOLDER_DELETED, 'false'}, JObj)
                    end
                   ],

--- a/core/kazoo_voicemail/src/kvm_messages.erl
+++ b/core/kazoo_voicemail/src/kvm_messages.erl
@@ -357,7 +357,9 @@ change_folder(Folder, Msgs, AccountId, BoxId) ->
                                 BoxId :: kz_term:ne_binary(),
                                 Functions :: update_funs().
 change_folder(Folder, Msgs, AccountId, BoxId, Funs) ->
-    Fun = [fun(JObj) -> kzd_box_message:apply_folder(Folder, JObj) end
+    Fun = [fun(JObj) ->
+                   kzd_box_message:apply_folder(Folder, JObj)
+           end
            | Funs
           ],
     update(AccountId, BoxId, Msgs, Fun).

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -18,7 +18,7 @@
         ,retention_seconds/0, retention_seconds/1
         ,enforce_retention/1, enforce_retention/2, is_prior_to_retention/2
 
-        ,publish_saved_notify/5, publish_voicemail_saved/5
+        ,publish_saved_notify/5, publish_voicemail_saved/5, publish_voicemail_deleted/3
         ,get_caller_id_name/1, get_caller_id_number/1
         ]).
 
@@ -340,6 +340,44 @@ publish_voicemail_saved(Length, BoxId, Call, MediaId, Timestamp) ->
            ],
     _ = kz_amqp_worker:cast(Prop, fun kapi_notifications:publish_voicemail_saved/1),
     lager:debug("published voicemail_saved for ~s", [BoxId]).
+
+%%------------------------------------------------------------------------------
+%% @doc Publishes `voicemail_deleted' notification.
+%% @end
+%%------------------------------------------------------------------------------
+-spec publish_voicemail_deleted(kz_term:ne_binary(), kz_json:object(), vm_delete_reason()) -> 'ok'.
+publish_voicemail_deleted(BoxId, Msg, Reason) ->
+    Metadata = kzd_box_message:metadata(Msg),
+    From = kz_json:get_ne_binary_value(<<"from">>, Metadata),
+    To = kz_json:get_ne_binary_value(<<"to">>, Metadata),
+
+    [FromUser, FromRealm] = binary:split(From, <<"@">>, [global]),
+    [ToUser, ToRealm] = binary:split(To, <<"@">>, [global]),
+
+    Prop = [{<<"From-User">>, FromUser}
+           ,{<<"From-Realm">>, FromRealm}
+           ,{<<"To-User">>, ToUser}
+           ,{<<"To-Realm">>, ToRealm}
+           ,{<<"Reason">>, Reason}
+           ,{<<"Account-DB">>, kz_json:get_ne_binary_value(<<"pvt_account_db">>, Msg)}
+           ,{<<"Account-ID">>, kz_json:get_ne_binary_value(<<"pvt_account_id">>, Msg)}
+           ,{<<"Voicemail-Box">>, BoxId}
+           ,{<<"Voicemail-ID">>, kz_json:get_ne_binary_value(<<"media_id">>, Metadata)}
+           ,{<<"Caller-ID-Number">>, kz_json:get_ne_binary_value(<<"caller_id_number">>, Metadata)}
+           ,{<<"Caller-ID-Name">>, kz_json:get_ne_binary_value(<<"caller_id_name">>, Metadata)}
+           ,{<<"Voicemail-Timestamp">>, kz_json:get_ne_binary_value(<<"timestamp">>, Metadata)}
+           ,{<<"Voicemail-Length">>, kz_json:get_ne_binary_value(<<"length">>, Metadata)}
+           ,{<<"Call-ID">>, kz_json:get_ne_binary_value(<<"call_id">>, Metadata)}
+            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           ],
+
+    case ?SEND_DELETE_NOTIFY_AMPQ of
+        true ->
+            _ = kz_amqp_worker:cast(Prop, fun kapi_notifications:publish_voicemail_deleted/1),
+            lager:debug("published voicemail_deleted for ~s", [BoxId]);
+        _ ->
+            ok
+    end.
 
 %%%=============================================================================
 %%% Internal functions

--- a/core/kazoo_voicemail/src/kz_voicemail.hrl
+++ b/core/kazoo_voicemail/src/kz_voicemail.hrl
@@ -11,6 +11,12 @@
 -define(VM_CONFIG_CAT, <<"callflow">>).
 -define(KEY_VOICEMAIL, <<"voicemail">>).
 -define(KEY_RETENTION_DURATION, <<"message_retention_duration">>).
+-define(KEY_VM_DELETE_NOTIFY_AMPQ, <<"vm_delete_amqp">>).
+
+-define(VM_DELETE_NOTIFY_AMPQ_PATH, [?KEY_VOICEMAIL, ?KEY_VM_DELETE_NOTIFY_AMPQ]).
+-define(SEND_DELETE_NOTIFY_AMPQ,
+        kapps_config:get_boolean(?VM_CONFIG_CAT, ?VM_DELETE_NOTIFY_AMPQ_PATH, false)
+       ).
 
 -define(RETENTION_PATH, [?KEY_VOICEMAIL, ?KEY_RETENTION_DURATION]).
 -define(RETENTION_DAYS,
@@ -33,6 +39,8 @@
                      }.
 
 -type next_account() :: {kz_term:ne_binary(), kz_time:gregorian_seconds(), kz_time:gregorian_seconds()}.
+
+-type vm_delete_reason() :: 'dtmf' | 'delete_after_notify' | 'crossbar_action'.
 
 -define(KZ_VOICEMAIL_HRL, 'true').
 -endif.


### PR DESCRIPTION
As a user, I may want to receive both AMQP and email notifications when a user deletes a voicemail.

AMQP messages (to the notifications exchange) are sent if voicemails are deleted via DTMF, delete after notify, and for crossbar actions.

A teletype email template: notification.voicemail_deleted is included and can be activated by:

```
# sup kapps_maintenance migrate
# sup teletype_voicemail_deleted init
# sup teletype_maintenance restore_system_templates
```

The teletype template can be made durable by adding it to system_config/notify.default.autoload_modules.

Right now, the voicemail delete template is essentially a copy of the voicemail new template with the Reason added.

This is a PR to 4.3 because we haven't been able to develop against master for a bit.  We'll submit a PR to master once we have all of the approvals for 4.3.