### PR TITLE
Allow webhooks to be sent using PUT

### DIFF
--- a/applications/webhooks/src/modules/webhooks_notifications.erl
+++ b/applications/webhooks/src/modules/webhooks_notifications.erl
@@ -119,6 +119,7 @@ handle_account_notification(Notification, <<"webhook">>) ->
     webhooks_util:fire_hooks(Data, [Hook]);
 handle_account_notification(Notification, EventName) ->
     AccountId = kapi_notifications:account_id(Notification),
+    lager:info("searching for hook ~s(~s) for account ~s", [EventName, ?HOOK_NAME, AccountId]),
     handle_account_notification(Notification, EventName, AccountId
                                ,webhooks_util:find_webhooks(?HOOK_NAME, AccountId)
                                ).

--- a/applications/webhooks/src/webhooks.hrl
+++ b/applications/webhooks/src/webhooks.hrl
@@ -4,11 +4,11 @@
 -include_lib("kazoo_stdlib/include/kz_databases.hrl").
 -include_lib("kazoo_events/include/kz_hooks.hrl").
 
--define(APP, webhooks).
--define(APP_NAME, (atom_to_binary(?APP, utf8))).
+-define(APP, 'webhooks').
+-define(APP_NAME, (atom_to_binary(?APP, 'utf8'))).
 -define(APP_VERSION, <<"4.0.0">>).
 
--type http_verb() :: 'get' | 'post'.
+-type http_verb() :: 'get' | 'post' | 'put'.
 -type hook_retries() :: 1..5.
 
 -record(webhook, {id :: kz_term:api_ne_binary() | '_'

--- a/applications/webhooks/src/webhooks_sup.erl
+++ b/applications/webhooks/src/webhooks_sup.erl
@@ -83,7 +83,7 @@ child_of_type(S, T) ->
 %%------------------------------------------------------------------------------
 -spec init(any()) -> kz_types:sup_init_ret().
 init([]) ->
-    kz_util:set_startup(),
+    _ = kz_util:set_startup(),
     RestartStrategy = 'one_for_one',
     MaxRestarts = 5,
     MaxSecondsBetweenRestarts = 10,

--- a/core/kazoo_documents/src/kzd_webhooks.erl
+++ b/core/kazoo_documents/src/kzd_webhooks.erl
@@ -205,7 +205,8 @@ disable(Hook, Reason) ->
     kz_json:set_values(disable_updates(Reason), Hook).
 
 -spec disable_updates(kz_term:api_ne_binary()) -> kz_json:flat_proplist().
-disable_updates('undefined') ->[{[<<"enabled">>], 'false'}];
+disable_updates('undefined') ->
+    [{[<<"enabled">>], 'false'}];
 disable_updates(Reason) ->
     [{[<<"enabled">>], 'false'}
     ,{[?DISABLED_MESSAGE], Reason}


### PR DESCRIPTION
- listen for and remove account hooks when account is deleted
- allow 'all' modifier for hook types and event types
- test put/post for webhooks