### PR TITLE
Long live the crossbar view

### DIFF
--- a/applications/acdc/src/cb_acdc_call_stats.erl
+++ b/applications/acdc/src/cb_acdc_call_stats.erl
@@ -127,7 +127,7 @@ load_stats_summary(Context, [_, {?KZ_ACCOUNTS_DB, [_]} | _]) ->
     lager:debug("loading call stats for account ~s", [cb_context:account_id(Context)]),
     Options = [{'is_chunked', 'true'}
               ,{'chunk_size', ?MAX_BULK}
-              ,{'mapper', crossbar_view:map_value_fun()}
+              ,{'mapper', crossbar_view:get_value_fun()}
               ],
     crossbar_view:load_modb(Context, ?CB_LIST, Options);
 load_stats_summary(Context, _Nouns) ->

--- a/applications/acdc/src/cb_agents.erl
+++ b/applications/acdc/src/cb_agents.erl
@@ -540,7 +540,7 @@ add_miss(Miss, Acc, QueueId) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', fun normalize_view_results/2}]).
 
 %%------------------------------------------------------------------------------
 %% @doc Normalizes the results of a view

--- a/applications/acdc/src/cb_queues.erl
+++ b/applications/acdc/src/cb_queues.erl
@@ -547,10 +547,11 @@ load_queue_agents(Id, Context) ->
     end.
 
 load_agent_roster(Id, Context) ->
-    crossbar_doc:load_view(?CB_AGENTS_LIST, [{'key', Id}, {'reduce', 'false'}]
-                          ,Context
-                          ,fun normalize_agents_results/2
-                          ).
+    Options = [{'key', Id}
+              ,{'mapper', crossbar_view:get_id_fun()}
+              ,{'reduce', 'false'}
+              ],
+    crossbar_view:load(Context, ?CB_AGENTS_LIST, Options).
 
 add_queue_to_agents(Id, Context) ->
     add_queue_to_agents(Id, Context, cb_context:req_data(Context)).
@@ -740,22 +741,7 @@ fetch_from_amqp(Context, Req) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST
-                          ,[]
-                          ,Context
-                          ,fun normalize_view_results/2
-                          ).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].
-
-normalize_agents_results(JObj, Acc) ->
-    [kz_doc:id(JObj) | Acc].
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc Creates an entry in the acdc db of the account's participation in acdc

--- a/applications/callflow/src/module/cf_dynamic_cid.erl
+++ b/applications/callflow/src/module/cf_dynamic_cid.erl
@@ -121,7 +121,7 @@ handle_static(Data, Call, CaptureGroup) ->
 %%------------------------------------------------------------------------------
 -type cid_entry() :: {kz_term:ne_binary(), kz_term:ne_binary(), binary()}.
 -type list_cid_entry() :: list_cid_entry() |
-                          {'error', kz_datamgr:data_error()}.
+                          kz_datamgr:data_error().
 
 -spec handle_list(kz_json:object(), kapps_call:call()) -> 'ok'.
 handle_list(Data, Call) ->

--- a/applications/callflow/src/module/cf_park.erl
+++ b/applications/callflow/src/module/cf_park.erl
@@ -146,7 +146,7 @@ retrieve(SlotNumber, Call) ->
     SlotReturn = get_slot(SlotNumber, kapps_call:account_db(Call)),
     retrieve(SlotNumber, SlotReturn, 1, Call).
 
--spec retrieve(kz_term:ne_binary(), {'ok', kz_json:object()} | {'error', kz_datamgr:data_error()}, 1..3, kapps_call:call()) ->
+-spec retrieve(kz_term:ne_binary(), {'ok', kz_json:object()} | kz_datamgr:data_error(), 1..3, kapps_call:call()) ->
           {'ok', 'retrieved'} |
           {'error', 'slot_empty' | 'timeout' | 'failed'}.
 retrieve(SlotNumber, {'error', 'not_found'}, _Try, _Call) ->

--- a/applications/cccp/src/cb_cccps.erl
+++ b/applications/cccp/src/cb_cccps.erl
@@ -209,7 +209,7 @@ update(Id, Context) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -220,14 +220,6 @@ on_successful_validation('undefined', Context) ->
     cb_context:set_doc(Context, kz_doc:set_type(cb_context:doc(Context), <<"cccp">>));
 on_successful_validation(Id, Context) ->
     crossbar_doc:load_merge(Id, Context, ?TYPE_CHECK_OPTION(<<"cccp">>)).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].
 
 %%------------------------------------------------------------------------------
 %% @doc Checks whether cid and pin are unique

