### PR TITLE
KZOO-41: handle number delete conflicts

### DIFF
--- a/core/kazoo_data/src/kzs_doc.erl
+++ b/core/kazoo_data/src/kzs_doc.erl
@@ -213,7 +213,7 @@ prepare_publish(JObj) ->
 
 -spec maybe_tombstone(kz_json:object()) -> kz_json:object().
 maybe_tombstone(JObj) ->
-    maybe_tombstone(JObj, kz_json:is_true(<<"_deleted">>, JObj, 'false')).
+    maybe_tombstone(JObj, kz_doc:is_deleted(JObj)).
 
 -spec maybe_tombstone(kz_json:object(), boolean()) -> kz_json:object().
 maybe_tombstone(JObj, 'true') ->

--- a/core/kazoo_numbers/src/knm_locality.erl
+++ b/core/kazoo_numbers/src/knm_locality.erl
@@ -24,7 +24,7 @@
 fetch(Numbers) when is_list(Numbers)->
     case knm_config:locality_url() of
         'undefined' ->
-            lager:error("could not get number locality url"),
+            ?LOG_WARNING("could not get number locality url"),
             {'error', 'missing_url'};
         Url ->
             Resp = fetch_req(Numbers, Url),

--- a/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
+++ b/core/kazoo_proper/src/pqc_cb_phone_numbers.erl
@@ -13,7 +13,8 @@
 -behaviour(proper_statem).
 
 %% Crossbar API test functions
--export([list_number/3
+-export([summary/2
+        ,list_number/3
         ,cleanup_numbers/2
         ,add_number/3
         ,activate_number/3
@@ -30,6 +31,10 @@
         ,correct_parallel/0
         ]).
 
+-export([seq/0
+        ,cleanup/0
+        ]).
+
 -include_lib("proper/include/proper.hrl").
 -include("kazoo_proper.hrl").
 
@@ -40,6 +45,10 @@
 cleanup_numbers(_API, Numbers) ->
     _ = knm_numbers:delete(Numbers, [{'auth_by',  <<"system">>}]),
     'ok'.
+
+-spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
+summary(API, AccountId) ->
+    pqc_cb_crud:summary(API, numbers_url(AccountId)).
 
 -spec list_number(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 list_number(_API, 'undefined', _Number) -> ?FAILED_RESPONSE;
@@ -57,9 +66,14 @@ list_number(API, AccountId, Number) ->
 -spec add_number(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 add_number(_API, 'undefined', _Number) -> ?FAILED_RESPONSE;
 add_number(API, AccountId, Number) ->
+    add_number(API, AccountId, Number, kz_json:new()).
+
+-spec add_number(pqc_cb_api:state(), kz_term:api_ne_binary(), kz_term:ne_binary(), kz_json:object()) ->
+          pqc_cb_api:response().
+add_number(API, AccountId, Number, RequestData) ->
     URL = number_url(AccountId, Number),
     RequestHeaders = pqc_cb_api:request_headers(API),
-    RequestEnvelope  = pqc_cb_api:create_envelope(kz_json:new()
+    RequestEnvelope  = pqc_cb_api:create_envelope(RequestData
                                                  ,kz_json:from_list([{<<"accept_charges">>, 'true'}])
                                                  ),
     Expectations = [#expectation{response_codes = [201, 404, 409]}],
@@ -96,6 +110,12 @@ activate_number(API, AccountId, Number) ->
                            ,RequestHeaders
                            ,kz_json:encode(RequestEnvelope)
                            ).
+
+-spec numbers_url(kz_term:ne_binary()) -> string().
+numbers_url(AccountId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "phone_numbers"]
+               ,"/"
+               ).
 
 -spec number_url(kz_term:ne_binary(), kz_term:ne_binary()) -> string().
 number_url(AccountId, Number) ->
@@ -306,3 +326,71 @@ postcondition(Model
 
 -spec precondition(pqc_kazoo_model:model(), any()) -> boolean().
 precondition(_Model, _Call) -> 'true'.
+
+-spec seq() -> 'ok'.
+seq() ->
+    _ = init(),
+    seq_kzoo_41().
+
+seq_kzoo_41() ->
+    Model = initial_state(),
+    API = pqc_kazoo_model:api(Model),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+    lager:info("created account ~s", [AccountId]),
+
+    EmptySummaryResp = summary(API, AccountId),
+    lager:info("empty summary: ~s", [EmptySummaryResp]),
+    'true' = kz_json:is_empty(kz_json:get_json_value([<<"data">>, <<"numbers">>], kz_json:decode(EmptySummaryResp))),
+
+    PhoneNumber = hd(?PHONE_NUMBERS),
+
+    CreateResp = add_number(API, AccountId, PhoneNumber, kz_json:from_list([{<<"carrier_name">>, <<"knm_other">>}])),
+    lager:info("create resp ~p", [CreateResp]),
+    NumberDoc = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
+    <<PhoneNumber/binary>> = kz_doc:id(NumberDoc),
+
+    SummaryResp = summary(API, AccountId),
+    lager:info("summary resp: ~s", [SummaryResp]),
+    SummaryJObj = kz_json:get_json_value([<<"data">>, <<"numbers">>, PhoneNumber], kz_json:decode(SummaryResp)),
+    'false' = kz_json:is_empty(SummaryJObj),
+
+    RemoveResp = remove_number(API, AccountId, PhoneNumber),
+    lager:info("removed resp: ~s", [RemoveResp]),
+
+    EmptyAgainResp = summary(API, AccountId),
+    lager:info("empty again: ~s", [EmptyAgainResp]),
+    EmptyAgainJObj = kz_json:decode(EmptyAgainResp),
+    lager:info("payload: ~p", [EmptyAgainJObj]),
+    EmptyData = kz_json:get_json_value([<<"data">>, <<"numbers">>], EmptyAgainJObj),
+    lager:info("empty again data: ~p", [EmptyData]),
+    'true' = kz_json:is_empty(EmptyData),
+
+    cleanup(API).
+
+init() ->
+    _ = kz_data_tracing:clear_all_traces(),
+    _ = [kapps_controller:start_app(App) ||
+            App <- ['crossbar']
+        ],
+    _ = [crossbar_maintenance:start_module(Mod) ||
+            Mod <- ['cb_phone_numbers_v2']
+        ],
+    lager:info("INIT FINISHED").
+
+-spec cleanup() -> any().
+cleanup() ->
+    lager:info("CLEANUP ALL THE THINGS"),
+    kz_data_tracing:clear_all_traces(),
+    cleanup(pqc_cb_api:authenticate()).
+
+-spec cleanup(pqc_cb_api:state()) -> any().
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    lager:info("~p", [API]),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _D = knm_numbers:delete(?PHONE_NUMBERS, [{'auth_by', pqc_cb_api:auth_account_id(API)}]),
+    lager:info("deleted numbers ~p", [_D]),
+    _ = pqc_cb_api:cleanup(API),
+    'ok'.


### PR DESCRIPTION
This is a forward port of the 4.3 version that corrects an error where
retrying deletes caused a save operation instead. This bug is
corrected in current master; this commit serves to forward-port the
pqc test recreation of the 4.3 issue.