### PR TITLE
pass relay setting as binary

### DIFF
--- a/applications/notify/src/notify_maintenance.erl
+++ b/applications/notify/src/notify_maintenance.erl
@@ -69,7 +69,7 @@ check_initial_registration(Account) when is_binary(Account) ->
 %%------------------------------------------------------------------------------
 -spec configure_smtp_relay(kz_term:ne_binary()) -> 'ok' | 'failed'.
 configure_smtp_relay(Value) ->
-    {'ok', _} = update_smtp_client_document(<<"relay">>, Value),
+    _ = kapps_config:set_string(?SMTP_CLIENT_DOC, <<"relay">>, Value),
     'ok'.
 %%------------------------------------------------------------------------------
 %% @doc Configures the username key of the SMTP_Client System Config document.
@@ -77,7 +77,7 @@ configure_smtp_relay(Value) ->
 %%------------------------------------------------------------------------------
 -spec configure_smtp_username(kz_term:ne_binary()) -> 'ok' | 'failed'.
 configure_smtp_username(Value) ->
-    {'ok', _} = update_smtp_client_document(<<"username">>, Value),
+    _ = kapps_config:set_string(?SMTP_CLIENT_DOC, <<"username">>, Value),
     'ok'.
 
 %%------------------------------------------------------------------------------
@@ -86,7 +86,7 @@ configure_smtp_username(Value) ->
 %%------------------------------------------------------------------------------
 -spec configure_smtp_password(kz_term:ne_binary()) -> 'ok' | 'failed'.
 configure_smtp_password(Value) ->
-    {'ok', _} = update_smtp_client_document(<<"password">>, Value),
+    _ = kapps_config:set_string(?SMTP_CLIENT_DOC, <<"password">>, Value),
     'ok'.
 
 %%------------------------------------------------------------------------------
@@ -95,7 +95,7 @@ configure_smtp_password(Value) ->
 %%------------------------------------------------------------------------------
 -spec configure_smtp_auth(kz_term:ne_binary()) -> 'ok' | 'failed'.
 configure_smtp_auth(Value) ->
-    {'ok', _} = update_smtp_client_document(<<"auth">>, Value),
+    _ = kapps_config:set_string(?SMTP_CLIENT_DOC, <<"auth">>, Value),
     'ok'.
 
 %%------------------------------------------------------------------------------
@@ -104,7 +104,7 @@ configure_smtp_auth(Value) ->
 %%------------------------------------------------------------------------------
 -spec configure_smtp_port(kz_term:ne_binary()) -> 'ok' | 'failed'.
 configure_smtp_port(Value) ->
-    {'ok', _} = update_smtp_client_document(<<"port">>, Value),
+    _ = kapps_config:set_integer(?SMTP_CLIENT_DOC, <<"port">>, Value),
     'ok'.
 
 %%------------------------------------------------------------------------------
@@ -336,12 +336,3 @@ open_system_config(Id) ->
         {'error', 'not_found'} -> 'not_found';
         {'error', _R} -> 'error'
     end.
-
-
-%%------------------------------------------------------------------------------
-%% @doc
-%% @end
-%%------------------------------------------------------------------------------
--spec update_smtp_client_document(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kz_json:object()}.
-update_smtp_client_document(Key, Value) ->
-    kapps_config:set(?SMTP_CLIENT_DOC, Key, Value).

--- a/applications/notify/src/notify_util.erl
+++ b/applications/notify/src/notify_util.erl
@@ -41,7 +41,7 @@ send_email(_, 'undefined', _) -> lager:debug("no email to send to");
 send_email(_, <<>>, _) -> lager:debug("empty email to send to");
 send_email(From, To, Email) ->
     Encoded = mimemail:encode(Email),
