### PR TITLE
[4.3] Ensure trunkstore uses account doc's realm

### DIFF
--- a/applications/crossbar/doc/connectivity.md
+++ b/applications/crossbar/doc/connectivity.md
@@ -10,7 +10,6 @@ Trunkstore configuration document - this is old stuff; do not recommend building
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`account.auth_realm` | The realm any device in the account will use to authenticate with | `string(1..)` |   | `false` |  
 `account.caller_id.cid_name` |   | `string(0..35)` |   | `false` |  
 `account.caller_id.cid_number` |   | `string(0..35)` |   | `false` |  
 `account.caller_id` |   | `object()` |   | `false` |  

--- a/applications/crossbar/doc/ref/connectivity.md
+++ b/applications/crossbar/doc/ref/connectivity.md
@@ -10,7 +10,6 @@ Trunkstore configuration document - this is old stuff; do not recommend building
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`account.auth_realm` | The realm any device in the account will use to authenticate with | `string(1..)` |   | `false` |  
 `account.caller_id.cid_name` |   | `string(0..35)` |   | `false` |  
 `account.caller_id.cid_number` |   | `string(0..35)` |   | `false` |  
 `account.caller_id` |   | `object()` |   | `false` |  

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -4924,11 +4924,6 @@
                 "account": {
                     "description": "Information that applies to the account as a whole",
                     "properties": {
-                        "auth_realm": {
-                            "description": "The realm any device in the account will use to authenticate with",
-                            "minLength": 1,
-                            "type": "string"
-                        },
                         "caller_id": {
                             "properties": {
                                 "cid_name": {

--- a/applications/crossbar/priv/couchdb/schemas/connectivity.json
+++ b/applications/crossbar/priv/couchdb/schemas/connectivity.json
@@ -6,11 +6,6 @@
         "account": {
             "description": "Information that applies to the account as a whole",
             "properties": {
-                "auth_realm": {
-                    "description": "The realm any device in the account will use to authenticate with",
-                    "minLength": 1,
-                    "type": "string"
-                },
                 "caller_id": {
                     "properties": {
                         "cid_name": {

--- a/applications/crossbar/src/modules/cb_connectivity.erl
+++ b/applications/crossbar/src/modules/cb_connectivity.erl
@@ -29,7 +29,7 @@
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec init() -> ok.
+-spec init() -> 'ok'.
 init() ->
     _ = crossbar_bindings:bind(<<"*.allowed_methods.connectivity">>, ?MODULE, 'allowed_methods'),
     _ = crossbar_bindings:bind(<<"*.resource_exists.connectivity">>, ?MODULE, 'resource_exists'),
@@ -38,7 +38,7 @@ init() ->
     _ = crossbar_bindings:bind(<<"*.execute.post.connectivity">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"*.execute.patch.connectivity">>, ?MODULE, 'patch'),
     _ = crossbar_bindings:bind(<<"*.execute.delete.connectivity">>, ?MODULE, 'delete'),
-    ok.
+    'ok'.
 
 %%------------------------------------------------------------------------------
 %% @doc This function determines the verbs that are appropriate for the
@@ -199,7 +199,11 @@ create(Context) ->
 
                         Doc = cb_context:doc(C1),
                         Nums = get_numbers(Doc),
-                        cb_modules_util:validate_number_ownership(Nums, C1)
+
+                        AccountDoc = cb_context:account_doc(Context),
+                        WithRealm = kzd_connectivity:set_account_auth_realm(Doc, kzd_accounts:realm(AccountDoc)),
+
+                        cb_modules_util:validate_number_ownership(Nums, cb_context:set_doc(C1, WithRealm))
                 end,
     cb_context:validate_request_data(<<"connectivity">>, Context, OnSuccess).
 
@@ -223,7 +227,11 @@ update(Id, Context) ->
 
                         Doc = cb_context:doc(C1),
                         Nums = get_numbers(Doc),
-                        cb_modules_util:validate_number_ownership(Nums, C1)
+
+                        AccountDoc = cb_context:account_doc(Context),
+                        WithRealm = kzd_connectivity:set_account_auth_realm(Doc, kzd_accounts:realm(AccountDoc)),
+
+                        cb_modules_util:validate_number_ownership(Nums, cb_context:set_doc(C1, WithRealm))
                 end,
     cb_context:validate_request_data(<<"connectivity">>, Context, OnSuccess).
 
@@ -242,7 +250,8 @@ validate_patch(Id, Context) ->
 %%------------------------------------------------------------------------------
 -spec on_successful_validation(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
 on_successful_validation('undefined', Context) ->
-    cb_context:set_doc(Context, kz_doc:set_type(cb_context:doc(Context), <<"sys_info">>));
+    Doc = kz_doc:set_type(cb_context:doc(Context), <<"sys_info">>),
+    cb_context:set_doc(Context, Doc);
 on_successful_validation(Id, Context) ->
     crossbar_doc:load_merge(Id, Context, ?TYPE_CHECK_OPTION(<<"sys_info">>)).
 

--- a/applications/trunkstore/src/ts_util.erl
+++ b/applications/trunkstore/src/ts_util.erl
@@ -226,7 +226,7 @@ merge_account_attributes(AccountDoc, JObj) ->
 
     Props = props:filter_undefined(
               [{<<"caller_id_options">>, CIDOptions}
-              ,{<<"auth_realm">>, kzd_accounts:real(AccountDoc)}
+              ,{<<"auth_realm">>, kzd_accounts:realm(AccountDoc)}
               ]
              ),
     kz_json:set_values(Props, JObj).

--- a/applications/trunkstore/src/ts_util.erl
+++ b/applications/trunkstore/src/ts_util.erl
@@ -166,7 +166,7 @@ lookup_user_flags('undefined', _, AccountId, DID) ->
             {'ok', kz_json:from_list(
                      [{<<"server">>, Server}
                      ,{<<"account">>,
-                       merge_account_attributes(AccountId, kz_json:get_value(<<"account">>, JObj, kz_json:new()))
+                       merge_account_attributes(AccountId, kz_json:get_json_value(<<"account">>, JObj, kz_json:new()))
                       }
                      ,{<<"call_restriction">>, kz_json:new()}
                      ])
@@ -203,7 +203,7 @@ lookup_user_flags(Name, Realm, AccountId, _) ->
                     Restriction = kz_json:get_value(<<"call_restriction">>, AccountJObj, kz_json:new()),
                     Props = [{<<"call_restriction">>, Restriction}
                             ,{<<"account">>
-                             ,merge_account_attributes(AccountJObj, kz_json:get_value(<<"account">>, JObj, kz_json:new()))
+                             ,merge_account_attributes(AccountJObj, kz_json:get_json_value(<<"account">>, JObj, kz_json:new()))
                              }
                             ],
                     FlagsJObj = kz_json:set_values(Props, JObj),
@@ -215,16 +215,18 @@ lookup_user_flags(Name, Realm, AccountId, _) ->
             end
     end.
 
--spec merge_account_attributes(kz_term:ne_binary() | kz_json:object(), kz_json:object()) -> kz_json:object().
-merge_account_attributes(?NE_BINARY=AccountId, JObj) ->
+-spec merge_account_attributes(kz_term:ne_binary() | kzd_accounts:doc(), kz_json:object()) -> kz_json:object().
+merge_account_attributes(<<AccountId/binary>>, JObj) ->
     case kzd_accounts:fetch(AccountId) of
         {'ok', Account} -> merge_account_attributes(Account, JObj);
         {'error', _} -> JObj
     end;
-merge_account_attributes(Account, JObj) ->
-    CidOptions = kz_json:get_ne_value(<<"caller_id_options">>, Account),
+merge_account_attributes(AccountDoc, JObj) ->
+    CIDOptions = kzd_accounts:caller_id_options(AccountDoc),
+
     Props = props:filter_undefined(
-              [{<<"caller_id_options">>, CidOptions}
+              [{<<"caller_id_options">>, CIDOptions}
+              ,{<<"auth_realm">>, kzd_accounts:real(AccountDoc)}
               ]
              ),
     kz_json:set_values(Props, JObj).

--- a/core/kazoo_documents/src/kzd_connectivity.erl.src
+++ b/core/kazoo_documents/src/kzd_connectivity.erl.src
@@ -7,7 +7,6 @@
 
 -export([new/0]).
 -export([account/1, account/2, set_account/2]).
--export([account_auth_realm/1, account_auth_realm/2, set_account_auth_realm/2]).
 -export([account_caller_id/1, account_caller_id/2, set_account_caller_id/2]).
 -export([account_caller_id_cid_name/1, account_caller_id_cid_name/2, set_account_caller_id_cid_name/2]).
 -export([account_caller_id_cid_number/1, account_caller_id_cid_number/2, set_account_caller_id_cid_number/2]).
@@ -41,18 +40,6 @@ account(Doc, Default) ->
 -spec set_account(doc(), kz_json:object()) -> doc().
 set_account(Doc, Account) ->
     kz_json:set_value([<<"account">>], Account, Doc).
-
--spec account_auth_realm(doc()) -> kz_term:api_ne_binary().
-account_auth_realm(Doc) ->
-    account_auth_realm(Doc, 'undefined').
-
--spec account_auth_realm(doc(), Default) -> kz_term:ne_binary() | Default.
-account_auth_realm(Doc, Default) ->
-    kz_json:get_ne_binary_value([<<"account">>, <<"auth_realm">>], Doc, Default).
-
--spec set_account_auth_realm(doc(), kz_term:ne_binary()) -> doc().
-set_account_auth_realm(Doc, AccountAuthenticationRealm) ->
-    kz_json:set_value([<<"account">>, <<"auth_realm">>], AccountAuthenticationRealm, Doc).
 
 -spec account_caller_id(doc()) -> kz_term:api_object().
 account_caller_id(Doc) ->

--- a/core/kazoo_proper/src/pqc_cb_connectivity.erl
+++ b/core/kazoo_proper/src/pqc_cb_connectivity.erl
@@ -1,0 +1,156 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2020, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pqc_cb_connectivity).
+
+-export([create/3
+        ,update/3
+        ,summary/2
+        ,delete/3
+        ]).
+
+%% Manual testing
+-export([seq/0
+        ,cleanup/0
+        ]).
+
+%% API Shims
+
+-include("kazoo_proper.hrl").
+
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
+
+-spec create(pqc_cb_api:state(), kz_term:ne_binary(), kzd_connectivity:doc()) -> pqc_cb_api:response().
+create(API, AccountId, ConnectivityDoc) ->
+    URL = connectivity_url(AccountId),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+    RequestEnvelope  = pqc_cb_api:create_envelope(ConnectivityDoc),
+
+    pqc_cb_api:make_request(#{'response_codes' => [201]}
+                           ,fun kz_http:put/3
+                           ,URL
+                           ,RequestHeaders
+                           ,kz_json:encode(RequestEnvelope)
+                           ).
+
+-spec update(pqc_cb_api:state(), kz_term:ne_binary(), kzd_connectivity:doc()) -> pqc_cb_api:response().
+update(API, AccountId, ConnectivityDoc) ->
+    URL = connectivity_url(AccountId, kz_doc:id(ConnectivityDoc)),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+    RequestEnvelope  = pqc_cb_api:create_envelope(ConnectivityDoc),
+
+    pqc_cb_api:make_request(#{'response_codes' => [200]}
+                           ,fun kz_http:post/3
+                           ,URL
+                           ,RequestHeaders
+                           ,kz_json:encode(RequestEnvelope)
+                           ).
+
+-spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+summary(API, AccountId) ->
+    pqc_cb_api:make_request(#{'response_codes' => [200]}
+                           ,fun kz_http:get/2
+                           ,connectivity_url(AccountId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+-spec delete(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+delete(API, AccountId, ConnectivityId) ->
+    pqc_cb_api:make_request(#{'response_codes' => [200]}
+                           ,fun kz_http:delete/2
+                           ,connectivity_url(AccountId, ConnectivityId)
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
+connectivity_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "connectivity"], "/").
+
+connectivity_url(AccountId, ConnectivityId) ->
+    string:join([connectivity_url(AccountId), kz_term:to_list(ConnectivityId)], "/").
+
+-spec seq() -> 'ok'.
+seq() ->
+    API = init_api(),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+    {'ok', AccountDoc} = kzd_accounts:fetch(AccountId),
+    AccountRealm = kzd_accounts:realm(AccountDoc),
+    lager:info("created account ~s ~s", [AccountId, AccountRealm]),
+
+    EmptySummaryResp = summary(API, AccountId),
+    lager:info("empty summary: ~s", [EmptySummaryResp]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
+
+    Doc = connectivity_doc(),
+    CreatedResp = create(API, AccountId, Doc),
+    lager:info("created resp: ~s", [CreatedResp]),
+    CreatedDoc = kz_json:get_json_value(<<"data">>, kz_json:decode(CreatedResp)),
+    AccountRealm = kzd_connectivity:account_auth_realm(CreatedDoc),
+
+    SummaryResp = summary(API, AccountId),
+    lager:info("summary: ~s", [SummaryResp]),
+    [SummaryId] = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
+    SummaryId = kz_doc:id(CreatedDoc),
+
+    Edited = kzd_connectivity:set_account_auth_realm(CreatedDoc, kz_binary:rand_hex(4)),
+    EditedResp = update(API, AccountId, Edited),
+    lager:info("edited resp: ~s", [EditedResp]),
+    EditedDoc = kz_json:get_json_value(<<"data">>, kz_json:decode(EditedResp)),
+    AccountRealm = kzd_connectivity:account_auth_realm(EditedDoc),
+    SummaryId = kz_doc:id(EditedDoc),
+
+    DeleteResp = delete(API, AccountId, SummaryId),
+    lager:info("delete resp: ~s", [DeleteResp]),
+
+    EmptyAgain = summary(API, AccountId),
+    lager:info("empty again: ~s", [EmptyAgain]),
+    [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptyAgain)),
+
+    lager:info("COMPLETED SUCCESSFULLY"),
+    cleanup(API).
+
+-spec cleanup() -> any().
+cleanup() ->
+    lager:info("CLEANUP ALL THE THINGS"),
+    kz_data_tracing:clear_all_traces(),
+    cleanup(pqc_cb_api:authenticate()).
+
+-spec cleanup(pqc_cb_api:state()) -> any().
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    pqc_cb_api:cleanup(API).
+
+connectivity_doc() ->
+    kz_doc:setters(kzd_connectivity:new()
+                  ,[{fun kzd_connectivity:set_account_auth_realm/2, kz_binary:rand_hex(4)}
+                   ,{fun kzd_connectivity:set_name/2, <<?MODULE_STRING>>}
+                   ,{fun kzd_connectivity:set_servers/2, []}
+                   ]).
+
+init_api() ->
+    Model = initial_state(),
+    pqc_kazoo_model:api(Model).
+
+-spec initial_state() -> pqc_kazoo_model:model().
+initial_state() ->
+    _ = init_system(),
+    API = pqc_cb_api:authenticate(),
+    pqc_kazoo_model:new(API).
+
+init_system() ->
+    TestId = kz_binary:rand_hex(5),
+    kz_util:put_callid(TestId),
+
+    _ = kz_data_tracing:clear_all_traces(),
+    _ = [kapps_controller:start_app(App) ||
+            App <- ['crossbar', 'trunkstore']
+        ],
+    _ = [crossbar_maintenance:start_module(Mod) ||
+            Mod <- ['cb_connectivity']
+        ],
+
+    ?INFO("INIT FINISHED").


### PR DESCRIPTION
Connectivity docs should not include an auth_realm as it leads users
to confusion thinking they can set an realm separate from the
account's - this is not the case!

Ensure connectivity docs have the account's realm (just in case) and
ensure Trunkstore sets the account's realm when processing calls.