### PR TITLE
PISTON-990: allow gen_listener implementers to hibernate

### DIFF
--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -837,6 +837,8 @@ handle_callback_info(Message
     try Module:handle_info(Message, ModuleState) of
         {'noreply', ModuleState1} ->
             {'noreply', State#state{module_state=ModuleState1}};
+        {'noreply', ModuleState1, 'hibernate'} ->
+            {'noreply', State#state{module_state=ModuleState1}, 'hibernate'};
         {'noreply', ModuleState1, Timeout} ->
             Ref = start_timer(Timeout),
             {'noreply', State#state{module_state=ModuleState1
@@ -1157,6 +1159,11 @@ handle_module_call(Request, From, #state{module=Module
                         ,module_timeout_ref='undefined'
                         }
             };
+        {'reply', Reply, ModuleState1, 'hibernate'} ->
+            {'reply', Reply
+            ,State#state{module_state=ModuleState1}
+            ,'hibernate'
+            };
         {'reply', Reply, ModuleState1, Timeout} ->
             {'reply', Reply
             ,State#state{module_state=ModuleState1
@@ -1165,6 +1172,8 @@ handle_module_call(Request, From, #state{module=Module
             };
         {'noreply', ModuleState1} ->
             {'noreply', State#state{module_state=ModuleState1}};
+        {'noreply', ModuleState1, 'hibernate'} ->
+            {'noreply', State#state{module_state=ModuleState1}, 'hibernate'};
         {'noreply', ModuleState1, Timeout} ->
             {'noreply'
             ,State#state{module_state=ModuleState1
@@ -1191,6 +1200,8 @@ handle_module_cast(Msg, #state{module=Module
     try Module:handle_cast(Msg, ModuleState) of
         {'noreply', ModuleState1} ->
             {'noreply', State#state{module_state=ModuleState1}};
+        {'noreply', ModuleState1, 'hibernate'} ->
+            {'noreply', State#state{module_state=ModuleState1}, 'hibernate'};
         {'noreply', ModuleState1, Timeout} ->
             Ref = start_timer(Timeout),
             {'noreply', State#state{module_state=ModuleState1


### PR DESCRIPTION
gen_listener implementers' handle_call, handle_cast, and handle_info cannot hibernate the gen_listener right now.
This has caused, as an example, kz_amqp_worker to consume a lot of binary ref memory over time without an opportunity for garbage collection to release its binary refs.
This can be seen by looking at the length of the binary list for a pid via
```
{'binary', Binaries} = process_info(Pid, 'binary'),
length(Binaries).
```
and comparing the results of the same commands after manually trigger a GC on the pid via `erlang:garbage_collect(Pid)`.
This change allows kz_amqp_worker as well as other gen_listener implementers to actually get hibernation on demand.