### PR TITLE
[4.3] make clear that the template is ignored, not disabled

### DIFF
--- a/applications/teletype/src/templates/teletype_transaction.erl
+++ b/applications/teletype/src/templates/teletype_transaction.erl
@@ -74,12 +74,18 @@ handle_req(JObj, 'true') ->
     ReqData =
         kz_json:set_value(<<"user">>, teletype_util:find_account_admin(AccountId), DataJObj),
 
-    case kz_json:is_true(<<"success">>, DataJObj) %% check if it's for transaction success template
-        andalso teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID)
-    of
+    case processability(kz_json:is_true(<<"success">>, DataJObj), JObj) of
+        'ignore' -> teletype_util:notification_ignored(?TEMPLATE_ID);
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
         'true' -> process_req(kz_json:merge_jobjs(DataJObj, ReqData), ?TEMPLATE_ID)
     end.
+
+-spec processability(boolean(), kz_json:object()) -> 'ignore' | boolean().
+processability('true', JObj) ->
+    %% it's for transaction template
+    teletype_util:is_notice_enabled(kz_json:get_value(<<"Account-ID">>, JObj), JObj, ?TEMPLATE_ID);
+processability('false', _) ->
+    'ignore'.
 
 -spec process_req(kz_json:object(), kz_term:ne_binary()) -> template_response().
 process_req(DataJObj, TemplateId) ->

--- a/applications/teletype/src/templates/teletype_transaction_failed.erl
+++ b/applications/teletype/src/templates/teletype_transaction_failed.erl
@@ -72,9 +72,15 @@ handle_req(JObj, 'true') ->
 
     ReqData =
         kz_json:set_value(<<"user">>, teletype_util:find_account_admin(AccountId), DataJObj),
-    case kz_json:is_false(<<"success">>, DataJObj) %% check if it's for transaction failed template
-        andalso teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID)
-    of
+    case processability(kz_json:is_false(<<"success">>, DataJObj), JObj) of
+        'ignore' -> teletype_util:notification_ignored(?TEMPLATE_ID);
         'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
         'true' -> teletype_transaction:process_req(kz_json:merge_jobjs(DataJObj, ReqData), ?TEMPLATE_ID)
     end.
+
+-spec processability(boolean(), kz_json:object()) -> 'ignore' | boolean().
+processability('true', JObj) ->
+    %% it's for transaction failed template
+    teletype_util:is_notice_enabled(kz_json:get_value(<<"Account-ID">>, JObj), JObj, ?TEMPLATE_ID);
+processability('false', _) ->
+    'ignore'.


### PR DESCRIPTION
Mark the notification as `ignored` when transaction templates (for successful transaction) or transaction failed template is not being processed.

Binding for these two notifications is same, and the templates are checking `success` in DataJObj to see if the notification is for them to process or the other module. Previously if the notification is for example for failed transaction, the successful template mark itself as disabled which is miss leading, because the template is not disabled it is simply is being process as this notification is irrelevant to the template. With current implementation in teletype these multiple templates can mark them as ignore when they don't want to process the notification so notification publisher consider it as done.

master pr: https://github.com/2600hz/kazoo/pull/6177