### PR TITLE
Stagger deleting a file based on filesize

### DIFF
--- a/core/kazoo_documents/src/kzd_accounts.erl
+++ b/core/kazoo_documents/src/kzd_accounts.erl
@@ -1733,6 +1733,7 @@ create_tree_from_master() ->
         {'ok', MasterAccountId} ->
             lager:info("using master account ~s as tree", [MasterAccountId]),
             [MasterAccountId];
+        {'error', 'no_accounts'} -> [];
         {'error', _} ->
             case kapps_util:get_all_accounts() of
                 [] -> [];

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -103,11 +103,10 @@ collect_paginated_results(BaseURL, URL, RequestHeaders, Expectations, Collected)
 
 handle_paginated_results(BaseURL, RequestHeaders, Expectations, Collected, RespJObj) ->
     Data = kz_json:get_list_value(<<"data">>, RespJObj, []),
-    ?INFO("adding page: ~p~n", [Data]),
     case kz_json:get_ne_binary_value(<<"next_start_key">>, RespJObj) of
         'undefined' -> Data ++ Collected;
         NextStartKey ->
-            ?INFO("collecting next page from ~s: ~s", [BaseURL, NextStartKey]),
+            lager:info("collecting next page from ~s: ~s", [BaseURL, NextStartKey]),
             collect_paginated_results(BaseURL
                                      ,BaseURL ++ [$& | start_key(NextStartKey)]
                                      ,update_request_id(RequestHeaders)
@@ -212,33 +211,30 @@ straight_seq() ->
     AccountId = create_account(API),
 
     EmptySummaryResp = summary(API, AccountId),
-    ?INFO("empty summary resp: ~s", [EmptySummaryResp]),
+    lager:info("empty summary resp: ~s", [EmptySummaryResp]),
     [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
 
     EmptyCSVResp = summary(API, AccountId, <<"text/csv">>),
-    ?INFO("empty CSV resp: ~s", [EmptyCSVResp]),
+    lager:info("empty CSV resp: ~s", [EmptyCSVResp]),
 
     CDRs = seed_cdrs(AccountId),
-    ?INFO("CDRs: ~p~n", [CDRs]),
+    lager:info("CDRs: ~p~n", [CDRs]),
 
     SummaryResp = summary(API, AccountId),
-    ?INFO("summary resp: ~s", [SummaryResp]),
+    lager:info("summary resp: ~s", [SummaryResp]),
     RespCDRs = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
-    ?INFO("resp CDRs: ~p~n", [lists:usort([cdr_id(RespCDR) || RespCDR <- RespCDRs])]),
-    ?INFO("base CDRs: ~p~n", [lists:usort([cdr_id(CDR) || CDR <- CDRs])]),
     'true' = cdrs_exist(CDRs, RespCDRs),
-    ?INFO("all cdrs found in response"),
 
     CSVResp = summary(API, AccountId, <<"text/csv">>),
-    ?INFO("csv resp: ~s", [CSVResp]),
+    lager:info("csv resp: ~s", [CSVResp]),
 
     InteractionsResp = interactions(API, AccountId),
-    ?INFO("interactions resp: ~s", [InteractionsResp]),
+    lager:info("interactions resp: ~s", [InteractionsResp]),
 
     lists:foreach(fun(CDR) -> seq_cdr(API, AccountId, CDR) end, CDRs),
 
     cleanup(API),
-    ?INFO("FINISHED STRAIGHT SEQ").
+    lager:info("FINISHED STRAIGHT SEQ").
 
 -spec paginated_seq() -> 'ok'.
 paginated_seq() ->
@@ -249,39 +245,34 @@ paginated_seq() ->
     OwnerId = create_owner(AccountId),
 
     EmptySummaryResp = paginated_summary(API, AccountId),
-    ?INFO("empty summary resp: ~p", [EmptySummaryResp]),
+    lager:info("empty summary resp: ~p", [EmptySummaryResp]),
     [] = EmptySummaryResp,
 
     CDRs = seed_cdrs(AccountId, OwnerId),
-    CDRIds = lists:sort([kz_doc:id(I) || I <- CDRs]),
-    ?INFO("CDRs: ~p~n", [CDRIds]),
 
     SummaryResp = paginated_summary(API, AccountId, OwnerId),
-    ?INFO("summary resp: ~p", [SummaryResp]),
+    lager:info("summary resp: ~p", [SummaryResp]),
 
     'true' = cdrs_exist(CDRs, SummaryResp),
-    ?INFO("all cdrs found in response"),
 
     InteractionsResp = paginated_interactions(API, AccountId, OwnerId),
     InteractionIds = lists:sort([kzd_cdrs:interaction_id(I) || I <- InteractionsResp]),
 
     CDRInteractionIDs = lists:usort([kzd_cdrs:interaction_id(CDR) || CDR <- CDRs]),
-    ?INFO("expected CDR interaction IDs: ~p", [CDRInteractionIDs]),
-    ?INFO("received interaction IDs: ~p", [InteractionIds]),
     case CDRInteractionIDs =:= InteractionIds of
         'true' -> 'ok';
         'false' ->
-            ?INFO("failed to fetch expected interaction IDs from API"),
-            ?INFO("missing from response: ~p", [CDRInteractionIDs -- InteractionIds]),
+            lager:info("failed to fetch expected interaction IDs from API"),
+            lager:info("missing from response: ~p", [CDRInteractionIDs -- InteractionIds]),
             throw({'error', 'interaction_ids', 'not_found'})
     end,
 
     cleanup(API),
-    ?INFO("FINISHED PAGINATED SEQ").
+    lager:info("FINISHED PAGINATED SEQ").
 
 -spec big_dataset_seq() -> 'ok'.
 big_dataset_seq() ->
-    ?INFO("creating large dataset and not paginating results"),
+    lager:info("creating large dataset and not paginating results"),
     API = pqc_cb_api:init_api(['crossbar'], ['cb_cdrs']),
     AccountId = create_account(API),
 
@@ -294,23 +285,25 @@ big_dataset_seq() ->
                                [create_cdr(AccountId, 'undefined', Year, Month, InteractionId) | Acc]
                        end
                       ,[]
-                      ,lists:seq(1,CDRCount)
+                      ,lists:seq(1, CDRCount)
                       ),
+    lager:info("generated ~p CDRs", [length(CDRs)]),
 
     AccountMODb = kzs_util:format_account_id(AccountId, Year, Month),
-    {'ok', _} = kazoo_modb:save_docs(AccountMODb, CDRs, [{'publish_change_notice', 'false'}]),
+    {'ok', _Saved} = kazoo_modb:save_docs(AccountMODb, CDRs, [{'publish_change_notice', 'false'}]),
+    lager:info("saved: ~p", [_Saved]),
 
     _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 'null'),
     ChunkedJSON = unpaginated_summary(API, AccountId),
     ChunkedJObj = kz_json:decode(ChunkedJSON),
     ChunkedCount = length(kz_json:get_list_value(<<"data">>, ChunkedJObj)),
