### PR TITLE
[4.3] KZOO-57: calculate presence id for route requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,14 @@ workflows:
               ignore: /.*/
           requires:
             - build
+      - release:
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
+          requires:
+            - build
       - build_centos7:
           filters:
             tags:
@@ -104,7 +112,7 @@ workflows:
             - checks
             - docs
             - analyze
-
+            - release
 defaults: &defaults
   docker:
     - image: offical2600hz/circleci:19.3.6.13

--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -6,24 +6,23 @@
 %%%-----------------------------------------------------------------------------
 -module(cf_route_win).
 
--export([execute_callflow/2
-        ]).
+-export([execute_callflow/2]).
 
 -include("callflow.hrl").
 
--define(JSON(L), kz_json:from_list(L)).
+-define(TO_JSON(L), kz_json:from_list(L)).
 
 -define(DEFAULT_SERVICES
-       ,?JSON([{<<"audio">>, ?JSON([{<<"enabled">>, 'true'}])}
-              ,{<<"video">>, ?JSON([{<<"enabled">>, 'true'}])}
-              ,{<<"sms">>, ?JSON([{<<"enabled">>, 'true'}])}
-              ]
-             )
+       ,?TO_JSON([{<<"audio">>, ?TO_JSON([{<<"enabled">>, 'true'}])}
+                 ,{<<"video">>, ?TO_JSON([{<<"enabled">>, 'true'}])}
+                 ,{<<"sms">>, ?TO_JSON([{<<"enabled">>, 'true'}])}
+                 ]
+                )
        ).
 
--spec execute_callflow(kz_json:object(), kapps_call:call()) ->
+-spec execute_callflow(kapi_route:win(), kapps_call:call()) ->
           kapps_call:call().
-execute_callflow(JObj, Call) ->
+execute_callflow(RouteWin, Call) ->
     case should_restrict_call(Call) of
         'true' ->
             lager:debug("endpoint is restricted from making this call, terminate", []),
@@ -33,7 +32,7 @@ execute_callflow(JObj, Call) ->
             Call;
         'false' ->
             lager:info("setting initial information about the call"),
-            bootstrap_callflow_executer(JObj, Call)
+            bootstrap_callflow_executer(RouteWin, Call)
     end.
 
 -spec should_restrict_call(kapps_call:call()) -> boolean().
