### PR TITLE
Protect system when pagination is disabled

### DIFF
--- a/applications/crossbar/doc/basics.md
+++ b/applications/crossbar/doc/basics.md
@@ -191,7 +191,7 @@ The pagination response keys are `next_start_key`, `page_size`, and `start_key`.
 
 Assuming no changes are made to the underlying documents, `start_key` will get you this page of results, and `next_start_key` will give you a pointer to the next page (imagine a linked-list).
 
-#### Encoded Start Keys (Kazoo 4.2+ Only)
+### Encoded Start Keys (Kazoo 4.2+ Only)
 
 As you can see from the response above, both the `start_key` and `next_start_key` are encoded as URL-safe Base64 strings of their Erlang term representation. A couple character substitutions (`_` for `/` and `_` for `+`) and one character removal (`=`) ensures a string that plays nice in URLs.
 
@@ -248,6 +248,12 @@ By default, Crossbar returns the results in descending order. To get results in 
 ### Disabling Pagination
 
 If you want to disable pagination for a request, simply include `paginate=false` on the query string.
+
+#### Protecting from (un)intentional abuse
+
+Since pagination can be turned off by a client-supplied query string parameter, it is important that KAZOO still protect itself from overly large datasets being loaded. Examples seen include large CDR listings, call recording listings, and ledger listings.
+
+Therefore, during a non-paginated request, KAZOO monitors memory consumption of the handling server process and will abort the request if the processing is exceeding a high watermark setting (configured by the system operator). The client can expect to receive an HTTP "416 Range Not Satisfiable" error as a result of exceeding the limit.
 
 ## Chunked Response
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -30513,6 +30513,10 @@
                     },
                     "type": "array"
                 },
+                "request_memory_limit": {
+                    "description": "Limit the amount of memory an API request can consume (in bytes)",
+                    "type": "integer"
+                },
                 "request_timeout_ms": {
                     "default": 10000,
                     "description": "crossbar request timeout in milliseconds",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.json
@@ -126,6 +126,10 @@
             },
             "type": "array"
         },
