### PR TITLE
[4.3] KZOO-54: ensure accounts are created with the realm specified

### DIFF
--- a/core/kazoo_proper/src/pqc_cb_accounts.erl
+++ b/core/kazoo_proper/src/pqc_cb_accounts.erl
@@ -18,7 +18,7 @@
         ,postcondition/3
 
          %% kapps_maintenance:check_release callback
-        ,seq/0, seq_44832/0
+        ,seq/0, seq_44832/0, seq_kzoo_54/0
         ]).
 
 -export([account_url/1]).
@@ -27,7 +27,7 @@
 
 -include("kazoo_proper.hrl").
 
--define(ACCOUNT_NAMES, [<<"account_for_accounts">>]).
+-define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
 
 -type account_id() :: {'call', 'pqc_kazoo_model', 'account_id_by_name', [pqc_cb_api:state() | proper_types:type()]} |
                       kz_term:ne_binary().
@@ -42,18 +42,20 @@ command(Model, Name) ->
 symbolic_account_id(Model, Name) ->
     {'call', 'pqc_kazoo_model', 'account_id_by_name', [Model, Name]}.
 
--spec create_account(pqc_cb_api:state(), kz_term:ne_binary()) -> pqc_cb_api:response().
-create_account(API, NewAccountName) ->
-    create_account(API, NewAccountName, pqc_cb_api:auth_account_id(API)).
+-spec create_account(pqc_cb_api:state(), kz_json:object() | kz_term:ne_binary()) -> pqc_cb_api:response().
+create_account(API, NewAccount) ->
+    create_account(API, NewAccount, pqc_cb_api:auth_account_id(API)).
 
--spec create_account(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
-create_account(API, NewAccountName, AccountId) ->
+-spec create_account(pqc_cb_api:state(), kz_json:object() | kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+create_account(API, <<NewAccountName/binary>>, AuthAccountId) ->
     RequestData = kz_json:from_list([{<<"name">>, NewAccountName}]),
+    create_account(API, RequestData, AuthAccountId);
+create_account(API, RequestData, AuthAccountId) ->
     RequestEnvelope = pqc_cb_api:create_envelope(RequestData),
 
     Resp = pqc_cb_api:make_request([201, 500]
                                   ,fun kz_http:put/3
-                                  ,account_url(AccountId)
+                                  ,account_url(AuthAccountId)
                                   ,pqc_cb_api:request_headers(API)
                                   ,kz_json:encode(RequestEnvelope)
                                   ),
@@ -162,7 +164,8 @@ postcondition(Model
 -spec seq() -> 'ok'.
 seq() ->
     enable_and_delete_topup(),
-    seq_44832().
+    seq_44832(),
+    seq_kzoo_54().
 
 -spec seq_44832() -> 'ok'.
 seq_44832() ->
@@ -188,6 +191,42 @@ seq_44832() ->
 
     _ = cleanup(API),
     ?INFO("finished double-POST check").
+
+-spec seq_kzoo_54() -> 'ok'.
+seq_kzoo_54() ->
+    API = pqc_cb_api:init_api(['crossbar'], ['cb_accounts']),
+
+    AccountReq = kz_json:from_list([{<<"name">>, <<?MODULE_STRING>>}
+                                   ,{<<"realm">>, <<?MODULE_STRING>>}
+                                   ]
+                                  ),
+
+    CustomAccountResp = create_account(API, AccountReq),
+    lager:info("created custom account ~s", [CustomAccountResp]),
+
+    CustomAccountJObj = kz_json:get_value(<<"data">>, kz_json:decode(CustomAccountResp)),
+    CustomAccountId = kz_doc:id(CustomAccountJObj),
+    <<?MODULE_STRING>> = kzd_accounts:name(CustomAccountJObj),
+    <<?MODULE_STRING>> = kzd_accounts:realm(CustomAccountJObj),
+
+    CustomDeleteResp = delete_account(API, CustomAccountId),
+    CustomAccountId = kz_doc:id(kz_json:get_value(<<"data">>, kz_json:decode(CustomDeleteResp))),
+
+    RealmSuffix = kapps_config:get_binary(<<"crossbar.accounts">>, <<"account_realm_suffix">>),
+    DefaultCreateResp = create_account(API, <<?MODULE_STRING>>),
+    lager:info("created default account ~s", [DefaultCreateResp]),
+
+    DefaultAccountJObj = kz_json:get_value(<<"data">>, kz_json:decode(DefaultCreateResp)),
+    DefaultAccountId = kz_doc:id(DefaultAccountJObj),
+    <<?MODULE_STRING>> = kzd_accounts:name(DefaultAccountJObj),
+    lager:info("realm ~s is suffixed by ~s", [kzd_accounts:realm(DefaultAccountJObj), RealmSuffix]),
+    {_, _} = binary:match(kzd_accounts:realm(DefaultAccountJObj), RealmSuffix),
+
+    DefaultDeleteResp = delete_account(API, DefaultAccountId),
+    DefaultAccountId = kz_doc:id(kz_json:get_value(<<"data">>, kz_json:decode(DefaultDeleteResp))),
+
+    _ = cleanup(API),
+    ?INFO("finished name/realm checks").
 
 -spec enable_and_delete_topup() -> 'ok'.
 enable_and_delete_topup() ->


### PR DESCRIPTION
If `realm` is included on the request, ensure created account reports
the custom `realm` after creation.

If `realm` is not included, ensure created account reports the `realm`
as a string containing the system-configured realm suffix.

Part of HELP-13467