### PR TITLE
[4.3] Protect system when pagination is disabled

### DIFF
--- a/applications/crossbar/doc/basics.md
+++ b/applications/crossbar/doc/basics.md
@@ -155,7 +155,7 @@ All listing APIs in `v2` will be paginated by default (`v1` will operate as befo
 
 Let's take a look at the CDRs API to see how to interpret pagination.
 
-#### CDR Pagination
+### CDR Pagination
 
 We start with the typical CDR request for a listing of CDRs:
 
@@ -191,13 +191,13 @@ The pagination response keys are `next_start_key`, `page_size`, and `start_key`.
 
 Assuming no changes are made to the underlying documents, `start_key` will get you this page of results, and `next_start_key` will give you a pointer to the next page (imagine a linked-list).
 
-##### Encoded Start Keys (Kazoo 4.2+ Only)
+### Encoded Start Keys (Kazoo 4.2+ Only)
 
 As you can see from the response above, both the `start_key` and `next_start_key` are encoded as URL-safe Base64 strings of their Erlang term representation. A couple character substitutions (`_` for `/` and `_` for `+`) and one character removal (`=`) ensures a string that plays nice in URLs.
 
 In practice, the client should treat these keys as opaque and supply them as-is in future requests.
 
-##### Requesting next page
+### Requesting next page
 
 Using the `next_start_key` value, let's request the next page of CDRs:
 
@@ -232,22 +232,28 @@ Observe now that `start_key` is the requested `start_key` and `next_start_key` p
 
 You can also choose to receive pages in bigger or smaller increments by specifying `page_size` on the request. Do take care, as the `next_start_key` will probably vary if you use the same `start_key` but differing `page_size` values.
 
-##### Setting Page Size
+### Setting Page Size
 
 By default, API requests have a page size of 50 results. This value is customizable by system administrator in the `crossbar.maximum_range` system config setting.
 
 For individual API request, you can also include a `page_size` query string parameter. For example: `http://{SERVER}:8000/v2/{API_URL}?page_size=25`.
 
-##### Setting sorting order
+### Setting sorting order
 
 By default, Crossbar returns the results in descending order. To get results in ascending order either set `ascending=true` (Kazoo 4.2+ only) or `descending=false` in the request query string.
 
 !!! note
     The field used to sort the individual API results depends on the internal implementation of the API endpoint and is not controllable by the client.
 
-##### Disabling Pagination
+### Disabling Pagination
 
 If you want to disable pagination for a request, simply include `paginate=false` on the query string.
+
+#### Protecting from (un)intentional abuse
+
+Since pagination can be turned off by a client-supplied query string parameter, it is important that KAZOO still protect itself from overly large datasets being loaded. Examples seen include large CDR listings, call recording listings, and ledger listings.
+
+Therefore, during a non-paginated request, KAZOO monitors memory consumption of the handling server process and will abort the request if the processing is exceeding a high watermark setting (configured by the system operator). The client can expect to receive an HTTP "416 Range Not Satisfiable" error as a result of exceeding the limit.
 
 ## Chunked Response
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -29724,6 +29724,10 @@
                     },
                     "type": "array"
                 },
+                "request_memory_limit": {
+                    "description": "Limit the amount of memory an API request can consume (in bytes)",
+                    "type": "integer"
+                },
                 "request_timeout_ms": {
                     "default": 10000,
                     "description": "crossbar request timeout in milliseconds",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
@@ -121,6 +121,10 @@
             },
             "type": "array"
         },
+        "request_memory_limit": {
+            "description": "Limit the amount of memory an API request can consume (in bytes)",
+            "type": "integer"
+        },
         "request_timeout_ms": {
             "default": 10000,
             "description": "crossbar request timeout in milliseconds",

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -110,11 +110,11 @@
 -define(KEY_ACCEPT_CHARGES, <<"accept_charges">>).
 
 -define(SHOULD_ENSURE_SCHEMA_IS_VALID
-       ,kapps_config:get_is_true(?CONFIG_CAT, <<"ensure_valid_schema">>, true)
+       ,kapps_config:get_is_true(?CONFIG_CAT, <<"ensure_valid_schema">>, 'true')
        ).
 
 -define(SHOULD_FAIL_ON_INVALID_DATA
-       ,kapps_config:get_is_true(?CONFIG_CAT, <<"schema_strict_validation">>, false)
+       ,kapps_config:get_is_true(?CONFIG_CAT, <<"schema_strict_validation">>, 'false')
        ).
 
 -define(PAGINATION_PAGE_SIZE
@@ -389,7 +389,7 @@ should_paginate(#cb_context{should_paginate='undefined'}=Context) ->
     case req_value(Context, <<"paginate">>) of
         'undefined' -> 'true';
         ShouldPaginate ->
-            lager:debug("request has paginate flag: ~s", [ShouldPaginate]),
+            lager:debug("request has paginate flag = '~s'", [ShouldPaginate]),
             kz_term:is_true(ShouldPaginate)
     end;
 should_paginate(#cb_context{should_paginate=Should}) -> Should.
@@ -398,12 +398,11 @@ should_paginate(#cb_context{should_paginate=Should}) -> Should.
 pagination_page_size() ->
     ?PAGINATION_PAGE_SIZE.
 
--spec pagination_page_size(context()) -> kz_term:api_pos_integer().
+-spec pagination_page_size(context()) -> pos_integer().
 pagination_page_size(Context) ->
     pagination_page_size(Context, api_version(Context)).
 
--spec pagination_page_size(context(), kz_term:ne_binary()) -> kz_term:api_pos_integer().
-pagination_page_size(_Context, ?VERSION_1) -> 'undefined';
+-spec pagination_page_size(context(), kz_term:ne_binary()) -> pos_integer().
 pagination_page_size(Context, _Version) ->
     case req_value(Context, <<"page_size">>) of
         'undefined' -> pagination_page_size();

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -397,8 +397,7 @@ load_view(#load_view_params{view = View
                            ,dbs = [Db|RestDbs]=Dbs
                            ,direction = _Direction
                            } = LVPs) ->
-    Limit = limit_by_page_size(Context, PageSize),
-    lager:debug("limit: ~p page_size: ~p dir: ~p", [Limit, PageSize, _Direction]),
+    Limit = PageSize + 1,
 
     DefaultOptions =
         props:filter_undefined(
@@ -433,35 +432,28 @@ load_view(#load_view_params{view = View
             handle_datamgr_errors(Error, View, Context);
         {'ok', JObjs} ->
             lager:debug("paginating view '~s' from '~s', starting at '~p'", [View, Db, StartKey]),
-            Pagination = case is_integer(Limit) of
-                             'true' -> PageSize;
-                             'false' -> Limit
-                         end,
-            handle_datamgr_pagination_success(JObjs
-                                             ,Pagination
-                                             ,cb_context:api_version(Context)
-                                             ,LVPs#load_view_params{dbs = Dbs
-                                                                   ,context = cb_context:set_resp_status(Context, 'success')
-                                                                   }
-                                             )
+            handle_query_results(JObjs
+                                ,LVPs#load_view_params{dbs = Dbs
+                                                      ,context = cb_context:set_resp_status(Context, 'success')
+                                                      }
+                                )
     end.
 
--spec limit_by_page_size(kz_term:api_binary() | pos_integer()) -> kz_term:api_pos_integer().
-limit_by_page_size('undefined') -> 'undefined';
-limit_by_page_size(N) when is_integer(N) -> N+1;
-limit_by_page_size(<<_/binary>> = B) -> limit_by_page_size(kz_term:to_integer(B)).
+handle_query_results(JObjs, LVPs) ->
+    [{'memory', End}] = process_info(self(), ['memory']),
+    MemoryLimit = kapps_config:get_integer(?CONFIG_CAT, <<"request_memory_limit">>),
+    handle_query_results(JObjs, LVPs, End, MemoryLimit).
 
--spec limit_by_page_size(cb_context:context(), kz_term:api_binary() | pos_integer()) -> kz_term:api_pos_integer().
-limit_by_page_size(Context, PageSize) ->
-    case cb_context:should_paginate(Context) of
-        'true' -> limit_by_page_size(PageSize);
-        'false' ->
-            lager:debug("pagination disabled in context"),
-            'undefined'
-    end.
+handle_query_results(JObjs, LVPs, _MemoryUsed, 'undefined') ->
+    handle_datamgr_pagination_success(JObjs, LVPs);
+handle_query_results(JObjs, LVPs, MemoryUsed, MemoryLimit) when MemoryUsed < MemoryLimit ->
+    lager:debug("under memory cap of ~p: ~p used", [MemoryLimit, MemoryUsed]),
+    handle_datamgr_pagination_success(JObjs, LVPs);
+handle_query_results(_JObjs, #load_view_params{context=Context}, _MemoryUsed, _MemoryLimit) ->
+    lager:warning("memory used ~p exceeds limit ~p", [_MemoryUsed, _MemoryLimit]),
+    crossbar_util:response_range_not_satisfiable(Context).
 
 %% @equiv cb_context:req_value(Context, <<"start_key">>)
-
 -spec start_key(cb_context:context()) -> kz_json:api_json_term().
 start_key(Context) ->
     cb_context:req_value(Context, <<"start_key">>).
@@ -875,27 +867,19 @@ update_pagination_envelope_params(Context, StartKey, PageSize, NextStartKey, 'tr
                                         ),
     cb_context:set_resp_envelope(Context, NewRespEnvelope).
 
--spec handle_datamgr_pagination_success(kz_json:objects(), kz_term:api_pos_integer(), kz_term:ne_binary(), load_view_params()) ->
+-spec handle_datamgr_pagination_success(kz_json:objects(), load_view_params()) ->
                                                cb_context:context().
 %% If v1, just append results and try next database
-handle_datamgr_pagination_success(JObjs
-                                 ,_PageSize
-                                 ,?VERSION_1
-                                 ,#load_view_params{context = Context
-                                                   ,filter_fun = FilterFun
-                                                   ,direction = Direction
-                                                   ,dbs=[_Db|Dbs]
+handle_datamgr_pagination_success([]
+                                 ,#load_view_params{dbs=[_Db|Dbs]
+                                                   ,should_paginate='false'
                                                    } = LVPs
                                  ) ->
-    NewDoc = apply_filter(FilterFun, JObjs, Context, Direction) ++ cb_context:doc(Context),
-    load_view(LVPs#load_view_params{context = cb_context:set_doc(Context, NewDoc)
-                                   ,dbs=Dbs
-                                   });
+    lager:info("no results left, trying next DB"),
+    load_view(LVPs#load_view_params{dbs=Dbs});
 
 %% if no results from this db, go to next db (if any)
 handle_datamgr_pagination_success([]
-                                 ,_PageSize
-                                 ,_Version
                                  ,#load_view_params{context = Context
                                                    ,start_key = StartKey
                                                    ,dbs=[_Db|Dbs]
@@ -905,72 +889,57 @@ handle_datamgr_pagination_success([]
                                    ,dbs=Dbs
                                    });
 
-%% if no page size was specified
 handle_datamgr_pagination_success([_|_]=JObjs
-                                 ,'undefined'
-                                 ,_Version
-                                 ,#load_view_params{context = Context
-                                                   ,start_key = StartKey
-                                                   ,filter_fun = FilterFun
-                                                   ,page_size = PageSize
-                                                   ,direction = Direction
-                                                   ,dbs = [_|Dbs]
-                                                   } = LVPs
-                                 ) ->
-    Filtered = apply_filter(FilterFun, JObjs, Context, Direction),
-    FilteredCount = length(Filtered),
-    ContextWithDocs = cb_context:set_doc(Context, Filtered ++ cb_context:doc(Context)),
-    NewContext = update_pagination_envelope_params(ContextWithDocs, StartKey, FilteredCount),
-    load_view(LVPs#load_view_params{context = NewContext
-                                   ,page_size = PageSize - FilteredCount
-                                   ,dbs = Dbs
-                                   });
-
-handle_datamgr_pagination_success([_|_]=JObjs
-                                 ,PageSize
-                                 ,_Version
                                  ,#load_view_params{context = Context
                                                    ,page_size = CurrentPageSize
+                                                   ,should_paginate = ShouldPaginate
                                                    ,start_key = StartKey
                                                    ,filter_fun = FilterFun
                                                    ,direction = Direction
                                                    ,dbs = [_|Dbs]
                                                    } = LVPs
                                  ) ->
-    try lists:split(PageSize, JObjs) of
+    PageSize = length(JObjs),
+    try lists:split(CurrentPageSize, JObjs) of
         {Results, []} ->
             %% exhausted this db, but may need more from Dbs to fulfill PageSize
             Filtered = apply_filter(FilterFun, Results, Context, Direction),
             UpdatedContext = update_pagination_envelope_params(Context, StartKey, PageSize),
             NewContext = cb_context:set_doc(UpdatedContext, Filtered ++ cb_context:doc(Context)),
             load_view(LVPs#load_view_params{context = NewContext
-                                           ,page_size = CurrentPageSize - PageSize
+                                           ,page_size = next_page_size(CurrentPageSize, PageSize, ShouldPaginate)
                                            ,dbs = Dbs
                                            });
         {Results, [NextJObj]} ->
             %% Current db may have more results to give
             NextStartKey = kz_json:get_value(<<"key">>, NextJObj),
             Filtered = apply_filter(FilterFun, Results, Context, Direction),
+            FilteredCount = length(Filtered),
             lager:debug("next start key: ~p", [NextStartKey]),
-            lager:debug("page size: ~p filtered: ~p", [PageSize, length(Filtered)]),
+            lager:debug("page size: ~p filtered: ~p", [PageSize, FilteredCount]),
             UpdatedContext = update_pagination_envelope_params(Context, StartKey, PageSize, NextStartKey),
             NewContext = cb_context:set_doc(UpdatedContext, Filtered ++ cb_context:doc(Context)),
             load_view(LVPs#load_view_params{context = NewContext
-                                           ,page_size = PageSize - length(Filtered)
+                                           ,page_size = next_page_size(CurrentPageSize, FilteredCount, ShouldPaginate)
                                            ,start_key = NextStartKey
                                            })
     catch
         'error':'badarg' ->
             Filtered = apply_filter(FilterFun, JObjs, Context, Direction),
             FilteredCount = length(Filtered),