@@ -198,8 +197,8 @@ get_callee_extension_info(Call) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec bootstrap_callflow_executer(kz_json:object(), kapps_call:call()) -> kapps_call:call().
-bootstrap_callflow_executer(_JObj, Call) ->
+-spec bootstrap_callflow_executer(kapi_route:win(), kapps_call:call()) -> kapps_call:call().
+bootstrap_callflow_executer(_RouteWin, Call) ->
     Routines = [fun store_owner_id/1
                ,fun set_language/1
                ,fun update_ccvs/1

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -547,7 +547,7 @@ channel_vars_set_overwrite({Props, Results}) ->
 channel_vars_handle_asserted_identity({Props, Results}=Acc) ->
     Name = props:get_ne_binary_value(<<"Asserted-Identity-Name">>, Props),
     Number = props:get_ne_binary_value(<<"Asserted-Identity-Number">>, Props),
-    CCVs = props:get_value(<<"Custom-Channel-Vars">>, Props, kz_json:new()),
+    CCVs = props:get_json_value(<<"Custom-Channel-Vars">>, Props, kz_json:new()),
     DefaultRealm = kz_json:get_ne_binary_value(<<"Realm">>, CCVs),
     Realm = props:get_ne_binary_value(<<"Asserted-Identity-Realm">>, Props, DefaultRealm),
     case create_asserted_identity_header(Name, Number, Realm) of
@@ -731,7 +731,8 @@ kazoo_var_to_fs_var_fold(K, V, Acc) ->
     case lists:keyfind(K, 1, ?SPECIAL_CHANNEL_VARS) of
         'false' ->
             [list_to_binary([?CHANNEL_VAR_PREFIX, kz_term:to_list(K)
-                            ,"='", kz_term:to_list(V), "'"])
+                            ,"='", kz_term:to_list(V), "'"
+                            ])
              | Acc];
         {_, <<"group_confirm_file">>} ->
             [list_to_binary(["group_confirm_file='"

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -547,7 +547,7 @@ channel_vars_set_overwrite({Props, Results}) ->
 channel_vars_handle_asserted_identity({Props, Results}=Acc) ->
     Name = props:get_ne_binary_value(<<"Asserted-Identity-Name">>, Props),
     Number = props:get_ne_binary_value(<<"Asserted-Identity-Number">>, Props),
-    CCVs = props:get_json_value(<<"Custom-Channel-Vars">>, Props, kz_json:new()),
+    CCVs = props:get_value(<<"Custom-Channel-Vars">>, Props, kz_json:new()),
     DefaultRealm = kz_json:get_ne_binary_value(<<"Realm">>, CCVs),
     Realm = props:get_ne_binary_value(<<"Asserted-Identity-Realm">>, Props, DefaultRealm),
     case create_asserted_identity_header(Name, Number, Realm) of

--- a/core/kazoo_call/src/kapps_call.erl
+++ b/core/kazoo_call/src/kapps_call.erl
@@ -1321,7 +1321,10 @@ handle_ccvs_update(CCVs, #kapps_call{}=Call) ->
                             'undefined' -> C;
                             Value -> setelement(Index, C, Value)
                         end
-                end, Call#kapps_call{ccvs=CCVs}, ?SPECIAL_VARS).
+                end
+               ,Call#kapps_call{ccvs=CCVs}
+               ,?SPECIAL_VARS
+               ).
 
 -spec set_custom_publish_function(kapps_custom_publish(), call()) -> call().
 set_custom_publish_function(Fun, #kapps_call{}=Call) when is_function(Fun, 2) ->

--- a/core/kazoo_data/src/kz_data.hrl
+++ b/core/kazoo_data/src/kz_data.hrl
@@ -114,8 +114,15 @@
                              'system' |
                              'undefined'.
 
--type db_create_options() :: [{'q',integer()} | {'n',integer()} | 'ensure_other_dbs'].
--type db_delete_options() :: ['ensure_other_dbs'].
+-type db_create_option() :: {'q', non_neg_integer()} |
+                            {'n', non_neg_integer()} |
+                            'ensure_other_dbs' |
+                            {'ensure_other_dbs', boolean()}.
+-type db_create_options() :: [db_create_option()].
+
+-type db_delete_option() :: 'ensure_other_dbs' |
+                            {'ensure_other_dbs', boolean()} .
+-type db_delete_options() :: [db_delete_options()].
 
 -type ddoc() :: kz_term:ne_binary() | 'all_docs' | 'design_docs'.
 

--- a/core/kazoo_documents/src/kzd_devices.erl
+++ b/core/kazoo_documents/src/kzd_devices.erl
@@ -40,7 +40,9 @@
 -export([name/1, name/2, set_name/2]).
 -export([outbound_flags/1, outbound_flags/2, set_outbound_flags/2]).
 -export([owner_id/1, owner_id/2, set_owner_id/2]).
--export([presence_id/1, presence_id/2, set_presence_id/2]).
+-export([presence_id/1, presence_id/2, set_presence_id/2
+        ,calculate_presence_id/1, calculate_presence_id/2
+        ]).
 -export([provision/1, provision/2, set_provision/2]).
 -export([provision_combo_keys/1, provision_combo_keys/2, set_provision_combo_keys/2]).
 -export([provision_combo_key/2, provision_combo_key/3, set_provision_combo_key/3]).
@@ -549,6 +551,55 @@ presence_id(Doc, Default) ->
 -spec set_presence_id(doc(), binary()) -> doc().
 set_presence_id(Doc, PresenceId) ->
     kz_json:set_value([<<"presence_id">>], PresenceId, Doc).
+
+-spec calculate_presence_id(doc()) -> kz_term:api_ne_binary().
+calculate_presence_id(Doc) ->
+    calculate_presence_id(Doc, sip_username(Doc)).
+
+-spec calculate_presence_id(doc(), Default) -> kz_term:ne_binary() | Default.
+calculate_presence_id(Doc, Default) ->
+    DevicePresenceId = presence_id(Doc, Default),
+    case calculate_presence_id(Doc, DevicePresenceId, owner_id(Doc)) of
+        'undefined' -> 'undefined';
+        PresenceId -> maybe_fix_presence_id(Doc, PresenceId)
+    end.
+
+-spec maybe_fix_presence_id(doc(), kz_term:ne_binary()) -> kz_term:ne_binary().
+maybe_fix_presence_id(Doc, PresenceId) ->
+    case binary:match(PresenceId, <<"@">>) of
+        'nomatch' -> fix_presence_id(Doc, PresenceId);
+        _Match -> PresenceId
+    end.
+
+-spec fix_presence_id(doc(), kz_term:ne_binary()) -> kz_term:ne_binary().
+fix_presence_id(Doc, PresenceId) ->
+    AccountRealm = kzd_accounts:fetch_realm(kz_doc:account_id(Doc)),
+    <<PresenceId/binary, "@", AccountRealm/binary>>.
+
+-spec calculate_presence_id(doc(), Default, kz_term:api_ne_binary()) -> kz_term:ne_binary() | Default.
+calculate_presence_id(Doc, DevicePresenceId, 'undefined') ->
+    calculate_presence_id_from_hotdesk(Doc, DevicePresenceId, hotdesk_ids(Doc, []));
+calculate_presence_id(Doc, DevicePresenceId, OwnerId) ->
+    calculate_presence_id_from_owner(Doc, DevicePresenceId, OwnerId).
+
+-spec calculate_presence_id_from_owner(doc(), Default, kz_term:ne_binary()) -> kz_term:ne_binary() | Default.
+calculate_presence_id_from_owner(Doc, DevicePresenceId, OwnerId) ->
+    case kzd_users:fetch(kz_doc:account_db(Doc), OwnerId) of
+        {'ok', Owner} ->
+            kzd_users:presence_id(Owner, DevicePresenceId);
+        {'error', _} ->
+            DevicePresenceId
+    end.
+
+-spec calculate_presence_id_from_hotdesk(doc(), Default, kz_term:ne_binary()) -> kz_term:ne_binary() | Default.
+calculate_presence_id_from_hotdesk(_Doc, DevicePresenceId, []) -> DevicePresenceId;
+calculate_presence_id_from_hotdesk(Doc, DevicePresenceId, [HotdeskId|HotdeskIds]) ->
+    case calculate_presence_id_from_owner(Doc, DevicePresenceId, HotdeskId) of
+        DevicePresenceId -> calculate_presence_id_from_hotdesk(Doc, DevicePresenceId, HotdeskIds);
+        HotdeskPresenceId ->
+            lager:debug("using hotdesk presence id ~s from ~s", [HotdeskPresenceId, HotdeskId]),
+            HotdeskPresenceId
+    end.
 
 -spec provision(doc()) -> kz_term:api_object().
 provision(Doc) ->

--- a/core/kazoo_documents/test/kzd_device_tests.erl
+++ b/core/kazoo_documents/test/kzd_device_tests.erl
@@ -267,9 +267,9 @@ test_calculating_presence_id() ->
                                       ,<<"call_forward">>
                                       ,<<"call_recording">>
                                       ,<<"call_restriction">>
-                                           ,<<"caller_id">>
-                                           ,<<"dial_plan">>
-                                           ,<<"media">>, <<"metaflows">>, <<"ringtones">>
+                                      ,<<"caller_id">>
+                                      ,<<"dial_plan">>
+                                      ,<<"media">>, <<"metaflows">>, <<"ringtones">>
                                       ]
                                      , Device),
     JustUsername = kzd_devices:set_sip_username(BlankDevice, SIPUsername),

--- a/core/kazoo_endpoint/src/kz_attributes.erl
+++ b/core/kazoo_endpoint/src/kz_attributes.erl
@@ -474,25 +474,8 @@ presence_id(Endpoint, Call) ->
     presence_id(Endpoint, Call, Username).
 
 -spec presence_id(kz_json:object(), kapps_call:call(), Default) -> kz_term:ne_binary() | Default.
-presence_id(Endpoint, Call, Default) ->
-    PresenceId = kzd_devices:presence_id(Endpoint, Default),
-    case kz_term:is_empty(PresenceId) of
-        'true' -> maybe_fix_presence_id_realm(Default, Endpoint, Call);
-        'false' -> maybe_fix_presence_id_realm(PresenceId, Endpoint, Call)
-    end.
-
--spec maybe_fix_presence_id_realm(kz_term:ne_binary(), kz_json:object(), kapps_call:call()) -> kz_term:api_ne_binary().
-maybe_fix_presence_id_realm('undefined', _Endpoint, _Call) -> 'undefined';
-maybe_fix_presence_id_realm(PresenceId, Endpoint, Call) ->
-    case binary:match(PresenceId, <<"@">>) of
-        'nomatch' ->
-            Realm = kz_endpoint:get_sip_realm(Endpoint
-                                             ,kapps_call:account_id(Call)
-                                             ,kapps_call:request_realm(Call)
-                                             ),
-            <<PresenceId/binary, $@, Realm/binary>>;
-        _Else -> PresenceId
-    end.
+presence_id(Endpoint, _Call, Default) ->
+    kzd_devices:calculate_presence_id(Endpoint, Default).
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
+++ b/core/kazoo_number_manager/src/kazoo_number_manager_maintenance.erl
@@ -278,7 +278,7 @@ update_number_services_view(?MATCH_ACCOUNT_ENCODED(_)=AccountDb) ->
                {'ok', JObj} -> JObj;
                {'error', _R} ->
                    lager:debug("reading account view ~s from disk (~p)", [ViewName, _R]),
-                   {ViewName,JObj} = kapps_util:get_view_json('crossbar', <<"account/numbers.json">>),
+                   {ViewName,JObj} = kapps_util:get_view_json('kazoo_apps', <<"account/numbers.json">>),
                    JObj
            end,
     PathMap = [<<"views">>, <<"reconcile_services">>, <<"map">>],

--- a/core/kazoo_proper/src/pqc_kz_datamgr.erl
+++ b/core/kazoo_proper/src/pqc_kz_datamgr.erl
@@ -24,12 +24,13 @@ run_it(F) -> F().
 
 -spec seq_kzoo_56() -> 'ok'.
 seq_kzoo_56() ->
+    kz_datamgr:suppress_change_notice(),
     Doc = kz_json:from_list([{<<"_id">>, ?FROM_DOC_ID}
                              | [{kz_binary:rand_hex(4), kz_binary:rand_hex(5)} || _ <- lists:seq(1,10)]
                             ]),
 
-    'true' = kz_datamgr:db_create(?FROM_DB),
-    'true' = kz_datamgr:db_create(?TO_DB),
+    'true' = kz_datamgr:db_create(?FROM_DB, [{'publish_db', 'false'}]),
+    'true' = kz_datamgr:db_create(?TO_DB, [{'publish_db', 'false'}]),
 
     {'ok', _SavedDoc} = kz_datamgr:save_doc(?FROM_DB, Doc),
 
@@ -50,6 +51,7 @@ seq_kzoo_56() ->
 cleanup() ->
     'true' = kz_datamgr:db_delete(?FROM_DB),
     'true' = kz_datamgr:db_delete(?TO_DB),
+    kz_datamgr:enable_change_notice(),
     lager:info("CLEANUP FINISHED").
 
 save_mp3(DB, DocId, AttId, MP3) ->


### PR DESCRIPTION
When a device registers, the calculated presence_id is cached and
passed along on subsequent INVITEs. If a user hotdesks into the
device, the cached presence_id (likely the SIP username of the device)
will continue to be used on call events related to that device.

This causes issues with applications (like Qubicle) that track a
user's calls based on the user's presence_id being present on dialog
update events (confirmed and terminated).

Instead, provide a uniform way to calculate a device's presence_id and
use it for setting CCVs on the route response in callflow and in
registrar for authn responses.