### PR TITLE
Add previous_day method to kz_date

### DIFF
--- a/core/kazoo_stdlib/src/kz_date.erl
+++ b/core/kazoo_stdlib/src/kz_date.erl
@@ -19,6 +19,7 @@
         ,to_iso_week/1
 
         ,find_next_weekday/2
+        ,previous_day/1
         ,normalize/1
         ,relative_difference/2
 
@@ -135,6 +136,21 @@ find_next_weekday({Y, M, D}, Weekday) ->
         DOW ->
             normalize({Y, M, D + ( 7 - DOW ) + RefDOW})
     end.
+
+%%------------------------------------------------------------------------------
+%% @doc Calculates the date of the previous day, while also handling the situation
+%% where that day falls on the previous month or previous year.
+%% @end
+%%------------------------------------------------------------------------------
+-spec previous_day(kz_time:date()) -> kz_time:date().
+previous_day({Y, 1, 1}) ->
+    {Y-1, 12, days_in_month(Y-1, 12)};
+
+previous_day({Y, M, 1}) ->
+    {Y, M-1, days_in_month(Y, M-1)};
+
+previous_day({Y, M, D}) ->
+    {Y, M, D-1}.
 
 -spec from_iso8601(binary()) -> kz_time:date() | 'error'.
 from_iso8601(<<Year:4/binary, Month:2/binary, Day:2/binary>>) ->

--- a/core/kazoo_stdlib/test/kz_date_tests.erl
+++ b/core/kazoo_stdlib/test/kz_date_tests.erl
@@ -23,6 +23,8 @@ prev_date_test_() ->
     [?_assertEqual({2020,02,02}, kz_date:previous_day({2020,02,03}))
     ,?_assertEqual({2020,01,31}, kz_date:previous_day({2020,02,01}))
     ,?_assertEqual({2019,12,31}, kz_date:previous_day({2020,01,01}))
+    ,?_assertEqual({2020,02,29}, kz_date:previous_day({2020,03,01}))
+    ,?_assertEqual({2019,02,28}, kz_date:previous_day({2019,03,01}))
     ].
 
 pad_month_test_() ->

--- a/core/kazoo_stdlib/test/kz_date_tests.erl
+++ b/core/kazoo_stdlib/test/kz_date_tests.erl
@@ -19,6 +19,12 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+prev_date_test_() ->
+    [?_assertEqual({2020,02,02}, kz_date:previous_day({2020,02,03}))
+    ,?_assertEqual({2020,01,31}, kz_date:previous_day({2020,02,01}))
+    ,?_assertEqual({2019,12,31}, kz_date:previous_day({2020,01,01}))
+    ].
+
 pad_month_test_() ->
     [?_assertEqual(<<"10">>, kz_date:pad_month(10))
     ,?_assertEqual(<<"10">>, kz_date:pad_month(<<"10">>))


### PR DESCRIPTION
    kz_date:previous_day/1 will correctly handle month/year boundries
when calculating the previous day