--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -237,7 +237,7 @@ is_authenticated(#cb_context{auth_doc='undefined'}) -> 'false';
 is_authenticated(#cb_context{}) -> 'true'.
 
 -spec master_account_id(context()) -> kz_term:api_ne_binary().
-master_account_id(#cb_context{master_account_id = ?NE_BINARY = MasterId}) ->
+master_account_id(#cb_context{master_account_id = <<MasterId/binary>>}) ->
     MasterId;
 master_account_id(_) ->
     case kapps_util:get_master_account_id() of

--- a/applications/crossbar/src/modules/cb_api_auth.erl
+++ b/applications/crossbar/src/modules/cb_api_auth.erl
@@ -30,7 +30,6 @@
 
 -include("crossbar.hrl").
 
--define(AGG_VIEW_FILE, <<"views/accounts.json">>).
 -define(AGG_VIEW_API, <<"accounts/listing_by_api">>).
 -define(API_AUTH_TOKENS, kapps_config:get_integer(?CONFIG_CAT, <<"api_auth_tokens">>, 35)).
 
@@ -137,10 +136,10 @@ on_successful_validation(Context) ->
 
 -spec validate_by_api_key(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 validate_by_api_key(Context, ApiKey) ->
-    Context1 = crossbar_doc:load_view(?AGG_VIEW_API
-                                     ,[{'key', ApiKey}]
-                                     ,cb_context:set_db_name(Context, ?KZ_ACCOUNTS_DB)
-                                     ),
+    Options = [{'databases', [?KZ_ACCOUNTS_DB]}
+              ,{'key', ApiKey}
+              ],
+    Context1 = crossbar_view:load(Context, ?AGG_VIEW_API, Options),
     case cb_context:resp_status(Context1) of
         'success' ->
             validate_by_api_key(Context1, ApiKey, cb_context:doc(Context1));

--- a/applications/crossbar/src/modules/cb_att_handlers_errors.erl
+++ b/applications/crossbar/src/modules/cb_att_handlers_errors.erl
@@ -115,7 +115,7 @@ read(<<Year:4/binary, Month:2/binary, _/binary>> = Id, Context) ->
 
 -spec read(kz_term:ne_binary(), kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
 read(<<"handler">>, HandlerId, Context) ->
-    Options = [{'mapper', crossbar_view:map_value_fun()}
+    Options = [{'mapper', crossbar_view:get_value_fun()}
               ,{'range_keymap', [HandlerId]}
               ],
     crossbar_view:load_modb(Context, ?CB_LIST_BY_HANDLER, Options).
@@ -126,5 +126,5 @@ read(<<"handler">>, HandlerId, Context) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    Options = [{'mapper', crossbar_view:map_value_fun()}],
+    Options = [{'mapper', crossbar_view:get_value_fun()}],
     crossbar_view:load_modb(Context, ?CB_LIST_ALL, Options).

--- a/applications/crossbar/src/modules/cb_basic_auth.erl
+++ b/applications/crossbar/src/modules/cb_basic_auth.erl
@@ -28,7 +28,6 @@
 
 -define(ACCT_MD5_LIST, <<"users/creds_by_md5">>).
 -define(ACCT_SHA1_LIST, <<"users/creds_by_sha">>).
--define(USERNAME_LIST, <<"users/list_by_username">>).
 
 %%%=============================================================================
 %%% API

--- a/applications/crossbar/src/modules/cb_blacklists.erl
+++ b/applications/crossbar/src/modules/cb_blacklists.erl
@@ -167,7 +167,7 @@ validate_patch(Id, Context) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -179,14 +179,6 @@ on_successful_validation('undefined', Context) ->
     cb_context:set_doc(Context, kz_doc:set_type(Doc, kzd_blacklists:type()));
 on_successful_validation(Id, Context) ->
     crossbar_doc:load_merge(Id, Context, ?TYPE_CHECK_OPTION(kzd_blacklists:type())).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj) | Acc].
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/applications/crossbar/src/modules/cb_callflows.erl
+++ b/applications/crossbar/src/modules/cb_callflows.erl
@@ -156,7 +156,7 @@ delete(Context, _CallflowId) ->
 %%------------------------------------------------------------------------------
 -spec load_callflow_summary(cb_context:context()) -> cb_context:context().
 load_callflow_summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc Load a callflow document from the database
@@ -342,15 +342,6 @@ on_successful_validation('undefined', Context) ->
                       );
 on_successful_validation(CallflowId, Context) ->
     crossbar_doc:load_merge(CallflowId, Context, ?TYPE_CHECK_OPTION(kzd_callflows:type())).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) ->
-          kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/applications/crossbar/src/modules/cb_channels.erl
+++ b/applications/crossbar/src/modules/cb_channels.erl
@@ -298,7 +298,7 @@ user_endpoints(Context, UserId) ->
     Options = [{'key', [UserId, <<"device">>]}
               ,'include_docs'
               ],
-    Context1 = crossbar_doc:load_view(<<"attributes/owned">>, Options, Context),
+    Context1 = crossbar_view:load(Context, <<"attributes/owned">>, Options),
     {cb_context:doc(Context1), Context1}.
 
 -spec group_summary(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().

--- a/applications/crossbar/src/modules/cb_clicktocall.erl
+++ b/applications/crossbar/src/modules/cb_clicktocall.erl
@@ -221,24 +221,12 @@ delete(Context, _) ->
 %%%=============================================================================
 
 %%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
+%% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].
-
--spec normalize_history_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_history_results(JObj, Acc) ->
-    [kz_json:get_json_value(<<"doc">>, JObj)|Acc].
-
 -spec load_c2c_summary(cb_context:context()) -> cb_context:context().
 load_c2c_summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST
-                          ,[]
-                          ,Context
-                          ,fun normalize_view_results/2
-                          ).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 -spec load_c2c(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
 load_c2c(C2CId, Context) ->
@@ -246,15 +234,11 @@ load_c2c(C2CId, Context) ->
 
 -spec load_c2c_history(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
 load_c2c_history(C2CId, Context) ->
-    Options = ['include_docs'
-              ,{'startkey', [C2CId]}
-              ,{'endkey', [C2CId, kz_json:new()]}
+    Options = [{'mapper', crossbar_view:get_doc_fun()}
+              ,{'range_keymap', [C2CId]}
+              ,'include_docs'
               ],
-    crossbar_doc:load_view(?HISTORY_LIST
-                          ,Options
-                          ,cb_context:set_db_name(Context, cb_context:account_modb(Context))
-                          ,fun normalize_history_results/2
-                          ).
+    crossbar_view:load_modb(Context, ?HISTORY_LIST, Options).
 
 -spec create_c2c(cb_context:context()) -> cb_context:context().
 create_c2c(Context) ->

--- a/applications/crossbar/src/modules/cb_conferences.erl
+++ b/applications/crossbar/src/modules/cb_conferences.erl
@@ -132,7 +132,7 @@ validate(Context, ConferenceId, ?PARTICIPANTS, ParticipantId) ->
 %%------------------------------------------------------------------------------
 -spec validate_conferences(http_method(), cb_context:context()) -> cb_context:context().
 validate_conferences(?HTTP_GET, Context) ->
-    LoadedContext = crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2),
+    LoadedContext = crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]),
     case cb_context:resp_status(LoadedContext) of
         'success' ->
             Context1 = search_conferences(LoadedContext),
@@ -267,10 +267,6 @@ on_successful_validation('undefined', Context) ->
     cb_context:update_doc(Context, {fun kz_doc:set_type/2, <<"conference">>});
 on_successful_validation(ConferenceId, Context) ->
     crossbar_doc:load_merge(ConferenceId, Context, ?TYPE_CHECK_OPTION(<<"conference">>)).
-
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(ViewResult, Acc) ->
-    [kz_json:get_json_value(<<"value">>, ViewResult) | Acc].
 
 empty_realtime_data() ->
     kz_json:from_list_recursive(

--- a/applications/crossbar/src/modules/cb_connectivity.erl
+++ b/applications/crossbar/src/modules/cb_connectivity.erl
@@ -267,16 +267,7 @@ on_successful_validation(Id, Context) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST
-                          ,[{'reduce', 'false'}]
-                          ,Context
-                          ,fun normalize_view_results/2
-                          ).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_doc:id(JObj) | Acc].
+    Options = [{'mapper', crossbar_view:get_id_fun()}
+              ,{'reduce', 'false'}
+              ],
+    crossbar_view:load(Context, ?CB_LIST, Options).

--- a/applications/crossbar/src/modules/cb_devices.erl
+++ b/applications/crossbar/src/modules/cb_devices.erl
@@ -255,19 +255,13 @@ load_device_summary(Context) ->
 
 -spec load_device_summary(cb_context:context(), req_nouns()) ->
           cb_context:context().
-load_device_summary(Context, [{<<"devices">>, []}
-                             ,{<<"users">>, [UserId]}
-                              |_]
-                   ) ->
-    load_users_device_summary(Context, UserId);
+load_device_summary(Context, [{<<"devices">>, []}, {<<"users">>, [UserId]} | _]) ->
+    ViewOptions = [{'key', UserId}
+                  ,{'mapper', crossbar_view:get_value_fun()}
+                  ],
+    crossbar_view:load(Context, ?OWNER_LIST, ViewOptions);
 load_device_summary(Context, _ReqNouns) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
-
--spec load_users_device_summary(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
-load_users_device_summary(Context, UserId) ->
-    View = ?OWNER_LIST,
-    ViewOptions = [{'key', UserId}],
-    crossbar_doc:load_view(View, ViewOptions, Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -327,14 +321,6 @@ load_device_status(Context) ->
     RegStatuses = lookup_regs(AccountRealm),
     lager:debug("reg statuses: ~p", [RegStatuses]),
     crossbar_util:response(RegStatuses, Context).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj) | Acc].
 
 %%------------------------------------------------------------------------------
 %% @doc Returns the complete list of registrations in a the first registrar

--- a/applications/crossbar/src/modules/cb_faxboxes.erl
+++ b/applications/crossbar/src/modules/cb_faxboxes.erl
@@ -312,12 +312,10 @@ generate_email_address(Context) ->
 %%------------------------------------------------------------------------------
 -spec faxbox_listing(cb_context:context()) -> cb_context:context().
 faxbox_listing(Context) ->
-    ViewOptions = ['include_docs'],
-    crossbar_doc:load_view(<<"faxbox/crossbar_listing">>
-                          ,ViewOptions
-                          ,Context
-                          ,fun normalize_view_results/2
-                          ).
+    ViewOptions = [{'mapper', fun normalize_view_results/2}
+                  ,'include_docs'
+                  ],
+    crossbar_view:load(Context, <<"faxbox/crossbar_listing">>, ViewOptions).
 
 -spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
 normalize_view_results(JObj, Acc) ->

--- a/applications/crossbar/src/modules/cb_faxes.erl
+++ b/applications/crossbar/src/modules/cb_faxes.erl
@@ -611,7 +611,7 @@ maybe_user_filter_doc(Context) ->
 
 -spec load_smtp_log(cb_context:context()) -> cb_context:context().
 load_smtp_log(Context) ->
-    Options = [{'mapper', crossbar_view:map_value_fun()}
+    Options = [{'mapper', crossbar_view:get_value_fun()}
               ,'include_docs'
               ],
     crossbar_view:load_modb(Context, ?CB_LIST_SMTP_LOG, Options).
@@ -709,7 +709,7 @@ get_timezone(Context) ->
 outgoing_summary(Context) ->
     JObj = cb_context:fetch(Context, <<"faxbox">>, kz_json:new()),
     {ViewName, Opts} = get_view_and_filter(Context, {kz_doc:id(JObj), kz_doc:type(JObj)}, 'undefined'),
-    Options = [{'mapper', crossbar_view:map_value_fun()}
+    Options = [{'mapper', crossbar_view:get_value_fun()}
               ,{'databases', [?KZ_FAXES_DB]}
               ,'include_docs'
                | Opts

--- a/applications/crossbar/src/modules/cb_groups.erl
+++ b/applications/crossbar/src/modules/cb_groups.erl
@@ -186,8 +186,13 @@ validate_patch(Id, Context) ->
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
     case cb_context:user_id(Context) of
-        'undefined' -> crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2);
-        UserId -> crossbar_doc:load_view(?CB_LIST_BY_USER, [{'key', UserId}], Context, fun normalize_view_results/2)
+        'undefined' ->
+            crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]);
+        UserId ->
+            Options = [{'key', UserId}
+                      ,{'mapper', crossbar_view:get_value_fun()}
+                      ],
+            crossbar_view:load(Context, ?CB_LIST_BY_USER, Options)
     end.
 
 %%------------------------------------------------------------------------------
@@ -199,11 +204,3 @@ on_successful_validation('undefined', Context) ->
     cb_context:set_doc(Context, kz_doc:set_type(cb_context:doc(Context), <<"group">>));
 on_successful_validation(Id, Context) ->
     crossbar_doc:load_merge(Id, Context, ?TYPE_CHECK_OPTION(<<"group">>)).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].

