### PR TITLE
Remote callflow actions

### DIFF
--- a/applications/callflow/src/cf_exe.erl
+++ b/applications/callflow/src/cf_exe.erl
@@ -606,6 +606,17 @@ handle_info({'EXIT', Pid, _Reason}, #state{cf_module_old_pid={Pid, Ref}
     LastAction = kapps_call:kvs_fetch('cf_old_action', Call),
     lager:error("action ~s died unexpectedly: ~p", [LastAction, _Reason]),
     {'noreply', State#state{cf_module_old_pid='undefined'}};
+handle_info({'amqp_return', _JObj, _Returned} = Msg, #state{cf_module_pid=PidRef
+                                                           ,call=Call
+                                                           } = State) ->
+    Others = kapps_call:kvs_fetch('cf_event_pids', [], Call),
+    Notify = case get_pid(PidRef) of
+                 'undefined' -> Others;
+                 ModPid -> [ModPid | Others]
+             end,
+    relay_message(Notify, Msg),
+    {'noreply', State};
+
 handle_info(_Msg, State) ->
     lager:debug("unhandled message: ~p", [_Msg]),
     {'noreply', State}.
@@ -742,7 +753,7 @@ do_launch_cf_module(#state{call=Call
                           ,flow=Flow
                           ,cf_module_pid=OldPidRef
                           }=State
-                   ,Action
+                   ,{Where, Action}
                    ) ->
     Data = kz_json:get_json_value(<<"data">>, Flow, kz_json:new()),
     lager:info("moving to action '~s'", [Action]),
@@ -750,24 +761,29 @@ do_launch_cf_module(#state{call=Call
     %% the module calls cf_exe:set_call/1 - that would undo the later
     %% old_action/last_action update
     Call1 = update_actions(Action, Call),
-    PidRef = spawn_cf_module(Action, Data, Call1),
+    PidRef = spawn_cf_module(Where, Action, Data, Call1),
     link(get_pid(PidRef)),
     State#state{cf_module_pid=PidRef
                ,cf_module_old_pid=OldPidRef
                ,call=Call1
                }.
 
--spec find_cf_module(kz_json:object()) -> kz_term:api_atom().
+-spec find_cf_module(kz_json:object()) -> 'undefined' | {'local' | 'remote', atom()}.
 find_cf_module(Flow) ->
-    ModuleBin = <<"cf_", (kz_json:get_ne_binary_value(<<"module">>, Flow))/binary>>,
+    Module = kz_json:get_ne_binary_value(<<"module">>, Flow),
+    ModuleBin = <<"cf_", Module/binary>>,
     Data = kz_json:get_json_value(<<"data">>, Flow, kz_json:new()),
     CFModule = kz_term:to_atom(ModuleBin, 'true'),
     IsExported = kz_module:is_exported(CFModule, 'handle', 2),
+    IsRemote = kz_json:is_true(<<"remote_execution">>, Flow),
     SkipModule = kz_json:is_true(<<"skip_module">>, Data, 'false'),
-    case IsExported
+    case (IsExported
+          orelse IsRemote
+         )
         andalso (not SkipModule)
     of
-        'true' -> CFModule;
+        'true' when IsRemote -> {'remote', kz_term:to_atom(Module, 'true')};
+        'true' -> {'local', CFModule};
         'false' ->
             lager:debug("skipping callflow module ~s (handle exported: ~s skip_module: ~s)"
                        ,[CFModule, IsExported, SkipModule]),
@@ -787,11 +803,18 @@ update_actions(Action, Call) ->
 %% point 'handle' having set the callid on the new process first.
 %% @end
 %%------------------------------------------------------------------------------
+-spec spawn_cf_module(atom(), atom(), kz_json:object(), kapps_call:call()) -> kz_term:pid_ref().
+spawn_cf_module('local', CFModule, Data, Call0) ->
+    Call = kapps_call:kvs_store('context-source', CFModule, Call0),
+    spawn_cf_module(CFModule, Data, Call);
+spawn_cf_module('remote', CFModule, Data, Call0) ->
+    Call = kapps_call:kvs_store('remote-action', CFModule, Call0),
+    spawn_cf_module('cf_remote_action', Data, Call).
+
 -spec spawn_cf_module(atom(), kz_json:object(), kapps_call:call()) -> kz_term:pid_ref().
-spawn_cf_module(CFModule, Data, Call0) ->
+spawn_cf_module(CFModule, Data, Call) ->
     AMQPConsumer = kz_amqp_channel:consumer_pid(),
     AMQPChannel = kz_amqp_channel:consumer_channel(),
