### PR TITLE
[4.3] KCRO-15: expose transcription capabilities in the crossbar authentication response

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -179,7 +179,7 @@
                  ,max_message_length = ?MAILBOX_DEFAULT_MSG_MAX_LENGTH :: pos_integer()
                  ,min_message_length = ?MAILBOX_DEFAULT_MSG_MIN_LENGTH :: pos_integer()
                  ,keys = #keys{} :: vm_keys()
-                 ,transcribe_voicemail = 'false' :: boolean()
+                 ,transcribe_voicemail = kvm_util:transcribe_default() :: boolean()
                  ,notifications :: kz_term:api_object()
                  ,after_notify_action = 'nothing' :: 'nothing' | 'delete' | 'save'
                  ,is_ff_rw_enabled = 'false' :: boolean()
@@ -1738,7 +1738,7 @@ get_mailbox_profile(Data, Call) ->
                     ,message_count =
                          MsgCount
                     ,transcribe_voicemail =
-                         kz_json:is_true(<<"transcribe">>, MailboxJObj, 'false')
+                         kz_json:is_true(<<"transcribe">>, MailboxJObj, kvm_util:transcribe_default())
                     ,notifications =
                          kz_json:get_json_value(<<"notifications">>, MailboxJObj)
                     ,after_notify_action = AfterNotifyAction

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -29129,6 +29129,10 @@
                     "description": "blackhole ssl_workers",
                     "type": "integer"
                 },
+                "url": {
+                    "description": "The advertised URL of the Kazoo websocket",
+                    "type": "string"
+                },
                 "use_plaintext": {
                     "default": true,
                     "description": "blackhole use_plaintext",
@@ -29476,6 +29480,11 @@
                             "minimum": 0,
                             "type": "integer"
                         },
