### PR TITLE
[4.3] HELP-13433: noop email conversions to avoid errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ core/kazoo_proper/priv/mp3.mp3
 
 # asdf-vm "local" versions handler
 .tool-versions
+/applications/fax/test/pdf.pdf

--- a/applications/fax/Makefile
+++ b/applications/fax/Makefile
@@ -1,6 +1,15 @@
 ROOT = ../..
 PROJECT = fax
 
+PDF = test/pdf.pdf
+
 all: compile
+
+comile-test: assets
+
+assets: $(PDF)
+
+$(PDF):
+	wget -qO $@ https://raw.githubusercontent.com/mathiasbynens/small/master/pdf.pdf
 
 include $(ROOT)/make/kz.mk

--- a/applications/fax/Makefile
+++ b/applications/fax/Makefile
@@ -3,6 +3,8 @@ PROJECT = fax
 
 PDF = test/pdf.pdf
 
+COMPILE_MOAR = assets
+
 all: compile assets
 
 comile-test: assets

--- a/applications/fax/Makefile
+++ b/applications/fax/Makefile
@@ -3,7 +3,7 @@ PROJECT = fax
 
 PDF = test/pdf.pdf
 
-all: compile
+all: compile assets
 
 comile-test: assets
 

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -24,6 +24,10 @@
         ,terminate/2
         ]).
 
+-ifdef(TEST).
+-export([decode_data/1]).
+-endif.
+
 -include("fax.hrl").
 
 -define(RELAY, 'true').
