### PR TITLE
Ensure trunkstore uses account doc's realm

### DIFF
--- a/applications/crossbar/doc/connectivity.md
+++ b/applications/crossbar/doc/connectivity.md
@@ -10,7 +10,6 @@ Trunkstore configuration document - this is old stuff; do not recommend building
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`account.auth_realm` | The realm any device in the account will use to authenticate with | `string(1..)` |   | `false` |  
 `account.caller_id.cid_name` |   | `string(0..35)` |   | `false` |  
 `account.caller_id.cid_number` |   | `string(0..35)` |   | `false` |  
 `account.caller_id` |   | `object()` |   | `false` |  

--- a/applications/crossbar/doc/ref/connectivity.md
+++ b/applications/crossbar/doc/ref/connectivity.md
@@ -10,7 +10,6 @@ Trunkstore configuration document - this is old stuff; do not recommend building
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`account.auth_realm` | The realm any device in the account will use to authenticate with | `string(1..)` |   | `false` |  
 `account.caller_id.cid_name` |   | `string(0..35)` |   | `false` |  
 `account.caller_id.cid_number` |   | `string(0..35)` |   | `false` |  
 `account.caller_id` |   | `object()` |   | `false` |  

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -5106,11 +5106,6 @@
                 "account": {
                     "description": "Information that applies to the account as a whole",
                     "properties": {
-                        "auth_realm": {
-                            "description": "The realm any device in the account will use to authenticate with",
-                            "minLength": 1,
-                            "type": "string"
-                        },
                         "caller_id": {
                             "properties": {
                                 "cid_name": {

--- a/applications/crossbar/priv/couchdb/schemas/connectivity.json
+++ b/applications/crossbar/priv/couchdb/schemas/connectivity.json
@@ -6,11 +6,6 @@
         "account": {
             "description": "Information that applies to the account as a whole",
             "properties": {
-                "auth_realm": {
-                    "description": "The realm any device in the account will use to authenticate with",
-                    "minLength": 1,
-                    "type": "string"
-                },
                 "caller_id": {
                     "properties": {
                         "cid_name": {

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -4021,10 +4021,6 @@
     'account':
       'description': Information that applies to the account as a whole
       'properties':
-        'auth_realm':
-          'description': The realm any device in the account will use to authenticate with
-          'minLength': 1
-          'type': string
         'caller_id':
           'properties':
             'cid_name':

--- a/applications/crossbar/src/modules/cb_connectivity.erl
+++ b/applications/crossbar/src/modules/cb_connectivity.erl
@@ -34,7 +34,7 @@
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec init() -> ok.
+-spec init() -> 'ok'.
 init() ->
     _ = crossbar_bindings:bind(<<"*.allowed_methods.connectivity">>, ?MODULE, 'allowed_methods'),
     _ = crossbar_bindings:bind(<<"*.resource_exists.connectivity">>, ?MODULE, 'resource_exists'),
@@ -43,7 +43,7 @@ init() ->
     _ = crossbar_bindings:bind(<<"*.execute.post.connectivity">>, ?MODULE, 'post'),
     _ = crossbar_bindings:bind(<<"*.execute.patch.connectivity">>, ?MODULE, 'patch'),
     _ = crossbar_bindings:bind(<<"*.execute.delete.connectivity">>, ?MODULE, 'delete'),
-    ok.
+    'ok'.
 
 %%------------------------------------------------------------------------------
 %% @doc This function determines the verbs that are appropriate for the
@@ -204,7 +204,11 @@ create(Context) ->
 
                         Doc = cb_context:doc(C1),
                         Nums = get_numbers(Doc),
-                        cb_modules_util:validate_number_ownership(Nums, C1)
+
+                        AccountDoc = cb_context:account_doc(Context),
+                        WithRealm = kzd_connectivity:set_account_auth_realm(Doc, kzd_accounts:realm(AccountDoc)),
+
+                        cb_modules_util:validate_number_ownership(Nums, cb_context:set_doc(C1, WithRealm))
                 end,
     cb_context:validate_request_data(<<"connectivity">>, Context, OnSuccess).
 
@@ -228,7 +232,11 @@ update(Id, Context) ->
 
                         Doc = cb_context:doc(C1),
                         Nums = get_numbers(Doc),
-                        cb_modules_util:validate_number_ownership(Nums, C1)
+
+                        AccountDoc = cb_context:account_doc(Context),
+                        WithRealm = kzd_connectivity:set_account_auth_realm(Doc, kzd_accounts:realm(AccountDoc)),
+
+                        cb_modules_util:validate_number_ownership(Nums, cb_context:set_doc(C1, WithRealm))
                 end,
     cb_context:validate_request_data(<<"connectivity">>, Context, OnSuccess).
 
@@ -247,7 +255,8 @@ validate_patch(Id, Context) ->
 %%------------------------------------------------------------------------------
 -spec on_successful_validation(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
 on_successful_validation('undefined', Context) ->
-    cb_context:set_doc(Context, kz_doc:set_type(cb_context:doc(Context), <<"sys_info">>));
+    Doc = kz_doc:set_type(cb_context:doc(Context), <<"sys_info">>),
+    cb_context:set_doc(Context, Doc);
 on_successful_validation(Id, Context) ->
     crossbar_doc:load_merge(Id, Context, ?TYPE_CHECK_OPTION(<<"sys_info">>)).
 

--- a/core/kazoo_documents/src/kzd_connectivity.erl.src
+++ b/core/kazoo_documents/src/kzd_connectivity.erl.src
@@ -7,7 +7,6 @@
 
 -export([new/0]).
 -export([account/1, account/2, set_account/2]).
--export([account_auth_realm/1, account_auth_realm/2, set_account_auth_realm/2]).
 -export([account_caller_id/1, account_caller_id/2, set_account_caller_id/2]).
 -export([account_caller_id_cid_name/1, account_caller_id_cid_name/2, set_account_caller_id_cid_name/2]).
 -export([account_caller_id_cid_number/1, account_caller_id_cid_number/2, set_account_caller_id_cid_number/2]).
@@ -41,18 +40,6 @@ account(Doc, Default) ->
 -spec set_account(doc(), kz_json:object()) -> doc().
 set_account(Doc, Account) ->
     kz_json:set_value([<<"account">>], Account, Doc).
-
--spec account_auth_realm(doc()) -> kz_term:api_ne_binary().
-account_auth_realm(Doc) ->
-    account_auth_realm(Doc, 'undefined').
-
--spec account_auth_realm(doc(), Default) -> kz_term:ne_binary() | Default.
-account_auth_realm(Doc, Default) ->
-    kz_json:get_ne_binary_value([<<"account">>, <<"auth_realm">>], Doc, Default).
-
--spec set_account_auth_realm(doc(), kz_term:ne_binary()) -> doc().
-set_account_auth_realm(Doc, AccountAuthenticationRealm) ->
-    kz_json:set_value([<<"account">>, <<"auth_realm">>], AccountAuthenticationRealm, Doc).
 
 -spec account_caller_id(doc()) -> kz_term:api_object().
 account_caller_id(Doc) ->


### PR DESCRIPTION
Connectivity docs should not include an auth_realm as it leads users
to confusion thinking they can set an realm separate from the
account's - this is not the case!

Ensure connectivity docs have the account's realm (just in case) and
ensure Trunkstore sets the account's realm when processing calls.