### PR TITLE
KZOO-57: calculate presence id for route requests

### DIFF
--- a/applications/callflow/src/cf_flow.erl
+++ b/applications/callflow/src/cf_flow.erl
@@ -54,8 +54,7 @@ return_callflow_doc(FlowId, AccountId) ->
 
 -spec return_callflow_doc(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> lookup_ret().
 return_callflow_doc(FlowId, AccountId, Props) ->
-    Db = kzs_util:format_account_db(AccountId),
-    case kz_datamgr:open_cache_doc(Db, FlowId) of
+    case kz_datamgr:open_cache_doc(AccountId, FlowId) of
         {'ok', Doc} ->
             {'ok', kz_json:set_values(Props, Doc), contains_no_match(Doc)};
         Error -> Error
@@ -63,28 +62,28 @@ return_callflow_doc(FlowId, AccountId, Props) ->
 
 -spec contains_no_match(kzd_callflows:doc()) -> boolean().
 contains_no_match(Doc) ->
-    lists:any(fun(Number) when Number =:= ?NO_MATCH_CF ->
-                      'true';
-                 (_) ->
-                      'false'
-              end, kzd_callflows:numbers(Doc)).
+    lists:any(fun is_no_match_number/1
+             ,kzd_callflows:numbers(Doc)
+             ).
+
+-spec is_no_match_number(kz_term:ne_binary()) -> boolean().
+is_no_match_number(Number) -> Number =:= ?NO_MATCH_CF.
 
 -spec do_lookup(kz_term:ne_binary(), kz_term:ne_binary()) -> lookup_ret().
 do_lookup(Number, AccountId) ->
-    Db = kzs_util:format_account_db(AccountId),
-    lager:info("searching for callflow in ~s to satisfy '~s'", [Db, Number]),
+    lager:info("searching for callflow in ~s to satisfy '~s'", [AccountId, Number]),
     Options = [{'key', Number}, 'include_docs'],
-    case kz_datamgr:get_results(Db, ?LIST_BY_NUMBER, Options) of
+    case kz_datamgr:get_results(AccountId, ?LIST_BY_NUMBER, Options) of
         {'error', _}=E -> E;
         {'ok', []} when Number =/= ?NO_MATCH_CF ->
             lookup_patterns(Number, AccountId);
         {'ok', []} -> {'error', 'not_found'};
         {'ok', [JObj]} ->
-            Flow = kz_json:get_value(<<"doc">>, JObj),
+            Flow = kz_json:get_json_value(<<"doc">>, JObj),
             cache_callflow_number(Number, AccountId, Flow);
         {'ok', [JObj | _Rest]} ->
             lager:info("lookup resulted in more than one result, using the first"),
-            Flow = kz_json:get_value(<<"doc">>, JObj),
+            Flow = kz_json:get_json_value(<<"doc">>, JObj),
             cache_callflow_number(Number, AccountId, Flow)
     end.
 

--- a/applications/callflow/src/cf_route_req.erl
+++ b/applications/callflow/src/cf_route_req.erl
@@ -192,7 +192,7 @@ send_route_response(Flow, RouteReq, Call) ->
              ,{<<"Custom-Channel-Vars">>, ccvs(Flow, RouteReq, Call)}
              ,{<<"Custom-Application-Vars">>, cavs(Flow, RouteReq, Call)}
              ,{<<"Context">>, kapps_call:context(Call)}
-             | kz_api:default_headers(ControllerQ, ?APP_NAME, ?APP_VERSION)
+              | kz_api:default_headers(ControllerQ, ?APP_NAME, ?APP_VERSION)
              ]),
     ServerId = kz_api:server_id(RouteReq),
     kapi_route:publish_resp(ServerId, Resp),

