### PR TITLE
Adjust page size based on chunked/pagination settings

### DIFF
--- a/applications/crossbar/src/crossbar_view.erl
+++ b/applications/crossbar/src/crossbar_view.erl
@@ -976,7 +976,7 @@ check_page_size_and_length(#{total_queried := TotalQueried
 limit_with_last_key('false', 'undefined', _, _) ->
     'undefined';
 %% explicitly disabled pagination
-limit_with_last_key('false', 'infinity', ChunkSize, _TotalQueried) ->
+limit_with_last_key(_IsChunked, 'infinity', ChunkSize, _TotalQueried) ->
     1 + ChunkSize;
 %% non-chunked limited request
 limit_with_last_key('false', PageSize, _, TotalQueried) ->


### PR DESCRIPTION
Add tests for 4 scenarios from "big data" fetches:
1. paginated and chunked
2. paginated and unchunked
3. unpaginated and chunked
4. unpaginated and unchunked

Wonderfully, 3 does not trip the memory limit while 4 does, so
chunking is a nice benefit for unpaginated requests. Might consider
defaulting to `is_chunked=true` when `paginate=false`...