### PR TITLE
[4.3] Kazoo 6127: Added configuration parameters to control cluster alerts

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -29922,6 +29922,47 @@
             },
             "type": "object"
         },
+        "system_config.crossbar.alerts": {
+            "description": "Schema for crossbar.alerts system_config",
+            "properties": {
+                "check_financials": {
+                    "default": true,
+                    "description": "crossbar alerts check_financials",
+                    "type": "boolean"
+                },
+                "check_low_balance": {
+                    "default": true,
+                    "description": "crossbar alerts check_low_balance",
+                    "type": "boolean"
+                },
+                "check_payment_token": {
+                    "default": true,
+                    "description": "crossbar alerts check_payment_token",
+                    "type": "boolean"
+                },
+                "check_port_action_required": {
+                    "default": true,
+                    "description": "crossbar alerts check_port_action_required",
+                    "type": "boolean"
+                },
+                "check_port_requests": {
+                    "default": true,
+                    "description": "crossbar alerts check_port_requests",
+                    "type": "boolean"
+                },
+                "check_port_suspended": {
+                    "default": true,
+                    "description": "crossbar alerts check_port_suspended",
+                    "type": "boolean"
+                },
+                "check_system_alerts": {
+                    "default": true,
+                    "description": "crossbar alerts check_system_alerts",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "system_config.crossbar.auth": {
             "description": "Schema for crossbar.auth system_config",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.alerts.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.alerts.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.crossbar.alerts",
+    "description": "Schema for crossbar.alerts system_config",
+    "properties": {
+        "check_financials": {
+            "default": true,
+            "description": "crossbar alerts check_financials",
+            "type": "boolean"
+        },
+        "check_low_balance": {
+            "default": true,
+            "description": "crossbar alerts check_low_balance",
+            "type": "boolean"
+        },
+        "check_payment_token": {
+            "default": true,
+            "description": "crossbar alerts check_payment_token",
+            "type": "boolean"
+        },
+        "check_port_action_required": {
+            "default": true,
+            "description": "crossbar alerts check_port_action_required",
+            "type": "boolean"
+        },
+        "check_port_requests": {
+            "default": true,
+            "description": "crossbar alerts check_port_requests",
+            "type": "boolean"
+        },
+        "check_port_suspended": {
+            "default": true,
+            "description": "crossbar alerts check_port_suspended",
+            "type": "boolean"
+        },
+        "check_system_alerts": {
+            "default": true,
+            "description": "crossbar alerts check_system_alerts",
+            "type": "boolean"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/src/modules/cb_alerts.erl
+++ b/applications/crossbar/src/modules/cb_alerts.erl
@@ -26,6 +26,7 @@
 -include_lib("kazoo_number_manager/include/knm_port_request.hrl").
 
 -define(AVAILABLE_LIST, <<"alerts/available">>).
+-define(MOD_CONFIG_CAT, <<(?CONFIG_CAT)/binary, ".alerts">>).
 
 %%%=============================================================================
 %%% API
@@ -197,9 +198,9 @@ summary(Context) ->
 %%------------------------------------------------------------------------------
 -spec load_summary(cb_context:context()) -> cb_context:context().
 load_summary(Context) ->
-    Routines = [fun check_port_requests/1
+    Routines = [fun maybe_check_port_requests/1
                ,fun maybe_check_financials/1
-               ,fun check_system_alerts/1
+               ,fun maybe_check_system_alerts/1
                ,fun set_success_resp_status/1
                ],
     lists:foldl(fun(F, C) -> F(C) end
@@ -219,6 +220,13 @@ set_success_resp_status(Context) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
+-spec maybe_check_port_requests(cb_context:context()) -> cb_context:context().
+maybe_check_port_requests(Context) ->
+    case kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"check_port_requests">>, 'true') of
+        'false' -> Context;
+        'true' -> check_port_requests(Context)
+    end.
+
 -spec check_port_requests(cb_context:context()) -> cb_context:context().
 check_port_requests(Context) ->
     case knm_port_request:account_active_ports(cb_context:account_id(Context)) of
@@ -234,8 +242,8 @@ check_port_requests(Context) ->
 check_port_requests([], Context) ->
     Context;
 check_port_requests([PortRequest|PortRequests], Context) ->
-    Routines = [fun check_port_action_required/2
-               ,fun check_port_suspended/2
+    Routines = [fun maybe_check_port_action_required/2
+               ,fun maybe_check_port_suspended/2
                ],
     Context1 = lists:foldl(fun(F, C) -> F(PortRequest, C) end
                           ,Context
@@ -247,6 +255,14 @@ check_port_requests([PortRequest|PortRequests], Context) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
+-spec maybe_check_port_action_required(kzd_port_requests:doc(), cb_context:context()) ->
+          cb_context:context().
+maybe_check_port_action_required(PortRequest, Context) ->
+    case kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"check_port_action_required">>, 'true') of
+        'false' -> Context;
+        'true' -> check_port_action_required(PortRequest, Context)
+    end.
+
 -spec check_port_action_required(kzd_port_requests:doc(), cb_context:context()) ->
           cb_context:context().
 check_port_action_required(PortRequest, Context) ->
@@ -289,6 +305,14 @@ port_request_last_comment(Context, PortRequest) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
+-spec maybe_check_port_suspended(kzd_port_requests:doc(), cb_context:context()) ->
+          cb_context:context().
+maybe_check_port_suspended(PortRequest, Context) ->
+    case kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"check_port_suspended">>, 'true') of
+        'false' -> Context;
+        'true' -> check_port_suspended(PortRequest, Context)
+    end.
+
 -spec check_port_suspended(kzd_port_requests:doc(), cb_context:context()) ->
           cb_context:context().
 check_port_suspended(PortRequest, Context) ->
@@ -337,12 +361,19 @@ check_port_suspended_message(_) ->
 %%------------------------------------------------------------------------------
 -spec maybe_check_financials(cb_context:context()) -> cb_context:context().
 maybe_check_financials(Context) ->
+    case kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"check_financials">>, 'true') of
+        'false' -> Context;
+        'true' -> check_financials(Context)
+    end.
+
+-spec check_financials(cb_conteext:context()) -> cb_context:context().
+check_financials(Context) ->
     Services = kz_services:fetch(cb_context:account_id(Context)),
     case kz_services_plans:is_empty(kz_services:plans(Services)) of
         'true' -> Context;
         'false' ->
-            Routines = [fun check_low_balance/1
-                       ,fun check_payment_token/1
+            Routines = [fun maybe_check_low_balance/1
+                       ,fun maybe_check_payment_token/1
                        ],
             lists:foldl(fun(F, C) -> F(C) end
                        ,Context
@@ -359,6 +390,13 @@ maybe_check_financials(Context) ->
 %%   is less than or equal to the maximum post pay amount.
 %% @end
 %%------------------------------------------------------------------------------
+-spec maybe_check_low_balance(cb_context:context()) -> cb_context:context().
+maybe_check_low_balance(Context) ->
+    case kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"check_low_balance">>, 'true') of
+        'false' -> Context;
+        'true' -> check_low_balance(Context)
+    end.
+
 -spec check_low_balance(cb_context:context()) -> cb_context:context().
 check_low_balance(Context) ->
     AccountId = cb_context:account_id(Context),
@@ -426,6 +464,13 @@ low_balance_alert(Context, AvailableDollars, ThresholdDollars) ->
 %%   token with an expiration that has expired or will expire within the 60 days.
 %% @end
 %%------------------------------------------------------------------------------
+-spec maybe_check_payment_token(cb_context:context()) -> cb_context:context().
+maybe_check_payment_token(Context) ->
+    case kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"check_payment_token">>, 'true') of
+        'false' -> Context;
+        'true' -> check_payment_token(Context)
+    end.
+
 -spec check_payment_token(cb_context:context()) -> cb_context:context().
 check_payment_token(Context) ->
     Services = kz_services:fetch(cb_context:account_id(Context)),
@@ -493,6 +538,13 @@ payment_token_alert(ExpiredToken, Context) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
+-spec maybe_check_system_alerts(cb_context:context()) -> cb_context:context().
+maybe_check_system_alerts(Context) ->
+    case kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"check_system_alerts">>, 'true') of
+        'false' -> Context;
+        'true' -> check_system_alerts(Context)
+    end.
+
 -spec check_system_alerts(cb_context:context()) -> cb_context:context().
 check_system_alerts(Context) ->
     ViewOptions = [{'keys', view_keys(Context)}],


### PR DESCRIPTION
Create the following parameters on the crossbar.alerts document in system config, each is a boolean value that when false suppresses that alert category or specific type:

- check_financials
  - check_low_balance
  - check_payment_token
- check_port_requests
    - check_port_action_required
    - check_port_suspended
- check_system_alerts

For example, setting "check_financials" to false will disable both low balance and payment token alerts.  To disable low balance alerts only, leave "check_financials" and set "check_low_balance" to false.