-    ?INFO("unpaginated and unbound memory resp returned ~p CDRs", [ChunkedCount]),
+    lager:info("unpaginated and unbound memory resp returned ~p CDRs", [ChunkedCount]),
     CDRCount = ChunkedCount,
 
     UnChunkedJSON = unpaginated_summary(API, AccountId, 'false'),
     UnChunkedJObj = kz_json:decode(UnChunkedJSON),
     UnChunkedCount = length(kz_json:get_list_value(<<"data">>, UnChunkedJObj)),
-    ?INFO("unpaginated/unchunked and unbound memory resp returned ~p CDRs", [UnChunkedCount]),
+    lager:info("unpaginated/unchunked and unbound memory resp returned ~p CDRs", [UnChunkedCount]),
     CDRCount = UnChunkedCount,
 
     _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 1024 * 1024 * 10), % cap at 10Mb
@@ -318,11 +311,11 @@ big_dataset_seq() ->
     ChunkedUnpaginatedJSON = unpaginated_summary(API, AccountId),
     ChunkedUnpaginatedJObj = kz_json:decode(ChunkedUnpaginatedJSON),
     ChunkedUnpaginatedCount = length(kz_json:get_list_value(<<"data">>, ChunkedUnpaginatedJObj)),
-    ?INFO("chunked/unpaginated and unbound memory resp returned ~p CDRs", [ChunkedUnpaginatedCount]),
+    lager:info("chunked/unpaginated and unbound memory resp returned ~p CDRs", [ChunkedUnpaginatedCount]),
     CDRCount = ChunkedUnpaginatedCount,
 
     {'error', UnChunkedErrorJSON} = unpaginated_summary(API, AccountId, 'false'),