-    Relay = kapps_config:get_ne_binary(<<"smtp_client">>, <<"relay">>, <<"localhost">>),
+    Relay = kapps_config:get_string(<<"smtp_client">>, <<"relay">>, "localhost"),
     Username = kapps_config:get_string(<<"smtp_client">>, <<"username">>, <<>>),
     Password = kapps_config:get_string(<<"smtp_client">>, <<"password">>, <<>>),
     Auth = kz_term:to_list(kapps_config:get_ne_binary(<<"smtp_client">>, <<"auth">>, <<"never">>)),

--- a/applications/notify/src/notify_util.erl
+++ b/applications/notify/src/notify_util.erl
@@ -41,9 +41,9 @@ send_email(_, 'undefined', _) -> lager:debug("no email to send to");
 send_email(_, <<>>, _) -> lager:debug("empty email to send to");
 send_email(From, To, Email) ->
     Encoded = mimemail:encode(Email),
-    Relay = kz_term:to_list(kapps_config:get_ne_binary(<<"smtp_client">>, <<"relay">>, <<"localhost">>)),
-    Username = kz_term:to_list(kapps_config:get_binary(<<"smtp_client">>, <<"username">>, <<>>)),
-    Password = kz_term:to_list(kapps_config:get_binary(<<"smtp_client">>, <<"password">>, <<>>)),
+    Relay = kapps_config:get_ne_binary(<<"smtp_client">>, <<"relay">>, <<"localhost">>),
+    Username = kapps_config:get_string(<<"smtp_client">>, <<"username">>, <<>>),
+    Password = kapps_config:get_string(<<"smtp_client">>, <<"password">>, <<>>),
     Auth = kz_term:to_list(kapps_config:get_ne_binary(<<"smtp_client">>, <<"auth">>, <<"never">>)),
     Port = kapps_config:get_integer(<<"smtp_client">>, <<"port">>, 25),
 

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -288,9 +288,7 @@ handle_relay_response(_To, _From, {'exit', Reason}) ->
 
 -spec smtp_options() -> kz_term:proplist().
 smtp_options() ->
-    %% there is a bug in gen_smtp_client which tries convert a string to string character by character
-    %% change this `relay' setting to binary so it would properly convert to string by gen_smtp_client
-    Relay = kapps_config:get_ne_binary(<<"smtp_client">>, <<"relay">>, "localhost"),
+    Relay = kapps_config:get_string(<<"smtp_client">>, <<"relay">>, "localhost"),
     Username = kapps_config:get_string(<<"smtp_client">>, <<"username">>, ""),
     Password = kapps_config:get_string(<<"smtp_client">>, <<"password">>, ""),
     Auth = kapps_config:get_binary(<<"smtp_client">>, <<"auth">>, <<"never">>),

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -95,8 +95,18 @@ send_email(Emails0, Subject, RenderedTemplates, Attachments) ->
             maybe_log_smtp(Emails, Subject, RenderedTemplates, 'undefined', kz_term:to_binary(Reason)),
             E;
         {'error', Reason} = E ->
-            maybe_log_smtp(Emails, Subject, RenderedTemplates, 'undefined', kz_term:to_binary(Reason)),
+            maybe_log_smtp(Emails, Subject, RenderedTemplates, 'undefined', send_error_reason(Reason)),
             E
+    end.
+
+-spec send_error_reason(any()) -> kz_term:ne_binary().
+send_error_reason(Reason) ->
+    try kz_term:to_binary(Reason)
+    catch
+        _:_ ->
+            kz_term:to_binary(
+              io_lib:format("~p", [Reason])
+             )
     end.
 
 -spec maybe_log_smtp(email_map(), kz_term:ne_binary(), list(), kz_term:api_binary(), kz_term:api_binary()) -> 'ok'.
@@ -269,20 +279,18 @@ handle_relay_response(To, From, {'ok', Receipt}) ->
 handle_relay_response(_To, _From, {'error', _Type, {_SubType, _FailHost, Message}}) ->
     lager:debug("error relaying message: ~p(~p): ~p", [_Type, _SubType, Message]),
     {'error', Message};
+handle_relay_response(_To, _From, {'exit', {'function_clause', Stacktrace}}) ->
+    kz_log:log_stacktrace(Stacktrace, "failed to send email", []),
+    {'error', kz_term:to_binary(io_lib:format("failed to send email: ~p", [Stacktrace]))};
 handle_relay_response(_To, _From, {'exit', Reason}) ->
-    lager:debug("failed to send email:"),
-    log_email_send_error(Reason),
-    {'error', Reason}.
-
--spec log_email_send_error(any()) -> 'ok'.
-log_email_send_error({'function_clause', Stacktrace}) ->
-    kz_log:log_stacktrace(Stacktrace);
-log_email_send_error(Reason) ->
-    lager:debug("exit relaying message: ~p", [Reason]).
+    lager:debug("failed to send email, exit realying message: ~p", [Reason]),
+    {'error', kz_term:to_binary(io_lib:format("failed to send email, exit realying message: ~p", [Reason]))}.
 
 -spec smtp_options() -> kz_term:proplist().
 smtp_options() ->
-    Relay = kapps_config:get_string(<<"smtp_client">>, <<"relay">>, "localhost"),
+    %% there is a bug in gen_smtp_client which tries convert a string to string character by character
+    %% change this `relay' setting to binary so it would properly convert to string by gen_smtp_client
+    Relay = kapps_config:get_ne_binary(<<"smtp_client">>, <<"relay">>, "localhost"),
     Username = kapps_config:get_string(<<"smtp_client">>, <<"username">>, ""),
     Password = kapps_config:get_string(<<"smtp_client">>, <<"password">>, ""),
     Auth = kapps_config:get_binary(<<"smtp_client">>, <<"auth">>, <<"never">>),

