### PR TITLE
[4.3] KZ00-41: handle number delete conflicts

### DIFF
--- a/core/kazoo_data/src/kzs_doc.erl
+++ b/core/kazoo_data/src/kzs_doc.erl
@@ -202,7 +202,7 @@ prepare_publish(JObj) ->
 
 -spec maybe_tombstone(kz_json:object()) -> kz_json:object().
 maybe_tombstone(JObj) ->
-    maybe_tombstone(JObj, kz_json:is_true(<<"_deleted">>, JObj, 'false')).
+    maybe_tombstone(JObj, kz_doc:is_deleted(JObj)).
 
 -spec maybe_tombstone(kz_json:object(), boolean()) -> kz_json:object().
 maybe_tombstone(JObj, 'true') ->

--- a/core/kazoo_number_manager/src/knm_locality.erl
+++ b/core/kazoo_number_manager/src/knm_locality.erl
@@ -20,7 +20,7 @@
 fetch(Numbers) when is_list(Numbers)->
     case knm_config:locality_url() of
         'undefined' ->
-            lager:error("could not get number locality url"),
+            ?LOG_WARNING("could not get number locality url"),
             {'error', 'missing_url'};
         Url ->
             Resp = fetch_req(Numbers, Url),

--- a/core/kazoo_number_manager/test/knm_create_new_number_tests.erl
+++ b/core/kazoo_number_manager/test/knm_create_new_number_tests.erl
@@ -18,8 +18,10 @@ create_new_number_test_() ->
              }
             ],
     {'ok', N} = knm_number:create(?TEST_CREATE_NUM, Props),
+
     JObj = knm_number:to_public_json(N),
     PN = knm_number:phone_number(N),
+
     [?_assert(knm_phone_number:is_dirty(PN))
     ,{"Verify phone number is assigned to reseller account"
      ,?_assertEqual(?RESELLER_ACCOUNT_ID, knm_phone_number:assigned_to(PN))
@@ -40,10 +42,10 @@ create_new_number_test_() ->
      ,?_assertEqual(?CARRIER_LOCAL, knm_phone_number:module_name(PN))
      }
     ,{"Verify getting created field returns a number"
-     ,?_assertEqual(true, is_integer(knm_phone_number:created(PN)))
+     ,?_assert(is_integer(knm_phone_number:created(PN)))
      }
     ,{"Verify the created field is stored as a number"
-     ,?_assertEqual(true, is_integer(kz_json:get_value([<<"_read_only">>, <<"created">>], JObj)))
+     ,?_assert(is_integer(kz_json:get_value([<<"_read_only">>, <<"created">>], JObj)))
      }
     ].
 

--- a/core/kazoo_proper/src/pqc_cb_accounts.erl
+++ b/core/kazoo_proper/src/pqc_cb_accounts.erl
@@ -186,7 +186,7 @@ seq_44832() ->
                  ,lists:seq(1, 4)
                  ),
 
-    cleanup(API),
+    _ = cleanup(API),
     ?INFO("finished double-POST check").
 
 -spec enable_and_delete_topup() -> 'ok'.
@@ -215,7 +215,7 @@ enable_and_delete_topup() ->
 
     'undefined' = kz_json:get_ne_value(<<"topup">>, kz_json:decode(Resp1)),
 
-    cleanup(API),
+    _ = cleanup(API),
     ?INFO("FINISHED ENABLE AND DISABLE TOPUP CHECKS").
 
 -spec cleanup(pqc_cb_api:state()) -> any().
@@ -236,4 +236,5 @@ topup_request(API, AccountId, RequestEnvelope) ->
 -spec cleanup() -> 'ok'.
 cleanup() ->
     API = pqc_cb_api:init_api(['crossbar'], ['cb_accounts']),
-    cleanup(API).
+    _ = cleanup(API),
+    'ok'.

--- a/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
+++ b/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
@@ -8,7 +8,8 @@
 -behaviour(proper_statem).
 
 %% Crossbar API test functions
