### PR TITLE
Remove kz_json:merge clauses that overwrite instead of merge nested JObjs

### DIFF
--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -448,8 +448,6 @@ merge_left(_K, {'right', ?JSON_WRAPPER(_)=Right}, Options) ->
     {'ok', merge(fun merge_left/3, Right, new(), Options)};
 merge_left(_K, {'right', V}, _Options) -> {'ok', V};
 
-merge_left(_K, {'both', ?EMPTY_JSON_OBJECT=Left, ?JSON_WRAPPER(_)=_Right}, _Options) ->
-    {'ok', Left};
 merge_left(_K, {'both', ?JSON_WRAPPER(_)=Left, ?JSON_WRAPPER(_)=Right}, Options) ->
     {'ok', merge(fun merge_left/3, Left, Right, Options)};
 merge_left(_K, {'both', Left, _Right}, _Options) -> {'ok', Left}.
@@ -474,8 +472,6 @@ merge_right(_K, {'right', ?JSON_WRAPPER(_)=Right}, Options) ->
     {'ok', merge(fun merge_right/3, new(), Right, Options)};
 merge_right(_K, {'right', V}, _Options) -> {'ok', V};
 
-merge_right(_K, {'both', ?JSON_WRAPPER(_)=_Left, ?EMPTY_JSON_OBJECT=Right}, _Options) ->
-    {'ok', Right};
 merge_right(_K, {'both', ?JSON_WRAPPER(_)=Left, ?JSON_WRAPPER(_)=Right}, Options) ->
     {'ok', merge(fun merge_right/3, Left, Right, Options)};
 merge_right(_K, {'both', _Left, Right}, _Options) -> {'ok', Right}.


### PR DESCRIPTION
This is a draft to discuss an oddity with `kz_json:merge_left` and `kz_json:merge_right`.
In the current version, there is inconsistent behaviour when merging nested JObjs.
Say you have A:
```
{
    "a": {
        "a1": "test",
        "a2": "test"
    }
}
{[{<<"a">>,
   {[{<<"a1">>,<<"test">>},{<<"a2">>,<<"test">>}]}}]}
```
and you merge B:
```
{
    "a": {}
}
{[{<<"a">>,{[]}}]}
```
the result is
```
{[{<<"a">>,{[]}}]}
```

But if you merge C:
```
{
    "a": {
        "a1": "overridden"
    }
}
{[{<<"a">>,{[{<<"a1">>,<<"overridden">>}]}}]}
```
the result is:
```
{[{<<"a">>,
   {[{<<"a2">>,<<"test">>},{<<"a1">>,<<"overridden">>}]}}]}
```

So in one case, the case where the node to be merged (source) is empty, _it erases all the keys in the target_. But when the node to be merged is not empty, _keys in the target are not erased, but just replaced if they happen to be in the source_.

It seems to me that the appropriate behaviour would be to always merge nested JObjs, but I could also be swayed in the direction that the source should always overwrite the target (this would make it no longer a recursive merge though). The former (always merge) would produce a result for `kz_json:merge(A, B)` like:
```
{[{<<"a">>,
   {[{<<"a2">>,<<"test">>},{<<"a1">>,<<"test">>}]}}]}
```

There's obviously a backwards-compatibility concern here. Maybe it would be good to pick a direction to go, deprecate the current implementation, and create a new, consistent implementation for future use?