### PR TITLE
PISTON-970: do not need to call kz_amqp_channel:release

### DIFF
--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -802,7 +802,6 @@ terminate(Reason, #state{module=Module
                         }) ->
     _ = (catch(lists:foreach(fun kz_amqp_util:basic_cancel/1, Tags))),
     _Terminated = (catch Module:terminate(Reason, ModuleState)),
-    _ = (catch kz_amqp_channel:release()),
     _ = [listener_federator:stop(F) || {_Broker, F} <- Fs],
     lager:debug("~s terminated (~p): ~p", [Module, Reason, _Terminated]).
 


### PR DESCRIPTION
- amqp_channel.erl in amqp_client will already deal with DOWN consumers and unregister handlers

There is a problem that occurs at scale when shutting down a supervisor tree containing very large numbers of gen_listener-behaviour children with non-infinity timeouts. In `gen_listener:terminate`, the call to `kz_amqp_channel:release` which eventually calls `kz_amqp_assignments:release` is a blocking `gen_server:call`. When the message queue to `kz_amqp_assignments` is extremely backed up because of the large number of children shutting down simultaneously, this blocking `gen_server:call` may cause the termination of the gen_listener-behaviour child to exceed the shutdown timeout given by its supervisor. The result of this is that the children are killed by the supervisor, triggering the `{'DOWN', _, process, ReturnHandler/ConfirmHandler/FlowHandler, _}` clauses of `amqp_channel:handle_info`, which release the same handlers as the `kz_amqp_assignments` releases would. Eventually, the message queue begins to catch up in `kz_amqp_assignments`, and the handlers are attempted to be released again. There is no clause in `amqp_channel:handle_info` for this, and the result is `Connection (<0.216.0>) closing: internal error in channel (<0.6745.5>)`. `kz_amqp_connection` responds to this by closing the AMQP connection to the broker.

The proposal of this very minor change is to remove the explicit `kz_amqp_channel:release` from `gen_listener:terminate`. `amqp_channel.erl` is already handling this itself, both silently in the case of a graceful shutdown of its bound handlers and verbosely otherwise. So there's really no need as I see it to do so in `gen_listener:terminate`.

I can also remove the (then) unused `kz_amqp_channel:release` and `kz_amqp_assignments:release` if desired.

To simulate this issue without needing to back up the `kz_amqp_assignments` message queue, you can pick some supervisor tree containing `gen_listener` modules to shutdown and add:
```
-spec bottlenecked_release(pid()) -> 'ok'.
bottlenecked_release(Consumer) ->
    gen_server:call(?SERVER, {'bottlenecked_release_handlers', Consumer}, 'infinity').
```
and (set the timer sleep timeout to something greater that the timeout of the worker modules in your supervisor tree)
```
handle_call({'bottlenecked_release_handlers', Consumer}, From, State) ->
    timer:sleep(6000),
    handle_call({'release_handlers', Consumer}, From, State);
```
to `kz_amqp_assignments`. Call `kz_amqp_assignments:bottlenecked_release(kz_amqp_channel:consumer_pid())` instead of `kz_amqp_channel:release()` in `gen_listener:terminate`. Shut down the supervisor tree.