### PR TITLE
HELP-11566: clarify precedence of call forward vs failover

### DIFF
--- a/applications/crossbar/doc/devices.md
+++ b/applications/crossbar/doc/devices.md
@@ -251,6 +251,10 @@ Key | Description | Type | Default | Required | Support Level
 
 
 
+### Call forwarding
+
+Currently the `call_forward` object allows you to define call forwarding *or* failover but not both. If `call_forward.enabled` is `true` it will take precedence and settings will be used only for call forwarding. If `call_forward.enabled` is `false` *and* `call_forward.failover` is `true`, failover settings will be used.
+
 ## Fetch
 
 > GET /v2/accounts/{ACCOUNT_ID}/devices

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -37,8 +37,8 @@
 -include("kazoo_endpoint.hrl").
 
 -type std_return() :: {'ok', kz_json:object()} |
-                      {'error', 'invalid_endpoint_id'} |
-                      kz_datamgr:data_error().
+                     {'error', 'invalid_endpoint_id'} |
+                     kz_datamgr:data_error().
 -export_type([std_return/0]).
 
 %%------------------------------------------------------------------------------
@@ -53,7 +53,6 @@ get(EndpointId, _Call) -> ?MOD:get(EndpointId, _Call).
 
 
 -ifdef(TEST).
-
 attributes_keys() -> ?MOD:attributes_keys().
 
 -spec merge_attribute(kz_term:ne_binary(), kz_term:api_object(), kz_term:api_object(), kz_term:api_object()) -> kz_json:object().
@@ -87,9 +86,9 @@ flush_local(Db, Id) -> ?MOD:flush_local(Db, Id).
 %% @end
 %%------------------------------------------------------------------------------
 -type build_errors() :: 'db_not_reachable' | 'endpoint_disabled'
-                      | 'endpoint_called_self' | 'endpoint_id_undefined'
-                      | 'invalid_endpoint_id' | 'not_found' | 'owner_called_self'
-                      | 'do_not_disturb' | 'no_resource_type'.
+                     | 'endpoint_called_self' | 'endpoint_id_undefined'
+                     | 'invalid_endpoint_id' | 'not_found' | 'owner_called_self'
+                     | 'do_not_disturb' | 'no_resource_type'.
 
 
 -spec build(kz_term:api_ne_binary() | kz_json:object(), kapps_call:call()) ->
