### PR TITLE
[master] KZOO-16: don't show port request alerts to managed sub-accounts

### DIFF
--- a/applications/crossbar/doc/voicemail.md
+++ b/applications/crossbar/doc/voicemail.md
@@ -48,7 +48,7 @@ Key | Description | Type | Default | Required | Support Level
 `skip_greeting` | Determines if the greeting should be skipped | `boolean()` | `false` | `false` | `supported`
 `skip_instructions` | Determines if the instructions after the greeting and prior to composing a message should be played | `boolean()` | `false` | `false` | `supported`
 `timezone` | The default timezone | `string(5..32)` |   | `false` | `supported`
-`transcribe` | Transcribe voicemail using ASR engine | `boolean()` | `false` | `false` | `alpha`
+`transcribe` | Transcribe voicemail using ASR engine | `boolean()` | `false` | `false` | `supported`
 
 ### notify.callback
 

--- a/applications/crossbar/doc/voicemail.md
+++ b/applications/crossbar/doc/voicemail.md
@@ -48,7 +48,7 @@ Key | Description | Type | Default | Required | Support Level
 `skip_greeting` | Determines if the greeting should be skipped | `boolean()` | `false` | `false` | `supported`
 `skip_instructions` | Determines if the instructions after the greeting and prior to composing a message should be played | `boolean()` | `false` | `false` | `supported`
 `timezone` | The default timezone | `string(5..32)` |   | `false` | `supported`
-`transcribe` | Transcribe voicemail using ASR engine | `boolean()` | `false` | `false` | `supported`
+`transcribe` | Transcribe voicemail using ASR engine | `boolean()` | `false` | `false` | `alpha`
 
 ### notify.callback
 

--- a/applications/crossbar/src/modules/cb_alerts.erl
+++ b/applications/crossbar/src/modules/cb_alerts.erl
@@ -286,7 +286,7 @@ get_active_ports({'ok', Active}) ->
 get_active_ports(_) ->
     [].
 
--spec do_check_port_requests(kz_term:api_ne_binary() | kz_json:objects(), cb_context:context()) -> cb_context:context().
+-spec do_check_port_requests(kz_json:objects(), cb_context:context()) -> cb_context:context().
 do_check_port_requests([], Context) ->
     Context;
 do_check_port_requests([PortRequest|PortRequests], Context) ->
@@ -297,15 +297,7 @@ do_check_port_requests([PortRequest|PortRequests], Context) ->
                           ,Context
                           ,Routines
                           ),
-    do_check_port_requests(PortRequests, Context1);
-do_check_port_requests({'ok', PortRequests}, Context) ->
-    do_check_port_requests(PortRequests, Context);
-do_check_port_requests({'error', _R}, Context) ->
-    lager:debug("unable to fetch port requests: ~p", [_R]),
-    Context;
-do_check_port_requests(Unexpected, Context) ->
-    lager:debug("unable to fetch port requests: ~p", [Unexpected]),
-    Context.
+    do_check_port_requests(PortRequests, Context1).
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/applications/crossbar/src/modules/cb_alerts.erl
+++ b/applications/crossbar/src/modules/cb_alerts.erl
@@ -20,7 +20,7 @@
         ]).
 
 -ifdef(TEST).