+        "request_memory_limit": {
+            "description": "Limit the amount of memory an API request can consume (in bytes)",
+            "type": "integer"
+        },
         "request_timeout_ms": {
             "default": 10000,
             "description": "crossbar request timeout in milliseconds",

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -9670,6 +9670,9 @@
       'items':
         'type': string
       'type': array
+    'request_memory_limit':
+      'description': Limit the amount of memory an API request can consume (in bytes)
+      'type': integer
     'request_timeout_ms':
       'default': 10000
       'description': crossbar request timeout in milliseconds

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -440,7 +440,7 @@ should_paginate(#cb_context{should_paginate='undefined'}=Context) ->
     case req_value(Context, <<"paginate">>) of
         'undefined' -> 'true';
         ShouldPaginate ->
-            lager:debug("request has paginate flag: ~s", [ShouldPaginate]),
+            lager:debug("request has paginate flag = '~s'", [ShouldPaginate]),
             kz_term:is_true(ShouldPaginate)
     end;
 should_paginate(#cb_context{should_paginate=Should}) -> Should.
@@ -449,12 +449,11 @@ should_paginate(#cb_context{should_paginate=Should}) -> Should.
 pagination_page_size() ->
     ?PAGINATION_PAGE_SIZE.
 
--spec pagination_page_size(context()) -> kz_term:api_pos_integer().
+-spec pagination_page_size(context()) -> pos_integer().
 pagination_page_size(Context) ->
     pagination_page_size(Context, api_version(Context)).
 
--spec pagination_page_size(context(), kz_term:ne_binary()) -> kz_term:api_pos_integer().
-pagination_page_size(_Context, ?VERSION_1) -> 'undefined';
+-spec pagination_page_size(context(), kz_term:ne_binary()) -> pos_integer().
 pagination_page_size(Context, _Version) ->
     case req_value(Context, <<"page_size">>) of
         'undefined' -> pagination_page_size();

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -507,7 +507,7 @@ setters(#cb_context{}=Context, [_|_]=Setters) ->
     lists:foldl(fun setters_fold/2, Context, Setters).
 
 -spec setters_fold(setter_kv(), context() | kz_json:object()) ->
-                          context() | kz_json:object().
+          context() | kz_json:object().
 setters_fold({F, V}, C) -> F(C, V);
 setters_fold({F, K, V}, C) -> F(C, K, V);
 setters_fold(F, C) when is_function(F, 1) -> F(C).
@@ -778,12 +778,12 @@ update_doc(#cb_context{doc=Doc}=Context, Updater) ->
 %% % Helpers
 
 -spec add_content_types_provided(context(), crossbar_content_handlers()) ->
-                                        context().
+          context().
 add_content_types_provided(#cb_context{content_types_provided=CTPs}=Context, NewCTPs) when is_list(NewCTPs) ->
     Context#cb_context{content_types_provided = NewCTPs ++ CTPs}.
 
 -spec add_content_types_accepted(context(), crossbar_content_handler() | crossbar_content_handlers()) ->
-                                        context().
+          context().
 add_content_types_accepted(#cb_context{content_types_accepted=CTAs}=Context, [_|_]=NewCTAs) ->
     Context#cb_context{content_types_accepted = NewCTAs ++ CTAs};
 add_content_types_accepted(#cb_context{}=Context, NewCTA) ->
@@ -860,7 +860,7 @@ import_errors(#cb_context{}=Context) ->
     end.
 
 -spec response(context()) -> {'ok', kz_json:object()} |
-                             {'error', {pos_integer(), kz_term:ne_binary(), kz_json:object()}}.
+          {'error', {pos_integer(), kz_term:ne_binary(), kz_json:object()}}.
 response(#cb_context{resp_status='success'
                     ,resp_data=JObj
                     }) ->
@@ -892,23 +892,23 @@ response(#cb_context{resp_error_code=Code
 %% @end
 %%------------------------------------------------------------------------------
 -spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context()) ->
-                                   context().
+          context().
 validate_request_data(SchemaId, Context) ->
     validate_request_data(SchemaId, Context, 'undefined').
 
 -spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context(), after_fun()) ->
-                                   context().
+          context().
 validate_request_data(SchemaId, Context, OnSuccess) ->
     validate_request_data(SchemaId, Context, OnSuccess, 'undefined').
 
 -spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context(), after_fun(), after_fun()) ->
-                                   context().
+          context().
 validate_request_data(SchemaId, Context, OnSuccess, OnFailure) ->
     SchemaRequired = fetch(Context, 'ensure_valid_schema', ?SHOULD_ENSURE_SCHEMA_IS_VALID),
     validate_request_data(SchemaId, Context, OnSuccess, OnFailure, SchemaRequired).
 
 -spec validate_request_data(kz_term:ne_binary() | kz_term:api_object(), context(), after_fun(), after_fun(), boolean()) ->
-                                   context().
+          context().
 validate_request_data('undefined', Context, OnSuccess, _OnFailure, 'false') ->
     lager:error("schema id or schema JSON not defined, continuing anyway"),
     validate_passed(Context, OnSuccess);
@@ -1129,7 +1129,7 @@ build_system_error(Code, Error, JObj, Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec add_validation_error(kz_json:get_key(), kz_term:ne_binary(), kz_term:ne_binary() | kz_json:object(), context()) ->
-                                  context().
+          context().
 add_validation_error(<<_/binary>> = Property, Code, Message, Context) ->
     add_validation_error([Property], Code, Message, Context);
 add_validation_error(Property, Code, <<_/binary>> = Message, Context) ->

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -97,7 +97,7 @@ current_doc_vsn() -> ?CROSSBAR_DOC_VSN.
 %% equiv load(DocId, Context, [])
 
 -spec load(kazoo_data:docid() | kazoo_data:docids(), cb_context:context()) ->
-                  cb_context:context().
+          cb_context:context().
 load({DocType, DocId}, Context) ->
     load(DocId, Context, [{'doc_type', DocType}]);
 load(DocId, Context) ->
@@ -113,14 +113,14 @@ load(DocId, Context) ->
 %%------------------------------------------------------------------------------
 
 -spec load(kazoo_data:docid() | kazoo_data:docids(), cb_context:context(), load_options()) ->
-                  cb_context:context().
+          cb_context:context().
 load({DocType, DocId}, Context, Options) ->
     load(DocId, Context, [{'doc_type', DocType} | Options]);
 load(DocId, Context, Options) ->
     load(DocId, Context, Options, cb_context:resp_status(Context)).
 
 -spec load(kz_term:ne_binary() | kz_term:ne_binaries(), cb_context:context(), load_options(), crossbar_status()) ->
-                  cb_context:context().
+          cb_context:context().
 load(_DocId, Context, _Options, 'error') -> Context;
 load(DocId, Context, Options, _RespStatus) when is_binary(DocId) ->
     case maybe_open_cache_doc(cb_context:account_db(Context), DocId, Options) of
@@ -152,8 +152,8 @@ load([_|_]=IDs, Context, Options, _RespStatus) ->
     end.
 
 -spec maybe_open_cache_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_term:proplist()) ->
-                                  {'ok', kz_json:object()} |
-                                  kz_datamgr:data_error().
+          {'ok', kz_json:object()} |
+          kz_datamgr:data_error().
 maybe_open_cache_doc(DbName, DocId, Options) ->
     case props:get_is_true('use_cache', Options, 'true') of
         'true' -> kz_datamgr:open_cache_doc(DbName, DocId, Options);
@@ -161,8 +161,8 @@ maybe_open_cache_doc(DbName, DocId, Options) ->
     end.
 
 -spec maybe_open_cache_docs(kz_term:ne_binary(), kazoo_data:docids(), kz_term:proplist()) ->
-                                   {'ok', kz_json:objects()} |
-                                   kz_datamgr:data_error().
+          {'ok', kz_json:objects()} |
+          kz_datamgr:data_error().
 maybe_open_cache_docs(DbName, DocIds, Options) ->
     case props:get_is_true('use_cache', Options, 'true') of
         'true' -> kz_datamgr:open_cache_docs(DbName, DocIds, Options);
@@ -180,7 +180,7 @@ maybe_open_cache_docs(DbName, DocIds, Options) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec check_document_type(cb_context:context(), kz_json:object() | kz_json:objects(), kz_term:proplist()) ->
-                                 boolean().
+          boolean().
 check_document_type(_Context, [], _Options) -> 'true';
 check_document_type(Context, [_|_]=JObjs, Options) ->
     F = fun(JObj) -> check_document_type(Context, JObj, Options) end,
@@ -268,12 +268,12 @@ load_merge(DocId, Context, Options) ->
 %%------------------------------------------------------------------------------
 
 -spec load_merge(kz_term:ne_binary(), kz_json:object(), cb_context:context(), kz_term:proplist()) ->
-                        cb_context:context().
+          cb_context:context().
 load_merge(DocId, DataJObj, Context, Options) ->
     load_merge(DocId, DataJObj, Context, Options, cb_context:load_merge_bypass(Context)).
 
 -spec load_merge(kz_term:ne_binary(), kz_json:object(), cb_context:context(), kz_term:proplist(), kz_term:api_object()) ->
-                        cb_context:context().
+          cb_context:context().
 load_merge(DocId, DataJObj, Context, Options, 'undefined') ->
     Context1 = load(DocId, Context, Options),
     case 'success' =:= cb_context:resp_status(Context1) of
@@ -289,18 +289,18 @@ load_merge(_DocId, _DataJObj, Context, _Options, BypassJObj) ->
 -type validate_fun() :: fun((kz_term:ne_binary(), cb_context:context()) -> cb_context:context()).
 
 -spec patch_and_validate(kz_term:ne_binary(), cb_context:context(), validate_fun()) ->
-                                cb_context:context().
+          cb_context:context().
 patch_and_validate(Id, Context, ValidateFun) ->
     patch_and_validate(Id, Context, ValidateFun, ?TYPE_CHECK_OPTION_ANY).
 
 -spec patch_and_validate(kz_term:ne_binary(), cb_context:context(), validate_fun(), load_options()) ->
-                                cb_context:context().
+          cb_context:context().
 patch_and_validate(Id, Context, ValidateFun, LoadOptions) ->
     Context1 = load(Id, Context, LoadOptions),
     patch_and_validate_doc(Id, Context1, ValidateFun, cb_context:resp_status(Context1)).
 
 -spec patch_and_validate_doc(kz_term:ne_binary(), cb_context:context(), validate_fun(), crossbar_status()) ->
-                                    cb_context:context().
+          cb_context:context().
 patch_and_validate_doc(Id, Context, ValidateFun, 'success') ->
     PatchedJObj = patch_the_doc(cb_context:req_data(Context), cb_context:doc(Context)),
     Context1 = cb_context:set_req_data(Context, PatchedJObj),
@@ -314,7 +314,7 @@ patch_the_doc(RequestData, ExistingDoc) ->
     kz_json:merge(fun kz_json:merge_left/2, PubJObj, ExistingDoc).
 
 -spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context()) ->
-                       cb_context:context().
+          cb_context:context().
 load_view(View, Options, Context) ->
     load_view(View, Options, Context
              ,start_key(Options, Context)
@@ -323,7 +323,7 @@ load_view(View, Options, Context) ->
              ).
 
 -spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context(), kz_json:json_term() | filter_fun()) ->
-                       cb_context:context().
+          cb_context:context().
 load_view(View, Options, Context, FilterFun)
   when is_function(FilterFun, 2);
        is_function(FilterFun, 3) ->
@@ -339,7 +339,7 @@ load_view(View, Options, Context, StartKey) ->
 %% @equiv load_view(View, Options, Context, StartKey, PageSize, 'undefined')
 
 -spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context(), kz_json:json_term(), pos_integer()) ->
-                       cb_context:context().
+          cb_context:context().
 load_view(View, Options, Context, StartKey, PageSize) ->
     load_view(View, Options, Context, StartKey, PageSize, 'undefined').
 
@@ -352,7 +352,7 @@ load_view(View, Options, Context, StartKey, PageSize) ->
 %%------------------------------------------------------------------------------
 
 -spec load_view(kz_term:ne_binary() | 'all_docs', kz_term:proplist(), cb_context:context(), kz_json:json_term(), pos_integer(), filter_fun()) ->
-                       cb_context:context().
+          cb_context:context().
 load_view(View, Options, Context, StartKey, PageSize, FilterFun) ->
     load_view(
       #load_view_params{view = View
@@ -518,7 +518,7 @@ load_docs(Context, Filter)
 %% @end
 %%------------------------------------------------------------------------------
 -spec load_attachment({kz_term:ne_binary(), kz_term:ne_binary()} | kazoo_data:docid() | kz_json:object(), kz_term:ne_binary(), kz_term:proplist(), cb_context:context()) ->
-                             cb_context:context().
+          cb_context:context().
 load_attachment({DocType, DocId}, AName, Options, Context) ->
     load_attachment(DocId, AName, [{'doc_type', DocType} | Options], Context);
 load_attachment(<<_/binary>>=DocId, AName, Options, Context) ->
@@ -564,7 +564,7 @@ save(Context, Options) ->
 %%------------------------------------------------------------------------------
 
 -spec save(cb_context:context(), kz_json:object() | kz_json:objects(), kz_term:proplist()) ->
-                  cb_context:context().
+          cb_context:context().
 save(Context, [], _Options) ->
     lager:debug("no docs to save"),
     cb_context:set_resp_status(Context, 'success');
@@ -582,7 +582,7 @@ save(Context, JObj, Options) ->
     end.
 
 -spec save_jobjs(cb_context:context(), kz_json:object() | kz_json:objects(), kz_term:proplist()) ->
-                        cb_context:context().
+          cb_context:context().
 save_jobjs(Context, JObjs0, Options) ->
     case kz_datamgr:save_docs(cb_context:account_db(Context), JObjs0, Options) of
         {'error', Error} ->
@@ -619,7 +619,7 @@ maybe_spawn_service_updates(Context, JObjs, 'true') ->
     'ok'.
 
 -spec save_jobj(cb_context:context(), kz_json:object() | kz_json:objects(), kz_term:proplist()) ->
-                       cb_context:context().
+          cb_context:context().
 save_jobj(Context, JObj0, Options) ->
     case kz_datamgr:save_doc(cb_context:account_db(Context), JObj0, Options) of
         {'error', Error} ->
@@ -633,12 +633,12 @@ save_jobj(Context, JObj0, Options) ->
     end.
 
 -spec update(cb_context:context(), kz_json:key(), kz_json:flat_proplist()) ->
-                    cb_context:context().
+          cb_context:context().
 update(Context, DocId, Updates) ->
     update(Context, DocId, Updates, []).
 
 -spec update(cb_context:context(), kz_json:key(), kz_json:flat_proplist(), kz_json:flat_proplist()) ->
-                    cb_context:context().
+          cb_context:context().
 update(Context, DocId, Updates, Creates) ->
     UpdateOptions = [{'update', Updates}
                     ,{'create', Creates}
@@ -664,7 +664,7 @@ save_attachment(DocId, AName, Contents, Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec save_attachment(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), cb_context:context(), kz_term:proplist()) ->
-                             cb_context:context().
+          cb_context:context().
 save_attachment(DocId, Name, Contents, Context, Options) ->
     Opts1 = case props:get_value('rev', Options) of
                 'undefined' ->
@@ -718,8 +718,8 @@ handle_saved_attachment(Context, DocId) ->
     load(DocId, Context).
 
 -spec maybe_delete_doc(cb_context:context(), kz_term:ne_binary()) ->
-                              {'ok', _} |
-                              {'error', any()}.
+          {'ok', _} |
+          {'error', any()}.
 maybe_delete_doc(Context, DocId) ->
     AccountDb = cb_context:account_db(Context),
     case kz_datamgr:open_doc(AccountDb, DocId) of
@@ -775,7 +775,7 @@ soft_delete(Context, Rev) ->
                                  kz_datamgr:data_error()).
 
 -spec do_delete(cb_context:context(), kz_json:object(), delete_fun()) ->
-                       cb_context:context().
+          cb_context:context().
 do_delete(Context, JObj, CouchFun) ->
     case CouchFun(cb_context:account_db(Context), JObj) of
         {'error', 'not_found'} ->
@@ -808,7 +808,7 @@ do_delete(Context, JObj, CouchFun) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec delete_attachment(kz_term:ne_binary(), kz_term:ne_binary(), cb_context:context()) ->
-                               cb_context:context().
+          cb_context:context().
 delete_attachment(DocId, AName, Context) ->
     case kz_datamgr:delete_attachment(cb_context:account_db(Context), DocId, AName) of
         {'error', 'not_found'} -> handle_datamgr_success(kz_json:new(), Context);
@@ -828,7 +828,7 @@ delete_attachment(DocId, AName, Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec rev_to_etag(kz_json:object() | kz_json:objects() | kz_term:ne_binary()) ->
-                         'automatic' | kz_term:api_string().
+          'automatic' | kz_term:api_string().
 rev_to_etag([_|_])-> 'automatic';
 rev_to_etag([]) -> 'undefined';
 rev_to_etag(Rev) when is_binary(Rev) -> kz_term:to_list(Rev);
@@ -843,7 +843,7 @@ rev_to_etag(JObj) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec update_pagination_envelope_params(cb_context:context(), any(), kz_term:api_non_neg_integer()) ->
-                                               cb_context:context().
+          cb_context:context().
 update_pagination_envelope_params(Context, StartKey, PageSize) ->
     update_pagination_envelope_params(Context
                                      ,StartKey
@@ -853,7 +853,7 @@ update_pagination_envelope_params(Context, StartKey, PageSize) ->
                                      ).
 
 -spec update_pagination_envelope_params(cb_context:context(), any(), kz_term:api_non_neg_integer(), kz_term:api_binary()) ->
-                                               cb_context:context().
+          cb_context:context().
 update_pagination_envelope_params(Context, StartKey, PageSize, NextStartKey) ->
     update_pagination_envelope_params(Context
                                      ,StartKey
@@ -863,7 +863,7 @@ update_pagination_envelope_params(Context, StartKey, PageSize, NextStartKey) ->
                                      ).
 
 -spec update_pagination_envelope_params(cb_context:context(), any(), kz_term:api_non_neg_integer(), kz_term:api_binary(), boolean()) ->
-                                               cb_context:context().
+          cb_context:context().
 update_pagination_envelope_params(Context, _StartKey, _PageSize, _NextStartKey, 'false') ->
     lager:debug("pagination disabled, removing resp envelope keys"),
     RespEnvelope = kz_json:delete_keys([<<"start_key">>
@@ -887,7 +887,7 @@ update_pagination_envelope_params(Context, StartKey, PageSize, NextStartKey, 'tr
     cb_context:set_resp_envelope(Context, NewRespEnvelope).
 
 -spec handle_datamgr_pagination_success(kz_json:objects(), load_view_params()) ->
-                                               cb_context:context().
+          cb_context:context().
 %% If v1, just append results and try next database
 handle_datamgr_pagination_success([]
                                  ,#load_view_params{dbs=[_Db|Dbs]
@@ -965,12 +965,12 @@ next_page_size(CurrentPageSize, FetchedPageSize, 'true') ->
                       'undefined'.
 
 -spec apply_filter(filter_fun(), kz_json:objects(), cb_context:context(), direction()) ->
-                          kz_json:objects().
+          kz_json:objects().
 apply_filter(FilterFun, JObjs, Context, Direction) ->
     apply_filter(FilterFun, JObjs, Context, Direction, crossbar_filter:is_defined(Context)).
 
 -spec apply_filter(filter_fun(), kz_json:objects(), cb_context:context(), direction(), boolean()) ->
-                          kz_json:objects().
+          kz_json:objects().
 apply_filter(FilterFun, JObjs, Context, Direction, HasQSFilter) ->
     lager:debug("applying filter fun: ~p, qs filter: ~p to dir ~p", [FilterFun, HasQSFilter, Direction]),
     Filtered0 = [JObj
@@ -1022,7 +1022,7 @@ handle_thing_success(Thing, Context) ->
                        ]).
 
 -spec handle_json_success(kz_json:object() | kz_json:objects(), cb_context:context()) ->
-                                 cb_context:context().
+          cb_context:context().
 handle_json_success(JObj, Context) ->
     handle_json_success(JObj, Context, cb_context:req_verb(Context)).
 
@@ -1039,7 +1039,7 @@ add_location_header(JObj, RHs) ->
     maps:put(<<"location">>, kz_doc:id(JObj), RHs).
 
 -spec handle_json_success(kz_json:object() | kz_json:objects(), cb_context:context(), http_method()) ->
-                                 cb_context:context().
+          cb_context:context().
 handle_json_success(JObjs, Context, ?HTTP_PUT) when is_list(JObjs) ->
     RespData = [public_and_read_only(JObj)
                 || JObj <- JObjs,
@@ -1110,7 +1110,7 @@ version_specific_success(JObjs, Context, _Version) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_datamgr_errors(kz_datamgr:data_errors(), kz_term:api_ne_binary() | kz_term:api_ne_binaries(), cb_context:context()) ->
-                                   cb_context:context().
+          cb_context:context().
 handle_datamgr_errors('invalid_db_name', _, Context) ->
     lager:debug("datastore ~s not_found", [cb_context:account_db(Context)]),
     cb_context:add_system_error('datastore_missing', kz_json:from_list([{<<"cause">>, cb_context:account_db(Context)}]), Context);
@@ -1140,7 +1140,7 @@ handle_datamgr_errors(Else, _View, Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec update_pvt_parameters(kz_json:object() | kz_json:objects(), cb_context:context()) ->
-                                   kz_json:object() | kz_json:objects().
+          kz_json:object() | kz_json:objects().
 update_pvt_parameters(JObjs, Context) when is_list(JObjs) ->
     [update_pvt_parameters(JObj, Context) || JObj <- JObjs];
 update_pvt_parameters(JObj0, Context) ->
@@ -1165,7 +1165,7 @@ add_pvt_vsn(JObj, Updates, _) ->
     end.
 
 -spec add_pvt_account_db(kz_json:object(), kz_json:json_proplist(), cb_context:context()) ->
-                                kz_json:json_proplist().
+          kz_json:json_proplist().
 add_pvt_account_db(JObj, Updates, Context) ->
     %% if no account db and the request is for an account, set db
     case kz_doc:account_db(JObj) =:= 'undefined' of
@@ -1178,7 +1178,7 @@ add_pvt_account_db(JObj, Updates, Context) ->
     end.
 
 -spec add_pvt_account_id(kz_json:object(), kz_json:json_proplist(), cb_context:context()) ->
-                                kz_json:json_proplist().
+          kz_json:json_proplist().
 add_pvt_account_id(JObj, Updates, Context) ->
     case kz_doc:account_id(JObj) =:= 'undefined' of
         'false' -> Updates;
@@ -1190,7 +1190,7 @@ add_pvt_account_id(JObj, Updates, Context) ->
     end.
 
 -spec add_pvt_created(kz_json:object(), kz_json:json_proplist(), cb_context:context()) ->
-                             kz_json:json_proplist().
+          kz_json:json_proplist().
 add_pvt_created(JObj, Updates, _Context) ->
     case kz_doc:revision(JObj) =:= 'undefined' of
         'true' -> [{kz_doc:path_created(), kz_time:now_s()} | Updates];
@@ -1198,12 +1198,12 @@ add_pvt_created(JObj, Updates, _Context) ->
     end.
 
 -spec add_pvt_modified(kz_json:object(), kz_json:json_proplist(), cb_context:context()) ->
-                              kz_json:json_proplist().
+          kz_json:json_proplist().
 add_pvt_modified(_JObj, Updates, _Context) ->
     [{kz_doc:path_modified(), kz_time:now_s()} | Updates].
 
 -spec add_pvt_request_id(kz_json:object(), kz_json:json_proplist(), cb_context:context()) ->
-                                kz_json:json_proplist().
+          kz_json:json_proplist().
 add_pvt_request_id(_JObj, Updates, Context) ->
     [{<<"pvt_request_id">>, cb_context:req_id(Context)} | Updates].
 
@@ -1216,7 +1216,7 @@ add_pvt_request_id(_JObj, Updates, Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec add_pvt_auth(kz_json:object(), kz_json:json_proplist(), cb_context:context()) ->
-                          kz_json:json_proplist().
+          kz_json:json_proplist().
 add_pvt_auth(_JObj, Updates, Context) ->
     case cb_context:is_authenticated(Context) of
         'false' ->
@@ -1233,12 +1233,12 @@ add_pvt_auth(_JObj, Updates, Context) ->
     end.
 
 -spec add_pvt_alphanum_name(kz_json:object(), kz_json:json_proplist(), cb_context:context()) ->
-                                   kz_json:json_proplist().
+          kz_json:json_proplist().
 add_pvt_alphanum_name(JObj, Updates, Context) ->
     add_pvt_alphanum_name(JObj, Updates, Context, kz_json:get_value(<<"name">>, JObj), kz_doc:type(JObj)).
 
 -spec add_pvt_alphanum_name(kz_json:object(), kz_json:json_proplist(), cb_context:context(), kz_term:api_binary(), kz_term:ne_binary()) ->
-                                   kz_json:json_proplist().
+          kz_json:json_proplist().
 add_pvt_alphanum_name(JObj, Updates, _Context, 'undefined', <<"user">>) ->
     Name = case {kz_json:get_ne_binary_value(<<"first_name">>, JObj)
                 ,kz_json:get_ne_binary_value(<<"last_name">>, JObj)
@@ -1264,7 +1264,7 @@ add_pvt_alphanum_name(_JObj, Updates, _Context, Name, _Type) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec extract_included_docs(cb_context:context(), kz_json:objects()) ->
-                                   {kz_json:objects(), cb_context:context()}.
+          {kz_json:objects(), cb_context:context()}.
 extract_included_docs(Context, JObjs) ->
     lists:foldl(fun extract_included_docs_fold/2, {[], Context}, JObjs).
 

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -98,22 +98,22 @@
 %% @end
 %%------------------------------------------------------------------------------
 -spec response(kz_json:json_term(), cb_context:context()) ->
-                      cb_context:context().
+          cb_context:context().
 response(JTerm, Context) ->
     create_response('success', 'undefined', 'undefined', JTerm, Context).
 
 -spec response_202(kz_term:api_ne_binary(), cb_context:context()) ->
-                          cb_context:context().
+          cb_context:context().
 response_202(Msg, Context) ->
     response_202(Msg, Msg, Context).
 
 -spec response_202(kz_term:api_ne_binary(), kz_json:json_term(), cb_context:context()) ->
-                          cb_context:context().
+          cb_context:context().
 response_202(Msg, JTerm, Context) ->
     create_response('accepted', Msg, 202, JTerm, Context).
 
 -spec response_400(kz_term:ne_binary(), kz_json:json_term(), cb_context:context()) ->
-                          cb_context:context().
+          cb_context:context().
 response_400(Message, Data, Context) ->
     create_response('error', Message, 400, Data, Context).
 
@@ -122,7 +122,7 @@ response_401(Context) ->
     response('error', <<"invalid credentials">>, 401, Context).
 
 -spec response_402(kz_json:json_term(), cb_context:context()) ->
-                          cb_context:context().
+          cb_context:context().
 response_402(Data, Context) ->
     create_response('error', <<"accept charges">>, 402, Data, Context).
 
@@ -132,7 +132,7 @@ response_402(Data, Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec response(fails(), kz_term:api_ne_binary(), cb_context:context()) ->
-                      cb_context:context().
+          cb_context:context().
 response('error', Msg, Context) ->
     create_response('error', Msg, 500, kz_json:new(), Context);
 response('fatal', Msg, Context) ->
@@ -144,7 +144,7 @@ response('fatal', Msg, Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec response(fails(), kz_term:api_ne_binary(), kz_term:api_integer(), cb_context:context()) ->
-                      cb_context:context().
+          cb_context:context().
 response('error', Msg, Code, Context) ->
     create_response('error', Msg, Code, kz_json:new(), Context);
 response('fatal', Msg, Code, Context) ->
@@ -212,24 +212,24 @@ response_deprecated(Context) ->
     create_response('error', <<"deprecated">>, 410, kz_json:new(), Context).
 
 -spec response_deprecated_redirect(cb_context:context(), kz_term:ne_binary()) ->
-                                          cb_context:context().
+          cb_context:context().
 response_deprecated_redirect(Context, RedirectUrl) ->
     response_deprecated_redirect(Context, RedirectUrl, kz_json:new()).
 
 -spec response_deprecated_redirect(cb_context:context(), kz_term:ne_binary(), kz_json:object()) ->
-                                          cb_context:context().
+          cb_context:context().
 response_deprecated_redirect(Context, RedirectUrl, JObj) ->
     create_response('error', <<"deprecated">>, 301, JObj
                    ,cb_context:add_resp_header(Context, <<"Location">>, RedirectUrl)
                    ).
 
 -spec response_redirect(cb_context:context(), kz_term:ne_binary(), kz_json:object()) ->
-                               cb_context:context().
+          cb_context:context().
 response_redirect(Context, RedirectUrl, JObj) ->
     response_redirect(Context, RedirectUrl, JObj, 301).
 
 -spec response_redirect(cb_context:context(), kz_term:ne_binary(), kz_json:object(), pos_integer()) ->
-                               cb_context:context().
+          cb_context:context().
 response_redirect(Context, RedirectUrl, JObj, Redirect) ->
     create_response('error', <<"redirect">>, Redirect, JObj
                    ,cb_context:add_resp_header(Context, <<"Location">>, RedirectUrl)
@@ -242,7 +242,7 @@ response_redirect(Context, RedirectUrl, JObj, Redirect) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec response_bad_identifier(atom() | kz_term:ne_binary(), cb_context:context()) ->
-                                     cb_context:context().
+          cb_context:context().
 response_bad_identifier(Id, Context) when is_atom(Id) ->
     response('error', <<"bad identifier">>, 404, [kz_term:to_binary(Id)], Context);
 response_bad_identifier(?NE_BINARY = Id, Context) ->
@@ -254,7 +254,7 @@ response_bad_identifier(?NE_BINARY = Id, Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec response_conflicting_docs(cb_context:context()) ->
-                                       cb_context:context().
+          cb_context:context().
 response_conflicting_docs(Context) ->
     response('error', <<"conflicting documents">>, 409, Context).
 
@@ -263,7 +263,7 @@ response_conflicting_docs(Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec response_missing_view(cb_context:context()) ->
-                                   cb_context:context().
+          cb_context:context().
 response_missing_view(Context) ->
     response('fatal', <<"datastore missing view">>, 503, Context).
 
@@ -272,7 +272,7 @@ response_missing_view(Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec response_datastore_timeout(cb_context:context()) ->
-                                        cb_context:context().
+          cb_context:context().
 response_datastore_timeout(Context) ->
     response('error', <<"datastore timeout">>, 503, Context).
 
@@ -281,7 +281,7 @@ response_datastore_timeout(Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec response_datastore_conn_refused(cb_context:context()) ->
-                                             cb_context:context().
+          cb_context:context().
 response_datastore_conn_refused(Context) ->
     response('error', <<"datastore connection refused">>, 503, Context).
 
@@ -290,7 +290,7 @@ response_datastore_conn_refused(Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec response_invalid_data(kz_json:json_term(), cb_context:context()) ->
-                                   cb_context:context().
+          cb_context:context().
 response_invalid_data(JTerm, Context) ->
     response('error', <<"invalid data">>, 400, JTerm, Context).
 
@@ -414,8 +414,8 @@ maybe_flush_registration_on_deleted(Realm, _OldDevice, NewDevice) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec move_account(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                          {'ok', kz_json:object()} |
-                          {'error', any()}.
+          {'ok', kz_json:object()} |
+          {'error', any()}.
 move_account(?MATCH_ACCOUNT_RAW(AccountId), ToAccount=?NE_BINARY) ->
     case validate_move(AccountId, ToAccount) of
         {'error', _E}=Error -> Error;
@@ -424,8 +424,8 @@ move_account(?MATCH_ACCOUNT_RAW(AccountId), ToAccount=?NE_BINARY) ->
     end.
 
 -spec move_account(kz_term:ne_binary(), kzd_accounts:doc(), kz_term:ne_binary(), kz_term:ne_binaries()) ->
-                          {'ok', kzd_services:doc()} |
-                          {'error', any()}.
+          {'ok', kzd_services:doc()} |
+          {'error', any()}.
 move_account(AccountId, JObj, ToAccount, ToTree) ->
     PreviousTree = kzd_accounts:tree(JObj),
     Updates = [{[?SERVICES_PVT_TREE], ToTree}
@@ -449,8 +449,8 @@ move_account(AccountId, JObj, ToAccount, ToTree) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec validate_move(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                           {'error', kz_datamgr:data_error() | 'forbidden'} |
-                           {'ok', kzd_accounts:doc(), kz_term:ne_binaries()}.
+          {'error', kz_datamgr:data_error() | 'forbidden'} |
+          {'ok', kzd_accounts:doc(), kz_term:ne_binaries()}.
 validate_move(AccountId, ToAccount) ->
     case kzd_accounts:fetch(AccountId) of
         {'error', _E}=Error -> Error;
@@ -467,14 +467,14 @@ validate_move(AccountId, ToAccount) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec move_descendants(kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary()) ->
-                              {'ok', 'done'} |
-                              {'error', any()}.
+          {'ok', 'done'} |
+          {'error', any()}.
 move_descendants(?MATCH_ACCOUNT_RAW(AccountId), Tree, NewResellerId) ->
     update_descendants_tree(get_descendants(AccountId), Tree, NewResellerId, AccountId).
 
 -spec update_descendants_tree(kz_term:ne_binaries(), kz_term:ne_binaries(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                     {'ok', 'done'} |
-                                     {'error', any()}.
+          {'ok', 'done'} |
+          {'error', any()}.
 update_descendants_tree([], _, _, _) -> {'ok', 'done'};
 update_descendants_tree([Descendant|Descendants], Tree, NewResellerId, MovedAccountId) ->
     case kzd_accounts:fetch(Descendant) of
@@ -540,9 +540,9 @@ disable_account(AccountId) ->
     end.
 
 -spec maybe_disable_account(kz_term:ne_binary()) ->
-                                   'ok' |
-                                   {'ok', kzd_accounts:doc()} |
-                                   kz_datamgr:data_error().
+          'ok' |
+          {'ok', kzd_accounts:doc()} |
+          kz_datamgr:data_error().
 maybe_disable_account(<<AccountId/binary>>) ->
     {'ok', AccountJObj} = kzd_accounts:fetch(AccountId),
     case kzd_accounts:is_enabled(AccountJObj) of
@@ -584,20 +584,20 @@ enable_account(AccountId) ->
 %%------------------------------------------------------------------------------
 
 -spec response_auth(kz_json:object()) ->
-                           kz_json:object().
+          kz_json:object().
 response_auth(JObj) ->
     AccountId = kz_json:get_first_defined([<<"account_id">>, <<"pvt_account_id">>], JObj),
     OwnerId = kz_json:get_first_defined([<<"owner_id">>, <<"user_id">>], JObj),
     response_auth(JObj, AccountId, OwnerId).
 
 -spec response_auth(kz_json:object(), kz_term:api_binary()) ->
-                           kz_json:object().
+          kz_json:object().
 response_auth(JObj, AccountId) ->
     OwnerId = kz_json:get_first_defined([<<"owner_id">>, <<"user_id">>], JObj),
     response_auth(JObj, AccountId, OwnerId).
 
 -spec response_auth(kz_json:object(), kz_term:api_binary(), kz_term:api_binary()) ->
-                           kz_json:object().
+          kz_json:object().
 response_auth(JObj, AccountId, UserId) ->
     populate_resp(JObj, AccountId, UserId).
 
@@ -651,7 +651,7 @@ format_app(Lang, AppJObj) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec change_pvt_enabled(boolean(), kz_term:api_ne_binary()) ->
-                                'ok' | {'error', any()}.
+          'ok' | {'error', any()}.
 change_pvt_enabled(_, 'undefined') -> 'ok';
 change_pvt_enabled(IsEnabled, <<AccountId/binary>>) ->
     Update = [{kzd_accounts:path_enabled(), IsEnabled}],
@@ -736,7 +736,7 @@ apply_response_map(Context, Map) ->
     cb_context:set_resp_data(Context, RespData).
 
 -spec apply_response_map_item({kz_json:path(), kz_json:path() | fun()}, kz_json:object(), kz_json:object()) ->
-                                     kz_json:object().
+          kz_json:object().
 apply_response_map_item({Key, Fun}, J, JObj) when is_function(Fun, 1) ->
     kz_json:set_value(Key, Fun(JObj), J);
 apply_response_map_item({Key, Fun}, J, JObj) when is_function(Fun, 2) ->
@@ -763,7 +763,7 @@ maybe_remove_attachments(Context) ->
     end.
 
 -spec create_auth_token(cb_context:context(), atom()) ->
-                               cb_context:context().
+          cb_context:context().
 create_auth_token(Context, AuthModule) ->
     JObj = cb_context:doc(Context),
     case kz_json:is_empty(JObj) of
@@ -775,7 +775,7 @@ create_auth_token(Context, AuthModule) ->
     end.
 
 -spec create_auth_token(cb_context:context(), atom(), kz_json:object()) ->
-                               cb_context:context().
+          cb_context:context().
 create_auth_token(Context, AuthModule, JObj) ->
     Data = cb_context:req_data(Context),
 
@@ -811,7 +811,7 @@ create_auth_token(Context, AuthModule, JObj) ->
     end.
 
 -spec get_token_restrictions(atom(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                    kz_term:api_object().
+          kz_term:api_object().
 get_token_restrictions(AuthModule, AccountId, OwnerId) ->
     case kzd_accounts:is_superduper_admin(AccountId) of
         'true' -> 'undefined';
@@ -924,7 +924,7 @@ handle_no_descendants(ViewOptions) ->
 %%------------------------------------------------------------------------------
 
 -spec format_emergency_caller_id_number(cb_context:context()) ->
-                                               cb_context:context().
+          cb_context:context().
 format_emergency_caller_id_number(Context) ->
     case cb_context:req_value(Context, [<<"caller_id">>, ?KEY_EMERGENCY]) of
         'undefined' -> Context;
@@ -933,7 +933,7 @@ format_emergency_caller_id_number(Context) ->
     end.
 
 -spec format_emergency_caller_id_number(cb_context:context(), kz_json:object()) ->
-                                               cb_context:context().
+          cb_context:context().
 format_emergency_caller_id_number(Context, Emergency) ->
     case kz_json:get_ne_binary_value(<<"number">>, Emergency) of
         'undefined' -> Context;
@@ -1094,8 +1094,8 @@ get_account_devices(Account) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec load_descendants_count(kz_term:proplist()) ->
-                                    {'ok', kz_term:proplist()} |
-                                    {'error', any()}.
+          {'ok', kz_term:proplist()} |
+          {'error', any()}.
 load_descendants_count(ViewOptions) ->
     lager:debug("counting descendants with ~p", [ViewOptions]),
     case kz_datamgr:get_results(?KZ_ACCOUNTS_DB, <<"accounts/listing_by_descendants_count">>, ViewOptions) of

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -31,6 +31,7 @@
         ]).
 -export([response_faulty_request/1]).
 -export([response_bad_identifier/2]).
+-export([response_range_not_satisfiable/1]).
 -export([response_conflicting_docs/1]).
 -export([response_datastore_timeout/1]).
 -export([response_datastore_conn_refused/1]).
@@ -186,6 +187,10 @@ create_response(Status, Msg, Code, JTerm, Context) ->
 -spec response_faulty_request(cb_context:context()) -> cb_context:context().
 response_faulty_request(Context) ->
     response('error', <<"faulty request">>, 404, Context).
+
+-spec response_range_not_satisfiable(cb_context:context()) -> cb_context:context().
+response_range_not_satisfiable(Context) ->
+    response('error', <<"range not satisfiable">>, 416, Context).
 
 %%------------------------------------------------------------------------------
 %% @doc When a module is no longer valid, alert the client of the deprecated status

--- a/applications/crossbar/src/modules/cb_multi_factor.erl
+++ b/applications/crossbar/src/modules/cb_multi_factor.erl
@@ -54,14 +54,14 @@ init() ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec authorize(cb_context:context()) ->
-                       boolean() |
-                       {'stop', cb_context:context()}.
+          boolean() |
+          {'stop', cb_context:context()}.
 authorize(Context) ->
     authorize_system_multi_factor(Context, cb_context:req_nouns(Context), cb_context:req_verb(Context)).
 
 -spec authorize(cb_context:context(), path_token()) ->
-                       boolean() |
-                       {'stop', cb_context:context()}.
+          boolean() |
+          {'stop', cb_context:context()}.
 authorize(Context, _) ->
     authorize_system_multi_factor(Context, cb_context:req_nouns(Context), cb_context:req_verb(Context)).
 
@@ -69,8 +69,8 @@ authorize(Context, _) ->
 authorize(_Context, _, _) -> 'true'.
 
 -spec authorize_system_multi_factor(cb_context:context(), req_nouns(), http_method()) ->
-                                           boolean() |
-                                           {'stop', cb_context:context()}.
+          boolean() |
+          {'stop', cb_context:context()}.
 authorize_system_multi_factor(_, [{<<"multi_factor">>, []}], ?HTTP_GET) -> 'true';
 authorize_system_multi_factor(C, [{<<"multi_factor">>, []}], ?HTTP_PUT) -> cb_context:is_superduper_admin(C);
 authorize_system_multi_factor(C, [{<<"multi_factor">>, _}], ?HTTP_GET) -> cb_context:is_superduper_admin(C);

--- a/applications/crossbar/src/modules/cb_multi_factor.erl
+++ b/applications/crossbar/src/modules/cb_multi_factor.erl
@@ -133,7 +133,7 @@ validate(Context) ->
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?ATTEMPTS) ->
-    Options = [{mapper, crossbar_view:map_value_fun()}
+    Options = [{'mapper', crossbar_view:map_value_fun()}
               ,{'range_keymap', <<"multi_factor">>}
               ],
     crossbar_view:load_modb(Context, ?CB_LIST_ATTEMPT_LOG, Options);

--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -240,7 +240,7 @@ validate(Context, UserId, ?PHOTO) ->
     validate_photo(Context, UserId , cb_context:req_verb(Context)).
 
 validate_users(Context, ?HTTP_GET) ->
-    load_user_summary(Context);
+    load_users_summary(Context);
 validate_users(Context, ?HTTP_PUT) ->
     validate_request('undefined', Context).
 
@@ -457,8 +457,8 @@ send_email(Context) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec load_user_summary(cb_context:context()) -> cb_context:context().
-load_user_summary(Context) ->
+-spec load_users_summary(cb_context:context()) -> cb_context:context().
+load_users_summary(Context) ->
     fix_envelope(
       crossbar_doc:load_view(?CB_LIST
                             ,[]

--- a/applications/crossbar/src/modules_v2/cb_users_v2.erl
+++ b/applications/crossbar/src/modules_v2/cb_users_v2.erl
@@ -101,17 +101,17 @@ allowed_methods(_UserId, ?VCARD) ->
 %%------------------------------------------------------------------------------
 
 -spec content_types_provided(cb_context:context()) ->
-                                    cb_context:context().
+          cb_context:context().
 content_types_provided(Context) ->
     Context.
 
 -spec content_types_provided(cb_context:context(), path_token()) ->
-                                    cb_context:context().
+          cb_context:context().
 content_types_provided(Context, _) ->
     Context.
 
 -spec content_types_provided(cb_context:context(), path_token(), path_token()) ->
-                                    cb_context:context().
+          cb_context:context().
 content_types_provided(Context, _, ?VCARD) ->
     cb_context:set_content_types_provided(Context, [{'to_binary', [{<<"text">>, <<"x-vcard">>}
                                                                   ,{<<"text">>, <<"directory">>}
@@ -341,7 +341,7 @@ patch(Context, Id) ->
 %%------------------------------------------------------------------------------
 
 -spec load_attachment(kz_term:ne_binary(), cb_context:context()) ->
-                             cb_context:context().
+          cb_context:context().
 load_attachment(AttachmentId, Context) ->
     Headers =
         #{<<"content-disposition">> => <<"attachment; filename=", AttachmentId/binary>>
@@ -355,7 +355,7 @@ load_attachment(AttachmentId, Context) ->
     cb_context:add_resp_headers(LoadedContext, Headers).
 
 -spec load_attachment(kz_term:ne_binary(), kz_term:ne_binary(), cb_context:context()) ->
-                             cb_context:context().
+          cb_context:context().
 load_attachment(UserId, AttachmentId, Context) ->
     Context1 = load_user(UserId, Context),
     case cb_context:resp_status(Context1) of
@@ -397,8 +397,8 @@ update_devices_presence(Context, DeviceDocs) ->
                  ).
 
 -spec user_devices(cb_context:context()) ->
-                          {'ok', kzd_devices:docs()} |
-                          {'error', any()}.
+          {'ok', kzd_devices:docs()} |
+          {'error', any()}.
 user_devices(Context) ->
     UserId = kz_doc:id(cb_context:doc(Context)),
     AccountDb = cb_context:account_db(Context),
@@ -803,7 +803,7 @@ remove_creds(Context) ->
     cb_context:set_doc(Context, kz_json:delete_keys(HashKeys, cb_context:doc(Context))).
 
 -spec rehash_creds(kz_term:api_binary(), kz_term:ne_binary(), cb_context:context()) ->
-                          cb_context:context().
+          cb_context:context().
 rehash_creds(Username, Password, Context) ->
     lager:debug("updating cred hashes for ~s", [Username]),
     CurrentJObj = cb_context:doc(Context),

--- a/core/kazoo_apps/src/kapps_config.erl
+++ b/core/kazoo_apps/src/kapps_config.erl
@@ -95,12 +95,12 @@ get_string(Category, Key) ->
     end.
 
 -spec get_string(config_category(), config_key(), Default) ->
-                        nonempty_string() | Default.
+          nonempty_string() | Default.
 get_string(Category, Key, Default) ->
     get_string(Category, Key, Default, kz_term:to_binary(node())).
 
 -spec get_string(config_category(), config_key(), Default, config_node()) ->
-                        nonempty_string() | Default.
+          nonempty_string() | Default.
 get_string(Category, Key, Default, Node) ->
     kz_term:to_list(get(Category, Key, Default, Node)).
 
@@ -130,7 +130,7 @@ get_binary(Category, Key, Default, Node) ->
 %%------------------------------------------------------------------------------
 
 -spec get_json(config_category(), config_key()) ->
-                      kz_term:api_object().
+          kz_term:api_object().
 get_json(Category, Key) ->
     V = get(Category, Key),
     as_json_value(V, 'undefined').
@@ -144,19 +144,19 @@ as_json_value(V, Default) ->
     end.
 
 -spec get_json(config_category(), config_key(), Default) ->
-                      kz_json:object() | Default.
+          kz_json:object() | Default.
 get_json(Category, Key, Default) ->
     get_json(Category, Key, Default, kz_term:to_binary(node())).
 
 -spec get_json(config_category(), config_key(), Default, config_node()) ->
-                      kz_json:object() | Default.
+          kz_json:object() | Default.
 get_json(Category, Key, Default, Node) ->
     V = get(Category, Key, Default, Node),
     as_json_value(V, Default).
 
 
 -spec get_jsons(config_category(), config_key()) ->
-                       kz_json:objects().
+          kz_json:objects().
 get_jsons(Category, Key) ->
     V = get(Category, Key),
     as_jsons_value(V, []).
@@ -170,12 +170,12 @@ as_jsons_value(V, Default) when is_list(V) ->
 as_jsons_value(_V, Default) -> Default.
 
 -spec get_jsons(config_category(), config_key(), Default) ->
-                       kz_json:objects() | Default.
+          kz_json:objects() | Default.
 get_jsons(Category, Key, Default) ->
     get_jsons(Category, Key, Default, kz_term:to_binary(node())).
 
 -spec get_jsons(config_category(), config_key(), Default, config_node()) ->
-                       kz_json:objects() | Default.
+          kz_json:objects() | Default.
 get_jsons(Category, Key, Default, Node) ->
     V = get(Category, Key, Default, Node),
     as_jsons_value(V, Default).
@@ -525,7 +525,7 @@ get_current(Category, Keys, Default, Node) ->
     end.
 
 -spec get_value(config_category(), config_key(), config_key(), Default, kz_json:object()) ->
-                       Default | any().
+          Default | any().
 get_value(Category, ?KEY_DEFAULT, Keys, Default, JObj) ->
     get_default_value(Category, Keys, Default, JObj);
 get_value(Category, Node, Keys, Default, JObj) ->
@@ -535,7 +535,7 @@ get_value(Category, Node, Keys, Default, JObj) ->
     end.
 
 -spec get_zone_value(config_category(), config_key(), config_key(), Default, kz_json:object()) ->
-                            Default | any().
+          Default | any().
 get_zone_value(Category, _Node, Keys, Default, JObj) ->
     Zone = kz_term:to_binary(kz_config:zone()),
     case kz_json:get_value([Zone | Keys], JObj) of
@@ -544,7 +544,7 @@ get_zone_value(Category, _Node, Keys, Default, JObj) ->
     end.
 
 -spec get_default_value(config_category(), config_key(), Default, kz_json:object()) ->
-                               Default | _.
+          Default | _.
 get_default_value(Category, [?KEY_DEFAULT | Keys]=Path, Default, JObj) ->
     case kz_json:get_value(Path, JObj) of
         'undefined' ->
@@ -586,27 +586,27 @@ get_all_default_kvs(JObj) ->
 %%------------------------------------------------------------------------------
 
 -spec set_string(config_category(), config_key(), kz_term:text()) ->
-                        {'ok', kz_json:object()}.
+          {'ok', kz_json:object()}.
 set_string(Category, Key, Value) ->
     set(Category, Key, kz_term:to_binary(Value)).
 
 -spec set_integer(config_category(), config_key(), kz_term:text() | integer()) ->
-                         {'ok', kz_json:object()}.
+          {'ok', kz_json:object()}.
 set_integer(Category, Key, Value) ->
     set(Category, Key, kz_term:to_integer(Value)).
 
 -spec set_float(config_category(), config_key(), kz_term:text() | float()) ->
-                       {'ok', kz_json:object()}.
+          {'ok', kz_json:object()}.
 set_float(Category, Key, Value) ->
     set(Category, Key, kz_term:to_float(Value)).
 
 -spec set_boolean(config_category(), config_key(), kz_term:text() | boolean()) ->
-                         {'ok', kz_json:object()}.
+          {'ok', kz_json:object()}.
 set_boolean(Category, Key, Value) ->
     set(Category, Key, kz_term:to_boolean(Value)).
 
 -spec set_json(config_category(), config_key(), kz_term:text() | kz_json:object()) ->
-                      {'ok', kz_json:object()}.
+          {'ok', kz_json:object()}.
 set_json(Category, Key, Value) ->
     set(Category, Key, kz_json:decode(Value)).
 
@@ -615,44 +615,44 @@ set_json(Category, Key, Value) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec set(config_category(), config_key(), kz_json:json_term()) ->
-                 {'ok', kz_json:object()}.
+          {'ok', kz_json:object()}.
 set(Category, Key, Value) ->
     set(Category, Key, Value, node()).
 
 -spec set(config_category(), config_key(), kz_json:json_term(), kz_term:ne_binary() | atom()) ->
-                 {'ok', kz_json:object()} |
-                 {'error', kz_datamgr:data_error()}.
+          {'ok', kz_json:object()} |
+          {'error', kz_datamgr:data_error()}.
 set(Category, Key, Value, Node) ->
     update_category(Category, Key, Value, Node, []).
 
 -spec set_default(config_category(), config_key(), kz_json:json_term()) ->
-                         {'ok', kz_json:object()} |
-                         {'error', kz_datamgr:data_error()}.
+          {'ok', kz_json:object()} |
+          {'error', kz_datamgr:data_error()}.
 set_default(Category, Key, Value) ->
     update_category(Category, Key, Value, ?KEY_DEFAULT, []).
 
 -spec update_default(config_category(), config_key(), kz_json:json_term()) ->
-                            {'ok', kz_json:object()} |
-                            {'error', kz_datamgr:data_error()}.
+          {'ok', kz_json:object()} |
+          {'error', kz_datamgr:data_error()}.
 update_default(Category, Key, Value) ->
     update_default(Category, Key, Value, []).
 
 -spec update_default(config_category(), config_key(), kz_json:json_term(), update_options()) ->
-                            {'ok', kz_json:object()} |
-                            {'error', kz_datamgr:data_error()}.
+          {'ok', kz_json:object()} |
+          {'error', kz_datamgr:data_error()}.
 update_default(Category, Key, Value, Options) ->
     update_category(Category, Key, Value, ?KEY_DEFAULT, Options).
 
 -spec set_node(config_category(), config_key(), kz_json:json_term(), kz_term:ne_binary() | atom()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', kz_datamgr:data_error()}.
+          {'ok', kz_json:object()} |
+          {'error', kz_datamgr:data_error()}.
 set_node(Category, _, _, 'undefined') -> get_category(Category);
 set_node(Category, Key, Value, Node) ->
     update_category(Category, Key, Value, Node, [{'node_specific', 'true'}]).
 
 -spec update_category(config_category(), config_key(), kz_json:json_term(), kz_term:ne_binary() | atom(), update_options()) ->
-                             {'ok', kz_json:object()} |
-                             {'error', kz_datamgr:data_error()}.
+          {'ok', kz_json:object()} |
+          {'error', kz_datamgr:data_error()}.
 -ifdef(TEST).
 update_category(Category, _, _, _, _) -> {'ok', Category}.
 -else.
@@ -685,7 +685,7 @@ update_category(Category, Keys, Value, Node, Options) ->
     end.
 
 -spec update_category(config_category(), config_key(), any(), kz_term:ne_binary(), update_options(), kz_json:object()) ->
-                             {'ok', kz_json:object()}.
+          {'ok', kz_json:object()}.
 update_category(Category, Keys, Value, Node, Options, JObj) ->
     PvtFields = props:get_value('pvt_fields', Options),
     NodePath = [Node | Keys],
@@ -709,27 +709,27 @@ update_category(Category, Keys, Value, Node, Options, JObj) ->
     end.
 
 -spec update_category(config_category(), kz_json:object(), kz_datamgr:update_options(), kz_term:api_object()) ->
-                             {'ok', kz_json:object()} |
-                             kz_datamgr:data_error().
+          {'ok', kz_json:object()} |
+          kz_datamgr:data_error().
 update_category(Category, JObj, Updates, PvtFields) ->
     maybe_save_category(Category, JObj, Updates, PvtFields).
 -endif.
 
 -spec maybe_save_category(config_category(), kz_json:object(), kz_datamgr:update_options(), kz_term:api_object()) ->
-                                 {'ok', kz_json:object()} |
-                                 kz_datamgr:data_error().
+          {'ok', kz_json:object()} |
+          kz_datamgr:data_error().
 maybe_save_category(Category, JObj, Updates, PvtFields) ->
     maybe_save_category(Category, JObj, Updates, PvtFields, 'false').
 
 -spec maybe_save_category(config_category(), kz_json:object(), kz_datamgr:update_options(), kz_term:api_object(), boolean()) ->
-                                 {'ok', kz_json:object()} |
-                                 kz_datamgr:data_error().
+          {'ok', kz_json:object()} |
+          kz_datamgr:data_error().
 maybe_save_category(Category, JObj, Updates, PvtFields, Looped) ->
     maybe_save_category(Category, JObj, Updates, PvtFields, Looped, is_locked()).
 
 -spec maybe_save_category(config_category(), kz_json:object(), kz_datamgr:update_options(), kz_term:api_object(), boolean(), boolean()) ->
-                                 {'ok', kz_json:object()} |
-                                 kz_datamgr:data_error().
+          {'ok', kz_json:object()} |
+          kz_datamgr:data_error().
 maybe_save_category(_Category, JObj, _Updates, _PvtFields, _Looped, 'true') ->
     lager:warning("failed to update category, system config database is locked!"),
     lager:warning("please update /etc/kazoo/config.ini or use 'sup kapps_config lock_db <boolean>' to enable system config writes."),
@@ -759,7 +759,7 @@ maybe_save_category(Category, JObj, Updates, PvtFields, Looped, _NotLocked) ->
     end.
 
 -spec update_pvt_fields(config_category(), kz_json:object(), kz_term:api_object()) ->
-                               kz_json:json_proplist().
+          kz_json:json_proplist().
 update_pvt_fields(Category, JObj, 'undefined') ->
     kz_doc:get_pvt_updates(kz_doc:set_id(JObj, Category)
                           ,?KZ_CONFIG_DB
@@ -1162,8 +1162,8 @@ migrate() ->
     lists:foreach(fun migrate_config_setting/1, ?CONFIG_MIGRATIONS).
 
 -spec migrate_config_setting({migrate_setting(), migrate_setting()}) ->
-                                    'ok' |
-                                    {'error', any()}.
+          'ok' |
+          {'error', any()}.
 migrate_config_setting({?NE_BINARY = FromId, ?NE_BINARY = ToId}) ->
     migrate_config_doc(FromId, ToId);
 migrate_config_setting({From, To}) ->
@@ -1177,8 +1177,8 @@ migrate_config_setting({From, To}) ->
     end.
 
 -spec migrate_config_setting(kz_json:object(), migrate_values(), migrate_setting()) ->
-                                    'ok' |
-                                    {'error', any()}.
+          'ok' |
+          {'error', any()}.
 migrate_config_setting(UpdatedFrom, Removed, Fun)
   when is_function(Fun) ->
     case migrate_config_setting_fun(Fun, Removed) of
@@ -1209,12 +1209,12 @@ migrate_config_setting(UpdatedFrom, Removed, {ToId, ToSetting}) ->
     end.
 
 -spec migrate_config_setting_fun(migrate_fun(), migrate_values()) ->
-                                        {migrate_values(), migrate_setting()}.
+          {migrate_values(), migrate_setting()}.
 migrate_config_setting_fun(Fun, Removed) ->
     migrate_config_setting_fun(Fun, Removed, 'undefined', []).
 
 -spec migrate_config_setting_fun(migrate_fun(), migrate_values(), 'undefined' | migrate_setting(), migrate_values()) ->
-                                        {migrate_values(), migrate_setting()}.
+          {migrate_values(), migrate_setting()}.
 migrate_config_setting_fun(_Fun, [], To, Removed) ->
     {Removed, To};
 migrate_config_setting_fun(Fun, [{FromId, Node, FromSetting, Value}=Remove|Removals], _To, Removed) ->
@@ -1241,8 +1241,8 @@ migrate_config_setting_fun(Fun, [{FromId, Node, FromSetting, Value}=Remove|Remov
     end.
 
 -spec add_config_setting(kz_term:ne_binary() | kz_json:object(), config_key(), migrate_values()) ->
-                                {'ok', kz_json:object()} |
-                                {'error', any()}.
+          {'ok', kz_json:object()} |
+          {'error', any()}.
 add_config_setting(Id, Setting, Values) when is_binary(Id) ->
     case kz_datamgr:open_doc(?KZ_CONFIG_DB, Id) of
         {'ok', JObj} -> add_config_setting(JObj, Setting, Values);
@@ -1282,14 +1282,14 @@ add_config_setting(JObj, ToSetting, [{FromId, Node, FromSetting, Value} | Values
     end.
 
 -spec remove_config_setting(migrate_setting()) ->
-                                   {'ok', kz_json:object(), migrate_values()} |
-                                   {'error', any()}.
+          {'ok', kz_json:object(), migrate_values()} |
+          {'error', any()}.
 remove_config_setting({Id, Setting}) ->
     remove_config_setting(Id, Setting).
 
 -spec remove_config_setting(kz_term:ne_binary() | kz_json:object(), config_key()) ->
-                                   {'ok', kz_json:object(), migrate_values()} |
-                                   {'error', any()}.
+          {'ok', kz_json:object(), migrate_values()} |
+          {'error', any()}.
 remove_config_setting(Id, Setting) when is_binary(Id) ->
     case kz_datamgr:open_doc(?KZ_CONFIG_DB, Id) of
         {'ok', JObj} -> remove_config_setting(JObj, Setting);
@@ -1304,7 +1304,7 @@ remove_config_setting(JObj, Setting) ->
     remove_config_setting(Keys, JObj, []).
 
 -spec remove_config_setting([{kz_term:ne_binary(), kz_term:ne_binary(), config_key()}], kz_json:object(), migrate_values()) ->
-                                   {'ok', kz_json:object(), migrate_values()}.
+          {'ok', kz_json:object(), migrate_values()}.
 remove_config_setting([], JObj, Removed) ->
     {'ok', JObj, Removed};
 remove_config_setting([{Id, Node, Setting} | Keys], JObj, Removed) ->
@@ -1365,7 +1365,7 @@ migrate_config_doc_node(FromNodeBefore, FromConfig, ToJObj) ->
                  ).
 
 -spec migrate_config_value(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:json_term(), kz_json:object()) ->
-                                  kz_json:object().
+          kz_json:object().
 migrate_config_value(FromNode, <<"whapps">>, ConfigValue, ToJObj) ->
     kz_json:set_value([FromNode, <<"kapps">>], ConfigValue, ToJObj);
 migrate_config_value(FromNode, ConfigKey, ConfigValue, ToJObj) ->

--- a/core/kazoo_apps/src/kapps_config.erl
+++ b/core/kazoo_apps/src/kapps_config.erl
@@ -232,7 +232,7 @@ get_integer(Category, Key, Default, Node) ->
 get_pos_integer(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
-        Else -> to_pos_integer(Else, undefined)
+        Else -> to_pos_integer(Else, 'undefined')
     end.
 
 -spec get_pos_integer(config_category(), config_key(), Default) -> pos_integer() | Default.
@@ -259,7 +259,7 @@ to_pos_integer(Value, Default) ->
 get_non_neg_integer(Category, Key) ->
     case get(Category, Key) of
         'undefined' -> 'undefined';
-        Else -> to_non_neg_integer(Else, undefined)
+        Else -> to_non_neg_integer(Else, 'undefined')
     end.
 
 -spec get_non_neg_integer(config_category(), config_key(), Default) -> non_neg_integer() | Default.

--- a/core/kazoo_couch/src/kazoo_couch.erl
+++ b/core/kazoo_couch/src/kazoo_couch.erl
@@ -73,7 +73,7 @@
 
 %% Server operations
 -spec new_connection(map()) -> kz_data:connection() |
-                               {'error', 'timeout' | 'ehostunreach' | _}.
+          {'error', 'timeout' | 'ehostunreach' | _}.
 new_connection(Map) ->
     kz_couch_util:new_connection(Map).
 
@@ -117,8 +117,8 @@ db_url(Server, DbName) ->
     kz_couch_util:db_url(Server, DbName).
 
 -spec server_info(kz_data:connection()) ->
-                         {'ok', kz_json:object()} |
-                         {'error', any()}.
+          {'ok', kz_json:object()} |
+          {'error', any()}.
 server_info(Server) ->
     kz_couch_util:server_info(Server).
 
@@ -140,8 +140,8 @@ db_info(Server) ->
     kz_couch_db:db_info(Server).
 
 -spec db_info(kz_data:connection(), kz_term:ne_binary()) ->
-                     {'ok', kz_json:object()} |
-                     couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 db_info(Server, DbName) ->
     kz_couch_db:db_info(Server, DbName).
 
@@ -150,19 +150,19 @@ db_exists(Server, DbName) ->
     kz_couch_db:db_exists(Server, DbName).
 
 -spec db_archive(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                        'ok' |
-                        couchbeam_error().
+          'ok' |
+          couchbeam_error().
 db_archive(Server, DbName, Filename) ->
     kz_couch_db:db_archive(Server, DbName, Filename).
 
 -spec db_import(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                       'ok' |
-                       couchbeam_error().
+          'ok' |
+          couchbeam_error().
 db_import(Server, DbName, Filename) ->
     kz_couch_db:db_import(Server, DbName, Filename).
 
 -spec db_list(kz_data:connection(), kz_data:options()) ->
-                     {'ok', kz_json:objects() | kz_term:ne_binaries()} | couchbeam_error().
+          {'ok', kz_json:objects() | kz_term:ne_binaries()} | couchbeam_error().
 db_list(Server, Options) ->
     db_list(server_version(Server), Server, Options).
 
@@ -180,69 +180,69 @@ db_list('couchdb_1_6', Server, Options) ->
 
 %% Document operations
 -spec open_doc(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) ->
-                      {'ok', kz_json:object()} |
-                      couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 open_doc(Server, DbName, DocId, Options) ->
     kz_couch_doc:open_doc(Server, DbName, DocId, Options).
 
 -spec lookup_doc_rev(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                            {'ok', kz_term:ne_binary()} |
-                            couchbeam_error().
+          {'ok', kz_term:ne_binary()} |
+          couchbeam_error().
 lookup_doc_rev(Server, DbName, DocId) ->
     kz_couch_doc:lookup_doc_rev(Server, DbName, DocId).
 
 -spec save_doc(kz_data:connection(), kz_term:ne_binary(), kz_data:document(), kz_data:options()) ->
-                      {'ok', kz_json:object()} |
-                      couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 save_doc(Server, DbName, Doc, Options) ->
     kz_couch_doc:save_doc(Server, DbName, Doc, Options).
 
 -spec save_docs(kz_data:connection(), kz_term:ne_binary(), kz_data:documents(), kz_data:options()) ->
-                       {'ok', kz_json:objects()} |
-                       couchbeam_error().
+          {'ok', kz_json:objects()} |
+          couchbeam_error().
 save_docs(Server, DbName, Docs, Options) ->
     kz_couch_doc:save_docs(Server, DbName, Docs, Options).
 
 -spec del_doc(kz_data:connection(), kz_term:ne_binary(), kz_data:document(), kz_data:options()) ->
-                     {'ok', kz_json:object()} |
-                     couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 del_doc(Server, DbName, Doc, Options) ->
     kz_couch_doc:del_doc(Server, DbName, Doc, Options).
 
 -spec del_docs(kz_data:connection(), kz_term:ne_binary(), kz_data:documents(), kz_data:options()) ->
-                      {'ok', kz_json:objects()} |
-                      couchbeam_error().
+          {'ok', kz_json:objects()} |
+          couchbeam_error().
 del_docs(Server, DbName, Docs, Options) ->
     kz_couch_doc:del_docs(Server, DbName, Docs, Options).
 
 -spec ensure_saved(kz_data:connection(), kz_term:ne_binary(), kz_data:document(), kz_data:options()) ->
-                          {'ok', kz_json:object()} |
-                          couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 ensure_saved(Server, DbName, DocId, Options) ->
     kz_couch_doc:ensure_saved(Server, DbName, DocId, Options).
 
 -spec copy_doc(kz_data:connection(), copy_doc(), kz_data:options()) ->
-                      {'ok', kz_json:object()} |
-                      couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 copy_doc(Server, CopySpec, Options) ->
     kz_couch_doc:copy_doc(Server, CopySpec, Options).
 
 -spec move_doc(kz_data:connection(), copy_doc(), kz_data:options()) ->
-                      {'ok', kz_json:object()} |
-                      couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 move_doc(Server, CopySpec, Options) ->
     kz_couch_doc:move_doc(Server, CopySpec, Options).
 
 %% Attachment-related
 -spec fetch_attachment(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                              {'ok', binary()} |
-                              couchbeam_error().
+          {'ok', binary()} |
+          couchbeam_error().
 fetch_attachment(Server, DbName, DocId, AName) ->
     kz_couch_attachments:fetch_attachment(Server, DbName, DocId, AName).
 
 -spec stream_attachment(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), pid()) ->
-                               {'ok', doc()} |
-                               {'error', any()}.
+          {'ok', doc()} |
+          {'error', any()}.
 stream_attachment(Server, DbName, DocId, AName, Caller) ->
     kz_couch_attachments:stream_attachment(Server, DbName, DocId, AName, Caller).
 
@@ -255,15 +255,15 @@ delete_attachment(Server, DbName, DocId, AName, Options) ->
     kz_couch_attachments:delete_attachment(Server, DbName, DocId, AName, Options).
 
 -spec attachment_url(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) ->
-                            kz_term:ne_binary() |
-                            {'proxy', tuple()}.
+          kz_term:ne_binary() |
+          {'proxy', tuple()}.
 attachment_url(Server, DbName, DocId, AName, Options) ->
     kz_couch_attachments:attachment_url(Server, DbName, DocId, AName, Options).
 
 %% View-related
 -spec design_info(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                         {'ok', kz_json:object()} |
-                         couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 design_info(Server, DBName, Design) ->
     kz_couch_view:design_info(Server, DBName, Design).
 
@@ -272,32 +272,32 @@ design_compact(Server, DbName, Design) ->
     kz_couch_view:design_compact(Server, DbName, Design).
 
 -spec all_design_docs(kz_data:connection(), kz_term:ne_binary(), kz_data:options()) ->
-                             {'ok', kz_json:objects()} |
-                             couchbeam_error().
+          {'ok', kz_json:objects()} |
+          couchbeam_error().
 all_design_docs(#server{}=Server, ?NE_BINARY = DBName, Options) ->
     kz_couch_view:all_design_docs(Server, DBName, Options).
 
--spec get_results(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) ->
-                         {'ok', kz_json:objects() | kz_json:path()} |
-                         couchbeam_error().
+-spec get_results(kz_data:connection(), 'all_docs' | kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) ->
+          {'ok', kz_json:objects() | kz_json:path()} |
+          couchbeam_error().
 get_results(Server, DbName, DesignDoc, ViewOptions) ->
     kz_couch_view:get_results(Server, DbName, DesignDoc, ViewOptions).
 
--spec get_results_count(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) ->
-                               {'ok', kz_term:api_integer()} |
-                               couchbeam_error().
+-spec get_results_count(kz_data:connection(), 'all_docs' | kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) ->
+          {'ok', kz_term:api_integer()} |
+          couchbeam_error().
 get_results_count(Server, DbName, DesignDoc, ViewOptions) ->
     kz_couch_view:get_results_count(Server, DbName, DesignDoc, ViewOptions).
 
 -spec show(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
-                  {'ok', kz_json:object()} |
-                  couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 show(Server, DbName, DesignDoc, DocId, Options) ->
     kz_couch_view:show(Server, DbName, DesignDoc, DocId, Options).
 
 -spec all_docs(kz_data:connection(), kz_term:ne_binary(), kz_data:options()) ->
-                      {'ok', kz_json:objects()} |
-                      couchbeam_error().
+          {'ok', kz_json:objects()} |
+          couchbeam_error().
 all_docs(Server, DbName, Options) ->
     kz_couch_view:all_docs(Server, DbName, Options).
 

--- a/core/kazoo_couch/src/kazoo_couch.erl
+++ b/core/kazoo_couch/src/kazoo_couch.erl
@@ -246,7 +246,7 @@ fetch_attachment(Server, DbName, DocId, AName) ->
 stream_attachment(Server, DbName, DocId, AName, Caller) ->
     kz_couch_attachments:stream_attachment(Server, DbName, DocId, AName, Caller).
 
--spec put_attachment(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) -> any().
+-spec put_attachment(kz_data:connection(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), iodata(), kz_data:options()) -> any().
 put_attachment(Server, DbName, DocId, AName, Contents, Options) ->
     kz_couch_attachments:put_attachment(Server, DbName, DocId, AName, Contents, Options).
 

--- a/core/kazoo_couch/src/kz_couch_view.erl
+++ b/core/kazoo_couch/src/kz_couch_view.erl
@@ -91,7 +91,7 @@ get_results(#server{}=Conn, DbName, DesignDoc, ViewOptions) ->
 %% Need to see how to get couchbeam to return the "rows" property instead of the result
 %% list; that would be better, but for not, setting the view's "reduce" to the _count
 %% function will suffice (provided a reduce isn't already defined).
--spec get_results_count(server(), kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
+-spec get_results_count(server(), 'all_docs' | kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
                                {'ok', kz_term:api_integer()} |
                                couchbeam_error().
 get_results_count(#server{}=Conn, DbName, DesignDoc, ViewOptions) ->
@@ -132,7 +132,7 @@ map_view_option({K, V})
     {kz_term:to_atom(K, 'true'), V};
 map_view_option(KV) -> KV.
 
--spec do_fetch_results_count(couchbeam_db(), ddoc(), view_options()) ->
+-spec do_fetch_results_count(couchbeam_db(), kz_term:ne_binary() | ddoc(), view_options()) ->
                                     {'ok', kz_term:api_integer()} |
                                     couchbeam_error().
 do_fetch_results_count(Db, <<DesignDoc/binary>>, Options) ->

--- a/core/kazoo_couch/src/kz_couch_view.erl
+++ b/core/kazoo_couch/src/kz_couch_view.erl
@@ -41,21 +41,21 @@ design_compact(#server{}=Conn, DbName, Design) ->
     end.
 
 -spec design_info(server(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                         {'ok', kz_json:object()} |
-                         couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 design_info(#server{}=Conn, DBName, Design) ->
     Db = kz_couch_util:get_db(Conn, DBName),
     do_get_design_info(Db, Design).
 
 -spec all_design_docs(kz_data:connection(), kz_term:ne_binary()) ->
-                             {'ok', kz_json:objects()} |
-                             couchbeam_error().
+          {'ok', kz_json:objects()} |
+          couchbeam_error().
 all_design_docs(#server{}=Conn, DBName) ->
     all_design_docs(#server{}=Conn, DBName, []).
 
 -spec all_design_docs(kz_data:connection(), kz_term:ne_binary(), view_options()) ->
-                             {'ok', kz_json:objects()} |
-                             couchbeam_error().
+          {'ok', kz_json:objects()} |
+          couchbeam_error().
 all_design_docs(#server{}=Conn, DBName, Options) ->
     Db = kz_couch_util:get_db(Conn, DBName),
     Filter = props:set_values([{'startkey', <<"_design/">>}
@@ -69,20 +69,20 @@ all_design_docs(#server{}=Conn, DBName, Options) ->
 all_docs(Db) -> all_docs(Db, []).
 
 -spec all_docs(db(), view_options()) -> {'ok', kz_json:objects()} |
-                                        couchbeam_error().
+          couchbeam_error().
 all_docs(#db{}=Db, Options) ->
     do_fetch_results(Db, 'all_docs', Options).
 
 -spec all_docs(server(), kz_term:ne_binary(), view_options()) ->
-                      {'ok', kz_json:objects()} |
-                      couchbeam_error().
+          {'ok', kz_json:objects()} |
+          couchbeam_error().
 all_docs(#server{}=Conn, DbName, Options) ->
     Db = kz_couch_util:get_db(Conn, DbName),
     do_fetch_results(Db, 'all_docs', Options).
 
 -spec get_results(server(), kz_term:ne_binary(), ddoc(), view_options()) ->
-                         {'ok', kz_json:objects() | kz_json:path()} |
-                         couchbeam_error().
+          {'ok', kz_json:objects() | kz_json:path()} |
+          couchbeam_error().
 get_results(#server{}=Conn, DbName, DesignDoc, ViewOptions) ->
     Db = kz_couch_util:get_db(Conn, DbName),
     do_fetch_results(Db, DesignDoc, ViewOptions).
@@ -92,16 +92,16 @@ get_results(#server{}=Conn, DbName, DesignDoc, ViewOptions) ->
 %% list; that would be better, but for not, setting the view's "reduce" to the _count
 %% function will suffice (provided a reduce isn't already defined).
 -spec get_results_count(server(), 'all_docs' | kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                               {'ok', kz_term:api_integer()} |
-                               couchbeam_error().
+          {'ok', kz_term:api_integer()} |
+          couchbeam_error().
 get_results_count(#server{}=Conn, DbName, DesignDoc, ViewOptions) ->
     Db = kz_couch_util:get_db(Conn, DbName),
     do_fetch_results_count(Db, DesignDoc, ViewOptions).
 
 %% Design Doc/View internal functions
 -spec do_fetch_results(couchbeam_db(), ddoc(), view_options()) ->
-                              {'ok', kz_json:objects() | kz_term:ne_binaries()} |
-                              couchbeam_error().
+          {'ok', kz_json:objects() | kz_term:ne_binaries()} |
+          couchbeam_error().
 do_fetch_results(Db, <<DesignDoc/binary>>, Options) ->
     [DesignName, ViewName|_] = binary:split(DesignDoc, <<"/">>, ['global']),
     do_fetch_results(Db, {DesignName, ViewName}, map_options(Options));
@@ -133,8 +133,8 @@ map_view_option({K, V})
 map_view_option(KV) -> KV.
 
 -spec do_fetch_results_count(couchbeam_db(), kz_term:ne_binary() | ddoc(), view_options()) ->
-                                    {'ok', kz_term:api_integer()} |
-                                    couchbeam_error().
+          {'ok', kz_term:api_integer()} |
+          couchbeam_error().
 do_fetch_results_count(Db, <<DesignDoc/binary>>, Options) ->
     [DesignName, ViewName | _] = binary:split(DesignDoc, <<"/">>, ['global']),
     do_fetch_results_count(Db, {DesignName, ViewName}, map_options(Options));
@@ -147,14 +147,14 @@ do_fetch_results_count(Db, DesignDoc, Options) ->
       ).
 
 -spec do_get_design_info(couchbeam_db(), kz_term:ne_binary()) ->
-                                {'ok', kz_json:object()} |
-                                couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 do_get_design_info(#db{}=Db, Design) ->
     ?RETRY_504(couchbeam:design_info(Db, Design)).
 
 -spec show(server(), kz_term:ne_binary(), show_doc(), binary() | 'null', [{'query_string', binary()}]) ->
-                  {'ok', kz_json:object()} |
-                  couchbeam_error().
+          {'ok', kz_json:object()} |
+          couchbeam_error().
 show(#server{}=Conn, <<DbName/binary>>, <<DesignDoc/binary>>, DocId, Options) ->
     [DesignName, ViewName|_] = binary:split(DesignDoc, <<"/">>, ['global']),
     show(Conn, DbName, {DesignName, ViewName}, DocId, Options);

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -1120,14 +1120,14 @@ stream_attachment(DbName, DocId, AName, Options, Pid) ->
 %% <div class="notice">Note atoms as keys in proplist.</div>
 %% @end
 %%------------------------------------------------------------------------------
--spec put_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+-spec put_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary(), iodata()) ->
           {'ok', kz_json:object()} |
           data_error() |
           kz_att_error:error().
 put_attachment(DbName, DocId, AName, Contents) ->
     put_attachment(DbName, DocId, AName, Contents, []).
 
--spec put_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
+-spec put_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary(), iodata(), kz_term:proplist()) ->
           {'ok', kz_json:object()} |
           {'ok', kz_json:object(), kz_term:proplist()} |
           data_error() |

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -137,8 +137,8 @@
 %% @end
 %%------------------------------------------------------------------------------
 -spec update_doc_from_file(kz_term:ne_binary(), nonempty_string() | kz_term:ne_binary()) ->
-                                  {'ok', kz_json:object()} |
-                                  data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 update_doc_from_file(DbName, Path) when ?VALID_DBNAME(DbName) ->
     lager:debug("update db ~s from CouchDB file: ~s", [DbName, Path]),
     try
@@ -160,8 +160,8 @@ update_doc_from_file(DbName, File) ->
     end.
 
 -spec maybe_update_doc_from_file(kz_term:ne_binary(), kz_json:object(), any()) ->
-                                        {'ok', kz_json:object()} |
-                                        data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 maybe_update_doc_from_file(DbName, JObj, {'ok', Doc}=OK) ->
     case should_update(DbName, JObj, OK) of
         'false' ->
@@ -184,8 +184,8 @@ maybe_update_doc_from_file(_, _, {'error', _}=Error) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec revise_doc_from_file(kz_term:ne_binary(), atom(), kz_term:ne_binary() | nonempty_string()) ->
-                                  {'ok', kz_json:object()} |
-                                  data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 revise_doc_from_file(DbName, App, File) ->
     Path = list_to_binary([code:priv_dir(App), "/couchdb/", File]),
     case update_doc_from_file(DbName, Path) of
@@ -241,8 +241,8 @@ do_revise_docs_from_folder(DbName, Sleep, [H|T]) ->
         end.
 
 -spec maybe_update_doc(kz_term:ne_binary(), kz_json:object()) ->
-                              {'ok', kz_json:object()} |
-                              data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 maybe_update_doc(DbName, JObj) ->
     case should_update(DbName, JObj) of
         'false' ->
@@ -287,7 +287,7 @@ maybe_adapt_multilines(JObj) ->
     end.
 
 -spec inline_js_fun(kz_term:ne_binary(), kz_term:ne_binaries() | kz_json:json_term(), kz_json:object()) ->
-                           kz_json:object().
+          kz_json:object().
 inline_js_fun(Type, Code=[<<"function",_/binary>>|_], Acc) ->
     kz_json:set_value(Type, iolist_to_binary(Code), Acc);
 inline_js_fun(Type, Code, Acc) ->
@@ -330,7 +330,7 @@ do_load_fixtures_from_folder(DbName, [F|Fs]) ->
 %% @doc Determines if a database exists.
 %% @end
 %%------------------------------------------------------------------------------
--spec db_exists(kz_term:text()) -> boolean().
+-spec db_exists(kz_term:ne_binary()) -> boolean().
 db_exists(DbName) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_exists(kzs_plan:plan(DbName), DbName);
 db_exists(DbName) ->
@@ -339,7 +339,7 @@ db_exists(DbName) ->
         {'error', _}=E -> E
     end.
 
--spec db_exists(kz_term:text(), kz_term:api_binary() | kz_term:proplist()) -> boolean().
+-spec db_exists(kz_term:ne_binary(), kz_term:api_binary() | kz_term:proplist()) -> boolean().
 db_exists(DbName, 'undefined') ->
     db_exists(DbName);
 db_exists(DbName, Type)
@@ -360,7 +360,7 @@ db_exists(DbName, Options) ->
 %% @doc Determines if a database exists, also checks other connections.
 %% @end
 %%------------------------------------------------------------------------------
--spec db_exists_all(kz_term:text()) -> boolean().
+-spec db_exists_all(kz_term:ne_binary()) -> boolean().
 db_exists_all(DbName) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_exists_all(kzs_plan:plan(DbName), DbName);
 db_exists_all(DbName) ->
@@ -374,7 +374,7 @@ db_exists_all(DbName) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec db_info() -> {'ok', kz_term:ne_binaries()} |
-                   data_error().
+          data_error().
 db_info() ->
     kzs_db:db_info(kzs_plan:plan()).
 
@@ -382,8 +382,8 @@ db_info() ->
 %% @doc Retrieve information regarding a database.
 %% @end
 %%------------------------------------------------------------------------------
--spec db_info(kz_term:text()) -> {'ok', kz_json:object()} |
-                                 data_error().
+-spec db_info(kz_term:ne_binary()) -> {'ok', kz_json:object()} |
+          data_error().
 db_info(DbName) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_info(kzs_plan:plan(DbName), DbName);
 db_info(DbName) ->
@@ -396,9 +396,9 @@ db_info(DbName) ->
 %% @doc Retrieve information regarding a database design doc.
 %% @end
 %%------------------------------------------------------------------------------
--spec design_info(kz_term:text(), kz_term:ne_binary()) ->
-                         {'ok', kz_json:object()} |
-                         data_error().
+-spec design_info(kz_term:ne_binary(), kz_term:ne_binary()) ->
+          {'ok', kz_json:object()} |
+          data_error().
 
 design_info(DbName, DesignName) when ?VALID_DBNAME(DbName) ->
     kzs_view:design_info(kzs_plan:plan(DbName, DesignName), DbName, DesignName);
@@ -431,16 +431,16 @@ db_view_cleanup(DbName) ->
     end.
 
 -spec db_view_update(kz_term:ne_binary(), views_listing()) ->
-                            boolean() |
-                            {'error', 'db_not_found'} |
-                            {'error', 'invalid_db_name'}.
+          boolean() |
+          {'error', 'db_not_found'} |
+          {'error', 'invalid_db_name'}.
 db_view_update(DbName, Views) ->
     db_view_update(DbName, Views, 'false').
 
 -spec db_view_update(kz_term:ne_binary(), views_listing(), boolean()) ->
-                            boolean() |
-                            {'error', 'db_not_found'} |
-                            {'error', 'invalid_db_name'}.
+          boolean() |
+          {'error', 'db_not_found'} |
+          {'error', 'invalid_db_name'}.
 db_view_update(DbName, Views0, Remove) when ?VALID_DBNAME(DbName) ->
     case lists:keymap(fun maybe_adapt_multilines/1, 2, Views0) of
         [] -> 'false';
@@ -482,8 +482,8 @@ db_view_update(DbName, Views, Remove) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec db_replicate(kz_term:proplist() | kz_json:object()) ->
-                          {'ok', kz_json:object()} |
-                          data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 db_replicate(Prop) when is_list(Prop) ->
     db_replicate(kz_json:from_list(Prop));
 db_replicate(JObj) ->
@@ -493,11 +493,11 @@ db_replicate(JObj) ->
 %% @doc Determines if a database exists.
 %% @end
 %%------------------------------------------------------------------------------
--spec db_create(kz_term:text()) -> boolean().
+-spec db_create(kz_term:ne_binary()) -> boolean().
 db_create(DbName) ->
     db_create(DbName, []).
 
--spec db_create(kz_term:text(), kzs_db:db_create_options()) -> boolean().
+-spec db_create(kz_term:ne_binary(), kzs_db:db_create_options()) -> boolean().
 db_create(DbName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_create(kzs_plan:plan(DbName), DbName, Options);
 db_create(DbName, Options) ->
@@ -510,7 +510,7 @@ db_create(DbName, Options) ->
 %% @doc Compact a database.
 %% @end
 %%------------------------------------------------------------------------------
--spec db_compact(kz_term:text()) -> boolean().
+-spec db_compact(kz_term:ne_binary()) -> boolean().
 
 db_compact(DbName) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_compact(kzs_plan:plan(DbName), DbName);
@@ -524,11 +524,11 @@ db_compact(DbName) ->
 %% @doc Delete a database (takes an `encoded' DbName).
 %% @end
 %%------------------------------------------------------------------------------
--spec db_delete(kz_term:text()) -> boolean().
+-spec db_delete(kz_term:ne_binary()) -> boolean().
 db_delete(DbName) ->
     db_delete(DbName, []).
 
--spec db_delete(kz_term:text(), db_delete_options()) -> boolean().
+-spec db_delete(kz_term:ne_binary(), db_delete_options()) -> boolean().
 db_delete(DbName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_db:db_delete(kzs_plan:plan(DbName), DbName, Options);
 db_delete(DbName, Options) ->
@@ -572,17 +572,17 @@ db_import(DbName, ArchiveFile) ->
 %% @doc fetch a cached doc or open it if not available.
 %% @end
 %%------------------------------------------------------------------------------
--spec open_cache_doc(kz_term:text(), docid()) ->
-                            {'ok', kz_json:object()} |
-                            data_error().
+-spec open_cache_doc(kz_term:ne_binary(), docid()) ->
+          {'ok', kz_json:object()} |
+          data_error().
 open_cache_doc(DbName, {DocType, DocId}) ->
     open_cache_doc(DbName, DocId, [{'doc_type', DocType}]);
 open_cache_doc(DbName, DocId) ->
     open_cache_doc(DbName, DocId, []).
 
--spec open_cache_doc(kz_term:text(), docid(), kz_term:proplist()) ->
-                            {'ok', kz_json:object()} |
-                            data_error().
+-spec open_cache_doc(kz_term:ne_binary(), docid(), kz_term:proplist()) ->
+          {'ok', kz_json:object()} |
+          data_error().
 open_cache_doc(DbName, {DocType, DocId}, Options) ->
     open_cache_doc(DbName, DocId, maybe_add_doc_type(DocType, Options));
 open_cache_doc(DbName, DocId, Options) when ?VALID_DBNAME(DbName) ->
@@ -593,9 +593,9 @@ open_cache_doc(DbName, DocId, Options) ->
         {'error', _}=E -> E
     end.
 
--spec add_to_doc_cache(kz_term:text(), kz_term:ne_binary(), kz_json:object()) ->
-                              'ok' |
-                              data_error().
+-spec add_to_doc_cache(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
+          'ok' |
+          data_error().
 add_to_doc_cache(DbName, DocId, Doc) when ?VALID_DBNAME(DbName) ->
     kzs_cache:add_to_doc_cache(DbName, DocId, Doc);
 add_to_doc_cache(DbName, DocId, Doc) ->
@@ -604,9 +604,9 @@ add_to_doc_cache(DbName, DocId, Doc) ->
         {'error', _}=E -> E
     end.
 
--spec update_cache_doc(kz_term:text(), kz_term:ne_binary(), fun((kz_json:object()) -> kz_json:object() | 'skip')) ->
-                              {'ok', kz_json:object()} |
-                              data_error().
+-spec update_cache_doc(kz_term:ne_binary(), kz_term:ne_binary(), fun((kz_json:object()) -> kz_json:object() | 'skip')) ->
+          {'ok', kz_json:object()} |
+          data_error().
 update_cache_doc(DbName, DocId, Fun) when is_function(Fun, 1) ->
     case open_cache_doc(DbName, DocId) of
         {'ok', JObj} ->
@@ -617,23 +617,23 @@ update_cache_doc(DbName, DocId, Fun) when is_function(Fun, 1) ->
             Else
     end.
 
--spec maybe_save_doc(kz_term:text(), kz_json:object() | 'skip', kz_json:object()) ->
-                            {'ok', kz_json:object() | kz_json:objects()} |
-                            data_error().
+-spec maybe_save_doc(kz_term:ne_binary(), kz_json:object() | 'skip', kz_json:object()) ->
+          {'ok', kz_json:object() | kz_json:objects()} |
+          data_error().
 maybe_save_doc(_DbName, 'skip', Jobj) ->
     {'ok', Jobj};
 maybe_save_doc(DbName, JObj, _OldJobj) ->
     save_doc(DbName, JObj).
 
 -spec flush_cache_doc(kz_term:ne_binary(), kz_term:ne_binary() | kz_json:object()) ->
-                             'ok' |
-                             {'error', 'invalid_db_name'}.
+          'ok' |
+          {'error', 'invalid_db_name'}.
 flush_cache_doc(DbName, Doc) ->
     flush_cache_doc(DbName, Doc, []).
 
 -spec flush_cache_doc(kz_term:ne_binary(), kz_term:ne_binary() | kz_json:object(), kz_term:proplist()) ->
-                             'ok' |
-                             {'error', 'invalid_db_name'}.
+          'ok' |
+          {'error', 'invalid_db_name'}.
 flush_cache_doc(DbName, Doc, Options) when ?VALID_DBNAME(DbName) ->
     kzs_cache:flush_cache_doc(DbName, Doc, Options);
 flush_cache_doc(DbName, Doc, Options) ->
@@ -645,7 +645,7 @@ flush_cache_doc(DbName, Doc, Options) ->
 -spec flush_cache_docs() -> 'ok'.
 flush_cache_docs() -> kzs_cache:flush_cache_docs().
 
--spec flush_cache_docs(kz_term:text()) -> 'ok' | {'error', 'invalid_db_name'}.
+-spec flush_cache_docs(kz_term:ne_binary()) -> 'ok' | {'error', 'invalid_db_name'}.
 flush_cache_docs(DbName) ->
     case maybe_convert_dbname(DbName) of
         {'ok', Db} -> kzs_cache:flush_cache_docs(Db);
@@ -669,19 +669,19 @@ flush_cache_docs(DbName) ->
 %% @doc open a document given a doc id returns an error tuple or the json.
 %% @end
 %%------------------------------------------------------------------------------
--spec open_doc(kz_term:text(), docid()) ->
-                      {'ok', kz_json:object()} |
-                      data_error() |
-                      {'error', 'not_found'}.
+-spec open_doc(kz_term:ne_binary(), docid()) ->
+          {'ok', kz_json:object()} |
+          data_error() |
+          {'error', 'not_found'}.
 open_doc(DbName, {DocType, DocId}) ->
     open_doc(DbName, DocId, [{'doc_type', DocType}]);
 open_doc(DbName, DocId) ->
     open_doc(DbName, DocId, []).
 
--spec open_doc(kz_term:text(), docid(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      data_error() |
-                      {'error', 'not_found'}.
+-spec open_doc(kz_term:ne_binary(), docid(), kz_term:proplist()) ->
+          {'ok', kz_json:object()} |
+          data_error() |
+          {'error', 'not_found'}.
 open_doc(DbName, {DocType, DocId}, Options) ->
     open_doc(DbName, DocId, maybe_add_doc_type(DocType, Options));
 open_doc(DbName, DocId, Options) when ?VALID_DBNAME(DbName) ->
@@ -699,17 +699,17 @@ open_doc(DbName, DocId, Options) ->
 %% So: match both error tuple and each JSON of the list.
 %% @end
 %%------------------------------------------------------------------------------
--spec open_docs(kz_term:text(), docids()) ->
-                       {'ok', kz_json:objects()} |
-                       data_error() |
-                       {'error', 'not_found'}.
+-spec open_docs(kz_term:ne_binary(), docids()) ->
+          {'ok', kz_json:objects()} |
+          data_error() |
+          {'error', 'not_found'}.
 open_docs(DbName, DocIds) ->
     open_docs(DbName, DocIds, []).
 
--spec open_docs(kz_term:text(), docids(), kz_term:proplist()) ->
-                       {'ok', kz_json:objects()} |
-                       data_error() |
-                       {'error', 'not_found'}.
+-spec open_docs(kz_term:ne_binary(), docids(), kz_term:proplist()) ->
+          {'ok', kz_json:objects()} |
+          data_error() |
+          {'error', 'not_found'}.
 open_docs(DbName, DocIds, Options) ->
     read_chunked(fun do_open_docs/3, DbName, DocIds, Options).
 
@@ -731,7 +731,7 @@ read_chunked(Opener, DbName, DocIds, Options, Acc) ->
             end
     end.
 
-read_chunked_results(_, _, _, _, {'error',_}=Acc) -> Acc;
+read_chunked_results(_, _, _, _, {'error', _}=Acc) -> Acc;
 read_chunked_results(Opener, DbName, DocIds, Options, Acc) ->
     read_chunked_results(DocIds, Opener(DbName, DocIds, Options), Acc).
 
@@ -757,17 +757,17 @@ read_chunked_results(DocIds, {'error', Reason}, Acc) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec open_cache_docs(kz_term:text(), docids()) ->
-                             {'ok', kz_json:objects()} |
-                             data_error() |
-                             {'error', 'not_found'}.
+-spec open_cache_docs(kz_term:ne_binary(), docids()) ->
+          {'ok', kz_json:objects()} |
+          data_error() |
+          {'error', 'not_found'}.
 open_cache_docs(DbName, DocIds) ->
     open_cache_docs(DbName, DocIds, []).
 
--spec open_cache_docs(kz_term:text(), docids(), kz_term:proplist()) ->
-                             {'ok', kz_json:objects()} |
-                             data_error() |
-                             {'error', 'not_found'}.
+-spec open_cache_docs(kz_term:ne_binary(), docids(), kz_term:proplist()) ->
+          {'ok', kz_json:objects()} |
+          data_error() |
+          {'error', 'not_found'}.
 open_cache_docs(DbName, DocIds, Options) when ?VALID_DBNAME(DbName) ->
     read_chunked(fun kzs_cache:open_cache_docs/3, DbName, DocIds, Options);
 open_cache_docs(DbName, DocIds, Options) ->
@@ -776,15 +776,15 @@ open_cache_docs(DbName, DocIds, Options) ->
         {'error', _}=E -> E
     end.
 
--spec all_docs(kz_term:text()) ->
-                      {'ok', kz_json:objects()} |
-                      data_error().
+-spec all_docs(kz_term:ne_binary()) ->
+          {'ok', kz_json:objects()} |
+          data_error().
 all_docs(DbName) ->
     all_docs(DbName, []).
 
--spec all_docs(kz_term:text(), kz_term:proplist()) ->
-                      {'ok', kz_json:objects()} |
-                      data_error().
+-spec all_docs(kz_term:ne_binary(), kz_term:proplist()) ->
+          {'ok', kz_json:objects()} |
+          data_error().
 all_docs(DbName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_view:all_docs(kzs_plan:plan(DbName, Options), DbName, Options);
 all_docs(DbName, Options) ->
@@ -792,7 +792,6 @@ all_docs(DbName, Options) ->
         {'ok', Db} -> all_docs(Db, Options);
         {'error', _}=E -> E
     end.
-
 
 -spec db_list() -> {'ok', kz_term:ne_binaries()} | data_error().
 db_list() ->
@@ -802,13 +801,13 @@ db_list() ->
 db_list(Options) ->
     kzs_db:db_list(kzs_plan:plan(), Options).
 
--spec all_design_docs(kz_term:text()) -> {'ok', kz_json:objects()} |
-                                         data_error().
+-spec all_design_docs(kz_term:ne_binary()) -> {'ok', kz_json:objects()} |
+          data_error().
 all_design_docs(DbName) ->
     all_design_docs(DbName, []).
 
--spec all_design_docs(kz_term:text(), kz_term:proplist()) -> {'ok', kz_json:objects()} |
-                                                             data_error().
+-spec all_design_docs(kz_term:ne_binary(), kz_term:proplist()) -> {'ok', kz_json:objects()} |
+          data_error().
 all_design_docs(DbName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_view:all_design_docs(kzs_plan:plan(DbName), DbName, Options);
 all_design_docs(DbName, Options) ->
@@ -821,16 +820,16 @@ all_design_docs(DbName, Options) ->
 %% @doc Get the revision of a document (much faster than requesting the whole document).
 %% @end
 %%------------------------------------------------------------------------------
--spec lookup_doc_rev(kz_term:text(), docid()) ->
-                            {'ok', kz_term:ne_binary()} |
-                            data_error().
+-spec lookup_doc_rev(kz_term:ne_binary(), docid()) ->
+          {'ok', kz_term:ne_binary()} |
+          data_error().
 lookup_doc_rev(DbName, {DocType, DocId}) ->
     lookup_doc_rev(DbName, DocId, [{'doc_type', DocType}]);
 lookup_doc_rev(DbName, DocId) ->
     lookup_doc_rev(DbName, DocId, []).
 
--spec lookup_doc_rev(kz_term:text(), docid(), kz_term:proplist()) ->
-                            {'ok', kz_term:ne_binary()} | data_error().
+-spec lookup_doc_rev(kz_term:ne_binary(), docid(), kz_term:proplist()) ->
+          {'ok', kz_term:ne_binary()} | data_error().
 lookup_doc_rev(DbName, {DocType, DocId}, Options) ->
     lookup_doc_rev(DbName, DocId, maybe_add_doc_type(DocType, Options));
 lookup_doc_rev(DbName, DocId, Options) when ?VALID_DBNAME(DbName) ->
@@ -845,9 +844,9 @@ lookup_doc_rev(DbName, DocId, Options) ->
 %% @doc Save document to database.
 %% @end
 %%------------------------------------------------------------------------------
--spec save_doc(kz_term:text(), kz_json:object() | kz_json:objects()) ->
-                      {'ok', kz_json:object() | kz_json:objects()} |
-                      data_error().
+-spec save_doc(kz_term:ne_binary(), kz_json:object() | kz_json:objects()) ->
+          {'ok', kz_json:object() | kz_json:objects()} |
+          data_error().
 save_doc(DbName, Docs) when is_list(Docs) ->
     save_docs(DbName, Docs, []);
 save_doc(DbName, Doc) ->
@@ -859,15 +858,15 @@ save_doc(DbName, Doc) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec ensure_saved(kz_term:text(), kz_json:object()) ->
-                          {'ok', kz_json:object()} |
-                          data_error().
+-spec ensure_saved(kz_term:ne_binary(), kz_json:object()) ->
+          {'ok', kz_json:object()} |
+          data_error().
 ensure_saved(DbName, Doc) ->
     ensure_saved(DbName, Doc, []).
 
--spec ensure_saved(kz_term:text(), kz_json:object(), kz_term:proplist()) ->
-                          {'ok', kz_json:object()} |
-                          data_error().
+-spec ensure_saved(kz_term:ne_binary(), kz_json:object(), kz_term:proplist()) ->
+          {'ok', kz_json:object()} |
+          data_error().
 ensure_saved(DbName, Doc, Options) when ?VALID_DBNAME(DbName) ->
     kzs_doc:ensure_saved(kzs_plan:plan(DbName, Doc), DbName, Doc, Options);
 ensure_saved(DbName, Doc, Options) ->
@@ -876,9 +875,9 @@ ensure_saved(DbName, Doc, Options) ->
         {'error', _}=E -> E
     end.
 
--spec save_doc(kz_term:text(), kz_json:object(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      data_error().
+-spec save_doc(kz_term:ne_binary(), kz_json:object(), kz_term:proplist()) ->
+          {'ok', kz_json:object()} |
+          data_error().
 save_doc(DbName, Doc, Options) when ?VALID_DBNAME(DbName) ->
     OldSetting = maybe_toggle_publish(Options),
     Result = kzs_doc:save_doc(kzs_plan:plan(DbName, Doc), DbName, Doc, Options),
@@ -907,15 +906,15 @@ maybe_revert_publish('false') ->
     suppress_change_notice().
 
 
--spec save_docs(kz_term:text(), kz_json:objects()) ->
-                       {'ok', kz_json:objects()} |
-                       data_error().
+-spec save_docs(kz_term:ne_binary(), kz_json:objects()) ->
+          {'ok', kz_json:objects()} |
+          data_error().
 save_docs(DbName, Docs) when is_list(Docs) ->
     save_docs(DbName, Docs, []).
 
--spec save_docs(kz_term:text(), kz_json:objects(), kz_term:proplist()) ->
-                       {'ok', kz_json:objects()} |
-                       data_error().
+-spec save_docs(kz_term:ne_binary(), kz_json:objects(), kz_term:proplist()) ->
+          {'ok', kz_json:objects()} |
+          data_error().
 save_docs(DbName, [Doc|_]=Docs, Options)
   when is_list(Docs), ?VALID_DBNAME(DbName) ->
     OldSetting = maybe_toggle_publish(Options),
@@ -936,8 +935,8 @@ save_docs(DbName, Docs, Options) when is_list(Docs) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec update_doc(kz_term:ne_binary(), docid(), update_options()) ->
-                        {'ok', kz_json:object()} |
-                        data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 update_doc(DbName, Id, Options) ->
     case open_doc(DbName, Id) of
         {'error', 'not_found'} ->
@@ -948,8 +947,8 @@ update_doc(DbName, Id, Options) ->
     end.
 
 -spec apply_updates_and_save(kz_term:ne_binary(), docid(), update_options(), kz_json:object()) ->
-                                    {'ok', kz_json:object()} |
-                                    data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 apply_updates_and_save(DbName, Id, Options, CurrentDoc) ->
     apply_updates_and_save(DbName, Id, Options, CurrentDoc, props:get_value('update', Options)).
 
@@ -969,8 +968,8 @@ apply_updates_and_save(DbName, Id, Options, CurrentDoc, UpdateProps) ->
     end.
 
 -spec save_update(kz_term:ne_binary(), docid(), update_options(), kz_json:object()) ->
-                         {'ok', kz_json:object()} |
-                         data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 save_update(DbName, Id, Options, UpdatedDoc) ->
     ExtraProps = props:get_value('extra_update', Options, []),
     ExtraUpdatedDoc = kz_json:set_values(ExtraProps, UpdatedDoc),
@@ -991,8 +990,8 @@ save_update(DbName, Id, Options, UpdatedDoc) ->
     end.
 
 -spec update_not_found(kz_term:ne_binary(), docid(), update_options(), boolean()) ->
-                              {'ok', kz_json:object()} |
-                              data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 update_not_found(_DbName, _Id, _Options, 'false') ->
     {'error', 'not_found'};
 update_not_found(DbName, Id, Options, 'true') ->
@@ -1012,15 +1011,15 @@ update_not_found(DbName, Id, Options, 'true') ->
 %% @doc Remove document from the db.
 %% @end
 %%------------------------------------------------------------------------------
--spec del_doc(kz_term:text(), kz_json:object() | kz_json:objects() | kz_term:ne_binary()) ->
-                     {'ok', kz_json:objects()} |
-                     data_error().
+-spec del_doc(kz_term:ne_binary(), kz_json:object() | kz_json:objects() | kz_term:ne_binary()) ->
+          {'ok', kz_json:objects()} |
+          data_error().
 del_doc(DbName, Doc) ->
     del_doc(DbName, Doc, []).
 
--spec del_doc(kz_term:text(), kz_json:object() | kz_json:objects() | kz_term:ne_binary(), kz_term:proplist()) ->
-                     {'ok', kz_json:objects()} |
-                     data_error().
+-spec del_doc(kz_term:ne_binary(), kz_json:object() | kz_json:objects() | kz_term:ne_binary(), kz_term:proplist()) ->
+          {'ok', kz_json:objects()} |
+          data_error().
 del_doc(DbName, Doc, Options) when is_list(Doc) ->
     del_docs(DbName, Doc, Options);
 del_doc(DbName, Doc, Options) when ?VALID_DBNAME(DbName) ->
@@ -1035,15 +1034,15 @@ del_doc(DbName, Doc, Options) ->
 %% @doc Remove documents from the db.
 %% @end
 %%------------------------------------------------------------------------------
--spec del_docs(kz_term:text(), kz_json:objects() | kz_term:ne_binaries()) ->
-                      {'ok', kz_json:objects()} |
-                      data_error().
+-spec del_docs(kz_term:ne_binary(), kz_json:objects() | kz_term:ne_binaries()) ->
+          {'ok', kz_json:objects()} |
+          data_error().
 del_docs(DbName, Docs) ->
     del_docs(DbName, Docs, []).
 
--spec del_docs(kz_term:text(), kz_json:objects() | kz_term:ne_binaries(), kz_term:proplist()) ->
-                      {'ok', kz_json:objects()} |
-                      data_error().
+-spec del_docs(kz_term:ne_binary(), kz_json:objects() | kz_term:ne_binaries(), kz_term:proplist()) ->
+          {'ok', kz_json:objects()} |
+          data_error().
 del_docs(DbName, Docs, Options)
   when is_list(Docs), ?VALID_DBNAME(DbName) ->
     kzs_doc:del_docs(kzs_plan:plan(DbName), DbName, Docs, Options);
@@ -1061,19 +1060,19 @@ del_docs(DbName, Docs, Options) when is_list(Docs) ->
 %% @doc Fetch attachment with `AName' from document `DocId'.
 %% @end
 %%------------------------------------------------------------------------------
--spec fetch_attachment(kz_term:text(), docid(), kz_term:ne_binary()) ->
-                              {'ok', binary()} |
-                              data_error() |
-                              kz_att_error:error().
+-spec fetch_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary()) ->
+          {'ok', binary()} |
+          data_error() |
+          kz_att_error:error().
 fetch_attachment(DbName, {DocType, DocId}, AName) ->
     fetch_attachment(DbName, DocId, AName, [{'doc_type', DocType}]);
 fetch_attachment(DbName, DocId, AName) ->
     fetch_attachment(DbName, DocId, AName, []).
 
--spec fetch_attachment(kz_term:text(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
-                              {'ok', binary()} |
-                              data_error() |
-                              kz_att_error:error().
+-spec fetch_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
+          {'ok', binary()} |
+          data_error() |
+          kz_att_error:error().
 fetch_attachment(DbName, {DocType, DocId}, AName, Options) when ?VALID_DBNAME(DbName) ->
     fetch_attachment(DbName, DocId, AName, maybe_add_doc_type(DocType, Options));
 fetch_attachment(DbName, DocId, AName, Options) when ?VALID_DBNAME(DbName) ->
@@ -1084,21 +1083,21 @@ fetch_attachment(DbName, DocId, AName, Options) ->
         {'error', _}=E -> E
     end.
 
--spec stream_attachment(kz_term:text(), docid(), kz_term:ne_binary()) ->
-                               {'ok', reference()} |
-                               {'error', any()}.
+-spec stream_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary()) ->
+          {'ok', reference()} |
+          {'error', any()}.
 stream_attachment(DbName, DocId, AName) ->
     stream_attachment(DbName, DocId, AName, []).
 
--spec stream_attachment(kz_term:text(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
-                               {'ok', reference()} |
-                               {'error', any()}.
+-spec stream_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
+          {'ok', reference()} |
+          {'error', any()}.
 stream_attachment(DbName, DocId, AName, Options) ->
     stream_attachment(DbName, DocId, AName, Options, self()).
 
--spec stream_attachment(kz_term:text(), docid(), kz_term:ne_binary(), kz_term:proplist(), pid()) ->
-                               {'ok', reference()} |
-                               {'error', any()}.
+-spec stream_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:proplist(), pid()) ->
+          {'ok', reference()} |
+          {'error', any()}.
 stream_attachment(DbName, {DocType, DocId}, AName, Options, Pid) when ?VALID_DBNAME(DbName) ->
     stream_attachment(DbName, DocId, AName, maybe_add_doc_type(DocType, Options), Pid);
 stream_attachment(DbName, DocId, AName, Options, Pid) when ?VALID_DBNAME(DbName) ->
@@ -1121,18 +1120,18 @@ stream_attachment(DbName, DocId, AName, Options, Pid) ->
 %% <div class="notice">Note atoms as keys in proplist.</div>
 %% @end
 %%------------------------------------------------------------------------------
--spec put_attachment(kz_term:text(), docid(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                            {'ok', kz_json:object()} |
-                            data_error() |
-                            kz_att_error:error().
+-spec put_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+          {'ok', kz_json:object()} |
+          data_error() |
+          kz_att_error:error().
 put_attachment(DbName, DocId, AName, Contents) ->
     put_attachment(DbName, DocId, AName, Contents, []).
 
--spec put_attachment(kz_term:text(), docid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
-                            {'ok', kz_json:object()} |
-                            {'ok', kz_json:object(), kz_term:proplist()} |
-                            data_error() |
-                            kz_att_error:error().
+-spec put_attachment(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
+          {'ok', kz_json:object()} |
+          {'ok', kz_json:object(), kz_term:proplist()} |
+          data_error() |
+          kz_att_error:error().
 put_attachment(DbName, {DocType, DocId}, AName, Contents, Options) ->
     put_attachment(DbName, DocId, AName, Contents, maybe_add_doc_type(DocType, Options));
 put_attachment(DbName, DocId, AName, Contents, Options) when ?VALID_DBNAME(DbName) ->
@@ -1148,15 +1147,15 @@ put_attachment(DbName, DocId, AName, Contents, Options) ->
         {'error', _}=E -> E
     end.
 
--spec delete_attachment(kz_term:text(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                               {'ok', kz_json:object()} |
-                               data_error().
+-spec delete_attachment(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+          {'ok', kz_json:object()} |
+          data_error().
 delete_attachment(DbName, DocId, AName) ->
     delete_attachment(DbName, DocId, AName, []).
 
--spec delete_attachment(kz_term:text(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
-                               {'ok', kz_json:object()} |
-                               data_error().
+-spec delete_attachment(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
+          {'ok', kz_json:object()} |
+          data_error().
 delete_attachment(DbName, DocId, AName, Options) when ?VALID_DBNAME(DbName) ->
     kzs_attachments:delete_attachment(kzs_plan:plan(DbName, DocId), DbName, DocId, AName, Options);
 delete_attachment(DbName, DocId, AName, Options) ->
@@ -1165,17 +1164,17 @@ delete_attachment(DbName, DocId, AName, Options) ->
         {'error', _}=E -> E
     end.
 
--spec attachment_url(kz_term:text(), docid(), kz_term:ne_binary()) ->
-                            kz_term:ne_binary() |
-                            {'proxy', tuple()} |
-                            {'error', any()}.
+-spec attachment_url(kz_term:ne_binary(), docid(), kz_term:ne_binary()) ->
+          kz_term:ne_binary() |
+          {'proxy', tuple()} |
+          {'error', any()}.
 attachment_url(DbName, DocId, AttachmentId) ->
     attachment_url(DbName, DocId, AttachmentId, []).
 
--spec attachment_url(kz_term:text(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
-                            kz_term:ne_binary() |
-                            {'proxy', tuple()} |
-                            {'error', any()}.
+-spec attachment_url(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
+          kz_term:ne_binary() |
+          {'proxy', tuple()} |
+          {'error', any()}.
 attachment_url(DbName, {DocType, DocId}, AttachmentId, Options) when ?VALID_DBNAME(DbName) ->
     attachment_url(DbName, DocId, AttachmentId, maybe_add_doc_type(DocType, Options));
 attachment_url(DbName, DocId, AttachmentId, Options) when ?VALID_DBNAME(DbName) ->
@@ -1278,15 +1277,15 @@ add_required_option({Key, Fun}, {JObj, Options}=Acc) ->
 %% Returns `{Total, Offset, Meta, Rows}'
 %% @end
 %%------------------------------------------------------------------------------
--spec get_all_results(kz_term:ne_binary(), kz_term:ne_binary()) -> get_results_return().
+-spec get_all_results(kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary()) -> get_results_return().
 get_all_results(DbName, DesignDoc) ->
     get_results(DbName, DesignDoc, []).
 
--spec get_results(kz_term:ne_binary(), kz_term:ne_binary()) -> get_results_return().
+-spec get_results(kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary()) -> get_results_return().
 get_results(DbName, DesignDoc) ->
     get_results(DbName, DesignDoc, []).
 
--spec get_results(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) -> get_results_return().
+-spec get_results(kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary(), view_options()) -> get_results_return().
 get_results(DbName, DesignDoc, Options) when ?VALID_DBNAME(DbName) ->
     ?GET_RESULTS(DbName, DesignDoc, Options),
     Opts = maybe_add_doc_type_from_view(DesignDoc, Options),
@@ -1302,20 +1301,20 @@ get_results(DbName, DesignDoc, Options) ->
     end.
 
 -spec show(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                  {'ok', kz_json:object()} |
-                  data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 show(DbName, DesignDoc) ->
     show(DbName, DesignDoc, 'null').
 
 -spec show(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary() | 'null') ->
-                  {'ok', kz_json:object()} |
-                  data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 show(DbName, DesignDoc, DocId) ->
     show(DbName, DesignDoc, DocId, []).
 
 -spec show(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary() | 'null', kz_term:proplist()) ->
-                  {'ok', kz_json:object()} |
-                  data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 show(DbName, DesignDoc, DocId, Options) when ?VALID_DBNAME(DbName) ->
     Plan = kzs_plan:plan(DbName),
     kzs_view:show(Plan, DbName, DesignDoc, DocId, Options);
@@ -1326,15 +1325,15 @@ show(DbName, DesignDoc, DocId, Options) ->
     end.
 
 -spec get_results_count(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                               {'ok', integer()} |
-                               data_error().
+          {'ok', integer()} |
+          data_error().
 get_results_count(DbName, DesignDoc, Options) ->
     ?GET_RESULTS(DbName, DesignDoc, Options),
     Opts = maybe_add_doc_type_from_view(DesignDoc, Options),
     kzs_view:get_results_count(kzs_plan:plan(DbName, Opts), DbName, DesignDoc, Options).
 
 -spec get_registered_view(map(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                 'not_registered' | kz_json:object().
+          'not_registered' | kz_json:object().
 get_registered_view(Plan, DbName, DesignDoc) ->
     Classification = kz_term:to_binary(kzs_util:db_classification(DbName)),
 
@@ -1350,7 +1349,7 @@ get_registered_view(Plan, DbName, DesignDoc) ->
     end.
 
 -spec query_registered_views(map(), view_options()) -> {'ok', kz_json:objects()} |
-                                                       data_error().
+          data_error().
 query_registered_views(Plan, Options) ->
     kzs_view:get_results(Plan, ?KZ_DATA_DB, <<"views/registered">>, Options).
 
@@ -1361,7 +1360,7 @@ registration_options(Keys) ->
     ].
 
 -spec registration_keys(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                               [[kz_term:ne_binary()]].
+          [[kz_term:ne_binary()]].
 registration_keys(DbName, DesignDoc, Classification) ->
     [[Classification, DesignDoc]
     ,[DbName, DesignDoc]
@@ -1379,8 +1378,8 @@ maybe_create_view(Plan, DbName, DesignDoc, Options, 'true') ->
                                 ,get_registered_view(Plan, DbName, DesignDoc)
                                 ).
 
--spec maybe_create_registered_view(map(), kz_term:ne_binary(), kz_term:ne_binary(), view_options(), kz_json:object() | 'not_registered') ->
-                                          get_results_return().
+-spec maybe_create_registered_view(map(), kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary(), view_options(), kz_json:object() | 'not_registered') ->
+          get_results_return().
 maybe_create_registered_view(_Plan, _DbName, _DesignDoc, _Options, 'not_registered') ->
     {'error', 'not_found'};
 maybe_create_registered_view(Plan, DbName, DesignDoc, Options, ViewJObj) ->
@@ -1424,12 +1423,12 @@ maybe_update_view(Plan, DbName, DesignDoc, ViewDoc, {'ok', CurrentDoc}) ->
 maybe_update_view(_, _, _, _, _Error) -> 'ok'.
 
 -spec get_result_keys(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                             {'ok', kz_term:ne_binaries() | [kz_term:ne_binaries()]} | data_error().
+          {'ok', kz_term:ne_binaries() | [kz_term:ne_binaries()]} | data_error().
 get_result_keys(DbName, DesignDoc) ->
     get_result_keys(DbName, DesignDoc, []).
 
 -spec get_result_keys(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                             {'ok', kz_term:ne_binaries() | [kz_term:ne_binaries()]} | data_error().
+          {'ok', kz_term:ne_binaries() | [kz_term:ne_binaries()]} | data_error().
 get_result_keys(DbName, DesignDoc, Options) ->
     ?GET_RESULTS(DbName, DesignDoc, Options),
     Opts = maybe_add_doc_type_from_view(DesignDoc, Options),
@@ -1445,12 +1444,12 @@ get_result_keys(JObjs) ->
     ].
 
 -spec get_result_ids(kz_term:ne_binary(), kz_term:ne_binary()) ->
-                            {'ok', kz_term:ne_binaries()} | data_error().
+          {'ok', kz_term:ne_binaries()} | data_error().
 get_result_ids(DbName, DesignDoc) ->
     get_result_ids(DbName, DesignDoc, []).
 
 -spec get_result_ids(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                            {'ok', kz_term:ne_binaries()} | data_error().
+          {'ok', kz_term:ne_binaries()} | data_error().
 get_result_ids(DbName, DesignDoc, Options) ->
     ?GET_RESULTS(DbName, DesignDoc, Options),
     Opts = maybe_add_doc_type_from_view(DesignDoc, Options),
@@ -1465,17 +1464,17 @@ get_result_ids(JObjs) ->
 
 %%------------------------------------------------------------------------------
 %% @doc Gets the only result of a view.
-%% If no result is found: returns `{error, not_found}'.
+%% If no result is found: returns `{'error', not_found}'.
 %% If more than one result is found, either:
 %% - if `Options' contains `first_when_multiple'
 %%     then the first one will be returned;
-%% - otherwise `{error, multiple_results}' is returned.
+%% - otherwise `{'error', multiple_results}' is returned.
 %% @end
 %%------------------------------------------------------------------------------
 -spec get_single_result(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                               {'ok', kz_json:object()} |
-                               {'error', 'multiple_results'} |
-                               data_error().
+          {'ok', kz_json:object()} |
+          {'error', 'multiple_results'} |
+          data_error().
 get_single_result(DbName, DesignDoc, Options) ->
     case get_results(DbName, DesignDoc, Options) of
         {'ok', [Result]} -> {'ok', Result};
@@ -1489,9 +1488,9 @@ get_single_result(DbName, DesignDoc, Options) ->
     end.
 
 -spec get_result_doc(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                            {'ok', kz_json:object()} |
-                            {'error', 'multiple_results'} |
-                            data_error().
+          {'ok', kz_json:object()} |
+          {'error', 'multiple_results'} |
+          data_error().
 get_result_doc(DbName, DesignDoc, Key) ->
     Options = ['include_docs'
               ,{'key', Key}
@@ -1504,8 +1503,8 @@ get_result_doc(DbName, DesignDoc, Key) ->
     end.
 
 -spec get_result_docs(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binaries()) ->
-                             {'ok', kz_json:objects()} |
-                             data_error().
+          {'ok', kz_json:objects()} |
+          data_error().
 get_result_docs(DbName, DesignDoc, Keys) ->
     Options = ['include_docs'
               ,{'keys', Keys}
@@ -1524,9 +1523,9 @@ get_result_docs(DbName, DesignDoc, Keys) ->
 -type paginated_results() :: {'ok', kz_json:objects(), kz_json:api_json_term()} |
                              data_error().
 
--spec paginate_results(kz_term:ne_binary(), kz_term:ne_binary(), paginate_options()) ->
-                              {'ok', kz_json:objects(), kz_json:api_json_term()} |
-                              data_error().
+-spec paginate_results(kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary(), paginate_options()) ->
+          {'ok', kz_json:objects(), kz_json:api_json_term()} |
+          data_error().
 paginate_results(DbName, DesignDoc, Options) ->
     {PageSize, ViewOptions} = props:take_value('page_size', Options, 50),
     GetResultsOptions = props:set_value('limit', PageSize+1, ViewOptions),
@@ -1536,8 +1535,8 @@ paginate_results(DbName, DesignDoc, Options) ->
     end.
 
 -spec paginate_results(pos_integer(), kz_json:objects()) ->
-                              {'ok', kz_json:objects(), kz_json:api_json_term()} |
-                              data_error().
+          {'ok', kz_json:objects(), kz_json:api_json_term()} |
+          data_error().
 paginate_results(_PageSize, []) -> {'ok', [], 'undefined'};
 paginate_results(PageSize, Results) ->
     try lists:split(PageSize, Results) of
@@ -1596,8 +1595,8 @@ change_notice() ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec maybe_convert_dbname(kz_term:text()) ->
-                                  {'ok', kz_term:ne_binary()} |
-                                  {'error', 'invalid_db_name'}.
+          {'ok', kz_term:ne_binary()} |
+          {'error', 'invalid_db_name'}.
 maybe_convert_dbname(DbName) ->
     case kz_term:is_empty(DbName) of
         'true' -> {'error', 'invalid_db_name'};
@@ -1605,14 +1604,14 @@ maybe_convert_dbname(DbName) ->
     end.
 
 -spec copy_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 copy_doc(FromDB, FromId, ToDB, Options) ->
     copy_doc(FromDB, FromId, ToDB, FromId, Options).
 
 -spec copy_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), docid(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 copy_doc(FromDB, {DocType, FromId}, ToDB, ToId, Options) ->
     copy_doc(FromDB, FromId, ToDB, ToId, maybe_add_doc_type(DocType, Options));
 copy_doc(FromDB, FromId, ToDB, {DocType, ToId}, Options) ->
@@ -1628,14 +1627,14 @@ copy_doc(FromDB, FromId, ToDB, ToId, Options) ->
     kzs_doc:copy_doc(Src, Dst, CopySpec, Options).
 
 -spec move_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 move_doc(FromDB, FromId, ToDB, Options) ->
     move_doc(FromDB, FromId, ToDB, FromId, Options).
 
 -spec move_doc(kz_term:ne_binary(), docid(), kz_term:ne_binary(), docid(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 move_doc(FromDB, {DocType, FromId}, ToDB, ToId, Options) ->
     move_doc(FromDB, FromId, ToDB, ToId, maybe_add_doc_type(DocType, Options));
 move_doc(FromDB, FromId, ToDB, {DocType, ToId}, Options) ->
@@ -1692,7 +1691,8 @@ maybe_add_doc_type_from_view(ViewName, Options) ->
         _ -> Options
     end.
 
--spec add_doc_type_from_view(kz_term:ne_binary(), view_options()) -> view_options().
+-spec add_doc_type_from_view(kz_term:ne_binary() | 'all_docs', view_options()) -> view_options().
+add_doc_type_from_view('all_docs', Options) -> Options;
 add_doc_type_from_view(View, Options) ->
     case binary:split(View, <<"/">>, ['global']) of
         [ViewType, ViewName] ->
@@ -1737,8 +1737,8 @@ register_views(App, [View | Other]) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec register_view(atom(), view_listing() | string() | kz_term:ne_binary()) ->
-                           {'ok', kz_json:object()} |
-                           data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 register_view(App, {_, ViewJObj}=View) ->
     Validate = validate_view_map(kz_json:get_ne_json_value(<<"kazoo">>, ViewJObj)),
     maybe_register_view(View, App, Validate);
@@ -1746,8 +1746,8 @@ register_view(App, ViewName) ->
     register_view(App, kzs_util:get_view_json(App, ViewName)).
 
 -spec maybe_register_view(view_listing(), atom(), {'error', any()} | {kz_term:ne_binary() | kz_json:objects()}) ->
-                                 {'ok', kz_json:object()} |
-                                 data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 maybe_register_view({<<"_design/", _Name/binary>>, _}, _App, {'error', _Reason}=Error) ->
     lager:error("can not register the view ~s for app ~s: ~s", [_Name, _App, _Reason]),
     Error;
@@ -1784,8 +1784,8 @@ log_register_views(Name, DocId, App, [ViewMap | ViewMaps]) ->
     log_register_views(Name, DocId, App, ViewMaps).
 
 -spec validate_view_map(kz_term:api_object()) ->
-                               {kz_term:ne_binary(), kz_json:objects()} |
-                               {'error', kz_term:ne_binary()}.
+          {kz_term:ne_binary(), kz_json:objects()} |
+          {'error', kz_term:ne_binary()}.
 validate_view_map('undefined') ->
     {'error', <<"no_view_registration_info">>};
 validate_view_map(JObj) ->
@@ -1793,8 +1793,8 @@ validate_view_map(JObj) ->
     validate_view_map(ViewMap, []).
 
 -spec validate_view_map(kz_json:objects(), kz_json:objects() | {'error', kz_term:ne_binary()}) ->
-                               {kz_term:ne_binary(), kz_json:objects()} |
-                               {'error', any()}.
+          {kz_term:ne_binary(), kz_json:objects()} |
+          {'error', any()}.
 validate_view_map(_, {'error', _}=Error) ->
     Error;
 validate_view_map([], []) ->
@@ -1846,8 +1846,8 @@ register_views_from_folder(App, Folder) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec refresh_views(kz_term:ne_binary()) ->
-                           boolean() |
-                           {'error', 'db_not_found' | 'invalid_db_name'}.
+          boolean() |
+          {'error', 'db_not_found' | 'invalid_db_name'}.
 refresh_views(DbName) when ?VALID_DBNAME(DbName) ->
     maybe_refresh_system_db(DbName, lists:member(DbName, ?KZ_SYSTEM_DBS));
 refresh_views(DbName) ->
@@ -1857,8 +1857,8 @@ refresh_views(DbName) ->
     end.
 
 -spec maybe_refresh_system_db(kz_term:ne_binary(), boolean()) ->
-                                     boolean() |
-                                     {'error', 'db_not_found' | 'invalid_db_name'}.
+          boolean() |
+          {'error', 'db_not_found' | 'invalid_db_name'}.
 maybe_refresh_system_db(DbName, 'false') ->
     do_refresh_views(DbName);
 maybe_refresh_system_db(DbName, 'true') ->
@@ -1872,8 +1872,8 @@ maybe_refresh_system_db(DbName, 'true') ->
     end.
 
 -spec do_refresh_views(kz_term:ne_binary()) ->
-                              boolean() |
-                              {'error', 'db_not_found' | 'invalid_db_name'}.
+          boolean() |
+          {'error', 'db_not_found' | 'invalid_db_name'}.
 do_refresh_views(DbName) ->
     suppress_change_notice(),
     Classification = kzs_util:db_classification(DbName),

--- a/core/kazoo_data/src/kzs_attachments.erl
+++ b/core/kazoo_data/src/kzs_attachments.erl
@@ -25,16 +25,16 @@
 
 %% Attachment-related functions ------------------------------------------------
 -spec fetch_attachment(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                              {'ok', binary()} |
-                              data_error() |
-                              kz_att_error:error().
+          {'ok', binary()} |
+          data_error() |
+          kz_att_error:error().
 fetch_attachment(#{}=Server, DbName, DocId, AName) ->
     fetch_attachment(Server, DbName, DocId, AName, []).
 
 -spec fetch_attachment(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) ->
-                              {'ok', binary()} |
-                              data_error() |
-                              kz_att_error:error().
+          {'ok', binary()} |
+          data_error() |
+          kz_att_error:error().
 fetch_attachment(#{}=Server, DbName, DocId, AName, Options) ->
     case kzs_cache:open_cache_doc(Server, DbName, DocId, []) of
         {'ok', Doc} ->
@@ -74,8 +74,8 @@ do_fetch_attachment_from_handler([{Handler, HandlerProps}], {Module, ModuleProps
     end.
 
 -spec stream_attachment(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), pid()) ->
-                               {'ok', reference()} |
-                               data_error().
+          {'ok', reference()} |
+          data_error().
 stream_attachment(#{}=Server, DbName, DocId, AName, Caller) ->
     case kzs_cache:open_cache_doc(Server, DbName, DocId, []) of
         {'ok', Doc} ->
@@ -134,11 +134,11 @@ relay_stream_attachment(Caller, Ref, Bin) ->
                     ,'server' := {module(), db()}
                     }.
 
--spec put_attachment(att_map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
-                            {'ok', kz_json:object()} |
-                            {'ok', kz_json:object(), kz_term:proplist()} |
-                            data_error() |
-                            kz_att_error:error().
+-spec put_attachment(att_map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), iodata(), kz_term:proplist()) ->
+          {'ok', kz_json:object()} |
+          {'ok', kz_json:object(), kz_term:proplist()} |
+          data_error() |
+          kz_att_error:error().
 
 put_attachment(#{att_handler := {Handler, Params}}=Map
               ,DbName, DocId, AName, Contents, Options
@@ -178,12 +178,10 @@ attachment_handler_jobj(Handler, Props) ->
     JObj = kz_json:from_list(props:get_value('attachment', Props, [])),
     kz_json:set_value(kz_term:to_binary(Handler), JObj, kz_json:new()).
 
--spec handle_put_attachment(att_map(), kz_term:api_object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()
-                           , kz_term:proplist(), kz_term:proplist()) ->
-                                   {'ok', kz_json:object()} |
-                                   {'ok', kz_json:object(), kz_term:proplist()} |
-                                   data_error().
-
+-spec handle_put_attachment(att_map(), kz_term:api_object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), iodata(), kz_term:proplist(), kz_term:proplist()) ->
+          {'ok', kz_json:object()} |
+          {'ok', kz_json:object(), kz_term:proplist()} |
+          data_error().
 handle_put_attachment(#{att_post_handler := 'external'}=Map, Att, DbName, DocId, _AName, _Contents, _Options, Props) ->
     case kzs_doc:open_doc(Map, DbName, DocId, []) of
         {'ok', JObj} ->
@@ -200,8 +198,8 @@ handle_put_attachment(#{server := {App, Conn}}=Map, _Att, DbName, DocId, AName, 
     end.
 
 -spec external_attachment(att_map(), kz_term:ne_binary(), kz_json:object(), kz_json:object(), Props) ->
-                                 {'ok', kz_json:object(), Props} |
-                                 data_error().
+          {'ok', kz_json:object(), Props} |
+          data_error().
 external_attachment(Map, DbName, JObj, Att, Props) ->
     Atts = kz_json:merge_jobjs(Att, kz_json:get_value(?KEY_STUB_ATTACHMENTS, JObj, kz_json:new())),
     case kzs_doc:save_doc(Map, DbName, kz_json:set_values([{?KEY_STUB_ATTACHMENTS, Atts}], JObj), []) of
@@ -210,8 +208,8 @@ external_attachment(Map, DbName, JObj, Att, Props) ->
     end.
 
 -spec delete_attachment(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) ->
-                               {'ok', kz_json:object()} |
-                               data_error().
+          {'ok', kz_json:object()} |
+          data_error().
 delete_attachment(#{server := {App, Conn}}=Map, DbName, DocId, AName, Options) ->
     case App:delete_attachment(Conn, DbName, DocId, AName, Options) of
         {'ok', _}=Result ->
@@ -230,13 +228,13 @@ publish_doc(Plan, DbName, DocId) ->
     end.
 
 -spec attachment_url(map(), DbName, DocId, AttachmentId, Handler, Options) ->
-                            kz_term:ne_binary() |
-                            {'proxy', {DbName, DocId, AttachmentId, [{'handler', Handler}] | Options}}
-                                when DbName :: kz_term:ne_binary()
-                                     ,DocId :: kz_term:ne_binary()
-                                     ,AttachmentId :: kz_term:ne_binary()
-                                     ,Handler :: kz_term:api_atom()
-                                     ,Options :: kz_term:proplist().
+          kz_term:ne_binary() |
+          {'proxy', {DbName, DocId, AttachmentId, [{'handler', Handler}] | Options}}
+              when DbName :: kz_term:ne_binary()
+                   ,DocId :: kz_term:ne_binary()
+                   ,AttachmentId :: kz_term:ne_binary()
+                   ,Handler :: kz_term:api_atom()
+                   ,Options :: kz_term:proplist().
 attachment_url(#{att_proxy := 'true'}, DbName, DocId, AttachmentId, 'undefined', Options) ->
     {'proxy', {DbName, DocId, AttachmentId, Options}};
 attachment_url(#{server := {App, Conn}}, DbName, DocId, AttachmentId, 'undefined', Options) ->
@@ -265,7 +263,7 @@ save_attachment_handler_error(Map
     lager:debug("attachment handler error stored with id: ~p", [kz_doc:id(SavedJObj)]).
 
 -spec handle_attachment_handler_error(kz_att_error:error(), kz_data:options()) ->
-                                             kz_att_error:error() | kz_datamgr:data_error().
+          kz_att_error:error() | kz_datamgr:data_error().
 handle_attachment_handler_error({'error', Reason, _ExtendedError}, []) ->
     {'error', Reason};
 handle_attachment_handler_error({'error', Reason, ExtendedError}, Options) ->

--- a/core/kazoo_data/src/kzs_view.erl
+++ b/core/kazoo_data/src/kzs_view.erl
@@ -31,20 +31,20 @@ design_compact(#{server := {App, Conn}}, DbName, Design) -> App:design_compact(C
 design_info(#{server := {App, Conn}}, DBName, Design) -> App:design_info(Conn, DBName, Design).
 
 -spec all_design_docs(map(), kz_term:ne_binary(), view_options()) ->
-                             {'ok', kz_json:objects()} |
-                             data_error().
+          {'ok', kz_json:objects()} |
+          data_error().
 all_design_docs(#{server := {App, Conn}}, DBName, Options) ->
     App:all_design_docs(Conn, DBName, Options).
 
 -spec all_docs(map(), kz_term:ne_binary(), view_options()) ->
-                      {'ok', kz_json:objects()} |
-                      data_error().
+          {'ok', kz_json:objects()} |
+          data_error().
 all_docs(#{server := {App, Conn}}, DbName, Options) ->
     App:all_docs(Conn, DbName, Options).
 
 -spec get_results(map(), kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary(), view_options()) ->
-                         {'ok', kz_json:objects() | kz_json:path()} |
-                         data_error().
+          {'ok', kz_json:objects() | kz_json:path()} |
+          data_error().
 get_results(#{server := {App, Conn}}, DbName, DesignDoc, ViewOptions) ->
     ResultKey = props:get_value('result_key', ViewOptions),
     case App:get_results(Conn, DbName, DesignDoc, ViewOptions) of
@@ -58,8 +58,8 @@ get_results(#{server := {App, Conn}}, DbName, DesignDoc, ViewOptions) ->
 %% list; that would be better, but for not, setting the view's "reduce" to the _count
 %% function will suffice (provided a reduce isn't already defined).
 -spec get_results_count(map(), kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                               {'ok', integer()} |
-                               data_error().
+          {'ok', integer()} |
+          data_error().
 get_results_count(#{server := {App, Conn}}, DbName, DesignDoc, ViewOptions) ->
     App:get_results_count(Conn, DbName, DesignDoc, ViewOptions).
 
@@ -72,7 +72,7 @@ doc_type_from_view(<<"sms">>, _ViewName) -> <<"sms">>;
 doc_type_from_view(_ViewType, _ViewName) -> <<"any">>.
 
 -spec show(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary() | 'null', kz_term:proplist()) ->
-                  {'ok', kz_json:objects() | kz_json:path()} |
-                  data_error().
+          {'ok', kz_json:objects() | kz_json:path()} |
+          data_error().
 show(#{server := {App, Conn}}, DbName, DesignDoc, DocId, Options) ->
     App:show(Conn, DbName, DesignDoc, DocId, Options).

--- a/core/kazoo_data/src/kzs_view.erl
+++ b/core/kazoo_data/src/kzs_view.erl
@@ -42,7 +42,7 @@ all_design_docs(#{server := {App, Conn}}, DBName, Options) ->
 all_docs(#{server := {App, Conn}}, DbName, Options) ->
     App:all_docs(Conn, DbName, Options).
 
--spec get_results(map(), kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
+-spec get_results(map(), kz_term:ne_binary(), 'all_docs' | kz_term:ne_binary(), view_options()) ->
                          {'ok', kz_json:objects() | kz_json:path()} |
                          data_error().
 get_results(#{server := {App, Conn}}, DbName, DesignDoc, ViewOptions) ->

--- a/core/kazoo_fixturedb/doc/db-to-disk.md
+++ b/core/kazoo_fixturedb/doc/db-to-disk.md
@@ -1,0 +1,17 @@
+# How to take a database in KAZOO to disk for FixtureDB
+
+It is helpful to do testing in KAZOO when developing a feature or testing a fix. However, to put all that work into a repeatable test when it involves the database is challenging with FixtureDB when the dataset is large.
+
+This guide will show the steps to take an existing database and populate the FixtureDB filesystem with the appropriate files and view indexes.
+
+## Database to disk
+
+Let's say you need account db `9c2e035c8559b175e58146f6a31a3e67` to persist to FixtureDB. `kz_fixturedb_util:db_to_disk(<<"9c2e035c8559b175e58146f6a31a3e67">>).` will write all the JSON objects in the database to disk. If you want to be selective on which documents to persist, `kz_fixturedb_util:db_to_disk(<<"account%2F9c%2F2e%2F035c8559b175e58146f6a31a3e67">>, FilterFun).` will do the job. `FilterFun` is a function of arity-1 that takes the document as an argument and returns a `boolean()` for whether to persist the document.
+
+## View index to disk
+
+FixtureDb requires the view index of a query to be statically configured into a file. Accomplish this by passing the relevant options into the following function:
+
+   kz_fixturedb_util:view_index_to_disk(<<"account%2F9c%2F2e%2F035c8559b175e58146f6a31a3e67">>, <<"design/view">>, [include_docs]).
+
+This will create the appropriately named view index `design+view-{options_hash}.json` and populate it with the results.

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/docs/device00000000000000000000000002.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/docs/device00000000000000000000000002.json
@@ -214,7 +214,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000002",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "6facbc71a03d95f95560043e15d47a02",
+    "pvt_document_hash": "a6f3bfdb517c26d4cb11e9ca4c11d91d",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/docs/user0000000000000000000000000002.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000000001/docs/user0000000000000000000000000002.json
@@ -221,7 +221,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000002",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "d156f2fbc4098e5db0a156a7471e598f",
+    "pvt_document_hash": "7713851c4b443be80a894ef49a34c2b2",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/14b279cdaef7d55cff7235ba2a5010e9.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/14b279cdaef7d55cff7235ba2a5010e9.json
@@ -81,6 +81,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63658530594,
+    "pvt_document_hash": "3144925c72896429a429bd1c5947bfe4",
     "pvt_is_authenticated": true,
     "pvt_modified": 63721599465,
     "pvt_request_id": "1613081d7962969b2e0096aee214f87f",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/239d0734328f7043629d425ce7d93a4d.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/239d0734328f7043629d425ce7d93a4d.json
@@ -76,6 +76,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63657326484,
+    "pvt_document_hash": "d3c3419ca15418de9332bf225c5ea5d6",
     "pvt_is_authenticated": true,
     "pvt_modified": 63721599464,
     "pvt_request_id": "078c2fa688aa6e653b603f4bc6550bc6",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/2fee5aa5a89193f63822d09019dca1d7.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/2fee5aa5a89193f63822d09019dca1d7.json
@@ -79,6 +79,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63735515296,
+    "pvt_document_hash": "8dd411f9f68ee696cc57ad7c318e5299",
     "pvt_is_authenticated": true,
     "pvt_modified": 63736044489,
     "pvt_request_id": "46ee3651702062f6d34ce14af426e755",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/7145b996f7ee0d40b314114a9869b7fe.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/7145b996f7ee0d40b314114a9869b7fe.json
@@ -84,6 +84,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63666931408,
+    "pvt_document_hash": "db0841c10e4ff51b92e9a893fcbf05a9",
     "pvt_is_authenticated": true,
     "pvt_modified": 63735963697,
     "pvt_request_id": "9ddf9842836ae240326e6d216cf06d5a",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/account0000000000000000000010722.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/account0000000000000000000010722.json
@@ -61,6 +61,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63656900535,
+    "pvt_document_hash": "c7aac5fe55d5d0b7319c2dcaf39e7340",
     "pvt_enabled": true,
     "pvt_is_authenticated": true,
     "pvt_modified": 63721959382,

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/e192d667e3abd732d802353b70c26248.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000010722/docs/e192d667e3abd732d802353b70c26248.json
@@ -76,6 +76,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "1eccbaa7e80d60837f2475ec4329ba8a",
     "pvt_created": 63657326407,
+    "pvt_document_hash": "f26bd079ab8a4deb301a17e54c0eaab7",
     "pvt_is_authenticated": true,
     "pvt_modified": 63735017363,
     "pvt_request_id": "ba677b4f4ef2d73c61f356808f33c705",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/account0000000000000000000044944.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/account0000000000000000000044944.json
@@ -85,7 +85,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63636183145,
-    "pvt_document_hash": "90fdcd9fca247297fb90e2245a0050b7",
+    "pvt_document_hash": "e44323f5090c3bb50993e5ba4988be7e",
     "pvt_enabled": true,
     "pvt_is_authenticated": true,
     "pvt_modified": 63667898685,

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000004.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000004.json
@@ -102,7 +102,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "dde1168ca937cdc2eeabb42ceee4ed81",
+    "pvt_document_hash": "2340934daa534679bff0ea07d537d6f4",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000005.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000005.json
@@ -100,7 +100,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "dde1168ca937cdc2eeabb42ceee4ed81",
+    "pvt_document_hash": "81fa8f6c47855fae0f975da9abab94f8",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000006.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/device00000000000000000000000006.json
@@ -89,7 +89,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "dde1168ca937cdc2eeabb42ceee4ed81",
+    "pvt_document_hash": "33b8ba0440b4143968137743b19aaed9",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/user0000000000000000000000000004.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/user0000000000000000000000000004.json
@@ -92,7 +92,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "78fc87e691bf352f7122301fe8d577e1",
+    "pvt_document_hash": "ef6dbc2c8104f5a4f235bf806badb197",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/user0000000000000000000000000005.json
+++ b/core/kazoo_fixturedb/priv/dbs/account%2Fac%2Fco%2Funt0000000000000000000044944/docs/user0000000000000000000000000005.json
@@ -91,7 +91,7 @@
     "pvt_auth_account_id": "account0000000000000000000000001",
     "pvt_auth_user_id": "user0000000000000000000000000001",
     "pvt_created": 63645260666,
-    "pvt_document_hash": "78fc87e691bf352f7122301fe8d577e1",
+    "pvt_document_hash": "20a92cb1677465cb84d552227f56885f",
     "pvt_is_authenticated": true,
     "pvt_modified": 63645260666,
     "pvt_request_id": "request0000000000000000000000001",

--- a/core/kazoo_fixturedb/src/kz_fixturedb.hrl
+++ b/core/kazoo_fixturedb/src/kz_fixturedb.hrl
@@ -18,17 +18,26 @@
                    ,name => kz_term:ne_binary()
                    }.
 
--type fixture_errors() :: not_found | timeout |
-                          conflict | db_not_found |
-                          empty_doc_id.
--type fixture_error() :: {error, fixture_errors()}.
+-type fixture_errors() :: 'conflict' |
+                          'db_not_found' |
+                          'empty_doc_id' |
+                          'invalid_view_name' |
+                          'not_found' |
+                          'timeout'.
+-type fixture_error() :: {'error', fixture_errors()}.
 
--type doc_resp() :: {ok, kz_json:object()} | fixture_error().
--type docs_resp() :: {ok, kz_json:objects()} | fixture_error().
+-type doc_resp() :: {'ok', kz_json:object()} | fixture_error().
+-type docs_resp() :: {'ok', kz_json:objects()} | fixture_error().
 
--define(DANGEROUS_VIEW_OPTS, [startkey, endkey, key
-                             ,keys, group, group_level
-                             ,reduce, list, skip
+-define(DANGEROUS_VIEW_OPTS, ['endkey'
+                             ,'group'
+                             ,'group_level'
+                             ,'key'
+                             ,'keys'
+                             ,'list'
+                             ,'reduce'
+                             ,'skip'
+                             ,'startkey'
                              ]).
 
 -define(KZ_FIXTUREDB_HRL, 'true').

--- a/core/kazoo_fixturedb/src/kz_fixturedb_util.erl
+++ b/core/kazoo_fixturedb/src/kz_fixturedb_util.erl
@@ -285,17 +285,17 @@ get_default_fixtures_db(DbName) ->
 %%------------------------------------------------------------------------------
 -spec read_json(file:filename_all()) -> {'ok', kz_json:object() | kz_json:objects()} | {'error', 'not_found'}.
 read_json(Path) ->
-    case read_file(Path) of
-        {'ok', Bin} -> {'ok', kz_json:decode(Bin)};
-        {'error', _} -> {'error', 'not_found'}
-    end.
+    process_read_json(read_file(Path)).
+
+process_read_json({'ok', Bin}) -> {'ok', kz_json:decode(Bin)};
+process_read_json({'error', _}) -> {'error', 'not_found'}.
 
 -spec read_file(file:filename_all()) -> binary_or_error().
 read_file(Path) ->
-    case file:read_file(Path) of
-        {'ok', _}=OK -> OK;
-        {'error', _} -> {'error', 'not_found'}
-    end.
+    process_read_file(file:read_file(Path)).
+
+process_read_file({'ok', _}=OK) -> OK;
+process_read_file({'error', _}) -> {'error', 'not_found'}.
 
 -spec update_index_file(file:filename_all(), kz_term:ne_binary(), kz_term:ne_binary()) ->
           binary_or_error().

--- a/core/kazoo_fixturedb/src/kz_fixturedb_view.erl
+++ b/core/kazoo_fixturedb/src/kz_fixturedb_view.erl
@@ -57,7 +57,9 @@ get_results(Server, DbName, Design, Options) ->
             {'error', 'invalid_view_name'}
     end.
 
--spec get_results_count(server_map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) -> {ok, non_neg_integer()} | fixture_error().
+-spec get_results_count(server_map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_data:options()) ->
+          {'ok', non_neg_integer()} |
+          fixture_error().
 get_results_count(Server, DbName, Design, Options) ->
     case get_results(Server, DbName, Design, Options) of
         {'ok', JObjs} -> {'ok', erlang:length(JObjs)};

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -47,15 +47,15 @@
 %%------------------------------------------------------------------------------
 
 -spec get_results(kz_term:ne_binary(), kz_term:ne_binary(), view_options()) ->
-                         {'ok', kz_json:json_terms()} |
-                         {'error', atom()}.
+          {'ok', kz_json:json_terms()} |
+          {'error', atom()}.
 get_results(Account, View, ViewOptions) ->
     MaxRetries = props:get_integer_value('max_retries', ViewOptions, ?MAX_RETRIES),
     get_results(Account, View, ViewOptions, 'first_try', MaxRetries).
 
 -spec get_results(kz_term:ne_binary(), kz_term:ne_binary(), view_options(), atom(), non_neg_integer()) ->
-                         {'ok', kz_json:json_terms()} |
-                         {'error', atom()}.
+          {'ok', kz_json:json_terms()} |
+          {'error', atom()}.
 get_results(_Account, _View, _ViewOptions, Reason, Retry) when Retry =< 0 ->
     lager:debug("max retries to get view ~s/~s results: ~p", [_Account, _View, Reason]),
     {'error', Reason};
@@ -90,7 +90,7 @@ is_modb_option('missing_as_error') -> 'true';
 is_modb_option(_) -> 'false'.
 
 -spec get_results_missing_db(kz_term:ne_binary(), kz_term:ne_binary(), view_options(), integer()) ->
-                                    {'ok', kz_json:objects()}.
+          {'ok', kz_json:objects()}.
 get_results_missing_db(Account, View, ViewOptions, Retry) ->
     AccountMODb = get_modb(Account, ViewOptions),
     ShouldCreate = props:get_is_true('create_db', ViewOptions, 'true'),
@@ -120,8 +120,8 @@ get_results_missing_db(Account, View, ViewOptions, Retry) ->
 %%------------------------------------------------------------------------------
 
 -spec open_doc(kz_term:ne_binary(), kazoo_data:docid()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 open_doc(Account, {_, ?MATCH_MODB_PREFIX(Year,Month,_)} = DocId) ->
     AccountMODb = get_modb(Account, kz_term:to_integer(Year), kz_term:to_integer(Month)),
     couch_open(AccountMODb, DocId);
@@ -133,8 +133,8 @@ open_doc(Account, DocId) ->
     couch_open(AccountMODb, DocId).
 
 -spec open_doc(kz_term:ne_binary(), kazoo_data:docid(), integer() | view_options()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 open_doc(Account, DocId, Options)
   when is_list(Options) ->
     AccountMODb = get_modb(Account, Options),
@@ -145,21 +145,21 @@ open_doc(Account, DocId, Timestamp)
     couch_open(AccountMODb, DocId).
 
 -spec open_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 open_doc(Account, DocId, Year, Month) ->
     AccountMODb = get_modb(Account, Year, Month),
     couch_open(AccountMODb, DocId).
 
 -spec couch_open(kz_term:ne_binary(), kazoo_data:docid()) ->
-                        {'ok', kz_json:object()} |
-                        {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 couch_open(AccountMODb, DocId) ->
     couch_open(AccountMODb, DocId, []).
 
 -spec couch_open(kz_term:ne_binary(), kazoo_data:docid(), kz_term:proplist()) ->
-                        {'ok', kz_json:object()} |
-                        {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 couch_open(AccountMODb, DocId, Options) ->
     EncodedMODb = kz_util:format_account_modb(AccountMODb, 'encoded'),
     case kz_datamgr:open_doc(EncodedMODb, DocId, Options) of
@@ -173,14 +173,14 @@ couch_open(AccountMODb, DocId, Options) ->
 %%------------------------------------------------------------------------------
 
 -spec save_doc(kz_term:ne_binary(), kz_json:object()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 save_doc(Account, Doc) ->
     save_doc(Account, Doc, []).
 
 -spec save_doc(kz_term:ne_binary(), kz_json:object(), kz_time:now() | kz_time:gregorian_seconds() | kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 save_doc(Account, Doc, Options) when is_list(Options) ->
     AccountMODb = get_modb(Account),
     MaxRetries = props:get_integer_value('max_retries', Options, ?MAX_RETRIES),
@@ -189,8 +189,8 @@ save_doc(Account, Doc, Timestamp) ->
     save_doc(Account, Doc, Timestamp, []).
 
 -spec save_doc(kz_term:ne_binary(), kz_json:object(), kz_time:year() | kz_term:ne_binary() | kz_time:now(), kz_time:month() | kz_term:ne_binary() | kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 save_doc(Account, Doc, Timestamp, Options) when is_list(Options) ->
     AccountMODb = get_modb(Account, Timestamp),
     MaxRetries = props:get_integer_value('max_retries', Options, ?MAX_RETRIES),
@@ -204,8 +204,8 @@ save_doc(Account, Doc, Year, Month, Options) ->
     couch_save(AccountMODb, Doc, Options, 'first_try', MaxRetries).
 
 -spec couch_save(kz_term:ne_binary(), kz_json:object(), kz_term:proplist(), atom(), integer()) ->
-                        {'ok', kz_json:object()} |
-                        {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 couch_save(AccountMODb, _Doc, _Options, Reason, Retry) when Retry =< 0 ->
     lager:debug("max retries to save doc in ~s: ~p", [AccountMODb, Reason]),
     {'error', Reason};
@@ -242,14 +242,14 @@ save_fun('true') -> fun kz_datamgr:ensure_saved/3.
 
 
 -spec save_docs(kz_term:text(), kz_json:objects()) ->
-                       {'ok', kz_json:objects()} |
-                       kz_datamgr:data_error().
+          {'ok', kz_json:objects()} |
+          kz_datamgr:data_error().
 save_docs(AccountMODb, Docs) ->
     save_docs(AccountMODb, Docs, []).
 
 -spec save_docs(kz_term:text(), kz_json:objects(), kz_term:proplist()) ->
-                       {'ok', kz_json:objects()} |
-                       kz_datamgr:data_error().
+          {'ok', kz_json:objects()} |
+          kz_datamgr:data_error().
 save_docs(AccountMODb, Docs, Options) ->
     kz_datamgr:save_docs(AccountMODb, Docs, Options).
 
@@ -262,21 +262,21 @@ save_docs(AccountMODb, Docs, Options) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec move_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary(), kazoo_data:docid()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 move_doc(FromDb, FromId, ToDb, ToId) ->
     move_doc(FromDb, FromId, ToDb, ToId, []).
 
 -spec move_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary(), kazoo_data:docid(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 move_doc(FromDb, FromId, ToDb, ToId, Options) ->
     MaxRetries = props:get_integer_value('max_retries', Options, ?MAX_RETRIES),
     move_doc(FromDb, FromId, ToDb, ToId, Options, 'first_try', MaxRetries).
 
 -spec move_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary(), kazoo_data:docid(), kz_term:proplist(), atom(), integer()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 move_doc(_FromDb, _FromId, _ToDb, _ToId, _Options, Reason, Retry) when Retry =< 0 ->
     lager:error("max retries to move doc from ~s/~p to ~s/~p : ~p"
                ,[_FromDb, _FromId, _ToDb, _ToId, Reason]
@@ -308,21 +308,21 @@ move_doc(FromDb, FromId, ToDb, ToId, Options, _Reason, Retry) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec copy_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary(), kazoo_data:docid()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 copy_doc(FromDb, FromId, ToDb, ToId) ->
     copy_doc(FromDb, FromId, ToDb, ToId, []).
 
 -spec copy_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary(), kazoo_data:docid(), kz_term:proplist()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 copy_doc(FromDb, FromId, ToDb, ToId, Options) ->
     MaxRetries = props:get_integer_value('max_retries', Options, ?MAX_RETRIES),
     copy_doc(FromDb, FromId, ToDb, ToId, Options, 'first_try', MaxRetries).
 
 -spec copy_doc(kz_term:ne_binary(), kazoo_data:docid(), kz_term:ne_binary(), kazoo_data:docid(), kz_term:proplist(), atom(), integer()) ->
-                      {'ok', kz_json:object()} |
-                      {'error', atom()}.
+          {'ok', kz_json:object()} |
+          {'error', atom()}.
 copy_doc(_FromDb, _FromId, _ToDb, _ToId, _Options, Reason, Retry) when Retry =< 0 ->
     lager:error("max retries to copy doc from ~s/~p to ~s/~p : ~p"
                ,[_FromDb, _FromId, _ToDb, _ToId, Reason]
@@ -346,9 +346,9 @@ copy_doc(FromDb, FromId, ToDb, ToId, Options, _Reason, Retry) ->
     end.
 
 -spec maybe_create_destination_db(kz_term:ne_binary(), kz_term:docid(), kz_term:ne_binary(), kz_term:proplist()) ->
-                                         'source_not_exists' |
-                                         'too_old'|
-                                         boolean().
+          'source_not_exists' |
+          'too_old'|
+          boolean().
 maybe_create_destination_db(FromDb, FromId, ToDb, Options) ->
     ShouldCreate = props:get_is_true('create_db', Options, 'true'),
     lager:info("destination modb ~p not found, maybe creating...", [ToDb]),
@@ -387,7 +387,7 @@ get_modb(Account) ->
     get_modb(AccountDb, Year, Month).
 
 -spec get_modb(kz_term:ne_binary(), view_options() | kz_time:gregorian_seconds() | kz_time:now()) ->
-                      kz_term:ne_binary().
+          kz_term:ne_binary().
 get_modb(Account, ViewOptions) when is_list(ViewOptions) ->
     AccountDb = kz_util:format_account_db(Account),
     case {props:get_value('month', ViewOptions)
@@ -406,7 +406,7 @@ get_modb(Account, Timestamp) ->
     kz_util:format_account_mod_id(Account, Timestamp).
 
 -spec get_modb(kz_term:ne_binary(), kz_time:year() | kz_term:ne_binary(), kz_time:month() | kz_term:ne_binary()) ->
-                      kz_term:ne_binary().
+          kz_term:ne_binary().
 get_modb(?MATCH_MODB_SUFFIX_RAW(_,_,_) = AccountMODb, _Year, _Month) ->
     AccountMODb;
 get_modb(?MATCH_MODB_SUFFIX_ENCODED(_,_,_) = AccountMODb, _Year, _Month) ->
@@ -604,12 +604,12 @@ delete_if_orphaned(AccountMODb, 'true') ->
     Succeeded.
 
 -spec get_range(kz_term:ne_binary(), kz_time:gregorian_seconds(), kz_time:gregorian_seconds()) ->
-                       kz_term:ne_binaries().
+          kz_term:ne_binaries().
 get_range(AccountId, From, To) ->
     get_range(<<"any">>, AccountId, From, To).
 
 -spec get_range(kz_term:ne_binary(), kz_term:ne_binary(), kz_time:gregorian_seconds(), kz_time:gregorian_seconds()) ->
-                       kz_term:ne_binaries().
+          kz_term:ne_binaries().
 get_range(Type, AccountId, From, To) ->
     {{FromYear, FromMonth, _}, _} = calendar:gregorian_seconds_to_datetime(From),
     {{ToYear,   ToMonth,   _}, _} = calendar:gregorian_seconds_to_datetime(To),
@@ -624,12 +624,12 @@ get_range(Type, AccountId, From, To) ->
 -type year_month_tuple() :: {kz_time:year(), kz_time:month()}.
 
 -spec get_year_month_sequence(kz_term:ne_binary(), year_month_tuple(), year_month_tuple()) ->
-                                     kz_term:ne_binaries().
+          kz_term:ne_binaries().
 get_year_month_sequence(Account, From, To) ->
     get_year_month_sequence(Account, From, To, []).
 
 -spec get_year_month_sequence(kz_term:ne_binary(), year_month_tuple(), year_month_tuple(), kz_term:proplist()) ->
-                                     kz_term:ne_binaries().
+          kz_term:ne_binaries().
 get_year_month_sequence(Account, Tuple, Tuple, Range) ->
     ToMODbId = fun ({Year,Month}, Acc) -> [get_modb(Account, Year, Month)|Acc] end,
     lists:foldl(ToMODbId, [], [Tuple|Range]);

--- a/core/kazoo_modb/src/kazoo_modb.erl
+++ b/core/kazoo_modb/src/kazoo_modb.erl
@@ -15,6 +15,7 @@
 -export([get_results/3]).
 -export([open_doc/2, open_doc/3, open_doc/4]).
 -export([save_doc/2, save_doc/3, save_doc/4]).
+-export([save_docs/2, save_docs/3]).
 -export([move_doc/4, move_doc/5]).
 -export([copy_doc/4, copy_doc/5]).
 -export([get_modb/1, get_modb/2, get_modb/3]).
@@ -238,6 +239,19 @@ couch_save(AccountMODb, Doc, Options, _Reason, Retry) ->
 -spec save_fun(boolean()) -> function().
 save_fun('false') -> fun kz_datamgr:save_doc/3;
 save_fun('true') -> fun kz_datamgr:ensure_saved/3.
+
+
+-spec save_docs(kz_term:text(), kz_json:objects()) ->
+                       {'ok', kz_json:objects()} |
+                       kz_datamgr:data_error().
+save_docs(AccountMODb, Docs) ->
+    save_docs(AccountMODb, Docs, []).
+
+-spec save_docs(kz_term:text(), kz_json:objects(), kz_term:proplist()) ->
+                       {'ok', kz_json:objects()} |
+                       kz_datamgr:data_error().
+save_docs(AccountMODb, Docs, Options) ->
+    kz_datamgr:save_docs(AccountMODb, Docs, Options).
 
 %%------------------------------------------------------------------------------
 %% @doc Move a document from source to destination with attachments,

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -10,7 +10,7 @@
 -module(pqc_cb_cdrs).
 
 %% Manual testing
--export([seq/0, straight_seq/0, paginated_seq/0, task_seq/0
+-export([seq/0, straight_seq/0, paginated_seq/0, task_seq/0, big_dataset_seq/0
         ,cleanup/0
         ]).
 
@@ -53,12 +53,24 @@ summary(API, AccountId, Accept) ->
                            ,RequestHeaders
                            ).
 
+unpaginated_summary(API, AccountId) ->
+    URL = cdrs_url(AccountId) ++ "?paginate=false&is_chunked=false",
+    RequestHeaders = pqc_cb_api:request_headers(API),
+
+    Expectations = [#expectation{response_codes = [200, 204]}],
+
+    pqc_cb_api:make_request(Expectations
+                           ,fun kz_http:get/2
+                           ,URL
+                           ,RequestHeaders
+                           ).
+
 paginated_summary(API, AccountId) ->
     paginated_summary(API, AccountId, 'undefined').
 
 -spec paginated_summary(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:api_ne_binary()) ->
-                               {'error', binary()} |
-                               kz_json:objects().
+          {'error', binary()} |
+          kz_json:objects().
 paginated_summary(API, AccountId, OwnerId) ->
     URL = paginated_cdrs_url(AccountId, OwnerId, ?CDRS_PER_MONTH div 2),
     RequestHeaders = pqc_cb_api:request_headers(API),
@@ -85,11 +97,11 @@ collect_paginated_results(BaseURL, URL, RequestHeaders, Expectations, Collected)
 
 handle_paginated_results(BaseURL, RequestHeaders, Expectations, Collected, RespJObj) ->
     Data = kz_json:get_list_value(<<"data">>, RespJObj, []),
-    ?INFO("adding page: ~p~n", [Data]),
+    lager:info("adding page: ~p~n", [Data]),
     case kz_json:get_ne_binary_value(<<"next_start_key">>, RespJObj) of
         'undefined' -> Data ++ Collected;
         NextStartKey ->
-            ?INFO("collecting next page from ~s: ~s", [BaseURL, NextStartKey]),
+            lager:info("collecting next page from ~s: ~s", [BaseURL, NextStartKey]),
             collect_paginated_results(BaseURL
                                      ,BaseURL ++ [$& | start_key(NextStartKey)]
                                      ,update_request_id(RequestHeaders)
@@ -129,8 +141,8 @@ interactions(API, AccountId) ->
                            ).
 
 -spec paginated_interactions(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                                    {'error', binary()} |
-                                    kz_json:objects().
+          {'error', binary()} |
+          kz_json:objects().
 paginated_interactions(API, AccountId, OwnerId) ->
     URL = paginated_interactions_url(AccountId, OwnerId, 2),
     RequestHeaders = pqc_cb_api:request_headers(API),
@@ -182,7 +194,8 @@ start_key(StartKey) -> "start_key=" ++ kz_term:to_list(StartKey).
 seq() ->
     _ = straight_seq(),
     _ = paginated_seq(),
-    task_seq().
+    _ = task_seq(),
+    big_dataset_seq().
 
 -spec straight_seq() -> 'ok'.
 straight_seq() ->
@@ -193,33 +206,33 @@ straight_seq() ->
     AccountId = create_account(API),
 
     EmptySummaryResp = summary(API, AccountId),
-    ?INFO("empty summary resp: ~s", [EmptySummaryResp]),
+    lager:info("empty summary resp: ~s", [EmptySummaryResp]),
     [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
 
     EmptyCSVResp = summary(API, AccountId, <<"text/csv">>),
-    ?INFO("empty CSV resp: ~s", [EmptyCSVResp]),
+    lager:info("empty CSV resp: ~s", [EmptyCSVResp]),
 
     CDRs = seed_cdrs(AccountId),
-    ?INFO("cdrs: ~p~n", [CDRs]),
+    ?INFO("CDRs: ~p~n", [CDRs]),
 
     SummaryResp = summary(API, AccountId),
-    ?INFO("summary resp: ~s", [SummaryResp]),
+    lager:info("summary resp: ~s", [SummaryResp]),
     RespCDRs = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
     ?INFO("resp CDRs: ~p~n", [lists:usort([cdr_id(RespCDR) || RespCDR <- RespCDRs])]),
     ?INFO("base CDRs: ~p~n", [lists:usort([cdr_id(CDR) || CDR <- CDRs])]),
     'true' = cdrs_exist(CDRs, RespCDRs),
-    ?INFO("all cdrs found in response"),
+    lager:info("all cdrs found in response"),
 
     CSVResp = summary(API, AccountId, <<"text/csv">>),
     ?INFO("csv resp: ~s", [CSVResp]),
 
     InteractionsResp = interactions(API, AccountId),
-    ?INFO("interactions resp: ~s", [InteractionsResp]),
+    lager:info("interactions resp: ~s", [InteractionsResp]),
 
     lists:foreach(fun(CDR) -> seq_cdr(API, AccountId, CDR) end, CDRs),
 
     cleanup(API),
-    ?INFO("FINISHED STRAIGHT SEQ").
+    lager:info("FINISHED STRAIGHT SEQ").
 
 -spec paginated_seq() -> 'ok'.
 paginated_seq() ->
@@ -230,35 +243,72 @@ paginated_seq() ->
     OwnerId = create_owner(AccountId),
 
     EmptySummaryResp = paginated_summary(API, AccountId),
-    ?INFO("empty summary resp: ~p", [EmptySummaryResp]),
+    lager:info("empty summary resp: ~p", [EmptySummaryResp]),
     [] = EmptySummaryResp,
 
     CDRs = seed_cdrs(AccountId, OwnerId),
     CDRIds = lists:sort([kz_doc:id(I) || I <- CDRs]),
-    ?INFO("CDRs: ~p~n", [CDRIds]),
+    lager:info("CDRs: ~p~n", [CDRIds]),
 
     SummaryResp = paginated_summary(API, AccountId, OwnerId),
-    ?INFO("summary resp: ~p", [SummaryResp]),
+    lager:info("summary resp: ~p", [SummaryResp]),
 
     'true' = cdrs_exist(CDRs, SummaryResp),
-    ?INFO("all cdrs found in response"),
+    lager:info("all cdrs found in response"),
 
     InteractionsResp = paginated_interactions(API, AccountId, OwnerId),
     InteractionIds = lists:sort([kzd_cdrs:interaction_id(I) || I <- InteractionsResp]),
 
     CDRInteractionIDs = lists:usort([kzd_cdrs:interaction_id(CDR) || CDR <- CDRs]),
-    ?INFO("expected CDR interaction IDs: ~p", [CDRInteractionIDs]),
-    ?INFO("received interaction IDs: ~p", [InteractionIds]),
+    lager:info("expected CDR interaction IDs: ~p", [CDRInteractionIDs]),
+    lager:info("received interaction IDs: ~p", [InteractionIds]),
     case CDRInteractionIDs =:= InteractionIds of
         'true' -> 'ok';
         'false' ->
-            ?INFO("failed to fetch expected interaction IDs from API"),
-            ?INFO("missing from response: ~p", [CDRInteractionIDs -- InteractionIds]),
+            lager:info("failed to fetch expected interaction IDs from API"),
+            lager:info("missing from response: ~p", [CDRInteractionIDs -- InteractionIds]),
             throw({'error', 'interaction_ids', 'not_found'})
     end,
 
     cleanup(API),
-    ?INFO("FINISHED PAGINATED SEQ").
+    lager:info("FINISHED PAGINATED SEQ").
+
+-spec big_dataset_seq() -> 'ok'.
+big_dataset_seq() ->
+    lager:info("creating large dataset and not paginating results"),
+    API = pqc_cb_api:init_api(['crossbar'], ['cb_cdrs']),
+    AccountId = create_account(API),
+
+    {Year, Month, Day} = erlang:date(),
+
+    CDRCount = 2600,
+
+    CDRs = lists:foldl(fun(_, Acc) ->
+                               InteractionId = interaction_id(Year, Month, Day),
+                               [create_cdr(AccountId, 'undefined', Year, Month, InteractionId) | Acc]
+                       end
+                      ,[]
+                      ,lists:seq(1,CDRCount)
+                      ),
+
+    AccountMODb = kz_util:format_account_id(AccountId, Year, Month),
+    {'ok', _} = kazoo_modb:save_docs(AccountMODb, CDRs, [{'publish_change_notice', 'false'}]),
+
+    _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 'null'),
+    JSON = unpaginated_summary(API, AccountId),
+    JObj = kz_json:decode(JSON),
+    lager:info("unpaginated and unbound memory resp returned ~p CDRs", [length(kz_json:get_list_value(<<"data">>, JObj))]),
+    CDRCount = length(kz_json:get_list_value(<<"data">>, JObj)),
+
+    _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 1024 * 1024 * 10), % cap at 10Mb
+    {'error', ErrorJSON} = unpaginated_summary(API, AccountId),
+    lager:info("unpaginated and bound memory resp: ~s", [ErrorJSON]),
+    ErrorJObj = kz_json:decode(ErrorJSON),
+    416 = kz_json:get_integer_value(<<"error">>, ErrorJObj),
+    <<"range not satisfiable">> = kz_json:get_ne_binary_value(<<"message">>, ErrorJObj),
+
+    cleanup(API),
+    lager:info("FINISHED BIG DATASET SEQ").
 
 -spec task_seq() -> 'ok'.
 task_seq() ->
@@ -290,16 +340,16 @@ seq_cdr(API, AccountId, CDR) ->
     InteractionId = kzd_cdrs:interaction_id(CDR),
 
     FetchResp = fetch(API, AccountId, CDRId),
-    ?INFO("~s: fetch resp ~s", [CDRId, FetchResp]),
+    lager:info("~s: fetch resp ~s", [CDRId, FetchResp]),
     'true' = cdr_exists(CDR, [kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp))]),
 
     %% Should be able to convert CDR ID to interaction_id
     LegsResp = legs(API, AccountId, CDRId),
-    ?INFO("~s: legs by id resp: ~s", [CDRId, LegsResp]),
+    lager:info("~s: legs by id resp: ~s", [CDRId, LegsResp]),
     'true' = cdr_exists(CDR, kz_json:get_list_value(<<"data">>, kz_json:decode(LegsResp))),
 
     InteractionResp = legs(API, AccountId, InteractionId),
-    ?INFO("~s: legs by interaction resp: ~s", [CDRId, InteractionResp]),
+    lager:info("~s: legs by interaction resp: ~s", [CDRId, InteractionResp]),
     'true' = cdr_exists(CDR, kz_json:get_list_value(<<"data">>, kz_json:decode(InteractionResp))).
 
 cdr_exists(CDR, RespCDRs) ->
@@ -309,11 +359,11 @@ cdr_exists(CDR, RespCDRs) ->
 cdrs_exist([], []) -> 'true';
 cdrs_exist([], APIs) ->
     IDs = [kz_doc:id(CDR) || CDR <- APIs],
-    ?INFO("  failed to find API results in CDRs: ~s", [kz_binary:join(IDs, <<", ">>)]),
+    lager:info("  failed to find API results in CDRs: ~s", [kz_binary:join(IDs, <<", ">>)]),
     'false';
 cdrs_exist(CDRs, []) ->
     IDs = [kz_doc:id(CDR) || CDR <- CDRs],
-    ?INFO("  failed to find CDR(s) in API response: ~s", [kz_binary:join(IDs, <<", ">>)]),
+    lager:info("  failed to find CDR(s) in API response: ~s", [kz_binary:join(IDs, <<", ">>)]),
     'false';
 cdrs_exist([_|_]=CDRs, [API|APIs]) ->
     lager:debug("filtering out ~s", [kz_doc:id(API)]),
@@ -323,7 +373,7 @@ cdrs_exist([_|_]=CDRs, [API|APIs]) ->
 
 create_account(API) ->
     AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
-    ?INFO("created account: ~s", [AccountResp]),
+    lager:info("created account: ~s", [AccountResp]),
 
     kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
 
@@ -333,16 +383,17 @@ create_owner(AccountId) ->
     OwnerId = kz_binary:rand_hex(16),
     Owner = kz_json:set_value(<<"_id">>, OwnerId, kzd_users:new()),
     {'ok', _Saved}= kz_datamgr:save_doc(AccountDb, Owner),
-    ?INFO("saved owner to ~s: ~p", [AccountDb, _Saved]),
+    lager:info("saved owner to ~s: ~p", [AccountDb, _Saved]),
     OwnerId.
 
 -spec cleanup() -> 'ok'.
 cleanup() ->
     _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
+    _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 'null'),
     cleanup_system().
 
 cleanup(API) ->
-    ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
     _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
     _ = pqc_cb_api:cleanup(API),
     cleanup_system().
@@ -363,6 +414,9 @@ seed_cdrs(AccountId, OwnerId) ->
 
 -spec seed_cdrs(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_time:year(), kz_time:month()) -> kz_json:objects().
 seed_cdrs(AccountId, OwnerId, Year, Month) ->
+    AccountMODb = kz_util:format_account_id(AccountId, Year, Month),
+    _ = kazoo_modb:create(AccountMODb),
+
     CDRs = seed_interaction(AccountId, OwnerId, Year, Month),
     MoreCDRs = seed_interaction(AccountId, OwnerId, Year, Month),
     EvenMoreCDRs = seed_interaction(AccountId, OwnerId, Year, Month),
@@ -390,11 +444,27 @@ interaction_id(Year, Month, Day) ->
     list_to_binary([integer_to_binary(InteractionTime), "-", InteractionKey]).
 
 seed_cdr(AccountId, OwnerId, Year, Month, InteractionId) ->
+    [ITime, InteractionKey] = binary:split(InteractionId, <<"-">>),
+    InteractionTime = kz_term:to_integer(ITime),
+
+    CDR = create_cdr(AccountId, OwnerId, Year, Month
+                    ,InteractionId, InteractionTime, InteractionKey
+                    ),
+
+    AccountMODb = kz_util:format_account_id(AccountId, InteractionTime),
+    kazoo_modb:save_doc(AccountMODb, CDR, ['allow_old_modb_creation']).
+
+create_cdr(AccountId, OwnerId, Year, Month, InteractionId) ->
+    [ITime, InteractionKey] = binary:split(InteractionId, <<"-">>),
+    InteractionTime = kz_term:to_integer(ITime),
+    create_cdr(AccountId, OwnerId, Year, Month, InteractionId, InteractionTime, InteractionKey).
+
+create_cdr(AccountId, OwnerId, Year, Month, InteractionId, InteractionTime, InteractionKey) ->
     CallId = kz_binary:rand_hex(6),
 
     CDRId = kzd_cdrs:create_doc_id(CallId, Year, Month),
-    [ITime, InteractionKey] = binary:split(InteractionId, <<"-">>),
-    InteractionTime = kz_term:to_integer(ITime),
+
+    AccountMODb = kz_util:format_account_id(AccountId, InteractionTime),
 
     JObj = kz_json:from_list([{<<"_id">>, CDRId}
                              ,{<<"call_id">>, CallId}
@@ -417,16 +487,11 @@ seed_cdr(AccountId, OwnerId, Year, Month, InteractionId) ->
                              ,{<<"timestamp">>, InteractionTime}
                              ]),
 
-    AccountMODb = kz_util:format_account_id(AccountId, InteractionTime),
-
     Props = [{'type', <<"cdr">>}
             ,{'account_id', AccountId}
             ,{'now', InteractionTime}
             ],
-    CDR = kz_doc:update_pvt_parameters(JObj, AccountMODb, Props),
-    ?INFO("creating ~s in ~s", [CDRId, AccountMODb]),
-
-    {'ok', _} = kazoo_modb:save_doc(AccountMODb, CDR).
+    kz_doc:update_pvt_parameters(JObj, AccountMODb, Props).
 
 interaction_time(Year, Month, Day) ->
     {Today, _} = calendar:universal_time(),
@@ -442,7 +507,7 @@ wait_for_task(API, AccountId, TaskId) ->
     wait_for_task(API, AccountId, TaskId, Start).
 
 -spec wait_for_task(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_time:start_time()) ->
-                           pqc_cb_api:response() | {'error', 'timeout'}.
+          pqc_cb_api:response() | {'error', 'timeout'}.
 wait_for_task(API, AccountId, TaskId, Start) ->
     wait_for_task(API, AccountId, TaskId, Start, kz_time:elapsed_s(Start)).
 

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -518,6 +518,7 @@ pages:
   - 'Kazoo Test FixtureDB':
     - 'core/kazoo_fixturedb/doc/README.md'
     - 'core/kazoo_fixturedb/doc/kz_fixturedb_maintenance.md'
+    - 'Persist Database to disk': 'core/kazoo_fixturedb/doc/db-to-disk.md'
 - 'Articles':
   - 'Introduction to Storage Plans - S3': 'doc/blog/storage.md'
   - 'Bypass Media Mode': 'doc/blog/bypass_media.md'


### PR DESCRIPTION
When fetching large datasets with pagination turned off, it is
possible to tank the system when the dataset causes memory pressure
during loading.

This change adds an optional system config parameter for determining
the maximum memory allowed for the Erlang process handling the API
request.

Additionally, even requests with `pagination=false` (or /v1) will
still be loaded on a per-page basis. Each page load will check the
memory consumption and error with an HTTP 416 response if memory usage
exceeds the configured maximum.

Until the maximum is reached, however, the pages will continue to be
fetched until exhausted as before.

FixtureDB has an added utility to make mirroring an existing CouchDB
database to the FixtureDB fixtures directory for easier conversion of
testing data.