### PR TITLE
[4.3] Include custom SIP headers in Pivot request

### DIFF
--- a/core/kazoo_translator/src/converters/kzt_kazoo.erl
+++ b/core/kazoo_translator/src/converters/kzt_kazoo.erl
@@ -67,27 +67,29 @@ req_params(Call) ->
                  [_|_]=IDs -> IDs
              end,
     props:filter_undefined(
-      [{<<"Call-ID">>, kapps_call:call_id(Call)}
-      ,{<<"Account-ID">>, kapps_call:account_id(Call)}
-      ,{<<"From">>, kapps_call:from_user(Call)}
-      ,{<<"From-Realm">>, kapps_call:from_realm(Call)}
-      ,{<<"To">>, kapps_call:to_user(Call)}
-      ,{<<"To-Realm">>, kapps_call:to_realm(Call)}
-      ,{<<"Request">>, kapps_call:request_user(Call)}
-      ,{<<"Request-Realm">>, kapps_call:request_realm(Call)}
-      ,{<<"Call-Status">>, kzt_util:get_call_status(Call)}
+      [{<<"Account-ID">>, kapps_call:account_id(Call)}
       ,{<<"Api-Version">>, <<"4.x">>}
-      ,{<<"Direction">>, <<"inbound">>}
+      ,{<<"Call-ID">>, kapps_call:call_id(Call)}
+      ,{<<"Call-Status">>, kzt_util:get_call_status(Call)}
       ,{<<"Caller-ID-Name">>, kapps_call:caller_id_name(Call)}
       ,{<<"Caller-ID-Number">>, kapps_call:caller_id_number(Call)}
-      ,{<<"User-ID">>, Owners}
+      ,{<<"Custom-Application-Vars">>, kapps_call:custom_application_vars(Call)}
+      ,{<<"Custom-SIP-Headers">>, kapps_call:custom_sip_headers(Call)}
+      ,{<<"Digits">>, kzt_util:get_digit_pressed(Call)}
+      ,{<<"Direction">>, <<"inbound">>}
+      ,{<<"From">>, kapps_call:from_user(Call)}
+      ,{<<"From-Realm">>, kapps_call:from_realm(Call)}
       ,{<<"Language">>, kapps_call:language(Call)}
-      ,{<<"Recording-Url">>, kzt_util:get_recording_url(Call)}
       ,{<<"Recording-Duration">>, kzt_util:get_recording_duration(Call)}
       ,{<<"Recording-ID">>, kzt_util:get_recording_sid(Call)}
-      ,{<<"Digits">>, kzt_util:get_digit_pressed(Call)}
+      ,{<<"Recording-Url">>, kzt_util:get_recording_url(Call)}
+      ,{<<"Request">>, kapps_call:request_user(Call)}
+      ,{<<"Request-Realm">>, kapps_call:request_realm(Call)}
+      ,{<<"To">>, kapps_call:to_user(Call)}
+      ,{<<"To-Realm">>, kapps_call:to_realm(Call)}
       ,{<<"Transcription-ID">>, kzt_util:get_transcription_sid(Call)}
-      ,{<<"Transcription-Text">>, kzt_util:get_transcription_text(Call)}
       ,{<<"Transcription-Status">>, kzt_util:get_transcription_status(Call)}
+      ,{<<"Transcription-Text">>, kzt_util:get_transcription_text(Call)}
       ,{<<"Transcription-Url">>, kzt_util:get_transcription_url(Call)}
+      ,{<<"User-ID">>, Owners}
       ]).


### PR DESCRIPTION
When the INVITE arrives with custom SIP headers, include those in the Pivot request so the receiving web service can make appropriate decisions.