### PR TITLE
[master] KCRO-15: expose transcription capabilities in the crossbar authentication response

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -184,7 +184,7 @@
                  ,max_message_length = ?MAILBOX_DEFAULT_MSG_MAX_LENGTH :: pos_integer()
                  ,min_message_length = ?MAILBOX_DEFAULT_MSG_MIN_LENGTH :: pos_integer()
                  ,keys = #keys{} :: vm_keys()
-                 ,transcribe_voicemail = 'false' :: boolean()
+                 ,transcribe_voicemail = kvm_util:transcribe_default() :: boolean()
                  ,notifications :: kz_term:api_object()
                  ,after_notify_action = 'nothing' :: 'nothing' | 'delete' | 'save'
                  ,is_ff_rw_enabled = 'false' :: boolean()
@@ -1748,7 +1748,7 @@ get_mailbox_profile(Data, Call) ->
                     ,message_count =
                          MsgCount
                     ,transcribe_voicemail =
-                         kz_json:is_true(<<"transcribe">>, MailboxJObj, 'false')
+                         kz_json:is_true(<<"transcribe">>, MailboxJObj, kvm_util:transcribe_default())
                     ,notifications =
                          kz_json:get_json_value(<<"notifications">>, MailboxJObj)
                     ,after_notify_action = AfterNotifyAction

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -31374,6 +31374,10 @@
                     "description": "blackhole ssl_workers",
                     "type": "integer"
                 },
+                "url": {
+                    "description": "The advertised URL of the Kazoo websocket",
+                    "type": "string"
+                },
                 "use_plaintext": {
                     "default": true,
                     "description": "blackhole use_plaintext",
@@ -31751,6 +31755,11 @@
                             "minimum": 0,
                             "type": "integer"
                         },
