### PR TITLE
[master] KCRO-14: emit the billing_seconds for the reduce

### DIFF
--- a/core/kazoo_modb/priv/couchdb/views/interactions.json
+++ b/core/kazoo_modb/priv/couchdb/views/interactions.json
@@ -53,6 +53,7 @@
                 "  emit([doc.custom_channel_vars.owner_id, doc.interaction_time, doc.interaction_key, channel_time], {",
                 "    id: doc._id,",
                 "    channel_time: channel_time,",
+                "    billing_seconds: doc.billing_seconds || 0,",
                 "    leg: doc.channel_loopback_leg || '_'",
                 "  });",
                 "}"


### PR DESCRIPTION
The reduce view for user interactions uses the billing seconds but it is not emitted from the map function.