--- a/applications/crossbar/src/modules/cb_hotdesks.erl
+++ b/applications/crossbar/src/modules/cb_hotdesks.erl
@@ -90,21 +90,12 @@ validate_hotdesks(Context, ?HTTP_GET, _) ->
     fetch_all_hotdesks(Context).
 
 %%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) ->
-          kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].
-
-%%------------------------------------------------------------------------------
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
 -spec fetch_all_hotdesks(cb_context:context()) -> cb_context:context().
 fetch_all_hotdesks(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 -spec fetch_user_hotdesks(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
 fetch_user_hotdesks(DeviceId, Context) ->
@@ -119,11 +110,14 @@ fetch_user_hotdesks(DeviceId, Context) ->
 
 -spec fetch_users(kz_term:ne_binaries(), cb_context:context()) -> cb_context:context().
 fetch_users(UserIds, Context) ->
-    ViewOptions = [{'keys', UserIds}],
-    View = <<"users/list_by_id">>,
-    crossbar_doc:load_view(View, ViewOptions, Context, fun normalize_view_results/2).
+    ViewOptions = [{'keys', UserIds}
+                  ,{'mapper', crossbar_view:get_value_fun()}
+                  ],
+    crossbar_view:load(Context, <<"users/list_by_id">>, ViewOptions).
 
 -spec fetch_device_hotdesks(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
 fetch_device_hotdesks(UserId, Context) ->
-    ViewOptions = [{'key', UserId}],
-    crossbar_doc:load_view(?CB_LIST, ViewOptions, Context, fun normalize_view_results/2).
+    ViewOptions = [{'key', UserId}
+                  ,{'mapper', crossbar_view:get_value_fun()}
+                  ],
+    crossbar_view:load(Context, ?CB_LIST, ViewOptions).

--- a/applications/crossbar/src/modules/cb_ledgers.erl
+++ b/applications/crossbar/src/modules/cb_ledgers.erl
@@ -326,7 +326,7 @@ summary(Context) ->
 -spec summary(cb_context:context(), kz_term:proplist()) -> cb_context:context().
 summary(Context, Options) ->
     ViewOptions = [{'group_level', 0}
-                  ,{'mapper', crossbar_view:map_value_fun()}
+                  ,{'mapper', crossbar_view:get_value_fun()}
                    | Options
                   ],
 

--- a/applications/crossbar/src/modules/cb_menus.erl
+++ b/applications/crossbar/src/modules/cb_menus.erl
@@ -133,7 +133,7 @@ delete(Context, _DocId) ->
 %%------------------------------------------------------------------------------
 -spec load_menu_summary(cb_context:context()) -> cb_context:context().
 load_menu_summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc Create a new menu document with the data provided, if it is valid
@@ -183,11 +183,3 @@ on_successful_validation('undefined', Context) ->
     cb_context:set_doc(Context, MenuDoc);
 on_successful_validation(DocId, Context) ->
     crossbar_doc:load_merge(DocId, Context, ?TYPE_CHECK_OPTION(kzd_menus:type())).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].

--- a/applications/crossbar/src/modules/cb_multi_factor.erl
+++ b/applications/crossbar/src/modules/cb_multi_factor.erl
@@ -133,7 +133,7 @@ validate(Context) ->
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?ATTEMPTS) ->
-    Options = [{'mapper', crossbar_view:map_value_fun()}
+    Options = [{'mapper', crossbar_view:get_value_fun()}
               ,{'range_keymap', <<"multi_factor">>}
               ],
     crossbar_view:load_modb(Context, ?CB_LIST_ATTEMPT_LOG, Options);
@@ -267,7 +267,7 @@ summary(Context) ->
     Options = [{'startkey', [<<"multi_factor">>]}
               ,{'endkey', [<<"multi_factor">>, kz_json:new()]}
               ,{'unchunkable', 'true'}
-              ,{'mapper', crossbar_view:map_value_fun()}
+              ,{'mapper', crossbar_view:get_value_fun()}
               ],
     C1 = crossbar_view:load(Context, <<"auth/providers_by_type">>, Options),
     C2 = system_summary(Context),
@@ -276,7 +276,7 @@ summary(Context) ->
 system_summary(Context) ->
     Options = [{'startkey', [<<"multi_factor">>]}
               ,{'endkey', [<<"multi_factor">>, kz_json:new()]}
-              ,{'mapper', crossbar_view:map_value_fun()}
+              ,{'mapper', crossbar_view:get_value_fun()}
               ,{'databases', [?KZ_AUTH_DB]}
               ,{'unchunkable', 'true'}
               ],

--- a/applications/crossbar/src/modules/cb_phone_numbers.erl
+++ b/applications/crossbar/src/modules/cb_phone_numbers.erl
@@ -324,7 +324,7 @@ classified_number(Context, Number, Classifier) ->
     ClassifierJObj = kz_json:get_value(Classifier, knm_converters:available_classifiers()),
     BaseData = base_classified_number(Context, Number),
     RespData = kz_json:set_values([{<<"name">>, Classifier}
-                                  | BaseData
+                                   | BaseData
                                   ]
                                  ,ClassifierJObj
                                  ),
@@ -350,7 +350,7 @@ post(Context, ?CHECK) ->
 post(Context, ?COLLECTION) ->
     {Numbers, ReqData} = take_collection_numbers(Context),
     Options = [{'assign_to', cb_context:account_id(Context)}
-              | default_knm_options(Context)
+               | default_knm_options(Context)
               ],
     Results = knm_numbers:update(Numbers, [{fun knm_phone_number:reset_doc/2, ReqData}], Options),
     CB = fun() -> ?MODULE:post(cb_context:set_accepting_charges(Context), ?COLLECTION) end,
@@ -359,7 +359,7 @@ post(Context, ?LOCALITY) ->
     fetch_locality(Context);
 post(Context, Number) ->
     Options = [{'assign_to', cb_context:account_id(Context)}
-              | default_knm_options(Context)
+               | default_knm_options(Context)
               ],
     JObj = cb_context:doc(Context),
     Result = knm_numbers:update(Number, [{fun knm_phone_number:reset_doc/2, JObj}], Options),
@@ -372,7 +372,7 @@ put(Context, ?COLLECTION) ->
     {Numbers, ReqData} = take_collection_numbers(Context),
     Options = [{'assign_to', cb_context:account_id(Context)}
               ,{'public_fields', kz_json:delete_key(?PUBLIC_FIELDS_STATE, ReqData)}
-              | maybe_ask_for_state(kz_json:get_ne_binary_value(?PUBLIC_FIELDS_STATE, ReqData))
+               | maybe_ask_for_state(kz_json:get_ne_binary_value(?PUBLIC_FIELDS_STATE, ReqData))
                ++ default_knm_options(Context)
               ],
     Results = knm_numbers:create(Numbers, Options),
@@ -382,7 +382,7 @@ put(Context, Number) ->
     Doc = cb_context:doc(Context),
     Options = [{'assign_to', cb_context:account_id(Context)}
               ,{'public_fields', kz_json:delete_key(?PUBLIC_FIELDS_STATE, Doc)}
-              | maybe_ask_for_state(kz_json:get_ne_binary_value(?PUBLIC_FIELDS_STATE, Doc))
+               | maybe_ask_for_state(kz_json:get_ne_binary_value(?PUBLIC_FIELDS_STATE, Doc))
                ++ default_knm_options(Context)
               ],
     Result = knm_numbers:create(Number, Options),
@@ -393,14 +393,14 @@ put(Context, Number) ->
 put(Context, ?COLLECTION, ?ACTIVATE) ->
     {Numbers, _} = take_collection_numbers(Context),
     Options = [{'public_fields', cb_context:req_data(Context)}
-              | default_knm_options(Context)
+               | default_knm_options(Context)
               ],
     Results = knm_numbers:move(Numbers, cb_context:account_id(Context), Options),
     CB = fun() -> ?MODULE:put(cb_context:set_accepting_charges(Context), ?COLLECTION, ?ACTIVATE) end,
     set_response(Results, Context, CB);
 put(Context, <<Number/binary>>, ?ACTIVATE) ->
     Options = [{'public_fields', cb_context:doc(Context)}
-              | default_knm_options(Context)
+               | default_knm_options(Context)
               ],
     Result = knm_numbers:move(Number, cb_context:account_id(Context), Options),
     CB = fun() -> ?MODULE:put(cb_context:set_accepting_charges(Context), Number, ?ACTIVATE) end,
@@ -408,7 +408,7 @@ put(Context, <<Number/binary>>, ?ACTIVATE) ->
 put(Context, Number, ?RESERVE) ->
     Options = [{'assign_to', cb_context:account_id(Context)}
               ,{'public_fields', cb_context:doc(Context)}
-              | default_knm_options(Context)
+               | default_knm_options(Context)
               ],
     Result = knm_numbers:reserve(Number, Options),
     CB = fun() -> ?MODULE:put(cb_context:set_accepting_charges(Context), Number, ?RESERVE) end,
@@ -417,7 +417,7 @@ put(Context, Number, ?PORT) ->
     Options = [{'assign_to', cb_context:account_id(Context)}
               ,{'public_fields', cb_context:doc(Context)}
               ,{'state', ?NUMBER_STATE_PORT_IN}
-              | default_knm_options(Context)
+               | default_knm_options(Context)
               ],
     Result = knm_numbers:create(Number, Options),
     CB = fun() -> ?MODULE:put(cb_context:set_accepting_charges(Context), Number, ?PORT) end,
@@ -427,14 +427,14 @@ put(Context, Number, ?PORT) ->
 patch(Context, ?COLLECTION) ->
     {Numbers, ReqData} = take_collection_numbers(Context),
     Options = [{'assign_to', cb_context:account_id(Context)}
-              | default_knm_options(Context)
+               | default_knm_options(Context)
               ],
     Results = knm_numbers:update(Numbers, [{fun knm_phone_number:update_doc/2, ReqData}], Options),
     CB = fun() -> ?MODULE:patch(cb_context:set_accepting_charges(Context), ?COLLECTION) end,
     set_response(Results, Context, CB);
 patch(Context, Number) ->
     Options = [{'assign_to', cb_context:account_id(Context)}
-              | default_knm_options(Context)
+               | default_knm_options(Context)
               ],
     JObj = cb_context:doc(Context),
     Result = knm_numbers:update(Number, [{fun knm_phone_number:update_doc/2, JObj}], Options),
@@ -536,7 +536,10 @@ summary(Context) ->
 
 -spec view_account_phone_numbers(cb_context:context()) -> cb_context:context().
 view_account_phone_numbers(Context) ->
-    Context1 = crossbar_doc:load_view(?CB_LIST, [], rename_qs_filters(Context), fun normalize_view_results/3),
+    Context1 = crossbar_view:load(rename_qs_filters(Context)
+                                 ,?CB_LIST
+                                 ,[{'mapper', fun normalize_view_results/3}]
+                                 ),
     case cb_context:resp_status(Context1) of
         'success' ->
             ListOfNumProps = cb_context:resp_data(Context1),

--- a/applications/crossbar/src/modules/cb_port_requests.erl
+++ b/applications/crossbar/src/modules/cb_port_requests.erl
@@ -968,7 +968,7 @@ load_summary_by_type(Context, Type) ->
                | by_types_view_options(Context, Type, IsRanged, AuthorityType)
               ],
     case IsRanged of
-        'true' -> crossbar_view:load_range(Context, View, Options);
+        'true' -> crossbar_view:load_time_range(Context, View, Options);
         'false' -> crossbar_view:load(Context, View, Options)
     end.
 

--- a/applications/crossbar/src/modules/cb_rates.erl
+++ b/applications/crossbar/src/modules/cb_rates.erl
@@ -290,29 +290,17 @@ ensure_routes_set(Rate, _Routes) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context(), kz_term:api_binary()) -> cb_context:context().
 summary(Context, 'undefined') ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2);
