### PR TITLE
[4.3] KCRO-10: expose the message counts per folder when listing vmboxes

### DIFF
--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -767,7 +767,11 @@ merge_summary_fold(BoxSummary, CountMap) ->
             MsgsArrayCount = kz_json:get_integer_value(?VM_KEY_MESSAGES, BoxSummary, 0),
             New = maps:get(?VM_FOLDER_NEW, BoxCountMap, 0),
             Saved = maps:get(?VM_FOLDER_SAVED, BoxCountMap, 0),
-            kz_json:set_value(?VM_KEY_MESSAGES, MsgsArrayCount + New + Saved, BoxSummary)
+            Summary = [{?VM_KEY_MESSAGES, MsgsArrayCount + New + Saved}
+                      ,{[<<"folders">>, ?VM_FOLDER_NEW], New}
+                      ,{[<<"folders">>, ?VM_FOLDER_SAVED], Saved}
+                      ],
+            kz_json:set_values(Summary, BoxSummary)
     end.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
When listing the voicemail boxes this adds a new object to each called "folders" if the vmbox has messages.  The object contains two properties that represent the quantity of messages in the 'new' and 'saved' folders.