### PR TITLE
[Master] - KZOO-46: Add Emergency Notification for E911 Compliance

### DIFF
--- a/applications/crossbar/doc/phone_numbers.md
+++ b/applications/crossbar/doc/phone_numbers.md
@@ -39,6 +39,8 @@ Key | Description | Type | Default | Required | Support Level
 `e911.locality` | The locality (city) where the number is in service | `string()` |   | `true` |  
 `e911.location_id` | The e911 provisioning system internal id for this service address | `string()` |   | `false` |  
 `e911.longitude` | The e911 provisioning system calculated service address longitude | `string()` |   | `false` |  
+`e911.notification_contact_emails.[]` |   | `string()` |   | `false` |  
+`e911.notification_contact_emails` | A list of email addresses to receive notification when this number places an emergency call | `array(string())` | `[]` | `false` |  
 `e911.plus_four` | The extended zip/postal code where the number is in service | `string()` |   | `false` |  
 `e911.postal_code` | The zip/postal code where the number is in service | `string()` |   | `true` |  
 `e911.region` | The region (state) where the number is in service | `string(2)` |   | `true` |  

--- a/applications/crossbar/doc/ref/phone_numbers.md
+++ b/applications/crossbar/doc/ref/phone_numbers.md
@@ -27,6 +27,8 @@ Key | Description | Type | Default | Required | Support Level
 `e911.locality` | The locality (city) where the number is in service | `string()` |   | `true` |  
 `e911.location_id` | The e911 provisioning system internal id for this service address | `string()` |   | `false` |  
 `e911.longitude` | The e911 provisioning system calculated service address longitude | `string()` |   | `false` |  
+`e911.notification_contact_emails.[]` |   | `string()` |   | `false` |  
+`e911.notification_contact_emails` | A list of email addresses to receive notification when this number places an emergency call | `array(string())` | `[]` | `false` |  
 `e911.plus_four` | The extended zip/postal code where the number is in service | `string()` |   | `false` |  
 `e911.postal_code` | The zip/postal code where the number is in service | `string()` |   | `true` |  
 `e911.region` | The region (state) where the number is in service | `string(2)` |   | `true` |  

--- a/applications/crossbar/doc/ref/resources.md
+++ b/applications/crossbar/doc/ref/resources.md
@@ -64,6 +64,8 @@ Key | Description | Type | Default | Required | Support Level
 `require_flags` | When set to true this resource is ignored if the request does not specify outbound flags | `boolean()` |   | `false` |  
 `rules.[]` |   | `string()` |   | `false` |  
 `rules` | A list of regular expressions of which one must match for the rule to be eligible, they can optionally contain capture groups | `array(string())` | `[]` | `false` |  
+`rules_test.[]` |   | `string()` |   | `false` |  
+`rules_test` | A list of regular expressions of which if matched denotes a test rule | `array(string())` | `[]` | `false` |  
 `weight_cost` | A value between 0 and 100 that determines the order of resources when multiple can be used | `integer()` | `50` | `false` |  
 
 ### custom_sip_headers

--- a/applications/crossbar/doc/resources.md
+++ b/applications/crossbar/doc/resources.md
@@ -80,6 +80,8 @@ Key | Description | Type | Default | Required | Support Level
 `require_flags` | When set to true this resource is ignored if the request does not specify outbound flags | `boolean()` |   | `false` |  
 `rules.[]` |   | `string()` |   | `false` |  
 `rules` | A list of regular expressions of which one must match for the rule to be eligible, they can optionally contain capture groups | `array(string())` | `[]` | `false` |  
+`rules_test.[]` |   | `string()` |   | `false` |  
+`rules_test` | A list of regular expressions of which if matched denotes a test rule | `array(string())` | `[]` | `false` |  
 `weight_cost` | A value between 0 and 100 that determines the order of resources when multiple can be used | `integer()` | `50` | `false` |  
 
 ### custom_sip_headers

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -19613,6 +19613,133 @@
             ],
             "type": "object"
         },
