### PR TITLE
[4.3] Configurable timeout on Pivot requests

### DIFF
--- a/applications/callflow/doc/pivot.md
+++ b/applications/callflow/doc/pivot.md
@@ -1,6 +1,6 @@
-## Pivot
+# Pivot
 
-### About Pivot
+## About Pivot
 
 Execute an HTTP request to a web server about the call, expecting more callflow instructions in the response.
 
@@ -15,10 +15,49 @@ Key | Description | Type | Default | Required | Support Level
 `cdr_url` | Optional URL to send the CDR to at the end of the call | `string()` |   | `false` |  
 `debug` | Store debug logs related to processing this Pivot call | `boolean()` | `false` | `false` |  
 `method` | What HTTP verb to send the request(s) with | `string('get' | 'post' | 'GET' | 'POST')` | `get` | `false` |  
-`req_body_format` | What format should the request body have | `string('form' | 'json')` | `form` | `false` |  
+`req_body_format` | What format should the request body have when using POST | `string('form' | 'json')` | `form` | `false` |  
 `req_format` | What format of Pivot will the your server respond with | `string('kazoo' | 'twiml')` | `kazoo` | `false` |  
+`req_timeout_ms` | How long, in milliseconds, to wait for a Pivot response from the HTTP server | `integer()` |   | `false` |  
 `skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
 `voice_url` | What URL to request the initial Pivot callflow | `string()` |   | `true` |  
 
 
 
+
+
+
+##### TwiML
+
+TwiML support is limited at the moment; KAZOO JSON is highly encouraged.
+
+!!! note
+    `cdr_url` is only applicable when using the XML (TwiML) format. When using the kazoo format, control is handed off to the Callflows app, with the Pivot process ending (and nothing waiting for the CDR). Instead, please use [webhooks](./webhooks.md) (specifically the CHANNEL_DESTROY event) to receive CDRs.
+
+### Allowed Hosts
+
+It is advisable to restrict the hostname in the `voice_url` by setting up some blacklists. These will be consulted when validating the URL provided by the client.
+
+By default RFC1918 IPs and `localhost` blocked.
+
+#### Blacklist CIDR
+
+Blacklist network ranges using CIDR notation:
+
+    sup kazoo_web_maintenance blacklist_client_ip aaa.bbb.ccc.ddd/32
+
+The default list is `127.0.0.1/32` and `0.0.0.0/32`. Consider adding RFC1918 addresses, `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`, as well as your cluster's subnets.
+
+#### Blacklist Hostname
+
+Blacklist a hostname:
+
+    sup kazoo_web_maintenance blacklist_client_host {HOSTNAME}
+
+`{HOSTNAME}` will just match the `HOST` portion of a URL. In the following examples, the `HOST` portion will be `client.host`:
+
+    http://client.host
+    https://client.host:9876
+    http://user@pass:client.host
+    https://user@pass:client.host:4356
+
+Currently, there is no attempt to resolve the hostname to an IP address for CIDR checking.

--- a/applications/callflow/doc/ref/pivot.md
+++ b/applications/callflow/doc/ref/pivot.md
@@ -13,8 +13,9 @@ Key | Description | Type | Default | Required | Support Level
 `cdr_url` | Optional URL to send the CDR to at the end of the call | `string()` |   | `false` |  
 `debug` | Store debug logs related to processing this Pivot call | `boolean()` | `false` | `false` |  
 `method` | What HTTP verb to send the request(s) with | `string('get' | 'post' | 'GET' | 'POST')` | `get` | `false` |  
-`req_body_format` | What format should the request body have | `string('form' | 'json')` | `form` | `false` |  
+`req_body_format` | What format should the request body have when using POST | `string('form' | 'json')` | `form` | `false` |  
 `req_format` | What format of Pivot will the your server respond with | `string('kazoo' | 'twiml')` | `kazoo` | `false` |  
+`req_timeout_ms` | How long, in milliseconds, to wait for a Pivot response from the HTTP server | `integer()` |   | `false` |  
 `skip_module` | When set to true this callflow action is skipped, advancing to the wildcard branch (if any) | `boolean()` |   | `false` |  
 `voice_url` | What URL to request the initial Pivot callflow | `string()` |   | `true` |  
 

--- a/applications/callflow/src/module/cf_pivot.erl
+++ b/applications/callflow/src/module/cf_pivot.erl
@@ -1,28 +1,6 @@
 %%%-----------------------------------------------------------------------------
 %%% @copyright (C) 2012-2019, 2600Hz
-%%% @doc Accept third-party `dialplan'.
-%%%
-%%% <h4>Data options:</h4>
-%%% <dl>
-%%%   <dt>`voice_url'</dt>
-%%%   <dd>Voice URL.</dd>
-%%%
-%%%   <dt>`cdr_url'</dt>
-%%%   <dd>CDR URL.</dd>
-%%%
-%%%   <dt>`req_format'</dt>
-%%%   <dd>`kazoo' or `twiml'.</dd>
-%%%
-%%%   <dt>`req_body_format'</dt>
-%%%   <dd>`form' or `json'.</dd>
-%%%
-%%%   <dt>`method'</dt>
-%%%   <dd>`get' or `post'.</dd>
-%%%
-%%%   <dt>`debug'</dt>
-%%%   <dd>`boolean()'</dd>
-%%% </dl>
-%%%
+%%% @doc Accept third-party `callflow' actions (or TwiML)
 %%% @author James Aimonetti
 %%% @end
 %%%-----------------------------------------------------------------------------
@@ -54,12 +32,13 @@
 handle(Data, Call) ->
     Prop = props:filter_empty(
              [{<<"Call">>, kapps_call:to_json(Call)}
-             ,{<<"Voice-URI">>, kz_json:get_ne_binary_value(<<"voice_url">>, Data)}
              ,{<<"CDR-URI">>, kz_json:get_ne_binary_value(<<"cdr_url">>, Data)}
-             ,{<<"Request-Format">>, kz_json:get_ne_binary_value(<<"req_format">>, Data)}
-             ,{<<"Request-Body-Format">>, kz_json:get_ne_binary_value(<<"req_body_format">>, Data, <<"form">>)}
-             ,{<<"HTTP-Method">>, kzt_util:http_method(kz_json:get_value(<<"method">>, Data, 'get'))}
              ,{<<"Debug">>, kz_json:is_true(<<"debug">>, Data, 'false')}
+             ,{<<"HTTP-Method">>, kzt_util:http_method(kz_json:get_value(<<"method">>, Data, 'get'))}
+             ,{<<"Request-Body-Format">>, kz_json:get_ne_binary_value(<<"req_body_format">>, Data, <<"form">>)}
+             ,{<<"Request-Format">>, kz_json:get_ne_binary_value(<<"req_format">>, Data)}
+             ,{<<"Request-Timeout">>, kz_json:get_integer_value(<<"req_timeout_ms">>, Data)}
+             ,{<<"Voice-URI">>, kz_json:get_ne_binary_value(<<"voice_url">>, Data)}
               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
              ]),
     kapi_pivot:publish_req(Prop),

--- a/applications/crossbar/doc/pivot.md
+++ b/applications/crossbar/doc/pivot.md
@@ -21,18 +21,7 @@ The Pivot endpoint is not loaded on start in a default Kazoo installation.
 
 ## Callflow Schema
 
-Any pivot callflow node must obey this schema.
-
-Key | Description | Type | Default | Required
---- | ----------- | ---- | ------- | --------
-`cdr_url` | Optional URL to send the CDR to at the end of the call | `string` |   | `false`
-`debug` | Store debug logs related to processing this Pivot call | `boolean` | `false` | `false`
-`method` | What HTTP verb to send the request(s) with | `string('get', 'post', 'GET', 'POST')` | `get` | `false`
-`req_format` | What format of Pivot will the your server respond with | `string('kazoo', 'twiml')` | `kazoo` | `false`
-`voice_url` | What URL to request the initial Pivot callflow | `string` |   | `true`
-
-!!! note
-    `cdr_url` is only applicable when using the XML (TwiML) format. When using the kazoo format, control is handed off to the Callflows app, with the Pivot process ending (and nothing waiting for the CDR). Instead, please use [webhooks](./webhooks.md) (specifically the CHANNEL_DESTROY event) to receive CDRs.
+See the [Pivot callflow schema](../../callflow/doc/pivot.md) for details.
 
 ## Debugging pivot attempts
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -3097,7 +3097,7 @@
                 },
                 "req_body_format": {
                     "default": "form",
-                    "description": "What format should the request body have",
+                    "description": "What format should the request body have when using POST",
                     "enum": [
                         "form",
                         "json"
@@ -3112,6 +3112,11 @@
                         "twiml"
                     ],
                     "type": "string"
+                },
+                "req_timeout_ms": {
+                    "description": "How long, in milliseconds, to wait for a Pivot response from the HTTP server",
+                    "maximum": 5000,
+                    "type": "integer"
                 },
                 "skip_module": {
                     "description": "When set to true this callflow action is skipped, advancing to the wildcard branch (if any)",
@@ -20374,6 +20379,9 @@
                 "Request-Format": {
                     "type": "string"
                 },
+                "Request-Timeout": {
+                    "type": "integer"
+                },
                 "Voice-URI": {
                     "type": "string"
                 }
@@ -32073,6 +32081,41 @@
             },
             "type": "object"
         },
+        "system_config.kazoo_web": {
+            "description": "Schema for kazoo_web system_config",
+            "properties": {
+                "client": {
+                    "properties": {
+                        "blacklist": {
+                            "properties": {
+                                "cidrs": {
+                                    "default": [
+                                        "127.0.0.1/32",
+                                        "0.0.0.0/32"
+                                    ],
+                                    "description": "kazoo_web client blacklist cidrs",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "hosts": {
+                                    "default": [
+                                        "localhost"
+                                    ],
+                                    "description": "kazoo_web client blacklist hosts",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "type": "object"
+        },
         "system_config.keys": {
             "description": "Schema for DTMF keys system_config",
             "properties": {
@@ -33511,6 +33554,11 @@
         "system_config.pivot": {
             "description": "Schema for pivot system_config",
             "properties": {
+                "request_timeout_ms": {
+                    "default": 5000,
+                    "description": "pivot request_timeout_ms",
+                    "type": "integer"
+                },
                 "tts_texts_size": {
                     "default": 4000,
                     "description": "pivot tts texts size",

--- a/applications/crossbar/priv/couchdb/schemas/call_recording.parameters.json
+++ b/applications/crossbar/priv/couchdb/schemas/call_recording.parameters.json
@@ -40,6 +40,7 @@
         "url": {
             "description": "The URL to use when sending the recording for storage",
             "format": "uri",
+            "kazoo-validation": true,
             "type": "string"
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/callflows.pivot.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.pivot.json
@@ -26,7 +26,7 @@
         },
         "req_body_format": {
             "default": "form",
-            "description": "What format should the request body have",
+            "description": "What format should the request body have when using POST",
             "enum": [
                 "form",
                 "json"
@@ -42,12 +42,18 @@
             ],
             "type": "string"
         },
+        "req_timeout_ms": {
+            "description": "How long, in milliseconds, to wait for a Pivot response from the HTTP server",
+            "maximum": 5000,
+            "type": "integer"
+        },
         "skip_module": {
             "description": "When set to true this callflow action is skipped, advancing to the wildcard branch (if any)",
             "type": "boolean"
         },
         "voice_url": {
             "description": "What URL to request the initial Pivot callflow",
+            "kazoo-validation": true,
             "pattern": "^https?://",
             "type": "string"
         }

--- a/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
@@ -78,6 +78,7 @@
         "url": {
             "description": "The URL to use when sending the recording for storage",
             "format": "uri",
+            "kazoo-validation": true,
             "type": "string"
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/callflows.record_caller.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.record_caller.json
@@ -34,6 +34,7 @@
         "url": {
             "description": "The URL to use when sending the recording for storage",
             "format": "uri",
+            "kazoo-validation": true,
             "type": "string"
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/callflows.webhook.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.webhook.json
@@ -25,6 +25,7 @@
         },
         "uri": {
             "description": "The HTTP URI to send the request",
+            "kazoo-validation": true,
             "type": "string"
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/faxbox.json
+++ b/applications/crossbar/priv/couchdb/schemas/faxbox.json
@@ -97,6 +97,7 @@
                                 },
                                 "url": {
                                     "description": "The URL to call back with the results",
+                                    "kazoo-validation": true,
                                     "pattern": "^https?://",
                                     "type": "string"
                                 }
@@ -168,6 +169,7 @@
                                 },
                                 "url": {
                                     "description": "The URL to call back with the results",
+                                    "kazoo-validation": true,
                                     "pattern": "^https?://",
                                     "type": "string"
                                 }

--- a/applications/crossbar/priv/couchdb/schemas/kapi.pivot.req.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.pivot.req.json
@@ -33,6 +33,9 @@
         "Request-Format": {
             "type": "string"
         },
+        "Request-Timeout": {
+            "type": "integer"
+        },
         "Voice-URI": {
             "type": "string"
         }

--- a/applications/crossbar/priv/couchdb/schemas/metaflows.pivot.json
+++ b/applications/crossbar/priv/couchdb/schemas/metaflows.pivot.json
@@ -35,6 +35,7 @@
         },
         "voice_url": {
             "description": "What URL to request the initial Pivot callflow",
+            "kazoo-validation": true,
             "pattern": "^https?://",
             "type": "string"
         }

--- a/applications/crossbar/priv/couchdb/schemas/metaflows.record_call.json
+++ b/applications/crossbar/priv/couchdb/schemas/metaflows.record_call.json
@@ -67,6 +67,7 @@
         },
         "url": {
             "description": "HTTP URL to send the finished recording",
+            "kazoo-validation": true,
             "type": "string"
         }
     },

--- a/applications/crossbar/priv/couchdb/schemas/storage.attachment.http.json
+++ b/applications/crossbar/priv/couchdb/schemas/storage.attachment.http.json
@@ -24,6 +24,7 @@
                 },
                 "url": {
                     "description": "The base HTTP(s) URL to use when creating the request",
+                    "kazoo-validation": true,
                     "type": "string"
                 },
                 "verb": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.kazoo_web.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.kazoo_web.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.kazoo_web",
+    "description": "Schema for kazoo_web system_config",
+    "properties": {
+        "client": {
+            "properties": {
+                "blacklist": {
+                    "properties": {
+                        "cidrs": {
+                            "default": [
+                                "127.0.0.1/32",
+                                "0.0.0.0/32"
+                            ],
+                            "description": "kazoo_web client blacklist cidrs",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "hosts": {
+                            "default": [
+                                "localhost"
+                            ],
+                            "description": "kazoo_web client blacklist hosts",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/system_config.pivot.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.pivot.json
@@ -3,6 +3,11 @@
     "_id": "system_config.pivot",
     "description": "Schema for pivot system_config",
     "properties": {
+        "request_timeout_ms": {
+            "default": 5000,
+            "description": "pivot request_timeout_ms",
+            "type": "integer"
+        },
         "tts_texts_size": {
             "default": 4000,
             "description": "pivot tts texts size",

--- a/applications/crossbar/priv/couchdb/schemas/webhooks.json
+++ b/applications/crossbar/priv/couchdb/schemas/webhooks.json
@@ -67,6 +67,7 @@
         "uri": {
             "description": "The 3rd party URI to call out to an event",
             "format": "uri",
+            "kazoo-validation": true,
             "support_level": "supported",
             "type": "string"
         }

--- a/applications/pivot/src/pivot_call.erl
+++ b/applications/pivot/src/pivot_call.erl
@@ -29,6 +29,9 @@
 -include("pivot.hrl").
 
 -define(SERVER, ?MODULE).
+-define(DEFAULT_REQ_TIMEOUT_MS
+       ,kapps_config:get_integer(?APP_NAME, <<"request_timeout_ms">>, 5 * ?MILLISECONDS_IN_SECOND)
+       ).
 
 -type http_method() :: 'get' | 'post'.
 
@@ -36,6 +39,7 @@
                ,cdr_uri :: kz_term:api_ne_binary()
                ,request_format = <<"kazoo">> :: kz_term:ne_binary()
                ,request_body_format = <<"form">> :: kz_term:ne_binary()
+               ,request_timeout_ms :: pos_integer()
                ,method = 'get' :: http_method()
                ,call :: kapps_call:call() | 'undefined'
                ,request_id :: kz_http:req_id() | 'undefined'
@@ -149,6 +153,7 @@ init([Call, JObj]) ->
            ,call=kzt_util:increment_iteration(Call)
            ,request_format=ReqFormat
            ,request_body_format=ReqBodyFormat
+           ,request_timeout_ms=kz_json:get_integer_value(<<"Request-Timeout">>, JObj, ?DEFAULT_REQ_TIMEOUT_MS)
            ,debug=kz_json:is_true(<<"Debug">>, JObj, 'false')
            ,requester_queue = kapps_call:controller_queue(Call)
            }
@@ -168,7 +173,7 @@ handle_call(_Request, _From, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_cast(any(), state()) -> {'noreply', state()} |
-                                     {'stop', 'normal', state()}.
+          {'stop', 'normal', state()}.
 handle_cast('usurp', State) ->
     lager:debug("terminating pivot call because of usurp"),
     {'stop', 'normal', State#state{call='undefined'}};
@@ -182,10 +187,11 @@ handle_cast({'request', Uri, Method, Params}
                   ,debug=Debug
                   ,requester_queue=Q
                   ,request_body_format=ReqBodyFormat
+                  ,request_timeout_ms=TimeoutMs
                   }=State) ->
     Call1 = kzt_util:set_voice_uri(Uri, Call),
 
-    case send_req(Call1, Uri, Method, Params, ReqBodyFormat, Debug) of
+    case send_req(Call1, Uri, Method, Params, ReqBodyFormat, TimeoutMs, Debug) of
         {'ok', ReqId, Call2} ->
             lager:debug("sent request ~p to '~s' via '~s'", [ReqId, Uri, Method]),
             {'noreply'
@@ -269,7 +275,7 @@ handle_cast(_Req, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_info(any(), state()) -> {'noreply', state()} |
-                                     {'stop', any(), state()}.
+          {'stop', any(), state()}.
 handle_info({'stop', _Call}, State) ->
     {'stop', 'normal', State};
 handle_info({'http', {ReqId, 'stream_start', Hdrs}}
@@ -407,34 +413,34 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec send_req(kapps_call:call(), kz_term:ne_binary(), http_method(), kz_json:object() | kz_term:proplist(), kz_term:ne_binary(), boolean()) ->
-                      {'ok', kz_http:req_id(), kapps_call:call()} |
-                      {'stop', kapps_call:call()}.
-send_req(Call, Uri, Method, BaseParams, ReqBodyFormat, Debug) when not is_list(BaseParams) ->
-    send_req(Call, Uri, Method, kz_json:to_proplist(BaseParams), ReqBodyFormat, Debug);
-send_req(Call, Uri, 'get', BaseParams, _ReqBodyFormat, Debug) ->
+-spec send_req(kapps_call:call(), kz_term:ne_binary(), http_method(), kz_json:object() | kz_term:proplist(), kz_term:ne_binary(), pos_integer(), boolean()) ->
+          {'ok', kz_http:req_id(), kapps_call:call()} |
+          {'stop', kapps_call:call()}.
+send_req(Call, Uri, Method, BaseParams, ReqBodyFormat, TimeoutMs, Debug) when not is_list(BaseParams) ->
+    send_req(Call, Uri, Method, kz_json:to_proplist(BaseParams), ReqBodyFormat, TimeoutMs, Debug);
+send_req(Call, Uri, 'get', BaseParams, _ReqBodyFormat, TimeoutMs, Debug) ->
     UserParams = kzt_translator:get_user_vars(Call),
     Params = kz_json:set_values(BaseParams, UserParams),
     UpdatedCall = kapps_call:kvs_erase(<<"digits_collected">>, Call),
-    send(UpdatedCall, uri(Uri, format_request(Params, <<"form">>)), 'get', [], [], Debug);
-send_req(Call, Uri, 'post', BaseParams, ReqBodyFormat, Debug) ->
+    send(UpdatedCall, uri(Uri, format_request(Params, <<"form">>)), 'get', [], [], TimeoutMs, Debug);
+send_req(Call, Uri, 'post', BaseParams, ReqBodyFormat, TimeoutMs, Debug) ->
     UserParams = kzt_translator:get_user_vars(Call),
     Params = kz_json:set_values(BaseParams, UserParams),
     UpdatedCall = kapps_call:kvs_erase(<<"digits_collected">>, Call),
     Headers = [{"Content-Type", req_content_type(ReqBodyFormat)}],
-    send(UpdatedCall, Uri, 'post', Headers, format_request(Params, ReqBodyFormat), Debug).
+    send(UpdatedCall, Uri, 'post', Headers, format_request(Params, ReqBodyFormat), TimeoutMs, Debug).
 
--spec send(kapps_call:call(), kz_term:ne_binary(), http_method(), kz_term:proplist(), iolist(), boolean()) ->
-                  {'ok', kz_http:req_id(), kapps_call:call()} |
-                  {'stop', kapps_call:call()}.
-send(Call, Uri, Method, ReqHdrs, ReqBody, Debug) ->
+-spec send(kapps_call:call(), kz_term:ne_binary(), http_method(), kz_term:proplist(), iolist(), pos_integer(), boolean()) ->
+          {'ok', kz_http:req_id(), kapps_call:call()} |
+          {'stop', kapps_call:call()}.
+send(Call, Uri, Method, ReqHdrs, ReqBody, TimeoutMs, Debug) ->
     lager:info("sending req to ~s(~s): ~s", [Uri, Method, iolist_to_binary(ReqBody)]),
 
     maybe_debug_req(Call, Uri, Method, ReqHdrs, ReqBody, Debug),
 
-    case kz_http:async_req(self(), Method, Uri, ReqHdrs, ReqBody) of
+    case kz_http:async_req(self(), Method, Uri, ReqHdrs, ReqBody, [{'timeout', TimeoutMs}]) of
         {'http_req_id', ReqId} ->
-            lager:debug("response coming in asynchronously to ~p", [ReqId]),
+            lager:debug("response coming in asynchronously to ~p(max ~p ms)", [ReqId, TimeoutMs]),
             {'ok', ReqId, Call};
         {'error', _Reason} ->
             lager:debug("error with req: ~p", [_Reason]),
@@ -465,10 +471,10 @@ handle_resp(RequesterQ, Call, CT, <<_/binary>> = RespBody, AMQPConsumer) ->
     end.
 
 -spec process_resp(kz_term:api_binary(), kapps_call:call(), list() | binary(), binary()) ->
-                          {'stop', kapps_call:call()} |
-                          {'ok', kapps_call:call()} |
-                          {'request', kapps_call:call()} |
-                          {'usurp', kapps_call:call()}.
+          {'stop', kapps_call:call()} |
+          {'ok', kapps_call:call()} |
+          {'request', kapps_call:call()} |
+          {'usurp', kapps_call:call()}.
 process_resp(_, Call, _, <<>>) ->
     lager:debug("no response body, finishing up"),
     {'stop', Call};
@@ -595,7 +601,7 @@ store_debug(Call, DebugJObj) ->
     end.
 
 -spec debug_doc(kapps_call:call(), kz_json:object(), kz_term:ne_binary()) ->
-                       kz_json:object().
+          kz_json:object().
 debug_doc(Call, DebugJObj, AccountModDb) ->
     WithCallJObj = kz_json:set_values([{<<"call_id">>, kapps_call:call_id(Call)}
                                       ,{<<"iteration">>, kzt_util:iteration(Call)}

--- a/core/kazoo_amqp/src/api/kapi_pivot.erl
+++ b/core/kazoo_amqp/src/api/kapi_pivot.erl
@@ -27,16 +27,21 @@
 
 -define(PIVOT_REQ_HEADERS, [<<"Call">>, <<"Voice-URI">>]).
 -define(OPTIONAL_PIVOT_REQ_HEADERS, [<<"CDR-URI">>
-                                    ,<<"Request-Format">>
-                                    ,<<"Request-Body-Format">>
-                                    ,<<"HTTP-Method">>
                                     ,<<"Debug">>
+                                    ,<<"HTTP-Method">>
+                                    ,<<"Request-Body-Format">>
+                                    ,<<"Request-Format">>
+                                    ,<<"Request-Timeout">>
                                     ]).
 -define(PIVOT_REQ_VALUES, [{<<"Event-Category">>,<<"dialplan">>}
                           ,{<<"Event-Name">>, <<"pivot_req">>}
                           ]).
 -define(PIVOT_REQ_TYPES, [{<<"Call">>, fun kz_json:is_json_object/1}
+                         ,{<<"CDR-URI">>, fun erlang:is_binary/1}
                          ,{<<"Debug">>, fun kz_term:is_boolean/1}
+                         ,{<<"Request-Body-Format">>, fun erlang:is_binary/1}
+                         ,{<<"Request-Format">>, fun erlang:is_binary/1}
+                         ,{<<"Request-Timeout">>, fun erlang:is_integer/1}
                          ]).
 
 -define(PIVOT_FAILED_HEADERS, [<<"Call-ID">>]).
@@ -54,7 +59,7 @@
 -define(PIVOT_PROCESSING_TYPES, []).
 
 -spec req(kz_term:api_terms()) -> {'ok', iolist()} |
-                                  {'error', string()}.
+          {'error', string()}.
 req(Prop) when is_list(Prop) ->
     case req_v(Prop) of
         'false' -> {'error', "Proplist failed validation for pivot_req"};
@@ -70,7 +75,7 @@ req_v(JObj) ->
     req_v(kz_json:to_proplist(JObj)).
 
 -spec failed(kz_term:api_terms()) -> {'ok', iolist()} |
-                                     {'error', string()}.
+          {'error', string()}.
 failed(Prop) when is_list(Prop) ->
     case failed_v(Prop) of
         'false' -> {'error', "Proplist failed validation for pivot_failed"};
@@ -86,7 +91,7 @@ failed_v(JObj) ->
     failed_v(kz_json:to_proplist(JObj)).
 
 -spec processing(kz_term:api_terms()) -> {'ok', iolist()} |
-                                         {'error', string()}.
+          {'error', string()}.
 processing(Prop) when is_list(Prop) ->
     case processing_v(Prop) of
         'false' -> {'error', "Proplist processing validation for pivot_processing"};

--- a/core/kazoo_proper/src/pqc_cb_api.erl
+++ b/core/kazoo_proper/src/pqc_cb_api.erl
@@ -193,7 +193,7 @@ default_request_headers(RequestId) ->
     ].
 
 -spec make_request(expectations() | expectation() | expected_code() | expected_codes(), fun_2(), string(), kz_term:proplist()) ->
-                          response().
+          response().
 make_request(Code, HTTP, URL, RequestHeaders) when is_integer(Code) ->
     make_request([#{'response_codes' => [Code]}], HTTP, URL, RequestHeaders);
 make_request([Code|_]=Codes, HTTP, URL, RequestHeaders) when is_integer(Code) ->
@@ -206,7 +206,7 @@ make_request([#{}|_]=Expectations, HTTP, URL, RequestHeaders) ->
     handle_response(Expectations, HTTP(URL, RequestHeaders)).
 
 -spec make_request(expectations() | expectation() | expected_code() | expected_codes(), fun_3(), string(), kz_term:proplist(), iodata()) ->
-                          response().
+          response().
 make_request(Code, HTTP, URL, RequestHeaders, RequestBody) when is_integer(Code) ->
     make_request([#{'response_codes' => [Code]}], HTTP, URL, RequestHeaders, RequestBody);
 make_request([Code|_]=Codes, HTTP, URL, RequestHeaders, RequestBody) when is_integer(Code) ->
@@ -220,12 +220,12 @@ make_request([#{}|_]=Expectations, HTTP, URL, RequestHeaders, RequestBody) ->
     handle_response(Expectations, HTTP(URL, RequestHeaders, iolist_to_binary(RequestBody))).
 
 -spec create_envelope(kz_json:json_term()) ->
-                             kz_json:object().
+          kz_json:object().
 create_envelope(Data) ->
     create_envelope(Data, kz_json:new()).
 
 -spec create_envelope(kz_json:json_term(), kz_json:object()) ->
-                             kz_json:object().
+          kz_json:object().
 create_envelope(Data, Envelope) ->
     kz_json:set_value(<<"data">>, Data, Envelope).
 

--- a/core/kazoo_proper/src/pqc_cb_callflows.erl
+++ b/core/kazoo_proper/src/pqc_cb_callflows.erl
@@ -21,8 +21,7 @@
 -define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
 
 -spec list_callflows(pqc_cb_api:state(), pqc_cb_accounts:account_id()) ->
-          {'error', 'not_found'} |
-          {'ok', kz_json:objects()}.
+          pqc_cb_api:response().
 list_callflows(API, AccountId) ->
     pqc_cb_api:make_request(#{'response_codes' => [200]}
                            ,fun kz_http:get/2
@@ -31,8 +30,7 @@ list_callflows(API, AccountId) ->
                            ).
 
 -spec fetch_callflow(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
-          {'ok', kz_json:object()} |
-          {'error', 'not_found'}.
+          pqc_cb_api:response().
 fetch_callflow(API, AccountId, CallflowId) ->
     pqc_cb_api:make_request(#{'response_codes' => [200]}
                            ,fun kz_http:get/2
@@ -41,7 +39,7 @@ fetch_callflow(API, AccountId, CallflowId) ->
                            ).
 
 -spec create_callflow(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kzd_callflows:doc()) ->
-          {'ok', kzd_call_callflows:doc()}.
+          pqc_cb_api:response().
 create_callflow(API, AccountId, CallflowDoc) ->
     URL = callflows_url(AccountId),
     RequestHeaders = pqc_cb_api:request_headers(API),
@@ -68,8 +66,7 @@ create_callflow_doc() ->
                ).
 
 -spec delete_callflow(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
-          {'ok', kz_json:object()} |
-          {'error', 'not_found'}.
+          pqc_cb_api:response().
 delete_callflow(API, AccountId, CallflowId) ->
     pqc_cb_api:make_request(#{'response_codes' => [200]}
                            ,fun kz_http:delete/2

--- a/core/kazoo_proper/src/pqc_cb_callflows.erl
+++ b/core/kazoo_proper/src/pqc_cb_callflows.erl
@@ -1,0 +1,182 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_callflows).
+
+-export([list_callflows/2
+        ,create_callflow/3
+        ,fetch_callflow/3
+        ,delete_callflow/3
+        ]).
+
+-export([seq/0, seq_url/0
+        ,cleanup/0
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
+
+-spec list_callflows(pqc_cb_api:state(), pqc_cb_accounts:account_id()) ->
+          {'error', 'not_found'} |
+          {'ok', kz_json:objects()}.
+list_callflows(API, AccountId) ->
+    pqc_cb_api:make_request(#{'response_codes' => [200]}
+                           ,fun kz_http:get/2
+                           ,callflows_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec fetch_callflow(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
+          {'ok', kz_json:object()} |
+          {'error', 'not_found'}.
+fetch_callflow(API, AccountId, CallflowId) ->
+    pqc_cb_api:make_request(#{'response_codes' => [200]}
+                           ,fun kz_http:get/2
+                           ,callflows_url(AccountId, CallflowId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec create_callflow(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kzd_callflows:doc()) ->
+          {'ok', kzd_call_callflows:doc()}.
+create_callflow(API, AccountId, CallflowDoc) ->
+    URL = callflows_url(AccountId),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+    RequestEnvelope  = pqc_cb_api:create_envelope(CallflowDoc),
+
+    pqc_cb_api:make_request(#{'response_codes' => [201]}
+                           ,fun kz_http:put/3
+                           ,URL
+                           ,RequestHeaders
+                           ,kz_json:encode(RequestEnvelope)
+                           ).
+
+-spec create_callflow_doc() -> kzd_callflows:doc().
+create_callflow_doc() ->
+    lists:foldl(fun({F, V}, Doc) -> F(Doc, V) end
+               ,kzd_callflows:new()
+               ,[{fun kzd_callflows:set_numbers/2, [<<"123">>]}
+                ,{fun kzd_callflows:set_flow/2
+                 ,kz_json:from_list([{<<"module">>, <<"response">>}
+                                    ,{<<"data">>, kz_json:from_list([{<<"code">>, 200}])}
+                                    ])
+                 }
+                ]
+               ).
+
+-spec delete_callflow(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
+          {'ok', kz_json:object()} |
+          {'error', 'not_found'}.
+delete_callflow(API, AccountId, CallflowId) ->
+    pqc_cb_api:make_request(#{'response_codes' => [200]}
+                           ,fun kz_http:delete/2
+                           ,callflows_url(AccountId, CallflowId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+callflows_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "callflows"], "/").
+
+callflows_url(AccountId, CallflowId) ->
+    string:join([callflows_url(AccountId), kz_term:to_list(CallflowId)], "/").
+
+-spec seq() -> 'ok'.
+seq() ->
+    _ = seq_crud(),
+    seq_url().
+
+seq_crud() ->
+    _ = init(),
+    Model = initial_state(),
+    API = pqc_kazoo_model:api(Model),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+    lager:info("created account ~s", [AccountId]),
+
+    EmptySummaryResp = list_callflows(API, AccountId),
+    lager:info("empty summary: ~s", [EmptySummaryResp]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
+
+    CreateResp = create_callflow(API, AccountId, create_callflow_doc()),
+    lager:info("create resp ~p", [CreateResp]),
+    CallflowDoc = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
+    <<CallflowId:32/binary>> = kz_doc:id(CallflowDoc),
+
+    SummaryResp = list_callflows(API, AccountId),
+    lager:info("summary resp: ~s", [SummaryResp]),
+    [SummaryJObj] = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
+    CallflowId = kz_doc:id(SummaryJObj),
+
+    FetchResp = fetch_callflow(API, AccountId, CallflowId),
+    lager:info("fetched resp: ~s", [FetchResp]),
+    FetchJObj = kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp)),
+    CallflowId = kz_doc:id(FetchJObj),
+
+    DeleteResp = delete_callflow(API, AccountId, CallflowId),
+    lager:info("delete resp: ~s", [DeleteResp]),
+    CallflowId = kz_doc:id(kz_json:get_json_value(<<"data">>, kz_json:decode(DeleteResp))),
+
+    EmptyAgainResp = list_callflows(API, AccountId),
+    lager:info("empty again resp: ~s", [EmptyAgainResp]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptyAgainResp)),
+
+    lager:info("COMPLETED SUCCESSFULLY!"),
+    _ = cleanup(API).
+
+-spec seq_url() -> any().
+seq_url() ->
+    _ = init(),
+    Model = initial_state(),
+    API = pqc_kazoo_model:api(Model),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+    lager:info("created account ~s", [AccountId]),
+
+    {'error', ErrorResp} = create_callflow(API, AccountId, pivot_url_callflow()),
+    lager:info("create resp failed with internal url: ~s", [ErrorResp]),
+
+    lager:info("COMPLETED SUCCESSFULLY!"),
+    _ = cleanup(API).
+
+pivot_url_callflow() ->
+    PivotData = kz_json:from_list([{<<"voice_url">>, <<"http://localhost/123">>}]),
+    Flow = kz_json:from_list([{<<"module">>, <<"pivot">>}
+                             ,{<<"data">>, PivotData}
+                             ]),
+    kz_doc:setters(kzd_callflows:new()
+                  ,[{fun kzd_callflows:set_numbers/2, [<<"345">>]}
+                   ,{fun kzd_callflows:set_flow/2, Flow}
+                   ]).
+
+init() ->
+    _ = kz_data_tracing:clear_all_traces(),
+    _ = [kapps_controller:start_app(App) ||
+            App <- ['crossbar']
+        ],
+    _ = [crossbar_maintenance:start_module(Mod) ||
+            Mod <- ['cb_callflows', 'cb_accounts']
+        ],
+    lager:info("INIT FINISHED").
+
+-spec initial_state() -> pqc_kazoo_model:model().
+initial_state() ->
+    API = pqc_cb_api:authenticate(),
+    lager:info("state initialized to ~p", [API]),
+    pqc_kazoo_model:new(API).
+
+-spec cleanup() -> any().
+cleanup() ->
+    lager:info("CLEANUP ALL THE THINGS"),
+    kz_data_tracing:clear_all_traces(),
+    cleanup(pqc_cb_api:authenticate()).
+
+-spec cleanup(pqc_cb_api:state()) -> any().
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    pqc_cb_api:cleanup(API).

--- a/core/kazoo_proper/src/pqc_cb_storage.erl
+++ b/core/kazoo_proper/src/pqc_cb_storage.erl
@@ -7,7 +7,7 @@
 -module(pqc_cb_storage).
 
 %% Manual testing
--export([seq/0
+-export([seq/0, blacklisted_url/0
         ,cleanup/0
         ,storage_doc/1
         ]).
@@ -39,12 +39,12 @@
 -define(SEND_MULTIPART, 'true').
 
 -spec create(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary() | kz_json:object()) ->
-                    pqc_cb_api:response().
+          pqc_cb_api:response().
 create(API, AccountId, StorageDoc) ->
     create(API, AccountId, StorageDoc, 'undefined').
 
 -spec create(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary() | kz_json:object(), kz_term:api_boolean()) ->
-                    pqc_cb_api:response().
+          pqc_cb_api:response().
 create(API, AccountId, ?NE_BINARY=UUID, ValidateSettings) ->
     create(API, AccountId, storage_doc(UUID), ValidateSettings);
 create(API, AccountId, StorageDoc, ValidateSettings) ->
@@ -86,9 +86,9 @@ init_system() ->
         ],
 
     _HTTPD = pqc_httpd:start_link(TestId),
-    ?INFO("HTTPD started: ~p", [_HTTPD]),
+    lager:info("HTTPD started: ~p", [_HTTPD]),
 
-    ?INFO("INIT FINISHED").
+    lager:info("INIT FINISHED").
 
 -spec seq() -> 'ok'.
 seq() ->
@@ -96,6 +96,7 @@ seq() ->
             ,fun skip_validation_test/0
             ,fun global_test/0
             ,fun missing_ref_test/0
+            ,fun blacklisted_url/0
             ],
     lists:foreach(fun run_test/1, Tests).
 
@@ -103,8 +104,23 @@ run_test(TestFun) ->
     TestFun(),
     cleanup().
 
+-spec blacklisted_url() -> 'ok'.
+blacklisted_url() ->
+    lager:info("SKIP TEST"),
+
+    API = init_api(),
+
+    AccountId = create_account(API),
+
+    StorageDoc = storage_doc(kz_binary:rand_hex(16), <<"https://ignore@me:0.0.0.0">>),
+    {'error', ShouldFailToCreate} = create(API, AccountId, StorageDoc),
+    lager:info("should fail: ~s", [ShouldFailToCreate]),
+
+    cleanup(API),
+    lager:info("FINISHED BLACKLIST").
+
 skip_validation_test() ->
-    ?INFO("SKIP TEST"),
+    lager:info("SKIP TEST"),
 
     API = init_api(),
 
@@ -112,65 +128,65 @@ skip_validation_test() ->
 
     StorageDoc = storage_doc(kz_binary:rand_hex(16)),
     {'error', ShouldFailToCreate} = create(API, AccountId, StorageDoc, 'false'),
-    ?INFO("should fail: ~s", [ShouldFailToCreate]),
+    lager:info("should fail: ~s", [ShouldFailToCreate]),
 
     check_if_allowed(kz_json:decode(ShouldFailToCreate), 'false'),
 
     kzs_plan:allow_validation_overrides(),
-    ?INFO("allowing validation overrides"),
+    lager:info("allowing validation overrides"),
 
     ShouldSucceedToCreate = create(API, AccountId, StorageDoc, 'false'),
-    ?INFO("should succeed: ~s", [ShouldSucceedToCreate]),
+    lager:info("should succeed: ~s", [ShouldSucceedToCreate]),
 
     check_if_allowed(kz_json:decode(ShouldSucceedToCreate), 'true'),
 
-    ?INFO("created without validation successfully"),
+    lager:info("created without validation successfully"),
 
     kzs_plan:disallow_validation_overrides(),
-    ?INFO("dis-allowing validation overrides"),
+    lager:info("dis-allowing validation overrides"),
 
     {'error', ShouldAgainFailToCreate} = create(API, AccountId, StorageDoc, 'false'),
-    ?INFO("should fail again: ~s", [ShouldAgainFailToCreate]),
+    lager:info("should fail again: ~s", [ShouldAgainFailToCreate]),
     check_if_allowed(kz_json:decode(ShouldAgainFailToCreate), 'false'),
 
     cleanup(API),
-    ?INFO("FINISHED NON-VALIDATION").
+    lager:info("FINISHED NON-VALIDATION").
 
 create_account(API) ->
     AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
-    ?INFO("created account: ~s", [AccountResp]),
+    lager:info("created account: ~s", [AccountResp]),
 
     kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
 
 check_if_allowed(RespJObj, ShouldAllow) ->
     Errored = 'undefined' =:= kz_json:get_json_value([<<"data">>, <<"validate_settings">>], RespJObj),
-    ?INFO("request errored: ~p", [Errored]),
+    lager:info("request errored: ~p", [Errored]),
     ShouldAllow = Errored.
 
 base_test() ->
-    ?INFO("BASE TEST"),
+    lager:info("BASE TEST"),
     API = init_api(),
 
     AccountId = create_account(API),
 
     StorageDoc = storage_doc(kz_binary:rand_hex(16)),
     CreatedStorage = create(API, AccountId, StorageDoc),
-    ?INFO("created storage: ~p", [CreatedStorage]),
+    lager:info("created storage: ~p", [CreatedStorage]),
 
     Test = pqc_httpd:get_req([<<?MODULE_STRING>>, AccountId]),
-    ?INFO("test created ~p", [Test]),
+    lager:info("test created ~p", [Test]),
 
     _ = test_vm_message(API, AccountId),
 
     cleanup(API),
-    ?INFO("FINISHED").
+    lager:info("FINISHED").
 
 init_api() ->
     Model = initial_state(),
     pqc_kazoo_model:api(Model).
 
 global_test() ->
-    ?INFO("GLOBAL TEST"),
+    lager:info("GLOBAL TEST"),
 
     API = init_api(),
 
@@ -178,43 +194,43 @@ global_test() ->
 
     StorageDoc = storage_doc(kz_binary:rand_hex(16)),
     CreatedStorage = create(API, 'undefined', StorageDoc),
-    ?INFO("created storage: ~p", [CreatedStorage]),
+    lager:info("created storage: ~p", [CreatedStorage]),
 
     Test = pqc_httpd:get_req([<<?MODULE_STRING>>, <<"system_data">>]),
-    ?INFO("test created ~p", [Test]),
+    lager:info("test created ~p", [Test]),
 
     _ = test_vm_message(API, AccountId),
     cleanup(API),
-    ?INFO("FINISHED").
+    lager:info("FINISHED").
 
 test_vm_message(API, AccountId) ->
     CreateBox = pqc_cb_vmboxes:create_box(API, AccountId, <<"1010">>),
-    ?INFO("create VM box: ~p", [CreateBox]),
+    lager:info("create VM box: ~p", [CreateBox]),
     BoxId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(CreateBox)),
 
     {'ok', MP3} = file:read_file(filename:join([code:priv_dir('kazoo_proper'), "mp3.mp3"])),
     CreateVM = create_voicemail(API, AccountId, BoxId, MP3),
-    ?INFO("create VM: ~p", [CreateVM]),
+    lager:info("create VM: ~p", [CreateVM]),
 
     CreatedVM = kz_json:decode(CreateVM),
     MediaId = kz_json:get_ne_binary_value([<<"data">>, <<"media_id">>], CreatedVM),
 
     {'ok', GetVM} = pqc_httpd:wait_for_req([<<?MODULE_STRING>>, AccountId, MediaId]),
-    ?INFO("get VM: ~p", [GetVM]),
+    lager:info("get VM: ~p", [GetVM]),
     {[RequestBody], [_AttachmentName]} = kz_json:get_values(GetVM),
 
     'true' = handle_multipart_store(MediaId, MP3, RequestBody),
-    ?INFO("got mp3 data on our web server!"),
+    lager:info("got mp3 data on our web server!"),
 
     %% pqc_httpd:update_req([<<?MODULE_STRING>>, AccountId, MediaId, AttachmentName], MP3),
-    %% ?INFO("updating media to non-encoded MP3"),
+    %% lager:info("updating media to non-encoded MP3"),
 
     MetadataResp = pqc_cb_vmboxes:fetch_message_metadata(API, AccountId, BoxId, MediaId),
-    ?INFO("message ~s meta: ~s", [MediaId, MetadataResp]),
+    lager:info("message ~s meta: ~s", [MediaId, MetadataResp]),
     MediaId = kz_json:get_ne_binary_value([<<"data">>, <<"media_id">>], kz_json:decode(MetadataResp)),
 
     MessageBin = pqc_cb_vmboxes:fetch_message_binary(API, AccountId, BoxId, MediaId),
-    ?INFO("message bin =:= MP3: ~p", [MessageBin =:= MP3]),
+    lager:info("message bin =:= MP3: ~p", [MessageBin =:= MP3]),
     MessageBin = MP3.
 
 create_voicemail(API, AccountId, BoxId, MP3) ->
@@ -234,10 +250,10 @@ handle_multipart_contents(_MediaId, _MP3, []) -> 'true';
 handle_multipart_contents(MediaId, MP3, [<<>> | Parts]) ->
     handle_multipart_contents(MediaId, MP3, Parts);
 handle_multipart_contents(MediaId, MP3, [<<"content-type: application/json">>, <<>>, JSON | Parts]) ->
-    ?INFO("json body: ~s", [JSON]),
+    lager:info("json body: ~s", [JSON]),
     JObj = kz_json:decode(JSON),
     MediaId = kz_json:get_ne_binary_value([<<"metadata">>, <<"media_id">>], JObj),
-    ?INFO("got expected media id ~s", [MediaId]),
+    lager:info("got expected media id ~s", [MediaId]),
 
     kz_json:all(fun({MessageKey, MessageValue}) ->
                         MessageValue =:= kz_json:get_value([<<"metadata">>, MessageKey], JObj)
@@ -263,10 +279,10 @@ handle_multipart_contents(MediaId, MP3, [_Part | Parts]) ->
     handle_multipart_contents(MediaId, MP3, Parts).
 
 handle_mp3_contents(MP3, Base64MP3, 'true') ->
-    ?INFO("checking base64-encoded data"),
+    lager:info("checking base64-encoded data"),
     case base64:decode(Base64MP3) of
         MP3 ->
-            ?INFO("got expected mp3 data"),
+            lager:info("got expected mp3 data"),
             'true';
         _Data ->
             ?ERROR("failed to decode to mp3: ~w", [Base64MP3]),
@@ -279,7 +295,7 @@ cleanup() ->
     cleanup_system().
 
 cleanup(API) ->
-    ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
     _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
     _ = pqc_cb_api:cleanup(API),
     cleanup_system().
@@ -291,23 +307,27 @@ cleanup_system() ->
 
 -spec storage_doc(kz_term:ne_binary()) -> kzd_storage:doc().
 storage_doc(UUID) ->
-    kz_json:from_list([{<<"attachments">>, storage_attachments(UUID)}
+    storage_doc(UUID, 'undefined').
+
+storage_doc(UUID, URL) ->
+    kz_json:from_list([{<<"attachments">>, storage_attachments(UUID, URL)}
                       ,{<<"plan">>, storage_plan(UUID)}
                       ]).
 
-storage_attachments(UUID) ->
-    kz_json:from_list([{UUID, http_handler()}]).
+storage_attachments(UUID, URL) ->
+    kz_json:from_list([{UUID, http_handler(URL)}]).
 
-http_handler() ->
+http_handler(URL) ->
     kz_json:from_list([{<<"handler">>, <<"http">>}
                       ,{<<"name">>, <<?MODULE_STRING>>}
-                      ,{<<"settings">>, http_handler_settings()}
+                      ,{<<"settings">>, http_handler_settings(URL)}
                       ]).
 
-http_handler_settings() ->
+http_handler_settings('undefined') ->
     Base = pqc_httpd:base_url(),
     URL = <<Base/binary, ?MODULE_STRING>>,
-
+    http_handler_settings(URL);
+http_handler_settings(<<URL/binary>>) ->
     kz_json:from_list([{<<"url">>, URL}
                       ,{<<"verb">>, <<"post">>}
                       ,{<<"send_multipart">>, ?SEND_MULTIPART}
@@ -343,13 +363,13 @@ mailbox_handler(AttUUID, ConnUUID) ->
                       ]).
 
 storage_doc_missing_conn(AttUUID, ConnUUID) ->
-    kz_json:from_list([{<<"attachments">>, storage_attachments(AttUUID)}
+    kz_json:from_list([{<<"attachments">>, storage_attachments(AttUUID, 'undefined')}
                       ,{<<"plan">>, storage_plan(AttUUID, ConnUUID)}
                       ]).
 
 -spec missing_ref_test() -> 'ok'.
 missing_ref_test() ->
-    ?INFO("GLOBAL TEST"),
+    lager:info("GLOBAL TEST"),
 
     API = init_api(),
 
@@ -357,4 +377,4 @@ missing_ref_test() ->
 
     MissingConnDoc = storage_doc_missing_conn(kz_binary:rand_hex(16), kz_binary:rand_hex(16)),
     {'error', ErrMsg} = create(API, AccountId, MissingConnDoc),
-    ?INFO("failed to create storage: ~s", [ErrMsg]).
+    lager:info("failed to create storage: ~s", [ErrMsg]).

--- a/core/kazoo_proper/src/pqc_cb_webhooks.erl
+++ b/core/kazoo_proper/src/pqc_cb_webhooks.erl
@@ -1,0 +1,176 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2019, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_webhooks).
+
+-export([list_webhooks/2
+        ,create_webhook/3
+        ,fetch_webhook/3
+        ,delete_webhook/3
+        ]).
+
+-export([seq/0, seq_url/0
+        ,cleanup/0
+        ]).
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
+
+-spec list_webhooks(pqc_cb_api:state(), pqc_cb_accounts:account_id()) ->
+          {'error', 'not_found'} |
+          {'ok', kz_json:objects()}.
+list_webhooks(API, AccountId) ->
+    pqc_cb_api:make_request(#{'response_codes' => [200]}
+                           ,fun kz_http:get/2
+                           ,webhooks_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec fetch_webhook(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
+          {'ok', kz_json:object()} |
+          {'error', 'not_found'}.
+fetch_webhook(API, AccountId, WebhookId) ->
+    pqc_cb_api:make_request(#{'response_codes' => [200]}
+                           ,fun kz_http:get/2
+                           ,webhooks_url(AccountId, WebhookId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec create_webhook(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kzd_webhooks:doc()) ->
+          {'ok', kzd_call_webhooks:doc()}.
+create_webhook(API, AccountId, WebhookDoc) ->
+    URL = webhooks_url(AccountId),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+    RequestEnvelope  = pqc_cb_api:create_envelope(WebhookDoc),
+
+    pqc_cb_api:make_request(#{'response_codes' => [201]}
+                           ,fun kz_http:put/3
+                           ,URL
+                           ,RequestHeaders
+                           ,kz_json:encode(RequestEnvelope)
+                           ).
+
+-spec create_webhook_doc() -> kzd_webhooks:doc().
+create_webhook_doc() ->
+    lists:foldl(fun({F, V}, Doc) -> F(Doc, V) end
+               ,kzd_webhooks:new()
+               ,[{fun kzd_webhooks:set_uri/2, <<"https://webhook.host/here">>}
+                ,{fun kzd_webhooks:set_name/2, <<?MODULE_STRING>>}
+                ,{fun kzd_webhooks:set_hook/2, <<"channel_create">>}
+                ]
+               ).
+
+-spec delete_webhook(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
+          {'ok', kz_json:object()} |
+          {'error', 'not_found'}.
+delete_webhook(API, AccountId, WebhookId) ->
+    pqc_cb_api:make_request(#{'response_codes' => [200]}
+                           ,fun kz_http:delete/2
+                           ,webhooks_url(AccountId, WebhookId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+webhooks_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "webhooks"], "/").
+
+webhooks_url(AccountId, WebhookId) ->
+    string:join([webhooks_url(AccountId), kz_term:to_list(WebhookId)], "/").
+
+-spec seq() -> 'ok'.
+seq() ->
+    _ = seq_crud(),
+    seq_url().
+
+seq_crud() ->
+    _ = init(),
+    Model = initial_state(),
+    API = pqc_kazoo_model:api(Model),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+    lager:info("created account ~s", [AccountId]),
+
+    EmptySummaryResp = list_webhooks(API, AccountId),
+    lager:info("empty summary: ~s", [EmptySummaryResp]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
+
+    CreateResp = create_webhook(API, AccountId, create_webhook_doc()),
+    lager:info("create resp ~p", [CreateResp]),
+    WebhookDoc = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
+    <<WebhookId:32/binary>> = kz_doc:id(WebhookDoc),
+
+    SummaryResp = list_webhooks(API, AccountId),
+    lager:info("summary resp: ~s", [SummaryResp]),
+    [SummaryJObj] = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
+    WebhookId = kz_doc:id(SummaryJObj),
+
+    FetchResp = fetch_webhook(API, AccountId, WebhookId),
+    lager:info("fetched resp: ~s", [FetchResp]),
+    FetchJObj = kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp)),
+    WebhookId = kz_doc:id(FetchJObj),
+
+    DeleteResp = delete_webhook(API, AccountId, WebhookId),
+    lager:info("delete resp: ~s", [DeleteResp]),
+    WebhookId = kz_doc:id(kz_json:get_json_value(<<"data">>, kz_json:decode(DeleteResp))),
+
+    EmptyAgainResp = list_webhooks(API, AccountId),
+    lager:info("empty again resp: ~s", [EmptyAgainResp]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptyAgainResp)),
+
+    lager:info("COMPLETED SUCCESSFULLY!"),
+    _ = cleanup(API).
+
+-spec seq_url() -> any().
+seq_url() ->
+    _ = init(),
+    Model = initial_state(),
+    API = pqc_kazoo_model:api(Model),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+    lager:info("created account ~s", [AccountId]),
+
+    {'error', ErrorResp} = create_webhook(API, AccountId, pivot_url_webhook()),
+    lager:info("create resp failed with internal url: ~s", [ErrorResp]),
+
+    lager:info("COMPLETED SUCCESSFULLY!"),
+    _ = cleanup(API).
+
+pivot_url_webhook() ->
+    kz_doc:setters(kzd_webhooks:new()
+                  ,[{fun kzd_webhooks:set_uri/2, <<"https://localhost:345/webhook">>}
+                   ,{fun kzd_webhooks:set_name/2, <<?MODULE_STRING>>}
+                   ,{fun kzd_webhooks:set_hook/2, <<"channel_destroy">>}
+                   ]).
+
+init() ->
+    _ = kz_data_tracing:clear_all_traces(),
+    _ = [kapps_controller:start_app(App) ||
+            App <- ['crossbar']
+        ],
+    _ = [crossbar_maintenance:start_module(Mod) ||
+            Mod <- ['cb_webhooks', 'cb_accounts']
+        ],
+    lager:info("INIT FINISHED").
+
+-spec initial_state() -> pqc_kazoo_model:model().
+initial_state() ->
+    API = pqc_cb_api:authenticate(),
+    lager:info("state initialized to ~p", [API]),
+    pqc_kazoo_model:new(API).
+
+-spec cleanup() -> any().
+cleanup() ->
+    lager:info("CLEANUP ALL THE THINGS"),
+    kz_data_tracing:clear_all_traces(),
+    cleanup(pqc_cb_api:authenticate()).
+
+-spec cleanup(pqc_cb_api:state()) -> any().
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    pqc_cb_api:cleanup(API).

--- a/core/kazoo_proper/src/pqc_cb_webhooks.erl
+++ b/core/kazoo_proper/src/pqc_cb_webhooks.erl
@@ -21,8 +21,7 @@
 -define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
 
 -spec list_webhooks(pqc_cb_api:state(), pqc_cb_accounts:account_id()) ->
-          {'error', 'not_found'} |
-          {'ok', kz_json:objects()}.
+          pqc_cb_api:response().
 list_webhooks(API, AccountId) ->
     pqc_cb_api:make_request(#{'response_codes' => [200]}
                            ,fun kz_http:get/2

--- a/core/kazoo_proper/src/pqc_cb_webhooks.erl
+++ b/core/kazoo_proper/src/pqc_cb_webhooks.erl
@@ -31,8 +31,7 @@ list_webhooks(API, AccountId) ->
                            ).
 
 -spec fetch_webhook(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
-          {'ok', kz_json:object()} |
-          {'error', 'not_found'}.
+          pqc_cb_api:response().
 fetch_webhook(API, AccountId, WebhookId) ->
     pqc_cb_api:make_request(#{'response_codes' => [200]}
                            ,fun kz_http:get/2
@@ -41,7 +40,7 @@ fetch_webhook(API, AccountId, WebhookId) ->
                            ).
 
 -spec create_webhook(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kzd_webhooks:doc()) ->
-          {'ok', kzd_call_webhooks:doc()}.
+          pqc_cb_api:response().
 create_webhook(API, AccountId, WebhookDoc) ->
     URL = webhooks_url(AccountId),
     RequestHeaders = pqc_cb_api:request_headers(API),
@@ -65,8 +64,7 @@ create_webhook_doc() ->
                ).
 
 -spec delete_webhook(pqc_cb_api:state(), pqc_cb_accounts:account_id(), kz_term:ne_binary()) ->
-          {'ok', kz_json:object()} |
-          {'error', 'not_found'}.
+          pqc_cb_api:response().
 delete_webhook(API, AccountId, WebhookId) ->
     pqc_cb_api:make_request(#{'response_codes' => [200]}
                            ,fun kz_http:delete/2

--- a/core/kazoo_schemas/src/kz_json_schema_extensions.erl
+++ b/core/kazoo_schemas/src/kz_json_schema_extensions.erl
@@ -32,7 +32,7 @@ extended_regexp(Value, State, _Options) ->
 -spec regexp_validation(jesse:json_term(), jesse_state:state()) -> jesse_state:state().
 regexp_validation(Value, State) ->
     case re:compile(Value) of
-        {error, _Reason} ->
+        {'error', _Reason} ->
             ErrMsg = <<"invalid regular expression: '", Value/binary,"'">>,
             jesse_error:handle_data_invalid({'external_error', ErrMsg}, Value, State);
         _ ->
@@ -55,6 +55,7 @@ extra_validation(Value, State) ->
     ElementId = kz_term:to_binary(lists:last(Path)),
     Keys = [SchemaId, ElementId],
     Key = kz_binary:join(lists:filter(fun kz_term:is_not_empty/1, Keys), <<".">>),
+    lager:info("extra for ~p : ~p", [Key, Value]),
     extra_validation(Key, Value, State).
 
 extra_validation(<<"metaflow.data">>, Value, State) ->
@@ -76,12 +77,12 @@ extra_validation(<<"metaflow.module">>, Value, State) ->
 extra_validation(<<"callflows.action.data">>, Value, State) ->
     JObj = jesse_state:get_current_value(State),
     [_Data | Path] = jesse_state:get_current_path(State),
-    case jesse_json_path:path(lists:reverse([<<"module">> | Path]), JObj, undefined) of
+
+    case jesse_json_path:path(lists:reverse([<<"module">> | Path]), JObj, 'undefined') of
         'undefined' -> State;
         Module -> validate_module_data(<<"callflows.", Module/binary>>, Value, State)
     end;
 extra_validation(<<"callflows.action.module">>, Value, State) ->
-    lager:debug("validating callflow action '~s'", [Value]),
     Schema = <<"callflows.", Value/binary>>,
     State1 = jesse_state:resolve_ref(State, Schema),
     State2 = case jesse_state:get_current_schema_id(State1) of
@@ -89,6 +90,28 @@ extra_validation(<<"callflows.action.module">>, Value, State) ->
                  _OtherSchema -> jesse_error:handle_data_invalid({'external_error', <<"unable to find callflow schema for module ", Value/binary>>}, Value, State)
              end,
     jesse_state:undo_resolve_ref(State2, State);
+extra_validation(<<"webhooks.uri">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"callflows.webhook.uri">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"callflows.pivot.voice_url">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"callflows.record_caller.url">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"callflows.record_call.url">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"metaflows.pivot.voice_url">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"metaflows.record_call.url">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"call_recording.parameters.url">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"faxbox.notifications.inbound.callback.url">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"faxbox.notifications.outbound.callback.url">>, URL, State) ->
+    url_validation(URL, State);
+extra_validation(<<"storage.attachment.http.url">>, URL, State) ->
+    url_validation(URL, State);
 extra_validation(<<"storage.plan.database.document.connection">>, Value, State) ->
     JObj = jesse_state:get_current_value(State),
     Keys = kz_json:get_keys(<<"connections">>, JObj),
@@ -118,7 +141,7 @@ extra_validation(<<"storage.attachment.onedrive.oauth_doc_id">>, Value, State) -
 extra_validation(<<"storage.attachment.dropbox.oauth_doc_id">>, Value, State) ->
     validate_attachment_oauth_doc_id(Value, State);
 extra_validation(_Key, _Value, State) ->
-    lager:debug("extra validation of ~s not handled for value ~p", [_Key, _Value]),
+    lager:info("extra validation of ~s not handled for value ~p", [_Key, _Value]),
     State.
 
 validate_module_data(Schema, Value, State) ->
@@ -134,16 +157,16 @@ validate_module_data(Schema, Value, State) ->
 validate_attachment_oauth_doc_id(Value, State) ->
     lager:debug("Validating oauth_doc_id: ~s", [Value]),
     case kz_datamgr:open_doc(<<"system_auth">>, Value) of
-        {ok, _Obj} ->
+        {'ok', _Obj} ->
             State;
-        {error, empty_doc_id} ->
+        {'error', 'empty_doc_id'} ->
             ErrorMsg = <<"empty oauth_doc_id">>,
             jesse_error:handle_data_invalid({'external_error', ErrorMsg}, Value, State);
-        {error, not_found} ->
+        {'error', 'not_found'} ->
             ErrorMsg = <<"Invalid oauth_doc_id: ", Value/binary>>,
             lager:debug("~s", [ErrorMsg]),
             jesse_error:handle_data_invalid({'external_error', ErrorMsg}, Value, State);
-        {error, _Err} ->
+        {'error', _Err} ->
             ErrorMsg = <<"Error validating oauth_doc_id: ", Value/binary>>,
             lager:debug("~s : ~p", [ErrorMsg, _Err]),
             jesse_error:handle_data_invalid({'external_error', ErrorMsg}, Value, State)
@@ -164,22 +187,80 @@ maybe_check_param_stability_level(SystemSL, ParamSL, Value, State) ->
     SystemSLInt = stability_level_to_int(SystemSL),
     ParamSLInt = stability_level_to_int(ParamSL),
     case check_param_stability_level(SystemSLInt, ParamSLInt) of
-        valid ->
+        'valid' ->
             State;
-        invalid ->
-            ErrorMsg = <<"Disallowed parameter, it has lower stability level (",
-                         ParamSL/binary, ") than system's stability level (",
-                         SystemSL/binary, ")">>,
+        'invalid' ->
+            ErrorMsg = <<"Disallowed parameter, it has lower stability level ("
+                        ,ParamSL/binary, ") than system's stability level ("
+                        ,SystemSL/binary, ")"
+                       >>,
             lager:debug("~s", [ErrorMsg]),
             jesse_error:handle_data_invalid({'external_error', ErrorMsg}, Value, State)
     end.
 
 check_param_stability_level(SystemSLInt, ParamSLInt) when ParamSLInt < SystemSLInt ->
-    invalid;
+    'invalid';
 check_param_stability_level(_SystemSLInt, _ParamSLInt) ->
-    valid.
+    'valid'.
 
 -spec stability_level_to_int(kz_term:ne_binary()) -> pos_integer().
 stability_level_to_int(<<"stable">>) -> 3;
 stability_level_to_int(<<"beta">>) -> 2;
 stability_level_to_int(<<"alpha">>) -> 1.
+
+url_validation(URL, State) ->
+    case is_valid_client_url(URL) of
+        'true' -> State;
+        'false' ->
+            lager:info("client URL '~s' not valid", [URL]),
+            UpdatedState = jesse_error:handle_data_invalid({'external_error', <<"invalid client URL">>}, URL, State),
+            lager:info("~p", [UpdatedState]),
+            UpdatedState
+    end.
+
+is_valid_client_url({Scheme, Host, _Path, _QueryString, _Fragment}) ->
+    lists:all(fun is_valid_url_part/1
+             ,[{fun is_valid_scheme/1, Scheme}
+              ,{fun is_valid_host/1, Host}
+              ]
+             );
+is_valid_client_url(<<URL/binary>>) ->
+    is_valid_client_url(kz_http_util:urlsplit(URL)).
+
+is_valid_url_part({Fun, Part}) ->
+    Fun(Part).
+
+is_valid_scheme(<<"http">>) -> 'true';
+is_valid_scheme(<<"https">>) -> 'true';
+is_valid_scheme(_) -> 'false'.
+
+-spec is_valid_host(kz_http_util:location()) -> boolean().
+is_valid_host(<<Host/binary>>) ->
+    is_valid_host(kz_term:to_lower_binary(Host), kz_network_utils:is_ip(Host));
+is_valid_host({Host, _Port}) when is_integer(_Port) ->
+    is_valid_host(Host);
+is_valid_host({Host, _Username, _Password}) ->
+    is_valid_host(Host).
+
+-spec is_valid_host(kz_term:ne_binary(), boolean()) -> boolean().
+is_valid_host(Host, 'true') ->
+    is_valid_host_value(Host, 'true', kz_http_util:client_ip_blacklist());
+is_valid_host(Host, 'false') ->
+    is_valid_host_value(Host, 'false', kz_http_util:client_host_blacklist()).
+
+-spec is_valid_host_value(kz_term:ne_binary(), boolean(), kz_term:api_ne_binaries()) -> boolean().
+is_valid_host_value(_Host, _IsIp, 'undefined') -> 'true';
+is_valid_host_value(Host, IsIp, Blacklist) ->
+    not lists:any(fun(B) -> is_host_blacklisted(Host, IsIp, B) end, Blacklist).
+
+is_host_blacklisted(Host, _IsIp, Host) ->
+    lager:debug("host matches blacklisted value ~s", [Host]),
+    'true';
+is_host_blacklisted(Host, 'true', CIDR) ->
+    case kz_network_utils:verify_cidr(Host, CIDR) of
+        'false' -> 'false';
+        'true' ->
+            lager:debug("host ~s is part of CIDR ~s", [Host, CIDR]),
+            'true'
+    end;
+is_host_blacklisted(_Host, 'false', _Hostname) -> 'false'.

--- a/core/kazoo_web/src/kazoo_web_maintenance.erl
+++ b/core/kazoo_web/src/kazoo_web_maintenance.erl
@@ -1,0 +1,29 @@
+-module(kazoo_web_maintenance).
+
+-export([blacklist_client_ip/1
+        ,blacklist_client_host/1
+        ,show_client_blacklists/0
+        ]).
+
+-spec blacklist_client_ip(kz_term:ne_binary()) -> kz_term:ne_binaries() | 'error'.
+blacklist_client_ip(CIDR) ->
+    blacklist_client_ip(CIDR, kz_network_utils:is_cidr(CIDR)).
+
+blacklist_client_ip(CIDR, 'false') ->
+    io:format("Please use CIDR notation (maybe ~s/32)~n", [CIDR]),
+    'error';
+blacklist_client_ip(CIDR, 'true') ->
+    CIDRs = kz_http_util:client_ip_blacklist(),
+    kz_http_util:set_client_ip_blacklist([CIDR | CIDRs]).
+
+-spec blacklist_client_host(kz_term:ne_binary()) -> kz_term:ne_binaries().
+blacklist_client_host(Host) ->
+    Hosts = kz_http_util:client_host_blacklist(),
+    kz_http_util:set_client_host_blacklist([Host | Hosts]).
+
+-spec show_client_blacklists() -> 'ok'.
+show_client_blacklists() ->
+    io:format("CLient Blacklists:~nCIDRS: ~p~nHosts: ~p~n"
+             ,[kz_http_util:client_ip_blacklist()
+              ,kz_http_util:client_host_blacklist()
+              ]).

--- a/core/kazoo_web/src/kz_http.erl
+++ b/core/kazoo_web/src/kz_http.erl
@@ -30,7 +30,7 @@
                   'trace'.
 
 -type field() :: string().
--type value() :: string().
+-type value() :: string() | integer().
 -type header() :: {field(), value()}.
 -type headers() :: [header()].
 

--- a/core/kazoo_web/src/kz_http_util.erl
+++ b/core/kazoo_web/src/kz_http_util.erl
@@ -17,9 +17,41 @@
         ,get_resp_header/2, get_resp_header/3
         ,encode_multipart/1, encode_multipart/2
         ,create_boundary/0
+
+        ,client_ip_blacklist/0, set_client_ip_blacklist/1
+        ,client_host_blacklist/0, set_client_host_blacklist/1
         ]).
 
+-include("kz_web.hrl").
 -include_lib("kazoo_stdlib/include/kazoo_json.hrl").
+
+-export_type([scheme/0
+             ,location/0
+             ,resource_path/0
+             ,querystring/0
+             ,fragment/0
+             ]).
+
+-define(INVALID_HOSTS, kapps_config:get(?APP_NAME
+                                       ,[<<"client">>, <<"blacklist">>, <<"hosts">>]
+                                       ,[<<"localhost">>]
+                                       )).
+-define(SET_INVALID_HOSTS(Hosts), kapps_config:set_default(?APP_NAME
+                                                          ,[<<"client">>, <<"blacklist">>, <<"hosts">>]
+                                                          ,Hosts
+                                                          )).
+
+-define(INVALID_NETWORK_CIDRS, kapps_config:get(?APP_NAME
+                                               ,[<<"client">>, <<"blacklist">>, <<"cidrs">>]
+                                               ,[<<"127.0.0.1/32">>
+                                                ,<<"0.0.0.0/32">>
+                                                ]
+                                               )).
+
+-define(SET_INVALID_NETWORK_CIDRS(Cidrs), kapps_config:set_default(?APP_NAME
+                                                                  ,[<<"client">>, <<"blacklist">>, <<"cidrs">>]
+                                                                  ,Cidrs
+                                                                  )).
 
 %%------------------------------------------------------------------------------
 %% @doc URL decodes a URL encoded string.
@@ -162,10 +194,22 @@ parse_query_string('val', <<C, R/binary>>, KeyAcc, ValAcc, RetAcc) ->
     parse_query_string('val', R, KeyAcc, <<ValAcc/binary, C>>, RetAcc).
 
 %%------------------------------------------------------------------------------
-%% @doc Splits a URL into scheme, location, path, query, and fragment parts.
+%% @doc Splits a URL
+%%
+%% Parts will be scheme, location, path, query, fragment parts, and optionally
+%% username/password if HTTP Basic Auth creds are included
 %% @end
 %%------------------------------------------------------------------------------
--spec urlsplit(binary()) -> {binary(), binary(), binary(), binary(), binary()}.
+-type scheme() :: binary().
+-type host() :: binary() | {binary(), inet:port_number()}.
+-type username() :: binary().
+-type password() :: binary().
+-type location() :: host() | {host(), username(), password()}.
+-type resource_path() :: binary().
+-type querystring() :: binary().
+-type fragment() :: binary().
+
+-spec urlsplit(binary()) -> {scheme(), location(), resource_path(), querystring(), fragment()}.
 urlsplit(Source) ->
     {Scheme, Url1}      = urlsplit_s(Source),
     {Location, Url2}    = urlsplit_l(Url1),
@@ -217,7 +261,8 @@ urlsplit_l(<<"//", R/binary>>) ->
 urlsplit_l(Source) ->
     {<<>>, Source}.
 
--spec urlsplit_l(binary(), binary()) -> {binary(), binary()}.
+-spec urlsplit_l(binary(), binary()) -> {binary(), binary()} |
+          {{binary(), binary(), binary()}, binary()}.
 urlsplit_l(<<>>, Acc) ->
     {Acc, <<>>};
 
@@ -230,8 +275,28 @@ urlsplit_l(<<$?, _I/binary>> = R, Acc) ->
 urlsplit_l(<<$#, _I/binary>> = R, Acc) ->
     {Acc, R};
 
+urlsplit_l(<<$@, Rest/binary>>, User) ->
+    urlsplit_basic_auth(Rest, User, []);
+
+urlsplit_l(<<$:, Rest/binary>>, Host) ->
+    urlsplit_host_port(Rest, Host, []);
+
 urlsplit_l(<<C, R/binary>>, Acc) ->
     urlsplit_l(R, <<Acc/binary, C>>).
+
+urlsplit_host_port(<<C, Rest/binary>>, Host, Trop) when C >= $0, C =< $9 ->
+    urlsplit_host_port(Rest, Host, [C | Trop]);
+urlsplit_host_port(Acc, Host, []) ->
+    {Host, Acc};
+urlsplit_host_port(Acc, Host, Trop) ->
+    {{Host, kz_term:to_integer(lists:reverse(Trop))}, Acc}.
+
+urlsplit_basic_auth(<<$:, Rest/binary>>, User, Ssap) ->
+    {Host, Acc} = urlsplit_l(Rest, <<>>),
+    {{Host, User, kz_term:to_binary(lists:reverse(Ssap))}, Acc};
+urlsplit_basic_auth(<<C:1/binary, Rest/binary>>, User, Ssap) ->
+    urlsplit_basic_auth(Rest, User, [C | Ssap]).
+
 
 %%------------------------------------------------------------------------------
 %% @doc Splits and returns the path, query string, and fragment portions
@@ -270,13 +335,19 @@ urlsplit_q(<<C, R/binary>>, Acc) ->
 %% @doc Joins the elements of a URL together.
 %% @end
 %%------------------------------------------------------------------------------
--spec urlunsplit({binary(), binary(), binary(), binary(), binary()}) -> binary().
+-spec urlunsplit({scheme(), location(), resource_path(), querystring(), fragment()}) -> binary().
 urlunsplit({S, N, P, Q, F}) ->
     Us = case S of <<>> -> <<>>; _ -> [S, "://"] end,
     Uq = case Q of <<>> -> <<>>; _ -> [$?, Q] end,
     Uf = case F of <<>> -> <<>>; _ -> [$#, F] end,
 
-    iolist_to_binary([Us, N, P, Uq, Uf]).
+    iolist_to_binary([Us, location_to_binary(N), P, Uq, Uf]).
+
+location_to_binary(<<Location/binary>>) -> Location;
+location_to_binary({<<Location/binary>>, Port}) when is_integer(Port) ->
+    [Location, ":", kz_term:to_list(Port)];
+location_to_binary({Host, <<Username/binary>>, <<Password/binary>>}) ->
+    [Username, "@", Password, ":", location_to_binary(Host)].
 
 %%------------------------------------------------------------------------------
 %% @doc Convert JSON object to encoded query string.
@@ -440,3 +511,19 @@ encode_multipart_headers([{K, V} | Headers], Encoded) ->
 -spec create_boundary() -> kz_term:ne_binary().
 create_boundary() ->
     cow_multipart:boundary().
+
+-spec client_ip_blacklist() -> kz_term:api_ne_binaries().
+client_ip_blacklist() -> ?INVALID_NETWORK_CIDRS.
+
+-spec set_client_ip_blacklist(kz_term:ne_binaries()) -> kz_term:ne_binaries().
+set_client_ip_blacklist(Blacklist) ->
+    {'ok', _} = ?SET_INVALID_NETWORK_CIDRS(Blacklist),
+    client_ip_blacklist().
+
+-spec client_host_blacklist() -> kz_term:api_ne_binaries().
+client_host_blacklist() -> ?INVALID_HOSTS.
+
+-spec set_client_host_blacklist(kz_term:ne_binaries()) -> kz_term:ne_binaries().
+set_client_host_blacklist(Blacklist) ->
+    {'ok', _} = ?SET_INVALID_HOSTS(Blacklist),
+    client_host_blacklist().

--- a/core/kazoo_web/src/kz_http_util.erl
+++ b/core/kazoo_web/src/kz_http_util.erl
@@ -343,6 +343,7 @@ urlunsplit({S, N, P, Q, F}) ->
 
     iolist_to_binary([Us, location_to_binary(N), P, Uq, Uf]).
 
+-spec location_to_binary(location()) -> iodata().
 location_to_binary(<<Location/binary>>) -> Location;
 location_to_binary({<<Location/binary>>, Port}) when is_integer(Port) ->
     [Location, ":", kz_term:to_list(Port)];

--- a/core/kazoo_web/test/kz_http_util_tests.erl
+++ b/core/kazoo_web/test/kz_http_util_tests.erl
@@ -44,14 +44,28 @@ encode_decode(Decoded, Encoded) ->
 
 urlsplit_test_() ->
     [?_assertEqual({<<"">>, <<"">>, <<"/foo">>, <<"">>, <<"bar?baz">>}, kz_http_util:urlsplit(<<"/foo#bar?baz">>))
-    ,?_assertEqual({<<"http">>, <<"host:port">>, <<"/foo">>, <<"">>, <<"bar?baz">>}, kz_http_util:urlsplit(<<"http://host:port/foo#bar?baz">>))
+    ,?_assertEqual({<<"http">>, {<<"host">>, 345}, <<"/foo">>, <<"">>, <<"bar?baz">>}, kz_http_util:urlsplit(<<"http://host:345/foo#bar?baz">>))
     ,?_assertEqual({<<"http">>, <<"host">>, <<"">>, <<"">>, <<"">>}, kz_http_util:urlsplit(<<"http://host">>))
     ,?_assertEqual({<<"">>, <<"">>, <<"/wiki/Category:Fruit">>, <<"">>, <<"">>}, kz_http_util:urlsplit(<<"/wiki/Category:Fruit">>))
+    ,?_assertEqual({<<"https">>, {{<<"client.host">>, 1234}, <<"username">>, <<"password">>}, <<>>, <<>>, <<>>}
+                  ,kz_http_util:urlsplit(<<"https://username@password:client.host:1234">>)
+                  )
     ].
 
 urlunsplit_test_() ->
     [?_assertEqual(<<"/foo#bar?baz">>, kz_http_util:urlunsplit({<<"">>, <<"">>, <<"/foo">>, <<"">>, <<"bar?baz">>}))
     ,?_assertEqual(<<"http://host:port/foo#bar?baz">>, kz_http_util:urlunsplit({<<"http">>, <<"host:port">>, <<"/foo">>, <<"">>, <<"bar?baz">>}))
+    ].
+
+url_split_unsplit_test_() ->
+    Tests = [{<<"">>, <<"">>, <<"/foo">>, <<"">>, <<"bar?baz">>}
+            ,{<<"http">>, {<<"host">>, 345}, <<"/foo">>, <<"">>, <<"bar?baz">>}
+            ,{<<"http">>, <<"host">>, <<"">>, <<"">>, <<"">>}
+            ,{<<"">>, <<"">>, <<"/wiki/Category:Fruit">>, <<"">>, <<"">>}
+            ,{<<"https">>, {{<<"client.host">>, 1234}, <<"username">>, <<"password">>}, <<>>, <<>>, <<>>}
+            ],
+    [?_assertEqual(Test, kz_http_util:urlsplit(kz_http_util:urlunsplit(Test)))
+     || Test <- Tests
     ].
 
 urlencode_test_() ->


### PR DESCRIPTION
It can be advantageous to timeout the Pivot request and allow the
callflow to progress to the failure branch.

Validated client-supplied URLs