### PR TITLE
[4.3] Listener federators and memory improvements

### DIFF
--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -853,6 +853,11 @@ code_change(_OldVersion, State, _Extra) ->
 %%%=============================================================================
 %%% Internal functions
 %%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
 handle_down({Pid, Ref}, Reason, #state{federators=Fs}=State) ->
     case lists:keytake({Pid, Ref}, 2, Fs) of
         'false' -> handle_callback_info({'DOWN', Ref, 'process', Pid, Reason}, State);

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -104,7 +104,7 @@
         ]).
 
 -export([federated_event/4
-        ,the_federator_lives/2
+        ,notify_of_federator_listener/2
         ]).
 -export([delayed_cast/3]).
 -export([distribute_event/3]).
@@ -395,8 +395,8 @@ rm_binding(Srv, Binding, Props) ->
 federated_event(Srv, JObj, BasicDeliver, BasicData) ->
     gen_server:cast(Srv, {'federated_event', JObj, BasicDeliver, BasicData}).
 
--spec the_federator_lives(pid(), {kz_term:ne_binary(), pid()}) -> 'ok'.
-the_federator_lives(Srv, {_Broker, _Pid}=Child) ->
+-spec notify_of_federator_listener(pid(), {kz_term:ne_binary(), pid()}) -> 'ok'.
+notify_of_federator_listener(Srv, {_Broker, _Pid}=Child) ->
     gen_server:cast(Srv, {'federator_listener', Child}).
 
 -spec execute(kz_types:server_ref(), module(), atom(), [any()]) -> 'ok'.

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -1594,5 +1594,4 @@ maybe_gc(Heap, Max) when Heap > Max ->
     [{'total_heap_size', NewHeapWords}] = process_info(self(), ['total_heap_size']),
     NewHeap = kz_term:words_to_bytes(NewHeapWords),
     lager:debug("new heap size ~p (delta ~p)", [NewHeap, Heap-NewHeap]);
-maybe_gc(_Heap, _Max) ->
-    lager:debug("current heap ~p", [_Heap]).
+maybe_gc(_Heap, _Max) -> 'ok'.

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -103,9 +103,10 @@
         ,execute/2
         ]).
 