--export([list_number/3
+-export([summary/2
+        ,list_number/3
         ,cleanup_numbers/2
         ,add_number/3
         ,activate_number/3
@@ -25,6 +26,10 @@
         ,correct_parallel/0
         ]).
 
+-export([seq/0
+        ,cleanup/0
+        ]).
+
 -include_lib("proper/include/proper.hrl").
 -include("kazoo_proper.hrl").
 
@@ -36,6 +41,13 @@ cleanup_numbers(_API, Numbers) ->
     _ = knm_numbers:delete(Numbers, [{'auth_by',  <<"system">>}]),
     'ok'.
 
+-spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+summary(API, AccountId) ->
+    URL = numbers_url(AccountId),
+    RequestHeaders = pqc_cb_api:request_headers(API),
+
+    pqc_cb_api:make_request([200], fun kz_http:get/2, URL, RequestHeaders).
+
 -spec list_number(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 list_number(_API, 'undefined', _Number) -> ?FAILED_RESPONSE;
 list_number(API, AccountId, Number) ->
@@ -44,12 +56,18 @@ list_number(API, AccountId, Number) ->
 
     pqc_cb_api:make_request([200, 404], fun kz_http:get/2, URL, RequestHeaders).
 
--spec add_number(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+-spec add_number(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary()) ->
+          pqc_cb_api:response().
 add_number(_API, 'undefined', _Number) -> ?FAILED_RESPONSE;
 add_number(API, AccountId, Number) ->
+    add_number(API, AccountId, Number, kz_json:new()).
+
+-spec add_number(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
+          pqc_cb_api:response().
+add_number(API, AccountId, Number, RequestData) ->
     URL = number_url(AccountId, Number),
     RequestHeaders = pqc_cb_api:request_headers(API),
-    RequestEnvelope  = pqc_cb_api:create_envelope(kz_json:new()
+    RequestEnvelope  = pqc_cb_api:create_envelope(RequestData
                                                  ,kz_json:from_list([{<<"accept_charges">>, 'true'}])
                                                  ),
     pqc_cb_api:make_request([201, 404, 409]
@@ -88,6 +106,12 @@ number_url(AccountId, Number) ->
     string:join([pqc_cb_accounts:account_url(AccountId)
                 ,"phone_numbers", kz_term:to_list(kz_http_util:urlencode(Number))
                 ]
+               ,"/"
+               ).
+
+-spec numbers_url(kz_term:ne_binary()) -> string().
+numbers_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "phone_numbers"]
                ,"/"
                ).
 
@@ -292,3 +316,71 @@ postcondition(Model
 
 -spec precondition(pqc_kazoo_model:model(), any()) -> boolean().
 precondition(_Model, _Call) -> 'true'.
+
+-spec seq() -> 'ok'.
+seq() ->
+    _ = init(),
+    seq_kzoo_41().
+
+seq_kzoo_41() ->
+    Model = initial_state(),
+    API = pqc_kazoo_model:api(Model),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+    lager:info("created account ~s", [AccountId]),
+
+    EmptySummaryResp = summary(API, AccountId),
+    lager:info("empty summary: ~s", [EmptySummaryResp]),
+    'true' = kz_json:is_empty(kz_json:get_json_value([<<"data">>, <<"numbers">>], kz_json:decode(EmptySummaryResp))),
+
+    PhoneNumber = hd(?PHONE_NUMBERS),
+
+    CreateResp = add_number(API, AccountId, PhoneNumber, kz_json:from_list([{<<"carrier_name">>, <<"knm_other">>}])),
+    lager:info("create resp ~p", [CreateResp]),
+    NumberDoc = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
+    <<PhoneNumber/binary>> = kz_doc:id(NumberDoc),
+
+    SummaryResp = summary(API, AccountId),
+    lager:info("summary resp: ~s", [SummaryResp]),
+    SummaryJObj = kz_json:get_json_value([<<"data">>, <<"numbers">>, PhoneNumber], kz_json:decode(SummaryResp)),
+    'false' = kz_json:is_empty(SummaryJObj),
+
+    RemoveResp = remove_number(API, AccountId, PhoneNumber),
+    lager:info("removed resp: ~s", [RemoveResp]),
+
+    EmptyAgainResp = summary(API, AccountId),
+    lager:info("empty again: ~s", [EmptyAgainResp]),
+    EmptyAgainJObj = kz_json:decode(EmptyAgainResp),
+    lager:info("payload: ~p", [EmptyAgainJObj]),
+    EmptyData = kz_json:get_json_value([<<"data">>, <<"numbers">>], EmptyAgainJObj),
+    lager:info("empty again data: ~p", [EmptyData]),
+    'true' = kz_json:is_empty(EmptyData),
+
+    cleanup(API).
+
+init() ->
+    _ = kz_data_tracing:clear_all_traces(),
+    _ = [kapps_controller:start_app(App) ||
+            App <- ['crossbar']
+        ],
+    _ = [crossbar_maintenance:start_module(Mod) ||
+            Mod <- ['cb_phone_numbers_v2']
+        ],
+    lager:info("INIT FINISHED").
+
+-spec cleanup() -> any().
+cleanup() ->
+    lager:info("CLEANUP ALL THE THINGS"),
+    kz_data_tracing:clear_all_traces(),
+    cleanup(pqc_cb_api:authenticate()).
+
+-spec cleanup(pqc_cb_api:state()) -> any().
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    lager:info("~p", [API]),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _D = knm_numbers:delete(?PHONE_NUMBERS, [{'auth_by', pqc_cb_api:auth_account_id(API)}]),
+    lager:info("deleted numbers ~p", [_D]),
+    pqc_cb_api:cleanup(API),
+    'ok'.


### PR DESCRIPTION
Previously, when deleting the number document from the account
database, a conflict almost always occurred on the first delete
attempt as the number doc from the number database was used (which
contained a different _rev).

However, `knm_phone_number:retry_conflicts/4` only had code for saving
to the target database (the account). The result is that the number
doc (now in the "available" state) would be `ensure_saved` to the
account database, resulting in number listings for the account to both
show the number belonging to the account *and* show it as "available",
an internal state that clients should not see.

This changeset provides additional context to handle_bulk_change about
what type of change, 'delete' or 'save', and informs retry_conflicts
of how to proceed.

Secondly, the likelyhood of conflict is high when saving/deleting from
the account database as the JSON object used is the number db's
version. `try_delete_from` has been updated to use just the number as
ID and lets kz_datamgr build the tombstone and delete accordingly.