### PR TITLE
HELP-12897: properly paginate directory's users

### DIFF
--- a/applications/crossbar/src/modules/cb_directories.erl
+++ b/applications/crossbar/src/modules/cb_directories.erl
@@ -305,7 +305,7 @@ read(Id, Context) ->
 -spec load_directory_users(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
 load_directory_users(Id, Context) ->
     Context1 = crossbar_doc:load_view(?CB_USERS_LIST
-                                     ,[{'key', Id}]
+                                     ,[{'startkey', [Id]}]
                                      ,Context
                                      ,fun normalize_users_results/2
                                      ),
@@ -368,7 +368,7 @@ normalize_view_results(JObj, Acc) ->
 -spec normalize_users_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
 normalize_users_results(JObj, Acc) ->
     [kz_json:from_list([{<<"user_id">>, kz_doc:id(JObj)}
-                       ,{<<"callflow_id">>, kz_json:get_value(<<"value">>, JObj)}
+                       ,{<<"callflow_id">>, kz_json:get_ne_binary_value(<<"value">>, JObj)}
                        ])
      | Acc
     ].

--- a/core/kazoo_apps/priv/couchdb/account/directories.json
+++ b/core/kazoo_apps/priv/couchdb/account/directories.json
@@ -13,7 +13,7 @@
             "map": "function(doc) { if (doc.pvt_type != 'directory' || doc.pvt_deleted) return; emit(doc._id, {'id': doc._id, 'name': doc.name, 'flags': doc.flags || []}); }"
         },
         "users_listing": {
-            "map": "function(doc) { if ( doc.pvt_deleted || typeof doc.directories !== 'object' ) return; for ( i in doc.directories ) { emit(i, doc.directories[i]); }}"
+            "map": "function(doc) { if ( doc.pvt_deleted || typeof doc.directories !== 'object' ) return; for ( directory_id in doc.directories ) { emit([directory_id, doc._id], doc.directories[directory_id]); }}"
         }
     }
 }

--- a/core/kazoo_apps/src/kapps_notify_publisher.erl
+++ b/core/kazoo_apps/src/kapps_notify_publisher.erl
@@ -23,11 +23,12 @@
 -define(DEFAULT_TIMEOUT, 30 * ?MILLISECONDS_IN_SECOND).
 -define(TIMEOUT, kapps_config:get_pos_integer(?NOTIFY_CAT, <<"notify_publisher_timeout_ms">>, ?DEFAULT_TIMEOUT)).
 
