### PR TITLE
KZOO-54: ensure accounts are created with the realm specified

### DIFF
--- a/applications/crossbar/src/modules/cb_accounts.erl
+++ b/applications/crossbar/src/modules/cb_accounts.erl
@@ -403,7 +403,7 @@ delete(Context, Account) ->
 
     case kzdb_account:delete(AccountId) of
         {'ok', AccountJObj} ->
-            Context1 = cb_context:set_doc(Context, AccountJObj),
+            Context1 = crossbar_doc:handle_datamgr_success(AccountJObj, Context),
             _ = maybe_update_descendants_count(kzd_accounts:tree(AccountJObj)),
             _ = provisioner_util:maybe_delete_account(cb_context:account_id(Context)
                                                      ,cb_context:auth_token(Context)

--- a/core/kazoo_databases/src/kzdb_account.erl
+++ b/core/kazoo_databases/src/kzdb_account.erl
@@ -57,7 +57,7 @@ delete(_AccountId, AccountJObj) ->
                     ,DeleteRoutines
                     )
     of
-        {DeletedAccount, []} -> {'ok', DeletedAccount};
+        {DeletedAccount, []} ->   {'ok', DeletedAccount};
         {_AccountJObj, Errors} -> {'error', Errors}
     end.
 


### PR DESCRIPTION
If `realm` is included on the request, ensure created account reports
the custom `realm` after creation.

If `realm` is not included, ensure created account reports the `realm`
as a string containing the system-configured realm suffix.

Part of HELP-13467