### PR TITLE
Don't publish AMQP updates during testing

### DIFF
--- a/core/kazoo_proper/src/pqc_kz_datamgr.erl
+++ b/core/kazoo_proper/src/pqc_kz_datamgr.erl
@@ -28,6 +28,7 @@ run_it(F) -> F().
 
 -spec seq_kzoo_56() -> 'ok'.
 seq_kzoo_56() ->
+    kz_datamgr:suppress_change_notice(),
     Doc = kz_json:from_list([{<<"_id">>, ?FROM_DOC_ID}
                              | [{kz_binary:rand_hex(4), kz_binary:rand_hex(5)} || _ <- lists:seq(1,10)]
                             ]),
@@ -54,6 +55,7 @@ seq_kzoo_56() ->
 cleanup() ->
     'true' = kz_datamgr:db_delete(?FROM_DB),
     'true' = kz_datamgr:db_delete(?TO_DB),
+    kz_datamgr:enable_change_notice(),
     lager:info("CLEANUP FINISHED").
 
 save_mp3(DB, DocId, AttId, MP3) ->


### PR DESCRIPTION
Listeners for db config change payloads try to load views into a
database which is going away quite fast. No need, we don't use views
in this test.