### PR TITLE
[master] KZOO-31: add privacy headers for carrier endpoints in bridge string

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -36803,6 +36803,11 @@
                     "description": "privacy method",
                     "type": "string"
                 },
+                "privacy_mode": {
+                    "default": "kazoo",
+                    "description": "Default privacy mode for anonymous calls",
+                    "type": "string"
+                },
                 "privacy_name": {
                     "default": "anonymous",
                     "description": "Default Caller ID Name should be shown for anonymous calls",
@@ -36814,7 +36819,7 @@
                     "type": "string"
                 },
                 "use_sip_privacy_header": {
-                    "default": false,
+                    "default": true,
                     "description": "privacy use_sip_privacy_header",
                     "type": "boolean"
                 }

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -36803,11 +36803,6 @@
                     "description": "privacy method",
                     "type": "string"
                 },
-                "privacy_mode": {
-                    "default": "kazoo",
-                    "description": "Default privacy mode for anonymous calls",
-                    "type": "string"
-                },
                 "privacy_name": {
                     "default": "anonymous",
                     "description": "Default Caller ID Name should be shown for anonymous calls",
@@ -36817,6 +36812,11 @@
                     "default": "0000000000",
                     "description": "Default Caller ID Number should be shown for anonymous calls",
                     "type": "string"
+                },
+                "use_sip_privacy_header": {
+                    "default": false,
+                    "description": "privacy use_sip_privacy_header",
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.privacy.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.privacy.json
@@ -64,6 +64,11 @@
             "default": "0000000000",
             "description": "Default Caller ID Number should be shown for anonymous calls",
             "type": "string"
+        },
+        "use_sip_privacy_header": {
+            "default": false,
+            "description": "privacy use_sip_privacy_header",
+            "type": "boolean"
         }
     },
     "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.privacy.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.privacy.json
@@ -55,11 +55,6 @@
             "description": "privacy method",
             "type": "string"
         },
-        "privacy_mode": {
-            "default": "kazoo",
-            "description": "Default privacy mode for anonymous calls",
-            "type": "string"
-        },
         "privacy_name": {
             "default": "anonymous",
             "description": "Default Caller ID Name should be shown for anonymous calls",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.privacy.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.privacy.json
@@ -55,6 +55,11 @@
             "description": "privacy method",
             "type": "string"
         },
+        "privacy_mode": {
+            "default": "kazoo",
+            "description": "Default privacy mode for anonymous calls",
+            "type": "string"
+        },
         "privacy_name": {
             "default": "anonymous",
             "description": "Default Caller ID Name should be shown for anonymous calls",
@@ -66,7 +71,7 @@
             "type": "string"
         },
         "use_sip_privacy_header": {
-            "default": false,
+            "default": true,
             "description": "privacy use_sip_privacy_header",
             "type": "boolean"
         }

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -12752,6 +12752,10 @@
       'default': 0000000000
       'description': Default Caller ID Number should be shown for anonymous calls
       'type': string
+    'use_sip_privacy_header':
+      'default': true
+      'description': privacy use_sip_privacy_header
+      'type': boolean
   'type': object
 'system_config.provisioner':
   'description': Schema for provisioner system_config

--- a/applications/ecallmgr/src/call_cmd/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/call_cmd/ecallmgr_call_command.erl
@@ -63,6 +63,18 @@ fetch_dialplan(Node, UUID, JObj, _ControlPid) ->
         [_|_]=Apps -> Apps
     end.
 
