### PR TITLE
Make bash script more portable

### DIFF
--- a/scripts/check-ref-docs.bash
+++ b/scripts/check-ref-docs.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
There's a `declare -A` in the script, which requires bash version > 4.  The default bash version shipped with OS X is lower than that :(