### PR TITLE
Add Primitive Erlang Security Tool ('PEST') to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ core/kazoo_proper/priv/mp3.mp3
 /doc/engineering/.org/proper.tex
 /todo.org
 *.tar
+/make/pest-*

--- a/Makefile
+++ b/Makefile
@@ -399,5 +399,6 @@ validate-schemas:
 include make/splchk.mk
 include make/ci.mk
 include make/fmt.mk
+include make/pest.mk
 
 circle: ci

--- a/doc/engineering/make.md
+++ b/doc/engineering/make.md
@@ -170,6 +170,12 @@ Attempts to build the docs site with `mkdocs` (basically a theme-less version of
 
 Runs an equivalent pass of CircleCI locally.
 
+## `make pest` and `make pest-all`
+
+[PEST](https://github.com/okeuday/pest#usage) - Primitive Erlang Security Tool
+
+Runs the security checks against changed (or all project) files and reports potential security threats. Not included in CI as most of the reports are speculative and probably not actionable (yet anyway)
+
 ## Spell checking
 
 With Kazoo's international audience, it is helpful to have a spellchecker available to help all contributors find and fix spelling mistakes.

--- a/make/pest.mk
+++ b/make/pest.mk
@@ -1,0 +1,21 @@
+PEST_SHA = 90609d16a45c558beeb67c16cc68bf630843c2e1
+PEST = $(ROOT)/make/pest-$(PEST_SHA)/pest.erl
+
+# See https://github.com/okeuday/pest#usage
+
+.PHONY: pest pest-all
+
+$(PEST):
+	wget -qO - 'https://codeload.github.com/okeuday/pest/tar.gz/$(PEST_SHA)' | tar -vxz -C $(ROOT)/make/
+	chmod 755 $(PEST)
+
+ifeq (,$(CHANGED_ERL))
+pest:
+	@echo No Erlang files changed
+else
+pest: $(PEST)
+	$(PEST) -e $(CHANGED_ERL)
+endif
+
+pest-all: $(PEST)
+	$(PEST) -v -b deps core applications


### PR DESCRIPTION
From the project's description: "Do a basic scan of Erlang source code
and report any function calls that may cause Erlang source code to be
insecure."

As PEST reports lots of "maybe" issues, this is more intended for
specific PEST-related coding. Mostly validating input before calling
os:cmd for instance.

Two targets:
- `make pest`: will run PEST on changed Erlang files (if any)
- `make pest-all`: will run PEST on all deps, core, and app BEAM files