### PR TITLE
Listener federators and memory improvements

### DIFF
--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -107,7 +107,7 @@
         ]).
 
 -export([federated_event/3
-        ,the_federator_lives/2
+        ,notify_of_federator_listener/2
         ]).
 -export([delayed_cast/3]).
 -export([distribute_event/3]).
@@ -401,8 +401,8 @@ rm_binding(Srv, Binding, Props) ->
 federated_event(Srv, JObj, Props) ->
     gen_server:cast(Srv, {'federated_event', JObj, Props}).
 
--spec the_federator_lives(pid(), {kz_term:ne_binary(), pid()}) -> 'ok'.
-the_federator_lives(Srv, {_Broker, _Pid}=Child) ->
+-spec notify_of_federator_listener(pid(), {kz_term:ne_binary(), pid()}) -> 'ok'.
+notify_of_federator_listener(Srv, {_Broker, _Pid}=Child) ->
     gen_server:cast(Srv, {'federator_listener', Child}).
 
 -spec execute(kz_types:server_ref(), module(), atom(), [any()]) -> 'ok'.

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -713,8 +713,8 @@ handle_info({#'basic.deliver'{}=BD
         end,
     case props:is_true('spawn_handle_event', Params, 'false') of
         'false' ->
-            NewState = handle_event(binary:copy(Payload), {CT, CE}, {BD, Basic}, State),
-            maybe_gc(NewState);
+            Reply = handle_event(binary:copy(Payload), {CT, CE}, {BD, Basic}, State),
+            maybe_gc(Reply);
         'true'  ->
             kz_process:spawn(fun handle_event/4, [Payload, {CT, CE}, {BD, Basic}, State]),
             {'noreply', State}
@@ -1609,12 +1609,12 @@ maybe_configure_auto_ack(Props, 'true') ->
 %% It is possible that apps may load more memory into their state
 %% which would cause gen_listener's state to exceed 10K in the steady
 %% state. We advise app developers to not do this :)
--spec maybe_gc(State) -> {'noreply', State}.
-maybe_gc(State) ->
+-spec maybe_gc(Reply) -> Reply.
+maybe_gc(Reply) ->
     maybe_gc(process_info(self(), ['total_heap_size'])
             ,100 * ?BYTES_K
             ),
-    {'noreply', State}.
+    Reply.
 
 maybe_gc([{'total_heap_size', Words}], MaxBytes) ->
     maybe_gc(kz_term:words_to_bytes(Words), MaxBytes);

--- a/core/kazoo_amqp/src/gen_listener.erl
+++ b/core/kazoo_amqp/src/gen_listener.erl
@@ -1623,5 +1623,4 @@ maybe_gc(Heap, Max) when Heap > Max ->
     [{'total_heap_size', NewHeapWords}] = process_info(self(), ['total_heap_size']),
     NewHeap = kz_term:words_to_bytes(NewHeapWords),
     lager:debug("new heap size ~p (delta ~p)", [NewHeap, Heap-NewHeap]);
-maybe_gc(_Heap, _Max) ->
-    lager:debug("current heap ~p", [_Heap]).
+maybe_gc(_Heap, _Max) -> 'ok'.

--- a/core/kazoo_amqp/src/kz_amqp_federated_listeners_sup.erl
+++ b/core/kazoo_amqp/src/kz_amqp_federated_listeners_sup.erl
@@ -1,0 +1,39 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2012-2020, 2600Hz
+%%% @doc
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(kz_amqp_federated_listeners_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0
+        ,start_child/3
+        ,init/1
+        ]).
+
+-include("kz_amqp_util.hrl").
+
+-define(CHILDREN, [?WORKER_TYPE('listener_federator', 'transient')]).
+
+-spec start_link() -> kz_types:startlink_ret().
+start_link() ->
+    supervisor:start_link({'local', ?MODULE}, ?MODULE, []).
+
+-spec start_child(pid(), kz_term:ne_binary(), kz_term:proplist()) -> kz_types:sup_startchild_ret().
+start_child(Parent, Broker, FederateParams) ->
+    ParentCallId = kz_log:get_callid(),
+    supervisor:start_child(?MODULE, [Parent, ParentCallId, Broker, FederateParams]).
+
+-spec init(any()) -> kz_types:sup_init_ret().
+init([]) ->
+    RestartStrategy = 'simple_one_for_one',
+    MaxRestarts = 5,
+    MaxSecondsBetweenRestarts = 10,
+    SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
+
+    {'ok', {SupFlags, ?CHILDREN}}.

--- a/core/kazoo_amqp/src/kz_amqp_sup.erl
+++ b/core/kazoo_amqp/src/kz_amqp_sup.erl
@@ -35,6 +35,7 @@
 
 -define(CHILDREN, [?WORKER('kz_amqp_connections')
                   ,?SUPER('kz_amqp_connection_sup')
+                  ,?SUPER('kz_amqp_federated_listeners_sup')
                   ,?WORKER('kz_amqp_assignments')
                   ,?WORKER('kz_amqp_bootstrap')
                   ]).

