### PR TITLE
PISTON-1002: use collect_digits for DTMF during vm greeting/instructions

### DIFF
--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -183,6 +183,7 @@
 -export([collect_digits/2, collect_digits/3
         ,collect_digits/4, collect_digits/5
         ,collect_digits/6, collect_digits/7
+        ,collect_digits/8
         ]).
 -export([send_command/2]).
 
@@ -346,7 +347,7 @@ presence(State, PresenceId, CallId, 'undefined', 'undefined') ->
                 ,{<<"To-Realm">>, Realm}
                 ,{<<"State">>, State}
                 ,{<<"Call-ID">>, CallId}
-                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                 | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                 ]),
     kapi_presence:publish_update(Command);
 presence(State, PresenceId, CallId, TargetURI, 'undefined') ->
@@ -361,7 +362,7 @@ presence(State, PresenceId, CallId, TargetURI, 'undefined') ->
                 ,{<<"To-Realm">>, Realm}
                 ,{<<"State">>, State}
                 ,{<<"Call-ID">>, CallId}
-                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                 | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                 ]),
     kapi_presence:publish_update(Command);
 presence(State, PresenceId, CallId, TargetURI, Call) ->
@@ -378,7 +379,7 @@ presence(State, PresenceId, CallId, TargetURI, Call) ->
                 ,{<<"To-Tag">>, kapps_call:to_tag(Call)}
                 ,{<<"State">>, State}
                 ,{<<"Call-ID">>, CallId}
-                | kz_api:default_headers(module_as_app(Call), ?APP_VERSION)
+                 | kz_api:default_headers(module_as_app(Call), ?APP_VERSION)
                 ]),
     kapi_presence:publish_update(Command).
 
@@ -426,7 +427,7 @@ channel_status(Call) ->
 b_channel_status('undefined') -> {'error', 'no_channel_id'};
 b_channel_status(<<ChannelId/binary>>) ->
     Command = [{<<"Call-ID">>, ChannelId}
-              | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
               ],
     Resp = kz_amqp_worker:call_collect(Command
                                       ,fun kapi_call:publish_channel_status_req/1
@@ -506,7 +507,7 @@ audio_macro(Prompts, Call, GroupId) ->
                   ,{<<"Msg-ID">>, NoopId}
                   ,{<<"Call-ID">>, kapps_call:call_id(Call)}
                   ])
-               | Queue
+                | Queue
                ],
     Command = [{<<"Application-Name">>, <<"queue">>}
               ,{<<"Commands">>, Commands}
@@ -956,7 +957,7 @@ receive_fax(ResourceFlag, ReceiveFlag, Call) ->
 receive_fax(ResourceFlag, ReceiveFlag, LocalFilename, Call) ->
     Commands = props:filter_undefined([{<<"Application-Name">>, <<"receive_fax">>}
                                       ,{<<"Fax-Local-Filename">>, LocalFilename}
-                                      | get_inbound_t38_settings(ResourceFlag, ReceiveFlag)
+                                       | get_inbound_t38_settings(ResourceFlag, ReceiveFlag)
                                       ]),
     send_command(Commands, Call).
 
@@ -1372,7 +1373,7 @@ soft_hold_command(CallId, UnholdKey, AMOH, BMOH, InsertAt) ->
                            ,{<<"Call-ID">>, CallId}
                            ,{<<"Insert-At">>, InsertAt}
                            ,{<<"Unhold-Key">>, UnholdKey}
-                           | build_moh_keys(AMOH, BMOH)
+                            | build_moh_keys(AMOH, BMOH)
                            ]).
 
 -spec build_moh_keys(kz_term:api_binary(), kz_term:api_binary()) ->
@@ -1835,7 +1836,7 @@ record_call(Media, Action, TimeLimit, Terminators, Call) ->
                 ,{<<"Time-Limit">>, Limit}
                 ,{<<"Terminators">>, Terminators}
                 ,{<<"Insert-At">>, <<"now">>}
-                | Media
+                 | Media
                 ]),
     send_command(Command, Call).
 
@@ -2537,6 +2538,19 @@ collect_digits(MaxDigits, Timeout, Interdigit, NoopId, Terminators, FlushOnDigit
                                          ,terminators=Terminators
                                          ,call=Call
                                          ,flush_on_digit=FlushOnDigit
+                                         }).
+
+-spec collect_digits(integer(), integer(), integer(), kz_term:api_binary(), list(), boolean(), integer(), kapps_call:call()) ->
+          collect_digits_return().
+collect_digits(MaxDigits, Timeout, Interdigit, NoopId, Terminators, FlushOnDigit, AfterTimeout, Call) ->
+    do_collect_digits(#wcc_collect_digits{max_digits=kz_term:to_integer(MaxDigits)
+                                         ,timeout=kz_term:to_integer(Timeout)
+                                         ,interdigit=kz_term:to_integer(Interdigit)
+                                         ,noop_id=NoopId
+                                         ,terminators=Terminators
+                                         ,call=Call
+                                         ,flush_on_digit=FlushOnDigit
+                                         ,after_timeout=kz_term:to_integer(AfterTimeout)
                                          }).
 
 -spec do_collect_digits(wcc_collect_digits()) -> collect_digits_return().
@@ -3398,7 +3412,7 @@ store_file(Filename, URLFun, Tries, Timeout, Call) ->
     API = fun() -> [{<<"Command">>, <<"send_http">>}
                    ,{<<"Args">>, kz_json:from_list(store_file_args(Filename, URLFun))}
                    ,{<<"FreeSWITCH-Node">>, kapps_call:switch_nodename(Call)}
-                   | kz_api:default_headers(AppName, AppVersion)
+                    | kz_api:default_headers(AppName, AppVersion)
                    ]
           end,
     do_store_file(Tries, Timeout, API, Msg, Call).
@@ -3562,7 +3576,7 @@ sound_touch_command(Options, Call) ->
       [{<<"Application-Name">>, <<"sound_touch">>}
       ,{<<"Insert-At">>, <<"now">>}
       ,{<<"Call-ID">>, kapps_call:call_id(Call)}
-      | Options
+       | Options
       ]).
 
 -spec start_sound_touch(kz_term:proplist(), kapps_call:call()) -> 'ok'.


### PR DESCRIPTION
When `play_greeting_intro`, `play_greeting`, or `play_instructions` play media, a noop is enqueued. `kapps_call_command:wait_for_application_or_dtmf` may continue on the noop from one of these play commands, rather than as expected due to `kapps_call_command:noop`. This means, for example, the user is unable to press a key to connect to the operator during instructions, if the greeting has already been played.

I introduced the 8-arity `collect_digits` for this purpose, too, as it allows a long initial timeout (`kapps_call_command:default_application_timeout`) but continues immediately after the expecting noop (the second argument set to 0).