### PR TITLE
pusher unique pm apps - 4.3

### DIFF
--- a/applications/pusher/src/modules/pm_apple.erl
+++ b/applications/pusher/src/modules/pm_apple.erl
@@ -116,7 +116,7 @@ maybe_load_apns(App, _, 'undefined', _, _) ->
 maybe_load_apns(App, ETS, CertBin, Host, Headers) ->
     {Key, Cert} = pusher_util:binary_to_keycert(CertBin),
     lager:debug("starting apple push connection for ~s : ~s", [App, Host]),
-    Connection = #{name => kz_term:to_atom(App, 'true')
+    Connection = #{name => kz_term:to_atom(<<"apns_", App/binary>>, 'true')
                   ,apple_host => kz_term:to_list(Host)
                   ,apple_port => 443
                   ,certdata => Cert

--- a/applications/pusher/src/modules/pm_firebase.erl
+++ b/applications/pusher/src/modules/pm_firebase.erl
@@ -110,7 +110,7 @@ maybe_load_fcm(App, _, 'undefined', _) ->
     lager:debug("firebase pusher api_key for app ~s not found", [App]),
     'undefined';
 maybe_load_fcm(App, ETS, APIKey, Envelope) ->
-    case fcm:start(kz_term:to_atom(App, 'true'), kz_term:to_list(APIKey)) of
+    case fcm:start(kz_term:to_atom(<<"fcm_", App/binary>>, 'true'), kz_term:to_list(APIKey)) of
         {'ok', Pid} ->
             ets:insert(ETS, {App, {Pid, Envelope}}),
             {Pid, Envelope};


### PR DESCRIPTION
* applications with same id for fcm/apns
  would only work for the first to be triggered
  because fcm/apns register the apps with {local', Name}