+        "kapi.notifications.emergency_bridge": {
+            "description": "AMQP API for notifications.emergency_bridge",
+            "properties": {
+                "Account-DB": {
+                    "type": "string"
+                },
+                "Account-ID": {
+                    "type": "string"
+                },
+                "Account-Name": {
+                    "type": "string"
+                },
+                "Attachment-URL": {
+                    "type": "string"
+                },
+                "Authorizing-ID": {
+                    "type": "string"
+                },
+                "Bcc": {
+                    "type": "string"
+                },
+                "Call-ID": {
+                    "type": "string"
+                },
+                "Cc": {
+                    "type": "string"
+                },
+                "Device-ID": {
+                    "type": "string"
+                },
+                "Device-Name": {
+                    "type": "string"
+                },
+                "Device-Owner-ID": {
+                    "type": "string"
+                },
+                "Emergency-Address-City": {
+                    "type": "string"
+                },
+                "Emergency-Address-Postal-Code": {
+                    "type": "string"
+                },
+                "Emergency-Address-Region": {
+                    "type": "string"
+                },
+                "Emergency-Address-Street-1": {
+                    "type": "string"
+                },
+                "Emergency-Address-Street-2": {
+                    "type": "string"
+                },
+                "Emergency-Caller-ID-Name": {
+                    "type": "string"
+                },
+                "Emergency-Caller-ID-Number": {
+                    "type": "string"
+                },
+                "Emergency-Notfication-Contact-Emails": {
+                    "type": "string"
+                },
+                "Emergency-Test-Call": {
+                    "type": "string"
+                },
+                "Emergency-To-DID": {
+                    "type": "string"
+                },
+                "Event-Category": {
+                    "enum": [
+                        "notification"
+                    ],
+                    "type": "string"
+                },
+                "Event-Name": {
+                    "enum": [
+                        "emergency_bridge"
+                    ],
+                    "type": "string"
+                },
+                "From": {
+                    "type": "string"
+                },
+                "HTML": {
+                    "type": "string"
+                },
+                "Outbound-Caller-ID-Name": {
+                    "type": "string"
+                },
+                "Outbound-Caller-ID-Number": {
+                    "type": "string"
+                },
+                "Owner-ID": {
+                    "type": "string"
+                },
+                "Preview": {
+                    "type": "boolean"
+                },
+                "Realm": {
+                    "type": "string"
+                },
+                "Reply-To": {
+                    "type": "string"
+                },
+                "Subject": {
+                    "type": "string"
+                },
+                "Text": {
+                    "type": "string"
+                },
+                "To": {
+                    "type": "string"
+                },
+                "User-Email": {
+                    "type": "string"
+                },
+                "User-First-Name": {
+                    "type": "string"
+                },
+                "User-Last-Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Account-ID",
+                "Call-ID"
+            ],
+            "type": "object"
+        },
         "kapi.notifications.first_occurrence": {
             "description": "AMQP API for notifications.first_occurrence",
             "properties": {
@@ -29967,6 +30094,14 @@
                             "description": "The e911 provisioning system calculated service address longitude",
                             "type": "string"
                         },
+                        "notification_contact_emails": {
+                            "default": [],
+                            "description": "A list of email addresses to receive notification when this number places an emergency call",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
                         "plus_four": {
                             "description": "The extended zip/postal code where the number is in service",
                             "type": "string"
@@ -31585,6 +31720,14 @@
                 "rules": {
                     "default": [],
                     "description": "A list of regular expressions of which one must match for the rule to be eligible, they can optionally contain capture groups",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "rules_test": {
+                    "default": [],
+                    "description": "A list of regular expressions of which if matched denotes a test rule",
                     "items": {
                         "type": "string"
                     },

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -19652,6 +19652,12 @@
                 "Emergency-Address-City": {
                     "type": "string"
                 },
+                "Emergency-Address-Latitude": {
+                    "type": "string"
+                },
+                "Emergency-Address-Longitude": {
+                    "type": "string"
+                },
                 "Emergency-Address-Postal-Code": {
                     "type": "string"
                 },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.emergency_bridge.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.emergency_bridge.json
@@ -39,6 +39,12 @@
         "Emergency-Address-City": {
             "type": "string"
         },
+        "Emergency-Address-Latitude": {
+            "type": "string"
+        },
+        "Emergency-Address-Longitude": {
+            "type": "string"
+        },
         "Emergency-Address-Postal-Code": {
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.emergency_bridge.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.emergency_bridge.json
@@ -1,0 +1,129 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.notifications.emergency_bridge",
+    "description": "AMQP API for notifications.emergency_bridge",
+    "properties": {
+        "Account-DB": {
+            "type": "string"
+        },
+        "Account-ID": {
+            "type": "string"
+        },
+        "Account-Name": {
+            "type": "string"
+        },
+        "Attachment-URL": {
+            "type": "string"
+        },
+        "Authorizing-ID": {
+            "type": "string"
+        },
+        "Bcc": {
+            "type": "string"
+        },
+        "Call-ID": {
+            "type": "string"
+        },
+        "Cc": {
+            "type": "string"
+        },
+        "Device-ID": {
+            "type": "string"
+        },
+        "Device-Name": {
+            "type": "string"
+        },
+        "Device-Owner-ID": {
+            "type": "string"
+        },
+        "Emergency-Address-City": {
+            "type": "string"
+        },
+        "Emergency-Address-Postal-Code": {
+            "type": "string"
+        },
+        "Emergency-Address-Region": {
+            "type": "string"
+        },
+        "Emergency-Address-Street-1": {
+            "type": "string"
+        },
+        "Emergency-Address-Street-2": {
+            "type": "string"
+        },
+        "Emergency-Caller-ID-Name": {
+            "type": "string"
+        },
+        "Emergency-Caller-ID-Number": {
+            "type": "string"
+        },
+        "Emergency-Notfication-Contact-Emails": {
+            "type": "string"
+        },
+        "Emergency-Test-Call": {
+            "type": "string"
+        },
+        "Emergency-To-DID": {
+            "type": "string"
+        },
+        "Event-Category": {
+            "enum": [
+                "notification"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "emergency_bridge"
+            ],
+            "type": "string"
+        },
+        "From": {
+            "type": "string"
+        },
+        "HTML": {
+            "type": "string"
+        },
+        "Outbound-Caller-ID-Name": {
+            "type": "string"
+        },
+        "Outbound-Caller-ID-Number": {
+            "type": "string"
+        },
+        "Owner-ID": {
+            "type": "string"
+        },
+        "Preview": {
+            "type": "boolean"
+        },
+        "Realm": {
+            "type": "string"
+        },
+        "Reply-To": {
+            "type": "string"
+        },
+        "Subject": {
+            "type": "string"
+        },
+        "Text": {
+            "type": "string"
+        },
+        "To": {
+            "type": "string"
+        },
+        "User-Email": {
+            "type": "string"
+        },
+        "User-First-Name": {
+            "type": "string"
+        },
+        "User-Last-Name": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Account-ID",
+        "Call-ID"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/phone_numbers.json
+++ b/applications/crossbar/priv/couchdb/schemas/phone_numbers.json
@@ -89,6 +89,14 @@
                     "description": "The e911 provisioning system calculated service address longitude",
                     "type": "string"
                 },
+                "notification_contact_emails": {
+                    "default": [],
+                    "description": "A list of email addresses to receive notification when this number places an emergency call",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "plus_four": {
                     "description": "The extended zip/postal code where the number is in service",
                     "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/resources.json
+++ b/applications/crossbar/priv/couchdb/schemas/resources.json
@@ -347,6 +347,14 @@
             },
             "type": "array"
         },
+        "rules_test": {
+            "default": [],
+            "description": "A list of regular expressions of which if matched denotes a test rule",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
         "weight_cost": {
             "default": 50,
             "description": "A value between 0 and 100 that determines the order of resources when multiple can be used",

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -6733,6 +6733,13 @@
         'longitude':
           'description': The e911 provisioning system calculated service address longitude
           'type': string
+        'notification_contact_emails':
+          'default': []
+          'description': |-
+            A list of email addresses to receive notification when this number places an emergency call
+          'items':
+            'type': string
+          'type': array
         'plus_four':
           'description': The extended zip/postal code where the number is in service
           'type': string
@@ -8127,6 +8134,12 @@
       'default': []
       'description': |-
         A list of regular expressions of which one must match for the rule to be eligible, they can optionally contain capture groups
+      'items':
+        'type': string
+      'type': array
+    'rules_test':
+      'default': []
+      'description': A list of regular expressions of which if matched denotes a test rule
       'items':
         'type': string
       'type': array

--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -552,6 +552,8 @@ publish_fun(<<"cnam_request">>) ->
     fun kapi_notifications:publish_cnam_request/1;
 publish_fun(<<"customer_update">>) ->
     fun kapi_notifications:publish_customer_update/1;
+publish_fun(<<"emergency_bridge">>) ->
+    fun kapi_notifications:publish_emergency_bridge/1;
 publish_fun(<<"denied_emergency_bridge">>) ->
     fun kapi_notifications:publish_denied_emergency_bridge/1;
 publish_fun(<<"deregister">>) ->

--- a/applications/stepswitch/src/stepswitch_bridge.erl
+++ b/applications/stepswitch/src/stepswitch_bridge.erl
@@ -316,7 +316,9 @@ maybe_bridge(#state{endpoints=Endpoints
                    ,control_queue=ControlQ
                    }=State) ->
     case contains_emergency_endpoints(Endpoints) of
-        'true' -> maybe_bridge_emergency(State);
+        'true' ->
+            _ = send_emergency_bridge_notification(State),
+            maybe_bridge_emergency(State);
         'false' ->
             Name = bridge_outbound_cid_name(OffnetReq),
             Number = bridge_outbound_cid_number(OffnetReq),
@@ -692,6 +694,110 @@ send_deny_emergency_response(OffnetReq, ControlQ) ->
                                       ,<<"prompt://system_media/stepswitch-emergency_not_configured/">>
                                       ),
     kz_call_response:send(CallId, ControlQ, Code, Cause, Media).
+
+-spec send_emergency_bridge_notification(state()) -> 'ok'.
+send_emergency_bridge_notification(#state{resource_req=OffnetReq}=State) ->
+    Setters = [{fun set_emergency_call_meta/2, State}
+              ,{fun set_emergency_device_meta/2, OffnetReq}
+              ,{fun set_emergency_address_meta/2, OffnetReq}
+              ,{fun set_emergency_user_meta/2, OffnetReq}
+              ,{fun set_default_headers/2, OffnetReq}
+              ],
+
+    Props = lists:foldl(fun({F, O}, A) -> F(O, A) end, [], Setters),
+    kapps_notify_publisher:cast(Props, fun kapi_notifications:publish_emergency_bridge/1).
+
+-spec set_default_headers(kapi_offnet_resource:req(), kz_term:proplist()) -> kz_term:proplist().
+set_default_headers(_OffnetReq, Props) ->
+    Props ++ kz_api:default_headers(?APP_NAME, ?APP_VERSION).
+
+-spec set_emergency_call_meta(state(), kz_term:proplist()) -> kz_term:proplist().
+set_emergency_call_meta(#state{resource_req=OffnetReq}=State, Props) ->
+    [{<<"Call-ID">>, kapi_offnet_resource:call_id(OffnetReq)}
+    ,{<<"Account-ID">>, kapi_offnet_resource:account_id(OffnetReq)}
+    ,{?KEY_E_CALLER_ID_NUMBER, kapi_offnet_resource:emergency_caller_id_number(OffnetReq)}
+    ,{?KEY_E_CALLER_ID_NAME, kapi_offnet_resource:emergency_caller_id_name(OffnetReq)}
+    ,{?KEY_OUTBOUND_CALLER_ID_NUMBER, kapi_offnet_resource:outbound_caller_id_number(OffnetReq)}
+    ,{?KEY_OUTBOUND_CALLER_ID_NAME, kapi_offnet_resource:outbound_caller_id_name(OffnetReq)}
+    ,{<<"Emergency-Test-Call">>, maybe_emergency_test_call(State)}
+    ,{<<"Emergency-To-DID">>, kapi_offnet_resource:to_did(OffnetReq)}
+     | Props
+    ].
+
+
+-spec set_emergency_device_meta(kapi_offnet_resource:req(), kz_term:proplist()) -> kz_term:proplist().
+set_emergency_device_meta(OffnetReq, Props) ->
+    AccountID = kapi_offnet_resource:account_id(OffnetReq),
+    DeviceID = kz_json:get_ne_value(<<"Authorizing-ID">>, kapi_offnet_resource:requestor_custom_channel_vars(OffnetReq), 'undefined'),
+    OwnerID =kz_json:get_ne_value(<<"Owner-ID">>, kapi_offnet_resource:requestor_custom_channel_vars(OffnetReq), 'undefined'),
+    {'ok', DeviceJObj} = kzd_devices:fetch(AccountID, DeviceID),
+    [{<<"Authorizing-ID">>, DeviceID}
+    ,{<<"Owner-ID">>, OwnerID}
+    ,{<<"Device-Name">>, kzd_devices:name(DeviceJObj)}
+     | Props
+    ].
+
+-spec set_emergency_address_meta(kapi_offnet_resource:req(), kz_term:proplist()) -> kz_term:proplist().
+set_emergency_address_meta(OffnetReq, Props) ->
+    AccountDB = kzs_util:format_account_db(kapi_offnet_resource:account_id(OffnetReq)),
+    {'ok', Doc} = kz_datamgr:open_doc(AccountDB, kapi_offnet_resource:emergency_caller_id_number(OffnetReq)),
+    [{<<"Emergency-Address-Street-1">>, extract_e911_street_address_field(Doc, <<"street_address">>)}
+    ,{<<"Emergency-Address-Street-2">>,  extract_e911_street_address_field(Doc, <<"street_address_extended">>)}
+    ,{<<"Emergency-Address-City">>,  kzd_phone_numbers:e911_locality(Doc)}
+    ,{<<"Emergency-Address-Latitude">>, kzd_phone_numbers:e911_latitude(Doc)}
+    ,{<<"Emergency-Address-Longitude">>, kzd_phone_numbers:e911_latitude(Doc)}
+    ,{<<"Emergency-Address-Region">>,  kzd_phone_numbers:e911_region(Doc)}
+    ,{<<"Emergency-Address-Postal-Code">>,  kzd_phone_numbers:e911_postal_code(Doc)}
+    ,{<<"Emergency-Notfication-Contact-Emails">>, kzd_phone_numbers:e911_notification_contact_emails(Doc)}
+     | Props
+    ].
+
+-spec maybe_emergency_test_call(state()) -> boolean().
+maybe_emergency_test_call(#state{endpoints=Endpoints
+                                ,resource_req=OffnetReq
+                                }=_State) ->
+    is_resource_test_rule(Endpoints, kapi_offnet_resource:to_did(OffnetReq)).
+
+-spec is_resource_test_rule(stepswitch_resources:endpoints(), kz_term:ne_binary()) -> boolean().
+is_resource_test_rule(Endpoints, To) ->
+    is_resource_test_rule(Endpoints, To, 'false').
+
+-spec is_resource_test_rule(stepswitch_resources:endpoints(), kz_term:ne_binary(), boolean()) -> boolean().
+is_resource_test_rule([], _To, Acc) -> Acc;
+is_resource_test_rule([E | Rest], To, Acc) ->
+    ResourceId = kz_json:get_ne_value([<<"Custom-Channel-Vars">>, <<"Resource-ID">>], E),
+    Match = stepswitch_resources:is_test_number(To, ResourceId),
+    is_resource_test_rule(Rest, To, Match or Acc).
+
+-spec extract_e911_street_address_field(kz_doc:doc(), kz_term:ne_binary()) -> kz_term:ne_binary() | 'undefined'.
+extract_e911_street_address_field(Doc, Key) ->
+    JObj = kzd_phone_numbers:e911(Doc),
+    case kz_json:get_ne_value(Key, JObj) of
+        'undefined' -> maybe_use_e911_legacy_value(Doc, Key);
+        Value -> Value
+    end.
+
+-spec maybe_use_e911_legacy_value(kz_doc:doc(), kz_term:ne_binary()) -> kz_term:ne_binary() | 'undefined'.
+maybe_use_e911_legacy_value(Doc, <<"street_address">>) ->
+    <<(kzd_phone_numbers:e911_legacy_data_house_number(Doc))/binary
+     ," "
+     ,(kzd_phone_numbers:e911_legacy_data_streetname(Doc))/binary>>;
+maybe_use_e911_legacy_value(Doc, <<"street_address_extended">>) ->
+    kzd_phone_numbers:e911_legacy_data_suite(Doc).
+
+-spec set_emergency_user_meta(kapi_offnet_resource:req(), kz_term:proplist()) -> kz_term:proplist().
+set_emergency_user_meta(OffnetReq, Props) ->
+    AccountID = kapi_offnet_resource:account_id(OffnetReq),
+    OwnerID =kz_json:get_ne_value(<<"Owner-ID">>, kapi_offnet_resource:requestor_custom_channel_vars(OffnetReq), 'undefined'),
+    case kzd_users:fetch(AccountID, OwnerID) of
+        {'ok', UserJObj} ->
+            [{<<"User-First-Name">>, kzd_users:first_name(UserJObj)}
+            ,{<<"User-Last-Name">>, kzd_users:last_name(UserJObj)}
+            ,{<<"User-Email">>, kzd_users:email(UserJObj)}
+             | Props
+            ];
+        {'error', _} -> Props
+    end.
 
 -spec get_event_type(kz_call_event:doc()) ->
           {kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()}.

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -255,24 +255,27 @@ endpoints(Number, OffnetJObj) ->
 
 -spec is_test_number(kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
 is_test_number(Number, ResourceId) ->
-    Resource = get_resource(ResourceId),
-    Rules = get_resrc_rules_test(Resource),
-    maybe_match_test_number(Rules, Number).
+    case get_resource(ResourceId) of
+        'undefined' -> 'false';
+        Resource ->
+            Rules = get_resrc_rules_test(Resource),
+            maybe_match_test_number(Rules, Number)
+    end.
 
+-spec maybe_match_test_number([re:mp()] , kz_term:ne_binary()) -> boolean().
 maybe_match_test_number([], _) -> 'false';
 maybe_match_test_number([Rule | Rules], Number) ->
     case re:run(Number, Rule) of
         {'match', _Captured} -> 'true';
         'nomatch' -> maybe_match_test_number(Rules, Number)
-    end;
-maybe_match_test_number(_, _) -> 'false'.
+    end.
 
 -spec maybe_get_endpoints(kz_term:ne_binary(), kapi_offnet_resource:req()) -> endpoints().
 maybe_get_endpoints(Number, OffnetJObj) ->
     case kapi_offnet_resource:hunt_account_id(OffnetJObj) of
         'undefined' -> get_global_endpoints(Number, OffnetJObj);
         HuntAccount -> maybe_get_local_endpoints(HuntAccount, Number, OffnetJObj)
-    end.
+        end.
 
 -spec maybe_get_local_endpoints(kz_term:ne_binary(), kz_term:ne_binary(), kapi_offnet_resource:req()) -> endpoints().
 maybe_get_local_endpoints(HuntAccount, Number, OffnetJObj) ->

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -264,7 +264,8 @@ maybe_match_test_number([Rule | Rules], Number) ->
     case re:run(Number, Rule) of
         {'match', _Captured} -> 'true';
         'nomatch' -> maybe_match_test_number(Rules, Number)
-    end.
+    end;
+maybe_match_test_number(_, _) -> 'false'.
 
 -spec maybe_get_endpoints(kz_term:ne_binary(), kapi_offnet_resource:req()) -> endpoints().
 maybe_get_endpoints(Number, OffnetJObj) ->

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -275,7 +275,7 @@ maybe_get_endpoints(Number, OffnetJObj) ->
     case kapi_offnet_resource:hunt_account_id(OffnetJObj) of
         'undefined' -> get_global_endpoints(Number, OffnetJObj);
         HuntAccount -> maybe_get_local_endpoints(HuntAccount, Number, OffnetJObj)
-        end.
+    end.
 
 -spec maybe_get_local_endpoints(kz_term:ne_binary(), kz_term:ne_binary(), kapi_offnet_resource:req()) -> endpoints().
 maybe_get_local_endpoints(HuntAccount, Number, OffnetJObj) ->

--- a/applications/stepswitch/src/stepswitch_resources.erl
+++ b/applications/stepswitch/src/stepswitch_resources.erl
@@ -19,6 +19,7 @@
 -export([maybe_add_proxies/3]).
 -export([gateways_to_endpoints/4]).
 -export([check_diversion_fields/1]).
+-export([is_test_number/2]).
 
 -export([get_resrc_id/1
         ,get_resrc_rev/1
@@ -27,7 +28,9 @@
         ,get_resrc_grace_period/1
         ,get_resrc_flags/1
         ,get_resrc_rules/1
+        ,get_resrc_rules_test/1
         ,get_resrc_raw_rules/1
+        ,get_resrc_raw_rules_test/1
         ,get_resrc_cid_rules/1
         ,get_resrc_cid_raw_rules/1
         ,get_resrc_gateways/1
@@ -55,7 +58,9 @@
         ,set_resrc_grace_period/2
         ,set_resrc_flags/2
         ,set_resrc_rules/2
+        ,set_resrc_rules_test/2
         ,set_resrc_raw_rules/2
+        ,set_resrc_raw_rules_test/2
         ,set_resrc_cid_rules/2
         ,set_resrc_cid_raw_rules/2
         ,set_resrc_gateways/2
@@ -135,7 +140,9 @@
                ,grace_period = 3 :: non_neg_integer()
                ,flags = [] :: list()
                ,rules = [] :: list()
+               ,rules_test = [] :: list()
                ,raw_rules = [] :: list()
+               ,raw_rules_test = [] :: list()
                ,cid_rules = [] :: list()
                ,cid_raw_rules = [] :: list()
                ,gateways = [] :: list()
@@ -221,6 +228,7 @@ resource_to_props(#resrc{}=Resource) ->
       ,{<<"Flags">>, Resource#resrc.flags}
       ,{<<"Codecs">>, Resource#resrc.codecs}
       ,{<<"Rules">>, Resource#resrc.raw_rules}
+      ,{<<"Rules-Test">>, Resource#resrc.raw_rules_test}
       ,{<<"Caller-ID-Rules">>, Resource#resrc.cid_raw_rules}
       ,{<<"Formatters">>, Resource#resrc.formatters}
       ,{<<"Privacy-Method">>,  Resource#resrc.privacy_method}
@@ -243,6 +251,19 @@ endpoints(Number, OffnetJObj) ->
     case maybe_get_endpoints(Number, OffnetJObj) of
         [] -> [];
         Endpoints -> sort_endpoints(Endpoints)
+    end.
+
+-spec is_test_number(kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
+is_test_number(Number, ResourceId) ->
+    Resource = get_resource(ResourceId),
+    Rules = get_resrc_rules_test(Resource),
+    maybe_match_test_number(Rules, Number).
+
+maybe_match_test_number([], _) -> 'false';
+maybe_match_test_number([Rule | Rules], Number) ->
+    case re:run(Number, Rule) of
+        {'match', _Captured} -> 'true';
+        'nomatch' -> maybe_match_test_number(Rules, Number)
     end.
 
 -spec maybe_get_endpoints(kz_term:ne_binary(), kapi_offnet_resource:req()) -> endpoints().
@@ -1083,7 +1104,9 @@ resource_from_jobj(JObj) ->
                      ,from_account_realm=kz_json:is_true(<<"from_account_realm">>, JObj)
                      ,fax_option=kz_json:is_true([<<"media">>, <<"fax_option">>], JObj)
                      ,raw_rules=kz_json:get_value(<<"rules">>, JObj, [])
+                     ,raw_rules_test=kz_json:get_value(<<"rules_test">>, JObj, [])
                      ,rules=resource_rules(JObj)
+                     ,rules_test=resource_rules_test(JObj)
                      ,cid_raw_rules=kz_json:get_value(<<"cid_rules">>, JObj, [])
                      ,cid_rules=resource_cid_rules(JObj)
                      ,weight=resource_weight(JObj)
@@ -1144,6 +1167,13 @@ resource_rules([Rule|Rules], CompiledRules) ->
             lager:warning("bad rule '~s': ~p", [Rule, _R]),
             resource_rules(Rules, CompiledRules)
     end.
+
+-spec resource_rules_test(kz_json:object()) -> rules().
+resource_rules_test(JObj) ->
+    Rules = kz_json:get_value(<<"rules_test">>, JObj, []),
+    lager:info("compiling resource test rules for ~s / ~s: ~p"
+              ,[kz_doc:account_db(JObj, <<"offnet">>), kz_doc:id(JObj), Rules]),
+    resource_rules(Rules, []).
 
 -spec resource_cid_rules(kz_json:object()) -> rules().
 resource_cid_rules(JObj) ->
@@ -1306,8 +1336,14 @@ get_resrc_flags(#resrc{flags=Flags}) -> Flags.
 -spec get_resrc_rules(resource()) -> list().
 get_resrc_rules(#resrc{rules=Rules}) -> Rules.
 
+-spec get_resrc_rules_test(resource()) -> list().
+get_resrc_rules_test(#resrc{rules_test=Rules}) -> Rules.
+
 -spec get_resrc_raw_rules(resource()) -> list().
 get_resrc_raw_rules(#resrc{raw_rules=RawRules}) -> RawRules.
+
+-spec get_resrc_raw_rules_test(resource()) -> list().
+get_resrc_raw_rules_test(#resrc{raw_rules_test=RawRules}) -> RawRules.
 
 -spec get_resrc_cid_rules(resource()) -> list().
 get_resrc_cid_rules(#resrc{cid_rules=CIDRules}) -> CIDRules.
@@ -1385,8 +1421,14 @@ set_resrc_flags(Resource, Flags) -> Resource#resrc{flags=Flags}.
 -spec set_resrc_rules(resource(), list()) -> resource().
 set_resrc_rules(Resource, Rules) -> Resource#resrc{rules=Rules}.
 
+-spec set_resrc_rules_test(resource(), list()) -> resource().
+set_resrc_rules_test(Resource, Rules) -> Resource#resrc{rules_test=Rules}.
+
 -spec set_resrc_raw_rules(resource(), list()) -> resource().
 set_resrc_raw_rules(Resource, RawRules) -> Resource#resrc{raw_rules=RawRules}.
+
+-spec set_resrc_raw_rules_test(resource(), list()) -> resource().
+set_resrc_raw_rules_test(Resource, RawRules) -> Resource#resrc{raw_rules_test=RawRules}.
 
 -spec set_resrc_cid_rules(resource(), list()) -> resource().
 set_resrc_cid_rules(Resource, CIDRules) -> Resource#resrc{cid_rules=CIDRules}.

--- a/applications/teletype/priv/templates/emergency_bridge.html
+++ b/applications/teletype/priv/templates/emergency_bridge.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="x-apple-disable-message-reformatting">
+    <title>Emergency Call</title>
+    <!--[if !mso]><link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'><![endif]-->
+    <style>
+        /* CSS Reset */
+        html,body{margin:0 auto !important;padding:0 !important;height:100% !important;width:100% !important;} *{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;}div[style*="margin:16px 0"]{margin:0 !important;}table,td{mso-table-lspace:0pt !important;mso-table-rspace:0pt !important;}table{border-spacing:0 !important;border-collapse:collapse !important;table-layout:fixed !important;margin:0 auto !important;}table table table{table-layout:auto;}img{-ms-interpolation-mode:bicubic;}*[x-apple-data-detectors]{color:inherit !important;text-decoration:none !important;}.x-gmail-data-detectors,.x-gmail-data-detectors *,.aBn{border-bottom:0 !important;cursor:default !important;}.a6S{display:none !important;opacity:0.01 !important;}img.g-img + div{display:none !important;}.button-link{text-decoration:none !important;}@media only screen and (min-device-width:375px) and (max-device-width:413px){.email-container{min-width:375px !important;}}
+        /* Progressive Enhancements */
+        *{font-family:'Open Sans',Arial,sans-serif;}
+        html,body{font-size:15px;line-height:20px;}
+    </style>
+</head>
+<body width="100%" bgcolor="#eaeaea" style="margin:0;mso-line-height-rule:exactly;background-color:#eaeaea">
+    <center style="padding:40px 0;width:100%;background:#eaeaea;text-align:left;">
+        <div style="display:none;font-size:1px;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;mso-hide:all;font-family:sans-serif;">
+            Attention! An Emergency {% if call.emergency_test_call %}Test{% endif %} Call has been placed -
+        </div>
+        <div style="max-width:600px; margin:auto;" class="email-container">
+            <!--[if mso]>
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" align="center">
+            <tr>
+            <td>
+            <![endif]-->
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#ff4a33" align="center" width="100%" style="background-color:#ff4a33;border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <tr>
+                    <td style="padding:40px;text-align:center;">
+                        <h2 style="margin:0;padding:0;text-align:center;font-family:'Open Sans',sans-serif;color:#ffffff;font-weight:100;">Emergency {% if call.emergency_test_call %}Test{% endif %} Call</h2>
+                    </td>
+                </tr>
+            </table>
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:40px;text-align:center;font-family:'Open Sans',sans-serif;color:#555555;">
+                        <p style="margin:0;padding:0;text-align:center;font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;">{% if call.owner_id %}{{call.user_first_name}} {{call.user_last_name}}{% else %}The device {{call.device_name}}{% endif %} has just placed an Emergency {% if call.emergency_test_call %}Test{% endif %} Call to {{call.emergency_to_did}} from Account {{account.name}}.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">
+                        <h3 style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">Emergency Call Details</h3>
+                    </td>
+                </tr>
+                    <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
+                        <dl style="padding:0;margin:0;">
+                             <dt style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding:0 0 10px;"><b>Call-ID:</b> <span style="font-family:monospace;">{{call.call_id}}</span></dt>
+                            <dt style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding:0 0 10px;"><b>Emergency Service Address:</b></dt>
+                             <dd style="padding:0;margin:0 0 0 40px;">
+                                {{call.emergency_address_street_1}}<br/>
+                                {{call.emergency_address_street_2}}<br/>
+                                {{call.emergency_address_city}}, {{call.emergency_address_region}} {{call.emergency_address_postal_code}}
+                            </dd>
+                            <dt style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding:10px 0;"><b>Emergency Caller ID:</b></dt>
+                            <dd style="padding:0;margin:0 0 0 40px;">
+                                <ul style="padding:0;margin:0;">
+                                    <li style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding: 3px 0;"><b>Name:</b> {{call.emergency_caller_id_name}}</li>
+                                    <li style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding: 3px 0;"><b>Number:</b> {{call.emergency_caller_id_number}}</li>
+                                </ul>
+                            </dd>
+                            <dt style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding:10px 0;"><b>External Caller ID:</b></dt>
+                            <dd style="padding:0;margin:0 0 0 40px;">
+                                <ul style="padding:0;margin:0;">
+                                    <li style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding: 3px 0;"><b>Name:</b> {{call.outbound_caller_id_name}}</li>
+                                    <li style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding: 3px 0;"><b>Number:</b> {{call.outbound_caller_id_number}}</li>
+                                </ul>
+                            </dd>
+                            <dt style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding:10px 0;"><b>Device:</b></dt>
+                            <dd style="padding:0;margin:0 0 0 40px;">
+                                <ul style="padding:0;margin:0;">
+                                    <li style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding: 3px 0;"><b>Device ID:</b> {{call.authorizing_id}}</li>
+                                    <li style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding: 3px 0;"><b>Device Name:</b> {{call.device_name}}</li>
+                                    {% if call.owner_id %}
+                                    <li style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding: 3px 0;"><b>User Name:</b> {{call.user_first_name}} {{call.user_last_name}} ({{call.owner_id}})</li>
+                                    <li style="font-family:'Open Sans',sans-serif;color:#555555;line-height:20px;padding: 3px 0;"><b>User Email:</b> {{call.user_email}}</li>
+                                    {% endif %}
+                                </ul>
+                            </dd>
+                        </dl>
+                    </td>
+                </tr>
+            </table>
+            <!-- Pre-Footer -->
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="border-color:#dedede;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <!-- Clear Spacer -->
+                <tr><td height="50" style="background-color:#ffffff;font-size:50px;line-height:50px;">&nbsp;</td></tr>
+                <tr><!-- #6a59f7 -->
+                    <td bgcolor="#e2e2e2" style="padding:0 20px;background-color:#e2e2e2;color:#555555;">
+                        <h4 style="font-weight:100;line-height:20px;margin:13px 0;font-family:'Open Sans',sans-serif;color:#555555;">Account Information</h4>
+                        <p style="margin:13px;padding:0;font-family:'Open Sans',sans-serif;color:#555555;font-size:11px;line-height:18px;">
+                            <b>-&nbsp;&nbsp;&nbsp;Account ID:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{account.id}}</span><br>
+                            <b>-&nbsp;&nbsp;&nbsp;Account Name:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{account.name}}</span><br>
+                            <b>-&nbsp;&nbsp;&nbsp;Account Realm:</b>&nbsp;&nbsp;<span style="font-family:monospace;">{{account.realm}}</span>
+                        </p>
+                    </td>
+                </tr>
+            </table>
+            <!-- Email Footer -->
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" bgcolor="#202029" align="center" width="100%" style="background-color:#202029;border-color:#202029;border-width:1px;border-left-style:solid;border-right-style:solid;max-width:600px;">
+                <tr><td style="font-size:50px;line-height:50px;" height="50">&nbsp;</td></tr>
+            </table>
+            <p style="margin:0;padding:5px 0;font-family:'Open Sans',sans-serif;color:#a9a9a9;font-size:10px;">Sent from {{system.encoded_node}}</p>
+            <!--[if mso]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+        </div>
+    </center>
+</body>
+</html>

--- a/applications/teletype/priv/templates/emergency_bridge.text
+++ b/applications/teletype/priv/templates/emergency_bridge.text
@@ -1,0 +1,45 @@
+                Emergency {% if call.emergency_test_call %}Test{% endif %} Call Notification
+
+{% if call.owner_id %}{{call.user_first_name}} {{call.user_last_name}}{% else %}The device {{call.device_name}}{% endif %} has just placed an Emergency {% if call.emergency_test_call %}Test{% endif %} Call to {{call.emergency_to_did}} from Account {{account.name}}. Here are the emergency call details:
+
+=== Emergency {% if call.emergency_test_call %}Test{% endif %} Call Details ===
+
+    Call-ID: {{call.call_id}}
+
+    Emergency Service Address:
+
+        {{call.emergency_address_street_1}}
+        {{call.emergency_address_street_2}}
+        {{call.emergency_address_city}}, {{call.emergency_address_region}} {{call.emergency_address_postal_code}}
+
+    Emergency Caller ID:
+        - Name: {{call.emergency_caller_id_name}}
+        - Number: {{call.emergency_caller_id_number}}
+
+
+    External Caller ID:
+        - Name: {{call.outbound_caller_id_name}}
+        - Number: {{call.outbound_caller_id_number}}
+
+    Device:
+        - Device ID: {{call.authorizing_id}}
+        - Device Name: {{call.device_name}}
+        {% if call.owner_id %}
+        - Owner Name: {{call.user_first_name}} {{call.user_last_name}} ({{call.owner_id}})
+        - Owner Email: {{call.user_email}}
+        {% endif %}
+
+
+Account Information
+
+    Account ID: {{account.id}}
+    Account Name: {{account.name}}
+    Account Realm: {{account.realm}}
+
+
+
+Sent from {{system.encoded_node}}
+
+
+
+

--- a/applications/teletype/src/templates/teletype_emergency_bridge.erl
+++ b/applications/teletype/src/templates/teletype_emergency_bridge.erl
@@ -71,7 +71,7 @@ init() ->
 
 -spec handle_req(kz_json:object()) -> template_response().
 handle_req(JObj) ->
-  handle_req(JObj, kapi_notifications:emergency_bridge_v(JObj)).
+    handle_req(JObj, kapi_notifications:emergency_bridge_v(JObj)).
 
 -spec handle_req(kz_json:object(), boolean()) -> template_response().
 handle_req(_, 'false') ->

--- a/applications/teletype/src/templates/teletype_emergency_bridge.erl
+++ b/applications/teletype/src/templates/teletype_emergency_bridge.erl
@@ -1,0 +1,126 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2014-2020, 2600Hz
+%%% @doc
+%%% @author James Aimonetti
+%%%
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(teletype_emergency_bridge).
+
+-export([init/0
+        ,handle_req/1
+        ]).
+
+-include("teletype.hrl").
+
+-define(TEMPLATE_ID, <<"emergency_bridge">>).
+
+-define(TEMPLATE_MACROS
+       ,kz_json:from_list(
+          [?MACRO_VALUE(<<"call.outbound_caller_id_name">>, <<"outbound_caller_id_name">>, <<"Outbound Caller ID Name">>, <<"Outbound Caller ID Name">>)
+          ,?MACRO_VALUE(<<"call.outbound_caller_id_number">>, <<"outbound_caller_id_number">>, <<"Outbound Caller ID Number">>, <<"Outbound Caller ID Number">>)
+          ,?MACRO_VALUE(<<"call.emergency_caller_id_name">>, <<"emergency_caller_id_name">>, <<"Emergency Caller ID Name">>, <<"Emergency Caller ID Name">>)
+          ,?MACRO_VALUE(<<"call.emergency_caller_id_number">>, <<"emergency_caller_id_number">>, <<"Emergency Caller ID Number">>, <<"Emergency Caller ID Number">>)
+          ,?MACRO_VALUE(<<"call.call_id">>, <<"call_id">>, <<"Call ID">>, <<"Call ID">>)
+          ,?MACRO_VALUE(<<"call.device_name">>, <<"device_name">>, <<"Device Name">>, <<"Device Name">>)
+          ,?MACRO_VALUE(<<"call.emergency_address_street_1">>, <<"emergency_address_street_1">>, <<"Emergency Address Street 1">>, <<"Emergency Address Street 1">>)
+          ,?MACRO_VALUE(<<"call.emergency_address_street_2">>, <<"emergency_address_street_2">>, <<"Emergency Address Street 2">>, <<"Emergency Address Street 2">>)
+          ,?MACRO_VALUE(<<"call.emergency_address_city">>, <<"emergency_address_city">>, <<"Emergency Address City">>, <<"Emergency Address City">>)
+          ,?MACRO_VALUE(<<"call.emergency_address_region">>, <<"emergency_address_region">>, <<"Emergency Address Region">>, <<"Emergency Address Region">>)
+          ,?MACRO_VALUE(<<"call.emergency_address_postal_code">>, <<"emergency_address_postal_code">>, <<"Emergency Address Postal Code">>, <<"Emergency Address Postal Code">>)
+          ,?MACRO_VALUE(<<"call.emergency_notification_contact_emails">>, <<"emergency_notification_contact_emails">>, <<"Emergency Contact Emails">>, <<"Emergency Contact Emails">>)
+          ,?MACRO_VALUE(<<"call.emergency_test_call">>, <<"emergency_test_call">>, <<"Emergency Test Call">>, <<"Emergency Test Call">>)
+          ,?MACRO_VALUE(<<"call.emergency_to_did">>, <<"emergency_to_did">>, <<"Emergency To DID">>, <<"Emergency To DID">>)
+          ,?MACRO_VALUE(<<"call.owner_id">>, <<"owner_id">>, <<"Owner ID">>, <<"Owner ID">>)
+          ,?MACRO_VALUE(<<"call.user_email">>, <<"user_email">>, <<"User Email">>, <<"User Email">>)
+          ,?MACRO_VALUE(<<"call.user_first_name">>, <<"user_first_name">>, <<"User First Name">>, <<"User First Name">>)
+          ,?MACRO_VALUE(<<"call.user_last_name">>, <<"user_last_name">>, <<"User Last Name">>, <<"User Last Name">>)
+           | ?COMMON_TEMPLATE_MACROS
+          ]
+         )
+       ).
+
+-define(TEMPLATE_SUBJECT, <<"Emergency{%if call.emergency_test_call %} Test{% endif %} Call Notification from Account '{{account.name}}'">>).
+-define(TEMPLATE_CATEGORY, <<"account">>).
+-define(TEMPLATE_NAME, <<"Emergency Bridge">>).
+
+-define(TEMPLATE_TO, ?CONFIGURED_EMAILS(?EMAIL_ADMINS)).
+-define(TEMPLATE_FROM, teletype_util:default_from_address()).
+-define(TEMPLATE_CC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
+-define(TEMPLATE_BCC, ?CONFIGURED_EMAILS(?EMAIL_SPECIFIED, [])).
+-define(TEMPLATE_REPLY_TO, teletype_util:default_reply_to()).
+
+-spec init() -> 'ok'.
+init() ->
+    kz_log:put_callid(?MODULE),
+    teletype_templates:init(?TEMPLATE_ID, [{'macros', ?TEMPLATE_MACROS}
+                                          ,{'subject', ?TEMPLATE_SUBJECT}
+                                          ,{'category', ?TEMPLATE_CATEGORY}
+                                          ,{'friendly_name', ?TEMPLATE_NAME}
+                                          ,{'to', ?TEMPLATE_TO}
+                                          ,{'from', ?TEMPLATE_FROM}
+                                          ,{'cc', ?TEMPLATE_CC}
+                                          ,{'bcc', ?TEMPLATE_BCC}
+                                          ,{'reply_to', ?TEMPLATE_REPLY_TO}
+                                          ]),
+    teletype_bindings:bind(<<"emergency_bridge">>, ?MODULE, 'handle_req').
+
+-spec handle_req(kz_json:object()) -> template_response().
+handle_req(JObj) ->
+  handle_req(JObj, kapi_notifications:emergency_bridge_v(JObj)).
+
+-spec handle_req(kz_json:object(), boolean()) -> template_response().
+handle_req(_, 'false') ->
+    lager:debug("invalid data for ~s", [?TEMPLATE_ID]),
+    teletype_util:notification_failed(?TEMPLATE_ID, <<"validation_failed">>);
+handle_req(JObj, 'true') ->
+    lager:debug("valid data for ~s, processing...", [?TEMPLATE_ID]),
+
+    %% Gather data for template
+    DataJObj = kz_json:normalize(JObj),
+    AccountId = kz_json:get_value(<<"account_id">>, DataJObj),
+
+    case teletype_util:is_notice_enabled(AccountId, JObj, ?TEMPLATE_ID) of
+        'false' -> teletype_util:notification_disabled(DataJObj, ?TEMPLATE_ID);
+        'true' -> process_req(DataJObj)
+    end.
+
+-spec process_req(kz_json:object()) -> template_response().
+process_req(DataJObj) ->
+    Macros = [{<<"system">>, teletype_util:system_params()}
+             ,{<<"account">>, teletype_util:account_params(DataJObj)}
+             ,{<<"call">>, kz_json:to_proplist(kz_api:remove_defaults(DataJObj))}
+             ],
+    %% Load templates
+    Templates = teletype_templates:render(?TEMPLATE_ID, Macros, DataJObj),
+
+
+    %% Populate templates
+    RenderedTemplates = [{ContentType, teletype_util:render(?TEMPLATE_ID, Template, Macros)}
+                         || {ContentType, Template} <- Templates
+                        ],
+
+    {'ok', TemplateMetaJObj} = teletype_templates:fetch_notification(?TEMPLATE_ID, kapi_notifications:account_id(DataJObj)),
+
+    Subject = teletype_util:render_subject(kz_json:find(<<"subject">>, [DataJObj, TemplateMetaJObj])
+                                          ,Macros
+                                          ),
+
+    Emails = maybe_update_to(DataJObj, TemplateMetaJObj),
+
+    case teletype_util:send_email(Emails, Subject, RenderedTemplates) of
+        'ok' -> teletype_util:notification_completed(?TEMPLATE_ID);
+        {'error', Reason} -> teletype_util:notification_failed(?TEMPLATE_ID, Reason)
+    end.
+
+-spec maybe_update_to(kz_json:object(), kz_json:object()) -> email_map().
+maybe_update_to(DataJObj, TemplateMetaJObj) ->
+    Emails = teletype_util:find_addresses(DataJObj, TemplateMetaJObj, ?TEMPLATE_ID),
+    case kz_json:get_list_value(<<"emergency_notfication_contact_emails">>, DataJObj, []) of
+        [] -> Emails;
+        ToList -> lists:keyreplace(<<"to">>, 1, Emails, {<<"to">>, ToList})
+    end.

--- a/applications/teletype/test/teletype_render_tests.erl
+++ b/applications/teletype/test/teletype_render_tests.erl
@@ -23,13 +23,14 @@ render_test_() ->
     ,fun setup/0
     ,fun cleanup/1
     ,fun(_ReturnOfSetup) ->
-             [?_assertEqual(38, length(?DEFAULT_MODULES))
+             [?_assertEqual(39, length(?DEFAULT_MODULES))
               %% ,test_rendering(teletype_account_zone_change)
              ,test_rendering(teletype_bill_reminder)
               %% ,test_rendering(teletype_cnam_request)
               %% ,test_rendering(teletype_customer_update)
               %% ,test_rendering(teletype_denied_emergency_bridge)
              ,test_rendering(teletype_deregister)
+              %% ,test_rendering(teletype_emergency_bridge)
               %% ,test_rendering(teletype_fax_inbound_error_to_email)
               %% ,test_rendering(teletype_fax_inbound_to_email)
               %% ,test_rendering(teletype_fax_outbound_error_to_email)

--- a/applications/webhooks/src/modules/webhooks_emergency_bridge.erl
+++ b/applications/webhooks/src/modules/webhooks_emergency_bridge.erl
@@ -1,0 +1,86 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2010-2020, 2600Hz
+%%%
+%%%
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(webhooks_emergency_bridge).
+
+-export([init/0
+        ,bindings_and_responders/0
+        ,account_bindings/1
+        ,handle_emergency_bridge/2
+        ]).
+
+-include("webhooks.hrl").
+
+-define(ID, kz_term:to_binary(?MODULE)).
+-define(HOOK_NAME, <<"emergency_bridge">>).
+-define(NAME, <<"Emergency Bridge">>).
+-define(DESC, <<"Receive notifications when an emergency call is placed.">>).
+
+-define(METADATA
+       ,kz_json:from_list(
+          [{<<"_id">>, ?ID}
+          ,{<<"name">>, ?NAME}
+          ,{<<"description">>, ?DESC}
+          ]
+         )
+       ).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec init() -> 'ok'.
+init() ->
+    webhooks_util:init_metadata(?ID, ?METADATA).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec bindings_and_responders() -> {gen_listener:bindings(), gen_listener:responders()}.
+bindings_and_responders() ->
+    Bindings = bindings(),
+    Responders = [{{?MODULE, 'handle_emergency_bridge'}, [{<<"notification">>, <<"emergency_bridge">>}]}],
+    {Bindings, Responders}.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec account_bindings(kz_term:ne_binary()) -> gen_listener:bindings().
+account_bindings(_AccountId) -> [].
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec handle_emergency_bridge(kz_json:object(), kz_term:proplist()) -> 'ok'.
+handle_emergency_bridge(Payload, _Props) ->
+    kz_log:put_callid(Payload),
+    AccountId = kz_json:get_ne_value(<<"Account-ID">>, Payload),
+    maybe_send_event(AccountId, Payload).
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec bindings() -> gen_listener:bindings().
+bindings() ->
+    [{'notifications', [{'restrict_to', ['emergency_bridge']}]}].
+
+maybe_send_event(AccountId, JObj) ->
+  case webhooks_util:find_webhooks(?HOOK_NAME, AccountId) of
+    [] -> lager:debug("no hooks to handle for ~s", [AccountId]);
+    Hooks -> webhooks_util:fire_hooks(JObj, Hooks)
+  end.

--- a/applications/webhooks/src/modules/webhooks_emergency_bridge.erl
+++ b/applications/webhooks/src/modules/webhooks_emergency_bridge.erl
@@ -80,7 +80,7 @@ bindings() ->
     [{'notifications', [{'restrict_to', ['emergency_bridge']}]}].
 
 maybe_send_event(AccountId, JObj) ->
-  case webhooks_util:find_webhooks(?HOOK_NAME, AccountId) of
-    [] -> lager:debug("no hooks to handle for ~s", [AccountId]);
-    Hooks -> webhooks_util:fire_hooks(JObj, Hooks)
-  end.
+    case webhooks_util:find_webhooks(?HOOK_NAME, AccountId) of
+        [] -> lager:debug("no hooks to handle for ~s", [AccountId]);
+        Hooks -> webhooks_util:fire_hooks(JObj, Hooks)
+    end.

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -1112,6 +1112,8 @@ emergency_bridge_definition() ->
                                                             ,<<"Emergency-Address-City">>
                                                             ,<<"Emergency-Address-Region">>
                                                             ,<<"Emergency-Address-Postal-Code">>
+                                                            ,<<"Emergency-Address-Latitude">>
+                                                            ,<<"Emergency-Address-Longitude">>
                                                             ,<<"Emergency-Notfication-Contact-Emails">>
                                                             ,<<"Outbound-Caller-ID-Name">>
                                                             ,<<"Outbound-Caller-ID-Number">>

--- a/core/kazoo_documents/src/kzd_phone_numbers.erl
+++ b/core/kazoo_documents/src/kzd_phone_numbers.erl
@@ -48,6 +48,7 @@
 -export([e911_locality/1, e911_locality/2, set_e911_locality/2]).
 -export([e911_location_id/1, e911_location_id/2, set_e911_location_id/2]).
 -export([e911_longitude/1, e911_longitude/2, set_e911_longitude/2]).
+-export([e911_notification_contact_emails/1, e911_notification_contact_emails/2, set_e911_notification_contact_emails/2]).
 -export([e911_plus_four/1, e911_plus_four/2, set_e911_plus_four/2]).
 -export([e911_postal_code/1, e911_postal_code/2, set_e911_postal_code/2]).
 -export([e911_region/1, e911_region/2, set_e911_region/2]).
@@ -578,6 +579,18 @@ e911_longitude(Doc, Default) ->
 -spec set_e911_longitude(doc(), binary()) -> doc().
 set_e911_longitude(Doc, E911Longitude) ->
     kz_json:set_value([<<"e911">>, <<"longitude">>], E911Longitude, Doc).
+
+-spec e911_notification_contact_emails(doc()) -> kz_term:ne_binaries().
+e911_notification_contact_emails(Doc) ->
+    e911_notification_contact_emails(Doc, []).
+
+-spec e911_notification_contact_emails(doc(), Default) -> kz_term:ne_binaries() | Default.
+e911_notification_contact_emails(Doc, Default) ->
+    kz_json:get_list_value([<<"e911">>, <<"notification_contact_emails">>], Doc, Default).
+
+-spec set_e911_notification_contact_emails(doc(), kz_term:ne_binaries()) -> doc().
+set_e911_notification_contact_emails(Doc, E911NotificationContactEmails) ->
+    kz_json:set_value([<<"e911">>, <<"notification_contact_emails">>], E911NotificationContactEmails, Doc).
 
 -spec e911_plus_four(doc()) -> kz_term:api_binary().
 e911_plus_four(Doc) ->

--- a/core/kazoo_documents/src/kzd_phone_numbers.erl.src
+++ b/core/kazoo_documents/src/kzd_phone_numbers.erl.src
@@ -24,6 +24,7 @@
 -export([e911_locality/1, e911_locality/2, set_e911_locality/2]).
 -export([e911_location_id/1, e911_location_id/2, set_e911_location_id/2]).
 -export([e911_longitude/1, e911_longitude/2, set_e911_longitude/2]).
+-export([e911_notification_contact_emails/1, e911_notification_contact_emails/2, set_e911_notification_contact_emails/2]).
 -export([e911_plus_four/1, e911_plus_four/2, set_e911_plus_four/2]).
 -export([e911_postal_code/1, e911_postal_code/2, set_e911_postal_code/2]).
 -export([e911_region/1, e911_region/2, set_e911_region/2]).
@@ -271,6 +272,18 @@ e911_longitude(Doc, Default) ->
 -spec set_e911_longitude(doc(), binary()) -> doc().
 set_e911_longitude(Doc, E911Longitude) ->
     kz_json:set_value([<<"e911">>, <<"longitude">>], E911Longitude, Doc).
+
+-spec e911_notification_contact_emails(doc()) -> kz_term:ne_binaries().
+e911_notification_contact_emails(Doc) ->
+    e911_notification_contact_emails(Doc, []).
+
+-spec e911_notification_contact_emails(doc(), Default) -> kz_term:ne_binaries() | Default.
+e911_notification_contact_emails(Doc, Default) ->
+    kz_json:get_list_value([<<"e911">>, <<"notification_contact_emails">>], Doc, Default).
+
+-spec set_e911_notification_contact_emails(doc(), kz_term:ne_binaries()) -> doc().
+set_e911_notification_contact_emails(Doc, E911NotificationContactEmails) ->
+    kz_json:set_value([<<"e911">>, <<"notification_contact_emails">>], E911NotificationContactEmails, Doc).
 
 -spec e911_plus_four(doc()) -> kz_term:api_binary().
 e911_plus_four(Doc) ->

--- a/core/kazoo_documents/src/kzd_resources.erl
+++ b/core/kazoo_documents/src/kzd_resources.erl
@@ -26,6 +26,7 @@
 -export([name/1, name/2, set_name/2]).
 -export([require_flags/1, require_flags/2, set_require_flags/2]).
 -export([rules/1, rules/2, set_rules/2]).
+-export([rules_test/1, rules_test/2, set_rules_test/2]).
 -export([weight_cost/1, weight_cost/2, set_weight_cost/2]).
 -export([fax_option/1, fax_option/2]).
 
@@ -232,6 +233,18 @@ rules(Doc, Default) ->
 -spec set_rules(doc(), kz_term:ne_binaries()) -> doc().
 set_rules(Doc, Rules) ->
     kz_json:set_value([<<"rules">>], Rules, Doc).
+
+-spec rules_test(doc()) -> kz_term:ne_binaries().
+rules_test(Doc) ->
+    rules_test(Doc, []).
+
+-spec rules_test(doc(), Default) -> kz_term:ne_binaries() | Default.
+rules_test(Doc, Default) ->
+    kz_json:get_list_value([<<"rules_test">>], Doc, Default).
+
+-spec set_rules_test(doc(), kz_term:ne_binaries()) -> doc().
+set_rules_test(Doc, RulesTest) ->
+    kz_json:set_value([<<"rules_test">>], RulesTest, Doc).
 
 -spec weight_cost(doc()) -> integer().
 weight_cost(Doc) ->

--- a/core/kazoo_documents/src/kzd_resources.erl.src
+++ b/core/kazoo_documents/src/kzd_resources.erl.src
@@ -22,6 +22,7 @@
 -export([name/1, name/2, set_name/2]).
 -export([require_flags/1, require_flags/2, set_require_flags/2]).
 -export([rules/1, rules/2, set_rules/2]).
+-export([rules_test/1, rules_test/2, set_rules_test/2]).
 -export([weight_cost/1, weight_cost/2, set_weight_cost/2]).
 
 
@@ -227,6 +228,18 @@ rules(Doc, Default) ->
 -spec set_rules(doc(), kz_term:ne_binaries()) -> doc().
 set_rules(Doc, Rules) ->
     kz_json:set_value([<<"rules">>], Rules, Doc).
+
+-spec rules_test(doc()) -> kz_term:ne_binaries().
+rules_test(Doc) ->
+    rules_test(Doc, []).
+
+-spec rules_test(doc(), Default) -> kz_term:ne_binaries() | Default.
+rules_test(Doc, Default) ->
+    kz_json:get_list_value([<<"rules_test">>], Doc, Default).
+
+-spec set_rules_test(doc(), kz_term:ne_binaries()) -> doc().
+set_rules_test(Doc, RulesTest) ->
+    kz_json:set_value([<<"rules_test">>], RulesTest, Doc).
 
 -spec weight_cost(doc()) -> integer().
 weight_cost(Doc) ->


### PR DESCRIPTION
This PR adds new functionality to help facilitate compliance with Kari's Law and notification for when an emergency call is placed.

An email contact list can now be set on a phone numbers emergency metadata.

Notification can now be achieved one of several ways:

* A new amqp event, `emergency_bridge` has been added to `kapi_notifications` to trigger a teletype notification email when an emergency call is placed.
* A new dedicated emergency bridge webhook can be configured

### KZOO-48: Create new teletype template for Emergency Call Notifcation
* Adds new text and html teletype templates
* Adds new teletype module to render template
* Template will distinguish between Emergency and test calls

### KZOO-49: Create AMQP Message For Emergency Notification
* Creates a new amqp definition ing `kapi_notifications` for usage when an emergency call is attempted.
* Publish callback as been added to `cb_notifications`
* Set emergency location data as well as user and device metadata

### KZOO-50: Trigger Notification When Emergency Call is Attempted
* Publishes `emergency_bridge` message when stepswitch determines an emergency call is being attempted
* Adds a new test rules object a resource to define test patterns for a resource to help differentiate between emergency and test calls.

 ### KZOO-51: Create a dedicated webhook module for emergency calls
* Adds `webhooks_emergency_bridge` which is explicitly dedicated to emergency call notification.
