### PR TITLE
crossbar: websocket support

### DIFF
--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -14,7 +14,7 @@
 -module(api_resource).
 -behaviour(cowboy_rest).
 
--export([init/2
+-export([init/2,rest_init/3
         ,context_init/2
         ,service_available/2
         ,terminate/3

--- a/applications/crossbar/src/api_resource.erl
+++ b/applications/crossbar/src/api_resource.erl
@@ -15,6 +15,7 @@
 -behaviour(cowboy_rest).
 
 -export([init/2
+        ,context_init/2
         ,service_available/2
         ,terminate/3
         ,known_methods/2
@@ -39,6 +40,7 @@
         ,is_conflict/2
 
         ,websocket_handle/2
+        ,websocket_info/2
 
          %% Content
         ,to_json/2
@@ -160,6 +162,10 @@ rest_init(Req0, Context0, Opts) ->
 -spec websocket_handle(any(), cb_context:context()) -> {cowboy_websocket:commands(), cb_context:context(), 'hibernate'}.
 websocket_handle(Frame, State) ->
     crossbar_websocket:recv(Frame, State).
+
+-spec websocket_info(any(), cb_context:context()) -> {cowboy_websocket:commands(), cb_context:context(), 'hibernate'}.
+websocket_info(Info, State) ->
+    crossbar_websocket:info(Info, State).
 
 -spec host_url(cb_context:context(), cowboy_req:req()) -> cb_context:context().
 host_url(Context, Req) ->

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -25,6 +25,7 @@
         ,get_auth_token/2
         ,get_pretty_print/2
         ,get_content_type/1
+        ,get_query_string_data/1
         ,is_authentic/2, is_early_authentic/2
         ,is_permitted/2
         ,is_known_content_type/2
@@ -57,6 +58,7 @@
 
         ,encode_start_key/1, decode_start_key/1
         ,normalize_envelope_keys/1
+        ,set_request_data_in_context/4
 
         ,exec_req/2
         ,get_request_body/1

--- a/applications/crossbar/src/api_util.erl
+++ b/applications/crossbar/src/api_util.erl
@@ -56,6 +56,7 @@
         ,create_event_name/2
 
         ,encode_start_key/1, decode_start_key/1
+        ,normalize_envelope_keys/1
 
         ,exec_req/2
         ,get_request_body/1

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -75,6 +75,7 @@
         ,resp_status/1, set_resp_status/2
         ,start/1, set_start/2
         ,user_id/1, set_user_id/2
+        ,websocket_flag/1, set_websocket_flag/2
 
         ,pretty_print/1
         ,path_tokens/1
@@ -1207,3 +1208,10 @@ system_error(Context, Error) ->
                ]),
     _ = kz_amqp_worker:cast(Notify, fun kapi_notifications:publish_system_alert/1),
     add_system_error(Error, Context).
+
+-spec websocket_flag(context()) -> boolean().
+websocket_flag(#cb_context{websocket_flag = Value}) -> Value.
+
+-spec set_websocket_flag(context(), boolean()) -> context().
+set_websocket_flag(#cb_context{}=Context, Value) ->
+    Context#cb_context{websocket_flag = Value}.

--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -198,6 +198,7 @@
                     ,is_superduper_admin = 'undefined' :: kz_term:api_boolean()
                     ,is_account_admin = 'undefined' :: kz_term:api_boolean()
                     ,master_account_id = 'undefined' :: kz_term:api_ne_binary()
+                    ,websocket_flag = 'false' :: boolean()
                     }).
 
 -define(MAX_RANGE, kapps_config:get_pos_integer(?CONFIG_CAT

--- a/applications/crossbar/src/crossbar_websocket.erl
+++ b/applications/crossbar/src/crossbar_websocket.erl
@@ -1,0 +1,24 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2020, 2600Hz
+%%% @doc
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(crossbar_websocket).
+
+-export([recv/2
+        ]).
+
+-type cb_ws_return() :: {cowboy_websocket:commands(), cb_context:context(), 'hibernate'}.
+
+-spec recv(cow_ws:frame(), cb_context:context()) -> cb_ws_return().
+recv({'text', _Data}, State) ->
+    {[{text, <<"{\"data\":\"responce\"}">>}], State, 'hibernate'};
+recv('ping', State) ->
+    {[], State, 'hibernate'};
+recv( Other, State) ->
+    lager:debug("not handling message : ~p", [Other]),
+    {[], State, 'hibernate'}.

--- a/applications/crossbar/src/crossbar_websocket.erl
+++ b/applications/crossbar/src/crossbar_websocket.erl
@@ -10,15 +10,137 @@
 -module(crossbar_websocket).
 
 -export([recv/2
+        ,info/2
         ]).
 
 -type cb_ws_return() :: {cowboy_websocket:commands(), cb_context:context(), 'hibernate'}.
 
 -spec recv(cow_ws:frame(), cb_context:context()) -> cb_ws_return().
-recv({'text', _Data}, State) ->
-    {[{text, <<"{\"data\":\"responce\"}">>}], State, 'hibernate'};
+recv({'text', Data}, State) ->
+    lager:info("received request from client IP: ~s", [cb_context:client_ip(State)]),
+    maybe_json(Data, State);
 recv('ping', State) ->
     {[], State, 'hibernate'};
 recv( Other, State) ->
     lager:debug("not handling message : ~p", [Other]),
     {[], State, 'hibernate'}.
+
+-spec info(any(), cb_context:context()) -> cb_ws_return().
+info({{_SenderPid, StreamId}, {'response', _HttpCode, #{<<"content-type">> := <<"application/json">>} = RespHeaders, Data}}, State) ->
+    lager:info("received responce for request: ~s", [StreamId]),
+    DataJObj = kz_json:decode(Data),
+    HeadersJObj = response_headers(RespHeaders),
+    Response = kz_json:merge_recursive(DataJObj,HeadersJObj),
+    Text = kz_json:encode(Response),
+    {[{'text', Text}], State, 'hibernate'};
+info(Info, State) ->
+    lager:info("unhandled websocket info: ~p", [Info]),
+    {[], State, 'hibernate'}.
+
+-spec maybe_json(iodata(), cb_context:context()) -> cb_ws_return().
+maybe_json(Data, State) ->
+    case decode_json_body(Data) of
+        {'error', Msg} ->
+            Req = fake_req(kz_json:new()),
+            Context0 = api_resource:context_init(Req, []),
+            Context1 = cb_context:set_resp_error_code(Context0, 400),
+            Context2 = cb_context:add_validation_error(<<"json">>
+                                                      ,<<"invalid">>
+                                                      ,kz_json:from_list(
+                                                         [{<<"message">>, Msg}
+                                                         ,{<<"target">>, <<"body">>}
+                                                         ]
+                                                        )
+                                                      , Context1
+                                                      ),
+            %% We stop processing here. Responce we receive via websocket_info callback and then send to client
+            {'stop', _ , _} = api_util:stop(Req, Context2),
+            {[], State, 'hibernate'};
+        {'ok', _JObj} ->
+            {[{text, <<"{\"data\":\"responce\"}">>}], State, 'hibernate'}
+    end.
+
+-spec decode_json_body(kz_term:ne_binary()) -> {'ok', kz_json:object()} | {'error', kz_term:ne_binary()}.
+decode_json_body(Data) ->
+    try kz_json:unsafe_decode(Data) of
+        JObj ->
+            lager:debug("request has a json payload: ~s", [Data]),
+            {'ok', api_util:normalize_envelope_keys(JObj)}
+    catch
+        'throw':{'invalid_json',{'error',{ErrLine, ErrMsg}}, _JSON} ->
+            lager:debug("failed to decode json near ~p: ~s", [ErrLine, ErrMsg]),
+            {'error', <<(kz_term:to_binary(ErrMsg))/binary, " around ", (kz_term:to_binary(ErrLine))/binary>>};
+        _E:_R ->
+            lager:debug("unknown catch from json decode ~p : ~p", [_E, _R]),
+            throw(_R)
+    end.
+
+
+-spec fake_req(kz_json:object()) -> cowboy_req:req().
+fake_req(JObj) ->
+    Props = [{<<"content-type">>, <<"application/json">>}
+            ,{<<"x-auth-token">>, kz_json:get_first_defined([<<"x-auth-token">>, <<"auth_token">>], JObj)}
+            ],
+    Headers = kz_json:to_map(kz_json:from_list(Props)),
+    RawPath = kz_json:get_ne_binary_value(<<"path">>, JObj, <<"/v2">>),
+    {Path, Qs} = split_path_qs(RawPath),
+
+    RespHeaders = #{<<"content-type">> => <<"application/json">>},
+    %% Generating fake cowboy request according cowboy_req:req() type (Cowboy 2.6.3 commit d846827b2a70317914621328bd617e4e5d4d13d8)
+    %% only mandatory keys
+    #{
+       %% Public interface.
+       method => kz_json:get_ne_binary_value(<<"method">>, JObj, <<"GET">>)
+     ,version => 'HTTP/1.0'
+     ,scheme => <<"https">> %% most of websocket connection over https
+     ,host => <<"localhost">>
+     ,port => 443
+     ,path => Path
+     ,qs => Qs
+     ,headers => Headers
+     ,peer => {{127,0,0,1}, 443}
+     ,sock => {{127,0,0,1}, 443}
+     ,cert => 'undefined'
+
+       %% Private interface.
+     ,ref => 'undefined'
+     ,pid => self()
+     ,streamid => get_request_id(JObj)
+
+     ,has_body => 'true'
+     ,body_length => 'undefined'
+       %% we set application/json content-type by default, if response return other, then headers will be set by crossbar module
+     ,resp_headers => RespHeaders
+     }.
+
+-spec split_path_qs(kz_term:ne_binary()) -> {kz_term:ne_binary(), kz_term:ne_binary()}.
+split_path_qs(RawPath) ->
+    case binary:split(RawPath, <<"?">>) of
+        [Path] -> {Path, <<>>};
+        [Path, Qs] -> {Path, Qs}
+    end.
+
+-spec get_request_id(kz_json:object()) -> kz_term:ne_binary().
+get_request_id(JObj) ->
+    ReqId = kz_json:get_ne_binary_value(<<"x-request-id">>, JObj, kz_datamgr:get_uuid()),
+    kz_log:put_callid(ReqId),
+    ReqId.
+
+-spec response_headers(map()) -> kz_term:object().
+response_headers(#{<<"access-control-expose-headers">> := KeysBinary} = Headers) ->
+    Keys = binary:split(KeysBinary, <<",">>),
+    response_headers(Keys, Headers, []);
+response_headers(_) ->
+    kz_json:new().
+
+-spec response_headers(kz_term:ne_binaries(), map(), kz_term:proplist()) -> kz_term:object().
+response_headers([Key|Rest], #{} = Headers, Acc) ->
+    case maps:is_key(Key, Headers) of
+        'false' -> response_headers(Rest, Headers, Acc);
+        'true' ->
+            Value = maps:get(Key, Headers),
+            Property = {Key, Value},
+            response_headers(Rest, Headers, [Property | Acc])
+    end;
+response_headers([], #{}, Acc) ->
+    kz_json:from_list(Acc).


### PR DESCRIPTION
My goal - add websocket support into crossbar.
Then I will be able use `crossbar_websocket` from `blackhole` application.
This will give ability manage channels (example `drop`) and stream (receive) call events via single websocket connection.

You can also look [related forum thread](https://forums.2600hz.com/forums/topic/10892-crossbar-json-api-over-web-socket/#comment-59097).
PR created as draft because need implement handler for case when user requested media other then JSON (example attachment).

PR created for review commit by commit.