### PR TITLE
KZOO-45: Filter just empty strings when normalizing CDRs

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -32879,6 +32879,11 @@
                     "description": "maximum range (in seconds) prior to the current date allowed for CDR requests",
                     "minimum": 1,
                     "type": "integer"
+                },
+                "should_filter_empty_strings": {
+                    "default": false,
+                    "description": "If true, API will strip keys with \"\" as values before sending the response (decrease payload)",
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.cdrs.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.crossbar.cdrs.json
@@ -19,6 +19,11 @@
             "description": "maximum range (in seconds) prior to the current date allowed for CDR requests",
             "minimum": 1,
             "type": "integer"
+        },
+        "should_filter_empty_strings": {
+            "default": false,
+            "description": "If true, API will strip keys with \"\" as values before sending the response (decrease payload)",
+            "type": "boolean"
         }
     },
     "type": "object"

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -9975,6 +9975,11 @@
         maximum range (in seconds) prior to the current date allowed for CDR requests
       'minimum': 1
       'type': integer
+    'should_filter_empty_strings':
+      'default': false
+      'description': |-
+        If true, API will strip keys with "" as values before sending the response (decrease payload)
+      'type': boolean
   'type': object
 'system_config.crossbar.channels':
   'description': Schema for crossbar.channels system_config

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -226,7 +226,7 @@ load_chunk_view(Context, ViewName, Options0) ->
     Options = [{'is_chunked', 'true'}
               ,{'chunk_size', ?MAX_BULK}
               ,{'max_range', ?MOD_MAX_RANGE}
-              | Options0
+               | Options0
               ],
     crossbar_view:load_modb(cb_context:setters(fix_qs_filter_keys(Context), Setters), ViewName, Options).
 
@@ -322,7 +322,7 @@ get_view_options([{<<"cdrs">>, [?PATH_INTERACTION]}, {?KZ_ACCOUNTS_DB, _}|_]) ->
        ,{'group_level', 2}
        ,{'reduce', 'true'}
        ,{'no_filter', 'true'}
-       | maybe_add_stale_to_options(?STALE_CDR)
+        | maybe_add_stale_to_options(?STALE_CDR)
        ])
     };
 get_view_options([{<<"cdrs">>, [?PATH_INTERACTION]}, {<<"users">>, [OwnerId]}|_]) ->
@@ -335,7 +335,7 @@ get_view_options([{<<"cdrs">>, [?PATH_INTERACTION]}, {<<"users">>, [OwnerId]}|_]
        ,{'group_level', 3}
        ,{'reduce', 'true'}
        ,{'no_filter', 'true'}
-       | maybe_add_stale_to_options(?STALE_CDR)
+        | maybe_add_stale_to_options(?STALE_CDR)
        ])
     };
 get_view_options(_) ->

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -226,7 +226,7 @@ load_chunk_view(Context, ViewName, Options0) ->
     Options = [{'is_chunked', 'true'}
               ,{'chunk_size', ?MAX_BULK}
               ,{'max_range', ?MOD_MAX_RANGE}
-               | Options0
+              | Options0
               ],
     crossbar_view:load_modb(cb_context:setters(fix_qs_filter_keys(Context), Setters), ViewName, Options).
 
@@ -322,7 +322,7 @@ get_view_options([{<<"cdrs">>, [?PATH_INTERACTION]}, {?KZ_ACCOUNTS_DB, _}|_]) ->
        ,{'group_level', 2}
        ,{'reduce', 'true'}
        ,{'no_filter', 'true'}
-        | maybe_add_stale_to_options(?STALE_CDR)
+       | maybe_add_stale_to_options(?STALE_CDR)
        ])
     };
 get_view_options([{<<"cdrs">>, [?PATH_INTERACTION]}, {<<"users">>, [OwnerId]}|_]) ->
@@ -335,7 +335,7 @@ get_view_options([{<<"cdrs">>, [?PATH_INTERACTION]}, {<<"users">>, [OwnerId]}|_]
        ,{'group_level', 3}
        ,{'reduce', 'true'}
        ,{'no_filter', 'true'}
-        | maybe_add_stale_to_options(?STALE_CDR)
+       | maybe_add_stale_to_options(?STALE_CDR)
        ])
     };
 get_view_options(_) ->
@@ -409,7 +409,9 @@ normalize_cdr(Context, <<"json">>, Result) ->
     Duration = kzd_cdrs:duration_seconds(JObj, 0),
     Timestamp = kzd_cdrs:timestamp(JObj, 0) - Duration,
 
-    kz_json:from_list([{K, apply_row_mapper(K, F, JObj, Timestamp, Context)} || {K, F} <- csv_rows(Context)]);
+    MappedFields = [{K, apply_row_mapper(K, F, JObj, Timestamp, Context)} || {K, F} <- csv_rows(Context)],
+    FilteredFields = props:filter_empty_strings(MappedFields),
+    kz_json:from_list(FilteredFields);
 normalize_cdr(Context, <<"csv">>, Result) ->
     JObj = kz_json:get_json_value(<<"doc">>, Result),
     Duration = kzd_cdrs:duration_seconds(JObj, 0),

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -28,7 +28,7 @@
 -include("kazoo_proper.hrl").
 -include_lib("kazoo_stdlib/include/kz_databases.hrl").
 
