### PR TITLE
HELP-13433: noop email conversions to avoid errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ core/kazoo_proper/priv/mp3.mp3
 /todo.org
 *.tar
 /make/pest-*
+# asdf-vm "local" versions handler
+.tool-versions
+/applications/fax/test/pdf.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,3 @@ core/kazoo_proper/priv/mp3.mp3
 /make/pest-*
 # asdf-vm "local" versions handler
 .tool-versions
-/applications/fax/test/pdf.pdf

--- a/applications/fax/.gitignore
+++ b/applications/fax/.gitignore
@@ -1,4 +1,3 @@
 .deps.mk
 *.beam
 *.app
-/test/pdf.pdf

--- a/applications/fax/.gitignore
+++ b/applications/fax/.gitignore
@@ -1,3 +1,4 @@
 .deps.mk
 *.beam
 *.app
+/test/pdf.pdf

--- a/applications/fax/Makefile
+++ b/applications/fax/Makefile
@@ -2,6 +2,15 @@ CWD = $(shell pwd -P)
 ROOT = $(realpath $(CWD)/../..)
 PROJECT = fax
 
+PDF = test/pdf.pdf
+
 all: compile
+
+comile-test: assets
+
+assets: $(PDF)
+
+$(PDF):
+	wget -qO $@ https://raw.githubusercontent.com/mathiasbynens/small/master/pdf.pdf
 
 include $(ROOT)/make/kz.mk

--- a/applications/fax/Makefile
+++ b/applications/fax/Makefile
@@ -2,19 +2,10 @@ CWD = $(shell pwd -P)
 ROOT = $(realpath $(CWD)/../..)
 PROJECT = fax
 
-PDF = test/pdf.pdf
+all: compile
 
-COMPILE_MOAR = assets
+comile-test:
 
-all: compile assets
-
-comile-test: assets
-
-comile-test-direct: assets
-
-assets: $(PDF)
-
-$(PDF):
-	wget -qO $@ https://raw.githubusercontent.com/mathiasbynens/small/master/pdf.pdf
+comile-test-direct:
 
 include $(ROOT)/make/kz.mk

--- a/applications/fax/Makefile
+++ b/applications/fax/Makefile
@@ -4,9 +4,13 @@ PROJECT = fax
 
 PDF = test/pdf.pdf
 
-all: compile
+COMPILE_MOAR = assets
+
+all: compile assets
 
 comile-test: assets
+
+comile-test-direct: assets
 
 assets: $(PDF)
 

--- a/applications/fax/src/fax_smtp.erl
+++ b/applications/fax/src/fax_smtp.erl
@@ -105,7 +105,7 @@ handle_EHLO(Hostname, Extensions, #state{options=Options, proxy = Proxy}=State) 
                            %% auth is enabled, so advertise it
                            [{"AUTH", "PLAIN LOGIN CRAM-MD5"}
                            ,{"STARTTLS", 'true'}
-                           | Extensions
+                            | Extensions
                            ]
                    end,
     {'ok', filter_extensions(MyExtensions, Options), State}.
@@ -352,7 +352,7 @@ system_report(#state{errors=[Error | _]}=State) ->
                ,{<<"Message">>, Error}
                ,{<<"Details">>, kz_json:from_list(Props)}
                ,{<<"Account-ID">>, props:get_value(<<"Account-ID">>, Props)}
-               | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                ]),
     kz_amqp_worker:cast(Notify, fun kapi_notifications:publish_system_alert/1).
 
@@ -366,7 +366,7 @@ faxbox_log(#state{account_id=AccountId}=State) ->
               ,{<<"pvt_type">>, <<"fax_smtp_log">>}
               ,{<<"pvt_created">>, kz_time:now_s()}
               ,{<<"_id">>, error_doc()}
-              | to_proplist(State)
+               | to_proplist(State)
               ]
              )
            ),