-    Call = kapps_call:kvs_store('context-source', CFModule, Call0),
     kz_process:spawn_monitor(fun cf_module_task/5, [CFModule, Data, Call, AMQPConsumer, AMQPChannel]).
 
 -spec cf_module_task(atom(), kz_json:object(), kapps_call:call(), pid(), pid()) -> any().
@@ -924,7 +947,7 @@ handle_error(CallId, Notify, JObj) ->
         _Else -> 'ok'
     end.
 
--spec relay_message(kz_term:pids(), kz_json:object()) -> 'ok'.
+-spec relay_message(kz_term:pids(), kz_json:object() | {'amqp_return', kz_json:object(), kz_json:object()}) -> 'ok'.
 relay_message(Notify, Message) ->
     _ = [kapps_call_command:relay_event(Pid, Message)
          || Pid <- Notify,

--- a/applications/callflow/src/cf_listener.erl
+++ b/applications/callflow/src/cf_listener.erl
@@ -86,7 +86,15 @@ handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
     {'noreply', State};
 handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
     {'noreply', State};
+handle_cast({'gen_listener', {'return', JObj, Returned}}, State) ->
+    ServerId = kz_api:server_id(JObj),
+    lager:debug("returned: ~p", [ServerId]),
+    Pid = kapi:decode_pid(ServerId),
+    lager:debug("returned: ~p", [Pid]),
+    Pid ! {'amqp_return', JObj, Returned},
+    {'noreply', State};
 handle_cast(_Msg, State) ->
+    lager:debug("unhandled cast: ~p", [_Msg]),
     {'noreply', State}.
 
 %%------------------------------------------------------------------------------

--- a/applications/callflow/src/cf_remote_action.erl
+++ b/applications/callflow/src/cf_remote_action.erl
@@ -1,0 +1,94 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2011-2019, 2600Hz
+%%% @doc Executes remote callflow actions.
+%%%
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(cf_remote_action).
+
+-export([handle/2
+        ,handle/3
+        ]).
+
+-include("callflow.hrl").
+
+-spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
+handle(Data, Call) ->
+    Action = kapps_call:kvs_fetch('remote-action', Call),
+    handle(Action, Data, Call).
+
+-spec handle(atom() | kz_term:ne_binary(), kz_json:object(), kapps_call:call()) -> 'ok'.
+handle(Action, Data, Call) ->
+    Q = kapps_call:controller_queue(Call),
+    ActionId = kz_binary:rand_hex(16),
+    API = [{<<"Call">>, call_to_jobj(Call)}
+          ,{<<"Data">>, Data}
+          ,{<<"Call-ID">>, kapps_call:call_id_direct(Call)}
+          ,{?KEY_MSG_ID, ActionId}
+           | kz_api:default_headers(Q, ?APP_NAME, ?APP_VERSION)
+          ],
+    kapi_callflow:publish_action_execute(kz_term:to_binary(Action), API),
+    wait_for_msg(ActionId, Call).
+
+-spec call_to_jobj(kapps_call:call()) -> kz_json:object().
+call_to_jobj(Call) ->
+    Flow = kapps_call:kvs_fetch('cf_flow', kz_json:new(), Call),
+    Keys = kz_json:get_keys(kz_json:get_json_value(<<"children">>, Flow, kz_json:new())),
+
+    Routines = [{fun kapps_call:kvs_erase/2, ['cf_flow']}
+               ,{fun kapps_call:kvs_store/3, 'action-exit-keys', Keys}
+               ,fun kapps_call:clear_helpers/1
+               ],
+    kapps_call:to_json(kapps_call:exec(Routines, Call)).
+
+-spec wait_for_msg(atom() | kz_term:ne_binary(), kapps_call:call()) -> 'ok'.
+wait_for_msg(ActionId, Call) ->
+    receive
+        {'amqp_msg', {'amqp_return', _JObj, _Returned}} ->
+            cf_exe:continue(<<"REMOTE_UNAVAILABLE">>, Call);
+
+        {'amqp_msg', JObj} ->
+            Evt = kz_util:get_event_type(JObj),
+            CallId = {kz_call_event:call_id(JObj), kapps_call:call_id(Call)},
+            MsgId = {kz_api:msg_id(JObj), ActionId},
+            handle_msg(Evt, CallId, MsgId, JObj, Call);
+        _Msg ->
+            lager:debug_unsafe("unhandled msg => ~p", [_Msg]),
+            wait_for_msg(ActionId, Call)
+    end.
+
+-spec handle_msg(tuple(), tuple(), tuple(), kz_json:object(), kapps_call:call()) -> any().
+handle_msg({<<"call_event">>, <<"CHANNEL_DESTROY">>} = _Evt, _CallId, _MsgId, _JObj, Call) ->
+    cf_exe:continue(Call);
+handle_msg({<<"callflow">>, <<"action.accepted">>}, {CallId, CallId}, {ActionId, ActionId}, JObj, Call) ->
+    lager:debug("remote action accepted by ~s", [kz_api:node(JObj)]),
+    wait_for_msg(ActionId, Call);
+handle_msg({<<"callflow">>, <<"action.result">>}, {CallId, CallId}, {ActionId, ActionId}, JObj, Call) ->
+    Result = binary_to_term(base64:decode(kz_json:get_binary_value(<<"Result">>, JObj))),
+    lager:debug("remote action result => ~p", [Result]),
+    handle_action_return(Result, Call);
+handle_msg(_Evt, _CallId, {_, ActionId} = _MsgId, _JObj, Call) ->
+    wait_for_msg(ActionId, Call).
+
+-spec handle_action_return(atom() | {'continue', kz_term:ne_binary()}, kapps_call:call()) -> any().
+handle_action_return({'continue', Key}, Call) ->
+    cf_exe:continue(Key, Call);
+handle_action_return('continue', Call) ->
+    cf_exe:continue(Call);
+handle_action_return({'continue_with_flow', Flow}, Call) ->
+    cf_exe:continue_with_flow(Flow, Call);
+handle_action_return({'stop', Reason}, Call) ->
+    cf_exe:stop(Call, Reason);
+handle_action_return('stop', Call) ->
+    cf_exe:stop(Call);
+handle_action_return('transfer', Call) ->
+    cf_exe:transfer(Call);
+handle_action_return('usurp', Call) ->
+    cf_exe:control_usurped(Call);
+handle_action_return(_Return, Call) ->
+    lager:warning("unhandled return from remote action : ~p", [_Return]),
+    cf_exe:continue(Call).

--- a/core/kazoo_amqp/src/api/kapi.erl
+++ b/core/kazoo_amqp/src/api/kapi.erl
@@ -24,6 +24,7 @@
 %% API
 -export([delivery_message/2
         ,encode_pid/1, encode_pid/2
+        ,decode_pid/1
         ]).
 
 -include_lib("kz_amqp_util.hrl").
@@ -57,3 +58,11 @@ encode_pid(Queue) ->
 -spec encode_pid(kz_term:ne_binary(), pid()) -> kz_term:ne_binary().
 encode_pid(Queue, Pid) ->
     list_to_binary(["pid://", kz_term:to_binary(Pid), "/", Queue]).
+
+-spec decode_pid(kz_term:ne_binary()) -> kz_term:api_pid().
+decode_pid(<<"pid://", Pid/binary>>) ->
+    case binary:split(Pid, <<"/">>) of
+        [Pid, _RK] -> kz_term:to_pid(Pid);
+        _ -> 'undefined'
+    end;
+decode_pid(_Queue) -> 'undefined'.

--- a/core/kazoo_amqp/test/kz_api_tests.erl
+++ b/core/kazoo_amqp/test/kz_api_tests.erl
@@ -33,3 +33,23 @@ has_any_test_() ->
     [?_assertEqual('true', kz_api:has_any(Prop, Headers))
     ,?_assertEqual('false', kz_api:has_any(Prop, [<<"k4">>]))
     ].
+
+-ifdef(PERF).
+-define(Q, <<"pid://<0.1.0>/2bdace1ec243711cc5236e01d5849d18.2bdace1ec243711cc5236e01d5849d18.2bdace1ec243711cc5236e01d5849d18.2bdace1ec243711cc5236e01d5849d180">>).
+-define(REPEAT, 100000).
+
+%% when i run locally:
+%% kz_api_tests:pid in 0.879099s
+%% kz_api_tests:pid2 in 0.057182s
+
+
+horse_pid() ->
+    horse:repeat(?REPEAT
+                ,kapi:decode_pid(?Q)
+                ).
+
+horse_pid2() ->
+    horse:repeat(?REPEAT
+                ,kapi:decode_pid2(?Q)
+                ).
+-endif.

--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -479,6 +479,7 @@ receive_event(Timeout, IgnoreOthers) ->
     Start = kz_time:start_time(),
     receive
         {'amqp_msg', JObj} -> {'ok', JObj};
+        {'kapi',{ _, _, JObj}} -> {'ok', JObj};
         _Msg when IgnoreOthers ->
             lager:debug_unsafe("ignoring received event : ~p", [_Msg]),
             receive_event(kz_time:decr_timeout(Timeout, Start), IgnoreOthers);


### PR DESCRIPTION

* early fail with amqp
* returned value to allow continuation
* cf_module can call cf_remote_action explicitly or `remote_execution: true` can be defined as a peer or `module` in `Flow`