--define(DEFAULT_PUBLISHER_ENABLED,
-        kapps_config:get_is_true(?NOTIFY_CAT, <<"notify_persist_enabled">>, true)
+-define(DEFAULT_PUBLISHER_ENABLED
+       ,kapps_config:get_is_true(?NOTIFY_CAT, <<"notify_persist_enabled">>, 'true')
        ).
--define(ACCOUNT_SHOULD_PERSIST(AccountId),
-        kapps_account_config:get_global(AccountId, ?NOTIFY_CAT, <<"should_persist_for_retry">>, true)
+
+-define(ACCOUNT_SHOULD_PERSIST(AccountId)
+       ,kapps_account_config:get_global(AccountId, ?NOTIFY_CAT, <<"should_persist_for_retry">>, 'true')
        ).
 
 -define(DEFAULT_TYPE_EXCEPTION, [<<"system_alert">>
@@ -35,15 +36,17 @@
                                 ,<<"register">>
                                 ,<<"webhook">>
                                 ]).
--define(GLOBAL_FORCE_NOTIFY_TYPE_EXCEPTION,
-        kapps_config:get_ne_binaries(?NOTIFY_CAT, <<"notify_persist_temporary_force_exceptions">>, [])
-       ).
--define(NOTIFY_TYPE_EXCEPTION(AccountId),
-        kapps_account_config:get_global(AccountId, ?NOTIFY_CAT, <<"notify_persist_exceptions">>, ?DEFAULT_TYPE_EXCEPTION)
+-define(GLOBAL_FORCE_NOTIFY_TYPE_EXCEPTION
+       ,kapps_config:get_ne_binaries(?NOTIFY_CAT, <<"notify_persist_temporary_force_exceptions">>, [])
        ).
 
--define(DEFAULT_RETRY_PERIOD,
-        kapps_config:get_integer(<<"tasks.notify_resend">>, <<"retry_after_fudge_s">>, 10 * ?SECONDS_IN_MINUTE)).
+-define(NOTIFY_TYPE_EXCEPTION(AccountId)
+       ,kapps_account_config:get_global(AccountId, ?NOTIFY_CAT, <<"notify_persist_exceptions">>, ?DEFAULT_TYPE_EXCEPTION)
+       ).
+
+-define(DEFAULT_RETRY_PERIOD
+       ,kapps_config:get_integer(<<"tasks.notify_resend">>, <<"retry_after_fudge_s">>, 10 * ?SECONDS_IN_MINUTE)
+       ).
 
 -type failure_reason() :: {kz_term:ne_binary(), kz_term:api_object()}.
 
@@ -319,12 +322,12 @@ cast_to_binary(Error) ->
 -spec notify_type(kz_amqp_worker:publish_fun() | kz_term:ne_binary()) -> kz_term:api_ne_binary().
 notify_type(<<"publish_", NotifyType/binary>>) ->
     NotifyType;
-notify_type(NotifyType) when is_binary(NotifyType) ->
+notify_type(<<NotifyType/binary>>) ->
     lager:error("unknown notification publish function ~s", [NotifyType]),
     'undefined';
 notify_type(PublishFun) ->
     case catch erlang:fun_info_mfa(PublishFun) of
-        {kapi_notifications, Fun, 1} -> notify_type(cast_to_binary(Fun));
+        {'kapi_notifications', Fun, 1} -> notify_type(cast_to_binary(Fun));
         _Other ->
             lager:error("unknown notification publish function: ~p", [_Other]),
             'undefined'

--- a/core/kazoo_proper/src/pqc_cb_directories.erl
+++ b/core/kazoo_proper/src/pqc_cb_directories.erl
@@ -13,14 +13,14 @@
 
 -export([summary/2]).
 -export([create/3]).
--export([fetch/3]).
+-export([fetch/3, fetch/4]).
 -export([update/3]).
 -export([patch/4]).
 -export([delete/3]).
 
 -export([seq/0
         ,cleanup/0
-        ,new_directorie/0
+        ,new_directory/0
         ]).
 
 -include("kazoo_proper.hrl").
@@ -32,37 +32,43 @@ summary(API, AccountId) ->
     pqc_cb_crud:summary(API, directories_url(AccountId)).
 
 -spec create(pqc_cb_api:state(), kz_term:ne_binary(), kzd_directories:doc()) -> pqc_cb_api:response().
-create(API, AccountId, DirectorieJObj) ->
-    Envelope = pqc_cb_api:create_envelope(DirectorieJObj),
+create(API, AccountId, DirectoryJObj) ->
+    Envelope = pqc_cb_api:create_envelope(DirectoryJObj),
     pqc_cb_crud:create(API, directories_url(AccountId), Envelope).
 
 -spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
-fetch(API, AccountId, DirectorieId) ->
-    pqc_cb_crud:fetch(API, directorie_url(AccountId, DirectorieId)).
+fetch(API, AccountId, DirectoryId) ->
+    fetch(API, AccountId, DirectoryId, 'undefined').
+
+-spec fetch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:api_proplist()) -> pqc_cb_api:response().
+fetch(API, AccountId, DirectoryId, QueryString) ->
+    pqc_cb_crud:fetch(API, directory_url(AccountId, DirectoryId) ++ querystring(QueryString)).
 
 -spec update(pqc_cb_api:state(), kz_term:ne_binary(), kzd_directorie:doc()) -> pqc_cb_api:response().
-update(API, AccountId, DirectorieJObj) ->
-    Envelope = pqc_cb_api:create_envelope(DirectorieJObj),
-    pqc_cb_crud:update(API, directorie_url(AccountId, kz_doc:id(DirectorieJObj)), Envelope).
+update(API, AccountId, DirectoryJObj) ->
+    Envelope = pqc_cb_api:create_envelope(DirectoryJObj),
+    pqc_cb_crud:update(API, directory_url(AccountId, kz_doc:id(DirectoryJObj)), Envelope).
 
 -spec patch(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> pqc_cb_api:response().
-patch(API, AccountId, DirectorieId, PatchJObj) ->
+patch(API, AccountId, DirectoryId, PatchJObj) ->
     Envelope = pqc_cb_api:create_envelope(PatchJObj),
-    pqc_cb_crud:patch(API, directorie_url(AccountId, DirectorieId), Envelope).
+    pqc_cb_crud:patch(API, directory_url(AccountId, DirectoryId), Envelope).
 
 -spec delete(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
-delete(API, AccountId, DirectorieId) ->
-    pqc_cb_crud:delete(API, directorie_url(AccountId, DirectorieId)).
-
+delete(API, AccountId, DirectoryId) ->
+    pqc_cb_crud:delete(API, directory_url(AccountId, DirectoryId)).
 
 -spec directories_url(kz_term:ne_binary()) -> string().
 directories_url(AccountId) ->
     pqc_cb_crud:collection_url(AccountId, <<"directories">>).
 
--spec directorie_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
-directorie_url(AccountId, DirectorieId) ->
-    pqc_cb_crud:entity_url(AccountId, <<"directories">>, DirectorieId).
+-spec directory_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
+directory_url(AccountId, DirectoryId) ->
+    pqc_cb_crud:entity_url(AccountId, <<"directories">>, DirectoryId).
 
+querystring('undefined') -> "";
+querystring([]) -> "";
+querystring(QS) -> ["?", kz_http_util:props_to_querystring(QS)].
 
 -spec seq() -> 'ok'.
 seq() ->
@@ -73,22 +79,38 @@ seq() ->
     lager:info("empty summary resp: ~s", [EmptySummaryResp]),
     [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySummaryResp)),
 
-    DirectorieJObj = new_directorie(),
-    CreateResp = create(API, AccountId, DirectorieJObj),
+    DirectoryJObj = new_directory(),
+    CreateResp = create(API, AccountId, DirectoryJObj),
     lager:info("created directorie ~s", [CreateResp]),
     CreatedDirectorie = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
-    DirectorieId = kz_doc:id(CreatedDirectorie),
+    DirectoryId = kz_doc:id(CreatedDirectorie),
 
     Patch = kz_json:from_list([{<<"custom">>, <<"value">>}]),
-    PatchResp = patch(API, AccountId, DirectorieId, Patch),
+    PatchResp = patch(API, AccountId, DirectoryId, Patch),
     lager:info("patched to ~s", [PatchResp]),
 
     SummaryResp = summary(API, AccountId),
     lager:info("summary resp: ~s", [SummaryResp]),
     [SummaryDirectorie] = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
-    DirectorieId = kz_doc:id(SummaryDirectorie),
+    DirectoryId = kz_doc:id(SummaryDirectorie),
 
-    DeleteResp = delete(API, AccountId, DirectorieId),
+    Users = create_users(API, AccountId, DirectoryId),
+    UserIds = [kz_doc:id(User) || User <- Users],
+
+    FetchResp = fetch(API, AccountId, DirectoryId, [{<<"paginate">>, 'false'}]),
+    lager:info("fetched directory: ~s", [FetchResp]),
+    FetchedUsers = kzd_directories:users(kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp))),
+
+    'true' = length(UserIds) =:= length(FetchedUsers),
+    'true' = lists:all(fun(FetchedUser) ->
+                               lists:member(kz_json:get_ne_binary_value(<<"user_id">>, FetchedUser)
+                                           ,UserIds
+                                           )
+                       end
+                      ,FetchedUsers
+                      ),
+
+    DeleteResp = delete(API, AccountId, DirectoryId),
     lager:info("delete resp: ~s", [DeleteResp]),
 
     EmptyAgain = summary(API, AccountId),
@@ -118,10 +140,22 @@ create_account(API) ->
 
     kz_json:get_ne_binary_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)).
 