@@ -396,7 +396,7 @@ to_proplist(#state{}=State) ->
       ,{<<"Filename">>, State#state.filename}
       ,{<<"Errors">>, lists:reverse(State#state.errors)}
       ,{<<"Account-ID">>, State#state.account_id}
-      | faxbox_to_proplist(State#state.faxbox)
+       | faxbox_to_proplist(State#state.faxbox)
        ++ faxdoc_to_proplist(State#state.doc)
       ]).
 
@@ -778,7 +778,7 @@ process_parts([], #state{filename='undefined'
 process_parts([], State) ->
     {'ok', State};
 process_parts([{Type, SubType, _Headers, Parameters, BodyPart}
-              |Parts
+               |Parts
               ], State) ->
     {_ , NewState}
         = maybe_process_part(kz_mime:normalize_content_type(<<Type/binary, "/", SubType/binary>>)
@@ -979,7 +979,7 @@ send_outbound_smtp_fax_error(#state{account_id=AccountId
                 ,{<<"Owner-ID">>, OwnerId}
                 ,{<<"Number">>, Number}
                 ,{<<"Timestamp">>, kz_time:now_s()}
-                | maybe_add_faxbox_info(State) ++ kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                 | maybe_add_faxbox_info(State) ++ kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                 ]),
     %% Do not crash if fields were undefined
     kapps_notify_publisher:cast(Message, fun kapi_notifications:publish_fax_outbound_smtp_error/1).

--- a/applications/fax/test/fax_smtp_tests.erl
+++ b/applications/fax/test/fax_smtp_tests.erl
@@ -1,3 +1,13 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2014-2020, 2600Hz
+%%% @doc
+%%%
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
 -module(fax_smtp_tests).
 
 -include_lib("eunit/include/eunit.hrl").

--- a/applications/fax/test/fax_smtp_tests.erl
+++ b/applications/fax/test/fax_smtp_tests.erl
@@ -19,8 +19,6 @@ decode_email_test() ->
 
     {T, S, Hs, Ps, Body} = fax_smtp:decode_data(Email),
 
-    ?debugFmt("~p/~p:~nhs: ~p~nps: ~p~nbd: ~p~n", [T, S, Hs, Ps, Body]),
-
     ?assertEqual(<<"multipart">>, T),
     ?assertEqual(<<"mixed">>, S),
 

--- a/applications/fax/test/fax_smtp_tests.erl
+++ b/applications/fax/test/fax_smtp_tests.erl
@@ -1,0 +1,72 @@
+-module(fax_smtp_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(FROM, <<"kazoo@2600hz.com">>).
+-define(DATE, <<"Fri, 21 Feb 2020 11:06:41 -0600">>).
+-define(SUBJECT, <<"Test attachment unpacking and decoding">>).
+
+-define(TEXT, <<"Please find the attached PDF">>).
+
+decode_email_test() ->
+    BaseDir = code:lib_dir('fax', 'test'),
+    {'ok', PDF} = file:read_file(filename:join([BaseDir, "pdf.pdf"])),
+    Encoded = base64:encode(PDF),
+
+    Boundary = kz_binary:rand_hex(4),
+
+    Email = create_email(Encoded, Boundary),
+
+    {T, S, Hs, Ps, Body} = fax_smtp:decode_data(Email),
+
+    ?debugFmt("~p/~p:~nhs: ~p~nps: ~p~nbd: ~p~n", [T, S, Hs, Ps, Body]),
+
+    ?assertEqual(<<"multipart">>, T),
+    ?assertEqual(<<"mixed">>, S),
+
+    ?assertEqual(?FROM, props:get_value(<<"From">>, Hs)),
+    ?assertEqual(?DATE, props:get_value(<<"Date">>, Hs)),
+    ?assertEqual(?SUBJECT, props:get_value(<<"Subject">>, Hs)),
+
+    ?assertEqual(Boundary, props:get_value([<<"content-type-params">>, <<"boundary">>], Ps)),
+
+    ?assertEqual(2, length(Body)),
+
+    [{PTType, PTSubType
+     ,_PTHeaders, _PTParameters
+     ,PTBody
+     }
+    ,{PDFType, PDFSubType
+     ,_PDFHeaders, _PDFParameters
+     ,PDFBody
+     }
+    ] = Body,
+
+    ?assertEqual(<<"text">>, PTType),
+    ?assertEqual(<<"plain">>, PTSubType),
+    ?assertEqual(?TEXT, PTBody),
+
+    ?assertEqual(<<"application">>, PDFType),
+    ?assertEqual(<<"pdf">>, PDFSubType),
+    ?assertEqual(PDF, PDFBody).
+
+create_email(Attachment, Boundary) ->
+    Email = ["From: ", ?FROM, "\r\n"
+            ,"Date: ", ?DATE, "\r\n"
+            ,"Subject: ", ?SUBJECT, "\r\n"
+            ,"Content-type: multipart/mixed; boundary=\"", Boundary, "\"\r\n"
+            ,"\r\n"
+            ,"--", Boundary, "\r\n"
+            ,"Content-Type: text/plain; charset=utf-8\r\n"
+            ,"Content-Disposition: inline\r\n"
+            ,"\r\n"
+            ,?TEXT, "\r\n"
+            ,"--", Boundary, "\r\n"
+            ,"Content-Type: application/pdf; charset=utf-8\r\n"
+            ,"Content-Disposition: attachment; filename=\"pdf.pdf\"\r\n"
+            ,"Content-Transfer-Encoding: base64\r\n"
+            ,"\r\n"
+            ,Attachment, "\r\n\r\n"
+            ,"--", Boundary, "--\r\n"
+            ],
+    iolist_to_binary(Email).

--- a/applications/fax/test/fax_smtp_tests.erl
+++ b/applications/fax/test/fax_smtp_tests.erl
@@ -1,7 +1,6 @@
 %%%-----------------------------------------------------------------------------
 %%% @copyright (C) 2014-2020, 2600Hz
 %%% @doc
-%%%
 %%% This Source Code Form is subject to the terms of the Mozilla Public
 %%% License, v. 2.0. If a copy of the MPL was not distributed with this
 %%% file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/applications/fax/test/pdf.pdf
+++ b/applications/fax/test/pdf.pdf
@@ -1,0 +1,6 @@
+%PDF-1.4
+%גדד׃
+1 0 obj<</Pages 2 0 R>>endobj
+2 0 obj<</Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Parent 2 0 R>>endobj
+trailer <</Root 1 0 R>>

--- a/core/kazoo_proper/Makefile
+++ b/core/kazoo_proper/Makefile
@@ -6,6 +6,8 @@ ERLC_OPTS = +'{lager_extra_sinks, [data]}'
 
 MP3 = priv/mp3.mp3
 
+COMPILE_MOAR = assets
+
 all: compile assets
 
 assets: $(MP3)

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -81,9 +81,9 @@ dep_erlcloud = git https://github.com/2600hz/erlang-erlcloud 3.2.7
 # dep_fs_event = git https://github.com/jamhed/fs_event 783400da08c2b55c295dbec81df0d926960c0346
 # dep_fs_sync = git https://github.com/jamhed/fs_sync 2cf85cf5861221128f020c453604d509fd37cd53
 
-dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 3d294c57153787027bea4011eeba268fee5d7165
+dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 01e004f4e6ef97802dbf0456385e81737dda706e
 # used by teletype, notify, and fax
-# SHA fixes spec for gen_smto_client:send/3
+# SHA fixes mimemail to no-op matching encodings
 
 dep_getopt = git https://github.com/2600hz/erlang-getopt v1.0.1
 # used in some scripts/ and sup

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -81,9 +81,9 @@ dep_erlcloud = git https://github.com/2600hz/erlang-erlcloud 3.2.7
 # dep_fs_event = git https://github.com/jamhed/fs_event 783400da08c2b55c295dbec81df0d926960c0346
 # dep_fs_sync = git https://github.com/jamhed/fs_sync 2cf85cf5861221128f020c453604d509fd37cd53
 
-dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 01e004f4e6ef97802dbf0456385e81737dda706e
+dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 973d3ea1867a6bb3565f67afb78b449253c3b76e
 # used by teletype, notify, and fax
-# SHA fixes mimemail to no-op matching encodings
+# latest commit to origin/2600Hz: SHA fixes mimemail to no-op matching encodings
 
 dep_getopt = git https://github.com/2600hz/erlang-getopt v1.0.1
 # used in some scripts/ and sup


### PR DESCRIPTION
On some email attachments (seemingly PDFs) the `iconv` program used to
convert between character encodings (via gen_smtp/mimemail) will fail,
causing the email to be thrown away as invalid. These emails and their
attachments are, in fact, valid and should be processed.

The gen_smtp commit hash is updated to change mimemail to consider
matching `From`/`To` encodings as a no-op and avoid the call to
`iconv` entirely. This allows the PDF to be processed out of the email
for use by fax_smtp.