+                        "transcribe_default": {
+                            "default": false,
+                            "description": "callflow voicemail transcribe_default",
+                            "type": "boolean"
+                        },
                         "vm_delete_amqp": {
                             "default": false,
                             "description": "send ampq message to notify about voicemail deletion",
@@ -29763,6 +29772,16 @@
                     "default": {},
                     "description": "cluster zones",
                     "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.cluster_manager": {
+            "description": "Schema for cluster_manager system_config",
+            "properties": {
+                "url": {
+                    "description": "The base URL of the 2600Hz cluster manager service",
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -32854,6 +32873,16 @@
             },
             "type": "object"
         },
+        "system_config.mobile": {
+            "description": "Schema for mobile system_config",
+            "properties": {
+                "url": {
+                    "description": "The base URL of the 2600Hz mobile service",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "system_config.mobile_manager": {
             "description": "Schema for mobile_manager system_config",
             "properties": {
@@ -33883,6 +33912,16 @@
                     "default": false,
                     "description": "omnipresence subscriptions sync enabled",
                     "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.phonebook": {
+            "description": "Schema for phonebook system_config",
+            "properties": {
+                "url": {
+                    "description": "The base URL of the 2600Hz phonebook service",
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -35332,6 +35371,16 @@
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.webrtc": {
+            "description": "Schema for webrtc system_config",
+            "properties": {
+                "url": {
+                    "description": "The advertised URL of the webrtc socket",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.blackhole.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.blackhole.json
@@ -83,6 +83,10 @@
             "description": "blackhole ssl_workers",
             "type": "integer"
         },
+        "url": {
+            "description": "The advertised URL of the Kazoo websocket",
+            "type": "string"
+        },
         "use_plaintext": {
             "default": true,
             "description": "blackhole use_plaintext",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
@@ -188,6 +188,11 @@
                     "minimum": 0,
                     "type": "integer"
                 },
+                "transcribe_default": {
+                    "default": false,
+                    "description": "callflow voicemail transcribe_default",
+                    "type": "boolean"
+                },
                 "vm_delete_amqp": {
                     "default": false,
                     "description": "send ampq message to notify about voicemail deletion",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.cluster_manager.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.cluster_manager.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.cluster_manager",
+    "description": "Schema for cluster_manager system_config",
+    "properties": {
+        "url": {
+            "description": "The base URL of the 2600Hz cluster manager service",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/system_config.mobile.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.mobile.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.mobile",
+    "description": "Schema for mobile system_config",
+    "properties": {
+        "url": {
+            "description": "The base URL of the 2600Hz mobile service",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/system_config.phonebook.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.phonebook.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.phonebook",
+    "description": "Schema for phonebook system_config",
+    "properties": {
+        "url": {
+            "description": "The base URL of the 2600Hz phonebook service",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/system_config.webrtc.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.webrtc.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.webrtc",
+    "description": "Schema for webrtc system_config",
+    "properties": {
+        "url": {
+            "description": "The advertised URL of the webrtc socket",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -606,9 +606,77 @@ populate_resp(JObj, AccountId, UserId) ->
               ,{<<"cluster_id">>, kzd_cluster:id()}
               ,{<<"reseller_id">>, kz_services_reseller:get_id(AccountId)}
               ,{<<"is_reseller">>, kz_services_reseller:is_reseller(AccountId)}
+              ,{<<"is_master_account">>, is_master_account(AccountId)}
               ,{<<"capabilities">>, get_capabilities()}
+              ,{<<"ui_config">>, get_ui_config()}
               ]),
     kz_json:set_values(Props, JObj).
+
+-spec get_ui_config() -> kz_json:object().
+get_ui_config() ->
+    Routines = [fun get_provisioner_config/1
+               ,fun get_mobile_config/1
+               ,fun get_kazoo_websocket_config/1
+               ,fun get_webrtc_websocket_config/1
+               ,fun get_phonebook_config/1
+               ,fun get_cluster_manager_config/1
+               ],
+    lists:foldl(fun(F, J) -> F(J) end, kz_json:new(), Routines).
+
+-spec get_provisioner_config(kz_json:object()) -> kz_json:object().
+get_provisioner_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"provisioner">>, <<"provisioning_url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"provisioner">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_mobile_config(kz_json:object()) -> kz_json:object().
+get_mobile_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"mobile">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"mobile">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_kazoo_websocket_config(kz_json:object()) -> kz_json:object().
+get_kazoo_websocket_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"blackhole">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"kazoo_websocket">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_webrtc_websocket_config(kz_json:object()) -> kz_json:object().
+get_webrtc_websocket_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"webrtc">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"webrtc_websocket">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_phonebook_config(kz_json:object()) -> kz_json:object().
+get_phonebook_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"phonebook">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"phonebook">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_cluster_manager_config(kz_json:object()) -> kz_json:object().
+get_cluster_manager_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"cluster_manager">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"cluster_manager">>, <<"url">>], URL, JObj)
+    end.
+
+-spec is_master_account(kz_term:ne_binary()) -> boolean().
+is_master_account(AccountId) ->
+    case kapps_util:get_master_account_id() of
+        {'ok', AccountId} -> 'true';
+        _Else -> 'false'
+    end.
 
 -spec get_capabilities() -> kz_json:object().
 get_capabilities() ->

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -603,9 +603,27 @@ populate_resp(JObj, AccountId, UserId) ->
               [{<<"apps">>, load_apps(AccountId, UserId, Language)}
               ,{<<"language">>, Language}
               ,{<<"account_name">>, kzd_accounts:fetch_name(AccountId)}
-              ,{<<"is_reseller">>, kz_services_reseller:is_reseller(AccountId)}
+              ,{<<"cluster_id">>, kzd_cluster:id()}
               ,{<<"reseller_id">>, kz_services_reseller:get_id(AccountId)}
+              ,{<<"is_reseller">>, kz_services_reseller:is_reseller(AccountId)}
+              ,{<<"capabilities">>, get_capabilities()}
               ]),
+    kz_json:set_values(Props, JObj).
+
+-spec get_capabilities() -> kz_json:object().
+get_capabilities() ->
+    Routines = [fun get_transcription_capabilities/1],
+    lists:foldl(fun(F, J) -> F(J) end, kz_json:new(), Routines).
+
+-spec get_transcription_capabilities(kz_json:object()) -> kz_json:object().
+get_transcription_capabilities(JObj) ->
+    Props = [{[<<"voicemail">>, <<"transcription">>, <<"supported">>]
+             ,kazoo_asr:available()
+             }
+            ,{[<<"voicemail">>, <<"transcription">>, <<"default">>]
+             ,kvm_util:transcribe_default()
+             }
+            ],
     kz_json:set_values(Props, JObj).
 
 %%------------------------------------------------------------------------------

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -617,7 +617,7 @@ get_capabilities() ->
 
 -spec get_transcription_capabilities(kz_json:object()) -> kz_json:object().
 get_transcription_capabilities(JObj) ->
-    Props = [{[<<"voicemail">>, <<"transcription">>, <<"supported">>]
+    Props = [{[<<"voicemail">>, <<"transcription">>, <<"available">>]
              ,kazoo_asr:available()
              }
             ,{[<<"voicemail">>, <<"transcription">>, <<"default">>]

--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -693,7 +693,19 @@ validate_unique_vmbox(VMBoxId, Context, _AccountDb) ->
 check_vmbox_schema(VMBoxId, Context) ->
     Context1 = maybe_migrate_notification_emails(Context),
     OnSuccess = fun(C) -> validate_media_extension(VMBoxId, C) end,
-    cb_context:validate_request_data(<<"vmboxes">>, Context1, OnSuccess).
+    cb_context:validate_request_data(find_schema(), Context1, OnSuccess).
+
+-spec find_schema() -> kz_json:api_object().
+find_schema() ->
+    case kz_json_schema:load(<<"vmboxes">>) of
+        {'ok', SchemaJObj} ->
+            Props = [{[<<"properties">>, <<"transcribe">>, <<"default">>]
+                     ,kvm_util:transcribe_default()
+                     }
+                    ],
+            kz_json:set_values(Props, SchemaJObj);
+        {'error', _E} -> 'undefined'
+    end.
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/core/kazoo_speech/src/asr/kazoo_asr_google.erl
+++ b/core/kazoo_speech/src/asr/kazoo_asr_google.erl
@@ -11,11 +11,11 @@
 -module(kazoo_asr_google).
 -behaviour(gen_asr_provider).
 
--export([preferred_content_type/0
-        ,accepted_content_types/0
-        ,freeform/4
-        ,commands/5
-        ]).
+-export([available/0]).
+-export([preferred_content_type/0]).
+-export([accepted_content_types/0]).
+-export([freeform/4]).
+-export([commands/5]).
 
 -include("kazoo_speech.hrl").
 
@@ -29,6 +29,14 @@
 -define(GOOGLE_ASR_USE_ENHANCED, kapps_config:get_is_true(?GOOGLE_CONFIG_CAT, <<"asr_use_enhanced">>, 'true')).
 -define(GOOGLE_ASR_PREFERRED_CONTENT_TYPE, <<"application/wav">>).
 -define(GOOGLE_ASR_ACCEPTED_CONTENT_TYPES, [<<"audio/wav">>, <<"application/wav">>]).
+
+%%%------------------------------------------------------------------------------
+%%% @doc Return true if Google ASR is configured / available otherwise false.
+%%% @end
+%%%------------------------------------------------------------------------------
+-spec available() -> boolean().
+available() ->
+    kz_term:is_not_empty(?GOOGLE_ASR_KEY).
 
 %%%-----------------------------------------------------------------------------
 %%% @doc Return or set the preferred asr content type for the ASR provider

--- a/core/kazoo_speech/src/asr/kazoo_asr_ispeech.erl
+++ b/core/kazoo_speech/src/asr/kazoo_asr_ispeech.erl
@@ -9,16 +9,24 @@
 -module(kazoo_asr_ispeech).
 -behaviour(gen_asr_provider).
 
--export([preferred_content_type/0
-        ,accepted_content_types/0
-        ,freeform/4
-        ,commands/5
-        ]).
+-export([available/0]).
+-export([preferred_content_type/0]).
+-export([accepted_content_types/0]).
+-export([freeform/4]).
+-export([commands/5]).
 
 -include("kazoo_speech.hrl").
 
 -define(DEFAULT_ASR_CONTENT_TYPE, <<"application/wav">>).
 -define(SUPPORTED_CONTENT_TYPES, [<<"application/wav">>]).
+
+%%%------------------------------------------------------------------------------
+%%% @doc Return true if iSpeech ASR is configured / available otherwise false.
+%%% @end
+%%%------------------------------------------------------------------------------
+-spec available() -> boolean().
+available() ->
+    kz_term:is_not_empty(default_api_key()).
 
 %%%-----------------------------------------------------------------------------
 %%% @doc Return or set the preferred asr content type for the ASR provider

--- a/core/kazoo_speech/src/gen_asr_provider.erl
+++ b/core/kazoo_speech/src/gen_asr_provider.erl
@@ -7,6 +7,7 @@
 
 -include("kazoo_speech.hrl").
 
+-callback available() -> boolean().
 -callback preferred_content_type() -> kz_term:ne_binary().
 -callback accepted_content_types() -> kz_term:ne_binaries().
 -callback freeform(binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> asr_resp().

--- a/core/kazoo_speech/src/kazoo_asr.erl
+++ b/core/kazoo_speech/src/kazoo_asr.erl
@@ -5,11 +5,23 @@
 %%%-----------------------------------------------------------------------------
 -module(kazoo_asr).
 
--export([freeform/1, freeform/2, freeform/3, freeform/4
-        ,commands/2, commands/3, commands/4, commands/5
-        ,accepted_content_types/0
-        ,default_provider/0
-        ,preferred_content_type/0, preferred_content_type/1
+-export([available/0
+        ,available/1
+        ]).
+-export([freeform/1
+        ,freeform/2
+        ,freeform/3
+        ,freeform/4
+        ]).
+-export([commands/2
+        ,commands/3
+        ,commands/4
+        ,commands/5
+        ]).
+-export([accepted_content_types/0]).
+-export([default_provider/0]).
+-export([preferred_content_type/0
+        ,preferred_content_type/1
         ]).
 
 -include("kazoo_speech.hrl").
@@ -18,6 +30,24 @@
 -define(DEFAULT_ASR_CONTENT_TYPE, <<"application/wav">>).
 -define(DEFAULT_ASR_LOCALE, <<"en-us">>).
 -define(ACCEPTED_CONTENT_TYPES, [<<"audio/mpeg">>, <<"audio/wav">>, <<"application/wav">>]).
+
+%%%------------------------------------------------------------------------------
+%%% @doc Return true if ASR is configured / available otherwise false.
+%%% @end
+%%%------------------------------------------------------------------------------
+-spec available() -> boolean().
+available() ->
+    available(default_provider()).
+
+-spec available(kz_term:ne_binary()) -> boolean().
+available(Provider) ->
+    try (kz_term:to_atom(<<"kazoo_asr_", Provider/binary>>, 'true')):available()
+    catch
+        'error':'undef' ->
+            lager:error("unknown provider ~s", [Provider]),
+            'false'
+    end.
+
 
 %%%------------------------------------------------------------------------------
 %%% @doc Return return configured or set the default ASR provider

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -20,6 +20,8 @@
 
         ,publish_saved_notify/5, publish_voicemail_saved/5, publish_voicemail_deleted/3
         ,get_caller_id_name/1, get_caller_id_number/1
+
+        ,transcribe_default/0
         ]).
 
 -include("kz_voicemail.hrl").
@@ -282,6 +284,14 @@ get_caller_id_number(Call) ->
             Pre = <<(kz_term:to_binary(Prepend))/binary, CallerIdNumber/binary>>,
             kz_binary:truncate_right(Pre, kzd_schema_caller_id:external_name_max_length())
     end.
+
+%%------------------------------------------------------------------------------
+%% @doc Get trascribe default.
+%% @end
+%%------------------------------------------------------------------------------
+-spec transcribe_default() -> boolean().
+transcribe_default() ->
+    kapps_config:get_is_true(?VM_CONFIG_CAT, [?KEY_VOICEMAIL, <<"transcribe_default">>], 'false').
 
 %%%=============================================================================
 %%% Publish Notification


### PR DESCRIPTION
When generating a new JWT for Crossbar the response now includes the cluster id as well as a new object 'capabilities'.  The capabilities object conveys services and settings of the cluster so the UI can modify the user experience to match.  At this time the only parameters that are exposed are voicemail.transcription.supported if a transcription service is configured with an API key and voicemail.transcription.default to inform the UI transcriptions are created by default. 