### PR TITLE
[master] KCRO-17: skip some routines during user creation if there were errors

### DIFF
--- a/applications/crossbar/src/modules/cb_users.erl
+++ b/applications/crossbar/src/modules/cb_users.erl
@@ -551,7 +551,9 @@ maybe_import_credentials(_UserId, Context) ->
 
 -spec maybe_set_identity_secret(kz_term:api_ne_binary(), cb_context:context()) -> cb_context:context().
 maybe_set_identity_secret(_UserId, Context) ->
-    case crossbar_auth:has_identity_secret(Context) of
+    case crossbar_auth:has_identity_secret(Context)
+        orelse cb_context:has_errors(Context)
+    of
         'true' -> Context;
         'false' ->
             lager:debug("initalizing identity secret"),
@@ -683,6 +685,13 @@ on_successful_validation(UserId, Context) ->
 
 -spec maybe_rehash_creds(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
 maybe_rehash_creds(_UserId, Context) ->
+    case cb_context:has_errors(Context) of
+        'false' -> rehash_creds(Context);
+        'true' -> Context
+    end.
+
+-spec rehash_creds(cb_context:context()) -> cb_context:context().
+rehash_creds(Context) ->
     JObj = cb_context:doc(Context),
     Username = kzd_users:username(JObj),
     CurrentJObj = cb_context:fetch(Context, 'db_doc', kz_json:new()),


### PR DESCRIPTION
Addresses payloads that fail validation but continue to execute routines that expected valid data:

01:00:29.333 error kazoo_bindings.690 unable to find function clause for kz_json:no_prune([<<"pvt_sha1_auth">>], undefined) in src/kz_json.erl:1369
01:00:29.334 error kazoo_bindings.696 as part of cb_users_v2:validate/2
01:00:29.334 error kazoo_bindings.697 st: {lists,foldr,3,[{file,"lists.erl"},{line,1276}]}
01:00:29.334 error kazoo_bindings.697 st: {cb_users_v2,remove_creds,1,[{file,"src/modules_v2/cb_users_v2.erl"},{line,770}]}
01:00:29.334 error kazoo_bindings.697 st: {lists,foldl,3,[{file,"lists.erl"},{line,1263}]}
01:00:29.334 error kazoo_bindings.697 st: {kazoo_bindings,fold_bind_results,5,[{file,"src/kazoo_bindings.erl"},{line,632}]}
01:00:29.334 error kazoo_bindings.697 st: {lists,foldl,3,[{file,"lists.erl"},{line,1263}]}
01:00:29.334 error kazoo_bindings.697 st: {kazoo_bindings,fold_processor,3,[{file,"src/kazoo_bindings.erl"},{line,860}]}
01:00:29.334 error kazoo_bindings.697 st: {api_util,validate_data,2,[{file,"src/api_util.erl"},{line,1077}]}