### PR TITLE
[4.3] KZOO-61: ensure reseller_id on account response

### DIFF
--- a/applications/cdr/src/cdr_channel_destroy.erl
+++ b/applications/cdr/src/cdr_channel_destroy.erl
@@ -128,7 +128,7 @@ update_ccvs(_, _, JObj) ->
 
 -spec update_ccvs_foldl(kz_json:get_key(), kz_json:json_term(), {kz_call_event:doc(), kz_json:object()}) ->
           {kz_call_event:doc(), kz_json:object()}.
-update_ccvs_foldl(Key, Value,  {JObj, CCVs}=Acc) ->
+update_ccvs_foldl(Key, Value, {JObj, CCVs}=Acc) ->
     case kz_doc:is_private_key(Key) of
         'false' -> Acc;
         'true' ->

--- a/core/kazoo_proper/src/pqc_cb_accounts.erl
+++ b/core/kazoo_proper/src/pqc_cb_accounts.erl
@@ -165,7 +165,8 @@ postcondition(Model
 seq() ->
     enable_and_delete_topup(),
     seq_44832(),
-    seq_kzoo_54().
+    seq_kzoo_54(),
+    seq_kzoo_61().
 
 -spec seq_44832() -> 'ok'.
 seq_44832() ->
@@ -256,6 +257,44 @@ enable_and_delete_topup() ->
 
     _ = cleanup(API),
     ?INFO("FINISHED ENABLE AND DISABLE TOPUP CHECKS").
+
+seq_kzoo_61() ->
+    API = pqc_cb_api:init_api(['crossbar'], ['cb_accounts']),
+
+    AccountReq = kz_json:from_list([{<<"name">>, <<?MODULE_STRING>>}
+                                   ,{<<"realm">>, <<?MODULE_STRING>>}
+                                   ]
+                                  ),
+    AccountResp = create_account(API, AccountReq),
+
+    lager:info("created account ~s", [AccountResp]),
+    AccountJObj = kz_json:get_json_value(<<"data">>, kz_json:decode(AccountResp)),
+
+    {'ok', AccountSchema} = kz_json_schema:load(<<"accounts">>),
+    Required = kz_json:get_list_value(<<"required">>, AccountSchema, []),
+
+    Fields = [<<"billing_mode">>
+             ,{<<"created">>, fun erlang:is_integer/1}
+             ,{<<"enabled">>, 'true'}
+             ,{<<"is_reseller">>, fun kz_term:is_boolean/1}
+             ,{<<"realm">>, <<?MODULE_STRING>>}
+             ,{<<"reseller_id">>, pqc_cb_api:auth_account_id(API)}
+             ,{<<"superduper_admin">>, 'false'}
+             ,{<<"wnm_allow_additions">>, fun kz_term:is_boolean/1}
+              | Required
+             ],
+    'true' = lists:all(fun(Field) -> response_has_field(Field, AccountJObj) end
+                       ,Fields
+                      ),
+    _ = cleanup(API),
+    lager:info("FINISHED EXPECTED FIELDS").
+
+response_has_field({Field, Predicate}, AccountJObj) when is_function(Predicate, 1) ->
+    Predicate(kz_json:get_value(Field, AccountJObj));
+response_has_field({Field, Value}, AccountJObj) ->
+    Value =:= kz_json:get_value(Field, AccountJObj);
+response_has_field(Field, AccountJObj) ->
+    kz_json:is_defined(Field, AccountJObj).
 
 -spec cleanup(pqc_cb_api:state()) -> any().
 cleanup(API) ->

--- a/core/kazoo_proper/src/pqc_cb_accounts.erl
+++ b/core/kazoo_proper/src/pqc_cb_accounts.erl
@@ -284,7 +284,7 @@ seq_kzoo_61() ->
               | Required
              ],
     'true' = lists:all(fun(Field) -> response_has_field(Field, AccountJObj) end
-                       ,Fields
+                      ,Fields
                       ),
     _ = cleanup(API),
     lager:info("FINISHED EXPECTED FIELDS").


### PR DESCRIPTION
Verify required schema fields and other expected fields are on the
response (including leaked pvt fields)