### PR TITLE
[4.3] KZOO-52: use a default empty list for messages

### DIFF
--- a/core/kazoo_proper/src/pqc_cb_vmboxes.erl
+++ b/core/kazoo_proper/src/pqc_cb_vmboxes.erl
@@ -4,7 +4,14 @@
         ,fetch_message_metadata/4
         ,fetch_message_binary/4
         ,create_box/3
+        ,delete_box/3
         ]).
+
+-export([seq/0
+        ,cleanup/0
+        ]).
+
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
 
 -spec new_message(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), binary()) ->
           pqc_cb_api:response().
@@ -76,8 +83,22 @@ create_box(API, AccountId, BoxName) ->
                            ,kz_json:encode(Req)
                            ).
 
+-spec delete_box(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+delete_box(API, AccountId, BoxId) ->
+    RequestHeaders = pqc_cb_api:request_headers(API),
+    BoxURL = box_url(AccountId, BoxId),
+
+    pqc_cb_api:make_request([200]
+                           ,fun kz_http:delete/2
+                           ,BoxURL
+                           ,RequestHeaders
+                           ).
+
 boxes_url(AccountId) ->
     string:join([pqc_cb_accounts:account_url(AccountId), "vmboxes"], "/").
+
+box_url(AccountId, BoxId) ->
+    string:join([pqc_cb_accounts:account_url(AccountId), "vmboxes", kz_term:to_list(BoxId)], "/").
 
 messages_url(AccountId, BoxId) ->
     string:join([pqc_cb_accounts:account_url(AccountId), "vmboxes", kz_term:to_list(BoxId), "messages"], "/").
@@ -87,3 +108,68 @@ message_url(AccountId, BoxId, MessageId) ->
 
 message_bin_url(AccountId, BoxId, MessageId) ->
     string:join([pqc_cb_accounts:account_url(AccountId), "vmboxes", kz_term:to_list(BoxId), "messages", kz_term:to_list(MessageId), "raw"], "/").
+
+-spec seq() -> 'ok'.
+seq() ->
+    Fs = [fun seq_kzoo_52/0],
+    lists:foreach(fun run/1, Fs).
+
+run(F) -> F().
+
+seq_kzoo_52() ->
+    Model = initial_state(),
+    API = pqc_kazoo_model:api(Model),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    lager:info("created account: ~s", [AccountResp]),
+
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+
+    BoxName = kz_binary:rand_hex(4),
+    CreateResp = create_box(API, AccountId, BoxName),
+    lager:info("create resp: ~s", [CreateResp]),
+    CreatedBox = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
+    BoxId = kz_doc:id(CreatedBox),
+    BoxName = kzd_vmboxes:name(CreatedBox),
+
+    DeleteResp = delete_box(API, AccountId, BoxId),
+    lager:info("delete resp: ~s", [DeleteResp]),
+    DeletedBox = kz_json:get_json_value(<<"data">>, kz_json:decode(DeleteResp)),
+    BoxId = kz_doc:id(DeletedBox),
+    BoxName = kzd_vmboxes:name(DeletedBox),
+    'true' = kz_json:is_true([<<"_read_only">>, <<"deleted">>], DeletedBox),
+
+    cleanup(API),
+    lager:info("FINISHED SEQ").
+
+-spec initial_state() -> pqc_kazoo_model:model().
+initial_state() ->
+    _ = init_system(),
+    API = pqc_cb_api:authenticate(),
+    pqc_kazoo_model:new(API).
+
+init_system() ->
+    TestId = kz_binary:rand_hex(5),
+    kz_util:put_callid(TestId),
+
+    _ = kz_data_tracing:clear_all_traces(),
+    _ = [kapps_controller:start_app(App) ||
+            App <- ['crossbar']
+        ],
+    _ = [crossbar_maintenance:start_module(Mod) ||
+            Mod <- ['cb_vmboxes']
+        ],
+    lager:info("INIT FINISHED").
+
+-spec cleanup() -> 'ok'.
+cleanup() ->
+    _ = pqc_cb_accounts:cleanup_accounts(?ACCOUNT_NAMES),
+    cleanup_system().
+
+cleanup(API) ->
+    lager:info("CLEANUP TIME, EVERYBODY HELPS"),
+    _ = pqc_cb_accounts:cleanup_accounts(API, ?ACCOUNT_NAMES),
+    _ = pqc_cb_api:cleanup(API),
+    cleanup_system().
+
+cleanup_system() -> 'ok'.


### PR DESCRIPTION
When a voicemail box is empty and deleted via API, an error would be
thrown during deletion when deciding to publish deleted
messages. kvm_messages:fetch/4 strips empty values from the results,
`succeeded` would be `[]` and thus stripped, so `get_list_value/2`
returned `undefined`. This caused the call to `lists:foreach/2` to
crash.

Instead, fetch `succeeded` with `[]` as a default and only process if
the result is a non-empty list.