### PR TITLE
PISTON-1032: Allow SUP to handle any argument type as long as the argument is surrounded by double quotes.

### DIFF
--- a/core/sup/src/sup.erl
+++ b/core/sup/src/sup.erl
@@ -70,7 +70,7 @@ main(CommandLineArgs, Loops) ->
                                            halt(1)
                                    end
                            end,
-            ParsedArgs = lists:map(ParseFunArgs ,Args),
+            ParsedArgs = lists:map(ParseFunArgs, Args),
             Timeout = case props:get_value('timeout', Options) of 0 -> 'infinity'; T -> T * 1000 end,
             IsVerbose
                 andalso stdout("Running ~s:~s(~s)", [Module, Function, string:join(Args, ", ")]),

--- a/core/sup/src/sup.erl
+++ b/core/sup/src/sup.erl
@@ -62,14 +62,14 @@ main(CommandLineArgs, Loops) ->
 
             %% Parse the function args to the correct types
             ParseFunArgs = fun(FunArg) ->
-                                {'ok', Tokens, _} = erl_scan:string(FunArg++"."),
-                                case erl_parse:parse_term(Tokens) of
-                                    {'ok', ParsedArg} -> ParsedArg;
-                                    Failed ->
-                                        stderr("Failed to parse term ~p, error ~p~n", [FunArg, Failed]),
-                                        halt(1)
-                                end
-                            end,
+                                   {'ok', Tokens, _} = erl_scan:string(FunArg++"."),
+                                   case erl_parse:parse_term(Tokens) of
+                                       {'ok', ParsedArg} -> ParsedArg;
+                                       Failed ->
+                                           stderr("Failed to parse term ~p, error ~p~n", [FunArg, Failed]),
+                                           halt(1)
+                                   end
+                           end,
             ParsedArgs = lists:map(ParseFunArgs ,Args),
             Timeout = case props:get_value('timeout', Options) of 0 -> 'infinity'; T -> T * 1000 end,
             IsVerbose

--- a/core/sup/src/sup.erl
+++ b/core/sup/src/sup.erl
@@ -60,22 +60,16 @@ main(CommandLineArgs, Loops) ->
                     F -> list_to_atom(F)
                 end,
 
-            %% Parse the function args to the correct types
-            ParseFunArgs = fun(FunArg) ->
-                                   {'ok', Tokens, _} = erl_scan:string(FunArg++"."),
-                                   case erl_parse:parse_term(Tokens) of
-                                       {'ok', ParsedArg} -> ParsedArg;
-                                       Failed ->
-                                           stderr("Failed to parse term ~p, error ~p~n", [FunArg, Failed]),
-                                           halt(1)
-                                   end
-                           end,
-            ParsedArgs = lists:map(ParseFunArgs, Args),
+            %% If erl_term_args is set then parse the args as erlang terms, else just convert to binary
+            Arguments = case erl_term_args(Options) of
+                            'true' -> parse_erl_terms_from_args(Args);
+                            'false' -> [list_to_binary(Arg) || Arg <- Args]
+                        end,
             Timeout = case props:get_value('timeout', Options) of 0 -> 'infinity'; T -> T * 1000 end,
             IsVerbose
                 andalso stdout("Running ~s:~s(~s)", [Module, Function, string:join(Args, ", ")]),
 
-            case rpc:call(Target, ?MODULE, 'in_kazoo', [SUPName, Module, Function, ParsedArgs], Timeout) of
+            case rpc:call(Target, ?MODULE, in_kazoo, [SUPName, Module, Function, Arguments], Timeout) of
                 {'badrpc', {'EXIT',{'undef', _}}} ->
                     print_invalid_cli_args();
                 {'badrpc', {'EXIT', {'timeout_value',[{Module,Function,_,_}|_]}}} ->
@@ -105,6 +99,24 @@ main(CommandLineArgs, Loops) ->
     end.
 
 %%% Internals