--spec new_directorie() -> kzd_directories:doc().
-new_directorie() ->
+-spec new_directory() -> kzd_directories:doc().
+new_directory() ->
     kz_doc:public_fields(
       kzd_directories:set_name(kzd_directories:new()
                               ,kz_binary:rand_hex(4)
                               )
      ).
+
+-spec create_users(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> [kzd_users:doc()].
+create_users(API, AccountId, DirectoryId) ->
+    [create_user(API, AccountId, DirectoryId, N) || N <- lists:seq(1, 100)].
+
+-spec create_user(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), 1..100) -> kzd_users:doc().
+create_user(API, AccountId, DirectoryId, NthUser) ->
+    Directories = kz_json:from_list([{DirectoryId, kz_binary:rand_hex(16)}]),
+    UserDoc = kzd_users:set_directories(pqc_cb_users:new_user(), Directories),
+
+    Results = pqc_cb_users:create(API, AccountId, kz_json:set_value(<<"nth">>, NthUser, UserDoc)),
+    kz_json:get_json_value(<<"data">>, kz_json:decode(Results)).


### PR DESCRIPTION
Prior, the view only indexed by the directory IDs on a user's
doc. When `paginate=false` was included on a fetch of the directory,
the directory/users_listing view did not interact nicely with the
internal pagination protections added.

The view arguments used `[{key, DirectoryId}, {limit, 50}]`; the first page would
be returned and since the next `startkey` would be `DirectoryId`
again, crossbar_doc gets stuck in a loop as there was no way to
"increment" the startkey.

Instead, the view now emits `[DirectoryId, UserId]` to allow
differentiation between rows, and view options are now passed in as
`[{startkey, [DirectoryId]}]`. This plays much nicer with pagination
regardless of whether pagination has been disabled or not.