### PR TITLE
PISTON-868:Storage plans will now take affect instantly after a crossbar create action

### DIFF
--- a/applications/crossbar/src/modules/cb_storage.erl
+++ b/applications/crossbar/src/modules/cb_storage.erl
@@ -209,11 +209,15 @@ validate_storage_plan(Context, PlanId, ?HTTP_DELETE) ->
 %%--------------------------------------------------------------------
 -spec put(cb_context:context()) -> cb_context:context().
 put(Context) ->
-    crossbar_doc:save(Context).
+    Return = crossbar_doc:save(Context),
+    kzs_plan:reload(cb_context:account_id(Context)),
+    Return.
 
 -spec put(cb_context:context(), path_token()) -> cb_context:context().
 put(Context, ?PLANS_TOKEN) ->
-    crossbar_doc:save(Context).
+    Return = crossbar_doc:save(Context),
+    kzs_plan:reload(cb_context:account_id(Context)),
+    Return.
 
 %%--------------------------------------------------------------------
 %% @public


### PR DESCRIPTION
Server side intervention was required after creating a storage plan through crossbar. This PR removes the need for server side intervention and will mean that once a storage plan is created through crossbar it will take affect immediately.

Updates and deletes to storage plans are left as before and will also take affect immediately.

 