--export([federated_event/4]).
--export([delayed_cast/3
+-export([federated_event/4
+        ,the_federator_lives/2
         ]).
+-export([delayed_cast/3]).
 -export([distribute_event/3]).
 
 -include("listener_types.hrl").
@@ -120,7 +121,7 @@
 
 -type module_state() :: any().
 
--type federator_listener() :: {kz_term:ne_binary(), pid()}.
+-type federator_listener() :: {kz_term:ne_binary(), {pid(), reference()}}.
 -type federator_listeners() :: [federator_listener()].
 
 -record(state, {queue :: kz_term:api_binary()
@@ -239,6 +240,10 @@ start_link(Name, Module, Params, InitArgs, Options) when is_atom(Module),
 -spec stop(kz_types:server_ref()) -> 'ok'.
 stop(Server) ->
     gen_server:stop(Server).
+
+-spec start_listener(pid(), kz_term:proplist()) -> 'ok'.
+start_listener(Srv, Params) ->
+    gen_server:cast(Srv, {'start_listener', Params}).
 
 -spec queue_name(kz_types:server_ref()) -> kz_term:api_ne_binary().
 queue_name(Srv) -> gen_server:call(Srv, 'queue_name').
@@ -390,6 +395,10 @@ rm_binding(Srv, Binding, Props) ->
 federated_event(Srv, JObj, BasicDeliver, BasicData) ->
     gen_server:cast(Srv, {'federated_event', JObj, BasicDeliver, BasicData}).
 
+-spec the_federator_lives(pid(), {kz_term:ne_binary(), pid()}) -> 'ok'.
+the_federator_lives(Srv, {_Broker, _Pid}=Child) ->
+    gen_server:cast(Srv, {'federator_listener', Child}).
+
 -spec execute(kz_types:server_ref(), module(), atom(), [any()]) -> 'ok'.
 execute(Srv, Module, Function, Args) ->
     gen_server:cast(Srv, {'$execute', Module, Function, Args}).
@@ -534,9 +543,11 @@ handle_cast({'rm_binding', Binding, Props}, State) ->
     {'noreply', handle_rm_binding(Binding, Props, State)};
 handle_cast({'federated_event', JObj, BasicDeliver, BasicData}, #state{params=Params}=State) ->
     case props:is_true('spawn_handle_event', Params, 'false') of
-        'true'  -> kz_util:spawn(fun distribute_event/3, [JObj, {BasicDeliver, BasicData}, State]),
-                   {'noreply', State};
-        'false' -> {'noreply', distribute_event(JObj, {BasicDeliver, BasicData}, State)}
+        'true'  ->
+            kz_util:spawn(fun distribute_event/3, [JObj, {BasicDeliver, BasicData}, State]),
+            {'noreply', State};
+        'false' ->
+            {'noreply', distribute_event(JObj, {BasicDeliver, BasicData}, State)}
     end;
 handle_cast({'$execute', Module, Function, Args}
            ,#state{federators=[]}=State
@@ -558,7 +569,7 @@ handle_cast({'$execute', Module, Function, Args}=Msg
            ) ->
     erlang:apply(Module, Function, Args),
     _ = [?MODULE:cast(Federator, Msg)
-         || {_Broker, Federator} <- Federators
+         || {_Broker, {Federator, _Ref}} <- Federators
         ],
     {'noreply', State};
 handle_cast({'$execute', Function, Args}=Msg
@@ -566,7 +577,7 @@ handle_cast({'$execute', Function, Args}=Msg
            ) ->
     erlang:apply(Function, Args),
     _ = [?MODULE:cast(Federator, Msg)
-         || {_Broker, Federator} <- Federators
+         || {_Broker, {Federator, _Ref}} <- Federators
         ],
     {'noreply', State};
 handle_cast({'$execute', Function}=Msg
@@ -574,7 +585,7 @@ handle_cast({'$execute', Function}=Msg
            ) ->
     Function(),
     _ = [?MODULE:cast(Federator, Msg)
-         || {_Broker, Federator} <- Federators
+         || {_Broker, {Federator, _Ref}} <- Federators
         ],
     {'noreply', State};
 handle_cast({'$client_cast', Message}, State) ->
@@ -600,12 +611,14 @@ handle_cast({'pause_consumers'}, #state{is_consuming='true', consumer_tags=Tags}
     {'noreply', State};
 handle_cast({'resume_consumers'}, #state{queue='undefined'}=State) ->
     {'noreply', State};
-handle_cast({'resume_consumers'}, #state{is_consuming='false'
-                                        ,params=Params
-                                        ,queue=Q
-                                        ,other_queues=OtherQueues
-                                        ,auto_ack=AutoAck
-                                        }=State) ->
+handle_cast({'resume_consumers'}
+           ,#state{is_consuming='false'
+                  ,params=Params
+                  ,queue=Q
+                  ,other_queues=OtherQueues
+                  ,auto_ack=AutoAck
+                  }=State
+           ) ->
     ConsumeOptions = props:get_value('consume_options', Params, []),
     _ = start_consumer(Q, maybe_configure_auto_ack(ConsumeOptions, AutoAck)),
     _ = [start_consumer(Q1, maybe_configure_auto_ack(props:get_value('consume_options', P, []), AutoAck))
@@ -613,24 +626,32 @@ handle_cast({'resume_consumers'}, #state{is_consuming='false'
         ],
     {'noreply', State};
 handle_cast({'federator_is_consuming', Broker, 'true'}, State) ->
-    lager:info("federator for ~p is consuming, waiting on: ~p", [Broker, State#state.waiting_federators]),
-
     Filter = fun(X) ->
                      kz_amqp_connections:broker_available_connections(X) > 0
              end,
 
     Waiting = lists:filter(Filter, State#state.waiting_federators),
 
-    lager:info("available waiting brokers: ~p", [Waiting]),
-
     case lists:subtract(Waiting, [Broker]) of
         [] ->
-            lager:info("all waiting federators are available!"),
+            lager:info("federator for ~s is consuming, all waiting federators are available!", [Broker]),
             handle_module_cast({?MODULE, {'federators_consuming', 'true'}}, State);
-
         Remaining ->
-            lager:info("still waiting for federators: ~p", [Remaining]),
+            lager:info("federator for ~s is consuming, still waiting for federators: ~p", [Broker, Remaining]),
             {'noreply', State#state{waiting_federators = Remaining}}
+    end;
+handle_cast({'federator_listener', {Broker, Pid}}, #state{federators=Fs}=State) ->
+    case lists:keytake(Pid, 2, Fs) of
+        'false' ->
+            Ref = monitor('process', Pid),
+            lager:info("federator ~p(~p) on broker ~s started", [Pid, Ref, Broker]),
+
+            {'noreply', State#state{federators=[{Broker, {Pid, Ref}} | Fs]}};
+        {'value', _FL, _Feds} ->
+            lager:debug("ignoring federator_listener message about ~p; have ~p already"
+                       ,[Pid, _FL]
+                       ),
+            {'noreply', State}
     end;
 handle_cast(Message, State) ->
     handle_module_cast(Message, State).
@@ -678,12 +699,16 @@ handle_info({#'basic.deliver'{}=BD
             }
            ,#state{params=Params, auto_ack=AutoAck}=State
            ) ->
+
     _ = case AutoAck of
             'true' -> (catch kz_amqp_util:basic_ack(BD));
             'false' -> 'ok'
         end,
     case props:is_true('spawn_handle_event', Params, 'false') of
-        'false' -> {'noreply', handle_event(Payload, CT, {BD, Basic}, State)};
+        'false' ->
+            NewState = handle_event(binary:copy(Payload), CT, {BD, Basic}, State),
+            maybe_gc(),
+            {'noreply', NewState};
         'true'  ->
             kz_util:spawn(fun handle_event/4, [Payload, CT, {BD, Basic}, State]),
             {'noreply', State}
@@ -695,7 +720,8 @@ handle_info({#'basic.return'{}=BR
             }
            ,State
            ) ->
-    handle_return(Payload, CT, BR, State);
+    LocalPayload = binary:copy(Payload),
+    handle_return(LocalPayload, CT, BR, State);
 handle_info(#'basic.consume_ok'{consumer_tag=CTag}
            ,#state{queue='undefined'}=State
            ) ->
@@ -737,6 +763,8 @@ handle_info({'kz_amqp_channel', {Client, Ref, 'consumer_tags'}}, #state{consumer
     {'noreply', State};
 handle_info(?CALLBACK_TIMEOUT_MSG, State) ->
     handle_callback_info('timeout', State);
+handle_info({'DOWN', Ref, 'process', Pid, Reason}, State) ->
+    handle_down({Pid, Ref}, Reason, State);
 handle_info(Message, State) ->
     handle_callback_info(Message, State).
 
@@ -811,7 +839,7 @@ terminate(Reason, #state{module=Module
     _ = (catch(lists:foreach(fun kz_amqp_util:basic_cancel/1, Tags))),
     _Terminated = (catch Module:terminate(Reason, ModuleState)),
     _ = (catch kz_amqp_channel:release()),
-    _ = [listener_federator:stop(F) || {_Broker, F} <- Fs],
+    _ = [listener_federator:stop(F) || {_Broker, {F, _Ref}} <- Fs],
     lager:debug("~s terminated cleanly, going down", [Module]).
 
 %%------------------------------------------------------------------------------
@@ -825,6 +853,13 @@ code_change(_OldVersion, State, _Extra) ->
 %%%=============================================================================
 %%% Internal functions
 %%%=============================================================================
+handle_down({Pid, Ref}, Reason, #state{federators=Fs}=State) ->
+    case lists:keytake({Pid, Ref}, 2, Fs) of
+        'false' -> handle_callback_info({'DOWN', Ref, 'process', Pid, Reason}, State);
+        {'value', {_Broker, _PidRef}, UpdatedFs} ->
+            lager:warning("federator ~p to ~s down: ~p", [_PidRef, _Broker, Reason]),
+            {'noreply', State#state{federators=UpdatedFs}}
+    end.
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -841,6 +876,8 @@ handle_callback_info(Message
     try Module:handle_info(Message, ModuleState) of
         {'noreply', ModuleState1} ->
             {'noreply', State#state{module_state=ModuleState1}};
+        {'noreply', ModuleState1, 'hibernate'} ->
+            {'noreply', State#state{module_state=ModuleState1}, 'hibernate'};
         {'noreply', ModuleState1, Timeout} ->
             Ref = start_timer(Timeout),
             {'noreply', State#state{module_state=ModuleState1
@@ -1147,10 +1184,19 @@ handle_module_call(Request, From, #state{module=Module
     _ = stop_timer(OldRef),
     try Module:handle_call(Request, From, ModuleState) of
         {'reply', Reply, ModuleState1} ->
-            {'reply', Reply
+            {'reply'
+            ,Reply
             ,State#state{module_state=ModuleState1
                         ,module_timeout_ref='undefined'
                         }
+            };
+        {'reply', Reply, ModuleState1, 'hibernate'} ->
+            {'reply'
+            ,Reply
+            ,State#state{module_state=ModuleState1
+                        ,module_timeout_ref='undefined'
+                        }
+            ,'hibernate'
             };
         {'reply', Reply, ModuleState1, Timeout} ->
             {'reply', Reply
@@ -1160,6 +1206,8 @@ handle_module_call(Request, From, #state{module=Module
             };
         {'noreply', ModuleState1} ->
             {'noreply', State#state{module_state=ModuleState1}};
+        {'noreply', ModuleState1, 'hibernate'} ->
+            {'noreply', State#state{module_state=ModuleState1}, 'hibernate'};
         {'noreply', ModuleState1, Timeout} ->
             {'noreply'
             ,State#state{module_state=ModuleState1
@@ -1187,6 +1235,8 @@ handle_module_cast(Msg, #state{module=Module
     try Module:handle_cast(Msg, ModuleState) of
         {'noreply', ModuleState1} ->
             {'noreply', State#state{module_state=ModuleState1}};
+        {'noreply', ModuleState1, 'hibernate'} ->
+            {'noreply', State#state{module_state=ModuleState1}, 'hibernate'};
         {'noreply', ModuleState1, Timeout} ->
             Ref = start_timer(Timeout),
             {'noreply', State#state{module_state=ModuleState1
@@ -1270,39 +1320,44 @@ is_federated_binding(Props) ->
     props:get_value('federate', Props) =:= 'true'.
 
 -spec update_federated_bindings(state()) -> state().
+update_federated_bindings(#state{}=State) ->
+    update_federated_bindings(State, kz_amqp_connections:federated_brokers()).
+
+update_federated_bindings(#state{bindings=[{Binding, _Props}|_]}=State, []) ->
+    lager:debug("no federated brokers to connect to, skipping federating binding '~s'", [Binding]),
+    State;
 update_federated_bindings(#state{bindings=[{Binding, Props}|_]
                                 ,federators=Fs
-                                }=State) ->
-    case kz_amqp_connections:federated_brokers() of
-        [] ->
-            lager:debug("no federated brokers to connect to, skipping federating binding '~s'", [Binding]),
-            State;
-        FederatedBrokers ->
-            NonFederatedProps = props:delete('federate', Props),
-            {_Existing, New} = broker_connections(Fs, FederatedBrokers),
-            'ok' = update_existing_listeners_bindings(Fs, Binding, NonFederatedProps),
-            {'ok', NewListeners} = start_new_listeners(New, Binding, NonFederatedProps, State),
-            State#state{federators=NewListeners ++ Fs, waiting_federators=New ++ State#state.waiting_federators}
-    end.
+                                }=State
+                         ,FederatedBrokers
+                         ) ->
+    NonFederatedProps = props:delete('federate', Props),
+    {_Existing, New} = broker_connections(Fs, FederatedBrokers),
+    'ok' = update_existing_listeners_bindings(Fs, Binding, NonFederatedProps),
+    {'ok', NewListeners} = start_new_listeners(New, Binding, NonFederatedProps, State),
+    State#state{federators=NewListeners ++ Fs
+               ,waiting_federators=New ++ State#state.waiting_federators
+               }.
 
 -spec maybe_remove_federated_binding(binding(), kz_term:proplist(), state()) -> 'ok'.
 maybe_remove_federated_binding(Binding, Props, State) ->
     maybe_remove_federated_binding(is_federated_binding(Props), Binding, Props, State).
 
 -spec maybe_remove_federated_binding(boolean(), binding(), kz_term:proplist(), state()) -> 'ok'.
-maybe_remove_federated_binding('true', Binding, Props, #state{federators=Fs}) when Fs =/= [] ->
+maybe_remove_federated_binding(_Flag, _Binding, _Props, #state{federators=[]}) -> 'ok';
+maybe_remove_federated_binding('true', Binding, Props, #state{federators=Fs}) ->
     NonFederatedProps = props:delete('federate', Props),
     remove_federated_binding(Fs, Binding, NonFederatedProps);
-
-maybe_remove_federated_binding(_Flag, _Binging, _Props, _State) ->
-    'ok'.
+maybe_remove_federated_binding(_Flag, _Binging, _Props, _State) -> 'ok'.
 
 -spec broker_connections(federator_listeners(), kz_term:ne_binaries()) ->
           {kz_term:ne_binaries(), kz_term:ne_binaries()}.
 broker_connections(Listeners, Brokers) ->
     lists:partition(fun(Broker) ->
                             props:get_value(Broker, Listeners) =/= 'undefined'
-                    end, Brokers).
+                    end
+                   ,Brokers
+                   ).
 
 -spec start_new_listeners(kz_term:ne_binaries(), binding_module(), kz_term:proplist(), state()) ->
           {'ok', federator_listeners()}.
@@ -1314,9 +1369,10 @@ start_new_listeners(Brokers, Binding, Props, State) ->
 -spec start_new_listener(kz_term:ne_binary(), binding_module(), kz_term:proplist(), state()) -> federator_listener().
 start_new_listener(Broker, Binding, Props, #state{params=Ps}) ->
     FederateParams = create_federated_params({Binding, Props}, Ps),
-    {'ok', Pid} = listener_federator:start_link(self(), Broker, FederateParams),
-    lager:debug("started federated listener on broker ~s: ~p", [Broker, Pid]),
-    {Broker, Pid}.
+    {'ok', Pid} = kz_amqp_federated_listeners_sup:start_child(self(), Broker, FederateParams),
+    Ref = monitor('process', Pid),
+    lager:debug("started federated listener on broker ~s: ~p(~p)", [Broker, Pid, Ref]),
+    {Broker, {Pid, Ref}}.
 
 -spec remove_federated_binding(federator_listeners(), binding_module(), kz_term:proplist()) -> 'ok'.
 remove_federated_binding(Listeners, Binding, Props) ->
@@ -1333,7 +1389,7 @@ update_existing_listeners_bindings(Listeners, Binding, Props) ->
     'ok'.
 
 -spec update_existing_listener_bindings(federator_listener(), binding_module(), kz_term:proplist()) -> 'ok'.
-update_existing_listener_bindings({_Broker, Pid}, Binding, Props) ->
+update_existing_listener_bindings({_Broker, {Pid, _Ref}}, Binding, Props) ->
     lager:debug("updating listener ~p with ~s", [Pid, Binding]),
     ?MODULE:add_binding(Pid, Binding, Props).
 
@@ -1499,10 +1555,39 @@ maybe_add_broker_connection(Broker, Count) when Count =:= 0 ->
 maybe_add_broker_connection(Broker, _Count) ->
     kz_amqp_channel:requisition(self(), Broker).
 
--spec start_listener(pid(), kz_term:proplist()) -> 'ok'.
-start_listener(Srv, Params) ->
-    gen_server:cast(Srv, {'start_listener', Params}).
-
 maybe_configure_auto_ack(Props, 'false') -> Props;
 maybe_configure_auto_ack(Props, 'true') ->
     [{'no_ack', 'false'} | props:delete('no_ack', Props)].
+
+%% @doc force GC of process if total_heap_size exceeds 10K
+%%
+%% In production, when compacting kz_amqp_workers and other
+%% gen_listener processes, we see a reduction in total_heap_size to
+%% about 4K on most processes.
+%%
+%% Old heap is used for "long-lived" terms. One of the issues was that
+%% when a binary Payload was received from AMQP, we would decode it
+%% directly which causes refc binaries to be put in the gen_listener's
+%% heap, keeping the binary alive. By using binary:copy/1 before
+%% decoding, Payload can be freed sooner. I suspect that Payload
+%% itself is a refc into the larger AMQP binary payload parsed by the
+%% AMQP client library.
+%%
+%% It is possible that apps may load more memory into their state
+%% which would cause gen_listener's state to exceed 10K in the steady
+%% state. We advise app developers to not do this :)
+-spec maybe_gc() -> 'ok'.
+maybe_gc() ->
+    maybe_gc(process_info(self(), ['total_heap_size'])
+            ,100 * ?BYTES_K
+            ).
+
+maybe_gc([{'total_heap_size', Words}], MaxBytes) ->
+    maybe_gc(kz_term:words_to_bytes(Words), MaxBytes);
+maybe_gc(Heap, Max) when Heap > Max ->
+    erlang:garbage_collect(self()),
+    [{'total_heap_size', NewHeapWords}] = process_info(self(), ['total_heap_size']),
+    NewHeap = kz_term:words_to_bytes(NewHeapWords),
+    lager:debug("new heap size ~p (delta ~p)", [NewHeap, Heap-NewHeap]);
+maybe_gc(_Heap, _Max) ->
+    lager:debug("current heap ~p", [_Heap]).

--- a/core/kazoo_amqp/src/kz_amqp_federated_listeners_sup.erl
+++ b/core/kazoo_amqp/src/kz_amqp_federated_listeners_sup.erl
@@ -1,0 +1,35 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2012-2020, 2600Hz
+%%% @doc
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kz_amqp_federated_listeners_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0
+        ,start_child/3
+        ,init/1
+        ]).
+
+-include("kz_amqp_util.hrl").
+
+-define(CHILDREN, [?WORKER_TYPE('listener_federator', 'transient')]).
+
+-spec start_link() -> kz_types:startlink_ret().
+start_link() ->
+    supervisor:start_link({'local', ?MODULE}, ?MODULE, []).
+
+-spec start_child(pid(), kz_term:ne_binary(), kz_term:proplist()) -> kz_types:sup_startchild_ret().
+start_child(Parent, Broker, FederateParams) ->
+    ParentCallId = kz_util:get_callid(),
+    supervisor:start_child(?MODULE, [Parent, ParentCallId, Broker, FederateParams]).
+
+-spec init(any()) -> kz_types:sup_init_ret().
+init([]) ->
+    RestartStrategy = 'simple_one_for_one',
+    MaxRestarts = 5,
+    MaxSecondsBetweenRestarts = 10,
+    SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
+
+    {'ok', {SupFlags, ?CHILDREN}}.

--- a/core/kazoo_amqp/src/kz_amqp_sup.erl
+++ b/core/kazoo_amqp/src/kz_amqp_sup.erl
@@ -36,6 +36,7 @@
 
 -define(CHILDREN, [?WORKER('kz_amqp_connections')
                   ,?SUPER('kz_amqp_connection_sup')
+                  ,?SUPER('kz_amqp_federated_listeners_sup')
                   ,?WORKER('kz_amqp_assignments')
                   ,?WORKER('kz_amqp_bootstrap')
                   ]).
@@ -133,7 +134,6 @@ pool_pid(Pool) ->
         [] -> 'undefined';
         [P | _] -> P
     end.
-
 
 %%==============================================================================
 %% Supervisor callbacks

--- a/core/kazoo_amqp/src/listener_federator.erl
+++ b/core/kazoo_amqp/src/listener_federator.erl
@@ -26,7 +26,7 @@
 
 -define(SERVER, ?MODULE).
 
--record(state, {parent :: pid()
+-record(state, {parent :: {pid(), reference()}
                ,broker :: kz_term:ne_binary()
                ,self_binary = kz_term:to_binary(pid_to_list(self())) :: kz_term:ne_binary()
                ,zone :: kz_term:ne_binary()
@@ -72,7 +72,7 @@ init([Parent, ParentCallId, Broker]=L) ->
 
     gen_listener:notify_of_federator_listener(Parent, {Broker, self()}),
 
-    {'ok', #state{parent=Parent
+    {'ok', #state{parent={Parent, monitor('process', Parent)}
                  ,broker=Broker
                  ,zone=Zone
                  }}.
@@ -82,7 +82,7 @@ init([Parent, ParentCallId, Broker]=L) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_call(any(), any(), state()) -> kz_types:handle_call_ret_state(state()).
-handle_call({'stop', Parent}, _From, #state{parent=Parent}=State) ->
+handle_call({'stop', Parent}, _From, #state{parent={Parent, _Ref}}=State) ->
     {'stop', 'normal', 'ok', State};
 handle_call('get_broker', _From, #state{broker=Broker}=State) ->
     {'reply', Broker, State};
@@ -96,7 +96,11 @@ handle_call(_Request, _From, State) ->
 -spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
 handle_cast({'gen_listener', {'created_queue', _}}, State) ->
     {'noreply', State};
-handle_cast({'gen_listener', {'is_consuming', 'true'}}, #state{parent=Parent, broker=Broker}=State) ->
+handle_cast({'gen_listener', {'is_consuming', 'true'}}
+           ,#state{parent={Parent, _Ref}
+                  ,broker=Broker
+                  }=State
+           ) ->
     gen_server:cast(Parent, {'federator_is_consuming', Broker, 'true'}),
     {'noreply', State};
 handle_cast(_Msg, State) ->
@@ -108,12 +112,17 @@ handle_cast(_Msg, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
+handle_info({'DOWN', Ref, 'process', Parent, _Reason}
+           ,#state{parent={Parent, Ref}}=State
+           ) ->
+    lager:info("parent gen_listener ~p down: ~p", [Parent, _Reason]),
+    {'stop', 'normal', State};
 handle_info(_Info, State) ->
     lager:info("unhandled message: ~p", [_Info]),
     {'noreply', State}.
 
 -spec handle_event(kz_json:object(), gen_listener:basic_deliver(), amqp_basic(), state()) -> gen_listener:handle_event_return().
-handle_event(JObj, BasicDeliver, BasicData, #state{parent=Parent
+handle_event(JObj, BasicDeliver, BasicData, #state{parent={Parent, _Ref}
                                                   ,broker=Broker
                                                   ,self_binary=Self
                                                   ,zone=Zone

--- a/core/kazoo_amqp/src/listener_federator.erl
+++ b/core/kazoo_amqp/src/listener_federator.erl
@@ -7,7 +7,7 @@
 
 -behaviour(gen_listener).
 
--export([start_link/3
+-export([start_link/4
         ,stop/1
         ,broker/1
         ]).
@@ -41,9 +41,8 @@
 %% @doc Starts the server.
 %% @end
 %%------------------------------------------------------------------------------
--spec start_link(pid(), kz_term:ne_binary(), kz_term:proplist()) -> kz_types:startlink_ret().
-start_link(Parent, Broker, Params) ->
-    ParentCallId = kz_util:get_callid(),
+-spec start_link(pid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> kz_types:startlink_ret().
+start_link(Parent, ParentCallId, Broker, Params) ->
     gen_listener:start_link(?SERVER, Params, [Parent, ParentCallId, Broker]).
 
 -spec broker(kz_types:server_ref()) -> kz_term:ne_binary().
@@ -70,6 +69,8 @@ init([Parent, ParentCallId, Broker]=L) ->
 
     CallId = kz_binary:join([ParentCallId, Zone], <<"-">>),
     kz_util:put_callid(CallId),
+
+    gen_listener:the_federator_lives(Parent, {Broker, self()}),
 
     {'ok', #state{parent=Parent
                  ,broker=Broker

--- a/core/kazoo_amqp/src/listener_federator.erl
+++ b/core/kazoo_amqp/src/listener_federator.erl
@@ -70,7 +70,7 @@ init([Parent, ParentCallId, Broker]=L) ->
     CallId = kz_binary:join([ParentCallId, Zone], <<"-">>),
     kz_util:put_callid(CallId),
 
-    gen_listener:the_federator_lives(Parent, {Broker, self()}),
+    gen_listener:notify_of_federator_listener(Parent, {Broker, self()}),
 
     {'ok', #state{parent=Parent
                  ,broker=Broker

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -1034,7 +1034,7 @@ fix_services_tree(AccountId, Tree) ->
     Services = kz_services:fetch(AccountId),
     fix_services_tree(Services, Tree, kz_services:services_jobj(Services)).
 
--spec fix_services_tree(kz_term:ne_binary(), kz_term:ne_binaries(), kzd_services:doc()) -> 'ok'.
+-spec fix_services_tree(kz_services:services(), kz_term:ne_binaries(), kzd_services:doc()) -> 'ok'.
 fix_services_tree(Services, Tree, ServicesJObj) ->
     case kzd_services:tree(ServicesJObj) =:= Tree of
         'true' -> 'ok';
@@ -2166,19 +2166,21 @@ check_release() ->
 
 -spec run_check(fun()) -> 'ok'.
 run_check(CheckFun) ->
+    StartTimeMs = kz_time:now_ms(),
     {Pid, Ref} = kz_util:spawn_monitor(CheckFun, []),
-    wait_for_check(Pid, Ref).
+    wait_for_check(Pid, Ref, StartTimeMs).
 
--spec wait_for_check(pid(), reference()) -> 'ok'.
-wait_for_check(Pid, Ref) ->
+-spec wait_for_check(pid(), reference(), pos_integer()) -> 'ok'.
+wait_for_check(Pid, Ref, StartTimeMs) ->
     receive
-        {'DOWN', Ref, 'process', Pid, 'normal'} -> 'ok';
+        {'DOWN', Ref, 'process', Pid, 'normal'} ->
+            lager:info("check finished in ~pms", [kz_time:elapsed_ms(StartTimeMs)]);
         {'DOWN', Ref, 'process', Pid, Reason} ->
-            lager:error("check in ~p failed to run: ~p", [Pid, Reason]),
+            lager:error("check in ~p failed to run after ~pms: ~p", [Pid, kz_time:elapsed_ms(StartTimeMs), Reason]),
             throw(Reason)
     after 5 * ?MILLISECONDS_IN_MINUTE ->
             lager:error("check in ~p timed out", [Pid]),
-            exit(Pid, 'timeout'),
+            exit(Pid, 'kill'),
             throw('timeout')
     end.
 

--- a/core/kazoo_proper/src/kazoo_proper_maintenance.erl
+++ b/core/kazoo_proper/src/kazoo_proper_maintenance.erl
@@ -47,13 +47,16 @@ run_seq_modules() ->
 
 -spec run_seq_module(atom() | kz_term:ne_binary()) -> 'no_return'.
 run_seq_module(Module) when is_atom(Module) ->
-    _ = [Module:Function()
-         || Function <- ['seq'],
-            kz_module:is_exported(Module, Function, 0)
-        ],
-    'no_return';
+    run_seq_module(Module, kz_module:is_exported(Module, 'seq', 0));
 run_seq_module(ModuleBin) ->
     run_seq_module(kz_term:to_atom(ModuleBin)).
+
+run_seq_module(_Module, 'false') -> 'no_return';
+run_seq_module(Module, 'true') ->
+    StartTimeMs = kz_time:now_ms(),
+    Module:seq(),
+    ?SUP_LOG_DEBUG("~s:seq() ran in ~pms", [Module, kz_time:elapsed_ms(StartTimeMs)]),
+    'no_return'.
 
 -spec modules() -> [module()].
 modules() ->

--- a/core/kazoo_services/src/kz_services.erl
+++ b/core/kazoo_services/src/kz_services.erl
@@ -947,18 +947,15 @@ handle_fetch_options(Services, ['skip_cache'|Options]) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec commit_updates(kz_term:ne_binary()
-                    ,kz_services_quantities:billables() | kz_services_quantities:billable()
-                    ,kz_services_quantities:billables() | kz_services_quantities:billable()
-                    ) -> services().
+-type billable_updates() :: 'undefined' | kz_services_quantities:billables() | kz_services_quantities:billable().
+
+-spec commit_updates(kz_term:ne_binary(), billable_updates(), billable_updates()) ->
+          services().
 commit_updates(Account, Current, Proposed) ->
     commit_updates(Account, Current, Proposed, kz_json:new()).
 
--spec commit_updates(kz_term:ne_binary()
-                    ,kz_services_quantities:billables() | kz_services_quantities:billable()
-                    ,kz_services_quantities:billables() | kz_services_quantities:billable()
-                    ,kz_json:object()
-                    ) -> services().
+-spec commit_updates(kz_term:ne_binary(), billable_updates(), billable_updates(), kz_json:object()) ->
+          services().
 commit_updates(Account, Current, Proposed, AuditLog) ->
     AccountId = kz_util:format_account_id(Account),
     FetchOptions = [{'updates', AccountId, to_billables(Current), to_billables(Proposed)}
@@ -974,7 +971,7 @@ commit_updates(Account, Current, Proposed, AuditLog) ->
             commit_updates(Services, FetchOptions)
     end.
 
--spec to_billables(kz_services_quantities:billables() | kz_services_quantities:billable()) -> kz_services_quantities:billables().
+-spec to_billables(billable_updates()) -> kz_services_quantities:billables().
 to_billables('undefined') -> [];
 to_billables(Bs) when is_list(Bs) -> Bs;
 to_billables(B) -> [B].


### PR DESCRIPTION
Prior, when a gen_listener needed to federate its queue and bindings
to other zones, it would start_link the listener_federator (and trap
exits). However, should a listener_federator process actually exit,
the parent gen_listener would receive the EXIT message but failed to
have a handle_info clause to restart the process.

Introduce a sofo supervisor for starting listener_federator processes
and restart them if they die unexpectedly (non-normal exits).

Secondly, introduce memory consumption checks and GC gen_listeners
when they exceed 100K in total_heap_size. In addition, copy the binary
payloads as they arrive off the AMQP channel has shown to decelerate
the memory growth as the original binary can be garbage collected
sooner and not count against the gen_listener's "old" heap.

All told, these manual GC runs appear to be minimal and only affect
long-running and busy gen_listeners; even fewer runs needed to release
memory after the binary:copy/1 introduction.