-    ?INFO("unchunked/unpaginated and bound memory resp: ~s", [UnChunkedErrorJSON]),
+    lager:info("unchunked/unpaginated and bound memory resp: ~s", [UnChunkedErrorJSON]),
     UnChunkedErrorJObj = kz_json:decode(UnChunkedErrorJSON),
     416 = kz_json:get_integer_value(<<"error">>, UnChunkedErrorJObj),
     <<"range not satisfiable">> = kz_json:get_ne_binary_value(<<"message">>, UnChunkedErrorJObj),
@@ -330,11 +323,11 @@ big_dataset_seq() ->
     _ = kapps_config:set_default(<<"crossbar">>, <<"request_memory_limit">>, 'null'),
     PaginatedSummary = paginated_summary(API, AccountId),
     PaginatedLength = length(PaginatedSummary),
-    ?INFO("paginated: ~p", [PaginatedLength]),
+    lager:info("paginated: ~p", [PaginatedLength]),
     CDRCount = PaginatedLength,
 
     cleanup(API),
-    ?INFO("FINISHED BIG DATASET SEQ").
+    lager:info("FINISHED BIG DATASET SEQ").
 
 -spec task_seq() -> 'ok'.
 task_seq() ->
@@ -343,39 +336,34 @@ task_seq() ->
                              ),
 
     AccountId = create_account(API),
-    CDRs = seed_cdrs(AccountId),
-    CDRIds = lists:sort([kz_doc:id(I) || I <- CDRs]),
-    ?INFO("CDRs: ~p~n", [CDRIds]),
+    _CDRs = seed_cdrs(AccountId),
 
     CreateResp = pqc_cb_tasks:create_account(API, AccountId, "category=billing&action=dump"),
-    ?INFO("created task ~s", [CreateResp]),
+    lager:info("created task ~s", [CreateResp]),
     TaskId = kz_json:get_ne_binary_value([<<"data">>, <<"_read_only">>, <<"id">>]
                                         ,kz_json:decode(CreateResp)
                                         ),
     _ExecResp = pqc_cb_tasks:execute(API, AccountId, TaskId),
-    ?INFO("exec task ~s: ~s", [TaskId, _ExecResp]),
+    lager:info("exec task ~s: ~s", [TaskId, _ExecResp]),
 
     _DelResp = wait_for_task(API, AccountId, TaskId),
-    ?INFO("finished task ~s: ~s", [TaskId, _DelResp]),
+    lager:info("finished task ~s: ~s", [TaskId, _DelResp]),
 
     cleanup(API),
-    ?INFO("FINISHED TASK SEQ").
+    lager:info("FINISHED TASK SEQ").
 
 seq_cdr(API, AccountId, CDR) ->
     CDRId = kz_doc:id(CDR),
     InteractionId = kzd_cdrs:interaction_id(CDR),
 
     FetchResp = fetch(API, AccountId, CDRId),
-    ?INFO("~s: fetch resp ~s", [CDRId, FetchResp]),
     'true' = cdr_exists(CDR, [kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp))]),
 
     %% Should be able to convert CDR ID to interaction_id
     LegsResp = legs(API, AccountId, CDRId),
-    ?INFO("~s: legs by id resp: ~s", [CDRId, LegsResp]),
     'true' = cdr_exists(CDR, kz_json:get_list_value(<<"data">>, kz_json:decode(LegsResp))),
 
     InteractionResp = legs(API, AccountId, InteractionId),
-    ?INFO("~s: legs by interaction resp: ~s", [CDRId, InteractionResp]),
     'true' = cdr_exists(CDR, kz_json:get_list_value(<<"data">>, kz_json:decode(InteractionResp))).
 
 cdr_exists(CDR, RespCDRs) ->
@@ -385,21 +373,20 @@ cdr_exists(CDR, RespCDRs) ->
 cdrs_exist([], []) -> 'true';
 cdrs_exist([], APIs) ->
     IDs = [kz_doc:id(CDR) || CDR <- APIs],
