### PR TITLE
PISTON-1091:Fixed kzs_publish bug where if a document with the same id is recreated kzs_publish should send a doc_created event and not doc_edited event

### DIFF
--- a/core/kazoo_data/src/kzs_doc.erl
+++ b/core/kazoo_data/src/kzs_doc.erl
@@ -239,10 +239,13 @@ prepare_doc_for_del(Server, DbName, Doc) ->
       ]).
 
 %%------------------------------------------------------------------------------
-%% @doc Prepare doc for save and generate a doc smaller doc for a publish event
-%% Returns {PreparedDoc, PublishDoc} where
-%% PreparedDoc is a JObj containing all the necessary key values / correct format for the save or delete operation
-%% PublishDoc is the JObj supplied with a possible changed id value
+%% @doc Prepare / convert a doc for save or delete.
+%% If the doc has the key `id' set,it will be deleted and a new `id' will be
+%% generated.
+%% @returns {PreparedDoc, PublishDoc} where:
+%% PreparedDoc is a JObj containing all the necessary key values and in the
+%% correct format for the save or delete operation.
+%% PublishDoc is the JObj supplied with a possible changed id value.
 %% @end
 %%------------------------------------------------------------------------------
 -spec prepare_doc_for_save(kz_term:ne_binary(), kz_json:object()) -> {kz_json:object(), kz_json:object()}.

--- a/core/kazoo_data/src/kzs_doc.erl
+++ b/core/kazoo_data/src/kzs_doc.erl
@@ -245,7 +245,7 @@ prepare_doc_for_del(Server, DbName, Doc) ->
 %% @returns {PreparedDoc, PublishDoc} where:
 %% PreparedDoc is a JObj containing all the necessary key values and in the
 %% correct format for the save or delete operation.
-%% PublishDoc is the JObj supplied with a possible changed id value.
+%% PublishDoc is a JObj containing a defined set of key value pairs (?PUBLISH_FIELDS + doc rev).
 %% @end
 %%------------------------------------------------------------------------------
 -spec prepare_doc_for_save(kz_term:ne_binary(), kz_json:object()) -> {kz_json:object(), kz_json:object()}.
@@ -262,7 +262,11 @@ prepare_doc_for_save(Db, JObj, 'false') ->
 
 -spec prepare_publish(kz_json:object()) -> {kz_json:object(), kz_json:object()}.
 prepare_publish(JObj) ->
-    {maybe_tombstone(JObj), JObj}.
+    PublishDoc = kz_json:from_list(
+                   [{<<"_rev">>, kz_doc:revision(JObj)}
+                    | kzs_publish:publish_fields(JObj)
+                   ]),
+    {maybe_tombstone(JObj), PublishDoc}.
 
 -spec maybe_tombstone(kz_json:object()) -> kz_json:object().
 maybe_tombstone(JObj) ->

--- a/core/kazoo_data/src/kzs_publish.erl
+++ b/core/kazoo_data/src/kzs_publish.erl
@@ -86,10 +86,11 @@ should_publish_db_changes(DbName) ->
 
 %%------------------------------------------------------------------------------
 %% @doc Publish doc event to amqp
-%% PreDbDoc - The doc before the database save or delete operation (Pre db operation)
-%% PostDbDoc - The doc returned from the database save or delete operation (Post db operation)
-%% The document event (deleted vs created vs edited) is labeled as 'deleted' if the deleted flag is set in 'PreDbDoc', 'created'
-%% if 'PreDbDoc' has no rev set and 'edited' if 'PreDbDoc' has a revision
+%% PreDbDoc - The doc before the database save or delete operation (Pre db operation).
+%% PostDbDoc - The doc returned from the database save or delete operation (Post db operation).
+%% The document event (deleted vs created vs edited) is labeled as 'deleted' if
+%% the deleted flag is set in 'PreDbDoc', 'created'.
+%% if 'PreDbDoc' has no rev set and 'edited' if 'PreDbDoc' has a revision.
 %% @end
 %%------------------------------------------------------------------------------
 -spec publish_doc(kz_term:ne_binary(), kz_json:object(), kz_json:object()) -> 'ok'.
