### PR TITLE
HELP-13212: Exclude attachments from being included if present

### DIFF
--- a/applications/teletype/priv/templates/voicemail_to_email.html
+++ b/applications/teletype/priv/templates/voicemail_to_email.html
@@ -41,7 +41,11 @@
                     </td>
                 </tr>
                     <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
-                        <p style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;">You have a new voicemail from <b>{{caller_id.name_number}}</b> for your voicemail box at <b>{{voicemail.vmbox_name}} ({{voicemail.vmbox_number}})</b>.<br><br>Please find the message audio file in the attachment.</p>
+                        <p style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;">You have a new voicemail from <b>{{caller_id.name_number}}</b> for your voicemail box at <b>{{voicemail.vmbox_name}} ({{voicemail.vmbox_number}})</b>.
+                        {% if voicemail.file_name %}
+                            <br><br>Please find the message audio file in the attachment.
+                        {% endif %}
+                        </p>
                     </td>
                 </tr>
             </table>

--- a/applications/teletype/priv/templates/voicemail_to_email.text
+++ b/applications/teletype/priv/templates/voicemail_to_email.text
@@ -5,7 +5,9 @@ Hi{% if user.first_name %} {{user.first_name}}{% endif %},
 
 You have a new voicemail from {{caller_id.name_number}} for
 your voicemail box at {{voicemail.vmbox_name}} (number: {{voicemail.vmbox_number}}).
+{% if voicemail.file_name %}
 Please find the message audio file in the attachment.
+{% endif %}
 {% if voicemail.transcription %}
 
 === Transcription ===

--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -175,12 +175,7 @@ do_process_req(DataJObj) ->
 -spec macros(kz_json:object()) -> kz_term:proplist().
 macros(DataJObj) ->
     TemplateData = template_data(DataJObj),
-    IncludeAttachment = kz_json:get_boolean_value([<<"vmbox_doc">>
-                                                  ,<<"should_include_attachment">>
-                                                  ]
-                                                 ,DataJObj
-                                                 ,'true'
-                                                 ),
+    IncludeAttachment = kz_json:is_true([<<"vmbox_doc">>, <<"should_include_attachment">>], DataJObj, 'true'),
     EmailAttachments = maybe_email_attachments(DataJObj, TemplateData, IncludeAttachment),
     Macros = maybe_add_file_data(TemplateData, EmailAttachments),
     props:set_value(<<"attachments">>, EmailAttachments, Macros).

--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -175,9 +175,15 @@ do_process_req(DataJObj) ->
 -spec macros(kz_json:object()) -> kz_term:proplist().
 macros(DataJObj) ->
     TemplateData = template_data(DataJObj),
-    EmailAttachements = email_attachments(DataJObj, TemplateData),
-    Macros = maybe_add_file_data(TemplateData, EmailAttachements),
-    props:set_value(<<"attachments">>, EmailAttachements, Macros).
+    IncludeAttachment = kz_json:get_boolean_value([<<"vmbox_doc">>
+                                                  ,<<"should_include_attachment">>
+                                                  ]
+                                                 ,DataJObj
+                                                 ,'true'
+                                                 ),
+    EmailAttachments = maybe_email_attachments(DataJObj, TemplateData, IncludeAttachment),
+    Macros = maybe_add_file_data(TemplateData, EmailAttachments),
+    props:set_value(<<"attachments">>, EmailAttachments, Macros).
 
 -spec template_data(kz_json:object()) -> kz_term:proplist().
 template_data(DataJObj) ->
@@ -185,8 +191,11 @@ template_data(DataJObj) ->
      | build_template_data(DataJObj)
     ].
 
--spec email_attachments(kz_json:object(), kz_term:proplist()) -> attachments().
-email_attachments(DataJObj, Macros) ->
+-spec maybe_email_attachments(kz_json:object(), kz_term:proplist(), boolean()) -> attachments().
+maybe_email_attachments(_DataJObj, _Macros, 'false') ->
+    lager:debug("configured to not include attachments for this VM"),
+    [];
+maybe_email_attachments(DataJObj, Macros, 'true') ->
     email_attachments(DataJObj, Macros, teletype_util:is_preview(DataJObj)).
 
 -spec email_attachments(kz_json:object(), kz_term:proplist(), boolean()) -> attachments().


### PR DESCRIPTION
Add configuration parameter to VM documents to decide whether or not to
include attachments when sending the voicemail_to_email notification.