+                        "transcribe_default": {
+                            "default": false,
+                            "description": "callflow voicemail transcribe_default",
+                            "type": "boolean"
+                        },
                         "vm_delete_amqp": {
                             "default": false,
                             "description": "send ampq message to notify about voicemail deletion",
@@ -32038,6 +32047,16 @@
                     "default": {},
                     "description": "cluster zones",
                     "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.cluster_manager": {
+            "description": "Schema for cluster_manager system_config",
+            "properties": {
+                "url": {
+                    "description": "The base URL of the 2600Hz cluster manager service",
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -35121,6 +35140,16 @@
             },
             "type": "object"
         },
+        "system_config.mobile": {
+            "description": "Schema for mobile system_config",
+            "properties": {
+                "url": {
+                    "description": "The base URL of the 2600Hz mobile service",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "system_config.mobile_manager": {
             "description": "Schema for mobile_manager system_config",
             "properties": {
@@ -36290,6 +36319,16 @@
                     "default": false,
                     "description": "omnipresence subscriptions sync enabled",
                     "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.phonebook": {
+            "description": "Schema for phonebook system_config",
+            "properties": {
+                "url": {
+                    "description": "The base URL of the 2600Hz phonebook service",
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -37754,6 +37793,16 @@
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "system_config.webrtc": {
+            "description": "Schema for webrtc system_config",
+            "properties": {
+                "url": {
+                    "description": "The advertised URL of the webrtc socket",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.blackhole.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.blackhole.json
@@ -88,6 +88,10 @@
             "description": "blackhole ssl_workers",
             "type": "integer"
         },
+        "url": {
+            "description": "The advertised URL of the Kazoo websocket",
+            "type": "string"
+        },
         "use_plaintext": {
             "default": true,
             "description": "blackhole use_plaintext",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
@@ -218,6 +218,11 @@
                     "minimum": 0,
                     "type": "integer"
                 },
+                "transcribe_default": {
+                    "default": false,
+                    "description": "callflow voicemail transcribe_default",
+                    "type": "boolean"
+                },
                 "vm_delete_amqp": {
                     "default": false,
                     "description": "send ampq message to notify about voicemail deletion",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.cluster_manager.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.cluster_manager.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.cluster_manager",
+    "description": "Schema for cluster_manager system_config",
+    "properties": {
+        "url": {
+            "description": "The base URL of the 2600Hz cluster manager service",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/system_config.mobile.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.mobile.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.mobile",
+    "description": "Schema for mobile system_config",
+    "properties": {
+        "url": {
+            "description": "The base URL of the 2600Hz mobile service",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/system_config.phonebook.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.phonebook.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.phonebook",
+    "description": "Schema for phonebook system_config",
+    "properties": {
+        "url": {
+            "description": "The base URL of the 2600Hz phonebook service",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/system_config.webrtc.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.webrtc.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "system_config.webrtc",
+    "description": "Schema for webrtc system_config",
+    "properties": {
+        "url": {
+            "description": "The advertised URL of the webrtc socket",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -8895,6 +8895,9 @@
       'default': 100
       'description': blackhole ssl_workers
       'type': integer
+    'url':
+      'description': The advertised URL of the Kazoo websocket
+      'type': string
     'use_plaintext':
       'default': true
       'description': blackhole use_plaintext
@@ -9197,6 +9200,10 @@
           'description': callflow fastforward and rewind seek duration
           'minimum': 0
           'type': integer
+        'transcribe_default':
+          'default': false
+          'description': callflow voicemail transcribe_default
+          'type': boolean
         'vm_delete_amqp':
           'default': false
           'description': send ampq message to notify about voicemail deletion
@@ -9418,6 +9425,13 @@
       'default': {}
       'description': cluster zones
       'type': object
+  'type': object
+'system_config.cluster_manager':
+  'description': Schema for cluster_manager system_config
+  'properties':
+    'url':
+      'description': The base URL of the 2600Hz cluster manager service
+      'type': string
   'type': object
 'system_config.cnam':
   'description': Schema for cnam system_config
@@ -11801,6 +11815,13 @@
       'description': milliwatt tone
       'type': object
   'type': object
+'system_config.mobile':
+  'description': Schema for mobile system_config
+  'properties':
+    'url':
+      'description': The base URL of the 2600Hz mobile service
+      'type': string
+  'type': object
 'system_config.mobile_manager':
   'description': Schema for mobile_manager system_config
   'properties':
@@ -12650,6 +12671,13 @@
       'default': false
       'description': omnipresence subscriptions sync enabled
       'type': boolean
+  'type': object
+'system_config.phonebook':
+  'description': Schema for phonebook system_config
+  'properties':
+    'url':
+      'description': The base URL of the 2600Hz phonebook service
+      'type': string
   'type': object
 'system_config.pivot':
   'description': Schema for pivot system_config
@@ -13790,6 +13818,13 @@
       'items':
         'type': string
       'type': array
+  'type': object
+'system_config.webrtc':
+  'description': Schema for webrtc system_config
+  'properties':
+    'url':
+      'description': The advertised URL of the webrtc socket
+      'type': string
   'type': object
 'system_config.whitelabel':
   'description': Schema for whitelabel system_config

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -609,9 +609,27 @@ populate_resp(JObj, AccountId, UserId) ->
               [{<<"apps">>, load_apps(AccountId, UserId, Language)}
               ,{<<"language">>, Language}
               ,{<<"account_name">>, kzd_accounts:fetch_name(AccountId)}
-              ,{<<"is_reseller">>, kz_services_reseller:is_reseller(AccountId)}
+              ,{<<"cluster_id">>, kzd_cluster:id()}
               ,{<<"reseller_id">>, kz_services_reseller:get_id(AccountId)}
+              ,{<<"is_reseller">>, kz_services_reseller:is_reseller(AccountId)}
+              ,{<<"capabilities">>, get_capabilities()}
               ]),
+    kz_json:set_values(Props, JObj).
+
+-spec get_capabilities() -> kz_json:object().
+get_capabilities() ->
+    Routines = [fun get_transcription_capabilities/1],
+    lists:foldl(fun(F, J) -> F(J) end, kz_json:new(), Routines).
+
+-spec get_transcription_capabilities(kz_json:object()) -> kz_json:object().
+get_transcription_capabilities(JObj) ->
+    Props = [{[<<"voicemail">>, <<"transcription">>, <<"supported">>]
+             ,kazoo_asr:available()
+             }
+            ,{[<<"voicemail">>, <<"transcription">>, <<"default">>]
+             ,kvm_util:transcribe_default()
+             }
+            ],
     kz_json:set_values(Props, JObj).
 
 %%------------------------------------------------------------------------------

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -612,9 +612,77 @@ populate_resp(JObj, AccountId, UserId) ->
               ,{<<"cluster_id">>, kzd_cluster:id()}
               ,{<<"reseller_id">>, kz_services_reseller:get_id(AccountId)}
               ,{<<"is_reseller">>, kz_services_reseller:is_reseller(AccountId)}
+              ,{<<"is_master_account">>, is_master_account(AccountId)}
               ,{<<"capabilities">>, get_capabilities()}
+              ,{<<"ui_config">>, get_ui_config()}
               ]),
     kz_json:set_values(Props, JObj).
+
+-spec get_ui_config() -> kz_json:object().
+get_ui_config() ->
+    Routines = [fun get_provisioner_config/1
+               ,fun get_mobile_config/1
+               ,fun get_kazoo_websocket_config/1
+               ,fun get_webrtc_websocket_config/1
+               ,fun get_phonebook_config/1
+               ,fun get_cluster_manager_config/1
+               ],
+    lists:foldl(fun(F, J) -> F(J) end, kz_json:new(), Routines).
+
+-spec get_provisioner_config(kz_json:object()) -> kz_json:object().
+get_provisioner_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"provisioner">>, <<"provisioning_url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"provisioner">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_mobile_config(kz_json:object()) -> kz_json:object().
+get_mobile_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"mobile">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"mobile">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_kazoo_websocket_config(kz_json:object()) -> kz_json:object().
+get_kazoo_websocket_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"blackhole">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"kazoo_websocket">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_webrtc_websocket_config(kz_json:object()) -> kz_json:object().
+get_webrtc_websocket_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"webrtc">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"webrtc_websocket">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_phonebook_config(kz_json:object()) -> kz_json:object().
+get_phonebook_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"phonebook">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"phonebook">>, <<"url">>], URL, JObj)
+    end.
+
+-spec get_cluster_manager_config(kz_json:object()) -> kz_json:object().
+get_cluster_manager_config(JObj) ->
+    case kapps_config:get_ne_binary(<<"cluster_manager">>, <<"url">>) of
+        'undefined' -> JObj;
+        URL ->
+            kz_json:set_value([<<"api">>, <<"cluster_manager">>, <<"url">>], URL, JObj)
+    end.
+
+-spec is_master_account(kz_term:ne_binary()) -> boolean().
+is_master_account(AccountId) ->
+    case kapps_util:get_master_account_id() of
+        {'ok', AccountId} -> 'true';
+        _Else -> 'false'
+    end.
 
 -spec get_capabilities() -> kz_json:object().
 get_capabilities() ->

--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -623,7 +623,7 @@ get_capabilities() ->
 
 -spec get_transcription_capabilities(kz_json:object()) -> kz_json:object().
 get_transcription_capabilities(JObj) ->
-    Props = [{[<<"voicemail">>, <<"transcription">>, <<"supported">>]
+    Props = [{[<<"voicemail">>, <<"transcription">>, <<"available">>]
              ,kazoo_asr:available()
              }
             ,{[<<"voicemail">>, <<"transcription">>, <<"default">>]

--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -698,7 +698,19 @@ validate_unique_vmbox(VMBoxId, Context, _AccountDb) ->
 check_vmbox_schema(VMBoxId, Context) ->
     Context1 = maybe_migrate_notification_emails(Context),
     OnSuccess = fun(C) -> validate_media_extension(VMBoxId, C) end,
-    cb_context:validate_request_data(<<"vmboxes">>, Context1, OnSuccess).
+    cb_context:validate_request_data(find_schema(), Context1, OnSuccess).
+
+-spec find_schema() -> kz_json:api_object().
+find_schema() ->
+    case kz_json_schema:load(<<"vmboxes">>) of
+        {'ok', SchemaJObj} ->
+            Props = [{[<<"properties">>, <<"transcribe">>, <<"default">>]
+                     ,kvm_util:transcribe_default()
+                     }
+                    ],
+            kz_json:set_values(Props, SchemaJObj);
+        {'error', _E} -> 'undefined'
+    end.
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/core/kazoo_speech/src/asr/kazoo_asr_google.erl
+++ b/core/kazoo_speech/src/asr/kazoo_asr_google.erl
@@ -11,12 +11,12 @@
 -module(kazoo_asr_google).
 -behaviour(gen_asr_provider).
 
--export([preferred_content_type/0
-        ,accepted_content_types/0
-        ,freeform/4
-        ,commands/5
-        ,set_api_key/1
-        ]).
+-export([available/0]).
+-export([preferred_content_type/0]).
+-export([accepted_content_types/0]).
+-export([freeform/4]).
+-export([commands/5]).
+-export([set_api_key/1]).
 
 -include("kazoo_speech.hrl").
 
@@ -30,6 +30,14 @@
 -define(GOOGLE_ASR_USE_ENHANCED, kapps_config:get_is_true(?GOOGLE_CONFIG_CAT, <<"asr_use_enhanced">>, 'true')).
 -define(GOOGLE_ASR_PREFERRED_CONTENT_TYPE, <<"application/wav">>).
 -define(GOOGLE_ASR_ACCEPTED_CONTENT_TYPES, [<<"audio/wav">>, <<"application/wav">>]).
+
+%%%------------------------------------------------------------------------------
+%%% @doc Return true if Google ASR is configured / available otherwise false.
+%%% @end
+%%%------------------------------------------------------------------------------
+-spec available() -> boolean().
+available() ->
+    kz_term:is_not_empty(?GOOGLE_ASR_KEY).
 
 %%%-----------------------------------------------------------------------------
 %%% @doc

--- a/core/kazoo_speech/src/asr/kazoo_asr_ispeech.erl
+++ b/core/kazoo_speech/src/asr/kazoo_asr_ispeech.erl
@@ -10,17 +10,25 @@
 -module(kazoo_asr_ispeech).
 -behaviour(gen_asr_provider).
 
--export([preferred_content_type/0
-        ,accepted_content_types/0
-        ,freeform/4
-        ,commands/5
-        ,set_api_key/1
-        ]).
+-export([available/0]).
+-export([preferred_content_type/0]).
+-export([accepted_content_types/0]).
+-export([freeform/4]).
+-export([commands/5]).
+-export([set_api_key/1]).
 
 -include("kazoo_speech.hrl").
 
 -define(DEFAULT_ASR_CONTENT_TYPE, <<"application/wav">>).
 -define(SUPPORTED_CONTENT_TYPES, [<<"application/wav">>]).
+
+%%%------------------------------------------------------------------------------
+%%% @doc Return true if iSpeech ASR is configured / available otherwise false.
+%%% @end
+%%%------------------------------------------------------------------------------
+-spec available() -> boolean().
+available() ->
+    kz_term:is_not_empty(default_api_key()).
 
 %%%-----------------------------------------------------------------------------
 %%% @doc

--- a/core/kazoo_speech/src/gen_asr_provider.erl
+++ b/core/kazoo_speech/src/gen_asr_provider.erl
@@ -11,6 +11,7 @@
 
 -include("kazoo_speech.hrl").
 
+-callback available() -> boolean().
 -callback preferred_content_type() -> kz_term:ne_binary().
 -callback accepted_content_types() -> kz_term:ne_binaries().
 -callback freeform(binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> asr_resp().

--- a/core/kazoo_speech/src/kazoo_asr.erl
+++ b/core/kazoo_speech/src/kazoo_asr.erl
@@ -9,14 +9,28 @@
 %%%-----------------------------------------------------------------------------
 -module(kazoo_asr).
 
--export([freeform/1, freeform/2, freeform/3, freeform/4
-        ,commands/2, commands/3, commands/4, commands/5
-        ,accepted_content_types/0
-        ,default_provider/0, default_provider/1, set_default_provider/1
-        ,preferred_content_type/0, preferred_content_type/1
-
-        ,provider_module/1
+-export([available/0
+        ,available/1
         ]).
+-export([freeform/1
+        ,freeform/2
+        ,freeform/3
+        ,freeform/4
+        ]).
+-export([commands/2
+        ,commands/3
+        ,commands/4
+        ,commands/5
+        ]).
+-export([accepted_content_types/0]).
+-export([default_provider/0
+        ,default_provider/1
+        ,set_default_provider/1
+        ]).
+-export([preferred_content_type/0
+        ,preferred_content_type/1
+        ]).
+-export([provider_module/1]).
 
 -include("kazoo_speech.hrl").
 
@@ -26,8 +40,24 @@
 -define(ACCEPTED_CONTENT_TYPES, [<<"audio/mpeg">>, <<"audio/wav">>, <<"application/wav">>]).
 
 %%%------------------------------------------------------------------------------
-%%% @doc
-%%% Return return configured or set the default ASR provider
+%%% @doc Return true if ASR is configured / available otherwise false.
+%%% @end
+%%%------------------------------------------------------------------------------
+-spec available() -> boolean().
+available() ->
+    available(default_provider()).
+
+-spec available(kz_term:ne_binary()) -> boolean().
+available(Provider) ->
+    try (kz_term:to_atom(<<"kazoo_asr_", Provider/binary>>, 'true')):available()
+    catch
+        'error':'undef' ->
+            lager:error("unknown provider ~s", [Provider]),
+            'false'
+    end.
+
+%%%------------------------------------------------------------------------------
+%%% @doc Return return configured or set the default ASR provider
 %%% @end
 %%%------------------------------------------------------------------------------
 -spec default_provider() -> kz_term:ne_binary().

--- a/core/kazoo_voicemail/src/kvm_util.erl
+++ b/core/kazoo_voicemail/src/kvm_util.erl
@@ -24,6 +24,8 @@
 
         ,publish_saved_notify/5, publish_voicemail_saved/5, publish_voicemail_deleted/3
         ,get_caller_id_name/1, get_caller_id_number/1
+
+        ,transcribe_default/0
         ]).
 
 -include("kz_voicemail.hrl").
@@ -286,6 +288,14 @@ get_caller_id_number(Call) ->
             Pre = <<(kz_term:to_binary(Prepend))/binary, CallerIdNumber/binary>>,
             kz_binary:truncate_right(Pre, kzd_schema_caller_id:external_name_max_length())
     end.
+
+%%------------------------------------------------------------------------------
+%% @doc Get trascribe default.
+%% @end
+%%------------------------------------------------------------------------------
+-spec transcribe_default() -> boolean().
+transcribe_default() ->
+    kapps_config:get_is_true(?VM_CONFIG_CAT, [?KEY_VOICEMAIL, <<"transcribe_default">>], 'false').
 
 %%%=============================================================================
 %%% Publish Notification


### PR DESCRIPTION
When generating a new JWT for Crossbar the response now includes the cluster id as well as a new object 'capabilities'. The capabilities object conveys services and settings of the cluster so the UI can modify the user experience to match. At this time the only parameters that are exposed are voicemail.transcription.supported if a transcription service is configured with an API key and voicemail.transcription.default to inform the UI transcriptions are created by default.