@@ -127,8 +128,8 @@ do_publish_db('true', DbName, Action) ->
 -endif.
 
 %%------------------------------------------------------------------------------
-%% @doc Return a predefined list of Key-Values from a Doc
-%% Keys are defined by ?PUBLISH_FIELDS
+%% @doc Return a predefined list of Key-Values from a doc.
+%% Keys are defined by `?PUBLISH_FIELDS'.
 %% @end
 %%------------------------------------------------------------------------------
 -spec publish_fields(kz_json:object()) -> kz_term:proplist().
@@ -139,9 +140,9 @@ publish_fields(Doc) ->
     ].
 
 %%------------------------------------------------------------------------------
-%% @doc Set select values defined by publish_fields/1 from PreDbDoc on PostDbDoc
-%% PreDbDoc - The doc before the database save or delete operation (Pre db operation)
-%% PostDbDoc - The doc returned from the database save or delete operation (Post db operation)
+%% @doc Set select values defined by publish_fields/1 from PreDbDoc on PostDbDoc.
+%% PreDbDoc - The doc before the database save or delete operation (Pre db operation).
+%% PostDbDoc - The doc returned from the database save or delete operation (Post db operation).
 %% @end
 %%------------------------------------------------------------------------------
 -spec publish_fields(kz_json:object(), kz_json:object()) -> kz_json:object().

--- a/core/kazoo_data/src/kzs_publish.erl
+++ b/core/kazoo_data/src/kzs_publish.erl
@@ -25,19 +25,19 @@
 -ifdef(TEST).
 maybe_publish_docs(_, _, _) -> 'ok'.
 -else.
-maybe_publish_docs(Db, Docs, JObjs) ->
+maybe_publish_docs(Db, PreDbDocs, PostDbDocs) ->
     _ = kz_datamgr:change_notice()
         andalso should_publish_db_changes(Db)
-        andalso publish_docs(Db, Docs, JObjs),
-    kzs_cache:flush_cache_docs(Db, JObjs).
+        andalso publish_docs(Db, PreDbDocs, PostDbDocs),
+    kzs_cache:flush_cache_docs(Db, PostDbDocs).
 
 -spec publish_docs(kz_term:ne_binary(), kz_json:objects(), kz_json:objects()) -> 'ok'.
-publish_docs(Db, Docs, JObjs) ->
+publish_docs(Db, PreDbDocs, PostDbDocs) ->
     _ = kz_process:spawn(
           fun() ->
-                  [publish_doc(Db, Doc, JObj)
-                   || {Doc, JObj} <- lists:zip(Docs, JObjs),
-                      should_publish_doc(Doc)
+                  [publish_doc(Db, PreDbDoc, PostDbDoc)
+                   || {PreDbDoc, PostDbDoc} <- lists:zip(PreDbDocs, PostDbDocs),
+                      should_publish_doc(PreDbDoc)
                   ]
           end),
     'ok'.
@@ -47,11 +47,11 @@ publish_docs(Db, Docs, JObjs) ->
 -ifdef(TEST).
 maybe_publish_doc(_, _, _) -> 'ok'.
 -else.
-maybe_publish_doc(Db, Doc, JObj) ->
+maybe_publish_doc(Db, PreDbDoc, PostDbDoc) ->
     _PidOrNot = kz_datamgr:change_notice()
         andalso should_publish_db_changes(Db)
-        andalso should_publish_doc(Doc)
-        andalso kz_process:spawn(fun publish_doc/3, [Db, Doc, JObj]),
+        andalso should_publish_doc(PreDbDoc)
+        andalso kz_process:spawn(fun publish_doc/3, [Db, PreDbDoc, PostDbDoc]),
     lager:debug("maybe publishing db/doc change: ~p", [_PidOrNot]).
 -endif.
 
@@ -84,18 +84,28 @@ should_publish_db_changes(DbName) ->
     kazoo_data_config:get_is_true(Key, 'true').
 -endif.
 
+%%------------------------------------------------------------------------------
+%% @doc Publish doc event to amqp
+%% PreDbDoc - The doc before the database save or delete operation (Pre db operation)
+%% PostDbDoc - The doc returned from the database save or delete operation (Post db operation)
+%% The document event (deleted vs created vs edited) is labeled as 'deleted' if the deleted flag is set in 'PreDbDoc', 'created'
+%% if 'PreDbDoc' has no rev set and 'edited' if 'PreDbDoc' has a revision
+%% @end
+%%------------------------------------------------------------------------------
 -spec publish_doc(kz_term:ne_binary(), kz_json:object(), kz_json:object()) -> 'ok'.
-publish_doc(DbName, Doc, JObj) ->
-    case kz_doc:is_soft_deleted(Doc)
-        orelse kz_doc:is_deleted(Doc)
-        orelse kz_doc:revision(JObj)
+publish_doc(DbName, PreDbDoc, PostDbDoc) ->
+    case kz_doc:is_soft_deleted(PreDbDoc)
+        orelse kz_doc:is_deleted(PreDbDoc)
+        orelse kz_doc:revision(PreDbDoc)
     of
         'true' ->
-            publish('deleted', kz_term:to_binary(DbName), publish_fields(Doc, JObj));
-        <<"1-", _/binary>> ->
-            publish('created', kz_term:to_binary(DbName), publish_fields(Doc, JObj));
-        _Else ->
-            publish('edited', kz_term:to_binary(DbName), publish_fields(Doc, JObj))
+            publish('deleted', kz_term:to_binary(DbName), publish_fields(PreDbDoc, PostDbDoc));
+        'undefined' ->
+            %% PreDbDoc rev is not set so its a create action
+            publish('created', kz_term:to_binary(DbName), publish_fields(PreDbDoc, PostDbDoc));
+        _RevIsSet ->
+            %% PreDbDoc rev is set so its a update / edited action
+            publish('edited', kz_term:to_binary(DbName), publish_fields(PreDbDoc, PostDbDoc))
     end.
 
 -ifndef(TEST).
@@ -116,6 +126,11 @@ do_publish_db('true', DbName, Action) ->
     kz_amqp_worker:cast(Props, Fun).
 -endif.
 
+%%------------------------------------------------------------------------------
+%% @doc Return a predefined list of Key-Values from a Doc
+%% Keys are defined by ?PUBLISH_FIELDS
+%% @end
+%%------------------------------------------------------------------------------
 -spec publish_fields(kz_json:object()) -> kz_term:proplist().
 publish_fields(Doc) ->
     [{Key, V} ||
@@ -123,9 +138,15 @@ publish_fields(Doc) ->
         kz_term:is_not_empty(V = kz_json:get_value(Key, Doc))
     ].
 
+%%------------------------------------------------------------------------------
+%% @doc Set select values defined by publish_fields/1 from PreDbDoc on PostDbDoc
+%% PreDbDoc - The doc before the database save or delete operation (Pre db operation)
+%% PostDbDoc - The doc returned from the database save or delete operation (Post db operation)
+%% @end
+%%------------------------------------------------------------------------------
 -spec publish_fields(kz_json:object(), kz_json:object()) -> kz_json:object().
-publish_fields(Doc, JObj) ->
-    kz_json:set_values(publish_fields(Doc), JObj).
+publish_fields(PreDbDoc, PostDbDoc) ->
+    kz_json:set_values(publish_fields(PreDbDoc), PostDbDoc).
 
 -spec publish(kapi_conf:action(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
 publish(Action, Db, Doc) ->


### PR DESCRIPTION
There is a bug in kzs_publish that assumes when a doc is created it will all ways have a rev of 1. 

This is not the case if a doc is created and then deleted and then recreated with the same id. The rev will be set to 3-xxx and in this case and publish a doc_edited event as apposed to a doc_created event that should be published. This happens in the case of kazoo_storage, The doc is all ways created with the id set to the account id.

I have changed the logic to now match:
If the doc is marked for deletion then its a delete event
If the doc before being saved has no rev set then its a created event
If the doc before being saved has a rev set then its a edited event

I think this logic will catch every case unless there is any you any think of? 

I have removed the call to kzs_publish:publish_fields/1 in kzs_doc for 2 reasons, It seems uanessacry and i need to keep the rev (if its set) of the original doc before the db operation to calculate the event type in kzs_publish.

There is also some changes to variable names and added some comments to help others better understand in the future