### PR TITLE
[4.3] KZOO-53: test when endpoint settings are empty objects

### DIFF
--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -438,7 +438,7 @@ get_user_record_call_properties(UserDoc) ->
 -spec get_device_record_call_properties(kzd_devices:doc() | 'undefined') -> kz_json:object().
 get_device_record_call_properties('undefined') -> kz_json:new();
 get_device_record_call_properties(DeviceDoc) ->
-    case kzd_users:call_recording(DeviceDoc) of
+    case kzd_devices:call_recording(DeviceDoc) of
         'undefined' -> get_legacy_record_call_properties(DeviceDoc);
         CallRecording -> endpoint_recording(CallRecording)
     end.
@@ -462,7 +462,12 @@ get_legacy_record_call_properties(EndpointDoc) ->
 
 -spec endpoint_recording(kzd_call_recording:doc()) -> kz_json:object().
 endpoint_recording(RecordCall) ->
-    kz_json:from_list([{<<"endpoint">>, merge_call_recording(RecordCall)}]).
+    endpoint_recording(RecordCall, kz_json:is_empty(RecordCall)).
+
+-spec endpoint_recording(kzd_call_recording:doc(), boolean()) -> kz_json:object().
+endpoint_recording(RecordCall, 'false') ->
+    kz_json:from_list([{<<"endpoint">>, merge_call_recording(RecordCall)}]);
+endpoint_recording(RecordCall, 'true') -> RecordCall.
 
 %% deprecated, to be removed
 -spec get_record_call_properties(kz_json:object()) -> kz_json:object().

--- a/core/kazoo_endpoint/test/kz_endpoint_tests.erl
+++ b/core/kazoo_endpoint/test/kz_endpoint_tests.erl
@@ -21,6 +21,7 @@ call_recording_test_() ->
     ,device_off_user_off_account_on()
     ,device_undefined_user_off_account_on()
     ,device_undefined_user_undefined_account_on()
+    ,empty_device()
     ].
 
 device_on() ->
@@ -177,6 +178,29 @@ all_on() ->
     Merged = kz_endpoint:merge_attribute(<<"call_recording">>, AccountDoc, DeviceDoc, UserDoc),
 
     check_expectations(?FUNCTION_NAME, Merged, Expectations).
+
+%% KZOO-53: if account is set to record, and device/user settings are empty JSON object, use account
+empty_device() ->
+    Expectations = [{<<"account">>, <<"inbound">>, <<"offnet">>,   'true'}
+                   ,{<<"account">>, <<"inbound">>, <<"onnet">>,    'true'}
+                   ,{<<"account">>, <<"outbound">>, <<"offnet">>,  'true'}
+                   ,{<<"account">>, <<"outbound">>, <<"onnet">>,   'true'}
+                   ,{<<"endpoint">>, <<"inbound">>, <<"offnet">>,  'false'}
+                   ,{<<"endpoint">>, <<"inbound">>, <<"onnet">>,   'false'}
+                   ,{<<"endpoint">>, <<"outbound">>, <<"offnet">>, 'false'}
+                   ,{<<"endpoint">>, <<"outbound">>, <<"onnet">>,  'false'}
+                   ],
+
+    AccountDoc = kzd_accounts:set_call_recording(kzd_accounts:new(), kz_json:from_list([{<<"account">>, all_on_object()}])),
+    UserDoc = kzd_users:set_call_recording(kzd_users:new(), empty_object()),
+    DeviceDoc = kzd_devices:set_call_recording(kzd_devices:new(), empty_object()),
+
+    Merged = kz_endpoint:merge_attribute(<<"call_recording">>, AccountDoc, DeviceDoc, UserDoc),
+
+    check_expectations(?FUNCTION_NAME, Merged, Expectations).
+
+empty_object() ->
+     kz_json:new().
 
 check_expectations(Test, Merged, Expectations) ->
     [{kz_term:to_list(kz_binary:join([Test, Type, Direction, Network]))

--- a/core/kazoo_endpoint/test/kz_endpoint_tests.erl
+++ b/core/kazoo_endpoint/test/kz_endpoint_tests.erl
@@ -200,7 +200,7 @@ empty_device() ->
     check_expectations(?FUNCTION_NAME, Merged, Expectations).
 
 empty_object() ->
-     kz_json:new().
+    kz_json:new().
 
 check_expectations(Test, Merged, Expectations) ->
     [{kz_term:to_list(kz_binary:join([Test, Type, Direction, Network]))


### PR DESCRIPTION
Make sure that account and endpoint settings are properly populated
when device/user settings are empty objects instead of undefined.

Part of HELP-13159