-            lager:debug("recv less than ~p results: ~p", [PageSize, FilteredCount]),
+            lager:debug("page size: ~p filtered: ~p", [PageSize, FilteredCount]),
             UpdatedContext = update_pagination_envelope_params(Context, StartKey, FilteredCount),
             NewContext = cb_context:set_doc(UpdatedContext, Filtered ++ cb_context:doc(Context)),
             load_view(LVPs#load_view_params{context = NewContext
-                                           ,page_size = PageSize - FilteredCount
+                                           ,page_size = next_page_size(CurrentPageSize, FilteredCount, ShouldPaginate)
                                            ,dbs = Dbs
                                            })
     end.
+
+next_page_size(CurrentPageSize, _FetchedPageSize, 'false') ->
+    CurrentPageSize;
+next_page_size(CurrentPageSize, FetchedPageSize, 'true') ->
+    CurrentPageSize - FetchedPageSize.
 
 -type filter_fun() :: fun((kz_json:object(), kz_json:objects()) -> kz_json:objects()) |
                       fun((cb_context:context(), kz_json:object(), kz_json:objects()) -> kz_json:objects()) |

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -26,6 +26,7 @@
         ]).
 -export([response_faulty_request/1]).
 -export([response_bad_identifier/2]).
+-export([response_range_not_satisfiable/1]).
 -export([response_conflicting_docs/1]).
 -export([response_datastore_timeout/1]).
 -export([response_datastore_conn_refused/1]).
@@ -181,6 +182,10 @@ create_response(Status, Msg, Code, JTerm, Context) ->
 -spec response_faulty_request(cb_context:context()) -> cb_context:context().
 response_faulty_request(Context) ->
     response('error', <<"faulty request">>, 404, Context).
+
+-spec response_range_not_satisfiable(cb_context:context()) -> cb_context:context().
+response_range_not_satisfiable(Context) ->
+    response('error', <<"range not satisfiable">>, 416, Context).
 
 %%------------------------------------------------------------------------------
 %% @doc When a module is no longer valid, alert the client of the deprecated status