@@ -116,7 +115,6 @@ maybe_start_metaflow(Call, Endpoint) -> ?MOD:maybe_start_metaflow(Call, Endpoint
           kz_json:object().
 create_sip_endpoint(Endpoint, Properties, Call) -> ?MOD:create_sip_endpoint(Endpoint, Properties, Call).
 
-
 %%------------------------------------------------------------------------------
 %% @doc Creates the Kazoo API endpoint for a bridge call command when
 %% the device (or owner) has forwarded their phone.  This endpoint
@@ -128,7 +126,6 @@ create_sip_endpoint(Endpoint, Properties, Call) -> ?MOD:create_sip_endpoint(Endp
 -spec create_call_fwd_endpoint(kz_json:object(), kz_json:object(), kapps_call:call()) ->
           kz_json:object().
 create_call_fwd_endpoint(Endpoint, Properties, Call) -> ?MOD:create_call_fwd_endpoint(Endpoint, Properties, Call).
-
 
 -spec encryption_method_map(kz_term:api_object(), kz_term:api_binaries() | kz_json:object()) -> kz_term:api_object().
 encryption_method_map(CCVs, Methods) -> ?MOD:encryption_method_map(CCVs, Methods).

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -37,8 +37,8 @@
 -include("kazoo_endpoint.hrl").
 
 -type std_return() :: {'ok', kz_json:object()} |
-                     {'error', 'invalid_endpoint_id'} |
-                     kz_datamgr:data_error().
+                      {'error', 'invalid_endpoint_id'} |
+                      kz_datamgr:data_error().
 -export_type([std_return/0]).
 
 %%------------------------------------------------------------------------------
@@ -86,9 +86,9 @@ flush_local(Db, Id) -> ?MOD:flush_local(Db, Id).
 %% @end
 %%------------------------------------------------------------------------------
 -type build_errors() :: 'db_not_reachable' | 'endpoint_disabled'
-                     | 'endpoint_called_self' | 'endpoint_id_undefined'
-                     | 'invalid_endpoint_id' | 'not_found' | 'owner_called_self'
-                     | 'do_not_disturb' | 'no_resource_type'.
+                      | 'endpoint_called_self' | 'endpoint_id_undefined'
+                      | 'invalid_endpoint_id' | 'not_found' | 'owner_called_self'
+                      | 'do_not_disturb' | 'no_resource_type'.
 
 
 -spec build(kz_term:api_ne_binary() | kz_json:object(), kapps_call:call()) ->

--- a/core/kazoo_endpoint/src/kz_endpoint_v4.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint_v4.erl
@@ -96,8 +96,8 @@
 -type sms_routes() :: [sms_route(), ...].
 
 -type std_return() :: {'ok', kz_json:object()} |
-                      {'error', 'invalid_endpoint_id'} |
-                      kz_datamgr:data_error().
+                     {'error', 'invalid_endpoint_id'} |
+                     kz_datamgr:data_error().
 -export_type([std_return/0]).
 
 %%------------------------------------------------------------------------------
@@ -805,7 +805,7 @@ evaluate_rules_for_creation(Endpoint, Properties, Call) ->
                ).
 
 -type create_ep_acc() :: {kz_json:object(), kz_json:object(), kapps_call:call()} |
-                         {'error', any()}.
+                        {'error', any()}.
 -type ep_routine_v() :: fun((kz_json:object(), kz_json:object(), kapps_call:call()) -> 'ok' | _).
 
 -spec should_create_endpoint_fold(ep_routine_v(), create_ep_acc()) -> create_ep_acc().
@@ -1775,7 +1775,12 @@ maybe_set_call_forward({Endpoint, Call, CallFwd, CCVs}) ->
 
 -spec is_failover(kz_json:object()) -> 'true' | 'undefined'.
 is_failover(CallFwd) ->
-    case kz_json:is_true(<<"failover">>, CallFwd) of
+    IsFailover = kz_json:is_true(<<"failover">>, CallFwd),
+    IsCallFwdEnabled = kz_json:is_true(<<"enabled">>, CallFwd),
+
+    case (not IsCallFwdEnabled)
+        andalso IsFailover
+    of
         'true' -> 'true';
         'false' -> 'undefined'
     end.

--- a/core/kazoo_endpoint/src/kz_endpoint_v4.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint_v4.erl
@@ -96,8 +96,8 @@
 -type sms_routes() :: [sms_route(), ...].
 
 -type std_return() :: {'ok', kz_json:object()} |
-                     {'error', 'invalid_endpoint_id'} |
-                     kz_datamgr:data_error().
+                      {'error', 'invalid_endpoint_id'} |
+                      kz_datamgr:data_error().
 -export_type([std_return/0]).
 
 %%------------------------------------------------------------------------------
@@ -805,7 +805,7 @@ evaluate_rules_for_creation(Endpoint, Properties, Call) ->
                ).
 
 -type create_ep_acc() :: {kz_json:object(), kz_json:object(), kapps_call:call()} |
-                        {'error', any()}.
+                         {'error', any()}.
 -type ep_routine_v() :: fun((kz_json:object(), kz_json:object(), kapps_call:call()) -> 'ok' | _).
 
 -spec should_create_endpoint_fold(ep_routine_v(), create_ep_acc()) -> create_ep_acc().

--- a/core/kazoo_endpoint/src/kz_endpoint_v5.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint_v5.erl
@@ -98,8 +98,8 @@
 -type sms_routes() :: [sms_route(), ...].
 
 -type std_return() :: {'ok', kz_json:object()} |
-                      {'error', 'invalid_endpoint_id'} |
-                      kz_datamgr:data_error().
+                     {'error', 'invalid_endpoint_id'} |
+                     kz_datamgr:data_error().
 -export_type([std_return/0]).
 
 %%------------------------------------------------------------------------------
@@ -809,7 +809,7 @@ evaluate_rules_for_creation(Endpoint, Properties, Call) ->
                ).
 
 -type create_ep_acc() :: {kz_json:object(), kz_json:object(), kapps_call:call()} |
-                         {'error', any()}.
+                        {'error', any()}.
 -type ep_routine_v() :: fun((kz_json:object(), kz_json:object(), kapps_call:call()) -> 'ok' | _).
 
 -spec should_create_endpoint_fold(ep_routine_v(), create_ep_acc()) -> create_ep_acc().