+
+%%------------------------------------------------------------------------------
+%% @doc Parse script args into erlang terms or halt and print help if fails to parse an arg.
+%% @end
+%%------------------------------------------------------------------------------
+-spec parse_erl_terms_from_args(list(list())) -> term() | no_return().
+parse_erl_terms_from_args(Args) -> lists:map(fun(Arg) -> parse_erl_terms_from_arg(Arg) end, Args).
+
+-spec parse_erl_terms_from_arg(list()) -> term() | no_return().
+parse_erl_terms_from_arg(Arg) ->
+    {'ok', Tokens, _} = erl_scan:string(Arg++"."),
+    case erl_parse:parse_term(Tokens) of
+        {'ok', ParsedArg} ->
+            ParsedArg;
+        Failed ->
+            stderr("Failed to parse term ~p, error ~p", [Arg, Failed]),
+            print_erl_term_args_help()
+    end.
 
 -spec in_kazoo(atom(), module(), atom(), kz_term:binaries()) -> no_return().
 in_kazoo(SUPName, M, F, As) ->
@@ -250,6 +262,20 @@ print_help() ->
     getopt:usage(option_spec_list(), "sup", "[args ...]"),
     halt(1).
 
+%%------------------------------------------------------------------------------
+%% @doc Print help for erl_term_args flag and halt.
+%% @end
+%%------------------------------------------------------------------------------
+-spec print_erl_term_args_help() -> no_return().
+print_erl_term_args_help() ->
+    stdout("Erlang term argumnets must be proplery encapsulated as below:", []),
+    stdout("  * Atoms: atom", []),
+    stdout("  * Srings: \"this is a string\"", []),
+    stdout("  * Binarys: \"<<\\\"Etc/UTC\\\">>\"", []),
+    stdout("  * Tuples: \"{{2020, 01, 01}, {01, 20, 30}}\"", []),
+    stdout("  * Lists: \"[1,2,3,4]\"", []),
+    halt(1).
+
 -spec stdout(string(), list()) -> 'ok'.
 stdout(Format, Things) ->
     io:format('standard_io', Format++"\n", Things).
@@ -268,6 +294,7 @@ option_spec_list() ->
     ,{'module', 'undefined', 'undefined', 'string', "The name of the remote module"}
     ,{'function', 'undefined', 'undefined', 'string', "The name of the remote module's function"}
     ,{'use_short', $s, "use_short", {'boolean', 'undefined'}, "Force using shortnames"}
+    ,{'erl_term_args', $e, "erl_term_args", {'boolean', 'false'}, "Parse function args to erlang terms"}
     ].
 
 -spec from_env(list(), list()) -> list().
@@ -280,5 +307,13 @@ from_env(Name, Default) ->
 -spec use_short(kz_term:proplist()) -> kz_term:api_boolean().
 use_short(Options) ->
     props:get_value('use_short', Options).
+
+%%------------------------------------------------------------------------------
+%% @doc Return true if the erl_term_args flag is passed by the user, else false
+%% @end
+%%------------------------------------------------------------------------------
+-spec erl_term_args(kz_term:proplist()) -> kz_term:api_boolean().
+erl_term_args(Options) ->
+    props:get_value('erl_term_args', Options).
 
 %%% End of Module

--- a/core/sup/src/sup.erl
+++ b/core/sup/src/sup.erl
@@ -268,12 +268,12 @@ print_help() ->
 %%------------------------------------------------------------------------------
 -spec print_erl_term_args_help() -> no_return().
 print_erl_term_args_help() ->
-    stdout("Erlang term argumnets must be proplery encapsulated as below:", []),
-    stdout("  * Atoms: atom", []),
-    stdout("  * Srings: \"this is a string\"", []),
-    stdout("  * Binarys: \"<<\\\"Etc/UTC\\\">>\"", []),
-    stdout("  * Tuples: \"{{2020, 01, 01}, {01, 20, 30}}\"", []),
-    stdout("  * Lists: \"[1,2,3,4]\"", []),
+    stdout("Erlang term arguments must be correctly wrapped / formated as below:", []),
+    stdout("  * Atom: atom", []),
+    stdout("  * String: \"this is a string\"", []),
+    stdout("  * Binary: \"<<\\\"Etc/UTC\\\">>\"", []),
+    stdout("  * Tuple: \"{{2020, 01, 01}, {01, 20, 30}}\"", []),
+    stdout("  * List: \"[1,2,3,4]\"", []),
     halt(1).
 
 -spec stdout(string(), list()) -> 'ok'.


### PR DESCRIPTION
Allow a user to pass any data type to a function call through the sup command

EG.  
sup kz_time to_gregorian_seconds "{{2020, 01, 01}, {01, 20, 30}}" "<<\"Etc/UTC\">>"