+    Options = [{'databases', [cb_context:db_name(Context)]}
+              ,{'mapper', crossbar_view:get_value_fun()}
+              ],
+    crossbar_view:load(Context, ?CB_LIST, Options);
 summary(Context, Prefix) ->
-    crossbar_doc:load_view(<<"rates/lookup">>
-                          ,[{'keys', kzdb_ratedeck:prefix_keys(Prefix)},'include_docs']
-                          ,Context
-                          ,fun normalize_rate_lookup/2
-                          ).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_rate_lookup(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_rate_lookup(JObj, Acc) ->
-    [kz_json:get_value(<<"doc">>, JObj)|Acc].
+    Options = [{'databases', [cb_context:db_name(Context)]}
+              ,{'keys', kzdb_ratedeck:prefix_keys(Prefix)}
+              ,{'mapper', crossbar_view:get_doc_fun()}
+              ,'include_docs'
+              ],
+    crossbar_view:load(Context, <<"rates/lookup">>, Options).
 
 -spec rate_for_number(kz_term:ne_binary(), cb_context:context()) -> cb_context:context().
 rate_for_number(Phonenumber, Context) ->

--- a/applications/crossbar/src/modules/cb_resource_selectors.erl
+++ b/applications/crossbar/src/modules/cb_resource_selectors.erl
@@ -241,58 +241,22 @@ delete(Context, _UUID) ->
 load_rules(Context) ->
     crossbar_doc:load(?RULES_PVT_TYPE, Context, ?TYPE_CHECK_OPTION(?RULES_PVT_TYPE)).
 
--spec summary(cb_context:context(), kz_term:api_binaries(), kz_term:api_binary(), boolean()) -> cb_context:context().
+-spec summary(cb_context:context(), kz_term:binaries(), kz_term:api_binary(), boolean()) -> cb_context:context().
 summary(Context, Prefix, ViewName, Reduce) ->
-    case kz_term:is_true(Reduce) of
-        'true' ->
-            Options = [{'startkey', build_start_key(Context, Prefix)}
-                      ,{'endkey', build_end_key(Context, Prefix)}
-                      ,'group'
-                      ],
-            Fun = fun normalize_view_results/2;
-        'false' ->
-            Options = [{'startkey', build_start_key(Context, Prefix)}
-                      ,{'endkey', build_end_key(Context, Prefix)}
-                      ],
-            Fun = fun normalize_resource_selector_result/2
-    end,
-    Context1 = crossbar_doc:load_view(ViewName, Options, Context, Fun),
-    RespEnvelope = fix_envelope_start_keys(cb_context:resp_envelope(Context1), Prefix),
-    cb_context:set_resp_envelope(Context1, RespEnvelope).
+    crossbar_view:load(Context, ViewName, view_options(Prefix, Reduce)).
 
--spec build_start_key(cb_context:context(), kz_term:api_binaries()) -> kz_term:api_binaries().
-build_start_key(Context, PrefixKeys) ->
-    case cb_context:req_value(Context, <<"start_key">>) of
-        'undefined' -> PrefixKeys;
-        StartKey -> build_key(PrefixKeys, StartKey)
-    end.
-
--spec build_end_key(cb_context:context(), kz_term:api_binaries()) -> kz_term:api_binaries().
-build_end_key(Context, PrefixKeys) ->
-    case cb_context:req_value(Context, <<"end_key">>) of
-        'undefined' -> build_key(PrefixKeys, <<16#fff0/utf8>>);
-        EndKey -> build_key(PrefixKeys, EndKey)
-    end.
-
--spec build_key(kz_term:api_binaries(), kz_term:api_binary()) -> kz_term:api_binaries().
-build_key(PrefixKeys, Suffix) ->
-    lists:reverse([Suffix | lists:reverse(PrefixKeys)]).
-
--spec fix_envelope_start_keys(kz_json:object(), kz_term:api_binaries()) -> kz_json:object().
-fix_envelope_start_keys(JObj, Prefix) ->
-    lists:foldl(fun(K,J) ->
-                        case {kz_json:get_value(K, J), Prefix} of
-                            {'undefined', _} -> J;
-                            {[], _} -> kz_json:delete_key(K, J);
-                            {_, []} -> J;
-                            {P, P} -> kz_json:delete_key(K, J);
-                            {[P, Value], [P]} -> kz_json:set_value(K, Value, J);
-                            {[P1, P2, Value], [P1, P2]} -> kz_json:set_value(K, Value, J)
-                        end
-                end
-               ,JObj
-               ,[<<"start_key">>, <<"next_start_key">>]
-               ).
+-spec view_options(kz_term:ne_binaries(), boolean()) -> crossbar_view:options().
+view_options(Prefix, 'true') ->
+    [{'startkey', Prefix}
+    ,{'endkey', Prefix ++ [crossbar_view:high_value_key()]}
+    ,{'mapper', fun normalize_view_results/2}
+    ,'group'
+    ];
+view_options(Prefix, 'false') ->
+    [{'startkey', Prefix}
+    ,{'endkey', Prefix ++ [crossbar_view:high_value_key()]}
+    ,{'mapper', fun normalize_resource_selector_result/2}
+    ].
 
 %%------------------------------------------------------------------------------
 %% @doc Normalizes the results of a view.

--- a/applications/crossbar/src/modules/cb_resource_templates.erl
+++ b/applications/crossbar/src/modules/cb_resource_templates.erl
@@ -88,7 +88,11 @@ validate(Context) ->
 
 -spec validate_resource_templates(http_method(), cb_context:context()) -> cb_context:context().
 validate_resource_templates(?HTTP_GET, Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2);
+    %% setting db here to make note that the db could be different account id
+    Options = [{'databases', [cb_context:db_name(Context)]}
+              ,{'mapper', crossbar_view:get_value_fun()}
+              ],
+    crossbar_view:load(Context, ?CB_LIST, Options);
 validate_resource_templates(?HTTP_PUT, Context) ->
     case is_allowed_to_update(Context) of
         'true' -> validate_request('undefined', Context);
@@ -232,11 +236,3 @@ merge(Context) ->
     ReqData = kz_doc:public_fields(cb_context:req_data(Context)),
     Doc = kz_doc:private_fields(cb_context:doc(Context)),
     cb_context:set_doc(Context, kz_json:merge_jobjs(Doc, ReqData)).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].

--- a/applications/crossbar/src/modules/cb_resources.erl
+++ b/applications/crossbar/src/modules/cb_resources.erl
@@ -414,7 +414,7 @@ leak_job_fields(Context) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc Attempt to load a summarized listing of all instances of this
@@ -423,15 +423,7 @@ summary(Context) ->
 %%------------------------------------------------------------------------------
 -spec jobs_summary(cb_context:context()) -> cb_context:context().
 jobs_summary(Context) ->
-    crossbar_view:load_modb(Context, ?JOBS_LIST, [{'mapper', crossbar_view:map_doc_fun()}]).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].
+    crossbar_view:load_modb(Context, ?JOBS_LIST, [{'mapper', crossbar_view:get_doc_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc Create a new instance with the data provided, if it is valid

--- a/applications/crossbar/src/modules/cb_search.erl
+++ b/applications/crossbar/src/modules/cb_search.erl
@@ -279,7 +279,7 @@ search(Context, Type, Query, Val, Opts) ->
     Options =
         [{'startkey', get_start_key(Context, Type, Value)}
         ,{'endkey', get_end_key(Context, Type, Value)}
-        ,{'mapper', crossbar_view:map_value_fun()}
+        ,{'mapper', crossbar_view:get_value_fun()}
          | Opts
         ],
     crossbar_view:load(Context, ViewName, Options).

--- a/applications/crossbar/src/modules/cb_security.erl
+++ b/applications/crossbar/src/modules/cb_security.erl
@@ -140,7 +140,7 @@ validate(Context) ->
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
 validate(Context, ?ATTEMPTS) ->
-    crossbar_view:load_modb(Context, ?CB_LIST_ATTEMPT_LOG, [{mapper, crossbar_view:map_value_fun()}]).
+    crossbar_view:load_modb(Context, ?CB_LIST_ATTEMPT_LOG, [{mapper, crossbar_view:get_value_fun()}]).
 
 -spec validate(cb_context:context(), path_token(), path_token()) -> cb_context:context().
 validate(Context, ?ATTEMPTS, AttemptId) ->

--- a/applications/crossbar/src/modules/cb_skels.erl
+++ b/applications/crossbar/src/modules/cb_skels.erl
@@ -309,7 +309,7 @@ validate_patch(Id, Context) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', fun normalize_view_results/2}]).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -323,6 +323,13 @@ on_successful_validation(Id, Context) ->
 
 %%------------------------------------------------------------------------------
 %% @doc Normalizes the results of a view.
+%%
+%% This is a simple normalizer function, for which you can just use this as
+%% mapper option:
+%%
+%% ```
+%%     {'mapper', crossbar_view:get_id_fun()}
+%% '''
 %% @end
 %%------------------------------------------------------------------------------
 -spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().

--- a/applications/crossbar/src/modules/cb_storage.erl
+++ b/applications/crossbar/src/modules/cb_storage.erl
@@ -304,14 +304,20 @@ summary(Context) ->
 
 -spec summary(cb_context:context(), scope()) -> cb_context:context().
 summary(Context, 'system_plans') ->
-    crossbar_doc:load_view(?CB_SYSTEM_LIST, ['include_docs'], Context, fun normalize_view_results/2);
+    Options = [{'databases', [?KZ_DATA_DB]}
+              ,{'mapper', crossbar_view:get_doc_fun()}
+              ,'include_docs'
+              ],
+    crossbar_view:load(Context, ?CB_SYSTEM_LIST, Options);
 
 summary(Context, {'reseller_plans', AccountId}) ->
-    Options = ['include_docs'
+    Options = [{'databases', [?KZ_DATA_DB]}
+              ,{'mapper', crossbar_view:get_doc_fun()}
               ,{'startkey', [AccountId]}
-              ,{'endkey', [AccountId, kz_json:new()]}
+              ,{'endkey', [AccountId, crossbar_view:high_value_key()]}
+              ,'include_docs'
               ],
-    crossbar_doc:load_view(?CB_ACCOUNT_LIST, Options, Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_ACCOUNT_LIST, Options).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -341,13 +347,9 @@ on_successful_validation(Id, ?HTTP_PATCH, Context) ->
     crossbar_doc:load_merge(Id, Context, ?STORAGE_CHECK_OPTIONS).
 
 %%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
+%% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"doc">>, JObj)|Acc].
-
 -spec scope(cb_context:context()) -> scope() | 'undefined'.
 scope(Context) ->
     cb_context:fetch(Context, 'scope').

--- a/applications/crossbar/src/modules/cb_system_configs.erl
+++ b/applications/crossbar/src/modules/cb_system_configs.erl
@@ -288,17 +288,15 @@ read_for_delete(Id, Context) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    View = <<"system_configs/crossbar_listing">>,
-    crossbar_doc:load_view(View, [], Context, fun normalize_view_results/2).
+    Options = [{'databases', [?KZ_CONFIG_DB]}
+              ,{'mapper', crossbar_view:get_key_fun()}
+              ],
+    crossbar_view:load(Context, <<"system_configs/crossbar_listing">>, Options).
 
 %%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
+%% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_term:ne_binaries()) -> kz_term:ne_binaries().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"key">>, JObj) | Acc].
-
 -spec set_db_to_system(cb_context:context()) -> cb_context:context().
 set_db_to_system(Context) ->
     cb_context:setters(Context

--- a/applications/crossbar/src/modules/cb_temporal_rules.erl
+++ b/applications/crossbar/src/modules/cb_temporal_rules.erl
@@ -166,7 +166,7 @@ validate_patch(Id, Context) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -177,11 +177,3 @@ on_successful_validation('undefined', Context) ->
     cb_context:set_doc(Context, kz_doc:set_type(cb_context:doc(Context), <<"temporal_rule">>));
 on_successful_validation(Id, Context) ->
     crossbar_doc:load_merge(Id, Context, ?TYPE_CHECK_OPTION(<<"temporal_rule">>)).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].

--- a/applications/crossbar/src/modules/cb_temporal_rules_sets.erl
+++ b/applications/crossbar/src/modules/cb_temporal_rules_sets.erl
@@ -168,7 +168,7 @@ validate_patch(Id, Context) ->
 %%------------------------------------------------------------------------------
 -spec summary(cb_context:context()) -> cb_context:context().
 summary(Context) ->
-    crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -180,11 +180,3 @@ on_successful_validation('undefined', Context) ->
     cb_context:set_doc(Context, kz_doc:set_type(Doc, <<"temporal_rule_set">>));
 on_successful_validation(Id, Context) ->
     crossbar_doc:load_merge(Id, Context, ?TYPE_CHECK_OPTION(<<"temporal_rule_set">>)).
-
-%%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_value(<<"value">>, JObj)|Acc].

--- a/applications/crossbar/src/modules/cb_user_auth.erl
+++ b/applications/crossbar/src/modules/cb_user_auth.erl
@@ -312,11 +312,10 @@ maybe_authenticate_user(Context) ->
 -spec maybe_authenticate_user(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
           cb_context:context().
 maybe_authenticate_user(Context, Credentials, <<"md5">>, ?NE_BINARY=Account) ->
-    AccountDb = kzs_util:format_account_db(Account),
-    Context1 = crossbar_doc:load_view(?ACCT_MD5_LIST
-                                     ,[{'key', Credentials}]
-                                     ,cb_context:set_db_name(Context, AccountDb)
-                                     ),
+    Options = [{'key', Credentials}
+              ,{'databases', [kzs_util:format_account_db(Account)]}
+              ],
+    Context1 = crossbar_view:load(Context, ?ACCT_MD5_LIST, Options),
     case cb_context:resp_status(Context1) of
         'success' -> load_md5_results(Context1, cb_context:doc(Context1), Account);
         _Status ->
@@ -327,11 +326,10 @@ maybe_authenticate_user(Context, Credentials, <<"md5">>, ?NE_BINARY=Account) ->
             cb_context:add_system_error('invalid_credentials', Context1)
     end;
 maybe_authenticate_user(Context, Credentials, <<"sha">>, ?NE_BINARY=Account) ->
-    AccountDb = kzs_util:format_account_db(Account),
-    Context1 = crossbar_doc:load_view(?ACCT_SHA1_LIST
-                                     ,[{'key', Credentials}]
-                                     ,cb_context:set_db_name(Context, AccountDb)
-                                     ),
+    Options = [{'key', Credentials}
+              ,{'databases', [kzs_util:format_account_db(Account)]}
+              ],
+    Context1 = crossbar_view:load(Context, ?ACCT_SHA1_LIST, Options),
     case cb_context:resp_status(Context1) of
         'success' -> load_sha1_results(Context1, cb_context:doc(Context1), Account);
         _Status ->

--- a/applications/crossbar/src/modules/cb_users.erl
+++ b/applications/crossbar/src/modules/cb_users.erl
@@ -358,7 +358,6 @@ load_attachment(UserId, AttachmentId, Context) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
-
 -spec maybe_update_devices_presence(cb_context:context()) -> 'ok'.
 maybe_update_devices_presence(Context) ->
     DbDoc = cb_context:fetch(Context, 'db_doc'),
@@ -417,7 +416,6 @@ update_device_presence(Context, DeviceDoc) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
-
 -spec maybe_send_email(cb_context:context()) -> 'ok'.
 maybe_send_email(Context) ->
     case kz_term:is_true(cb_context:req_value(Context, <<"send_email_on_creation">>, 'true')) of
@@ -429,7 +427,6 @@ maybe_send_email(Context) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
-
 -spec send_email(cb_context:context()) -> 'ok'.
 send_email(Context) ->
     lager:debug("trying to publish new user notification"),
@@ -447,26 +444,14 @@ send_email(Context) ->
 %% account summary.
 %% @end
 %%------------------------------------------------------------------------------
-
 -spec load_users_summary(cb_context:context()) -> cb_context:context().
 load_users_summary(Context) ->
-    fix_envelope(
-      crossbar_doc:load_view(?CB_LIST
-                            ,[]
-                            ,Context
-                            ,fun normalize_view_results/2
-                            )).
-
--spec fix_envelope(cb_context:context()) -> cb_context:context().
-fix_envelope(Context) ->
-    RespData = cb_context:resp_data(Context),
-    cb_context:set_resp_data(Context, lists:reverse(RespData)).
+    crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]).
 
 %%------------------------------------------------------------------------------
 %% @doc Load a user document from the database
 %% @end
 %%------------------------------------------------------------------------------
-
 -spec load_user(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
 load_user(UserId, Context) -> crossbar_doc:load(UserId, Context, ?TYPE_CHECK_OPTION(kzd_users:type())).
 
@@ -474,7 +459,6 @@ load_user(UserId, Context) -> crossbar_doc:load(UserId, Context, ?TYPE_CHECK_OPT
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
-
 -spec validate_patch(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
 validate_patch(UserId, Context) ->
     crossbar_doc:patch_and_validate(UserId, Context, fun validate_request/2).
@@ -823,18 +807,9 @@ rehash_creds(Username, Password, Context) ->
     end.
 
 %%------------------------------------------------------------------------------
-%% @doc Normalizes the results of a view.
-%% @end
-%%------------------------------------------------------------------------------
-
--spec(normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects()).
-normalize_view_results(JObj, Acc) -> [kz_json:get_value(<<"value">>, JObj)|Acc].
-
-%%------------------------------------------------------------------------------
 %% @doc Converts context to vcard
 %% @end
 %%------------------------------------------------------------------------------
-
 -spec convert_to_vcard(cb_context:context()) -> cb_context:context().
 convert_to_vcard(Context) ->
     JObj = cb_context:doc(Context),

--- a/applications/crossbar/src/modules/cb_vmboxes.erl
+++ b/applications/crossbar/src/modules/cb_vmboxes.erl
@@ -774,14 +774,16 @@ validate_patch(Context, BoxId)->
 %%------------------------------------------------------------------------------
 -spec load_vmbox_summary(cb_context:context()) -> cb_context:context().
 load_vmbox_summary(Context) ->
-    Context1 = crossbar_doc:load_view(?CB_LIST, [], Context, fun normalize_view_results/2),
-    CountMap = kvm_messages:count(cb_context:account_id(Context)),
-    RspData = add_counts_to_summary_results(cb_context:doc(Context1), CountMap),
-    cb_context:set_resp_data(cb_context:set_doc(Context1, RspData), RspData).
+    Context1 = crossbar_view:load(Context, ?CB_LIST, [{'mapper', crossbar_view:get_value_fun()}]),
+    load_vmbox_summary(Context, cb_context:resp_status(Context1)).
 
--spec normalize_view_results(kz_json:object(), kz_json:objects()) -> kz_json:objects().
-normalize_view_results(JObj, Acc) ->
-    [kz_json:get_json_value(<<"value">>, JObj)|Acc].
+-spec load_vmbox_summary(cb_context:cb_context(), crossbar_status()) -> cb_context:context().
+load_vmbox_summary(Context, 'success') ->
+    CountMap = kvm_messages:count(cb_context:account_id(Context)),
+    RspData = add_counts_to_summary_results(cb_context:doc(Context), CountMap),
+    cb_context:set_resp_data(cb_context:set_doc(Context, RspData), RspData);
+load_vmbox_summary(Context, _) ->
+    Context.
 
 -spec add_counts_to_summary_results(kz_json:objects(), map()) -> kz_json:objects().
 add_counts_to_summary_results(BoxSummaries, CountMap) ->

--- a/applications/crossbar/src/modules/cb_webhooks.erl
+++ b/applications/crossbar/src/modules/cb_webhooks.erl
@@ -416,7 +416,7 @@ update(Id, Context) ->
 summary(Context) ->
     Options = [{'startkey', [cb_context:account_id(Context)]}
               ,{'endkey', [cb_context:account_id(Context), kz_json:new()]}
-              ,{'mapper', crossbar_view:map_value_fun()}
+              ,{'mapper', crossbar_view:get_value_fun()}
               ],
     crossbar_view:load(Context, ?CB_LIST, Options).
 

--- a/applications/ecallmgr/src/ecallmgr_fs_channels.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channels.erl
@@ -845,13 +845,13 @@ max_channel_uptime() ->
 
 -spec set_max_channel_uptime(non_neg_integer()) ->
           {'ok', kz_json:object()} |
-          {'error', kz_datamgr:data_error()}.
+          kz_datamgr:data_error().
 set_max_channel_uptime(MaxAge) ->
     set_max_channel_uptime(MaxAge, 'true').
 
 -spec set_max_channel_uptime(non_neg_integer(), boolean()) ->
           {'ok', kz_json:object()} |
-          {'error', kz_datamgr:data_error()}.
+          kz_datamgr:data_error().
 set_max_channel_uptime(MaxAge, 'true') ->
     kapps_config:set_default(?APP_NAME, ?MAX_CHANNEL_UPTIME_KEY, kz_term:to_integer(MaxAge));
 set_max_channel_uptime(MaxAge, 'false') ->

--- a/applications/ecallmgr/src/ecallmgr_maintenance.erl
+++ b/applications/ecallmgr/src/ecallmgr_maintenance.erl
@@ -108,11 +108,11 @@
 
 -type config_fun() :: fun((kapps_config:config_category(), kapps_config:config_key(), any()) ->
                                  {'ok', kz_json:object()} |
-                                 {'error', kz_datamgr:data_error()}
+                                 kz_datamgr:data_error()
                                      ) |
                       fun((kapps_config:config_category(), kapps_config:config_key(), any(), node()) ->
                                  {'ok', kz_json:object()} |
-                                 {'error', kz_datamgr:data_error()}
+                                 kz_datamgr:data_error()
                                      ).
 
 -type acl_fun() :: fun((kz_term:ne_binary()) -> kz_json:object()).
@@ -592,7 +592,7 @@ modify_acls(Name, IP0, ACLS, ACLFun, ConfigFun) ->
 
 -spec run_config_fun(config_fun(), kz_json:key(), kz_json:json_term()) ->
           {'ok', kz_json:object()} |
-          {'error', kz_datamgr:data_error()}.
+          kz_datamgr:data_error().
 run_config_fun(ConfigFun, Key, Value) when is_function(ConfigFun, 3) ->
     ConfigFun(?APP_NAME, Key, Value);
 run_config_fun(ConfigFun, Key, Value) when is_function(ConfigFun, 4) ->

--- a/core/kazoo_apps/src/kapps_config.erl
+++ b/core/kazoo_apps/src/kapps_config.erl
@@ -584,29 +584,26 @@ get_all_default_kvs(JObj) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
+-type set_return() :: {'ok', kz_json:object()} |
+                      kz_datamgr:data_error().
 
--spec set_string(config_category(), config_key(), kz_term:text()) ->
-          {'ok', kz_json:object()}.
+-spec set_string(config_category(), config_key(), kz_term:text()) -> set_return().
 set_string(Category, Key, Value) ->
     set(Category, Key, kz_term:to_binary(Value)).
 
--spec set_integer(config_category(), config_key(), kz_term:text() | integer()) ->
-          {'ok', kz_json:object()}.
+-spec set_integer(config_category(), config_key(), kz_term:text() | integer()) -> set_return().
 set_integer(Category, Key, Value) ->
     set(Category, Key, kz_term:to_integer(Value)).
 
--spec set_float(config_category(), config_key(), kz_term:text() | float()) ->
-          {'ok', kz_json:object()}.
+-spec set_float(config_category(), config_key(), kz_term:text() | float()) -> set_return().
 set_float(Category, Key, Value) ->
     set(Category, Key, kz_term:to_float(Value)).
 
--spec set_boolean(config_category(), config_key(), kz_term:text() | boolean()) ->
-          {'ok', kz_json:object()}.
+-spec set_boolean(config_category(), config_key(), kz_term:text() | boolean()) -> set_return().
 set_boolean(Category, Key, Value) ->
     set(Category, Key, kz_term:to_boolean(Value)).
 
--spec set_json(config_category(), config_key(), kz_term:text() | kz_json:object()) ->
-          {'ok', kz_json:object()}.
+-spec set_json(config_category(), config_key(), kz_term:text() | kz_json:object()) -> set_return().
 set_json(Category, Key, Value) ->
     set(Category, Key, kz_json:decode(Value)).
 
@@ -614,45 +611,42 @@ set_json(Category, Key, Value) ->
 %% @doc Set the key to the value in the given category but specific to this node.
 %% @end
 %%------------------------------------------------------------------------------
--spec set(config_category(), config_key(), kz_json:json_term()) ->
-          {'ok', kz_json:object()}.
+-spec set(config_category(), config_key(), kz_json:json_term()) -> set_return().
 set(Category, Key, Value) ->
     set(Category, Key, Value, node()).
 
 -spec set(config_category(), config_key(), kz_json:json_term(), kz_term:ne_binary() | atom()) ->
-          {'ok', kz_json:object()} |
-          {'error', kz_datamgr:data_error()}.
+          set_return().
 set(Category, Key, Value, Node) ->
     update_category(Category, Key, Value, Node, []).
 
 -spec set_default(config_category(), config_key(), kz_json:json_term()) ->
-          {'ok', kz_json:object()} |
-          {'error', kz_datamgr:data_error()}.
+          set_return().
 set_default(Category, Key, Value) ->
     update_category(Category, Key, Value, ?KEY_DEFAULT, []).
 
 -spec update_default(config_category(), config_key(), kz_json:json_term()) ->
           {'ok', kz_json:object()} |
-          {'error', kz_datamgr:data_error()}.
+          kz_datamgr:data_error().
 update_default(Category, Key, Value) ->
     update_default(Category, Key, Value, []).
 
 -spec update_default(config_category(), config_key(), kz_json:json_term(), update_options()) ->
           {'ok', kz_json:object()} |
-          {'error', kz_datamgr:data_error()}.
+          kz_datamgr:data_error().
 update_default(Category, Key, Value, Options) ->
     update_category(Category, Key, Value, ?KEY_DEFAULT, Options).
 
 -spec set_node(config_category(), config_key(), kz_json:json_term(), kz_term:ne_binary() | atom()) ->
           {'ok', kz_json:object()} |
-          {'error', kz_datamgr:data_error()}.
+          kz_datamgr:data_error().
 set_node(Category, _, _, 'undefined') -> get_category(Category);
 set_node(Category, Key, Value, Node) ->
     update_category(Category, Key, Value, Node, [{'node_specific', 'true'}]).
 
 -spec update_category(config_category(), config_key(), kz_json:json_term(), kz_term:ne_binary() | atom(), update_options()) ->
           {'ok', kz_json:object()} |
-          {'error', kz_datamgr:data_error()}.
+          kz_datamgr:data_error().
 -ifdef(TEST).
 update_category(Category, _, _, _, _) -> {'ok', Category}.
 -else.

--- a/core/kazoo_auth/src/kz_auth_identity.erl
+++ b/core/kazoo_auth/src/kz_auth_identity.erl
@@ -306,7 +306,8 @@ token(#{auth_provider := #{name := <<"kazoo">>
                           ,jwt_user_id_signature_hash := Hash
                           }
        ,payload := #{<<"identity_sig">> := IdentitySig}
-       }=Token) ->
+       }=Token
+     ) ->
     case kz_term:is_not_empty(IdentitySig)
         andalso identity_secret(Token)
     of
@@ -383,7 +384,7 @@ verify(Token) ->
 %% @doc Reset system key (provider identity secret).
 %% @end
 %%------------------------------------------------------------------------------
--spec reset_system_secret() -> {'ok', kz_json:object()} | {'error', any()}.
+-spec reset_system_secret() -> {'ok', kz_json:object()} | kz_datamgr:data_error().
 reset_system_secret() ->
     lager:warning("resetting system identity secret"),
     kapps_config:set_string(?CONFIG_CAT, ?KAZOO_SIGNATURE_ID, ?KAZOO_GEN_SIGNATURE_SECRET).
@@ -443,7 +444,8 @@ has_doc_secret(JObj) ->
 -spec reset_identity_secret(map()) -> 'ok' | {'error', any()}.
 reset_identity_secret(#{auth_db := Db
                        ,auth_id := Key
-                       }=Token) ->
+                       }=Token
+                     ) ->
     lager:debug("resetting identity secret, auth_db ~s auth_id ~s", [Db, Key]),
     case kz_datamgr:open_cache_doc(Db, Key) of
         {'ok', _JObj} ->

--- a/core/kazoo_auth/src/kz_auth_keys.erl
+++ b/core/kazoo_auth/src/kz_auth_keys.erl
@@ -381,7 +381,7 @@ gen_private_key(Size) ->
     {'ok', Key}.
 
 %% @equiv reset_private_key(kz_auth_apps:get_auth_app(<<"kazoo">>))
--spec reset_kazoo_private_key() -> {'ok', kz_term:ne_binary()} | {'error', any()}.
+-spec reset_kazoo_private_key() -> {'ok', kz_term:ne_binary()} | kz_datamgr:data_error().
 reset_kazoo_private_key() ->
     lager:warning("trying to reset kazoo private key"),
     reset_private_key(kz_auth_apps:get_auth_app(<<"kazoo">>)).
@@ -392,12 +392,12 @@ reset_kazoo_private_key() ->
 %% and put it in cache.
 %% @end
 %%------------------------------------------------------------------------------
--spec reset_private_key(map() | kz_term:ne_binary()) -> {'ok', kz_term:ne_binary()} | {'error', any()}.
+-spec reset_private_key(map() | kz_term:ne_binary()) -> {'ok', kz_json:object()} | kz_datamgr:data_error().
 reset_private_key(#{pvt_server_key := KeyId}) ->
     reset_private_key(KeyId);
 reset_private_key(#{}) ->
     {'error', 'invalid_identity_provider'};
-reset_private_key(?NE_BINARY=KeyId) ->
+reset_private_key(<<KeyId/binary>>) ->
     lager:warning("deleting private key ~s", [KeyId]),
     case kz_datamgr:del_doc(?KZ_AUTH_DB, KeyId) of
         {'ok', _}=OK -> OK;

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -905,7 +905,7 @@ update_not_found(Database, Id, Options, 'true') ->
 
     JObj = kz_json:set_values(CreateProps, kz_json:new()),
     Updated = kz_json:set_values([{kz_doc:path_id(), Id}
-                                 | props:get_value('update', Options)
+                                  | props:get_value('update', Options)
                                  ]
                                  ++ props:get_value('extra_update', Options, [])
                                 ,JObj
@@ -918,13 +918,13 @@ update_not_found(Database, Id, Options, 'true') ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec del_doc(database_name(), kz_json:object() | kz_json:objects() | kz_term:ne_binary()) ->
-          {'ok', kz_json:objects()} |
+          {'ok', kz_json:object() | kz_json:objects()} |
           data_error().
 del_doc(DbName, Doc) ->
     del_doc(DbName, Doc, []).
 
 -spec del_doc(database_name(), kz_json:object() | kz_json:objects() | kz_term:ne_binary(), kz_term:proplist()) ->
-          {'ok', kz_json:objects()} |
+          {'ok', kz_json:object() | kz_json:objects()} |
           data_error().
 del_doc(DbName, Doc, Options) when is_list(Doc) ->
     del_docs(DbName, Doc, Options);
@@ -1065,7 +1065,7 @@ attachment_url(DbName, DocId, AttachmentId, Options) ->
     case kzs_doc:open_doc(Plan, Database, DocId, props:delete('plan_override', Options)) of
         {'ok', JObj} ->
             NewOptions = [{'rev', kz_doc:revision(JObj)}
-                         | maybe_add_doc_type(kz_doc:type(JObj), Options)
+                          | maybe_add_doc_type(kz_doc:type(JObj), Options)
                          ],
             Handler = kz_doc:attachment_property(JObj, AttachmentId, <<"handler">>),
             kzs_attachments:attachment_url(Plan, Database, DocId, AttachmentId, Handler, NewOptions);

--- a/core/kazoo_fixturedb/doc/db-to-disk.md
+++ b/core/kazoo_fixturedb/doc/db-to-disk.md
@@ -6,7 +6,7 @@ This guide will show the steps to take an existing database and populate the Fix
 
 ## Database to disk
 
-Let's say you need account db `9c2e035c8559b175e58146f6a31a3e67` to persist to FixtureDB. `kz_fixturedb_util:db_to_disk(<<"9c2e035c8559b175e58146f6a31a3e67">>).` will write all the JSON objects in the database to disk. If you want to be selective on which documents to persist, `kz_fixturedb_util:db_to_disk(<<"account%2F9c%2F2e%2F035c8559b175e58146f6a31a3e67">>, FilterFun).` will do the job. `FilterFun` is a function of arity-1 that takes the document as an argument and returns a `boolean()` for whether to persist the document.
+Let's say you need account db `9c2e035c8559b175e58146f6a31a3e67` to persist to FixtureDB. `kz_fixturedb_maintenance:db_to_disk(<<"9c2e035c8559b175e58146f6a31a3e67">>).` will write all the JSON objects in the database to disk. If you want to be selective on which documents to persist, `kz_fixturedb_maintenance:db_to_disk(<<"account%2F9c%2F2e%2F035c8559b175e58146f6a31a3e67">>, FilterFun).` will do the job. `FilterFun` is a function of arity-1 that takes the document as an argument and returns a `boolean()` for whether to persist the document.
 
 ## View index to disk
 

--- a/core/kazoo_fixturedb/doc/kz_fixturedb_maintenance.md
+++ b/core/kazoo_fixturedb/doc/kz_fixturedb_maintenance.md
@@ -2,6 +2,18 @@
 
 | Function | Arguments | Description |
 | -------- | --------- | ----------- |
+| `db_to_disk/1` | `(Database)` | |
+| `db_to_disk/2` | `(Database,FilterFun)` | |
 | `dummy_plan/0` |  | |
 | `new_connection/0` |  | |
 | `new_connection/1` | `(Map)` | |
+
+
+## `db_to_disk/1,2`
+
+Let's say you need account db `9c2e035c8559b175e58146f6a31a3e67` to persist to FixtureDB. `kz_fixturedb_maintenance:db_to_disk(<<"9c2e035c8559b175e58146f6a31a3e67">>).` will write all the JSON objects in the database to disk. If you want to be selective on which documents to persist, `kz_fixturedb_maintenance:db_to_disk(<<"account%2F9c%2F2e%2F035c8559b175e58146f6a31a3e67">>, FilterFun).` will do the job. `FilterFun` is a function of arity-1 that takes the document as an argument and returns a `boolean()` for whether to persist the document.
+
+## `dummy_plan/0` and `new_connection/0,1`
+
+Sometimes you're in `fixture_shell` (using `make fixture_shell`) and you don't want care about starting kazoo_data and kazoo_fixturedb and want just to grab some docs using kazoo_fixturedb directly.
+In this case instead you can use these functions to get dummy plan and connection.

--- a/core/kazoo_fixturedb/doc/ref/kz_fixturedb_maintenance.md
+++ b/core/kazoo_fixturedb/doc/ref/kz_fixturedb_maintenance.md
@@ -2,6 +2,8 @@
 
 | Function | Arguments | Description |
 | -------- | --------- | ----------- |
+| `db_to_disk/1` | `(Database)` | |
+| `db_to_disk/2` | `(Database,FilterFun)` | |
 | `dummy_plan/0` |  | |
 | `new_connection/0` |  | |
 | `new_connection/1` | `(Map)` | |

--- a/core/kazoo_ledgers/src/kz_ledgers.erl
+++ b/core/kazoo_ledgers/src/kz_ledgers.erl
@@ -426,7 +426,7 @@ rollover(MODB, Year, Month, Total) ->
                         ).
 
 -type save_result() :: {'ok', kz_json:object()} |
-                       {'error', kz_datamgr:data_error()}.
+                       kz_datamgr:data_error().
 
 -spec handle_rollover_save(kz_term:ne_binary(), kz_time:year(), kz_time:month(), save_result()) ->
           kz_currency:available_units_return().


### PR DESCRIPTION
Use `crossbar_view` in all crossbar modules and remove deprecated  `crossbar_doc:load_view/3,4,5,6`.

It has been a while crossbar_doc load_view has been announced deprecated and all new codes are using `crossbar_view`. 

it's time to remove the `crossbar_doc:load_view` now to use the crossbar_view which is already fixing multiple issues related to pagination and provides new features like chunking, Also this removal allows expanding the functionality crossbar.