--define(ACCOUNT_NAMES, [<<"account_for_cdrs">>]).
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
 -define(CDRS_PER_MONTH, 4).
 
 -spec summary(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
@@ -357,7 +357,11 @@ seq_cdr(API, AccountId, CDR) ->
     InteractionId = kzd_cdrs:interaction_id(CDR),
 
     FetchResp = fetch(API, AccountId, CDRId),
-    'true' = cdr_exists(CDR, [kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp))]),
+    FetchedJObj = kz_json:get_json_value(<<"data">>, kz_json:decode(FetchResp)),
+    'true' = cdr_exists(CDR, [FetchedJObj]),
+
+    %% KZOO-45: Ensure empty strings have been stripped
+    'undefined' = kz_json:get_ne_binary_value(<<"media_server">>, FetchedJObj),
 
     %% Should be able to convert CDR ID to interaction_id
     LegsResp = legs(API, AccountId, CDRId),

--- a/core/kazoo_proper/src/pqc_cb_cdrs.erl
+++ b/core/kazoo_proper/src/pqc_cb_cdrs.erl
@@ -197,6 +197,7 @@ start_key(StartKey) -> "start_key=" ++ kz_term:to_list(StartKey).
 
 -spec seq() -> 'ok'.
 seq() ->
+    kapps_config:set_default(<<"crossbar.cdrs">>, <<"should_filter_empty_strings">>, 'true'),
     _ = straight_seq(),
     _ = paginated_seq(),
     _ = task_seq(),

--- a/core/kazoo_stdlib/src/props.erl
+++ b/core/kazoo_stdlib/src/props.erl
@@ -33,7 +33,7 @@
         ,replace_value/3
         ,unique/1
         ,filter/2
-        ,filter_empty/1
+        ,filter_empty/1, filter_empty_strings/1
         ,filter_undefined/1
         ,to_log/1, to_log/2
         ]).
@@ -111,6 +111,14 @@ filter_empty(Props) ->
 -spec is_not_empty(kz_term:proplist_property()) -> boolean().
 is_not_empty({_, V}) -> not kz_term:is_empty(V);
 is_not_empty(_V) -> 'true'.
+
+-spec filter_empty_strings([{any(), any()} | atom()]) -> [{any(), any()} | atom()].
+filter_empty_strings(Props) ->
+    filter(fun is_not_empty_string/1, Props).
+
+-spec is_not_empty_string(kz_term:proplist_property()) -> boolean().
+is_not_empty_string({_, <<>>}) -> 'false';
+is_not_empty_string(_) -> 'true'.
 
 -spec filter_undefined(kz_term:proplist()) -> kz_term:proplist().
 filter_undefined(Props) ->

--- a/core/kazoo_stdlib/test/props_tests.erl
+++ b/core/kazoo_stdlib/test/props_tests.erl
@@ -34,9 +34,20 @@ filter_empty_test_() ->
     ,?_assertEqual([], props:filter_empty([{'a', 0}, {'b', []}, {'c', <<>>}, {'z', 'undefined'}]))
     ,?_assertEqual(['a'], props:filter_empty(['a']))
     ,?_assertEqual(['a'], props:filter_empty(['a', {'b', 0}]))
-    ,?_assertEqual([], props:filter_empty([{<<"a">>, undefined}]))
-    ,?_assertEqual([{<<"a">>, false}], props:filter_empty([{<<"a">>, false}]))
-    ,?_assertEqual([{<<"a">>, true}], props:filter_empty([{<<"a">>, true}]))
+    ,?_assertEqual([], props:filter_empty([{<<"a">>, 'undefined'}]))
+    ,?_assertEqual([{<<"a">>, 'false'}], props:filter_empty([{<<"a">>, 'false'}]))
+    ,?_assertEqual([{<<"a">>, 'true'}], props:filter_empty([{<<"a">>, 'true'}]))
+    ].
+
+filter_empty_strings_test_() ->
+    [?_assertEqual([], props:filter_empty_strings([]))
+    ,?_assertEqual([{'a', 10}, {'b', 8}, {'c', 6}], props:filter_empty_strings([{'a', 10}, {'b', 8}, {'c', 6}]))
+    ,?_assertEqual([{'a', 0}, {'b', []}, {'z', 'undefined'}], props:filter_empty_strings([{'a', 0}, {'b', []}, {'c', <<>>}, {'z', 'undefined'}]))
+    ,?_assertEqual(['a'], props:filter_empty_strings(['a']))
+    ,?_assertEqual(['a', {'b', 0}], props:filter_empty_strings(['a', {'b', 0}]))
+    ,?_assertEqual([{<<"a">>, 'undefined'}], props:filter_empty_strings([{<<"a">>, 'undefined'}]))
+    ,?_assertEqual([{<<"a">>, 'false'}], props:filter_empty_strings([{<<"a">>, 'false'}]))
+    ,?_assertEqual([{<<"a">>, 'true'}], props:filter_empty_strings([{<<"a">>, 'true'}]))
     ].
 
 filter_undefined_test_() ->
@@ -45,7 +56,7 @@ filter_undefined_test_() ->
     ,?_assertEqual([], props:filter_undefined([]))
     ,?_assertEqual([{'a', 10}, {'b', 8}, {'c', 6}], props:filter_undefined([{'a', 10}, {'b', 8}, {'c', 6}]))
     ,?_assertEqual([{'a', 0}, {'b', []}, {'c', <<>>}], props:filter_undefined([{'a', 0}, {'b', []}, {'c', <<>>}, {'z', 'undefined'}]))
-    ,?_assertEqual([{<<"pouet">>, null}], props:filter_undefined([{<<"pouet">>, null}]))
+    ,?_assertEqual([{<<"pouet">>, 'null'}], props:filter_undefined([{<<"pouet">>, 'null'}]))
     ].
 
 unique_test_() ->


### PR DESCRIPTION
An addition to filter_empty fields from the CDR summary response is
causing expected fields like `cost` to be stripped when they are
0. The intent of the change was to filter keys with empty strings ("")
to reduce payload size.

Instead, let's add a `filter_empty_strings` to narrow down what is
removed from the payload.