### PR TITLE
[4.3] fallback to en-US if i18n label is missing

### DIFF
--- a/applications/crossbar/src/crossbar_util.erl
+++ b/applications/crossbar/src/crossbar_util.erl
@@ -716,14 +716,18 @@ load_apps(AccountId, UserId, Language) ->
 %%------------------------------------------------------------------------------
 -spec format_app(kz_term:ne_binary(), kz_json:object()) -> kz_json:object().
 format_app(Lang, AppJObj) ->
-    I18N = kzd_app:i18n(AppJObj),
-    DefaultLabel = kz_json:get_value([?DEFAULT_LANGUAGE, <<"label">>], I18N),
+    Label = kz_json:get_first_defined([[Lang, <<"label">>]
+                                      ,[?DEFAULT_LANGUAGE, <<"label">>]
+                                      ,[<<"en-US">>, <<"label">>]
+                                      ]
+                                     ,kzd_app:i18n(AppJObj)
+                                     ),
     kz_json:from_list(
       [{<<"id">>, kz_doc:id(AppJObj)}
       ,{<<"name">>, kzd_app:name(AppJObj)}
       ,{<<"api_url">>, kzd_app:api_url(AppJObj)}
       ,{<<"source_url">>, kzd_app:source_url(AppJObj)}
-      ,{<<"label">>, kz_json:get_value([Lang, <<"label">>], I18N, DefaultLabel)}
+      ,{<<"label">>, Label}
       ]).
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
Fallback to en-US label of UI app when user, account and system default language is not en-US.