@@ -96,7 +100,7 @@ handle_EHLO(Hostname, Extensions, #state{options=Options, proxy = Proxy}=State) 
                            %% auth is enabled, so advertise it
                            [{"AUTH", "PLAIN LOGIN CRAM-MD5"}
                            ,{"STARTTLS", 'true'}
-                            | Extensions
+                           | Extensions
                            ]
                    end,
     {'ok', filter_extensions(MyExtensions, Options), State}.
@@ -158,42 +162,56 @@ handle_DATA(From, To, Data, #state{doc='undefined'}=State) ->
         Error -> Error
     end;
 handle_DATA(From, To, Data, #state{options=Options}=State) ->
-    lager:debug("Handle Data From ~p to ~p", [From,To]),
+    Reference = kz_binary:rand_hex(16),
 
-    %% JMA: Can this be done with kz_binary:rand_hex() ?
-    Reference = lists:flatten(
-                  [io_lib:format("~2.16.0b", [X])
-                   || <<X>> <= erlang:md5(term_to_binary(kz_time:now()))
-                  ]),
+    lager:debug("Handle Data From ~p to ~p: reference: ~s", [From, To, Reference]),
 
-    try mimemail:decode(Data) of
+    case decode_data(Data) of
         {Type, SubType, Headers, Parameters, Body} ->
             lager:debug("Message decoded successfully!"),
             case process_message(Type, SubType, Headers, Parameters, Body, State) of
                 {ProcessResult, #state{errors=[]}=NewState} ->
                     {ProcessResult, Reference, NewState};
                 {ProcessResult, #state{errors=[Error | _]}=NewState} ->
-                    {ProcessResult, <<"554 ",Error/binary>>, NewState}
-            end
-    catch
-        _What:_Why ->
-            lager:debug("Message decode FAILED with ~p:~p", [_What, _Why]),
+                    {ProcessResult, <<"554 ", Error/binary>>, NewState}
+            end;
+        'error' ->
             handle_DATA_exception(Options, Reference, Data),
             {'error', "554 Message decode failed", State#state{errors=[<<"Message decode failed">>]
                                                               ,has_smtp_errors='true'
                                                               }}
     end.
 
--spec handle_DATA_exception(kz_term:proplist(), list(), binary()) -> 'ok'.
+-spec decode_data(iodata()) ->
+          'error' | mimemail:mimetuple().
+decode_data(Data) ->
+    DecodeOptions = [{'encoding', <<"utf-8">>}           %% default to utf8
+                    ,{'decode_attachments', 'true'}      %% decode base64/quoted-printable attachments
+                    ,{'allow_missing_version', 'true'}   %% assume default MIME version
+                    ,{'default_mime_version', <<"1.0">>} %% default MIME version
+                    ],
+
+    try mimemail:decode(Data, DecodeOptions)
+    catch
+        _What:_Why ->
+            ?LOG_INFO("Message decode FAILED with ~p:~p", [_What, _Why]),
+            'error'
+    end.
+
+-spec handle_DATA_exception(kz_term:proplist(), kz_term:ne_binary(), binary()) -> 'ok'.
 handle_DATA_exception(Options, Reference, Data) ->
     case props:get_is_true('dump', Options, 'false') of
         'false' -> 'ok';
         'true' ->
             %% optionally dump the failed email somewhere for analysis
-            File = "/tmp/"++Reference,
+            File = filename:join(["/tmp/", Reference]),
             case filelib:ensure_dir(File) of
-                'ok' -> kz_util:write_file(File, Data);
-                _ -> 'ok'
+                'ok' ->
+                    case kz_util:write_file(File, Data) of
+                        'ok' -> lager:debug("wrote DATA exception data to ~s", [File]);
+                        {'error', _E} -> lager:debug("failed to write DATA exception data to ~s: ~p", [File, _E])
+                    end;
+                {'error', _E} -> lager:debug("failed to ensure ~s: ~p", [File, _E])
             end
     end.
 
@@ -329,7 +347,7 @@ system_report(#state{errors=[Error | _]}=State) ->
                ,{<<"Message">>, Error}
                ,{<<"Details">>, kz_json:from_list(Props)}
                ,{<<"Account-ID">>, props:get_value(<<"Account-ID">>, Props)}
-                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                ]),
     kz_amqp_worker:cast(Notify, fun kapi_notifications:publish_system_alert/1).
 
@@ -343,7 +361,7 @@ faxbox_log(#state{account_id=AccountId}=State) ->
               ,{<<"pvt_type">>, <<"fax_smtp_log">>}
               ,{<<"pvt_created">>, kz_time:now_s()}
               ,{<<"_id">>, error_doc()}
-               | to_proplist(State)
+              | to_proplist(State)
               ]
              )
            ),
@@ -373,7 +391,7 @@ to_proplist(#state{}=State) ->
       ,{<<"Filename">>, State#state.filename}
       ,{<<"Errors">>, lists:reverse(State#state.errors)}
       ,{<<"Account-ID">>, State#state.account_id}
-       | faxbox_to_proplist(State#state.faxbox)
+      | faxbox_to_proplist(State#state.faxbox)
        ++ faxdoc_to_proplist(State#state.doc)
       ]).
 
@@ -755,7 +773,7 @@ process_parts([], #state{filename='undefined'
 process_parts([], State) ->
     {'ok', State};
 process_parts([{Type, SubType, _Headers, Parameters, BodyPart}
-               |Parts
+              |Parts
               ], State) ->
     {_ , NewState}
         = maybe_process_part(kz_mime:normalize_content_type(<<Type/binary, "/", SubType/binary>>)
@@ -956,7 +974,7 @@ send_outbound_smtp_fax_error(#state{account_id=AccountId
                 ,{<<"Owner-ID">>, OwnerId}
                 ,{<<"Number">>, Number}
                 ,{<<"Timestamp">>, kz_time:now_s()}
-                 | maybe_add_faxbox_info(State) ++ kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                | maybe_add_faxbox_info(State) ++ kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                 ]),
     %% Do not crash if fields were undefined
     kapps_notify_publisher:cast(Message, fun kapi_notifications:publish_fax_outbound_smtp_error/1).

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -987,3 +987,4 @@ maybe_add_faxbox_info(#state{faxbox=FaxBoxDoc}) ->
     ,{<<"FaxBox-Name">>, kzd_faxbox:name(FaxBoxDoc)}
     ,{<<"FaxBox-Timezone">>, kzd_fax_box:timezone(FaxBoxDoc)}
     ].
+

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -100,7 +100,7 @@ handle_EHLO(Hostname, Extensions, #state{options=Options, proxy = Proxy}=State) 
                            %% auth is enabled, so advertise it
                            [{"AUTH", "PLAIN LOGIN CRAM-MD5"}
                            ,{"STARTTLS", 'true'}
-                           | Extensions
+                            | Extensions
                            ]
                    end,
     {'ok', filter_extensions(MyExtensions, Options), State}.
@@ -347,7 +347,7 @@ system_report(#state{errors=[Error | _]}=State) ->
                ,{<<"Message">>, Error}
                ,{<<"Details">>, kz_json:from_list(Props)}
                ,{<<"Account-ID">>, props:get_value(<<"Account-ID">>, Props)}
-               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                ]),
     kz_amqp_worker:cast(Notify, fun kapi_notifications:publish_system_alert/1).
 
@@ -361,7 +361,7 @@ faxbox_log(#state{account_id=AccountId}=State) ->
               ,{<<"pvt_type">>, <<"fax_smtp_log">>}
               ,{<<"pvt_created">>, kz_time:now_s()}
               ,{<<"_id">>, error_doc()}
-              | to_proplist(State)
+               | to_proplist(State)
               ]
              )
            ),
@@ -391,7 +391,7 @@ to_proplist(#state{}=State) ->
       ,{<<"Filename">>, State#state.filename}
       ,{<<"Errors">>, lists:reverse(State#state.errors)}
       ,{<<"Account-ID">>, State#state.account_id}
-      | faxbox_to_proplist(State#state.faxbox)
+       | faxbox_to_proplist(State#state.faxbox)
        ++ faxdoc_to_proplist(State#state.doc)
       ]).
 
@@ -773,7 +773,7 @@ process_parts([], #state{filename='undefined'
 process_parts([], State) ->
     {'ok', State};
 process_parts([{Type, SubType, _Headers, Parameters, BodyPart}
-              |Parts
+               |Parts
               ], State) ->
     {_ , NewState}
         = maybe_process_part(kz_mime:normalize_content_type(<<Type/binary, "/", SubType/binary>>)
@@ -974,7 +974,7 @@ send_outbound_smtp_fax_error(#state{account_id=AccountId
                 ,{<<"Owner-ID">>, OwnerId}
                 ,{<<"Number">>, Number}
                 ,{<<"Timestamp">>, kz_time:now_s()}
-                | maybe_add_faxbox_info(State) ++ kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                 | maybe_add_faxbox_info(State) ++ kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                 ]),
     %% Do not crash if fields were undefined
     kapps_notify_publisher:cast(Message, fun kapi_notifications:publish_fax_outbound_smtp_error/1).

--- a/applications/fax/test/fax_smtp_tests.erl
+++ b/applications/fax/test/fax_smtp_tests.erl
@@ -19,8 +19,6 @@ decode_email_test() ->
 
     {T, S, Hs, Ps, Body} = fax_smtp:decode_data(Email),
 
-    ?debugFmt("~p/~p:~nhs: ~p~nps: ~p~nbd: ~p~n", [T, S, Hs, Ps, Body]),
-
     ?assertEqual(<<"multipart">>, T),
     ?assertEqual(<<"mixed">>, S),
 

--- a/applications/fax/test/fax_smtp_tests.erl
+++ b/applications/fax/test/fax_smtp_tests.erl
@@ -1,0 +1,72 @@
+-module(fax_smtp_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(FROM, <<"kazoo@2600hz.com">>).
+-define(DATE, <<"Fri, 21 Feb 2020 11:06:41 -0600">>).
+-define(SUBJECT, <<"Test attachment unpacking and decoding">>).
+
+-define(TEXT, <<"Please find the attached PDF">>).
+
+decode_email_test() ->
+    BaseDir = code:lib_dir('fax', 'test'),
+    {'ok', PDF} = file:read_file(filename:join([BaseDir, "pdf.pdf"])),
+    Encoded = base64:encode(PDF),
+
+    Boundary = kz_binary:rand_hex(4),
+
+    Email = create_email(Encoded, Boundary),
+
+    {T, S, Hs, Ps, Body} = fax_smtp:decode_data(Email),
+
+    ?debugFmt("~p/~p:~nhs: ~p~nps: ~p~nbd: ~p~n", [T, S, Hs, Ps, Body]),
+
+    ?assertEqual(<<"multipart">>, T),
+    ?assertEqual(<<"mixed">>, S),
+
+    ?assertEqual(?FROM, props:get_value(<<"From">>, Hs)),
+    ?assertEqual(?DATE, props:get_value(<<"Date">>, Hs)),
+    ?assertEqual(?SUBJECT, props:get_value(<<"Subject">>, Hs)),
+
+    ?assertEqual(Boundary, props:get_value([<<"content-type-params">>, <<"boundary">>], Ps)),
+
+    ?assertEqual(2, length(Body)),
+
+    [{PTType, PTSubType
+     ,_PTHeaders, _PTParameters
+     ,PTBody
+     }
+    ,{PDFType, PDFSubType
+     ,_PDFHeaders, _PDFParameters
+     ,PDFBody
+     }
+    ] = Body,
+
+    ?assertEqual(<<"text">>, PTType),
+    ?assertEqual(<<"plain">>, PTSubType),
+    ?assertEqual(?TEXT, PTBody),
+
+    ?assertEqual(<<"application">>, PDFType),
+    ?assertEqual(<<"pdf">>, PDFSubType),
+    ?assertEqual(PDF, PDFBody).
+
+create_email(Attachment, Boundary) ->
+    Email = ["From: ", ?FROM, "\r\n"
+            ,"Date: ", ?DATE, "\r\n"
+            ,"Subject: ", ?SUBJECT, "\r\n"
+            ,"Content-type: multipart/mixed; boundary=\"", Boundary, "\"\r\n"
+            ,"\r\n"
+            ,"--", Boundary, "\r\n"
+            ,"Content-Type: text/plain; charset=utf-8\r\n"
+            ,"Content-Disposition: inline\r\n"
+            ,"\r\n"
+            ,?TEXT, "\r\n"
+            ,"--", Boundary, "\r\n"
+            ,"Content-Type: application/pdf; charset=utf-8\r\n"
+            ,"Content-Disposition: attachment; filename=\"pdf.pdf\"\r\n"
+            ,"Content-Transfer-Encoding: base64\r\n"
+            ,"\r\n"
+            ,Attachment, "\r\n\r\n"
+            ,"--", Boundary, "--\r\n"
+            ],
+    iolist_to_binary(Email).

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -107,5 +107,6 @@ dep_syslog = git https://github.com/2600hz/erlang-syslog bbad537a1cb5e4f37e672d2
 
 dep_fcm = git https://github.com/softwarejoint/fcm-erlang.git b2f68a4c6f0f59475597a35e2dc9be13d9ba2910
 
-dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp f82a135bf5ce6dc8ca29bd4e30cbdc98cd089ee2
+dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 3fe1abaed7adfbb2c13bfa95f2d12e57dfa157d5
 ## pinning gen_smtp because upstream made some breaking changes (using maps in some options)
+## adding check to not convert if the From/To encodings match


### PR DESCRIPTION
On some email attachments (seemingly PDFs) the `iconv` program used to
convert between character encodings (via gen_smtp/mimemail) will fail,
causing the email to be thrown away as invalid. These emails and their
attachments are, in fact, valid and should be processed.

The gen_smtp commit hash is updated to change mimemail to consider
matching `From`/`To` encodings as a no-op and avoid the call to
`iconv` entirely. This allows the PDF to be processed out of the email
for use by fax_smtp.