### PR TITLE
more crossbar bindings

### DIFF
--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -311,7 +311,7 @@ is_account_admin(AuthAccountId, AuthUserId) ->
             'false'
     end.
 
--spec auth_token_type(context()) -> 'x-auth-token' | 'basic' | 'oauth' | 'unknown'.
+-spec auth_token_type(context()) -> 'x-auth-token' | 'basic' | 'bearer' | 'unknown'.
 auth_token_type(#cb_context{auth_token_type=AuthTokenType}) -> AuthTokenType.
 
 -spec auth_token(context()) -> kz_term:api_ne_binary().
@@ -555,7 +555,7 @@ set_device_id(#cb_context{}=Context, DeviceId) ->
 set_reseller_id(#cb_context{}=Context, AcctId) ->
     Context#cb_context{reseller_id=AcctId}.
 
--spec set_auth_token_type(context(), 'x-auth-token' | 'basic' | 'oauth' | 'unknown') -> context().
+-spec set_auth_token_type(context(), 'x-auth-token' | 'basic' | 'bearer' | 'unknown') -> context().
 set_auth_token_type(#cb_context{}=Context, AuthTokenType) ->
     Context#cb_context{auth_token_type=AuthTokenType}.
 

--- a/applications/crossbar/src/crossbar.hrl
+++ b/applications/crossbar/src/crossbar.hrl
@@ -36,6 +36,8 @@
 
 -define(CB_ACCOUNT_TOKEN_RESTRICTIONS, <<"token_restrictions">>).
 
+-define(DEFAULT_ACCEPT_HEADER, [{{<<"*">>, <<"*">>, []}, 1000, []}]).
+
 -define(CONTENT_PROVIDED, [{'to_json', ?JSON_CONTENT_TYPES}
                           ,{'to_csv', ?CSV_CONTENT_TYPES}
                           ]).
@@ -51,7 +53,6 @@
                          ,?HTTP_PATCH
                          ,?HTTP_OPTIONS
                          ]).
-
 -define(QUICKCALL_PATH_TOKEN, <<"quickcall">>).
 -define(DEVICES_QCALL_NOUNS(DeviceId, Number)
        ,[{<<"quickcall">>, [Number]}
@@ -151,7 +152,7 @@
                     ,charsets_provided = [<<"iso-8859-1">>] :: kz_term:ne_binaries() %% all charsets provided
                     ,encodings_provided = [<<"gzip;q=1.0">>,<<"identity;q=0.5">>] :: kz_term:ne_binaries() %% gzip and identity
                     ,auth_token = 'undefined' :: kz_term:api_ne_binary()
-                    ,auth_token_type = 'x-auth-token' :: 'x-auth-token' | 'basic' | 'oauth' | 'unknown'
+                    ,auth_token_type = 'x-auth-token' :: 'x-auth-token' | 'basic' | 'bearer' | 'unknown'
                     ,auth_account_id :: kz_term:api_ne_binary()
                     ,auth_doc :: kz_term:api_object()
                     ,req_verb = ?HTTP_GET :: http_method() % see ?ALLOWED_METHODS

--- a/applications/crossbar/src/crossbar_doc.erl
+++ b/applications/crossbar/src/crossbar_doc.erl
@@ -1226,9 +1226,9 @@ add_pvt_auth(_JObj, Updates, Context) ->
 add_pvt_alphanum_name(JObj, Updates, Context) ->
     add_pvt_alphanum_name(JObj, Updates, Context, kz_json:get_value(<<"name">>, JObj), kz_doc:type(JObj)).
 
--spec add_pvt_alphanum_name(kz_json:object(), kz_json:json_proplist(), cb_context:context(), kz_term:api_binary(), kz_term:ne_binary()) ->
+-spec add_pvt_alphanum_name(kz_json:object(), kz_json:json_proplist(), cb_context:context(), kz_term:api_binary(), kz_term:api_ne_binary()) ->
           kz_json:json_proplist().
-add_pvt_alphanum_name(JObj, Updates, _Context, 'undefined', <<"user">>) ->
+add_pvt_alphanum_name(JObj, Updates, Context, 'undefined', <<"user">>) ->
     Name = case {kz_json:get_ne_binary_value(<<"first_name">>, JObj)
                 ,kz_json:get_ne_binary_value(<<"last_name">>, JObj)
                 }
@@ -1238,15 +1238,16 @@ add_pvt_alphanum_name(JObj, Updates, _Context, 'undefined', <<"user">>) ->
                {FirstName, 'undefined'} -> FirstName;
                {FirstName, LastName} -> <<FirstName/binary, LastName/binary>>
            end,
+    add_pvt_alphanum_name(JObj, Updates, Context, Name, 'undefined');
+add_pvt_alphanum_name(_JObj, Updates, _Context, 'undefined', _Type) ->
+    Updates;
+add_pvt_alphanum_name(_JObj, Updates, _Context, Name, _Type)
+  when is_binary(Name) ->
     [{<<"pvt_alphanum_name">>, cb_modules_util:normalize_alphanum_name(Name)}
      | Updates
     ];
-add_pvt_alphanum_name(_JObj, Updates, _Context, 'undefined', _Type) ->
-    Updates;
-add_pvt_alphanum_name(_JObj, Updates, _Context, Name, _Type) ->
-    [{<<"pvt_alphanum_name">>, cb_modules_util:normalize_alphanum_name(Name)}
-     | Updates
-    ].
+add_pvt_alphanum_name(_JObj, Updates, _Context, _Name, _Type) ->
+    Updates.
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/applications/crossbar/src/crossbar_types.hrl
+++ b/applications/crossbar/src/crossbar_types.hrl
@@ -67,6 +67,7 @@
 -type couch_schema() :: [{couch_doc_path(), validator_rules()}].
 
 -type cb_cowboy_payload() :: {cowboy_req:req(), cb_context:context()}.
+-type cb_cowboy_req_data() :: {cowboy_req:req(), cb_context:context(), cowboy_content_type(), kz_json:object()}.
 
 -define(CSV_CONTENT_TYPES, [{<<"application">>, <<"octet-stream">>, '*'}
                            ,{<<"text">>, <<"csv">>, '*'}

--- a/applications/crossbar/src/modules/cb_token_auth.erl
+++ b/applications/crossbar/src/modules/cb_token_auth.erl
@@ -155,6 +155,8 @@ early_authenticate(Context) ->
           {'true', cb_context:context()}.
 early_authenticate(Context, 'x-auth-token') ->
     early_authenticate_token(Context, cb_context:auth_token(Context));
+early_authenticate(Context, 'bearer') ->
+    early_authenticate_token(Context, kz_auth_bearer:fetch(cb_context:auth_token(Context)));
 early_authenticate(_Context, _TokenType) -> 'false'.
 
 -spec early_authenticate_token(cb_context:context(), kz_term:api_binary()) ->
@@ -162,7 +164,7 @@ early_authenticate(_Context, _TokenType) -> 'false'.
           {'true', cb_context:context()}.
 early_authenticate_token(Context, AuthToken) when is_binary(AuthToken) ->
     validate_auth_token(Context, AuthToken);
-early_authenticate_token(_Context, 'undefined') -> 'true'.
+early_authenticate_token(_Context, 'undefined') -> 'false'.
 
 -spec check_auth_token(cb_context:context(), kz_term:api_binary(), boolean()) ->
           boolean() |

--- a/applications/crossbar/src/modules/cb_users.erl
+++ b/applications/crossbar/src/modules/cb_users.erl
@@ -522,12 +522,14 @@ updates_if_validation_passed(UserId, Context) ->
 -spec normalize_username(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
 normalize_username(_UserId, Context) ->
     JObj = cb_context:req_data(Context),
+    Normalize = cb_context:fetch(Context, 'normalize_username', true),
     case kzd_users:username(JObj) of
         'undefined' -> Context;
-        Username ->
+        Username when Normalize ->
             NormalizedUsername = kz_term:to_lower_binary(Username),
             lager:debug("normalized '~s' to '~s'", [Username, NormalizedUsername]),
-            cb_context:set_req_data(Context, kzd_users:set_username(JObj, NormalizedUsername))
+            cb_context:set_req_data(Context, kzd_users:set_username(JObj, NormalizedUsername));
+        _ -> Context
     end.
 
 %%------------------------------------------------------------------------------

--- a/core/kazoo_auth/src/kz_auth_bearer.erl
+++ b/core/kazoo_auth/src/kz_auth_bearer.erl
@@ -1,0 +1,48 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2012-2020, 2600Hz
+%%% @doc
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kz_auth_bearer).
+
+%%==============================================================================
+%% API functions
+%%==============================================================================
+
+-export([create/1
+        ,fetch/1
+        ]).
+
+-include("kazoo_auth.hrl").
+
+-spec create(kz_term:proplist()) ->
+          {'ok', kz_term:ne_binary()} |
+          {'error', 'algorithm_not_supported'} |
+          kz_datamgr:data_error().
+create(Claims) ->
+    case kz_auth:create_token(Claims) of
+        {'ok', Token} -> save_token(Token);
+        Else -> Else
+    end.
+
+-spec fetch(kz_term:ne_binary()) -> kz_term:api_ne_binary().
+fetch(Bearer) ->
+    case kz_datamgr:open_cache_doc(?KZ_AUTH_DB, Bearer) of
+        {'ok', JObj} -> kz_json:get_ne_binary_value(<<"Token">>, JObj);
+        Else -> Else
+    end.
+
+-spec save_token(binary()) ->
+          {'ok', kz_term:ne_binary()} |
+          kz_datamgr:data_error().
+save_token(Token) ->
+    JObj = kz_json:from_list([{<<"Token">>, Token}]),
+    Doc = kz_doc:update_pvt_parameters(JObj, ?KZ_AUTH_DB, [{'type', <<"bearer-token">>}]),
+    case kz_datamgr:save_doc(?KZ_AUTH_DB, Doc) of
+        {'ok', Created} -> {'ok', kz_doc:id(Created)};
+        Else -> Else
+    end.

--- a/core/kazoo_auth/src/kz_auth_keys.erl
+++ b/core/kazoo_auth/src/kz_auth_keys.erl
@@ -11,7 +11,7 @@
 
 -export([get_public_key_from_cert/1]).
 -export([get_public_key_from_private_key/1]).
--export([gen_private_key/0]).
+-export([gen_private_key/0, gen_private_key/1]).
 -export([get_public_key/2]).
 -export([get_private_key_from_file/1]).
 -export([from_pem/1, to_pem/1]).
@@ -373,7 +373,11 @@ save_private_key(JObj, Key) ->
 
 -spec gen_private_key() -> {'ok', public_key:rsa_private_key()}.
 gen_private_key() ->
-    Key = public_key:generate_key({'rsa', ?RSA_KEY_SIZE, ?RSA_KEY_SIZE + 1}),
+    gen_private_key(?RSA_KEY_SIZE).
+
+-spec gen_private_key(integer()) -> {'ok', public_key:rsa_private_key()}.
+gen_private_key(Size) ->
+    Key = public_key:generate_key({'rsa', Size, Size + 1}),
     {'ok', Key}.
 
 %% @equiv reset_private_key(kz_auth_apps:get_auth_app(<<"kazoo">>))

--- a/core/kazoo_stdlib/include/kazoo_json.hrl
+++ b/core/kazoo_stdlib/include/kazoo_json.hrl
@@ -42,7 +42,7 @@
 -type keys() :: [key(),...].
 
 %% Denotes a flatten version of JSON proplist, `[{full_path, value}]'.
--type flat_proplist() :: [{keys(), flat_json_term()},...].
+-type flat_proplist() :: [{keys(), flat_json_term()}].
 
 %% Denotes array in JSON.
 -type json_array() :: json_terms() | [].


### PR DESCRIPTION

- Kazoo Bearer Tokens

* Sometimes JWT Tokens can be excessive in size.
  for long running integrations, we need to provide
  Bearer Tokens that can be scoped and invalidated
  at any time.

* this is not a replacement for user auth

- Crossbar Bindings

* modules should be allowed to fetch
  the request data to avoid normalizing
  the payload.

- Other minor fixes

