### PR TITLE
[4.3] KZOO-45: Filter just empty strings when normalizing CDRs

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -30415,6 +30415,11 @@
                     "default": 2682000,
                     "description": "crossbar.cdrs maximum range",
                     "type": "integer"
+                },
+                "should_filter_empty_strings": {
+                    "default": false,
+                    "description": "crossbar cdrs should_filter_empty_strings",
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.cdrs.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.cdrs.json
@@ -18,6 +18,11 @@
             "default": 2682000,
             "description": "crossbar.cdrs maximum range",
             "type": "integer"
+        },
+        "should_filter_empty_strings": {
+            "default": false,
+            "description": "crossbar cdrs should_filter_empty_strings",
+            "type": "boolean"
         }
     },
     "type": "object"

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -452,7 +452,7 @@ normalize_cdr(Context, <<"json">>, Result) ->
     Duration = kzd_cdrs:duration_seconds(JObj, 0),
     Timestamp = kzd_cdrs:timestamp(JObj, 0) - Duration,
 
-    kz_json:from_list(props:filter_empty([{K, F(JObj, Timestamp, Context)} || {K, F} <- json_rows(Context)]));
+    kz_json:from_list(props:filter_empty_strings([{K, F(JObj, Timestamp, Context)} || {K, F} <- json_rows(Context)]));
 normalize_cdr(Context, <<"csv">>, Result) ->
     JObj = kz_json:get_json_value(<<"doc">>, Result),
     Duration = kzd_cdrs:duration_seconds(JObj, 0),

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -452,13 +452,20 @@ normalize_cdr(Context, <<"json">>, Result) ->
     Duration = kzd_cdrs:duration_seconds(JObj, 0),
     Timestamp = kzd_cdrs:timestamp(JObj, 0) - Duration,
 
-    kz_json:from_list(props:filter_empty_strings([{K, F(JObj, Timestamp, Context)} || {K, F} <- json_rows(Context)]));
+    MappedRows = [{K, F(JObj, Timestamp, Context)} || {K, F} <- json_rows(Context)],
+    maybe_filter_empties(MappedRows, kapps_config:is_true(?MOD_CONFIG_CAT, <<"should_filter_empty_strings">>, 'false'));
 normalize_cdr(Context, <<"csv">>, Result) ->
     JObj = kz_json:get_json_value(<<"doc">>, Result),
     Duration = kzd_cdrs:duration_seconds(JObj, 0),
     Timestamp = kzd_cdrs:timestamp(JObj, 0) - Duration,
 
     <<(kz_binary:join([F(JObj, Timestamp, Context) || {_, F} <- csv_rows(Context)], <<",">>))/binary, "\r\n">>.
+
+-spec maybe_filter_empties(kz_term:proplist(), boolean()) -> kz_json:objects().
+maybe_filter_empties(Rows, 'true') ->
+    kz_json:from_list(props:filter_empty_strings(Rows));
+maybe_filter_empties(Rows, 'false') ->
+    kz_json:from_list(Rows).
 
 -spec maybe_add_csv_header(cb_context:context(), kz_term:ne_binary(), kz_json:objects() | kz_term:binaries()) -> cb_context:context().
 maybe_add_csv_header(Context, _, []) ->

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -188,6 +188,7 @@ start_key(StartKey) -> "start_key=" ++ kz_term:to_list(StartKey).
 
 -spec seq() -> 'ok'.
 seq() ->
+    kapps_config:set_default(<<"crossbar.cdrs">>, <<"should_filter_empty_strings">>, 'true'),
     _ = straight_seq(),
     _ = paginated_seq(),
     big_dataset_seq().

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -1,7 +1,7 @@
 -module(pqc_cb_cdrs).
 
 %% Manual testing
--export([seq/0, big_dataset_seq/0
+-export([seq/0, big_dataset_seq/0, straight_seq/0
         ,cleanup/0
         ]).
 
@@ -18,7 +18,7 @@
 -include("kazoo_proper.hrl").
 -include_lib("kazoo_stdlib/include/kz_databases.hrl").
 
--define(ACCOUNT_NAMES, [<<"account_for_cdrs">>]).
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
 -define(CDRS_PER_MONTH, 4).
 
 -spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
@@ -192,6 +192,7 @@ seq() ->
     _ = paginated_seq(),
     big_dataset_seq().
 
+-spec straight_seq() -> 'ok'.
 straight_seq() ->
     API = pqc_cb_api:init_api(['crossbar'], ['cb_cdrs']),
     AccountId = create_account(API),
@@ -209,8 +210,6 @@ straight_seq() ->
     SummaryResp = summary(API, AccountId),
     lager:info("summary resp: ~s", [SummaryResp]),
     RespCDRs = kz_json:get_list_value(<<"data">>, kz_json:decode(SummaryResp)),
-    lager:info("Resp CDRs: ~p~n", [lists:usort([kz_doc:id(RespCDR) || RespCDR <- RespCDRs])]),
-    lager:info("Base CDRs: ~p~n", [lists:usort([kz_doc:id(CDR) || CDR <- CDRs])]),
     'true' = cdrs_exist(CDRs, RespCDRs),
     lager:info("all cdrs found in response"),
 
@@ -324,7 +323,11 @@ seq_cdr(API, AccountId, CDR) ->
 
     FetchResp = fetch(API, AccountId, CDRId),
     lager:info("~s: fetch resp ~s", [CDRId, FetchResp]),
-    'true' = cdr_exists(CDR, [kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp))]),
+    FetchedJObj = kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp)),
+    'true' = cdr_exists(CDR, [FetchedJObj]),
+
+    %% KZOO-45: Ensure empty strings have been stripped
+    'undefined' = kz_json:get_ne_binary_value(<<"media_server">>, FetchedJObj),
 
     %% Should be able to convert CDR ID to interaction_id
     LegsResp = legs(API, AccountId, CDRId),