--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -140,7 +140,7 @@ enforce_closed_groups(EndpointJObj, Call) ->
 get_caller_groups(Groups, EndpointJObj, Call) ->
     Ids = [kapps_call:authorizing_id(Call)
           ,kz_json:get_ne_binary_value(<<"owner_id">>, EndpointJObj)
-          | kz_json:get_keys([<<"hotdesk">>, <<"users">>], EndpointJObj)
+           | kz_json:get_keys([<<"hotdesk">>, <<"users">>], EndpointJObj)
           ],
     lists:foldl(fun('undefined', Set) -> Set;
                    (Id, Set) -> get_group_associations(Id, Groups, Set)

--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -49,36 +49,36 @@ should_restrict_call('undefined', _Call) -> 'false';
 should_restrict_call(EndpointId, Call) ->
     case kz_endpoint:get(EndpointId, Call) of
         {'error', _R} -> 'false';
-        {'ok', JObj} -> maybe_service_unavailable(JObj, Call)
+        {'ok', EndpointJObj} -> maybe_service_unavailable(EndpointJObj, Call)
     end.
 
 -spec maybe_service_unavailable(kz_json:object(), kapps_call:call()) -> boolean().
-maybe_service_unavailable(JObj, Call) ->
-    Id = kz_doc:id(JObj),
-    Services = get_services(JObj),
+maybe_service_unavailable(EndpointJObj, Call) ->
+    Id = kz_doc:id(EndpointJObj),
+    Services = get_services(EndpointJObj),
     case kz_json:is_true([<<"audio">>,<<"enabled">>], Services, 'true') of
         'true' ->
-            maybe_account_service_unavailable(JObj, Call);
+            maybe_account_service_unavailable(EndpointJObj, Call);
         'false' ->
             lager:debug("device ~s does not have audio service enabled", [Id]),
             'true'
     end.
 
 -spec get_services(kz_json:object()) -> kz_json:object().
-get_services(JObj) ->
-    kz_json:merge(kz_json:get_json_value(<<"services">>, JObj, ?DEFAULT_SERVICES)
-                 ,kz_json:get_json_value(<<"pvt_services">>, JObj, kz_json:new())
+get_services(EndpointJObj) ->
+    kz_json:merge(kz_json:get_json_value(<<"services">>, EndpointJObj, ?DEFAULT_SERVICES)
+                 ,kz_json:get_json_value(<<"pvt_services">>, EndpointJObj, kz_json:new())
                  ).
 
 -spec maybe_account_service_unavailable(kz_json:object(), kapps_call:call()) -> boolean().
-maybe_account_service_unavailable(JObj, Call) ->
+maybe_account_service_unavailable(EndpointJObj, Call) ->
     AccountId = kapps_call:account_id(Call),
-    {'ok', Doc} = kzd_accounts:fetch(AccountId),
-    Services = get_services(Doc),
+    {'ok', AccountDoc} = kzd_accounts:fetch(AccountId),
+    Services = get_services(AccountDoc),
 
     case kz_json:is_true([<<"audio">>,<<"enabled">>], Services, 'true') of
         'true' ->
-            maybe_closed_group_restriction(JObj, Call);
+            maybe_closed_group_restriction(EndpointJObj, Call);
         'false' ->
             lager:debug("account ~s does not have audio service enabled", [AccountId]),
             'true'
@@ -86,24 +86,24 @@ maybe_account_service_unavailable(JObj, Call) ->
 
 -spec maybe_closed_group_restriction(kz_json:object(), kapps_call:call()) ->
           boolean().
-maybe_closed_group_restriction(JObj, Call) ->
-    case kz_json:get_value([<<"call_restriction">>, <<"closed_groups">>, <<"action">>], JObj) of
-        <<"deny">> -> enforce_closed_groups(JObj, Call);
-        _Else -> maybe_classification_restriction(JObj, Call)
+maybe_closed_group_restriction(EndpointJObj, Call) ->
+    case kz_json:get_value([<<"call_restriction">>, <<"closed_groups">>, <<"action">>], EndpointJObj) of
+        <<"deny">> -> enforce_closed_groups(EndpointJObj, Call);
+        _Else -> maybe_classification_restriction(EndpointJObj, Call)
     end.
 
 -spec maybe_classification_restriction(kz_json:object(), kapps_call:call()) ->
           boolean().
-maybe_classification_restriction(JObj, Call) ->
+maybe_classification_restriction(EndpointJObj, Call) ->
     Request = find_request(Call),
     AccountId = kapps_call:account_id(Call),
-    DialPlan = kz_json:get_json_value(<<"dial_plan">>, JObj, kz_json:new()),
+    DialPlan = kz_json:get_json_value(<<"dial_plan">>, EndpointJObj, kz_json:new()),
     Number = knm_converters:normalize(Request, AccountId, DialPlan),
     Classification = knm_converters:classify(Number),
     lager:debug("classified number ~s as ~s, testing for call restrictions"
                ,[Number, Classification]
                ),
-    kz_json:get_value([<<"call_restriction">>, Classification, <<"action">>], JObj) =:= <<"deny">>.
+    kz_json:get_value([<<"call_restriction">>, Classification, <<"action">>], EndpointJObj) =:= <<"deny">>.
 
 -spec find_request(kapps_call:call()) -> kz_term:ne_binary().
 find_request(Call) ->
@@ -118,29 +118,29 @@ find_request(Call) ->
     end.
 
 -spec enforce_closed_groups(kz_json:object(), kapps_call:call()) -> boolean().
-enforce_closed_groups(JObj, Call) ->
+enforce_closed_groups(EndpointJObj, Call) ->
     case get_callee_extension_info(Call) of
         'undefined' ->
             lager:info("dialed number is not an extension, using classification restrictions", []),
-            maybe_classification_restriction(JObj, Call);
+            maybe_classification_restriction(EndpointJObj, Call);
         {<<"user">>, CalleeId} ->
             lager:info("dialed number is user ~s extension, checking groups", [CalleeId]),
             Groups = kz_attributes:groups(Call),
-            CallerGroups = get_caller_groups(Groups, JObj, Call),
+            CallerGroups = get_caller_groups(Groups, EndpointJObj, Call),
             CalleeGroups = get_group_associations(CalleeId, Groups),
             sets:size(sets:intersection(CallerGroups, CalleeGroups)) =:= 0;
         {<<"device">>, CalleeId} ->
             lager:info("dialed number is device ~s extension, checking groups", [CalleeId]),
             Groups = kz_attributes:groups(Call),
-            CallerGroups = get_caller_groups(Groups, JObj, Call),
+            CallerGroups = get_caller_groups(Groups, EndpointJObj, Call),
             maybe_device_groups_intersect(CalleeId, CallerGroups, Groups, Call)
     end.
 
 -spec get_caller_groups(kz_json:objects(), kz_json:object(), kapps_call:call()) -> sets:set().
-get_caller_groups(Groups, JObj, Call) ->
+get_caller_groups(Groups, EndpointJObj, Call) ->
     Ids = [kapps_call:authorizing_id(Call)
-          ,kz_json:get_ne_binary_value(<<"owner_id">>, JObj)
-           | kz_json:get_keys([<<"hotdesk">>, <<"users">>], JObj)
+          ,kz_json:get_ne_binary_value(<<"owner_id">>, EndpointJObj)
+          | kz_json:get_keys([<<"hotdesk">>, <<"users">>], EndpointJObj)
           ],
     lists:foldl(fun('undefined', Set) -> Set;
                    (Id, Set) -> get_group_associations(Id, Groups, Set)

--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -15,19 +15,19 @@
 
 -include("callflow.hrl").
 
--define(JSON(L), kz_json:from_list(L)).
+-define(TO_JSON(L), kz_json:from_list(L)).
 
 -define(DEFAULT_SERVICES
-       ,?JSON([{<<"audio">>, ?JSON([{<<"enabled">>, 'true'}])}
-              ,{<<"video">>, ?JSON([{<<"enabled">>, 'true'}])}
-              ,{<<"sms">>, ?JSON([{<<"enabled">>, 'true'}])}
-              ]
-             )
+       ,?TO_JSON([{<<"audio">>, ?TO_JSON([{<<"enabled">>, 'true'}])}
+                 ,{<<"video">>, ?TO_JSON([{<<"enabled">>, 'true'}])}
+                 ,{<<"sms">>, ?TO_JSON([{<<"enabled">>, 'true'}])}
+                 ]
+                )
        ).
 
--spec execute_callflow(kz_json:object(), kapps_call:call()) ->
+-spec execute_callflow(kapi_route:win(), kapps_call:call()) ->
           {'ok' | 'restricted', kapps_call:call()}.
-execute_callflow(JObj, Call) ->
+execute_callflow(RouteWin, Call) ->
     case should_restrict_call(Call) of
         'true' ->
             lager:debug("endpoint is restricted from making this call, terminate", []),
@@ -37,7 +37,7 @@ execute_callflow(JObj, Call) ->
             {'restricted', Call};
         'false' ->
             lager:info("setting initial information about the call"),
-            {'ok', bootstrap_callflow_executer(JObj, Call)}
+            {'ok', bootstrap_callflow_executer(RouteWin, Call)}
     end.
 
 -spec should_restrict_call(kapps_call:call()) -> boolean().
@@ -202,8 +202,8 @@ get_callee_extension_info(Call) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec bootstrap_callflow_executer(kz_json:object(), kapps_call:call()) -> kapps_call:call().
-bootstrap_callflow_executer(_JObj, Call) ->
+-spec bootstrap_callflow_executer(kapi_route:win(), kapps_call:call()) -> kapps_call:call().
+bootstrap_callflow_executer(_RouteWin, Call) ->
     Routines = [fun store_owner_id/1
                ,fun set_language/1
                ,fun include_denied_call_restrictions/1

--- a/applications/crossbar/doc/callflows.md
+++ b/applications/crossbar/doc/callflows.md
@@ -19,10 +19,14 @@ Key | Description | Type | Default | Required | Support Level
 `flags` | Flags set by external applications | `array(string())` |   | `false` | `supported`
 `flow` | A callflow node defines a module to execute, data to provide to that module, and zero or more children to branch to | [#/definitions/callflows.action](#callflowsaction) |   | `false` |  
 `metaflow` | Actions applied to a call outside of the normal callflow, initiated by the caller(s) | [#/definitions/metaflows](#metaflows) |   | `false` |  
+`name` | Friendly name of the callflow | `string()` |   | `false` |  
 `numbers.[]` |   | `string(1..36)` |   | `false` |  
 `numbers` | A list of static numbers that the callflow should execute for | `array(string(1..36))` | `[]` | `false` |  
 `patterns.[]` |   | `string(1..)` |   | `false` |  
 `patterns` | A list of regular expressions that the callflow should execute for, with optional capture groups | `array(string(1..))` | `[]` | `false` |  
+`ringback.early` | Media ID for the early ringback media | `string()` |   | `false` |  
+`ringback.transfer` | Media ID for transfer ringback media | `string()` |   | `false` |  
+`ringback` | Ringback settings for early media and transfers | `object()` |   | `false` |  
 
 ### callflows.action
 

--- a/applications/crossbar/doc/ref/callflows.md
+++ b/applications/crossbar/doc/ref/callflows.md
@@ -17,10 +17,14 @@ Key | Description | Type | Default | Required | Support Level
 `flags` | Flags set by external applications | `array(string())` |   | `false` | `supported`
 `flow` | A callflow node defines a module to execute, data to provide to that module, and zero or more children to branch to | [#/definitions/callflows.action](#callflowsaction) |   | `false` |  
 `metaflow` | Actions applied to a call outside of the normal callflow, initiated by the caller(s) | [#/definitions/metaflows](#metaflows) |   | `false` |  
+`name` | Friendly name of the callflow | `string()` |   | `false` |  
 `numbers.[]` |   | `string(1..36)` |   | `false` |  
 `numbers` | A list of static numbers that the callflow should execute for | `array(string(1..36))` | `[]` | `false` |  
 `patterns.[]` |   | `string(1..)` |   | `false` |  
 `patterns` | A list of regular expressions that the callflow should execute for, with optional capture groups | `array(string(1..))` | `[]` | `false` |  
+`ringback.early` | Media ID for the early ringback media | `string()` |   | `false` |  
+`ringback.transfer` | Media ID for transfer ringback media | `string()` |   | `false` |  
+`ringback` | Ringback settings for early media and transfers | `object()` |   | `false` |  
 
 ### callflows.action
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -1356,6 +1356,10 @@
                     "$ref": "#/definitions/metaflows",
                     "description": "Actions applied to a call outside of the normal callflow, initiated by the caller(s)"
                 },
+                "name": {
+                    "description": "Friendly name of the callflow",
+                    "type": "string"
+                },
                 "numbers": {
                     "default": [],
                     "description": "A list of static numbers that the callflow should execute for",
@@ -1375,6 +1379,20 @@
                         "type": "string"
                     },
                     "type": "array"
+                },
+                "ringback": {
+                    "description": "Ringback settings for early media and transfers",
+                    "properties": {
+                        "early": {
+                            "description": "Media ID for the early ringback media",
+                            "type": "string"
+                        },
+                        "transfer": {
+                            "description": "Media ID for transfer ringback media",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/callflows.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.json
@@ -35,6 +35,10 @@
             "$ref": "metaflows",
             "description": "Actions applied to a call outside of the normal callflow, initiated by the caller(s)"
         },
+        "name": {
+            "description": "Friendly name of the callflow",
+            "type": "string"
+        },
         "numbers": {
             "default": [],
             "description": "A list of static numbers that the callflow should execute for",
@@ -54,6 +58,20 @@
                 "type": "string"
             },
             "type": "array"
+        },
+        "ringback": {
+            "description": "Ringback settings for early media and transfers",
+            "properties": {
+                "early": {
+                    "description": "Media ID for the early ringback media",
+                    "type": "string"
+                },
+                "transfer": {
+                    "description": "Media ID for transfer ringback media",
+                    "type": "string"
+                }
+            },
+            "type": "object"
         }
     },
     "type": "object"

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -1112,6 +1112,9 @@
       '$ref': '#/metaflows'
       'description': |-
         Actions applied to a call outside of the normal callflow, initiated by the caller(s)
+    'name':
+      'description': Friendly name of the callflow
+      'type': string
     'numbers':
       'default': []
       'description': A list of static numbers that the callflow should execute for
@@ -1129,6 +1132,16 @@
         'minLength': 1
         'type': string
       'type': array
+    'ringback':
+      'description': Ringback settings for early media and transfers
+      'properties':
+        'early':
+          'description': Media ID for the early ringback media
+          'type': string
+        'transfer':
+          'description': Media ID for transfer ringback media
+          'type': string
+      'type': object
   'type': object
 'callflows.acdc_agent':
   'description': Validator for the acdc_agent callflow data object

--- a/applications/ecallmgr/src/ecallmgr_discovery.erl
+++ b/applications/ecallmgr/src/ecallmgr_discovery.erl
@@ -49,7 +49,7 @@ start_link() ->
 %%
 %% @end
 %%------------------------------------------------------------------------------
--spec init(list()) -> {'ok', state(), pos_integer()}.
+-spec init(list()) -> {'ok', state(), ?MILLISECONDS_IN_SECOND}.
 init([]) ->
     lager:info("starting discovery"),
     {'ok', kz_time:start_time(), ?MILLISECONDS_IN_SECOND}.
@@ -61,7 +61,7 @@ init([]) ->
 %%------------------------------------------------------------------------------
 -spec handle_call(any(), kz_term:pid_ref(), state()) -> kz_types:handle_call_ret_state(state()).
 handle_call(_Request, _From, Startup) ->
-    {'reply', {'error', 'not_implemented'}, next_timeout(kz_time:elapsed_s(Startup))}.
+    {'reply', {'error', 'not_implemented'}, Startup, next_timeout(kz_time:elapsed_s(Startup))}.
 
 %%------------------------------------------------------------------------------
 %% @doc Handling cast messages

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -455,7 +455,6 @@ route_resp_cavs(JObj) ->
 
 -spec route_ccvs_list(kz_term:proplist()) -> kz_term:ne_binary().
 route_ccvs_list(CCVs) ->
-    lager:debug("route ccvs: ~p", [CCVs]),
     L = [kz_term:to_list(ecallmgr_util:get_fs_kv(K, V))
          || {K, V} <- CCVs
         ],

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -579,7 +579,7 @@ channel_vars_set_overwrite({Props, Results}) ->
 channel_vars_handle_asserted_identity({Props, Results}=Acc) ->
     Name = props:get_ne_binary_value(<<"Asserted-Identity-Name">>, Props),
     Number = props:get_ne_binary_value(<<"Asserted-Identity-Number">>, Props),
-    CCVs = props:get_json_value(<<"Custom-Channel-Vars">>, Props, kz_json:new()),
+    CCVs = props:get_value(<<"Custom-Channel-Vars">>, Props, kz_json:new()),
     DefaultRealm = kz_json:get_ne_binary_value(<<"Realm">>, CCVs),
     Realm = props:get_ne_binary_value(<<"Asserted-Identity-Realm">>, Props, DefaultRealm),
     case create_asserted_identity_header(Name, Number, Realm) of

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -579,7 +579,7 @@ channel_vars_set_overwrite({Props, Results}) ->
 channel_vars_handle_asserted_identity({Props, Results}=Acc) ->
     Name = props:get_ne_binary_value(<<"Asserted-Identity-Name">>, Props),
     Number = props:get_ne_binary_value(<<"Asserted-Identity-Number">>, Props),
-    CCVs = props:get_value(<<"Custom-Channel-Vars">>, Props, kz_json:new()),
+    CCVs = props:get_json_value(<<"Custom-Channel-Vars">>, Props, kz_json:new()),
     DefaultRealm = kz_json:get_ne_binary_value(<<"Realm">>, CCVs),
     Realm = props:get_ne_binary_value(<<"Asserted-Identity-Realm">>, Props, DefaultRealm),
     case create_asserted_identity_header(Name, Number, Realm) of
@@ -792,7 +792,8 @@ kazoo_var_to_fs_var_fold(K, V, Acc) ->
                             ,kz_term:to_list(ecallmgr_util:media_path(V, 'extant', get('callid'), kz_json:new()))
                             ,"'"
                             ])
-             | Acc];
+             | Acc
+            ];
         {_, Prefix} ->
             Val = ecallmgr_util:maybe_sanitize_fs_value(K, V),
             [encode_fs_val(Prefix, Val) | Acc]

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -455,6 +455,7 @@ route_resp_cavs(JObj) ->
 
 -spec route_ccvs_list(kz_term:proplist()) -> kz_term:ne_binary().
 route_ccvs_list(CCVs) ->
+    lager:debug("route ccvs: ~p", [CCVs]),
     L = [kz_term:to_list(ecallmgr_util:get_fs_kv(K, V))
          || {K, V} <- CCVs
         ],

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -547,6 +547,7 @@ get_fs_kv(<<"Hold-Media">>, Media, UUID) ->
 get_fs_kv(?CCV(Key), Val, UUID) ->
     get_fs_kv(Key, Val, UUID);
 get_fs_kv(Key, Val, _) ->
+    lager:debug("get_fs_kv ~p ~p", [Key, Val]),
     list_to_binary([get_fs_key(Key), "=", maybe_sanitize_fs_value(Key, Val)]).
 
 -spec get_fs_key(kz_term:ne_binary()) -> binary().

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -547,7 +547,6 @@ get_fs_kv(<<"Hold-Media">>, Media, UUID) ->
 get_fs_kv(?CCV(Key), Val, UUID) ->
     get_fs_kv(Key, Val, UUID);
 get_fs_kv(Key, Val, _) ->
-    lager:debug("get_fs_kv ~p ~p", [Key, Val]),
     list_to_binary([get_fs_key(Key), "=", maybe_sanitize_fs_value(Key, Val)]).
 
 -spec get_fs_key(kz_term:ne_binary()) -> binary().
@@ -623,7 +622,9 @@ maybe_sanitize_fs_value(<<"Export-Bridge-Variables">>, Val) ->
     kz_binary:join(Val, <<",">>);
 maybe_sanitize_fs_value(<<"Export-Variables">>, Val) ->
     kz_binary:join(Val, <<",">>);
-maybe_sanitize_fs_value(<<"Require-Fail-On-Single-Reject">>, Val) ->
+maybe_sanitize_fs_value(<<"Require-Fail-On-Single-Reject">>, <<Val/binary>>) ->
+    Val;
+maybe_sanitize_fs_value(<<"Require-Fail-On-Single-Reject">>, Val) when is_list(Val) ->
     kz_binary:join(Val, <<",">>);
 maybe_sanitize_fs_value(Key, Val) when not is_binary(Key) ->
     maybe_sanitize_fs_value(kz_term:to_binary(Key), Val);

--- a/applications/registrar/src/reg_authn_req.erl
+++ b/applications/registrar/src/reg_authn_req.erl
@@ -115,11 +115,10 @@ create_ccvs(#auth_user{doc=JObj}=AuthUser) ->
 -spec maybe_get_presence_id(auth_user()) -> kz_term:api_binary().
 maybe_get_presence_id(#auth_user{account_db=AccountDb
                                 ,authorizing_id=DeviceId
-                                ,owner_id=OwnerId
                                 ,account_realm=AccountRealm
                                 }
                      ) ->
-    case get_presence_id(AccountDb, DeviceId, OwnerId) of
+    case get_presence_id(AccountDb, DeviceId) of
         'undefined' -> 'undefined';
         PresenceId ->
             case binary:match(PresenceId, <<"@">>) of
@@ -128,31 +127,18 @@ maybe_get_presence_id(#auth_user{account_db=AccountDb
             end
     end.
 
--spec get_presence_id(kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()) -> kz_term:api_binary().
-get_presence_id('undefined', _, _) -> 'undefined';
-get_presence_id(_, 'undefined', 'undefined') -> 'undefined';
-get_presence_id(AccountDb, DeviceId, 'undefined') ->
-    get_device_presence_id(AccountDb, DeviceId);
-get_presence_id(AccountDb, DeviceId, OwnerId) ->
-    maybe_get_owner_presence_id(AccountDb, DeviceId, OwnerId).
+-spec get_presence_id(kz_term:api_ne_binary(), kz_term:api_ne_binary()) -> kz_term:api_ne_binary().
+get_presence_id('undefined', _) -> 'undefined';
+get_presence_id(_, 'undefined') -> 'undefined';
+get_presence_id(AccountDb, DeviceId) ->
+    get_device_presence_id(AccountDb, DeviceId).
 
--spec maybe_get_owner_presence_id(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_binary().
-maybe_get_owner_presence_id(AccountDb, DeviceId, OwnerId) ->
-    case kz_datamgr:open_cache_doc(AccountDb, OwnerId) of
-        {'error', _} -> 'undefined';
-        {'ok', UserJObj} ->
-            case kzd_users:presence_id(UserJObj) of
-                'undefined' -> get_device_presence_id(AccountDb, DeviceId);
-                PresenceId -> PresenceId
-            end
-    end.
-
--spec get_device_presence_id(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_binary().
+-spec get_device_presence_id(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_term:api_ne_binary().
 get_device_presence_id(AccountDb, DeviceId) ->
     case kz_datamgr:open_cache_doc(AccountDb, DeviceId) of
         {'error', _} -> 'undefined';
-        {'ok', JObj} ->
-            case kzd_devices:presence_id(JObj) of
+        {'ok', DeviceJObj} ->
+            case kzd_devices:calculate_presence_id(DeviceJObj) of
                 'undefined' -> 'undefined';
                 PresenceId -> PresenceId
             end

--- a/core/kazoo_amqp/src/api/kapi_authn.erl
+++ b/core/kazoo_amqp/src/api/kapi_authn.erl
@@ -221,7 +221,7 @@ resp_definition() ->
                                      ,<<"a1-hash">>, <<"error">>
                                      ,<<"gsm">>, <<"nonce">>, <<"a3a8">>
                                      ]}
-                 | kapi_definition:event_type_headers(Category, EventName)
+                | kapi_definition:event_type_headers(Category, EventName)
                 ]
                }
               ,{fun kapi_definition:set_types/2
@@ -455,10 +455,10 @@ unbind_q(Q, Props) ->
     unbind_q(Q, Realm, RestrictTo).
 
 unbind_q(Q, Realm, ['authn_req' | RestrictTo]) ->
-    kz_amqp_util:unbind_q_from_callmgr(Q, get_authn_req_routing(Realm)),
+    _ = kz_amqp_util:unbind_q_from_callmgr(Q, get_authn_req_routing(Realm)),
     unbind_q(Q, Realm, RestrictTo);
 unbind_q(Q, Realm, ['token_req' | RestrictTo]) ->
-    kz_amqp_util:unbind_q_from_callmgr(Q, get_authn_token_req_routing(Realm)),
+    _ = kz_amqp_util:unbind_q_from_callmgr(Q, get_authn_token_req_routing(Realm)),
     unbind_q(Q, Realm, RestrictTo);
 unbind_q(_Q, _Realm, []) -> 'ok'.
 

--- a/core/kazoo_amqp/src/api/kapi_authn.erl
+++ b/core/kazoo_amqp/src/api/kapi_authn.erl
@@ -221,7 +221,7 @@ resp_definition() ->
                                      ,<<"a1-hash">>, <<"error">>
                                      ,<<"gsm">>, <<"nonce">>, <<"a3a8">>
                                      ]}
-                | kapi_definition:event_type_headers(Category, EventName)
+                 | kapi_definition:event_type_headers(Category, EventName)
                 ]
                }
               ,{fun kapi_definition:set_types/2

--- a/core/kazoo_amqp/src/api/kapi_self.erl
+++ b/core/kazoo_amqp/src/api/kapi_self.erl
@@ -41,7 +41,7 @@ publish_message(ServerId, API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, [], fun build/1),
     kz_amqp_util:targeted_publish(ServerId, Payload, ContentType).
 
--spec build(kz_term:api_terms()) -> {'ok', iolist()}.
+-spec build(kz_term:api_terms()) -> kz_api:api_formatter_return().
 build(Prop) when is_list(Prop) ->
     kz_api:build_message(Prop, [], []);
 build(JObj) ->

--- a/core/kazoo_data/src/kz_data.hrl
+++ b/core/kazoo_data/src/kz_data.hrl
@@ -114,8 +114,15 @@
                              'system' |
                              'undefined'.
 
--type db_create_options() :: [{'q',integer()} | {'n',integer()} | 'ensure_other_dbs'].
--type db_delete_options() :: ['ensure_other_dbs'].
+-type db_create_option() :: {'q', non_neg_integer()} |
+                            {'n', non_neg_integer()} |
+                            'ensure_other_dbs' |
+                            {'ensure_other_dbs', boolean()}.
+-type db_create_options() :: [db_create_option()].
+
+-type db_delete_option() :: 'ensure_other_dbs' |
+                            {'ensure_other_dbs', boolean()}.
+-type db_delete_options() :: [db_delete_option()].
 
 -type ddoc() :: kz_term:ne_binary() | 'all_docs' | 'design_docs'.
 

--- a/core/kazoo_directory/src/kz_directory_endpoint.erl
+++ b/core/kazoo_directory/src/kz_directory_endpoint.erl
@@ -99,7 +99,7 @@ presence_id(Endpoint, CCVs) ->
 
 -spec hold_music(kz_json:object(), kz_json:object()) -> kz_json:object().
 hold_music(Endpoint, CCVs) ->
-    case kz_json:get_value([<<"music_on_hold">>, <<"media_id">>], Endpoint) of
+    case kz_json:get_ne_binary_value([<<"music_on_hold">>, <<"media_id">>], Endpoint) of
         'undefined' -> CCVs;
         MediaId ->
             MOH = kz_media_util:media_path(MediaId, kz_doc:account_id(Endpoint)),
@@ -226,8 +226,8 @@ add_alert_info(Endpoint, CCVs) ->
 
 -spec get_codecs(kz_json:object()) -> 'undefined' | kz_term:ne_binaries().
 get_codecs(JObj) ->
-    case kz_json:get_value([<<"media">>, <<"audio">>, <<"codecs">>], JObj, [])
-        ++ kz_json:get_value([<<"media">>, <<"video">>, <<"codecs">>], JObj, [])
+    case kz_json:get_list_value([<<"media">>, <<"audio">>, <<"codecs">>], JObj, [])
+        ++ kz_json:get_list_value([<<"media">>, <<"video">>, <<"codecs">>], JObj, [])
     of
         [] -> 'undefined';
         Codecs -> Codecs
@@ -246,7 +246,7 @@ profile(EndpointId, AccountId, Options) ->
 
 -spec generate_ccvs(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 generate_ccvs(_EndpointId, AccountId, Endpoint) ->
-    Realm = kzd_devices:sip_realm(Endpoint, kz_json:get_value(<<"realm">>, Endpoint)),
+    Realm = kzd_devices:sip_realm(Endpoint, kz_json:get_ne_binary_value(<<"realm">>, Endpoint)),
     Props = [{<<"Account-ID">>, AccountId}
             ,{<<"Reseller-ID">>, kz_services_reseller:get_id(AccountId)}
             ,{<<"Realm">>, Realm}
@@ -255,32 +255,31 @@ generate_ccvs(_EndpointId, AccountId, Endpoint) ->
             ],
     CCVs = kz_json:from_list(Props),
 
-    CCVFuns = [fun endpoint_id/2
-              ,fun owner_id/2
-              ,fun rtcp_mux/2
-              ,fun webrtc/2
-              ,fun enable_fax/2
-              ,fun enforce_security/2
-              ,fun encryption_flags/2
-              ,fun presence_id/2
-              ,fun add_alert_info/2
-              ,fun hold_music/2
-              ,fun invite_uri/2
-              ,fun call_waiting/2
-              ,fun progress_timeout/2
-              ,fun ignore_early_media/2
-              ,fun bypass_media/2
-              ,fun ignore_completed_elsewhere/2
+    CCVFuns = [{fun endpoint_id/2, Endpoint}
+              ,{fun owner_id/2, Endpoint}
+              ,{fun rtcp_mux/2, Endpoint}
+              ,{fun webrtc/2, Endpoint}
+              ,{fun enable_fax/2, Endpoint}
+              ,{fun enforce_security/2, Endpoint}
+              ,{fun encryption_flags/2, Endpoint}
+              ,{fun presence_id/2, Endpoint}
+              ,{fun add_alert_info/2, Endpoint}
+              ,{fun hold_music/2, Endpoint}
+              ,{fun invite_uri/2, Endpoint}
+              ,{fun call_waiting/2, Endpoint}
+              ,{fun progress_timeout/2, Endpoint}
+              ,{fun ignore_early_media/2, Endpoint}
+              ,{fun bypass_media/2, Endpoint}
+              ,{fun ignore_completed_elsewhere/2, Endpoint}
               ],
-    lists:foldl(fun(Fun, Acc) -> Fun(Endpoint, Acc) end, CCVs, CCVFuns).
+    kz_json:exec(CCVFuns, CCVs).
 
 -spec generate_sip_headers(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 generate_sip_headers(_EndpointId, _AccountId, Endpoint) ->
-    Headers = kz_json:new(),
-    HeaderFuns = [fun add_sip_headers/2
-                 ,fun maybe_add_aor/2
+    HeaderFuns = [{fun add_sip_headers/2, Endpoint}
+                 ,{fun maybe_add_aor/2, Endpoint}
                  ],
-    lists:foldl(fun(Fun, Acc) -> Fun(Endpoint, Acc) end, Headers, HeaderFuns).
+    kz_json:exec(HeaderFuns, kz_json:new()).
 
 -spec add_sip_headers(kz_json:object(), kz_json:object()) -> kz_json:object().
 add_sip_headers(Endpoint, Headers) ->
@@ -297,7 +296,7 @@ maybe_add_aor(Endpoint, Headers) ->
 -spec maybe_add_aor(kz_term:api_binary(), kz_json:object(), kz_json:object()) -> kz_json:object().
 maybe_add_aor('undefined', _Endpoint, Headers) -> Headers;
 maybe_add_aor(Username, Endpoint, Headers) ->
-    Realm = kzd_devices:sip_realm(Endpoint,  kz_json:get_value(<<"realm">>, Endpoint)),
+    Realm = kzd_devices:sip_realm(Endpoint,  kz_json:get_ne_binary_value(<<"realm">>, Endpoint)),
     Format = kzd_devices:sip_invite_format(Endpoint),
     AOR = [{<<"X-KAZOO-AOR">>, <<"sip:", Username/binary, "@", Realm/binary>>}
           ,{<<"X-KAZOO-INVITE-FORMAT">>, Format}
@@ -431,4 +430,4 @@ call_forward_maybe_retain_cid(_EndpointId, _AccountId, Endpoint) ->
 
 -spec get_realm(kz_json:object()) -> kz_term:ne_binary().
 get_realm(Endpoint) ->
-    kz_json:get_value(<<"realm">>, Endpoint, <<"norealm">>).
+    kz_json:get_ne_binary_value(<<"realm">>, Endpoint, <<"norealm">>).

--- a/core/kazoo_documents/src/kzd_callflows.erl
+++ b/core/kazoo_documents/src/kzd_callflows.erl
@@ -16,14 +16,22 @@
 -export([flags/1, flags/2, set_flags/2]).
 -export([flow/1, flow/2, set_flow/2]).
 -export([metaflow/1, metaflow/2, set_metaflow/2]).
+-export([name/1, name/2, set_name/2]).
 -export([numbers/1, numbers/2, set_numbers/2]).
 -export([patterns/1, patterns/2, set_patterns/2]).
+-export([ringback/1, ringback/2, set_ringback/2]).
+-export([ringback_early/1, ringback_early/2, set_ringback_early/2]).
+-export([ringback_transfer/1, ringback_transfer/2, set_ringback_transfer/2]).
 
 -export([type/0
         ,is_feature_code/1
         ,validate/1
         ,validate_flow/1
         ,prepend_preflow/2
+
+         %% Dynamically added per-call
+        ,capture_group/1, capture_group/2, set_capture_group/2
+        ,capture_groups/1, capture_groups/2, set_capture_groups/2
         ]).
 
 -include("kz_documents.hrl").
@@ -119,6 +127,18 @@ metaflow(Doc, Default) ->
 set_metaflow(Doc, Metaflow) ->
     kz_json:set_value([<<"metaflow">>], Metaflow, Doc).
 
+-spec name(doc()) -> kz_term:api_binary().
+name(Doc) ->
+    name(Doc, 'undefined').
+
+-spec name(doc(), Default) -> binary() | Default.
+name(Doc, Default) ->
+    kz_json:get_binary_value([<<"name">>], Doc, Default).
+
+-spec set_name(doc(), binary()) -> doc().
+set_name(Doc, Name) ->
+    kz_json:set_value([<<"name">>], Name, Doc).
+
 -spec numbers(doc()) -> kz_term:ne_binaries().
 numbers(Doc) ->
     numbers(Doc, []).
@@ -191,3 +211,63 @@ prepend_preflow(Callflow, PreflowId) ->
                           ,{<<"children">>, kz_json:from_list([{<<"_">>, flow(Callflow)}])}
                           ]),
     set_flow(Callflow, AmendedFlow).
+
+-spec ringback(doc()) -> kz_term:api_object().
+ringback(Doc) ->
+    ringback(Doc, 'undefined').
+
+-spec ringback(doc(), Default) -> kz_json:object() | Default.
+ringback(Doc, Default) ->
+    kz_json:get_json_value([<<"ringback">>], Doc, Default).
+
+-spec set_ringback(doc(), kz_json:object()) -> doc().
+set_ringback(Doc, Ringback) ->
+    kz_json:set_value([<<"ringback">>], Ringback, Doc).
+
+-spec ringback_early(doc()) -> kz_term:api_binary().
+ringback_early(Doc) ->
+    ringback_early(Doc, 'undefined').
+
+-spec ringback_early(doc(), Default) -> binary() | Default.
+ringback_early(Doc, Default) ->
+    kz_json:get_binary_value([<<"ringback">>, <<"early">>], Doc, Default).
+
+-spec set_ringback_early(doc(), binary()) -> doc().
+set_ringback_early(Doc, RingbackEarly) ->
+    kz_json:set_value([<<"ringback">>, <<"early">>], RingbackEarly, Doc).
+
+-spec ringback_transfer(doc()) -> kz_term:api_binary().
+ringback_transfer(Doc) ->
+    ringback_transfer(Doc, 'undefined').
+
+-spec ringback_transfer(doc(), Default) -> binary() | Default.
+ringback_transfer(Doc, Default) ->
+    kz_json:get_binary_value([<<"ringback">>, <<"transfer">>], Doc, Default).
+
+-spec set_ringback_transfer(doc(), binary()) -> doc().
+set_ringback_transfer(Doc, RingbackTransfer) ->
+    kz_json:set_value([<<"ringback">>, <<"transfer">>], RingbackTransfer, Doc).
+
+-spec capture_group(doc()) -> kz_term:api_ne_binary().
+capture_group(Doc) ->
+    capture_group(Doc, 'undefined').
+
+-spec capture_group(doc(), Default) -> kz_term:ne_binary() | Default.
+capture_group(Doc, Default) ->
+    kz_json:get_ne_binary_value([<<"capture_group">>], Doc, Default).
+
+-spec set_capture_group(doc(), kz_term:ne_binary()) -> doc().
+set_capture_group(Doc, CaptureGroup) ->
+    kz_json:set_value([<<"capture_group">>], CaptureGroup, Doc).
+
+-spec capture_groups(doc()) -> kz_term:api_object().
+capture_groups(Doc) ->
+    capture_groups(Doc, 'undefined').
+
+-spec capture_groups(doc(), Default) -> kz_json:object() | Default.
+capture_groups(Doc, Default) ->
+    kz_json:get_json_value([<<"capture_groups">>], Doc, Default).
+
+-spec set_capture_groups(doc(), kz_json:object()) -> doc().
+set_capture_groups(Doc, CaptureGroups) ->
+    kz_json:set_value([<<"capture_groups">>], CaptureGroups, Doc).

--- a/core/kazoo_documents/src/kzd_callflows.erl.src
+++ b/core/kazoo_documents/src/kzd_callflows.erl.src
@@ -12,8 +12,12 @@
 -export([flags/1, flags/2, set_flags/2]).
 -export([flow/1, flow/2, set_flow/2]).
 -export([metaflow/1, metaflow/2, set_metaflow/2]).
+-export([name/1, name/2, set_name/2]).
 -export([numbers/1, numbers/2, set_numbers/2]).
 -export([patterns/1, patterns/2, set_patterns/2]).
+-export([ringback/1, ringback/2, set_ringback/2]).
+-export([ringback_early/1, ringback_early/2, set_ringback_early/2]).
+-export([ringback_transfer/1, ringback_transfer/2, set_ringback_transfer/2]).
 
 
 -include("kz_documents.hrl").
@@ -99,6 +103,18 @@ metaflow(Doc, Default) ->
 set_metaflow(Doc, Metaflow) ->
     kz_json:set_value([<<"metaflow">>], Metaflow, Doc).
 
+-spec name(doc()) -> kz_term:api_binary().
+name(Doc) ->
+    name(Doc, 'undefined').
+
+-spec name(doc(), Default) -> binary() | Default.
+name(Doc, Default) ->
+    kz_json:get_binary_value([<<"name">>], Doc, Default).
+
+-spec set_name(doc(), binary()) -> doc().
+set_name(Doc, Name) ->
+    kz_json:set_value([<<"name">>], Name, Doc).
+
 -spec numbers(doc()) -> kz_term:ne_binaries().
 numbers(Doc) ->
     numbers(Doc, []).
@@ -122,3 +138,39 @@ patterns(Doc, Default) ->
 -spec set_patterns(doc(), kz_term:ne_binaries()) -> doc().
 set_patterns(Doc, Patterns) ->
     kz_json:set_value([<<"patterns">>], Patterns, Doc).
+
+-spec ringback(doc()) -> kz_term:api_object().
+ringback(Doc) ->
+    ringback(Doc, 'undefined').
+
+-spec ringback(doc(), Default) -> kz_json:object() | Default.
+ringback(Doc, Default) ->
+    kz_json:get_json_value([<<"ringback">>], Doc, Default).
+
+-spec set_ringback(doc(), kz_json:object()) -> doc().
+set_ringback(Doc, Ringback) ->
+    kz_json:set_value([<<"ringback">>], Ringback, Doc).
+
+-spec ringback_early(doc()) -> kz_term:api_binary().
+ringback_early(Doc) ->
+    ringback_early(Doc, 'undefined').
+
+-spec ringback_early(doc(), Default) -> binary() | Default.
+ringback_early(Doc, Default) ->
+    kz_json:get_binary_value([<<"ringback">>, <<"early">>], Doc, Default).
+
+-spec set_ringback_early(doc(), binary()) -> doc().
+set_ringback_early(Doc, RingbackEarly) ->
+    kz_json:set_value([<<"ringback">>, <<"early">>], RingbackEarly, Doc).
+
+-spec ringback_transfer(doc()) -> kz_term:api_binary().
+ringback_transfer(Doc) ->
+    ringback_transfer(Doc, 'undefined').
+
+-spec ringback_transfer(doc(), Default) -> binary() | Default.
+ringback_transfer(Doc, Default) ->
+    kz_json:get_binary_value([<<"ringback">>, <<"transfer">>], Doc, Default).
+
+-spec set_ringback_transfer(doc(), binary()) -> doc().
+set_ringback_transfer(Doc, RingbackTransfer) ->
+    kz_json:set_value([<<"ringback">>, <<"transfer">>], RingbackTransfer, Doc).

--- a/core/kazoo_documents/src/kzd_devices.erl
+++ b/core/kazoo_documents/src/kzd_devices.erl
@@ -601,7 +601,7 @@ calculate_presence_id_from_owner(Doc, DevicePresenceId, OwnerId) ->
             DevicePresenceId
     end.
 
--spec calculate_presence_id_from_hotdesk(doc(), Default, kz_term:ne_binary()) -> kz_term:ne_binary() | Default.
+-spec calculate_presence_id_from_hotdesk(doc(), Default, kz_term:ne_binaries()) -> kz_term:ne_binary() | Default.
 calculate_presence_id_from_hotdesk(_Doc, DevicePresenceId, []) -> DevicePresenceId;
 calculate_presence_id_from_hotdesk(Doc, DevicePresenceId, [HotdeskId|HotdeskIds]) ->
     case calculate_presence_id_from_owner(Doc, DevicePresenceId, HotdeskId) of

--- a/core/kazoo_documents/src/kzd_devices.erl
+++ b/core/kazoo_documents/src/kzd_devices.erl
@@ -44,7 +44,9 @@
 -export([name/1, name/2, set_name/2]).
 -export([outbound_flags/1, outbound_flags/2, set_outbound_flags/2]).
 -export([owner_id/1, owner_id/2, set_owner_id/2]).
--export([presence_id/1, presence_id/2, set_presence_id/2]).
+-export([presence_id/1, presence_id/2, set_presence_id/2
+        ,calculate_presence_id/1, calculate_presence_id/2
+        ]).
 -export([provision/1, provision/2, set_provision/2]).
 -export([provision_combo_keys/1, provision_combo_keys/2, set_provision_combo_keys/2]).
 -export([provision_combo_key/2, provision_combo_key/3, set_provision_combo_key/3]).
@@ -559,6 +561,55 @@ presence_id(Doc, Default) ->
 -spec set_presence_id(doc(), binary()) -> doc().
 set_presence_id(Doc, PresenceId) ->
     kz_json:set_value([<<"presence_id">>], PresenceId, Doc).
+
+-spec calculate_presence_id(doc()) -> kz_term:api_ne_binary().
+calculate_presence_id(Doc) ->
+    calculate_presence_id(Doc, sip_username(Doc)).
+
+-spec calculate_presence_id(doc(), Default) -> kz_term:ne_binary() | Default.
+calculate_presence_id(Doc, Default) ->
+    DevicePresenceId = presence_id(Doc, Default),
+    case calculate_presence_id(Doc, DevicePresenceId, owner_id(Doc)) of
+        'undefined' -> 'undefined';
+        PresenceId -> maybe_fix_presence_id(Doc, PresenceId)
+    end.
+
+-spec maybe_fix_presence_id(doc(), kz_term:ne_binary()) -> kz_term:ne_binary().
+maybe_fix_presence_id(Doc, PresenceId) ->
+    case binary:match(PresenceId, <<"@">>) of
+        'nomatch' -> fix_presence_id(Doc, PresenceId);
+        _Match -> PresenceId
+    end.
+
+-spec fix_presence_id(doc(), kz_term:ne_binary()) -> kz_term:ne_binary().
+fix_presence_id(Doc, PresenceId) ->
+    AccountRealm = kzd_accounts:fetch_realm(kz_doc:account_id(Doc)),
+    <<PresenceId/binary, "@", AccountRealm/binary>>.
+
+-spec calculate_presence_id(doc(), Default, kz_term:api_ne_binary()) -> kz_term:ne_binary() | Default.
+calculate_presence_id(Doc, DevicePresenceId, 'undefined') ->
+    calculate_presence_id_from_hotdesk(Doc, DevicePresenceId, hotdesk_ids(Doc, []));
+calculate_presence_id(Doc, DevicePresenceId, OwnerId) ->
+    calculate_presence_id_from_owner(Doc, DevicePresenceId, OwnerId).
+
+-spec calculate_presence_id_from_owner(doc(), Default, kz_term:ne_binary()) -> kz_term:ne_binary() | Default.
+calculate_presence_id_from_owner(Doc, DevicePresenceId, OwnerId) ->
+    case kzd_users:fetch(kz_doc:account_db(Doc), OwnerId) of
+        {'ok', Owner} ->
+            kzd_users:presence_id(Owner, DevicePresenceId);
+        {'error', _} ->
+            DevicePresenceId
+    end.
+
+-spec calculate_presence_id_from_hotdesk(doc(), Default, kz_term:ne_binary()) -> kz_term:ne_binary() | Default.
+calculate_presence_id_from_hotdesk(_Doc, DevicePresenceId, []) -> DevicePresenceId;
+calculate_presence_id_from_hotdesk(Doc, DevicePresenceId, [HotdeskId|HotdeskIds]) ->
+    case calculate_presence_id_from_owner(Doc, DevicePresenceId, HotdeskId) of
+        DevicePresenceId -> calculate_presence_id_from_hotdesk(Doc, DevicePresenceId, HotdeskIds);
+        HotdeskPresenceId ->
+            lager:debug("using hotdesk presence id ~s from ~s", [HotdeskPresenceId, HotdeskId]),
+            HotdeskPresenceId
+    end.
 
 -spec provision(doc()) -> kz_term:api_object().
 provision(Doc) ->

--- a/core/kazoo_documents/test/kzd_device_tests.erl
+++ b/core/kazoo_documents/test/kzd_device_tests.erl
@@ -13,8 +13,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
+-include_lib("kazoo_stdlib/include/kazoo_dbg.hrl").
 -include_lib("kazoo_fixturedb/include/kz_fixturedb.hrl").
-
 
 -define(DEVICE_1_ID, <<"device00000000000000000000000001">>).
 -define(DEVICE_2_ID, <<"device00000000000000000000000002">>).
@@ -36,6 +36,7 @@ kz_device_test_() ->
              ,test_outbound_flags_static()
              ,test_outbound_dynamic_flags()
              ,test_device_param_setting()
+             ,test_calculating_presence_id()
              ]
      end
     }.
@@ -257,6 +258,44 @@ test_device_param_setting() ->
             ],
 
     [?_assertEqual(Value, Get(Set(Device, Value))) || {Value, Set, Get} <- Setup].
+
+test_calculating_presence_id() ->
+    {'ok', Device} = kzd_devices:fetch(?FIXTURE_MASTER_ACCOUNT_ID, ?DEVICE_1_ID),
+    OwnerId = kzd_devices:owner_id(Device),
+    {'ok', User} = kzd_users:fetch(?FIXTURE_MASTER_ACCOUNT_ID, OwnerId),
+
+    SIPUsername = kz_binary:rand_hex(5),
+    AccountRealm = <<"4a6863.sip.2600hz.local">>,
+
+    BlankDevice = kz_json:delete_keys([<<"presence_id">>
+                                      ,<<"owner_id">>
+                                      ,<<"call_forward">>
+                                      ,<<"call_recording">>
+                                      ,<<"call_restriction">>
+                                      ,<<"caller_id">>
+                                      ,<<"dial_plan">>
+                                      ,<<"media">>, <<"metaflows">>, <<"ringtones">>
+                                      ]
+                                     , Device),
+    JustUsername = kzd_devices:set_sip_username(BlankDevice, SIPUsername),
+
+    DevicePresenceId = kz_binary:rand_hex(5),
+    WithDevicePresenceId = kzd_devices:set_presence_id(JustUsername, DevicePresenceId),
+
+    OwnerPresenceId = kzd_users:presence_id(User),
+
+    HotdeskedDevice = kzd_devices:set_hotdesk(JustUsername, kz_json:from_list([{<<"users">>, kz_json:from_list([{OwnerId, kz_binary:rand_hex(16)}])}])),
+    HotdeskedAndOwnedDevice = kzd_devices:set_owner_id(HotdeskedDevice, OwnerId),
+
+    Tests = [{"SIP username", <<SIPUsername/binary, "@", AccountRealm/binary>>, JustUsername}
+            ,{"Device presence_id", <<DevicePresenceId/binary, "@", AccountRealm/binary>>, WithDevicePresenceId}
+            ,{"Owner presence_id", OwnerPresenceId, Device}
+            ,{"Hotdesked presence_id", OwnerPresenceId, HotdeskedDevice}
+            ,{"Hotdesked and owned presence_id", OwnerPresenceId, HotdeskedAndOwnedDevice}
+            ],
+    [{Label, ?_assertEqual(PresenceId, kzd_devices:calculate_presence_id(DeviceJObj))}
+     || {Label, PresenceId, DeviceJObj} <- Tests
+    ].
 
 validate(Schema, Device) ->
     kz_json_schema:validate(Schema

--- a/core/kazoo_endpoint/src/kz_attributes.erl
+++ b/core/kazoo_endpoint/src/kz_attributes.erl
@@ -488,25 +488,8 @@ presence_id(Endpoint, Call) ->
     presence_id(Endpoint, Call, Username).
 
 -spec presence_id(kz_json:object(), kapps_call:call(), Default) -> kz_term:ne_binary() | Default.
-presence_id(Endpoint, Call, Default) ->
-    PresenceId = kzd_devices:presence_id(Endpoint, Default),
-    case kz_term:is_empty(PresenceId) of
-        'true' -> maybe_fix_presence_id_realm(Default, Endpoint, Call);
-        'false' -> maybe_fix_presence_id_realm(PresenceId, Endpoint, Call)
-    end.
-
--spec maybe_fix_presence_id_realm(kz_term:ne_binary(), kz_json:object(), kapps_call:call()) -> kz_term:api_ne_binary().
-maybe_fix_presence_id_realm('undefined', _Endpoint, _Call) -> 'undefined';
-maybe_fix_presence_id_realm(PresenceId, Endpoint, Call) ->
-    case binary:match(PresenceId, <<"@">>) of
-        'nomatch' ->
-            Realm = kz_endpoint:get_sip_realm(Endpoint
-                                             ,kapps_call:account_id(Call)
-                                             ,kapps_call:request_realm(Call)
-                                             ),
-            <<PresenceId/binary, $@, Realm/binary>>;
-        _Else -> PresenceId
-    end.
+presence_id(Endpoint, _Call, Default) ->
+    kzd_devices:calculate_presence_id(Endpoint, Default).
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -51,7 +51,6 @@ get(Call) -> ?MOD:get(Call).
 -spec get(kz_term:api_binary(), kz_term:ne_binary() | kapps_call:call()) -> std_return().
 get(EndpointId, _Call) -> ?MOD:get(EndpointId, _Call).
 
-
 -ifdef(TEST).
 attributes_keys() -> ?MOD:attributes_keys().
 

--- a/core/kazoo_numbers/src/kazoo_numbers_maintenance.erl
+++ b/core/kazoo_numbers/src/kazoo_numbers_maintenance.erl
@@ -293,7 +293,7 @@ update_number_services_view(?MATCH_ACCOUNT_ENCODED(_)=AccountDb) ->
                {'ok', JObj} -> JObj;
                {'error', _R} ->
                    lager:debug("reading account view ~s from disk (~p)", [ViewName, _R]),
-                   {ViewName,JObj} = kapps_util:get_view_json('crossbar', <<"account/numbers.json">>),
+                   {ViewName,JObj} = kapps_util:get_view_json('kazoo_apps', <<"account/numbers.json">>),
                    JObj
            end,
     PathMap = [<<"views">>, <<"reconcile_services">>, <<"map">>],

--- a/core/kazoo_proper/src/pqc_kz_datamgr.erl
+++ b/core/kazoo_proper/src/pqc_kz_datamgr.erl
@@ -30,7 +30,7 @@ run_it(F) -> F().
 seq_kzoo_56() ->
     kz_datamgr:suppress_change_notice(),
     Doc = kz_json:from_list([{<<"_id">>, ?FROM_DOC_ID}
-                            | [{kz_binary:rand_hex(4), kz_binary:rand_hex(5)} || _ <- lists:seq(1,10)]
+                             | [{kz_binary:rand_hex(4), kz_binary:rand_hex(5)} || _ <- lists:seq(1,10)]
                             ]),
 
     'true' = kz_datamgr:db_create(?FROM_DB),

--- a/core/kazoo_proper/src/pqc_kz_datamgr.erl
+++ b/core/kazoo_proper/src/pqc_kz_datamgr.erl
@@ -28,8 +28,9 @@ run_it(F) -> F().
 
 -spec seq_kzoo_56() -> 'ok'.
 seq_kzoo_56() ->
+    kz_datamgr:suppress_change_notice(),
     Doc = kz_json:from_list([{<<"_id">>, ?FROM_DOC_ID}
-                             | [{kz_binary:rand_hex(4), kz_binary:rand_hex(5)} || _ <- lists:seq(1,10)]
+                            | [{kz_binary:rand_hex(4), kz_binary:rand_hex(5)} || _ <- lists:seq(1,10)]
                             ]),
 
     'true' = kz_datamgr:db_create(?FROM_DB),
@@ -54,6 +55,7 @@ seq_kzoo_56() ->
 cleanup() ->
     'true' = kz_datamgr:db_delete(?FROM_DB),
     'true' = kz_datamgr:db_delete(?TO_DB),
+    kz_datamgr:enable_change_notice(),
     lager:info("CLEANUP FINISHED").
 
 save_mp3(DB, DocId, AttId, MP3) ->


### PR DESCRIPTION
When a device registers, the calculated presence_id is cached and
passed along on subsequent INVITEs. If a user hotdesks into the
device, the cached presence_id (likely the SIP username of the device)
will continue to be used on call events related to that device.

This causes issues with applications (like Qubicle) that track a
user's calls based on the user's presence_id being present on dialog
update events (confirmed and terminated).

Instead, provide a uniform way to calculate a device's presence_id and
use it for setting CCVs on the route response in callflow and in
registrar for authn responses.