### PR TITLE
[master] KCRO-7: new filter to find missing keys OR keys with empty values

### DIFF
--- a/applications/crossbar/doc/filters.md
+++ b/applications/crossbar/doc/filters.md
@@ -13,6 +13,7 @@ Filter | Operates On | Description
 `has_key` | `{KEY}` | Doc included if `{KEY}` is present on the doc
 `key_missing` | `{KEY}` | Doc included if `{KEY}` is *not* present on the doc
 `has_value` | `{KEY}` | Doc included if `{KEY}` exists *and* the `{VALUE}` is non-empty
+`missing_value` | `{KEY}` | Doc included if `{KEY}` is not present *or* the `{VALUE}` is empty
 `created_from` | `{VALUE}` | Doc included if the created time is greater than or equal to `{VALUE}` (in Gregorian seconds)
 `created_to` | `{VALUE}` | Doc included if the created time is less than or equal to `{VALUE}` (in Gregorian seconds)
 `modified_from` | `{VALUE}` | Doc included if the last-modified time is greater than or equal to `{VALUE}` (in Gregorian seconds)

--- a/applications/crossbar/doc/ref/filters.md
+++ b/applications/crossbar/doc/ref/filters.md
@@ -11,6 +11,7 @@ Filter | Operates On | Description
 `has_key` | `{KEY}` | 
 `key_missing` | `{KEY}` | 
 `has_value` | `{KEY}` | 
+`value_missing` | `{KEY}` | 
 `created_from` | `{VALUE}` | 
 `created_to` | `{VALUE}` | 
 `modified_from` | `{VALUE}` | 

--- a/applications/crossbar/src/crossbar_filter.erl
+++ b/applications/crossbar/src/crossbar_filter.erl
@@ -181,6 +181,7 @@ is_filter_key({<<"filter_not_", _/binary>>, _}) -> 'true';
 is_filter_key({<<"has_key", _/binary>>, _}) -> 'true';
 is_filter_key({<<"key_missing", _/binary>>, _}) -> 'true';
 is_filter_key({<<"has_value", _/binary>>, _}) -> 'true';
+is_filter_key({<<"value_missing", _/binary>>, _}) -> 'true';
 is_filter_key({<<"created_from">>, _}) -> 'true';
 is_filter_key({<<"created_to">>, _}) -> 'true';
 is_filter_key({<<"modified_from">>, _}) -> 'true';
@@ -217,6 +218,8 @@ filter_prop(Doc, <<"key_missing">>, Key) ->
     not has_key(Doc, Key);
 filter_prop(Doc, <<"has_value">>, Key) ->
     has_value(Doc, Key);
+filter_prop(Doc, <<"value_missing">>, Key) ->
+    not has_value(Doc, Key);
 filter_prop(Doc, <<"created_from">>, Val) ->
     lowerbound(kz_doc:created(Doc), kz_term:to_integer(Val));
 filter_prop(Doc, <<"created_to">>, Val) ->

--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -859,6 +859,8 @@ prefix_filter_key(<<"key_missing">>, Key) ->
     {<<"key_missing">>, <<"metadata.", Key/binary>>};
 prefix_filter_key(<<"has_value">>, Key) ->
     {<<"has_value">>, <<"metadata.", Key/binary>>};
+prefix_filter_key(<<"value_missing">>, Key) ->
+    {<<"value_missing">>, <<"metadata.", Key/binary>>};
 prefix_filter_key(Key, Value) ->
     {Key, Value}.
 


### PR DESCRIPTION
If you want to find a document by missing a value for a parameter the only way currently is to use the filter for a missing key.  However, this filter does not emit the document if the key is present but the value is empty/null.  There is a has_value filter but no inverse of that.  This adds a new query filter `missing_value` that will return a document if the key is missing OR the value is empty.