--- a/core/kazoo_ast/src/kapps_config_usage.erl
+++ b/core/kazoo_ast/src/kapps_config_usage.erl
@@ -337,9 +337,12 @@ guess_type('get_hierarchy', Default) -> guess_type_by_default(Default);
 guess_type('get_with_strategy', Default) -> guess_type_by_default(Default);
 guess_type('set_default', _) -> 'undefined';
 guess_type('set', Default) -> guess_type_by_default(Default);
-guess_type('set_string', _) -> <<"string">>;
+guess_type('set_boolean', _) -> <<"boolean">>;
+guess_type('set_float', _) -> <<"float">>;
+guess_type('set_integer', _) -> <<"integer">>;
 guess_type('set_json', _) -> <<"object">>;
 guess_type('set_node', Default) -> guess_type_by_default(Default);
+guess_type('set_string', _) -> <<"string">>;
 guess_type('update_default', Default) -> guess_type_by_default(Default).
 
 guess_type_by_default('undefined') -> 'undefined';

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -81,7 +81,7 @@ dep_erlcloud = git https://github.com/2600hz/erlang-erlcloud 3.2.7
 # dep_fs_event = git https://github.com/jamhed/fs_event 783400da08c2b55c295dbec81df0d926960c0346
 # dep_fs_sync = git https://github.com/jamhed/fs_sync 2cf85cf5861221128f020c453604d509fd37cd53
 
-dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 033f2d133e733304d591fef4b05ea58e8c220e92
+dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 3d294c57153787027bea4011eeba268fee5d7165
 # used by teletype, notify, and fax
 # SHA fixes spec for gen_smto_client:send/3
 


### PR DESCRIPTION
`gen_smtp_client` has been changed to accept more `relay` as a list. But it has a bug to use list comprehensive to convert a list to string, which also cause a genuine string to be converted to string char by char.

This is trying to pass the `relay` option as a binary so it would be properly converted to string by `gen_smtp_client`.

commit that changed the the `deps.mk`: https://github.com/2600hz/kazoo/commit/4aab964987de4bd1e3233aba94c2e119cc5eefeb
commit that changed the gen_smtp: https://github.com/2600hz/erlang-gen_smtp/commit/033f2d133e733304d591fef4b05ea58e8c220e92