--- a/core/kazoo_amqp/src/listener_federator.erl
+++ b/core/kazoo_amqp/src/listener_federator.erl
@@ -11,7 +11,7 @@
 
 -behaviour(gen_listener).
 
--export([start_link/3
+-export([start_link/4
         ,stop/1
         ,broker/1
         ]).
@@ -45,9 +45,8 @@
 %% @doc Starts the server.
 %% @end
 %%------------------------------------------------------------------------------
--spec start_link(pid(), kz_term:ne_binary(), kz_term:proplist()) -> kz_types:startlink_ret().
-start_link(Parent, Broker, Params) ->
-    ParentCallId = kz_log:get_callid(),
+-spec start_link(pid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> kz_types:startlink_ret().
+start_link(Parent, ParentCallId, Broker, Params) ->
     gen_listener:start_link(?SERVER, Params, [Parent, ParentCallId, Broker]).
 
 -spec broker(kz_types:server_ref()) -> kz_term:ne_binary().
@@ -74,6 +73,8 @@ init([Parent, ParentCallId, Broker]=L) ->
 
     CallId = kz_binary:join([ParentCallId, Zone], <<"-">>),
     kz_log:put_callid(CallId),
+
+    gen_listener:the_federator_lives(Parent, {Broker, self()}),
 
     {'ok', #state{parent=Parent
                  ,broker=Broker

--- a/core/kazoo_amqp/src/listener_federator.erl
+++ b/core/kazoo_amqp/src/listener_federator.erl
@@ -30,7 +30,7 @@
 
 -define(SERVER, ?MODULE).
 
--record(state, {parent :: pid()
+-record(state, {parent :: {pid(), reference()}
                ,broker :: kz_term:ne_binary()
                ,self_binary = kz_term:to_binary(pid_to_list(self())) :: kz_term:ne_binary()
                ,zone :: kz_term:ne_binary()
@@ -76,7 +76,7 @@ init([Parent, ParentCallId, Broker]=L) ->
 
     gen_listener:notify_of_federator_listener(Parent, {Broker, self()}),
 
-    {'ok', #state{parent=Parent
+    {'ok', #state{parent={Parent, monitor('process', Parent)}
                  ,broker=Broker
                  ,zone=Zone
                  }}.
@@ -86,7 +86,7 @@ init([Parent, ParentCallId, Broker]=L) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_call(any(), any(), state()) -> kz_types:handle_call_ret_state(state()).
-handle_call({'stop', Parent}, _From, #state{parent=Parent}=State) ->
+handle_call({'stop', Parent}, _From, #state{parent={Parent, _Ref}}=State) ->
     {'stop', 'normal', 'ok', State};
 handle_call('get_broker', _From, #state{broker=Broker}=State) ->
     {'reply', Broker, State};
@@ -100,7 +100,11 @@ handle_call(_Request, _From, State) ->
 -spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
 handle_cast({'gen_listener', {'created_queue', _}}, State) ->
     {'noreply', State};
-handle_cast({'gen_listener', {'is_consuming', 'true'}}, #state{parent=Parent, broker=Broker}=State) ->
+handle_cast({'gen_listener', {'is_consuming', 'true'}}
+           ,#state{parent={Parent, _Ref}
+                  ,broker=Broker
+                  }=State
+           ) ->
     gen_server:cast(Parent, {'federator_is_consuming', Broker, 'true'}),
     {'noreply', State};
 handle_cast(_Msg, State) ->
@@ -112,12 +116,17 @@ handle_cast(_Msg, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
+handle_info({'DOWN', Ref, 'process', Parent, _Reason}
+           ,#state{parent={Parent, Ref}}=State
+           ) ->
+    lager:info("parent gen_listener ~p down: ~p", [Parent, _Reason]),
+    {'stop', 'normal', State};
 handle_info(_Info, State) ->
     lager:info("unhandled message: ~p", [_Info]),
     {'noreply', State}.
 
 -spec handle_event(kz_json:object(), kz_term:proplist(), state()) -> gen_listener:handle_event_return().
-handle_event(JObj, Props, #state{parent=Parent
+handle_event(JObj, Props, #state{parent={Parent, _Ref}
                                 ,broker=Broker
                                 ,self_binary=Self
                                 ,zone=Zone

--- a/core/kazoo_amqp/src/listener_federator.erl
+++ b/core/kazoo_amqp/src/listener_federator.erl
@@ -74,7 +74,7 @@ init([Parent, ParentCallId, Broker]=L) ->
     CallId = kz_binary:join([ParentCallId, Zone], <<"-">>),
     kz_log:put_callid(CallId),
 
-    gen_listener:the_federator_lives(Parent, {Broker, self()}),
+    gen_listener:notify_of_federator_listener(Parent, {Broker, self()}),
 
     {'ok', #state{parent=Parent
                  ,broker=Broker

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -2169,19 +2169,21 @@ check_release() ->
 
 -spec run_check(fun()) -> 'ok'.
 run_check(CheckFun) ->
+    StartTimeMs = kz_time:now_ms(),
     {Pid, Ref} = kz_process:spawn_monitor(CheckFun, []),
-    wait_for_check(Pid, Ref).
+    wait_for_check(Pid, Ref, StartTimeMs).
 
--spec wait_for_check(pid(), reference()) -> 'ok'.
-wait_for_check(Pid, Ref) ->
+-spec wait_for_check(pid(), reference(), pos_integer()) -> 'ok'.
+wait_for_check(Pid, Ref, StartTimeMs) ->
     receive
-        {'DOWN', Ref, 'process', Pid, 'normal'} -> 'ok';
+        {'DOWN', Ref, 'process', Pid, 'normal'} ->
+            lager:info("check finished in ~pms", [kz_time:elapsed_ms(StartTimeMs)]);
         {'DOWN', Ref, 'process', Pid, Reason} ->
-            lager:error("check in ~p failed to run: ~p", [Pid, Reason]),
+            lager:error("check in ~p failed to run after ~pms: ~p", [Pid, kz_time:elapsed_ms(StartTimeMs), Reason]),
             throw(Reason)
     after 5 * ?MILLISECONDS_IN_MINUTE ->
             lager:error("check in ~p timed out", [Pid]),
-            exit(Pid, 'timeout'),
+            exit(Pid, 'kill'),
             throw('timeout')
     end.
 

--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -858,7 +858,7 @@ handle_info({'heartbeat', Ref}
             andalso kapi_nodes:publish_advertise(advertise_payload(Node)),
         {'noreply', State#state{heartbeat_ref=Reference, me=Node}}
     catch
-        _:{noproc,_}:_ST ->
+        _:{'noproc',_}:_ST ->
             {'noreply', State#state{heartbeat_ref=Reference}, 'hibernate'};
         'exit' : {'timeout' , _}:_ST when Me =/= 'undefined' ->
             NewMe = Me#kz_node{expires=Heartbeat},
@@ -1092,7 +1092,6 @@ from_json(JObj, State) ->
             ,modules=kz_json:get_json_value(<<"Modules">>, JObj)
             ,roles=kz_json:to_proplist(kz_json:get_json_value(<<"Roles">>, JObj, kz_json:new()))
             }.
-
 
 -spec kapps_from_json(kz_term:api_terms()) -> kz_types:kapps_info().
 kapps_from_json(Whapps) when is_list(Whapps) ->

--- a/core/kazoo_proper/src/kazoo_proper_maintenance.erl
+++ b/core/kazoo_proper/src/kazoo_proper_maintenance.erl
@@ -52,13 +52,16 @@ run_seq_modules() ->
 
 -spec run_seq_module(atom() | kz_term:ne_binary()) -> 'no_return'.
 run_seq_module(Module) when is_atom(Module) ->
-    _ = [Module:Function()
-         || Function <- ['seq'],
-            kz_module:is_exported(Module, Function, 0)
-        ],
-    'no_return';
+    run_seq_module(Module, kz_module:is_exported(Module, 'seq', 0));
 run_seq_module(ModuleBin) ->
     run_seq_module(kz_term:to_atom(ModuleBin)).
+
+run_seq_module(_Module, 'false') -> 'no_return';
+run_seq_module(Module, 'true') ->
+    StartTimeMs = kz_time:now_ms(),
+    Module:seq(),
+    ?SUP_LOG_DEBUG("~s:seq() ran in ~pms", [Module, kz_time:elapsed_ms(StartTimeMs)]),
+    'no_return'.
 
 -spec modules() -> [module()].
 modules() ->


### PR DESCRIPTION
Prior, when a gen_listener needed to federate its queue and bindings
to other zones, it would start_link the listener_federator (and trap
exits). However, should a listener_federator process actually exit,
the parent gen_listener would receive the EXIT message but failed to
have a handle_info clause to restart the process.

Introduce a sofo supervisor for starting listener_federator processes
and restart them if they die unexpectedly (non-normal exits).

Secondly, introduce memory consumption checks and GC gen_listeners
when they exceed 100K in total_heap_size. In addition, copy the binary
payloads as they arrive off the AMQP channel has shown to decelerate
the memory growth as the original binary can be garbage collected
sooner and not count against the gen_listener's "old" heap.

All told, these manual GC runs appear to be minimal and only affect
long-running and busy gen_listeners; even fewer runs needed to release
memory after the binary:copy/1 introduction.