+%%------------------------------------------------------------------------------
+%% @doc Anonymize CIDs if privacy method is kazoo and execute privacy command if
+%% privacy method is `sip'.
+%%
+%% FIXME: This would execute privacy command twice for outgoing calls:
+%% 1) when cf_privacy is setting CCVs
+%% 2) when stepswitch bridges the call
+%%
+%% Maybe we can check for the app to be `bridge' or `privacy', the only side
+%% down is that it won't do anything for one leg call during `set' command.
+%% @end
+%%------------------------------------------------------------------------------
 -spec enforce_privacy(atom(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 enforce_privacy(Node, UUID, JObj) ->
     AnonymizedJObj = kz_privacy:enforce(JObj),

--- a/applications/ecallmgr/src/call_cmd/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/call_cmd/ecallmgr_call_command.erl
@@ -67,12 +67,12 @@ fetch_dialplan(Node, UUID, JObj, _ControlPid) ->
 %% @doc Anonymize CIDs if privacy method is kazoo and execute privacy command if
 %% privacy method is `sip'.
 %%
-%% FIXME: This would execute privacy command twice for outgoing calls:
+%% FIXME: This would execute privacy command twice for calls:
 %% 1) when cf_privacy is setting CCVs
 %% 2) when stepswitch bridges the call
 %%
-%% Maybe we can check for the app to be `bridge' or `privacy', the only side
-%% down is that it won't do anything for one leg call during `set' command.
+%% Maybe we can check for the app to be `bridge' or `privacy', but it also has
+%% side effect that it won't do anything for one leg call during `set' command.
 %% @end
 %%------------------------------------------------------------------------------
 -spec enforce_privacy(atom(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -533,7 +533,9 @@ get_leg_vars(JObj) -> get_leg_vars(kz_json:to_proplist(JObj)).
 
 -spec maybe_endpoint_privacy_header(kz_term:proplist()) -> kz_term:ne_binaries().
 maybe_endpoint_privacy_header(Prop) ->
-    case kz_privacy:has_flags(Prop) of
+    case kz_privacy:has_flags(Prop)
+        andalso kz_privacy:use_sip_privacy_header()
+    of
         'true' -> [<<"sip_h_Privacy=id">>];
         'false' -> []
     end.
@@ -589,23 +591,12 @@ channel_vars_handle_asserted_identity({Props, Results}=Acc) ->
 
 -spec build_asserted_identity(kz_term:ne_binary(), kz_term:prolist(), iolist()) -> channel_var_fold().
 build_asserted_identity(AssertedIdentity, Props, Results) ->
-    case kz_privacy:has_flags(Props) of
-        'true' ->
-            {Props
-            ,[<<"sip_cid_type=none">>
-             ,<<"sip_h_Privacy=id">>
-             ,<<"sip_h_P-Asserted-Identity='", AssertedIdentity/binary, "'">>
-                  | Results
-             ]
-            };
-        'false' ->
-            {Props
-            ,[<<"sip_cid_type=none">>
-             ,<<"sip_h_P-Asserted-Identity='", AssertedIdentity/binary, "'">>
-                  | Results
-             ]
-            }
-    end.
+    {Props
+    ,[<<"sip_cid_type=none">>
+     ,<<"sip_h_P-Asserted-Identity='", AssertedIdentity/binary, "'">>
+          | Results
+     ] ++ maybe_endpoint_privacy_header(Props)
+    }.
 
 -spec create_asserted_identity_header(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()) ->
           kz_term:api_binary().

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -520,12 +520,19 @@ get_leg_vars([_|_]=Prop) ->
     ["[^^", ?BRIDGE_CHANNEL_VAR_SEPARATOR
     ,string:join([kz_term:to_list(V)
                   || V <- lists:foldr(fun kazoo_var_to_fs_var/2, [], Prop)
-                 ]
+                 ] ++ maybe_endpoint_privacy_header(Prop)
                 ,?BRIDGE_CHANNEL_VAR_SEPARATOR
                 )
     ,"]"
     ];
 get_leg_vars(JObj) -> get_leg_vars(kz_json:to_proplist(JObj)).
+
+-spec maybe_endpoint_privacy_header(kz_term:proplist()) -> kz_term:ne_binaries().
+maybe_endpoint_privacy_header(Prop) ->
+    case kz_privacy:has_flags(Prop) of
+        'true' -> [<<"sip_h_Privacy=id">>];
+        'false' -> []
+    end.
 
 -spec get_channel_vars(kz_json:object() | kz_term:proplist()) -> iolist().
 get_channel_vars(Param) ->

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -503,7 +503,8 @@ check_dtmf_type(#{payload := Payload}) ->
 
 -spec build_leg_vars(kz_json:object() | kz_term:proplist()) -> kz_term:ne_binaries().
 build_leg_vars([]) -> [];
-build_leg_vars([_|_]=Prop) -> lists:foldr(fun kazoo_var_to_fs_var/2, [], Prop);
+build_leg_vars([_|_]=Prop) ->
+    lists:foldr(fun kazoo_var_to_fs_var/2, maybe_endpoint_privacy_header(Prop), Prop);
 build_leg_vars(JObj) -> build_leg_vars(kz_json:to_proplist(JObj)).
 
 -spec get_leg_vars(kz_json:object() | kz_term:proplist()) -> iolist().
@@ -519,8 +520,11 @@ get_leg_vars([Binary|_]=Binaries)
 get_leg_vars([_|_]=Prop) ->
     ["[^^", ?BRIDGE_CHANNEL_VAR_SEPARATOR
     ,string:join([kz_term:to_list(V)
-                  || V <- lists:foldr(fun kazoo_var_to_fs_var/2, [], Prop)
-                 ] ++ maybe_endpoint_privacy_header(Prop)
+                  || V <- lists:foldr(fun kazoo_var_to_fs_var/2
+                                     ,maybe_endpoint_privacy_header(Prop)
+                                     ,Prop
+                                     )
+                 ]
                 ,?BRIDGE_CHANNEL_VAR_SEPARATOR
                 )
     ,"]"

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -583,14 +583,14 @@ build_asserted_identity(AssertedIdentity, Props, Results) ->
             {Props
             ,[<<"sip_cid_type=none">>
              ,<<"sip_h_Privacy=id">>
-             ,<<"sip_h_P-Asserted-Identity=", AssertedIdentity/binary>>
+             ,<<"sip_h_P-Asserted-Identity='", AssertedIdentity/binary, "'">>
                   | Results
              ]
             };
         'false' ->
             {Props
             ,[<<"sip_cid_type=none">>
-             ,<<"sip_h_P-Asserted-Identity=", AssertedIdentity/binary>>
+             ,<<"sip_h_P-Asserted-Identity='", AssertedIdentity/binary, "'">>
                   | Results
              ]
             }

--- a/core/kazoo_endpoint/src/kz_privacy.erl
+++ b/core/kazoo_endpoint/src/kz_privacy.erl
@@ -32,6 +32,7 @@
 -export([anonymous_caller_id_name/0, anonymous_caller_id_name/1
         ,anonymous_caller_id_number/0, anonymous_caller_id_number/1
         ]).
+-export([use_sip_privacy_header/0]).
 
 -include("kazoo_endpoint.hrl").
 -include_lib("kazoo_amqp/include/kapi_offnet_resource.hrl").
@@ -43,6 +44,8 @@
 
 -define(KEY_ANONYMOUS_NUMBER, <<"default_privacy_number">>).
 -define(DEFAULT_ANONYMOUS_NUMBER, <<"anonymous">>).
+
+-define(KEY_PRIVACY_HEADER, <<"use_sip_privacy_header">>).
 
 -define(KEY_ANONYMOUS_NAMES, <<"anonymous_cid_names">>).
 -define(KEY_ANONYMOUS_NUMBERS, <<"anonymous_cid_numbers">>).
@@ -462,6 +465,14 @@ anonymous_caller_id_number('undefined') ->
     anonymous_caller_id_number();
 anonymous_caller_id_number(AccountId) ->
     kapps_account_config:get_global(AccountId, ?PRIVACY_CAT, ?KEY_ANONYMOUS_NUMBER, ?DEFAULT_ANONYMOUS_NUMBER).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec use_sip_privacy_header() -> boolean().
+use_sip_privacy_header() ->
+    kapps_config:get_is_true(?PRIVACY_CAT, ?KEY_PRIVACY_HEADER, 'true').
 
 %%------------------------------------------------------------------------------
 %% @doc Get Key from JObj, if not found look into CCV

--- a/core/kazoo_endpoint/src/kz_privacy.erl
+++ b/core/kazoo_endpoint/src/kz_privacy.erl
@@ -77,10 +77,9 @@ get_method(JObj, Default) ->
     case kz_json:get_first_defined(Keys, JObj, Default) of
         <<"sip">> -> <<"sip">>;
         %% none is set by stepswitch_bridge when the call is emergency
-        % <<"none">> -> <<"none">>;
-        % <<"kazoo">> -> <<"kazoo">>;
-        % _Else -> Default
-        _Else -> <<"kazoo">>
+        <<"none">> -> <<"none">>;
+        <<"kazoo">> -> <<"kazoo">>;
+        _Else -> Default
     end.
 
 -spec get_default_privacy_mode() -> kz_term:ne_binary().

--- a/core/kazoo_endpoint/src/kz_privacy.erl
+++ b/core/kazoo_endpoint/src/kz_privacy.erl
@@ -76,6 +76,10 @@ get_method(JObj, Default) ->
            ],
     case kz_json:get_first_defined(Keys, JObj, Default) of
         <<"sip">> -> <<"sip">>;
+        %% none is set by stepswitch_bridge when the call is emergency
+        % <<"none">> -> <<"none">>;
+        % <<"kazoo">> -> <<"kazoo">>;
+        % _Else -> Default
         _Else -> <<"kazoo">>
     end.
 
@@ -148,7 +152,7 @@ should_hide_number(JObj, Default) ->
 %%------------------------------------------------------------------------------
 -spec enforce(kz_json:object()) -> kz_json:object().
 enforce(JObj) ->
-    enforce(JObj, get_method(JObj)).
+    enforce(JObj, get_default_privacy_mode()).
 
 -spec enforce(kz_json:object(), kz_term:ne_binary()) -> kz_json:object().
 enforce(JObj, DefaultMethod) ->
@@ -172,7 +176,13 @@ maybe_anonymize_name(JObj, Method) ->
     end.
 
 -spec hide_name(kz_json:object(), kz_term:ne_binary()) -> kz_json:object().
+hide_name(JObj, <<"none">>) ->
+    %% This is emergency call, don't enforce privacy
+    %% none is set by stepswitch_bridge to avoid enforcing privacy
+    JObj;
 hide_name(JObj, <<"sip">>) ->
+    %% let freeswitch deal with hiding cid
+    %% through remote-party or p-asserted-identity headers
     JObj;
 hide_name(JObj, _Method) ->
     Keys = [<<"Outbound-Caller-ID-Name">>
@@ -194,7 +204,13 @@ maybe_anonymize_number(JObj, Method) ->
     end.
 
 -spec hide_number(kz_json:object(), kz_term:ne_binary()) -> kz_json:object().
+hide_number(JObj, <<"none">>) ->
+    %% This is emergency call, don't enforce privacy
+    %% none is set by stepswitch_bridge to avoid enforcing privacy
+    JObj;
 hide_number(JObj, <<"sip">>) ->
+    %% let freeswitch deal with hiding cid
+    %% through remote-party or p-asserted-identity headers
     JObj;
 hide_number(JObj, _Method) ->
     Keys = [<<"Outbound-Caller-ID-Number">>


### PR DESCRIPTION
This adds the Privacy: id SIP header on the endpoints string if only some of carriers/endpoints have the privacy flags during building the bridge string.

If there is only one carrier or the only some of the carriers have privacy settings, the P-Asserted-Identity tend to not be lifted in bridge object and ecallmgr_fs_xml during creating bridge string won't add Privacy: id header because the Privacy-Hide-Name or Privacy-Hide-Number are set on the endpoint Prop.

Also when adding P-Asserted-Identity, its value in the bridge string should be single quoted.

If this PR causes issues with your devices you can opt-out of the feature by setting use_sip_privacy_header to false on that system_config privacy document.