@@ -1715,7 +1715,12 @@ maybe_set_call_forward({Endpoint, Call, CallFwd, CCVs}) ->
 
 -spec is_failover(kz_json:object()) -> 'true' | 'undefined'.
 is_failover(CallFwd) ->
-    case kz_json:is_true(<<"failover">>, CallFwd) of
+    IsFailover = kz_json:is_true(<<"failover">>, CallFwd),
+    IsCallFwdEnabled = kz_json:is_true(<<"enabled">>, CallFwd),
+
+    case (not IsCallFwdEnabled)
+        andalso IsFailover
+    of
         'true' -> 'true';
         'false' -> 'undefined'
     end.
@@ -1750,11 +1755,11 @@ maybe_set_confirm_properties({Endpoint, Call, CallFwd, CCVs}=Acc) ->
                       ,{<<"Confirm-File">>, ?CONFIRM_FILE(Call)}
                       ,{<<"Require-Ignore-Early-Media">>, <<"true">>}
                       ,{<<"Require-Fail-On-Single-Reject">>, [<<"USER_BUSY">>
-                                                             ,<<"CALL_REJECTED">>
-                                                             ,<<"NO_ANSWER">>
-                                                             ,<<"NORMAL_CLEARING">>
-                                                             ,<<"PROGRESS_TIMEOUT">>
-                                                             ]}
+                                                           ,<<"CALL_REJECTED">>
+                                                           ,<<"NO_ANSWER">>
+                                                           ,<<"NORMAL_CLEARING">>
+                                                           ,<<"PROGRESS_TIMEOUT">>
+                                                           ]}
                       ],
             {Endpoint, Call, CallFwd
             ,kz_json:merge_jobjs(kz_json:from_list(Confirm), CCVs)

--- a/core/kazoo_endpoint/src/kz_endpoint_v5.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint_v5.erl
@@ -98,8 +98,8 @@
 -type sms_routes() :: [sms_route(), ...].
 
 -type std_return() :: {'ok', kz_json:object()} |
-                     {'error', 'invalid_endpoint_id'} |
-                     kz_datamgr:data_error().
+                      {'error', 'invalid_endpoint_id'} |
+                      kz_datamgr:data_error().
 -export_type([std_return/0]).
 
 %%------------------------------------------------------------------------------
@@ -809,7 +809,7 @@ evaluate_rules_for_creation(Endpoint, Properties, Call) ->
                ).
 
 -type create_ep_acc() :: {kz_json:object(), kz_json:object(), kapps_call:call()} |
-                        {'error', any()}.
+                         {'error', any()}.
 -type ep_routine_v() :: fun((kz_json:object(), kz_json:object(), kapps_call:call()) -> 'ok' | _).
 
 -spec should_create_endpoint_fold(ep_routine_v(), create_ep_acc()) -> create_ep_acc().
@@ -1755,11 +1755,11 @@ maybe_set_confirm_properties({Endpoint, Call, CallFwd, CCVs}=Acc) ->
                       ,{<<"Confirm-File">>, ?CONFIRM_FILE(Call)}
                       ,{<<"Require-Ignore-Early-Media">>, <<"true">>}
                       ,{<<"Require-Fail-On-Single-Reject">>, [<<"USER_BUSY">>
-                                                           ,<<"CALL_REJECTED">>
-                                                           ,<<"NO_ANSWER">>
-                                                           ,<<"NORMAL_CLEARING">>
-                                                           ,<<"PROGRESS_TIMEOUT">>
-                                                           ]}
+                                                             ,<<"CALL_REJECTED">>
+                                                             ,<<"NO_ANSWER">>
+                                                             ,<<"NORMAL_CLEARING">>
+                                                             ,<<"PROGRESS_TIMEOUT">>
+                                                             ]}
                       ],
             {Endpoint, Call, CallFwd
             ,kz_json:merge_jobjs(kz_json:from_list(Confirm), CCVs)


### PR DESCRIPTION
The `call_forward` object handles configuration for both call
forwarding and for failover. In its current implementation, only one
of those features can be "active".

Prior to this change, if `call_forward.failover` was `true` it would
be included on the endpoint object and ecallmgr would treat the
`call_forward` settings as a failover endpoint, regardless of the
`call_forward.enabled` flag's setting.

This change clarifies that if `call_forward.enabled` is `true`, the
settings should only be considered for call forwarding. If the setting
is `false` *and* `call_forward.failover` is `true` then consider the
settings as a failover endpoint.