--- a/applications/crossbar/src/crossbar_view.erl
+++ b/applications/crossbar/src/crossbar_view.erl
@@ -903,7 +903,7 @@ handle_query_result(#{page_size := PageSize
     case check_page_size_and_length(LoadMap, FilteredLength, FilteredJObjs, NewLastKey) of
         {'exhausted', LoadMap2} -> LoadMap2;
         {'next_db', LoadMap2} when PageSize =:= 'infinity', NewLastKey =/= 'undefined' ->
-            lager:info("updating new last key to ~p from ~p", [NewLastKey, _OldLastKey]),
+            lager:debug("updating new last key to ~p from ~p", [NewLastKey, _OldLastKey]),
             get_results(LoadMap2#{last_key => NewLastKey});
         {'next_db', LoadMap2} -> get_results(LoadMap2#{databases => RestDbs})
     end.
@@ -1047,16 +1047,16 @@ filter_foldl(Mapper, [JObj | JObjs], Acc) ->
 -spec last_key(last_key(), kz_json:objects(), non_neg_integer() | 'undefined', non_neg_integer(), page_size()) ->
                       {last_key(), kz_json:objects()}.
 last_key(LastKey, [], _Limit, _Returned, _PageSize) ->
-    lager:info("no results same last key ~p", [LastKey]),
+    lager:debug("no results same last key ~p", [LastKey]),
     {LastKey, []};
 last_key(LastKey, JObjs, 'undefined', _Returned, _PageSize) ->
-    lager:info("no limit, re-using last key ~p", [LastKey]),
+    lager:debug("no limit, re-using last key ~p", [LastKey]),
     {LastKey, lists:reverse(JObjs)};
 last_key(_LastKey, JObjs, Limit, Limit, _PageSize) ->
-    lager:info("full page fetched, calculating new key"),
+    lager:debug("full page fetched, calculating new key"),
     new_last_key(JObjs);
 last_key(_LastKey, JObjs, _Limit, _Returned, _PageSize) ->
-    lager:info("returned ~p < limit ~p ps: ~p lk: ~p", [_Returned, _Limit, _PageSize, _LastKey]),
+    lager:debug("returned page ~p smaller than page limit ~p", [_Returned, _Limit]),
     {'undefined', lists:reverse(JObjs)}.
 
 -spec new_last_key(kz_json:objects()) -> {last_key(), kz_json:objects()}.
@@ -1073,9 +1073,7 @@ new_last_key(JObjs) ->
 format_response(#{context := Context}=LoadMap) ->
     case cb_context:resp_status(Context) of
         'success' -> format_success_response(LoadMap);
-        _Error ->
-            lager:info("returning ~p context", [_Error]),
-            Context
+        _Error -> Context
     end.
 
 -spec format_success_response(load_params()) -> cb_context:context().

--- a/applications/crossbar/src/modules/cb_multi_factor.erl
+++ b/applications/crossbar/src/modules/cb_multi_factor.erl
@@ -128,7 +128,7 @@ validate(Context) ->
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?ATTEMPTS) ->
-    Options = [{mapper, crossbar_view:map_value_fun()}
+    Options = [{'mapper', crossbar_view:map_value_fun()}
               ,{'range_keymap', <<"multi_factor">>}
               ],
     crossbar_view:load_modb(Context, ?CB_LIST_ATTEMPT_LOG, Options);

--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -231,7 +231,7 @@ validate(Context, UserId, ?PHOTO) ->
     validate_photo(Context, UserId , cb_context:req_verb(Context)).
 
 validate_users(Context, ?HTTP_GET) ->
-    load_user_summary(Context);
+    load_users_summary(Context);
 validate_users(Context, ?HTTP_PUT) ->
     validate_request('undefined', Context).
 
@@ -437,8 +437,8 @@ send_email(Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec load_user_summary(cb_context:context()) -> cb_context:context().
-load_user_summary(Context) ->
+-spec load_users_summary(cb_context:context()) -> cb_context:context().
+load_users_summary(Context) ->
     fix_envelope(
       crossbar_doc:load_view(?CB_LIST
                             ,[]

--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -740,7 +740,7 @@ maybe_generated_username_hash('false', _Password, Context) ->
     cb_context:add_validation_error(<<"username">>, <<"required">>, Msg, Context);
 maybe_generated_username_hash('true', Password, Context) ->
     Username = generate_username(),
-    JObj = kzd_users:set_username(Username, cb_context:doc(Context)),
+    JObj = kzd_users:set_username(cb_context:doc(Context), Username),
     rehash_creds(Username, Password, cb_context:set_doc(Context, JObj)).
 
 -spec maybe_generated_creds_hash(boolean(), cb_context:context()) -> cb_context:context().
@@ -748,7 +748,7 @@ maybe_generated_creds_hash('false', Context) ->
     remove_creds(Context);
 maybe_generated_creds_hash('true', Context) ->
     Username = generate_username(),
-    JObj = kzd_users:set_username(Username, cb_context:doc(Context)),
+    JObj = kzd_users:set_username(cb_context:doc(Context), Username),
     rehash_creds(Username, generate_password(), cb_context:set_doc(Context, JObj)).
 
 -spec generate_username() -> kz_term:ne_binary().

--- a/core/kazoo_apps/src/kapps_config.erl
+++ b/core/kazoo_apps/src/kapps_config.erl
@@ -227,7 +227,7 @@ get_integer(Category, Key, Default, Node) ->
 get_pos_integer(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
-        Else -> to_pos_integer(Else, undefined)
+        Else -> to_pos_integer(Else, 'undefined')
     end.
 
 -spec get_pos_integer(config_category(), config_key(), Default) -> pos_integer() | Default.
@@ -254,7 +254,7 @@ to_pos_integer(Value, Default) ->
 get_non_neg_integer(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
-        Else -> to_non_neg_integer(Else, undefined)
+        Else -> to_non_neg_integer(Else, 'undefined')
     end.
 
 -spec get_non_neg_integer(config_category(), config_key(), Default) -> non_neg_integer() | Default.

--- a/core/kazoo_couch/src/kazoo_couch.erl
+++ b/core/kazoo_couch/src/kazoo_couch.erl
@@ -243,7 +243,7 @@ all_design_docs(#server{}=Server, ?NE_BINARY = DBName, Options) ->
 get_results(Server, DbName, DesignDoc, ViewOptions) ->
     kz_couch_view:get_results(Server, DbName, DesignDoc, ViewOptions).
 
--spec get_results_count(server(), kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
+-spec get_results_count(server(), 'all_docs' | kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
                                {'ok', kz_term:api_integer()} |
                                couchbeam_error().
 get_results_count(Server, DbName, DesignDoc, ViewOptions) ->

--- a/core/kazoo_couch/src/kazoo_couch.erl
+++ b/core/kazoo_couch/src/kazoo_couch.erl
@@ -237,7 +237,7 @@ design_compact(Server, DbName, Design) ->
 all_design_docs(#server{}=Server, ?NE_BINARY = DBName, Options) ->
     kz_couch_view:all_design_docs(Server, DBName, Options).
 
--spec get_results(server(), kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
+-spec get_results(server(), kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary(), view_options()) ->
                          {'ok', kz_json:objects() | kz_json:path()} |
                          couchbeam_error().
 get_results(Server, DbName, DesignDoc, ViewOptions) ->

--- a/core/kazoo_couch/src/kz_couch_view.erl
+++ b/core/kazoo_couch/src/kz_couch_view.erl
@@ -82,7 +82,7 @@ get_results(#server{}=Conn, DbName, DesignDoc, ViewOptions) ->
 %% Need to see how to get couchbeam to return the "rows" property instead of the result
 %% list; that would be better, but for not, setting the view's "reduce" to the _count
 %% function will suffice (provided a reduce isn't already defined).
--spec get_results_count(server(), kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
+-spec get_results_count(server(), 'all_docs' | kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
                                {'ok', kz_term:api_integer()} |
                                couchbeam_error().
 get_results_count(#server{}=Conn, DbName, DesignDoc, ViewOptions) ->
@@ -120,7 +120,7 @@ map_view_option({K, V})
     {kz_term:to_atom(K, 'true'), V};
 map_view_option(KV) -> KV.
 
--spec do_fetch_results_count(couchbeam_db(), ddoc(), view_options()) ->
+-spec do_fetch_results_count(couchbeam_db(), kz_term:ne_binary() | ddoc(), view_options()) ->
                                     {'ok', kz_term:api_integer()} |
                                     couchbeam_error().
 do_fetch_results_count(Db, DesignDoc, Options)

--- a/core/kazoo_couch/src/kz_couch_view.erl
+++ b/core/kazoo_couch/src/kz_couch_view.erl
@@ -93,7 +93,7 @@ get_results_count(#server{}=Conn, DbName, DesignDoc, ViewOptions) ->
 -spec do_fetch_results(couchbeam_db(), kz_term:ne_binary() | ddoc(), view_options()) ->
                               {'ok', kz_json:objects() | kz_term:ne_binaries()} |
                               couchbeam_error().
-do_fetch_results(Db, <<DesignDoc/binary>>, Options) ->
+do_fetch_results(Db, ?NE_BINARY = DesignDoc, Options) ->
     [DesignName, ViewName|_] = binary:split(DesignDoc, <<"/">>, ['global']),
     do_fetch_results(Db, {DesignName, ViewName}, map_options(Options));
 do_fetch_results(Db, DesignDoc, Options)

--- a/core/kazoo_couch/src/kz_couch_view.erl
+++ b/core/kazoo_couch/src/kz_couch_view.erl
@@ -93,7 +93,7 @@ get_results_count(#server{}=Conn, DbName, DesignDoc, ViewOptions) ->
 -spec do_fetch_results(couchbeam_db(), kz_term:ne_binary() | ddoc(), view_options()) ->
                               {'ok', kz_json:objects() | kz_term:ne_binaries()} |
                               couchbeam_error().
-do_fetch_results(Db, ?NE_BINARY = DesignDoc, Options) ->
+do_fetch_results(Db, <<DesignDoc/binary>>, Options) ->
     [DesignName, ViewName|_] = binary:split(DesignDoc, <<"/">>, ['global']),
     do_fetch_results(Db, {DesignName, ViewName}, map_options(Options));
 do_fetch_results(Db, DesignDoc, Options)

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -1331,7 +1331,7 @@ maybe_create_view(Plan, DbName, DesignDoc, Options, 'true') ->
                                 ,get_registered_view(Plan, DbName, DesignDoc)
                                 ).
 
--spec maybe_create_registered_view(map(), kz_term:ne_binary(), kz_term:ne_binary(), view_options(), kz_json:object() | 'not_registered') ->
+-spec maybe_create_registered_view(map(), kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary(), view_options(), kz_json:object() | 'not_registered') ->
                                           get_results_return().
 maybe_create_registered_view(_Plan, _DbName, _DesignDoc, _Options, 'not_registered') ->
     {'error', 'not_found'};
@@ -1476,7 +1476,7 @@ get_result_docs(DbName, DesignDoc, Keys) ->
 -type paginated_results() :: {'ok', kz_json:objects(), kz_json:api_json_term()} |
                              data_error().
 
--spec paginate_results(kz_term:ne_binary(), kz_term:ne_binary(), paginate_options()) ->
+-spec paginate_results(kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary(), paginate_options()) ->
                               {'ok', kz_json:objects(), kz_json:api_json_term()} |
                               data_error().
 paginate_results(DbName, DesignDoc, Options) ->

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -707,7 +707,7 @@ open_docs(DbName, DocIds, Options) ->
     read_chunked(fun do_open_docs/3, DbName, DocIds, Options).
 
 do_open_docs(DbName, DocIds, Options) ->
-    NewOptions = [{keys, DocIds}, include_docs | Options],
+    NewOptions = [{'keys', DocIds}, 'include_docs' | Options],
     all_docs(DbName, NewOptions).
 
 read_chunked(Opener, DbName, DocIds, Options) ->
@@ -717,22 +717,22 @@ read_chunked(Opener, DbName, DocIds, Options, Acc) ->
         {NewDocIds, DocIdsLeft} ->
             NewAcc = read_chunked_results(Opener, DbName, NewDocIds, Options, Acc),
             read_chunked(Opener, DbName, DocIdsLeft, Options, NewAcc)
-    catch error:badarg ->
+    catch 'error':'badarg' ->
             case read_chunked_results(Opener, DbName, DocIds, Options, Acc) of
-                {error, _R}=E -> E;
-                JObjs -> {ok, lists:flatten(lists:reverse(JObjs))}
+                {'error', _R}=E -> E;
+                JObjs -> {'ok', lists:flatten(lists:reverse(JObjs))}
             end
     end.
 
-read_chunked_results(_, _, _, _, {error,_}=Acc) -> Acc;
+read_chunked_results(_, _, _, _, {'error', _}=Acc) -> Acc;
 read_chunked_results(Opener, DbName, DocIds, Options, Acc) ->
     read_chunked_results(DocIds, Opener(DbName, DocIds, Options), Acc).
 
-read_chunked_results(_DocIds, {ok, JObjs}, Acc) ->
+read_chunked_results(_DocIds, {'ok', JObjs}, Acc) ->
     [JObjs | Acc];
-read_chunked_results(_DocIds, {error,_}=Reason, []) ->
+read_chunked_results(_DocIds, {'error',_}=Reason, []) ->
     Reason;
-read_chunked_results(DocIds, {error, Reason}, Acc) ->
+read_chunked_results(DocIds, {'error', Reason}, Acc) ->
     [kz_json:from_list(
        [{<<"id">>, DocId}
        ,{<<"error">>, Reason}
@@ -787,7 +787,6 @@ all_docs(DbName, Options) ->
         {'ok', Db} -> all_docs(Db, Options);
         {'error', _}=E -> E
     end.
-
 
 -spec db_list() -> {'ok', kz_term:ne_binaries()} | data_error().
 db_list() ->
@@ -1418,11 +1417,11 @@ get_result_ids(JObjs) ->
 
 %%------------------------------------------------------------------------------
 %% @doc Gets the only result of a view.
-%% If no result is found: returns `{error, not_found}'.
+%% If no result is found: returns `{'error', not_found}'.
 %% If more than one result is found, either:
 %% - if `Options' contains `first_when_multiple'
 %%     then the first one will be returned;
-%% - otherwise `{error, multiple_results}' is returned.
+%% - otherwise `{'error', multiple_results}' is returned.
 %% @end
 %%------------------------------------------------------------------------------
 -spec get_single_result(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
@@ -1645,7 +1644,8 @@ maybe_add_doc_type_from_view(ViewName, Options) ->
         _ -> Options
     end.
 
--spec add_doc_type_from_view(kz_term:ne_binary(), view_options()) -> view_options().
+-spec add_doc_type_from_view(kz_term:ne_binary() | 'all_docs', view_options()) -> view_options().
+add_doc_type_from_view('all_docs', Options) -> Options;
 add_doc_type_from_view(View, Options) ->
     case binary:split(View, <<"/">>, ['global']) of
         [ViewType, ViewName] ->

--- a/core/kazoo_data/src/kzs_view.erl
+++ b/core/kazoo_data/src/kzs_view.erl
@@ -36,7 +36,7 @@ all_design_docs(#{server := {App, Conn}}, DBName, Options) ->
 all_docs(#{server := {App, Conn}}, DbName, Options) ->
     App:all_docs(Conn, DbName, Options).
 
--spec get_results(map(), kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
+-spec get_results(map(), kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary(), view_options()) ->
                          {'ok', kz_json:objects() | kz_json:path()} |
                          data_error().
 get_results(#{server := {App, Conn}}, DbName, DesignDoc, ViewOptions) ->

--- a/core/kazoo_fixturedb/doc/db-to-disk.md
+++ b/core/kazoo_fixturedb/doc/db-to-disk.md
@@ -1,0 +1,17 @@
+# How to take a database in KAZOO to disk for FixtureDB
+
+It is helpful to do testing in KAZOO when developing a feature or testing a fix. However, to put all that work into a repeatable test when it involves the database is challenging with FixtureDB when the dataset is large.
+
+This guide will show the steps to take an existing database and populate the FixtureDB filesystem with the appropriate files and view indexes.
+
+## Database to disk
+
+Let's say you need account db `9c2e035c8559b175e58146f6a31a3e67` to persist to FixtureDB. `kz_fixturedb_util:db_to_disk(<<"9c2e035c8559b175e58146f6a31a3e67">>).` will write all the JSON objects in the database to disk. If you want to be selective on which documents to persist, `kz_fixturedb_util:db_to_disk(<<"account%2F9c%2F2e%2F035c8559b175e58146f6a31a3e67">>, FilterFun).` will do the job. `FilterFun` is a function of arity-1 that takes the document as an argument and returns a `boolean()` for whether to persist the document.
+
+## View index to disk
+
+FixtureDb requires the view index of a query to be statically configured into a file. Accomplish this by passing the relevant options into the following function:
+
+   kz_fixturedb_util:view_index_to_disk(<<"account%2F9c%2F2e%2F035c8559b175e58146f6a31a3e67">>, <<"design/view">>, [include_docs]).
+
+This will create the appropriately named view index `design+view-{options_hash}.json` and populate it with the results.

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/docs/device00000000000000000000000002.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/docs/device00000000000000000000000002.json
@@ -214,7 +214,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000002",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "6facbc71a03d95f95560043e15d47a02",
+    "pvt_document_hash": "a6f3bfdb517c26d4cb11e9ca4c11d91d",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/docs/user0000000000000000000000000002.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/docs/user0000000000000000000000000002.json
@@ -221,7 +221,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000002",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "d156f2fbc4098e5db0a156a7471e598f",
+    "pvt_document_hash": "7713851c4b443be80a894ef49a34c2b2",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/14b279cdaef7d55cff7235ba2a5010e9.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/14b279cdaef7d55cff7235ba2a5010e9.json
@@ -81,6 +81,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63658530594,
+    "pvt_document_hash": "3144925c72896429a429bd1c5947bfe4",
     "pvt_is_authenticated": true,
     "pvt_modified": 63721599465,
     "pvt_request_id": "1613081d7962969b2e0096aee214f87f",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/239d0734328f7043629d425ce7d93a4d.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/239d0734328f7043629d425ce7d93a4d.json
@@ -76,6 +76,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63657326484,
+    "pvt_document_hash": "d3c3419ca15418de9332bf225c5ea5d6",
     "pvt_is_authenticated": true,
     "pvt_modified": 63721599464,
     "pvt_request_id": "078c2fa688aa6e653b603f4bc6550bc6",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/2fee5aa5a89193f63822d09019dca1d7.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/2fee5aa5a89193f63822d09019dca1d7.json
@@ -79,6 +79,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63735515296,
+    "pvt_document_hash": "8dd411f9f68ee696cc57ad7c318e5299",
     "pvt_is_authenticated": true,
     "pvt_modified": 63736044489,
     "pvt_request_id": "46ee3651702062f6d34ce14af426e755",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/7145b996f7ee0d40b314114a9869b7fe.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/7145b996f7ee0d40b314114a9869b7fe.json
@@ -84,6 +84,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63666931408,
+    "pvt_document_hash": "db0841c10e4ff51b92e9a893fcbf05a9",
     "pvt_is_authenticated": true,
     "pvt_modified": 63735963697,
     "pvt_request_id": "9ddf9842836ae240326e6d216cf06d5a",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/account0000000000000000000010722.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/account0000000000000000000010722.json
@@ -61,6 +61,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63656900535,
+    "pvt_document_hash": "c7aac5fe55d5d0b7319c2dcaf39e7340",
     "pvt_enabled": true,
     "pvt_is_authenticated": true,
     "pvt_modified": 63721959382,

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/e192d667e3abd732d802353b70c26248.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/e192d667e3abd732d802353b70c26248.json
@@ -76,6 +76,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63657326407,
+    "pvt_document_hash": "f26bd079ab8a4deb301a17e54c0eaab7",
     "pvt_is_authenticated": true,
     "pvt_modified": 63735017363,
     "pvt_request_id": "ba677b4f4ef2d73c61f356808f33c705",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/account0000000000000000000044944.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/account0000000000000000000044944.json
@@ -85,7 +85,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63636183145,
-    "pvt_document_hash": "90fdcd9fca247297fb90e2245a0050b7",
+    "pvt_document_hash": "e44323f5090c3bb50993e5ba4988be7e",
     "pvt_enabled": true,
     "pvt_is_authenticated": true,
     "pvt_modified": 63667898685,

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000004.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000004.json
@@ -102,7 +102,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "dde1168ca937cdc2eeabb42ceee4ed81",
+    "pvt_document_hash": "2340934daa534679bff0ea07d537d6f4",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000005.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000005.json
@@ -100,7 +100,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "dde1168ca937cdc2eeabb42ceee4ed81",
+    "pvt_document_hash": "81fa8f6c47855fae0f975da9abab94f8",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000006.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000006.json
@@ -89,7 +89,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "dde1168ca937cdc2eeabb42ceee4ed81",
+    "pvt_document_hash": "33b8ba0440b4143968137743b19aaed9",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/user0000000000000000000000000004.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/user0000000000000000000000000004.json
@@ -92,7 +92,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "78fc87e691bf352f7122301fe8d577e1",
+    "pvt_document_hash": "ef6dbc2c8104f5a4f235bf806badb197",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/user0000000000000000000000000005.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/user0000000000000000000000000005.json
@@ -91,7 +91,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "78fc87e691bf352f7122301fe8d577e1",
+    "pvt_document_hash": "20a92cb1677465cb84d552227f56885f",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/src/kz_fixturedb_util.erl
+++ b/core/kazoo_fixturedb/src/kz_fixturedb_util.erl
@@ -6,8 +6,7 @@
 -module(kz_fixturedb_util).
 
 %% Driver callbacks
--export([format_error/1
-        ]).
+-export([format_error/1]).
 
 %% API
 -export([open_json/2, doc_path/2
@@ -32,6 +31,9 @@
         ,update_pvt_doc_hash/0, update_pvt_doc_hash/1
 
         ,start_me/0, start_me/1, stop_me/1
+
+        ,db_to_disk/1, db_to_disk/2
+        ,view_index_to_disk/3
         ]).
 
 -include("kz_fixturedb.hrl").
@@ -45,10 +47,10 @@
 %% @end
 %%------------------------------------------------------------------------------
 -spec format_error(any()) -> any().
-format_error(timeout) -> timeout;
-format_error(conflict) -> conflict;
-format_error(not_found) -> not_found;
-format_error(db_not_found) -> db_not_found;
+format_error('timeout') -> 'timeout';
+format_error('conflict') -> 'conflict';
+format_error('not_found') -> 'not_found';
+format_error('db_not_found') -> 'db_not_found';
 format_error(Other) -> Other.
 
 %%%=============================================================================
@@ -63,7 +65,7 @@ format_error(Other) -> Other.
 open_json(Db, DocId) ->
     read_json(doc_path(Db, DocId)).
 
--spec open_attachment(db_map(), kz_term:ne_binary(), kz_term:ne_binary()) -> {ok, binary()} | {error, not_found}.
+-spec open_attachment(db_map(), kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', binary()} | {'error', 'not_found'}.
 open_attachment(Db, DocId, AName) ->
     read_file(att_path(Db, DocId, AName)).
 
@@ -115,7 +117,7 @@ update_doc(JObj) ->
 -spec update_revision(kz_json:object()) -> kz_json:object().
 update_revision(JObj) ->
     case kz_json:get_value(<<"_rev">>, JObj) of
-        undefined ->
+        'undefined' ->
             kz_doc:set_revision(JObj, <<"1-", (kz_binary:rand_hex(16))/binary>>);
         Rev ->
             [RevPos|_] = binary:split(Rev, <<"-">>),
@@ -133,28 +135,28 @@ update_revision(JObj) ->
 %%------------------------------------------------------------------------------
 -spec start_me() -> pid().
 start_me() ->
-    start_me(false).
+    start_me('false').
 
 -spec start_me(boolean()) -> pid().
 start_me(SilentLager) ->
     ?LOG_DEBUG(":: Starting up Kazoo FixtureDB"),
-    {ok, _} = application:ensure_all_started(kazoo_config),
-    {ok, Pid} = kazoo_data_link_sup:start_link(),
+    {'ok', _} = application:ensure_all_started('kazoo_config'),
+    {'ok', Pid} = kazoo_data_link_sup:start_link(),
     'ignore' = kazoo_data_bootstrap:start_link(),
 
     _ = case SilentLager of
-            true ->
-                _ = lager:set_loglevel(lager_console_backend, none),
-                _ = lager:set_loglevel(lager_file_backend, none),
-                lager:set_loglevel(lager_syslog_backend, none);
-            false -> ok
+            'true' ->
+                _ = lager:set_loglevel('lager_console_backend', 'none'),
+                _ = lager:set_loglevel('lager_file_backend', 'none'),
+                lager:set_loglevel('lager_syslog_backend', 'none');
+            'false' -> 'ok'
         end,
     Pid.
 
--spec stop_me(pid()) -> ok.
+-spec stop_me(pid()) -> 'ok'.
 stop_me(Pid) ->
-    _ = erlang:exit(Pid, normal),
-    _ = application:stop(kazoo_config),
+    _ = erlang:exit(Pid, 'normal'),
+    _ = application:stop('kazoo_config'),
     ?LOG_DEBUG(":: Stopped Kazoo FixtureDB").
 
 -spec get_doc_path(kz_term:ne_binary(), kz_term:ne_binary()) -> file:filename_all().
@@ -184,12 +186,12 @@ get_view_path(DbName, Design, Options) ->
 get_view_path(#{server := {_, Conn}}=_Plan, DbName, Design, Options) ->
     view_path(kz_fixturedb_server:get_db(Conn, DbName), Design, Options).
 
--spec add_att_to_index(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> {ok, binary()} | {error, any()}.
+-spec add_att_to_index(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', binary()} | {'error', any()}.
 add_att_to_index(DbName, DocId, AName) ->
     Plan = kz_fixturedb_server:get_dummy_plan(),
     add_att_to_index(Plan, DbName, DocId, AName).
 
--spec add_att_to_index(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> {ok, binary()} | {error, any()}.
+-spec add_att_to_index(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', binary()} | {'error', any()}.
 add_att_to_index(#{server := {_, Conn}}=_Plan, DbName, DocId, AName) ->
     #{server := #{url := Url}} = Db = kz_fixturedb_server:get_db(Conn, DbName),
     AttPath = att_path(Db, DocId, AName),
@@ -198,36 +200,36 @@ add_att_to_index(#{server := {_, Conn}}=_Plan, DbName, DocId, AName) ->
 
     IndexPath = index_file_path("attachment", Url, DbName),
     case write_index_file(IndexPath, Header, Row) of
-        {ok, _} -> maybe_symlink_att_file(AName, AttPath, Row);
-        {error, _}=Error -> Error
+        {'ok', _} -> maybe_symlink_att_file(AName, AttPath, Row);
+        {'error', _}=Error -> Error
     end.
 
--spec maybe_symlink_att_file(kz_term:ne_binary(), kz_term:ne_binary(), {ok, binary()} | {error, any()}) -> {ok, binary()} | {error, any()}.
-maybe_symlink_att_file(_, _, {error, _}=Error) -> Error;
+-spec maybe_symlink_att_file(kz_term:ne_binary(), kz_term:ne_binary(), {'ok', binary()} | {'error', any()}) -> {'ok', binary()} | {'error', any()}.
+maybe_symlink_att_file(_, _, {'error', _}=Error) -> Error;
 maybe_symlink_att_file(AName, AttPath, OK) ->
-    case filelib:is_regular(filename:join([code:priv_dir(kazoo_fixturedb), "media_files/", AName])) of
-        true ->
+    case filelib:is_regular(filename:join([code:priv_dir('kazoo_fixturedb'), "media_files/", AName])) of
+        'true' ->
             case file:make_symlink(<<"../../../media_files/", AName/binary>>, AttPath) of
-                ok ->
+                'ok' ->
                     ?DEV_LOG("created a sym-link for ~s to kazoo_fixturedb/priv/media_files/~s", [filename:basename(AttPath), AName]);
-                {error, enotsup} ->
+                {'error', 'enotsup'} ->
                     ?DEV_LOG("creating sym-link is not supported by your platform");
-                {error, _Reason} ->
+                {'error', _Reason} ->
                     ?DEV_LOG("Existing ~p~nAttPath ~p", [<<"../../../media_files/", AName/binary>>, AttPath]),
                     ?DEV_LOG("failed to create sym-link for attachment to kazoo_fixturedb/priv/media_files/~s: ~p", [AName, _Reason]),
                     ?DEV_LOG("you have to create the attachment manually.")
             end,
             OK;
-        false -> OK
+        'false' -> OK
     end.
 
 
--spec add_view_to_index(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> {ok, binary()} | {error, any()}.
+-spec add_view_to_index(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> {'ok', binary()} | {'error', any()}.
 add_view_to_index(DbName, Design, Options) ->
     Plan = kz_fixturedb_server:get_dummy_plan(),
     add_view_to_index(Plan, DbName, Design, Options).
 
--spec add_view_to_index(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> {ok, binary()} | {error, any()}.
+-spec add_view_to_index(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> {'ok', binary()} | {'error', any()}.
 add_view_to_index(#{server := {_, Conn}}=_Plan, DbName, Design, Options) ->
     #{server := #{url := Url}} = Db = kz_fixturedb_server:get_db(Conn, DbName),
     ViewPath = view_path(Db, Design, Options),
@@ -236,32 +238,32 @@ add_view_to_index(#{server := {_, Conn}}=_Plan, DbName, Design, Options) ->
 
     IndexPath = index_file_path("view", Url, DbName),
     case write_index_file(IndexPath, Header, Row) of
-        {ok, _}=OK -> OK;
-        {error, _}=Error -> Error
+        {'ok', _}=OK -> OK;
+        {'error', _}=Error -> Error
     end.
 
 -spec index_file_path(kz_term:text(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:text().
 index_file_path(Mode, Url, DbName) ->
     kz_term:to_list(Url) ++ "/" ++ kz_term:to_list(DbName) ++ "/" ++ Mode ++ "-index.csv".
 
--spec update_pvt_doc_hash() -> ok.
+-spec update_pvt_doc_hash() -> 'ok'.
 update_pvt_doc_hash() ->
-    Paths = filelib:wildcard(code:priv_dir(kazoo_fixturedb) ++ "/dbs/*/docs/*.json"),
+    Paths = filelib:wildcard(code:priv_dir('kazoo_fixturedb') ++ "/dbs/*/docs/*.json"),
     _ = [update_pvt_doc_hash(Path) || Path <- Paths],
-    ok.
+    'ok'.
 
--spec update_pvt_doc_hash(kz_term:text() | kz_term:ne_binary()) -> ok | {error, any()}.
+-spec update_pvt_doc_hash(kz_term:text() | kz_term:ne_binary()) -> 'ok' | {'error', any()}.
 update_pvt_doc_hash(Path) ->
     case read_json(Path) of
-        {ok, JObj} ->
+        {'ok', JObj} ->
             NewJObj = kz_doc:set_document_hash(JObj, kz_doc:calculate_document_hash(JObj)),
-            file:write_file(Path, kz_json:encode(NewJObj, [pretty]));
-        {error, _}=Error -> Error
+            file:write_file(Path, kz_json:encode(NewJObj, ['pretty']));
+        {'error', _}=Error -> Error
     end.
 
 -spec get_default_fixtures_db(kz_term:ne_binary()) -> db_map().
 get_default_fixtures_db(DbName) ->
-    {ok, Server} = kz_fixturedb_server:new_connection(#{}),
+    {'ok', Server} = kz_fixturedb_server:new_connection(#{}),
     kz_fixturedb_server:get_db(Server, DbName).
 
 %%%=============================================================================
@@ -272,28 +274,28 @@ get_default_fixtures_db(DbName) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec read_json(file:filename_all()) -> {ok, kz_json:object() | kz_json:objects()} | {error, not_found}.
+-spec read_json(file:filename_all()) -> {'ok', kz_json:object() | kz_json:objects()} | {'error', 'not_found'}.
 read_json(Path) ->
     case read_file(Path) of
-        {ok, Bin} -> {ok, kz_json:decode(Bin)};
-        {error, _} -> {error, not_found}
+        {'ok', Bin} -> {'ok', kz_json:decode(Bin)};
+        {'error', _} -> {'error', 'not_found'}
     end.
 
--spec read_file(file:filename_all()) -> {ok, binary()} | {error, not_found}.
+-spec read_file(file:filename_all()) -> {'ok', binary()} | {'error', 'not_found'}.
 read_file(Path) ->
     case file:read_file(Path) of
-        {ok, _}=OK -> OK;
-        {error, _} -> {error, not_found}
+        {'ok', _}=OK -> OK;
+        {'error', _} -> {'error', 'not_found'}
     end.
 
--spec write_index_file(file:filename_all(), kz_term:ne_binary(), kz_term:ne_binary() | {ok, binary()} | {error, any()}) ->
-                              {ok, binary()} | {error, any()}.
+-spec write_index_file(file:filename_all(), kz_term:ne_binary(), kz_term:ne_binary() | {'ok', binary()} | {'error', any()}) ->
+                              {'ok', binary()} | {'error', any()}.
 write_index_file(Path, Header, NewLine) when is_binary(NewLine) ->
     write_index_file(Path, NewLine, read_index_file(Path, Header, NewLine));
-write_index_file(_, _, {error, _}=Error) ->
+write_index_file(_, _, {'error', _}=Error) ->
     Error;
-write_index_file(Path, NewLine, {ok, IndexLines}) ->
-    [Header|Lines] = binary:split(IndexLines, <<"\n">>, [global]),
+write_index_file(Path, NewLine, {'ok', IndexLines}) ->
+    [Header|Lines] = binary:split(IndexLines, <<"\n">>, ['global']),
     ToWrite = [<<Header/binary, "\n">>
                    | [<<L/binary, "\n">>
                           || L <- lists:usort(Lines),
@@ -301,22 +303,22 @@ write_index_file(Path, NewLine, {ok, IndexLines}) ->
                      ]
               ],
     case file:write_file(Path, ToWrite) of
-        ok -> {ok, NewLine};
-        {error, _Reason}=Error ->
+        'ok' -> {'ok', NewLine};
+        {'error', _Reason}=Error ->
             ?DEV_LOG("failed to write index file ~s: ~p", [Path, _Reason]),
             Error
     end.
 
--spec read_index_file(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> {ok, binary()} | {error, any()}.
+-spec read_index_file(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', binary()} | {'error', any()}.
 read_index_file(Path, Header, NewLine) ->
     HSize = size(Header),
     case file:read_file(Path) of
-        {ok, <<>>} ->                              {ok, <<Header/binary  , "\n", NewLine/binary>>};
-        {ok, <<Header:HSize/binary, "\n">>=H} ->   {ok, <<H/binary       ,       NewLine/binary>>};
-        {ok, Header} ->                            {ok, <<Header/binary  , "\n", NewLine/binary>>};
-        {ok, IndexBin} ->                          {ok, <<IndexBin/binary, "\n", NewLine/binary>>};
-        {error, enoent} ->                         {ok, <<Header/binary  , "\n", NewLine/binary>>};
-        {error, _Reason}=Error ->
+        {'ok', <<>>} ->                              {'ok', <<Header/binary  , "\n", NewLine/binary>>};
+        {'ok', <<Header:HSize/binary, "\n">>=H} ->   {'ok', <<H/binary       ,       NewLine/binary>>};
+        {'ok', Header} ->                            {'ok', <<Header/binary  , "\n", NewLine/binary>>};
+        {'ok', IndexBin} ->                          {'ok', <<IndexBin/binary, "\n", NewLine/binary>>};
+        {'error', 'enoent'} ->                         {'ok', <<Header/binary  , "\n", NewLine/binary>>};
+        {'error', _Reason}=Error ->
             ?DEV_LOG("failed to open index file ~s: ~p", [Path, _Reason]),
             Error
     end.
@@ -327,12 +329,12 @@ encode_query_options(Design, [], _, []) ->
     kz_term:to_list(<<DesignView/binary, ".json">>);
 encode_query_options(Design, [], _, Acc) ->
     DesignView = design_view(Design),
-    QueryHash = kz_binary:hexencode(crypto:hash(md5, erlang:term_to_binary(Acc))),
+    QueryHash = kz_binary:hexencode(crypto:hash('md5', erlang:term_to_binary(Acc))),
 
     kz_term:to_list(<<DesignView/binary, "-", QueryHash/binary, ".json">>);
 encode_query_options(Design, [Key|Keys], Options, Acc) ->
-    case props:get_value(Key, Options, not_defined) of
-        not_defined -> encode_query_options(Design, Keys, Options, Acc);
+    case props:get_value(Key, Options, 'not_defined') of
+        'not_defined' -> encode_query_options(Design, Keys, Options, Acc);
         Value -> encode_query_options(Design, Keys, Options, ["&", Key, "=", Value | Acc])
     end.
 
@@ -342,3 +344,55 @@ design_view(Design) ->
         [DesignName] -> DesignName;
         [DesignName, ViewName|_] -> <<DesignName/binary, "+", ViewName/binary>>
     end.
+
+-spec db_to_disk(kz_term:ne_binary()) -> 'ok' | {'error', kz_datamgr:data_error()}.
+db_to_disk(Database) ->
+    db_to_disk(Database, fun kz_term:always_true/1).
+
+-type filter_fun() :: fun((kz_json:object()) -> boolean()).
+-spec db_to_disk(kz_term:ne_binary(), filter_fun()) -> 'ok' | {'error', kz_datamgr:data_error()}.
+db_to_disk(Database, FilterFun) ->
+    case kz_datamgr:db_exists(Database) of
+        'true' -> db_to_disk_persist(Database, FilterFun);
+        'false' -> {'error', 'not_found'}
+    end.
+
+db_to_disk_persist(Database, FilterFun) ->
+    db_to_disk_persist(Database, FilterFun, get_page(Database, 'undefined')).
+
+get_page(Database, 'undefined') ->
+    query(Database, []);
+get_page(Database, StartKey) ->
+    query(Database, [{'startkey', StartKey}]).
+
+query(Database, Options) ->
+    kz_datamgr:paginate_results(Database, 'all_docs', ['include_docs' | Options]).
+
+db_to_disk_persist(Database, FilterFun, {'ok', ViewResults, 'undefined'}) ->
+    _ = filter_and_persist(Database, FilterFun, ViewResults),
+    lager:info("finished persisting ~s", [Database]);
+db_to_disk_persist(Database, FilterFun, {'ok', ViewResults, NextStartKey}) ->
+    _ = filter_and_persist(Database, FilterFun, ViewResults),
+    db_to_disk_persist(Database, FilterFun, get_page(Database, NextStartKey)).
+
+filter_and_persist(Database, FilterFun, ViewResults) ->
+    _ = [persist(Database, Document) || ViewResult <- ViewResults,
+                                        Document <- [kz_json:get_json_value(<<"doc">>, ViewResult)],
+                                        FilterFun(Document)
+        ].
+
+persist(Database, Document) ->
+    Path = get_doc_path(Database, kz_doc:id(Document)),
+    'ok' = filelib:ensure_dir(Path),
+
+    lager:info("  persisting doc ~s to ~s", [kz_doc:id(Document), Path]),
+    'ok' = file:write_file(Database, kz_json:encode(Document, ['pretty'])).
+
+-spec view_index_to_disk(kz_term:ne_binary(), kz_term:ne_binary(), kz_datamgr:view_options()) -> 'ok'.
+view_index_to_disk(Database, ViewName, Options) ->
+    Path = get_view_path(Database, ViewName, Options),
+    'ok' = filelib:ensure_dir(Path),
+
+    {'ok', Results} = kz_datamgr:get_results(Database, ViewName, Options),
+    lager:info(" persisting view index ~s/~s to ~s", [Database, ViewName, Path]),
+    'ok' = file:write_file(Path, kz_json:encode(Results, ['pretty'])).

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -11,6 +11,7 @@
 -export([get_results/3]).
 -export([open_doc/2, open_doc/3, open_doc/4]).
 -export([save_doc/2, save_doc/3, save_doc/4]).
+-export([save_docs/2, save_docs/3]).
 -export([move_doc/4, move_doc/5]).
 -export([copy_doc/4, copy_doc/5]).
 -export([get_modb/1, get_modb/2, get_modb/3]).
@@ -234,6 +235,19 @@ couch_save(AccountMODb, Doc, Options, _Reason, Retry) ->
 -spec save_fun(boolean()) -> function().
 save_fun('false') -> fun kz_datamgr:save_doc/3;
 save_fun('true') -> fun kz_datamgr:ensure_saved/3.
+
+
+-spec save_docs(kz_term:text(), kz_json:objects()) ->
+                       {'ok', kz_json:objects()} |
+                       kz_datamgr:data_error().
+save_docs(AccountMODb, Docs) ->
+    save_docs(AccountMODb, Docs, []).
+
+-spec save_docs(kz_term:text(), kz_json:objects(), kz_term:proplist()) ->
+                       {'ok', kz_json:objects()} |
+                       kz_datamgr:data_error().
+save_docs(AccountMODb, Docs, Options) ->
+    kz_datamgr:save_docs(AccountMODb, Docs, Options).
 
 %%------------------------------------------------------------------------------
 %% @doc Move a document from source to destination with attachments,

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -274,15 +274,15 @@ big_dataset_seq() ->
                       ),
 
     AccountMODb = kz_util:format_account_id(AccountId, Year, Month),
-    kazoo_modb:save_docs(AccountMODb, CDRs, [{'publish_change_notice', 'false'}]),
+    {'ok', _} = kazoo_modb:save_docs(AccountMODb, CDRs, [{'publish_change_notice', 'false'}]),
 
-    kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 'null'),
+    _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 'null'),
     JSON = unpaginated_summary(API, AccountId),
     JObj = kz_json:decode(JSON),
     lager:info("unpaginated and unbound memory resp returned ~p CDRs", [length(kz_json:get_list_value(<<"data">>, JObj))]),
     CDRCount = length(kz_json:get_list_value(<<"data">>, JObj)),
 
-    kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 1024 * 1024 * 10), % cap at 10Mb
+    _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 1024 * 1024 * 10), % cap at 10Mb
     {'error', ErrorJSON} = unpaginated_summary(API, AccountId),
     ErrorJObj = kz_json:decode(ErrorJSON),
     416 = kz_json:get_integer_value(<<"error">>, ErrorJObj),
@@ -346,7 +346,7 @@ create_owner(AccountId) ->
 -spec cleanup() -> 'ok'.
 cleanup() ->
     _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
-    kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 'null'),
+    _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 'null'),
     cleanup_system().
 
 cleanup(API) ->

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -1,7 +1,7 @@
 -module(pqc_cb_cdrs).
 
 %% Manual testing
--export([seq/0
+-export([seq/0, big_dataset_seq/0
         ,cleanup/0
         ]).
 
@@ -88,11 +88,11 @@ collect_paginated_results(BaseURL, URL, RequestHeaders, Expectations, Collected)
 
 handle_paginated_results(BaseURL, RequestHeaders, Expectations, Collected, RespJObj) ->
     Data = kz_json:get_list_value(<<"data">>, RespJObj, []),
-    ?INFO("adding page: ~p~n", [Data]),
+    lager:info("adding page: ~p~n", [Data]),
     case kz_json:get_ne_binary_value(<<"next_start_key">>, RespJObj) of
         'undefined' -> Data ++ Collected;
         NextStartKey ->
-            ?INFO("collecting next page from ~s: ~s", [BaseURL, NextStartKey]),
+            lager:info("collecting next page from ~s: ~s", [BaseURL, NextStartKey]),
             collect_paginated_results(BaseURL
                                      ,BaseURL ++ [$& | start_key(NextStartKey)]
                                      ,update_request_id(RequestHeaders)
@@ -191,33 +191,33 @@ straight_seq() ->
     AccountId = create_account(API),
 
     EmptySummaryResp = summary(API, AccountId),
-    ?INFO("empty summary resp: ~s", [EmptySummaryResp]),
+    lager:info("empty summary resp: ~s", [EmptySummaryResp]),
     [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
 
     EmptyCSVResp = summary(API, AccountId, <<"text/csv">>),
-    ?INFO("empty CSV resp: ~s", [EmptyCSVResp]),
+    lager:info("empty CSV resp: ~s", [EmptyCSVResp]),
 
     CDRs = seed_cdrs(AccountId),
-    ?INFO("CDRs: ~p~n", [CDRs]),
+    lager:info("CDRs: ~p~n", [CDRs]),
 
     SummaryResp = summary(API, AccountId),
-    ?INFO("summary resp: ~s", [SummaryResp]),
+    lager:info("summary resp: ~s", [SummaryResp]),
     RespCDRs = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
-    ?INFO("Resp CDRs: ~p~n", [lists:usort([kz_doc:id(RespCDR) || RespCDR <- RespCDRs])]),
-    ?INFO("Base CDRs: ~p~n", [lists:usort([kz_doc:id(CDR) || CDR <- CDRs])]),
+    lager:info("Resp CDRs: ~p~n", [lists:usort([kz_doc:id(RespCDR) || RespCDR <- RespCDRs])]),
+    lager:info("Base CDRs: ~p~n", [lists:usort([kz_doc:id(CDR) || CDR <- CDRs])]),
     'true' = cdrs_exist(CDRs, RespCDRs),
-    ?INFO("all cdrs found in response"),
+    lager:info("all cdrs found in response"),
 
     CSVResp = summary(API, AccountId, <<"text/csv">>),
-    ?INFO("CSV resp: ~s", [CSVResp]),
+    lager:info("CSV resp: ~s", [CSVResp]),
 
     InteractionsResp = interactions(API, AccountId),
-    ?INFO("interactions resp: ~s", [InteractionsResp]),
+    lager:info("interactions resp: ~s", [InteractionsResp]),
 
     lists:foreach(fun(CDR) -> seq_cdr(API, AccountId, CDR) end, CDRs),
 
     cleanup(API),
-    ?INFO("FINISHED STRAIGHT SEQ").
+    lager:info("FINISHED STRAIGHT SEQ").
 
 paginated_seq() ->
     API = pqc_cb_api:init_api(['crossbar'], ['cb_cdrs']),
@@ -225,45 +225,45 @@ paginated_seq() ->
     OwnerId = create_owner(AccountId),
 
     EmptySummaryResp = paginated_summary(API, AccountId),
-    ?INFO("empty summary resp: ~p", [EmptySummaryResp]),
+    lager:info("empty summary resp: ~p", [EmptySummaryResp]),
     [] = EmptySummaryResp,
 
     CDRs = seed_cdrs(AccountId, OwnerId),
     CDRIds = lists:sort([kz_doc:id(I) || I <- CDRs]),
-    ?INFO("CDRs: ~p~n", [CDRIds]),
+    lager:info("CDRs: ~p~n", [CDRIds]),
 
     SummaryResp = paginated_summary(API, AccountId, OwnerId),
-    ?INFO("summary resp: ~p", [SummaryResp]),
+    lager:info("summary resp: ~p", [SummaryResp]),
 
     'true' = cdrs_exist(CDRs, SummaryResp),
-    ?INFO("all cdrs found in response"),
+    lager:info("all cdrs found in response"),
 
     InteractionsResp = paginated_interactions(API, AccountId, OwnerId),
     InteractionIds = lists:sort([kzd_cdrs:interaction_id(I) || I <- InteractionsResp]),
 
     CDRInteractionIDs = lists:usort([kzd_cdrs:interaction_id(CDR) || CDR <- CDRs]),
-    ?INFO("expected CDR interaction IDs: ~p", [CDRInteractionIDs]),
-    ?INFO("received interaction IDs: ~p", [InteractionIds]),
+    lager:info("expected CDR interaction IDs: ~p", [CDRInteractionIDs]),
+    lager:info("received interaction IDs: ~p", [InteractionIds]),
     case CDRInteractionIDs =:= InteractionIds of
         'true' -> 'ok';
         'false' ->
-            ?INFO("failed to fetch expected interaction IDs from API"),
-            ?INFO("missing from response: ~p", [CDRInteractionIDs -- InteractionIds]),
+            lager:info("failed to fetch expected interaction IDs from API"),
+            lager:info("missing from response: ~p", [CDRInteractionIDs -- InteractionIds]),
             throw({'error', 'interaction_ids', 'not_found'})
     end,
 
     cleanup(API),
-    ?INFO("FINISHED PAGINATED SEQ").
+    lager:info("FINISHED PAGINATED SEQ").
 
 -spec big_dataset_seq() -> 'ok'.
 big_dataset_seq() ->
-    ?INFO("creating large dataset and not paginating results"),
+    lager:info("creating large dataset and not paginating results"),
     API = pqc_cb_api:init_api(['crossbar'], ['cb_cdrs']),
     AccountId = create_account(API),
 
     {Year, Month, Day} = erlang:date(),
 
-    CDRCount = 5000,
+    CDRCount = 2600,
 
     CDRs = lists:foldl(fun(_, Acc) ->
                                InteractionId = interaction_id(Year, Month, Day),
@@ -284,29 +284,29 @@ big_dataset_seq() ->
 
     _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 1024 * 1024 * 10), % cap at 10Mb
     {'error', ErrorJSON} = unpaginated_summary(API, AccountId),
+    lager:info("unpaginated and bound memory resp: ~s", [ErrorJSON]),
     ErrorJObj = kz_json:decode(ErrorJSON),
     416 = kz_json:get_integer_value(<<"error">>, ErrorJObj),
     <<"range not satisfiable">> = kz_json:get_ne_binary_value(<<"message">>, ErrorJObj),
-    lager:info("unpaginated and bound memory resp: ~s", [ErrorJSON]),
 
     cleanup(API),
-    ?INFO("FINISHED BIG DATASET SEQ").
+    lager:info("FINISHED BIG DATASET SEQ").
 
 seq_cdr(API, AccountId, CDR) ->
     CDRId = kz_doc:id(CDR),
     InteractionId = kzd_cdrs:interaction_id(CDR),
 
     FetchResp = fetch(API, AccountId, CDRId),
-    ?INFO("~s: fetch resp ~s", [CDRId, FetchResp]),
+    lager:info("~s: fetch resp ~s", [CDRId, FetchResp]),
     'true' = cdr_exists(CDR, [kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp))]),
 
     %% Should be able to convert CDR ID to interaction_id
     LegsResp = legs(API, AccountId, CDRId),
-    ?INFO("~s: legs by id resp: ~s", [CDRId, LegsResp]),
+    lager:info("~s: legs by id resp: ~s", [CDRId, LegsResp]),
     'true' = cdr_exists(CDR, kz_json:get_list_value(<<"data">>, kz_json:decode(LegsResp))),
 
     InteractionResp = legs(API, AccountId, InteractionId),
-    ?INFO("~s: legs by interaction resp: ~s", [CDRId, InteractionResp]),
+    lager:info("~s: legs by interaction resp: ~s", [CDRId, InteractionResp]),
     'true' = cdr_exists(CDR, kz_json:get_list_value(<<"data">>, kz_json:decode(InteractionResp))).
 
 cdr_exists(CDR, RespCDRs) ->
@@ -316,11 +316,11 @@ cdr_exists(CDR, RespCDRs) ->
 cdrs_exist([], []) -> 'true';
 cdrs_exist([], APIs) ->
     IDs = [kz_doc:id(CDR) || CDR <- APIs],
-    ?INFO("  failed to find API results in CDRs: ~s", [kz_binary:join(IDs, <<", ">>)]),
+    lager:info("  failed to find API results in CDRs: ~s", [kz_binary:join(IDs, <<", ">>)]),
     'false';
 cdrs_exist(CDRs, []) ->
     IDs = [kz_doc:id(CDR) || CDR <- CDRs],
-    ?INFO("  failed to find CDR(s) in API response: ~s", [kz_binary:join(IDs, <<", ">>)]),
+    lager:info("  failed to find CDR(s) in API response: ~s", [kz_binary:join(IDs, <<", ">>)]),
     'false';
 cdrs_exist([_|_]=CDRs, [API|APIs]) ->
     lager:debug("filtering out ~s", [kz_doc:id(API)]),
@@ -330,7 +330,7 @@ cdrs_exist([_|_]=CDRs, [API|APIs]) ->
 
 create_account(API) ->
     AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
-    ?INFO("created account: ~s", [AccountResp]),
+    lager:info("created account: ~s", [AccountResp]),
 
     kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
 
@@ -340,7 +340,7 @@ create_owner(AccountId) ->
     OwnerId = kz_binary:rand_hex(16),
     Owner = kz_json:set_value(<<"_id">>, OwnerId, kzd_users:new()),
     {'ok', _Saved}= kz_datamgr:save_doc(AccountDb, Owner),
-    ?INFO("saved owner to ~s: ~p", [AccountDb, _Saved]),
+    lager:info("saved owner to ~s: ~p", [AccountDb, _Saved]),
     OwnerId.
 
 -spec cleanup() -> 'ok'.
@@ -350,7 +350,7 @@ cleanup() ->
     cleanup_system().
 
 cleanup(API) ->
-    ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
     _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
     _ = pqc_cb_api:cleanup(API),
     cleanup_system().

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -397,7 +397,7 @@ seed_cdr(AccountId, OwnerId, Year, Month, InteractionId) ->
                     ),
 
     AccountMODb = kz_util:format_account_id(AccountId, InteractionTime),
-    kazoo_modb:save_doc(AccountMODb, CDR).
+    kazoo_modb:save_doc(AccountMODb, CDR, ['allow_old_modb_creation']).
 
 create_cdr(AccountId, OwnerId, Year, Month, InteractionId) ->
     [ITime, InteractionKey] = binary:split(InteractionId, <<"-">>),

--- a/core/kazoo_proper/src/pqc_cb_rates.erl
+++ b/core/kazoo_proper/src/pqc_cb_rates.erl
@@ -79,6 +79,7 @@ upload_csv(API, CSV, _RatedeckId) ->
                                  'ok' | {'error', any()}.
 create_service_plan(API, RatedeckId) ->
     RatesResp = get_rates(API, RatedeckId),
+    ?INFO("rate resp: ~s~n", [RatesResp]),
     case kz_json:get_list_value(<<"data">>, kz_json:decode(RatesResp), []) of
         [] ->
             ?INFO("no rates in ratedeck ~s, not creating service plan", [RatedeckId]),
@@ -151,7 +152,7 @@ wait_for_task(API, TaskId) ->
 
 get_csvs(_API, _TaskId, []) -> 'ok';
 get_csvs(API, TaskId, [CSV|CSVs]) ->
-    get_csv(API, TaskId, CSV),
+    _ = get_csv(API, TaskId, CSV),
     get_csvs(API, TaskId, CSVs).
 
 get_csv(API, TaskId, CSV) ->
@@ -338,6 +339,7 @@ seq() ->
     ?INFO("uploaded task: ~s~n", [TaskId]),
 
     GetResp = ?MODULE:get_rate(API, RateDoc),
+    ?INFO("get rate: ~s", [GetResp]),
     GetJObj = kz_json:decode(GetResp),
     RateJObj = kz_json:get_json_value(<<"data">>, GetJObj),
     ?INFO("get rate: ~p~n", [RateJObj]),

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -451,6 +451,7 @@ pages:
       - 'core/kazoo_perf/doc/maintenance.md'
   - 'Kazoo Test FixtureDB':
       - 'core/kazoo_fixturedb/doc/README.md'
+      - 'Persist Database to disk': 'core/kazoo_fixturedb/doc/db-to-disk.md'
 - 'Articles':
   - 'Introduction to Storage Plans - S3': 'doc/blog/storage.md'
   - 'Bypass Media Mode': 'doc/blog/bypass_media.md'


### PR DESCRIPTION
When fetching large datasets with pagination turned off, it is
possible to tank the system when the dataset causes memory pressure
during loading.

This change adds an optional system config parameter for determining
the maximum memory allowed for the Erlang process handling the API
request.

Additionally, even requests with `pagination=false` (or /v1) will
still be loaded on a per-page basis. Each page load will check the
memory consumption and error with an HTTP 416 response if memory usage
exceeds the configured maximum.

Until the maximum is reached, however, the pages will continue to be
fetched until exhausted as before.

FixtureDB has an added utility to make mirroring an existing CouchDB
database to the FixtureDB fixtures directory for easier conversion of
testing data.