### PR TITLE
PISTON-1021: enabled toggle for pusher apps

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -35777,6 +35777,11 @@
                             "description": "PEM-encoded key and certificate",
                             "type": "string"
                         },
+                        "enabled": {
+                            "default": true,
+                            "description": "Whether the app is enabled for push notifications",
+                            "type": "boolean"
+                        },
                         "headers": {
                             "default": {},
                             "description": "pusher apple headers",
@@ -35797,6 +35802,11 @@
                         "api_key": {
                             "description": "API Key for firebase",
                             "type": "string"
+                        },
+                        "enabled": {
+                            "default": true,
+                            "description": "Whether the app is enabled for push notifications",
+                            "type": "boolean"
                         },
                         "headers": {
                             "default": {},

--- a/applications/crossbar/priv/couchdb/schemas/system_config.pusher.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.pusher.json
@@ -20,6 +20,11 @@
                     "description": "PEM-encoded key and certificate",
                     "type": "string"
                 },
+                "enabled": {
+                    "default": true,
+                    "description": "Whether the app is enabled for push notifications",
+                    "type": "boolean"
+                },
                 "headers": {
                     "default": {},
                     "description": "pusher apple headers",
@@ -40,6 +45,11 @@
                 "api_key": {
                     "description": "API Key for firebase",
                     "type": "string"
+                },
+                "enabled": {
+                    "default": true,
+                    "description": "Whether the app is enabled for push notifications",
+                    "type": "boolean"
                 },
                 "headers": {
                     "default": {},

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -12804,6 +12804,10 @@
         'certificate':
           'description': PEM-encoded key and certificate
           'type': string
+        'enabled':
+          'default': true
+          'description': Whether the app is enabled for push notifications
+          'type': boolean
         'headers':
           'default': {}
           'description': pusher apple headers
@@ -12820,6 +12824,10 @@
         'api_key':
           'description': API Key for firebase
           'type': string
+        'enabled':
+          'default': true
+          'description': Whether the app is enabled for push notifications
+          'type': boolean
         'headers':
           'default': {}
           'description': pusher firebase headers


### PR DESCRIPTION
Simple flag to enable/disable push notifications for an app as a whole, without having to remove/lose app configuration including token/cert/private key