### PR TITLE
Remove TTS cache objects

### DIFF
--- a/core/kazoo_media/src/kz_media_tts_cache.erl
+++ b/core/kazoo_media/src/kz_media_tts_cache.erl
@@ -314,8 +314,9 @@ stop_timer(Ref) when is_reference(Ref) ->
 
 -spec publish_doc_update(kz_term:ne_binary()) -> 'ok'.
 publish_doc_update(Id) ->
+    DbId = kz_binary:md5(Id),
     API =
-        [{<<"ID">>, Id}
+        [{<<"ID">>, DbId}
         ,{<<"Type">>, Type = <<"media">>}
         ,{<<"Database">>, Db = <<"tts">>}
         ,{<<"Rev">>, <<"0">>}


### PR DESCRIPTION
Fixed removing tts cache records from ecallmgr_util_cache after
kz_media_tts_cache is terminated.

Forward-port of #6169