--export([maybe_check_port_requests/1
+-export([do_check_port_requests/2
         ,maybe_check_financials/1
         ,check_low_balance/1
         ,check_payment_token/1
@@ -226,48 +226,64 @@ set_success_resp_status(Context) ->
 %%------------------------------------------------------------------------------
 -spec maybe_check_port_requests(cb_context:context()) -> cb_context:context().
 maybe_check_port_requests(Context) ->
-    ResellerId = cb_context:reseller_id(Context),
     AccountId = cb_context:account_id(Context),
-
-    case {is_reseller_handling_port_requests(ResellerId)
-         ,kz_services_reseller:is_reseller(AccountId)
-          andalso is_reseller_handling_port_requests(AccountId)
-         }
-    of
-        {'true', _} ->
-            %% Reseller is handling port requests so not bother the user with port request alerts.
-            Context;
-        {'false', 'true'} ->
-            %% Reseller is NOT handling port requests for sub-accounts and current request
-            %% was made by a reseller and it is handling port requests for its sub-accounts
-            %% so get the alerts (if any) for each sub-account.
-            do_check_port_requests(knm_port_request:descendant_active_ports(ResellerId), Context);
-        {'false', _} ->
-            %% Reseller is not handling port requests and either the current account is
-            %% not a reseller or it is not handling port requests for its sub-accounts.
-            Ports = maybe_merge_active_and_unconfirmed_ports(
-                      knm_port_request:account_active_ports(AccountId)
-                     ,knm_port_request:account_ports_by_state(AccountId, ?PORT_UNCONFIRMED)
-                     ),
-            do_check_port_requests(Ports, Context)
+    MasterId = cb_context:master_account_id(Context),
+    AuthId = cb_context:auth_account_id(Context),
+    case AuthId =:= MasterId of
+        'true' ->
+            %% Authenticated account is master
+            %% show only masqueraded account's port alerts
+            do_check_port_requests(fetch_account_active_ports(AccountId), Context);
+        'false' ->
+            IsReseller = kz_services_reseller:is_reseller(AccountId),
+            IsPortAuthority = cb_context:fetch(Context, 'is_port_authority'),
+            maybe_check_port_requests(Context, IsReseller, IsPortAuthority)
     end.
 
--spec is_reseller_handling_port_requests(kz_term:api_ne_binary() | {'ok', kz_json:object()} | {'error', any()}) -> boolean().
-is_reseller_handling_port_requests('undefined') ->
+-spec maybe_check_port_requests(cb_context:context(), boolean(), boolean()) -> cb_context:context().
+maybe_check_port_requests(Context, 'true', 'true') ->
+    %% Authenticated account is reseller AND port authority
+    %% so show only masqueraded account's port alerts
+    %% (because reseller is port authority, this is whose rejected ports or made action required
+    %% comments on the ports, so it shouldn't get alerted for its own doing!)
+    do_check_port_requests(fetch_account_active_ports(cb_context:account_id(Context)), Context);
+maybe_check_port_requests(Context, 'true', 'false') ->
+    %% Authenticated account is reseller lets always show alerts
+    %% from its own account and all sub-accounts (no matter what port app is hidden or not)
+    ResellerId = cb_context:reseller_id(Context),
+    Ports = fetch_account_active_ports(ResellerId)
+        ++ get_active_ports(knm_port_request:descendant_active_ports(ResellerId)),
+    do_check_port_requests(Ports, Context);
+maybe_check_port_requests(Context, 'false', _) ->
+    %% Authenticated account is neither master or reseller
+    %% show alerts if its reseller is not hiding port app
+    AccountId = cb_context:account_id(Context),
+    ResellerId = cb_context:reseller_id(Context),
+    case should_hide_port(ResellerId) of
+        'true' -> Context;
+        'false' -> do_check_port_requests(fetch_account_active_ports(AccountId), Context)
+    end.
+
+-spec should_hide_port(kz_term:api_ne_binary() | {'ok', kz_json:object()} | {'error', any()}) -> boolean().
+should_hide_port('undefined') ->
     'false';
-is_reseller_handling_port_requests(<<_/binary>> = ResellerId) ->
-    is_reseller_handling_port_requests(kzd_whitelabel:fetch(ResellerId));
-is_reseller_handling_port_requests({'ok', Whitelabel}) ->
-    kz_json:is_true(<<"hide_port">>, Whitelabel);
-is_reseller_handling_port_requests({'error', 'not_found'}) ->
+should_hide_port(<<ResellerId/binary>>) ->
+    should_hide_port(kzd_whitelabel:fetch(ResellerId));
+should_hide_port({'ok', Whitelabel}) ->
+    kzd_whitelabel:hide_port(Whitelabel);
+should_hide_port({'error', 'not_found'}) ->
     'false'.
 
--spec maybe_merge_active_and_unconfirmed_ports({'ok', kz_json:objects()} | {'error', 'not_found'}
-                                              ,{'ok', kz_json:objects()} | {'error', 'not_found'}
-                                              ) -> kz_json:objects().
-maybe_merge_active_and_unconfirmed_ports({'ok', Active}, {'ok', Unconfirmed}) ->
-    lists:flatten([Active, Unconfirmed]);
-maybe_merge_active_and_unconfirmed_ports(_, _) ->
+-spec fetch_account_active_ports(kz_term:api_ne_binary()) -> kz_json:objects().
+fetch_account_active_ports('undefined') -> [];
+fetch_account_active_ports(AccountId) ->
+    get_active_ports(knm_port_request:account_active_ports(AccountId))
+        ++ get_active_ports(knm_port_request:account_ports_by_state(AccountId, ?PORT_UNCONFIRMED)).
+
+-spec get_active_ports({'ok', kz_json:objects()} | {'error', 'not_found'}) -> kz_json:objects().
+get_active_ports({'ok', Active}) ->
+    Active;
+get_active_ports(_) ->
     [].
 
 -spec do_check_port_requests(kz_term:api_ne_binary() | kz_json:objects(), cb_context:context()) -> cb_context:context().

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -722,7 +722,9 @@ validate_port_comments(Context, OnSuccess, NewComments) ->
 
 -spec validate_comments(cb_context:context(), kz_json:objects()) -> cb_context:context().
 validate_comments(Context, NewComments) ->
+    AccountId = cb_context:account_id(Context),
     IsPortAuthority = cb_context:fetch(Context, 'is_port_authority', 'false')
+        orelse (AccountId =:= kzd_whitelabel:fetch_port_authority(AccountId, 'undefined'))
         orelse cb_context:is_superduper_admin(Context),
     ContextToValidate = cb_context:set_req_data(Context, kzd_port_requests:set_comments(kz_json:new(), NewComments)),
     ValidatedContext = cb_context:validate_request_data(<<"comments">>, ContextToValidate),
@@ -734,22 +736,44 @@ validate_comments(Context, NewComments) ->
     end.
 
 -spec validate_comments(cb_context:context(), kz_json:objects(), boolean()) -> cb_context:context().
-validate_comments(Context, NewComments, 'true') ->
-    add_commentors_info(Context, NewComments);
 validate_comments(Context, NewComments, 'false') ->
     Filters = [{kzd_comment:action_required_path(), fun kz_term:is_true/1}
               ,{kzd_comment:superduper_comment_path(), fun kz_term:is_true/1} %% old key
-              ,{kzd_comment:is_private_path(), fun kz_term:is_false/1}
+              ,{kzd_comment:is_private_path(), fun kz_term:is_true/1}
               ],
     case run_comment_filter(NewComments, Filters) of
         [] ->
             add_commentors_info(Context, NewComments);
         [_|_] ->
+            Msg = kz_json:from_list_recursive(
+                    [{<<"comments">>
+                     ,[{<<"forbidden">>
+                       ,[{<<"message">>, <<"you're not allowed to make private comment or set action_required">>}
+                        ,{<<"cause">>, <<"comments">>}
+                        ]
+                       }
+                      ]
+                     }
+                    ]),
+            cb_context:add_system_error('forbidden', Msg, Context)
+    end;
+validate_comments(Context, NewComments, 'true') ->
+    Filters = [{kzd_comment:superduper_comment_path(), fun kz_term:is_false/1} %% old key
+              ,{kzd_comment:is_private_path(), fun kz_term:is_true/1}
+              ],
+    case [Comment
+          || Comment <- run_comment_filter(NewComments, Filters),
+             kz_json:is_true(<<"action_required">>, Comment, 'false')
+         ]
+    of
+        [] ->
+            add_commentors_info(Context, NewComments);
+        [_|_] ->
             Msg = kz_json:from_list(
-                    [{<<"message">>, <<"you're not allowed to make private comment or set action_required">>}
+                    [{<<"message">>, <<"setting action_required on private comment is not allowed">>}
                     ,{<<"cause">>, <<"comments">>}
                     ]),
-            cb_context:add_validation_error(<<"comments">>, <<"forbidden">>, Msg, Context)
+            cb_context:add_validation_error(<<"comments">>, <<"rejected">>, Msg, Context)
     end.
 
 -spec add_commentors_info(cb_context:context(), kz_json:objects()) -> cb_context:context().

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -722,9 +722,7 @@ validate_port_comments(Context, OnSuccess, NewComments) ->
 
 -spec validate_comments(cb_context:context(), kz_json:objects()) -> cb_context:context().
 validate_comments(Context, NewComments) ->
-    AccountId = cb_context:account_id(Context),
     IsPortAuthority = cb_context:fetch(Context, 'is_port_authority', 'false')
-        orelse (AccountId =:= kzd_whitelabel:fetch_port_authority(AccountId, 'undefined'))
         orelse cb_context:is_superduper_admin(Context),
     ContextToValidate = cb_context:set_req_data(Context, kzd_port_requests:set_comments(kz_json:new(), NewComments)),
     ValidatedContext = cb_context:validate_request_data(<<"comments">>, ContextToValidate),
@@ -758,7 +756,7 @@ validate_comments(Context, NewComments, 'false') ->
             cb_context:add_system_error('forbidden', Msg, Context)
     end;
 validate_comments(Context, NewComments, 'true') ->
-    Filters = [{kzd_comment:superduper_comment_path(), fun kz_term:is_false/1} %% old key
+    Filters = [{kzd_comment:superduper_comment_path(), fun kz_term:is_true/1} %% old key
               ,{kzd_comment:is_private_path(), fun kz_term:is_true/1}
               ],
     case [Comment

--- a/applications/crossbar/test/cb_alerts_tests.erl
+++ b/applications/crossbar/test/cb_alerts_tests.erl
@@ -45,6 +45,7 @@ maybe_check_port_requests() ->
     ToMeck = ['kz_services_reseller', Mod],
     _ = lists:foreach(fun(M) -> meck:new(M, [passthrough]) end, ToMeck),
     meck:expect('kz_services_reseller', 'is_reseller', fun(_) -> 'false' end),
+    meck:expect('knm_port_request', 'account_ports_by_state', fun(_, ?PORT_UNCONFIRMED) -> {'ok', []} end),
 
     Context = cb_context:set_resp_data(cb_context:new(), []),
     {'ok', ActivePorts} = AccountActivePorts = account_active_ports(),

--- a/applications/crossbar/test/cb_alerts_tests.erl
+++ b/applications/crossbar/test/cb_alerts_tests.erl
@@ -42,30 +42,30 @@ cb_alerts_test_() ->
 -spec do_check_port_requests() -> [{string(), boolean()}].
 do_check_port_requests() ->
     Context = cb_context:set_resp_data(cb_context:new(), []),
-    {'ok', ActivePorts} = AccountActivePorts = account_active_and_unconfirmed_ports(),
+    {'ok', ActivePorts} = account_active_and_unconfirmed_ports(),
 
     %% 1 submitted, 1 unconfirmed, and 1 rejected.
-    Context1 = cb_alerts:do_check_port_requests(AccountActivePorts, Context),
+    Context1 = cb_alerts:do_check_port_requests(ActivePorts, Context),
     Resp = cb_context:resp_data(Context1),
     [Alert1, Alert2] = Resp,
 
     %% All ports (3) have last comment with `action_required=true' within the last comment
     %% and also there is 1 rejected and 1 unconfirmed.
     PortsWithComments = [add_comments(Port) || Port <- ActivePorts],
-    Context2 = cb_alerts:do_check_port_requests({'ok', PortsWithComments}, Context),
+    Context2 = cb_alerts:do_check_port_requests(PortsWithComments, Context),
 
     %% Only 1 port with `action_required=true' within the last comment
     Port = add_comments(example_port_request()),
     %% Same as Port but last comment doesn't have `action_required=true'
     Port1 = swap_comments(Port),
-    Context3 = cb_alerts:do_check_port_requests({'ok', [Port, Port1]}, Context),
+    Context3 = cb_alerts:do_check_port_requests([Port, Port1], Context),
     [Alert3] = cb_context:resp_data(Context3),
 
     %% Not active ports found.
-    Context4 = cb_alerts:do_check_port_requests({'error', 'not_found'}, Context),
+    Context4 = cb_alerts:do_check_port_requests([], Context),
 
     %% Ports with state /= (unconfirmed|rejected) and no comments.
-    Context5 = cb_alerts:do_check_port_requests({'ok', [example_port_request()]}, Context),
+    Context5 = cb_alerts:do_check_port_requests([example_port_request()], Context),
 
     [{"Only return ports with `last_comment`.action_required=true or state=(rejected|unconfirmed)"
      ,?_assertEqual({'true', <<"port_suspended">>},

--- a/core/kazoo_numbers/src/knm_port_request.erl
+++ b/core/kazoo_numbers/src/knm_port_request.erl
@@ -189,7 +189,7 @@ account_ports_by_state(AccountId, PortState) ->
                   ,'include_docs'
                   ],
     case lists:member(PortState, ?PORT_STATES) %% Make sure it is a valid state
-         andalso kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB, ?PORT_LISTING_BY_STATE, ViewOptions)
+        andalso kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB, ?PORT_LISTING_BY_STATE, ViewOptions)
     of
         {'ok', []} -> {'error', 'not_found'};
         {'ok', Ports} -> {'ok', [kz_json:get_value(<<"doc">>, Doc) || Doc <- Ports]};

--- a/core/kazoo_numbers/src/knm_port_request.erl
+++ b/core/kazoo_numbers/src/knm_port_request.erl
@@ -130,7 +130,7 @@ read_only_public_fields(Doc) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec get(kz_term:ne_binary()) -> {'ok', kz_json:object()} |
-          {'error', any()}.
+          kz_datamgr:data_error().
 get(DID=?NE_BINARY) ->
     View = ?ACTIVE_PORT_IN_NUMBERS,
     ViewOptions = [{'key', DID}, 'include_docs'],
@@ -146,7 +146,7 @@ get(DID=?NE_BINARY) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec get_portin_number(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kz_json:objects()} |
-          {'error', any()}.
+          kz_datamgr:data_error().
 get_portin_number(AccountId, DID=?NE_BINARY) ->
     ViewOptions = [{'key', [AccountId, DID]}
                   ,'include_docs'
@@ -164,17 +164,16 @@ get_portin_number(AccountId, DID=?NE_BINARY) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec account_active_ports(kz_term:ne_binary()) -> {'ok', kz_json:objects()} |
-          {'error', 'not_found'}.
+          kz_datamgr:data_error().
 account_active_ports(AccountId) ->
     ViewOptions = [{'key', AccountId}
                   ,'include_docs'
                   ],
     case kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB, ?ACTIVE_PORT_LISTING, ViewOptions) of
-        {'ok', []} -> {'error', 'not_found'};
         {'ok', Ports} -> {'ok', [kz_json:get_value(<<"doc">>, Doc) || Doc <- Ports]};
-        {'error', _R} ->
+        {'error', _R} = Err ->
             lager:error("failed to query for account port numbers ~p", [_R]),
-            {'error', 'not_found'}
+            Err
     end.
 
 %%------------------------------------------------------------------------------
@@ -182,20 +181,17 @@ account_active_ports(AccountId) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec account_ports_by_state(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kz_json:objects()} |
-          {'error', 'not_found'}.
+          kz_datamgr:data_error().
 account_ports_by_state(AccountId, PortState) ->
     ViewOptions = [{'startkey', [AccountId, PortState]}
                   ,{endkey, [AccountId, PortState, kz_json:new()]}
                   ,'include_docs'
                   ],
-    case lists:member(PortState, ?PORT_STATES) %% Make sure it is a valid state
-        andalso kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB, ?PORT_LISTING_BY_STATE, ViewOptions)
-    of
-        {'ok', []} -> {'error', 'not_found'};
+    case kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB, ?PORT_LISTING_BY_STATE, ViewOptions) of
         {'ok', Ports} -> {'ok', [kz_json:get_value(<<"doc">>, Doc) || Doc <- Ports]};
-        {'error', _R} ->
+        {'error', _R} = Err ->
             lager:error("failed to query for account port numbers ~p", [_R]),
-            {'error', 'not_found'}
+            Err
     end.
 
 %%------------------------------------------------------------------------------
@@ -203,23 +199,22 @@ account_ports_by_state(AccountId, PortState) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec descendant_active_ports(kz_term:ne_binary()) -> {'ok', kz_json:objects()} |
-          {'error', 'not_found'}.
+          kz_datamgr:data_error().
 descendant_active_ports(AccountId) ->
     ViewOptions = [{'startkey', [AccountId]}
                   ,{'endkey', [AccountId, kz_json:new()]}
                   ,'include_docs'
                   ],
     case kz_datamgr:get_results(?KZ_PORT_REQUESTS_DB, ?DESCENDANT_ACTIVE_PORT_LISTING, ViewOptions) of
-        {'ok', []} -> {'error', 'not_found'};
         {'ok', Ports} ->
             {'ok', [kz_json:get_value(<<"doc">>, Doc)
                     || Doc <- Ports
                            ,is_active_descendant_port(Doc)
                    ]
             };
-        {'error', _R} ->
+        {'error', _R} = Err ->
             lager:error("failed to query for descendant port numbers ~p", [_R]),
-            {'error', 'not_found'}
+            Err
     end.
 
 -spec is_active_descendant_port(kz_json:object()) -> boolean().
@@ -234,8 +229,9 @@ is_active_descendant_port(JObj) ->
 -spec account_has_active_port(kz_term:ne_binary()) -> boolean().
 account_has_active_port(AccountId) ->
     case account_active_ports(AccountId) of
+        {'ok', []} -> 'false';
         {'ok', [_|_]} -> 'true';
-        {'error', 'not_found'} -> 'false'
+        {'error', _} -> 'false'
     end.
 
 %%------------------------------------------------------------------------------

--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -861,6 +861,9 @@ validation_error(Property, <<"unique">> = C, Message, Options) ->
 %% User is not authorized to update the property
 validation_error(Property, <<"forbidden">> = C, Message, Options) ->
     depreciated_validation_error(Property, C, Message, Options);
+%% Request to update the property was rejected
+validation_error(Property, <<"rejected">> = C, Message, Options) ->
+    depreciated_validation_error(Property, C, Message, Options);
 %% Date range is invalid, too small, or too large
 validation_error(Property, <<"date_range">> = C, Message, Options) ->
     depreciated_validation_error(Property, C, Message, Options);


### PR DESCRIPTION
In the UI, a sub-account of a whitelabel domain where the domain admin has selected "
I will request ports on behalf of customers" should not see port alerts in the UI.  Those should be shown to the account managing the ports.

In addition, port requests' comments should only honor action_required on comments that are from the port authority AND public.