### PR TITLE
Remove ecallmgr cache object when TTS media expires

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -1441,7 +1441,7 @@ lookup_media(MediaName, Type, CallId, JObj) ->
 -spec remove_media(kz_term:ne_binary()) -> 'ok'.
 remove_media(MediaName) ->
     kz_cache:erase_local(?ECALLMGR_UTIL_CACHE
-                         ,?ECALLMGR_PLAYBACK_MEDIA_KEY(MediaName)
+                        ,?ECALLMGR_PLAYBACK_MEDIA_KEY(MediaName)
                         ).
 
 -spec request_media_url(kz_term:ne_binary(), media_types(), kz_term:ne_binary(), kz_json:object()) ->

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -38,6 +38,7 @@
 -export([media_path/1, media_path/2, media_path/3, media_path/4
         ,lookup_media/4
         ]).
+-export([remove_media/1]).
 -export([unserialize_fs_array/1, unserialize_fs_props/1]).
 -export([convert_fs_evt_name/1, convert_kazoo_app_name/1]).
 -export([fax_filename/1
@@ -1437,6 +1438,11 @@ lookup_media(MediaName, Type, CallId, JObj) ->
         {'error', 'not_found'} ->
             request_media_url(MediaName, Type, CallId, JObj)
     end.
+-spec remove_media(kz_term:ne_binary()) -> 'ok'.
+remove_media(MediaName) ->
+    kz_cache:erase_local(?ECALLMGR_UTIL_CACHE
+                         ,?ECALLMGR_PLAYBACK_MEDIA_KEY(MediaName)
+                        ).
 
 -spec request_media_url(kz_term:ne_binary(), media_types(), kz_term:ne_binary(), kz_json:object()) ->
                                {'ok', kz_term:ne_binary()} |

--- a/core/kazoo_media/src/kz_media_tts_cache.erl
+++ b/core/kazoo_media/src/kz_media_tts_cache.erl
@@ -274,6 +274,7 @@ log_error(_Error, _Contents) ->
 %%------------------------------------------------------------------------------
 -spec terminate(any(), state()) -> 'ok'.
 terminate(_Reason, #state{id=Id, reqs=Reqs}) ->
+    'ok' = ecallmgr_util:remove_media(<<"tts://", Id/bytes>>),
     publish_doc_update(Id),
     _ = [gen_server:reply(From, {'error', 'shutdown'}) || From <- Reqs],
     lager:debug("media tts ~s going down: ~p", [Id, _Reason]).


### PR DESCRIPTION
When a TTS media object expires, we should remove the cached object from ecallmgr's cache.