### PR TITLE
PISTON-1000: refactor kapps_config_util to use kapps_account_config

### DIFF
--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -210,6 +210,7 @@
 -define(TYPE_CHECK_OPTION_ANY, ?TYPE_CHECK_OPTION(<<"any">>)).
 
 -define(SPECIAL_EXPECTED_TYPE, [{<<"allotments">>, <<"limits">>}
+                               ,{<<"configs">>, <<"account_config">>}
                                ,{<<"connectivity">>, <<"sys_info">>}
                                ,{<<"directories">>, <<"directory">>}
                                ,{<<"faxes">>, <<"fax">>}

--- a/core/kazoo_apps/src/kapps_account_config.erl
+++ b/core/kazoo_apps/src/kapps_account_config.erl
@@ -570,7 +570,7 @@ config_origins(AccountId, Category, <<"global">>) ->
     account_origins(AccountId, Category) ++ config_origins(AccountId, Category, <<"reseller">>);
 
 config_origins(AccountId, Category, <<"reseller">>) ->
-    ResellerOrigins = case kzd_accounts:reseller_id(AccountId) of
+    ResellerOrigins = case kz_services_reseller:get_id(AccountId) of
                           'undefined' -> [];
                           ResellerId ->
                               ResellerDb = kz_util:format_account_db(ResellerId),
@@ -581,8 +581,8 @@ config_origins(AccountId, Category, <<"reseller">>) ->
 
 config_origins(AccountId, Category, <<"hierarchy">>) ->
     account_origins(AccountId, Category)
-    ++ hierarchy_origins(AccountId, Category)
-    ++ system_origins(Category).
+        ++ hierarchy_origins(AccountId, Category)
+        ++ system_origins(Category).
 
 account_origins(AccountId, Category) ->
     DocId = kapps_config_util:account_doc_id(Category),
@@ -592,7 +592,7 @@ account_origins(AccountId, Category) ->
 
 hierarchy_origins(AccountId, Category) ->
     {'ok', AccountDoc} = kzd_accounts:fetch(AccountId),
-    hierarchy_origins(Category, kzd_accounts:reseller_id(AccountId), lists:reverse(kzd_accounts:tree(AccountDoc)), []).
+    hierarchy_origins(Category, kz_services_reseller:get_id(AccountId), lists:reverse(kzd_accounts:tree(AccountDoc)), []).
 
 hierarchy_origins(_, _, [], Origins) -> Origins;
 hierarchy_origins(Category, ResellerId, [Parent|Ancestors], Origins) ->

--- a/core/kazoo_apps/src/kapps_config_util.erl
+++ b/core/kazoo_apps/src/kapps_config_util.erl
@@ -35,8 +35,7 @@ get_config(Account, Config) ->
 get_reseller_config(Account, Config) ->
     get_config(Account, Config, <<"reseller">>).
 
--spec get_config(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
-                        kz_json:object().
+-spec get_config(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_json:object().
 get_config(Account, Config, Strategy) ->
     JObj = maybe_new(
              kapps_account_config:get_category_with_strategy(Strategy, Account, Config)

--- a/core/kazoo_apps/src/kapps_config_util.erl
+++ b/core/kazoo_apps/src/kapps_config_util.erl
@@ -13,7 +13,6 @@
 
 -export([get_config/2
         ,get_reseller_config/2
-        ,load_config_from_account/2
         ,account_schema_name/1
         ,system_schema_name/1
         ,account_schema/1
@@ -30,53 +29,26 @@ account_doc_id(Category) -> <<(?KZ_ACCOUNT_CONFIGS)/binary, Category/binary>>.
 
 -spec get_config(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_json:object().
 get_config(Account, Config) ->
-    Programm = [fun load_config_from_account/2
-               ,fun load_config_from_reseller/2
-               ,fun load_config_from_system/2
-               ,fun load_default_config/2
-               ],
-    Schema = account_schema(Config),
-    kz_json_schema:filter(get_config(Account, Config, Programm), Schema).
-
--spec get_config(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:functions()) -> kz_json:object().
-get_config(Account, Config, Programm) ->
-    Confs = [maybe_new(P(Account, Config)) || P <- Programm],
-    kz_json:merge(lists:reverse(Confs)).
+    get_config(Account, Config, <<"global">>).
 
 -spec get_reseller_config(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_json:object().
 get_reseller_config(Account, Config) ->
-    Programm = [fun load_config_from_reseller/2
-               ,fun load_config_from_system/2
-               ,fun load_default_config/2
-               ],
+    get_config(Account, Config, <<"reseller">>).
+
+-spec get_config(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
+                        kz_json:object().
+get_config(Account, Config, Strategy) ->
+    JObj = maybe_new(
+             kapps_account_config:get_category_with_strategy(Strategy, Account, Config)
+            ),
+    JObj1 = kz_json:merge(load_default_config(Account, Config), JObj, #{'recursive' => 'true'}),
     Schema = account_schema(Config),
-    kz_json_schema:filter(get_config(Account, Config, Programm), Schema).
+    kz_json_schema:filter(JObj1, Schema).
 
--spec load_config_from_account(kz_term:api_binary(), kz_term:ne_binary()) -> {ok, kz_json:object()} | {error, any()}.
-load_config_from_account(undefined, _Config) -> {ok, kz_json:new()};
-load_config_from_account(Account, Config) ->
-    AccountDb = kzs_util:format_account_db(Account),
-    kz_datamgr:open_cache_doc(AccountDb, account_doc_id(Config), [{cache_failures, [not_found]}]).
-
--spec load_config_from_reseller(kz_term:api_binary(), kz_term:ne_binary()) -> {ok, kz_json:object()} | {error, any()}.
-load_config_from_reseller(undefined, _Config) -> {error, not_found};
-load_config_from_reseller(Account, Config) ->
-    case kz_services_reseller:get_id(Account) of
-        undefined -> {error, not_found};
-        %% should get from direct reseller only
-        %% same logic as kapps_account_config:get_from_reseller
-        Account -> {error, not_found};
-        ResellerId -> load_config_from_account(ResellerId, Config)
-    end.
-
--spec load_config_from_system(kz_term:api_binary(), kz_term:ne_binary()) -> {ok, kz_json:object()}.
-load_config_from_system(_Account, Config) ->
-    {'ok', kz_json:get_value(<<"default">>, maybe_new(kapps_config:get_category(Config)), kz_json:new())}.
-
--spec load_default_config(kz_term:api_binary(), kz_term:ne_binary()) -> {ok, kz_json:object()}.
+-spec load_default_config(kz_term:api_binary(), kz_term:ne_binary()) -> kz_json:object().
 load_default_config(_Account, Config) ->
     Schema = system_schema(Config),
-    {'ok', kz_doc:set_id(kz_json_schema:default_object(Schema), account_doc_id(Config))}.
+    kz_doc:set_id(kz_json_schema:default_object(Schema), account_doc_id(Config)).
 
 -spec maybe_new({'ok', kz_json:object()} | {'error', any()}) -> kz_json:object().
 maybe_new({'ok', JObj}) -> JObj;

--- a/core/kazoo_apps/test/kapps_account_config_tests.erl
+++ b/core/kazoo_apps/test/kapps_account_config_tests.erl
@@ -173,7 +173,7 @@ test_get_with_strategy(_) ->
      ,[get_with_strategy_general()
       ,get_strategy_global()
       ,get_strategy_reseller()
-      ,get_strategy_hierarchy_merge()
+      ,get_strategy_hierarchy()
       ]
      }
     ].
@@ -242,7 +242,7 @@ get_strategy_reseller() ->
      }
     ].
 
-get_strategy_hierarchy_merge() ->
+get_strategy_hierarchy() ->
     SysRootObjKey = get_fixture_value([<<"default">>, <<"root_obj_key">>], ?KZ_CONFIG_DB, ?TEST_CAT),
     ResellerRootJObjKey = get_fixture_value(<<"root_obj_key">>, ?FIXTURE_RESELLER_ACCOUNT_ID, ?TEST_CAT),
     ParentRootObjKey = get_fixture_value(<<"root_obj_key">>, ?FIXTURE_PARENT_ACCOUNT_ID, ?TEST_CAT),
@@ -252,10 +252,10 @@ get_strategy_hierarchy_merge() ->
     SometimesEmptyValue_Reseller = kz_json:get_value([<<"obj_empty_test">>, <<"obj_empty_sometimes">>], ResellerRootJObjKey),
     SometimesEmptyValue_Sub1 = kz_json:get_value([<<"obj_empty_test">>, <<"obj_empty_sometimes">>], ParentRootObjKey),
 
-    [{"Testing get config hierarchy_merge strategy"
+    [{"Testing get config hierarchy strategy"
      ,[{"defined value in account where account is reseller itself should result in merged value of reseller and system"
        ,?_assertEqual(kz_json:merge_recursive([SysRootObjKey, ResellerRootJObjKey])
-                     ,kapps_account_config:get_with_strategy(<<"hierarchy_merge">>, ?FIXTURE_RESELLER_ACCOUNT_ID, ?TEST_CAT, <<"root_obj_key">>)
+                     ,kapps_account_config:get_with_strategy(<<"hierarchy">>, ?FIXTURE_RESELLER_ACCOUNT_ID, ?TEST_CAT, <<"root_obj_key">>)
                      )
        }
       ,{"defined value in parent-account and reseller should result in merged value of parent-account, reseller and system"

--- a/core/kazoo_ast/src/kapps_config_usage.erl
+++ b/core/kazoo_ast/src/kapps_config_usage.erl
@@ -242,9 +242,8 @@ config_to_schema(Source, F='get_hierarchy', [_Account, Cat, K, Default], Schemas
 config_to_schema(Source, F='get_with_strategy', [Strategy, Account, Cat, K], Schemas) ->
     config_to_schema(Source, F, [Strategy, Account, Cat, K, 'undefined'], Schemas);
 config_to_schema(Source, F='get_with_strategy', [?BINARY_MATCH([?BINARY_STRING(Strategy)]), _Account, Cat, K, Default], Schemas)
-  when Strategy =:= "hierarchy_merge";
-       Strategy =:= "global";
-       Strategy =:= "global_merge" ->
+  when Strategy =:= "hierarchy";
+       Strategy =:= "global" ->
     Document = category_to_document(Cat),
     case key_to_key_path(K) of
         'undefined' -> Schemas;


### PR DESCRIPTION
- also use kapps_config_cache more - no restriction on merging as the
  results are the same

Relates to discussion here: https://github.com/2600hz/kazoo/pull/6242

Depends on https://github.com/2600hz/kazoo/pull/6254 for the `'recursive'` option in `kz_json:merge`.

Wanted to refactor some similar code between `kapps_config_util` and `kapps_account_config` so that `kapps_config_util` wraps called to the other module and tacks on a few extra things only where necessary. This meant that the introduction of `get_category_with_strategy` was needed, which unlike `get_with_strategy`, gets the entire category's JSON object.
This required reworking `walk_the_walk` a bit and I observed the opportunity to be more aggressive about caching of the results. It became clear that it was OK to _always_ merge and cache the results, provided the appropriate cache origins were specified.
Another observation was that docs managed by `cb_configs` were not being considered `"pvt_type": "account_config"` so I've added `set_pvt_type` to that mod. This is important to ensure the appropriate cache clearing happens with the more aggressive caching.

Looking for feedback!