### PR TITLE
PISTON-974: set cid name/number on kapps_call when performing conf dial action

### DIFF
--- a/applications/crossbar/src/modules/cb_conferences.erl
+++ b/applications/crossbar/src/modules/cb_conferences.erl
@@ -33,7 +33,7 @@
         ]).
 
 -ifdef(TEST).
--export([build_valid_endpoints/3]).
+-export([build_valid_endpoints/2]).
 -endif.
 
 -include("crossbar.hrl").


### PR DESCRIPTION
create_call creates a kapps_call used for generating the endpoints for the dial request. Right now, with the authorizing_id set on the kapps_call, it is not possible to override the Caller ID used for ringing the endpoints. kz_attributes will choose the endpoint CID (either the name of the user that owns the conference or the conference name). By explicitly setting the caller ID to the values supplied in the HTTP request body and not setting the authorizing ID, the caller ID can be set as desired.

Looking for critique here in case there is something that I may be breaking, especially by removing the authorizing ID. I think that this proposed change results in not using the owner user's name at all. If that is fine then great, but maybe there is a better way to fix this.