--- a/core/kazoo_stdlib/src/props.erl
+++ b/core/kazoo_stdlib/src/props.erl
@@ -29,7 +29,7 @@
         ,replace_value/3
         ,unique/1
         ,filter/2
-        ,filter_empty/1
+        ,filter_empty/1, filter_empty_strings/1
         ,filter_undefined/1
         ,to_log/1, to_log/2
         ]).
@@ -107,6 +107,14 @@ filter_empty(Props) ->
 -spec is_not_empty(kz_term:proplist_property()) -> boolean().
 is_not_empty({_, V}) -> not kz_term:is_empty(V);
 is_not_empty(_V) -> 'true'.
+
+-spec filter_empty_strings([{any(), any()} | atom()]) -> [{any(), any()} | atom()].
+filter_empty_strings(Props) ->
+    filter(fun is_not_empty_string/1, Props).
+
+-spec is_not_empty_string(kz_term:proplist_property()) -> boolean().
+is_not_empty_string({_, <<>>}) -> 'false';
+is_not_empty_string(_) -> 'true'.
 
 -spec filter_undefined(kz_term:proplist()) -> kz_term:proplist().
 filter_undefined(Props) ->

--- a/core/kazoo_stdlib/test/props_tests.erl
+++ b/core/kazoo_stdlib/test/props_tests.erl
@@ -29,9 +29,20 @@ filter_empty_test_() ->
     ,?_assertEqual([], props:filter_empty([{'a', 0}, {'b', []}, {'c', <<>>}, {'z', 'undefined'}]))
     ,?_assertEqual(['a'], props:filter_empty(['a']))
     ,?_assertEqual(['a'], props:filter_empty(['a', {'b', 0}]))
-    ,?_assertEqual([], props:filter_empty([{<<"a">>, undefined}]))
-    ,?_assertEqual([{<<"a">>, false}], props:filter_empty([{<<"a">>, false}]))
-    ,?_assertEqual([{<<"a">>, true}], props:filter_empty([{<<"a">>, true}]))
+    ,?_assertEqual([], props:filter_empty([{<<"a">>, 'undefined'}]))
+    ,?_assertEqual([{<<"a">>, 'false'}], props:filter_empty([{<<"a">>, 'false'}]))
+    ,?_assertEqual([{<<"a">>, 'true'}], props:filter_empty([{<<"a">>, 'true'}]))
+    ].
+
+filter_empty_strings_test_() ->
+    [?_assertEqual([], props:filter_empty_strings([]))
+    ,?_assertEqual([{'a', 10}, {'b', 8}, {'c', 6}], props:filter_empty_strings([{'a', 10}, {'b', 8}, {'c', 6}]))
+    ,?_assertEqual([{'a', 0}, {'b', []}, {'z', 'undefined'}], props:filter_empty_strings([{'a', 0}, {'b', []}, {'c', <<>>}, {'z', 'undefined'}]))
+    ,?_assertEqual(['a'], props:filter_empty_strings(['a']))
+    ,?_assertEqual(['a', {'b', 0}], props:filter_empty_strings(['a', {'b', 0}]))
+    ,?_assertEqual([{<<"a">>, 'undefined'}], props:filter_empty_strings([{<<"a">>, 'undefined'}]))
+    ,?_assertEqual([{<<"a">>, 'false'}], props:filter_empty_strings([{<<"a">>, 'false'}]))
+    ,?_assertEqual([{<<"a">>, 'true'}], props:filter_empty_strings([{<<"a">>, 'true'}]))
     ].
 
 filter_undefined_test_() ->
@@ -40,7 +51,7 @@ filter_undefined_test_() ->
     ,?_assertEqual([], props:filter_undefined([]))
     ,?_assertEqual([{'a', 10}, {'b', 8}, {'c', 6}], props:filter_undefined([{'a', 10}, {'b', 8}, {'c', 6}]))
     ,?_assertEqual([{'a', 0}, {'b', []}, {'c', <<>>}], props:filter_undefined([{'a', 0}, {'b', []}, {'c', <<>>}, {'z', 'undefined'}]))
-    ,?_assertEqual([{<<"pouet">>, null}], props:filter_undefined([{<<"pouet">>, null}]))
+    ,?_assertEqual([{<<"pouet">>, 'null'}], props:filter_undefined([{<<"pouet">>, 'null'}]))
     ].
 
 unique_test() ->


### PR DESCRIPTION
An addition to filter_empty fields from the CDR summary response is
causing expected fields like `cost` to be stripped when they are
0. The intent of the change was to filter keys with empty strings ("")
to reduce payload size.

Instead, let's add a `filter_empty_strings` to narrow down what is
removed from the payload.