### PR TITLE
[PROD-170]:  Announcement Only Mode for vmboxes - 4.3

### DIFF
--- a/applications/crossbar/doc/ref/vmboxes.md
+++ b/applications/crossbar/doc/ref/vmboxes.md
@@ -10,6 +10,7 @@ Schema for a voicemail box
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
+`announcement_only` | Determine if the mailbox should only play announcements | `boolean()` | `false` | `false` | `unsupported`
 `check_if_owner` | Determines if when the user calls their own voicemail they should be prompted to sign in | `boolean()` | `true` | `false` | `supported`
 `delete_after_notify` | Move the voicemail to delete folder after the notification has been sent | `boolean()` | `false` | `false` | `supported`
 `flags.[]` |   | `string()` |   | `false` | `supported`

--- a/applications/crossbar/doc/voicemail.md
+++ b/applications/crossbar/doc/voicemail.md
@@ -21,6 +21,7 @@ Schema for a voicemail box
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
+`announcement_only` | Determine if the mailbox should only play announcements | `boolean()` | `false` | `false` | `unsupported`
 `check_if_owner` | Determines if when the user calls their own voicemail they should be prompted to sign in | `boolean()` | `true` | `false` | `supported`
 `delete_after_notify` | Move the voicemail to delete folder after the notification has been sent | `boolean()` | `false` | `false` | `supported`
 `flags.[]` |   | `string()` |   | `false` | `supported`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -36304,6 +36304,11 @@
         "vmboxes": {
             "description": "Schema for a voicemail box",
             "properties": {
+                "announcement_only": {
+                    "default": false,
+                    "description": "Determine if the mailbox should only play announcements",
+                    "type": "boolean"
+                },
                 "check_if_owner": {
                     "default": true,
                     "description": "Determines if when the user calls their own voicemail they should be prompted to sign in",

--- a/applications/crossbar/priv/couchdb/schemas/vmboxes.json
+++ b/applications/crossbar/priv/couchdb/schemas/vmboxes.json
@@ -3,6 +3,12 @@
     "_id": "vmboxes",
     "description": "Schema for a voicemail box",
     "properties": {
+        "announcement_only": {
+            "default": false,
+            "description": "Determine if the mailbox should only play announcements",
+            "support_level": "unsupported",
+            "type": "boolean"
+        },
         "check_if_owner": {
             "default": true,
             "description": "Determines if when the user calls their own voicemail they should be prompted to sign in",

--- a/core/kazoo_documents/src/kzd_vmboxes.erl.src
+++ b/core/kazoo_documents/src/kzd_vmboxes.erl.src
@@ -6,6 +6,7 @@
 -module(kzd_vmboxes).
 
 -export([new/0]).
+-export([announcement_only/1, announcement_only/2, set_announcement_only/2]).
 -export([check_if_owner/1, check_if_owner/2, set_check_if_owner/2]).
 -export([delete_after_notify/1, delete_after_notify/2, set_delete_after_notify/2]).
 -export([flags/1, flags/2, set_flags/2]).
@@ -43,6 +44,18 @@
 -spec new() -> doc().
 new() ->
     kz_json_schema:default_object(?SCHEMA).
+
+-spec announcement_only(doc()) -> boolean().
+announcement_only(Doc) ->
+    announcement_only(Doc, false).
+
+-spec announcement_only(doc(), Default) -> boolean() | Default.
+announcement_only(Doc, Default) ->
+    kz_json:get_boolean_value([<<"announcement_only">>], Doc, Default).
+
+-spec set_announcement_only(doc(), boolean()) -> doc().
+set_announcement_only(Doc, AnnouncementOnly) ->
+    kz_json:set_value([<<"announcement_only">>], AnnouncementOnly, Doc).
 
 -spec check_if_owner(doc()) -> boolean().
 check_if_owner(Doc) ->

--- a/core/kazoo_documents/src/kzd_voicemail_box.erl
+++ b/core/kazoo_documents/src/kzd_voicemail_box.erl
@@ -7,6 +7,7 @@
 -module(kzd_voicemail_box).
 
 -export([new/0
+        ,announcement_only/1, announcement_only/2, set_announcement_only/2
         ,type/0
         ,notification_emails/1, notification_emails/2
         ,owner_id/1, owner_id/2
@@ -61,6 +62,18 @@ new() ->
 
 -spec type() -> kz_term:ne_binary().
 type() -> ?PVT_TYPE.
+
+-spec announcement_only(doc()) -> boolean().
+announcement_only(Doc) ->
+    announcement_only(Doc, 'false').
+
+-spec announcement_only(doc(), boolean()) -> boolean().
+announcement_only(Doc, Default) ->
+    kz_json:get_boolean_value(<<"announcement_only">>, Doc, Default).
+
+-spec set_announcement_only(doc(), boolean()) -> doc().
+set_announcement_only(Doc, AnnoucementOnly) ->
+    kz_json:set_value(<<"announcement_only">>, AnnoucementOnly, Doc).
 
 -spec notification_emails(doc()) -> kz_term:ne_binaries().
 notification_emails(Box) ->

--- a/doc/announcements.md
+++ b/doc/announcements.md
@@ -20,6 +20,15 @@ The old `save/2` took an updater function and tried to save the result. Because 
 
 4. New parameters were added to the account, user and device documents to set the asserted identity.  These parameters are currently free-form but will be strictly verified by default in the future!
 
+5. The default prompt for the voicemail configuration menu has changed.
+
+Two new **en-US** prompts have been added to handle this feature and should be imported in conjunction with the upgrade of KAZOO.
+
+* vm-settings\_menu\_announcement_on
+* vm-settings\_menu\_announcement_off
+
+For instructions on how to import prompts please consult the [Kazoo Core Media](https://github.com/2600hz/kazoo-sounds/tree/master/kazoo-core#importing-prompts-for-a-language) documentation.
+
 ### 4.2
 
 1.  Erlang Version Support


### PR DESCRIPTION
# Announcement Only Mode for Vmboxes

This PR adds new functionality to a voicemail box, enabling a mailbox to only play the greeting and advance to the next node of the current callflow.

Announcement only mode can be controlled with the `announcement_only` boolean in the vmbox schema or by the mailbox owner via the voicemail config menu.  This default setting for this feature's is disabled or `false`.

Mailbox owners will now hear new options in the voicemail configuration menu as two new prompts have been added to [Kazoo Core Media](https://github.com/2600hz/kazoo-sounds/tree/master/kazoo-core#importing-prompts-for-a-language).

## Kazoo-Sounds Prompt Changes
Two new en-US prompts have been added to handle this feature and should be imported in conjunction with the upgrade of KAZOO.

* vm-settings\_menu
* vm-settings\_menu\_announcement_on

For instructions on how to import prompts, please consult the [Kazoo Core Media documentation](https://github.com/2600hz/kazoo-sounds/tree/master/kazoo-core#importing-prompts-for-a-language).