-    ?INFO("  failed to find API results in CDRs: ~s", [kz_binary:join(IDs, <<", ">>)]),
+    lager:info("  failed to find API results in CDRs: ~s", [kz_binary:join(IDs, <<", ">>)]),
     'false';
 cdrs_exist(CDRs, []) ->
     IDs = [kz_doc:id(CDR) || CDR <- CDRs],
-    ?INFO("  failed to find CDR(s) in API response: ~s", [kz_binary:join(IDs, <<", ">>)]),
+    lager:info("  failed to find CDR(s) in API response: ~s", [kz_binary:join(IDs, <<", ">>)]),
     'false';
 cdrs_exist([_|_]=CDRs, [API|APIs]) ->
-    lager:debug("filtering out ~s", [kz_doc:id(API)]),
     cdrs_exist([CDR || CDR <- CDRs, kz_doc:id(CDR) =/= kz_doc:id(API)]
               ,APIs
               ).
 
 create_account(API) ->
     AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
-    ?INFO("created account: ~s", [AccountResp]),
+    lager:info("created account: ~s", [AccountResp]),
 
     kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
 
@@ -409,7 +396,7 @@ create_owner(AccountId) ->
     OwnerId = kz_binary:rand_hex(16),
     Owner = kz_json:set_value(<<"_id">>, OwnerId, kzd_users:new()),
     {'ok', _Saved}= kz_datamgr:save_doc(AccountDb, Owner),
-    ?INFO("saved owner to ~s: ~p", [AccountDb, _Saved]),
+    lager:info("saved owner to ~s: ~p", [AccountDb, _Saved]),
     OwnerId.
 
 -spec cleanup() -> 'ok'.
@@ -419,7 +406,7 @@ cleanup() ->
     cleanup_system().
 
 cleanup(API) ->
-    ?INFO("CLEANUP TIME, EVERYBODY HELPS"),
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
     _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
     _ = pqc_cb_api:cleanup(API),
     cleanup_system().
@@ -550,7 +537,7 @@ wait_for_task(API, AccountId, TaskId, Start, _ElapsedS) ->
     of
         <<"success">> ->
             %% fetch csv
-            ?INFO("task fininshed: ~s", [GetResp]),
+            lager:info("task fininshed: ~s", [GetResp]),
             get_csvs(API, AccountId, TaskId, kz_json:get_list_value([<<"data">>, <<"_read_only">>, <<"csvs">>], GetJObj, [])),
             pqc_cb_tasks:delete(API, AccountId, TaskId);
         <<"failure">> ->
@@ -560,7 +547,7 @@ wait_for_task(API, AccountId, TaskId, Start, _ElapsedS) ->
             lager:warning("task failed with internal error: ~s", [GetResp]),
             pqc_cb_tasks:delete(API, AccountId, TaskId);
         _Status ->
-            ?INFO("wrong status(~s) for task in ~s", [_Status, GetResp]),
+            lager:info("wrong status(~s) for task in ~s", [_Status, GetResp]),
             timer:sleep(1000),
             wait_for_task(API, AccountId, TaskId, Start)
     end.
@@ -572,12 +559,4 @@ get_csvs(API, AccountId, TaskId, [CSV|CSVs]) ->
 
 get_csv(API, AccountId, TaskId, CSV) ->
     FetchResp = pqc_cb_tasks:fetch_csv(API, AccountId, TaskId, CSV),
-    ?INFO("fetched ~s(~s): ~s", [TaskId, CSV, FetchResp]).
-
-cdr_id(JObj) ->
-    case kz_doc:id(JObj) of
-        'undefined' ->
-            lager:warning("no id on ~p", [JObj]),
-            'undefined';
-        Id -> Id
-    end.
+    lager:info("fetched ~s(~s): ~s", [TaskId, CSV, FetchResp]).


### PR DESCRIPTION
When using sendfile in Crossbar, there can exist a race condition
where the filename has been passed to Cowboy for sending, Cowboy
handles streaming the file asynchronously, and calls Crossbar's
finish_request callback.

Because the streaming and finish_request callback are happening in
parallel, it is possible for the file to be deleted from the local
disk before streaming has completed.

pqc_cb_ledgers will occassionally provoke this race condition.

Since deleting the file occurs in a spawned process itself, use the
rounded natural log of the file's size * 10 to calculate a small sleep
timeout before deleting the file.