### PR TITLE
Add missing fields from resources schema

### DIFF
--- a/applications/crossbar/doc/devices.md
+++ b/applications/crossbar/doc/devices.md
@@ -70,16 +70,21 @@ Key | Description | Type | Default | Required | Support Level
 `sip.custom_sip_headers.out` | Custom SIP Headers to be applied to calls outbound from Kazoo to the endpoint | [#/definitions/custom_sip_headers](#custom_sip_headers) |   | `false` |  
 `sip.custom_sip_headers.^[a-zA-z0-9_\-]+$` | The SIP header to add | `string()` |   | `false` |  
 `sip.custom_sip_headers` | A property list of SIP headers | `object()` |   | `false` |  
+`sip.custom_sip_interface` | If the bridge string should target a different SIP interface | `string()` |   | `false` |  
 `sip.expire_seconds` | The time, in seconds, sent to the provisioner for the registration period that the device should be configured with. | `integer()` | `300` | `false` | `supported`
+`sip.forward` | Forward IP to use | `string()` |   | `false` |  
 `sip.ignore_completed_elsewhere` | When set to false the phone should not consider ring group calls answered elsewhere as missed | `boolean()` |   | `false` |  
 `sip.invite_format` | The SIP request URI invite format | `string('username' | 'npan' | '1npan' | 'e164' | 'route' | 'contact')` | `contact` | `false` | `supported`
 `sip.ip` | IP address for this device | `string()` |   | `false` | `supported`
 `sip.method` | Method of authentication | `string('password' | 'ip')` | `password` | `false` | `supported`
 `sip.number` | The number used if the invite format is 1npan, npan, or e164 (if not set the dialed number is used) | `string()` |   | `false` |  
 `sip.password` | SIP authentication password | `string(5..32)` |   | `false` | `supported`
+`sip.proxy` | Proxy IP address to use | `string()` |   | `false` |  
 `sip.realm` | The realm this device should use, overriding the account realm. Should rarely be necessary. | `string(4..253)` |   | `false` |  
 `sip.route` | The SIP URL used if the invite format is 'route' | `string()` |   | `false` | `supported`
+`sip.static_invite` | SIP To user | `string()` |   | `false` |  
 `sip.static_route` | Sends all inbound calls to this string (instead of dialed number or username) | `string()` |   | `false` |  
+`sip.transport` | SIP Transport to use | `string()` |   | `false` |  
 `sip.username` | SIP authentication username | `string(2..32)` |   | `false` | `supported`
 `sip` | SIP Parameters | `object()` | `{}` | `false` |  
 `suppress_unregister_notifications` | When true disables deregister notifications | `boolean()` | `false` | `false` |  

--- a/applications/crossbar/doc/ref/devices.md
+++ b/applications/crossbar/doc/ref/devices.md
@@ -67,16 +67,21 @@ Key | Description | Type | Default | Required | Support Level
 `sip.custom_sip_headers.out` | Custom SIP Headers to be applied to calls outbound from Kazoo to the endpoint | [#/definitions/custom_sip_headers](#custom_sip_headers) |   | `false` |  
 `sip.custom_sip_headers.^[a-zA-z0-9_\-]+$` | The SIP header to add | `string()` |   | `false` |  
 `sip.custom_sip_headers` | A property list of SIP headers | `object()` |   | `false` |  
+`sip.custom_sip_interface` | If the bridge string should target a different SIP interface | `string()` |   | `false` |  
 `sip.expire_seconds` | The time, in seconds, sent to the provisioner for the registration period that the device should be configured with. | `integer()` | `300` | `false` | `supported`
+`sip.forward` | Forward IP to use | `string()` |   | `false` |  
 `sip.ignore_completed_elsewhere` | When set to false the phone should not consider ring group calls answered elsewhere as missed | `boolean()` |   | `false` |  
 `sip.invite_format` | The SIP request URI invite format | `string('username' | 'npan' | '1npan' | 'e164' | 'route' | 'contact')` | `contact` | `false` | `supported`
 `sip.ip` | IP address for this device | `string()` |   | `false` | `supported`
 `sip.method` | Method of authentication | `string('password' | 'ip')` | `password` | `false` | `supported`
 `sip.number` | The number used if the invite format is 1npan, npan, or e164 (if not set the dialed number is used) | `string()` |   | `false` |  
 `sip.password` | SIP authentication password | `string(5..32)` |   | `false` | `supported`
+`sip.proxy` | Proxy IP address to use | `string()` |   | `false` |  
 `sip.realm` | The realm this device should use, overriding the account realm. Should rarely be necessary. | `string(4..253)` |   | `false` |  
 `sip.route` | The SIP URL used if the invite format is 'route' | `string()` |   | `false` | `supported`
+`sip.static_invite` | SIP To user | `string()` |   | `false` |  
 `sip.static_route` | Sends all inbound calls to this string (instead of dialed number or username) | `string()` |   | `false` |  
+`sip.transport` | SIP Transport to use | `string()` |   | `false` |  
 `sip.username` | SIP authentication username | `string(2..32)` |   | `false` | `supported`
 `sip` | SIP Parameters | `object()` | `{}` | `false` |  
 `suppress_unregister_notifications` | When true disables deregister notifications | `boolean()` | `false` | `false` |  

--- a/applications/crossbar/doc/ref/resources.md
+++ b/applications/crossbar/doc/ref/resources.md
@@ -10,6 +10,17 @@ Schema for resources
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
+`caller_id_options.type` | Caller ID type to choose | `string('internal' | 'external' | 'emergency')` |   | `false` |  
+`caller_id_options` | Caller ID options | `object()` |   | `false` |  
+`cid_rules.[]` |   | `string()` |   | `false` |  
+`cid_rules` | Regexps to match against caller ID | `array(string())` |   | `false` |  
+`classifiers.emergency` | Determines if the resource represents emergency services | `boolean()` | `false` | `false` |  
+`classifiers.enabled` | Determines if the resource is currently enabled | `boolean()` | `true` | `false` |  
+`classifiers.prefix` | A string to prepend to the dialed number or capture group of the matching rule | `string(0..64)` |   | `false` |  
+`classifiers.regex` | regexp to match against dialed number | `string()` |   | `false` |  
+`classifiers.suffix` | A string to append to the dialed number or capture group of the matching rule | `string(0..64)` |   | `false` |  
+`classifiers.weight_cost` | A value between 0 and 100 that determines the order of resources when multiple can be used | `integer()` | `50` | `false` |  
+`classifiers` | Resource classifiers to use as rules when matching against dialed numbers | `object()` |   | `false` |  
 `emergency` | Determines if the resource represents emergency services | `boolean()` | `false` | `false` |  
 `enabled` | Determines if the resource is currently enabled | `boolean()` | `true` | `false` |  
 `flags.[]` |   | `string()` |   | `false` |  
@@ -18,6 +29,7 @@ Key | Description | Type | Default | Required | Support Level
 `flat_rate_whitelist` | Regex for determining if the number is eligible for flat-rate trunking | `string()` |   | `false` |  
 `format_from_uri` | When set to true requests to this resource will have a reformatted SIP From Header | `boolean()` |   | `false` |  
 `formatters` | Schema for request formatters | `object()` |   | `false` |  
+`from_account_realm` | When formatting SIP From on outbound requests, use the calling account's SIP realm | `boolean()` | `false` | `false` |  
 `from_uri_realm` | When formatting SIP From on outbound requests this can be used to override the realm | `string()` |   | `false` |  
 `gateway_strategy` | The strategy of choosing gateways from list: sequential or random | `string('sequential' | 'random')` |   | `false` |  
 `gateways.[].bypass_media` | The resource gateway bypass media mode | `boolean()` |   | `false` |  

--- a/applications/crossbar/doc/resources.md
+++ b/applications/crossbar/doc/resources.md
@@ -26,6 +26,17 @@ Schema for resources
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
+`caller_id_options.type` | Caller ID type to choose | `string('internal' | 'external' | 'emergency')` |   | `false` |  
+`caller_id_options` | Caller ID options | `object()` |   | `false` |  
+`cid_rules.[]` |   | `string()` |   | `false` |  
+`cid_rules` | Regexps to match against caller ID | `array(string())` |   | `false` |  
+`classifiers.emergency` | Determines if the resource represents emergency services | `boolean()` | `false` | `false` |  
+`classifiers.enabled` | Determines if the resource is currently enabled | `boolean()` | `true` | `false` |  
+`classifiers.prefix` | A string to prepend to the dialed number or capture group of the matching rule | `string(0..64)` |   | `false` |  
+`classifiers.regex` | regexp to match against dialed number | `string()` |   | `false` |  
+`classifiers.suffix` | A string to append to the dialed number or capture group of the matching rule | `string(0..64)` |   | `false` |  
+`classifiers.weight_cost` | A value between 0 and 100 that determines the order of resources when multiple can be used | `integer()` | `50` | `false` |  
+`classifiers` | Resource classifiers to use as rules when matching against dialed numbers | `object()` |   | `false` |  
 `emergency` | Determines if the resource represents emergency services | `boolean()` | `false` | `false` |  
 `enabled` | Determines if the resource is currently enabled | `boolean()` | `true` | `false` |  
 `flags.[]` |   | `string()` |   | `false` |  
@@ -34,6 +45,7 @@ Key | Description | Type | Default | Required | Support Level
 `flat_rate_whitelist` | Regex for determining if the number is eligible for flat-rate trunking | `string()` |   | `false` |  
 `format_from_uri` | When set to true requests to this resource will have a reformatted SIP From Header | `boolean()` |   | `false` |  
 `formatters` | Schema for request formatters | `object()` |   | `false` |  
+`from_account_realm` | When formatting SIP From on outbound requests, use the calling account's SIP realm | `boolean()` | `false` | `false` |  
 `from_uri_realm` | When formatting SIP From on outbound requests this can be used to override the realm | `string()` |   | `false` |  
 `gateway_strategy` | The strategy of choosing gateways from list: sequential or random | `string('sequential' | 'random')` |   | `false` |  
 `gateways.[].bypass_media` | The resource gateway bypass media mode | `boolean()` |   | `false` |  

--- a/applications/crossbar/doc/resources.md
+++ b/applications/crossbar/doc/resources.md
@@ -157,7 +157,7 @@ The `INVITE` parameters object defines both static and dynamic parameters that s
 
 Static parameters are added 'as-is' and can be any format.  However, they should follow the SIP standard for the header field format and should not include a semi-colon.
 
-Dynamic parameters obtain the value from properties of the initiating call (requestor) if present, and are ignored if not. Dynamic parameters can be defined either as a string or an object.  When defined as a string the property is extracted from the requestor and if found the resulting value used without modification as an `INVITE` parameter.  When defined as an object both a tag as well as a key property must be defined.  The key property is used to extract the value from the requestor and the tag is appended as the `INVITE` parameter name.  By default the `INVITE` parameter name and value are separated by an equals sign but this can be overridden by providing a separator property.
+Dynamic parameters obtain the value from properties of the initiating call (requester) if present, and are ignored if not. Dynamic parameters can be defined either as a string or an object.  When defined as a string the property is extracted from the requester and if found the resulting value used without modification as an `INVITE` parameter.  When defined as an object both a tag as well as a key property must be defined.  The key property is used to extract the value from the requester and the tag is appended as the `INVITE` parameter name.  By default the `INVITE` parameter name and value are separated by an equals sign but this can be overridden by providing a separator property.
 
 For example, if a resource gateway contains the following object:
 
@@ -182,6 +182,13 @@ and assuming the requesting call has pass-through (with value `pass-through=0288
 INVITE sip:+14158867900@10.26.0.88;npid;id=XXXX;pass-through=0288 SIP/2.0
 ```
 
+## Formatting the From
+
+Some upstream carriers require the From address' realm to be formatted. There are a couple toggles you have to control this realm. First, you will need to configure `"format_from_uri":true` to enable this formatting functionality. Then you have 3 options, evaluated in this order:
+
+1. Set `"from_uri_realm":"{CUSTOM_REALM}"` where `{CUSTOM_REALM}` is the static realm you'd like on the From
+2. Set `"from_account_realm":true` to use the calling account's realm
+3. Set `"realm":"{CUSTOM_REALM}"` on a per-gateway basis (not on the top-level resource)
 
 ## Fetch
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -5790,10 +5790,18 @@
                             "description": "A property list of SIP headers",
                             "type": "object"
                         },
+                        "custom_sip_interface": {
+                            "description": "If the bridge string should target a different SIP interface",
+                            "type": "string"
+                        },
                         "expire_seconds": {
                             "default": 300,
                             "description": "The time, in seconds, sent to the provisioner for the registration period that the device should be configured with.",
                             "type": "integer"
+                        },
+                        "forward": {
+                            "description": "Forward IP to use",
+                            "type": "string"
                         },
                         "ignore_completed_elsewhere": {
                             "description": "When set to false the phone should not consider ring group calls answered elsewhere as missed",
@@ -5835,6 +5843,10 @@
                             "minLength": 5,
                             "type": "string"
                         },
+                        "proxy": {
+                            "description": "Proxy IP address to use",
+                            "type": "string"
+                        },
                         "realm": {
                             "description": "The realm this device should use, overriding the account realm. Should rarely be necessary.",
                             "maxLength": 253,
@@ -5846,8 +5858,16 @@
                             "description": "The SIP URL used if the invite format is 'route'",
                             "type": "string"
                         },
+                        "static_invite": {
+                            "description": "SIP To user",
+                            "type": "string"
+                        },
                         "static_route": {
                             "description": "Sends all inbound calls to this string (instead of dialed number or username)",
+                            "type": "string"
+                        },
+                        "transport": {
+                            "description": "SIP Transport to use",
                             "type": "string"
                         },
                         "username": {
@@ -6943,11 +6963,11 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "offline",
-                        "online",
                         "trying",
-                        "confirmed",
+                        "online",
+                        "offline",
                         "early",
+                        "confirmed",
                         "terminated"
                     ],
                     "type": "string"
@@ -6991,11 +7011,11 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "offline",
-                        "online",
                         "trying",
-                        "confirmed",
+                        "online",
+                        "offline",
                         "early",
+                        "confirmed",
                         "terminated"
                     ],
                     "type": "string"
@@ -7067,11 +7087,11 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "offline",
-                        "online",
                         "trying",
-                        "confirmed",
+                        "online",
+                        "offline",
                         "early",
+                        "confirmed",
                         "terminated"
                     ],
                     "type": "string"
@@ -7115,11 +7135,11 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "offline",
-                        "online",
                         "trying",
-                        "confirmed",
+                        "online",
+                        "offline",
                         "early",
+                        "confirmed",
                         "terminated"
                     ],
                     "type": "string"

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -31246,6 +31246,66 @@
         "resources": {
             "description": "Schema for resources",
             "properties": {
+                "caller_id_options": {
+                    "description": "Caller ID options",
+                    "properties": {
+                        "type": {
+                            "description": "Caller ID type to choose",
+                            "enum": [
+                                "internal",
+                                "external",
+                                "emergency"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "cid_rules": {
+                    "description": "Regexps to match against caller ID",
+                    "items": {
+                        "description": "Regexp to match against caller ID",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "classifiers": {
+                    "description": "Resource classifiers to use as rules when matching against dialed numbers",
+                    "properties": {
+                        "emergency": {
+                            "default": false,
+                            "description": "Determines if the resource represents emergency services",
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "default": true,
+                            "description": "Determines if the resource is currently enabled",
+                            "type": "boolean"
+                        },
+                        "prefix": {
+                            "description": "A string to prepend to the dialed number or capture group of the matching rule",
+                            "maxLength": 64,
+                            "type": "string"
+                        },
+                        "regex": {
+                            "description": "regexp to match against dialed number",
+                            "type": "string"
+                        },
+                        "suffix": {
+                            "description": "A string to append to the dialed number or capture group of the matching rule",
+                            "maxLength": 64,
+                            "type": "string"
+                        },
+                        "weight_cost": {
+                            "default": 50,
+                            "description": "A value between 0 and 100 that determines the order of resources when multiple can be used",
+                            "maximum": 100,
+                            "minimum": 0,
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
                 "emergency": {
                     "default": false,
                     "description": "Determines if the resource represents emergency services",
@@ -31279,6 +31339,11 @@
                 "formatters": {
                     "$ref": "#/definitions/formatters",
                     "type": "object"
+                },
+                "from_account_realm": {
+                    "default": false,
+                    "description": "When formatting SIP From on outbound requests, use the calling account's SIP realm",
+                    "type": "boolean"
                 },
                 "from_uri_realm": {
                     "description": "When formatting SIP From on outbound requests this can be used to override the realm",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6915,12 +6915,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "confirmed",
-                        "early",
-                        "offline",
+                        "trying",
                         "online",
-                        "terminated",
-                        "trying"
+                        "offline",
+                        "early",
+                        "confirmed",
+                        "terminated"
                     ],
                     "type": "string"
                 },
@@ -6963,12 +6963,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "confirmed",
-                        "early",
-                        "offline",
+                        "trying",
                         "online",
-                        "terminated",
-                        "trying"
+                        "offline",
+                        "early",
+                        "confirmed",
+                        "terminated"
                     ],
                     "type": "string"
                 },
@@ -7011,12 +7011,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "confirmed",
-                        "early",
-                        "offline",
+                        "trying",
                         "online",
-                        "terminated",
-                        "trying"
+                        "offline",
+                        "early",
+                        "confirmed",
+                        "terminated"
                     ],
                     "type": "string"
                 },
@@ -7087,12 +7087,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "confirmed",
-                        "early",
-                        "offline",
+                        "trying",
                         "online",
-                        "terminated",
-                        "trying"
+                        "offline",
+                        "early",
+                        "confirmed",
+                        "terminated"
                     ],
                     "type": "string"
                 },
@@ -7135,12 +7135,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "confirmed",
-                        "early",
-                        "offline",
+                        "trying",
                         "online",
-                        "terminated",
-                        "trying"
+                        "offline",
+                        "early",
+                        "confirmed",
+                        "terminated"
                     ],
                     "type": "string"
                 },
@@ -7183,12 +7183,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "confirmed",
-                        "early",
-                        "offline",
+                        "trying",
                         "online",
-                        "terminated",
-                        "trying"
+                        "offline",
+                        "early",
+                        "confirmed",
+                        "terminated"
                     ],
                     "type": "string"
                 },
@@ -7231,12 +7231,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "confirmed",
-                        "early",
-                        "offline",
+                        "trying",
                         "online",
-                        "terminated",
-                        "trying"
+                        "offline",
+                        "early",
+                        "confirmed",
+                        "terminated"
                     ],
                     "type": "string"
                 },
@@ -23958,12 +23958,12 @@
                 },
                 "State": {
                     "enum": [
-                        "confirmed",
-                        "early",
-                        "offline",
+                        "trying",
                         "online",
-                        "terminated",
-                        "trying"
+                        "offline",
+                        "early",
+                        "confirmed",
+                        "terminated"
                     ],
                     "type": "string"
                 },

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6915,12 +6915,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -6963,12 +6963,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7011,12 +7011,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7087,12 +7087,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7135,12 +7135,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7183,12 +7183,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7231,12 +7231,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -23958,12 +23958,12 @@
                 },
                 "State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6915,12 +6915,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -6963,12 +6963,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7011,12 +7011,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7087,12 +7087,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7135,12 +7135,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7183,12 +7183,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },
@@ -7231,12 +7231,12 @@
                 },
                 "Presence-State": {
                     "enum": [
-                        "trying",
-                        "online",
-                        "offline",
-                        "early",
                         "confirmed",
-                        "terminated"
+                        "early",
+                        "offline",
+                        "online",
+                        "terminated",
+                        "trying"
                     ],
                     "type": "string"
                 },

--- a/applications/crossbar/priv/couchdb/schemas/devices.json
+++ b/applications/crossbar/priv/couchdb/schemas/devices.json
@@ -346,11 +346,19 @@
                     "description": "A property list of SIP headers",
                     "type": "object"
                 },
+                "custom_sip_interface": {
+                    "description": "If the bridge string should target a different SIP interface",
+                    "type": "string"
+                },
                 "expire_seconds": {
                     "default": 300,
                     "description": "The time, in seconds, sent to the provisioner for the registration period that the device should be configured with.",
                     "support_level": "supported",
                     "type": "integer"
+                },
+                "forward": {
+                    "description": "Forward IP to use",
+                    "type": "string"
                 },
                 "ignore_completed_elsewhere": {
                     "description": "When set to false the phone should not consider ring group calls answered elsewhere as missed",
@@ -396,6 +404,10 @@
                     "support_level": "supported",
                     "type": "string"
                 },
+                "proxy": {
+                    "description": "Proxy IP address to use",
+                    "type": "string"
+                },
                 "realm": {
                     "description": "The realm this device should use, overriding the account realm. Should rarely be necessary.",
                     "maxLength": 253,
@@ -408,8 +420,16 @@
                     "support_level": "supported",
                     "type": "string"
                 },
+                "static_invite": {
+                    "description": "SIP To user",
+                    "type": "string"
+                },
                 "static_route": {
                     "description": "Sends all inbound calls to this string (instead of dialed number or username)",
+                    "type": "string"
+                },
+                "transport": {
+                    "description": "SIP Transport to use",
                     "type": "string"
                 },
                 "username": {

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.end_wrapup.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.end_wrapup.json
@@ -26,12 +26,12 @@
         },
         "Presence-State": {
             "enum": [
-                "trying",
-                "online",
-                "offline",
-                "early",
                 "confirmed",
-                "terminated"
+                "early",
+                "offline",
+                "online",
+                "terminated",
+                "trying"
             ],
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.pause.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.pause.json
@@ -26,12 +26,12 @@
         },
         "Presence-State": {
             "enum": [
-                "trying",
-                "online",
-                "offline",
-                "early",
                 "confirmed",
-                "terminated"
+                "early",
+                "offline",
+                "online",
+                "terminated",
+                "trying"
             ],
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.resume.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.resume.json
@@ -26,12 +26,12 @@
         },
         "Presence-State": {
             "enum": [
-                "trying",
-                "online",
-                "offline",
-                "early",
                 "confirmed",
-                "terminated"
+                "early",
+                "offline",
+                "online",
+                "terminated",
+                "trying"
             ],
             "type": "string"
         },

--- a/applications/crossbar/priv/couchdb/schemas/resources.json
+++ b/applications/crossbar/priv/couchdb/schemas/resources.json
@@ -3,6 +3,66 @@
     "_id": "resources",
     "description": "Schema for resources",
     "properties": {
+        "caller_id_options": {
+            "description": "Caller ID options",
+            "properties": {
+                "type": {
+                    "description": "Caller ID type to choose",
+                    "enum": [
+                        "internal",
+                        "external",
+                        "emergency"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "cid_rules": {
+            "description": "Regexps to match against caller ID",
+            "items": {
+                "description": "Regexp to match against caller ID",
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "classifiers": {
+            "description": "Resource classifiers to use as rules when matching against dialed numbers",
+            "properties": {
+                "emergency": {
+                    "default": false,
+                    "description": "Determines if the resource represents emergency services",
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "default": true,
+                    "description": "Determines if the resource is currently enabled",
+                    "type": "boolean"
+                },
+                "prefix": {
+                    "description": "A string to prepend to the dialed number or capture group of the matching rule",
+                    "maxLength": 64,
+                    "type": "string"
+                },
+                "regex": {
+                    "description": "regexp to match against dialed number",
+                    "type": "string"
+                },
+                "suffix": {
+                    "description": "A string to append to the dialed number or capture group of the matching rule",
+                    "maxLength": 64,
+                    "type": "string"
+                },
+                "weight_cost": {
+                    "default": 50,
+                    "description": "A value between 0 and 100 that determines the order of resources when multiple can be used",
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
         "emergency": {
             "default": false,
             "description": "Determines if the resource represents emergency services",
@@ -36,6 +96,11 @@
         "formatters": {
             "$ref": "formatters",
             "type": "object"
+        },
+        "from_account_realm": {
+            "default": false,
+            "description": "When formatting SIP From on outbound requests, use the calling account's SIP realm",
+            "type": "boolean"
         },
         "from_uri_realm": {
             "description": "When formatting SIP From on outbound requests this can be used to override the realm",

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -4591,12 +4591,18 @@
                     Custom SIP Headers to be applied to calls outbound from Kazoo to the endpoint
           'description': A property list of SIP headers
           'type': object
+        'custom_sip_interface':
+          'description': If the bridge string should target a different SIP interface
+          'type': string
         'expire_seconds':
           'default': 300
           'description': |-
             The time, in seconds, sent to the provisioner for the registration period that the device should be configured with.
           'type': integer
           'x-support_level': supported
+        'forward':
+          'description': Forward IP to use
+          'type': string
         'ignore_completed_elsewhere':
           'description': |-
             When set to false the phone should not consider ring group calls answered elsewhere as missed
@@ -4635,6 +4641,9 @@
           'minLength': 5
           'type': string
           'x-support_level': supported
+        'proxy':
+          'description': Proxy IP address to use
+          'type': string
         'realm':
           'description': |-
             The realm this device should use, overriding the account realm. Should rarely be necessary.
@@ -4646,9 +4655,15 @@
           'description': The SIP URL used if the invite format is 'route'
           'type': string
           'x-support_level': supported
+        'static_invite':
+          'description': SIP To user
+          'type': string
         'static_route':
           'description': |-
             Sends all inbound calls to this string (instead of dialed number or username)
+          'type': string
+        'transport':
+          'description': SIP Transport to use
           'type': string
         'username':
           'description': SIP authentication username

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -7861,6 +7861,56 @@
 'resources':
   'description': Schema for resources
   'properties':
+    'caller_id_options':
+      'description': Caller ID options
+      'properties':
+        'type':
+          'description': Caller ID type to choose
+          'enum':
+            - internal
+            - external
+            - emergency
+          'type': string
+      'type': object
+    'cid_rules':
+      'description': Regexps to match against caller ID
+      'items':
+        'description': Regexp to match against caller ID
+        'type': string
+      'type': array
+    'classifiers':
+      'description': |-
+        Resource classifiers to use as rules when matching against dialed numbers
+      'properties':
+        'emergency':
+          'default': false
+          'description': Determines if the resource represents emergency services
+          'type': boolean
+        'enabled':
+          'default': true
+          'description': Determines if the resource is currently enabled
+          'type': boolean
+        'prefix':
+          'description': |-
+            A string to prepend to the dialed number or capture group of the matching rule
+          'maxLength': 64
+          'type': string
+        'regex':
+          'description': regexp to match against dialed number
+          'type': string
+        'suffix':
+          'description': |-
+            A string to append to the dialed number or capture group of the matching rule
+          'maxLength': 64
+          'type': string
+        'weight_cost':
+          'default': 50
+          'description': |-
+            A value between 0 and 100 that determines the order of resources when multiple can be used
+          'maximum': 100
+          'minimum': 0
+          'type': integer
+      'type': object
     'emergency':
       'default': false
       'description': Determines if the resource represents emergency services
@@ -7890,6 +7940,11 @@
     'formatters':
       '$ref': '#/formatters'
       'type': object
+    'from_account_realm':
+      'default': false
+      'description': |-
+        When formatting SIP From on outbound requests, use the calling account's SIP realm
+      'type': boolean
     'from_uri_realm':
       'description': |-
         When formatting SIP From on outbound requests this can be used to override the realm

--- a/applications/crossbar/src/modules/cb_resources.erl
+++ b/applications/crossbar/src/modules/cb_resources.erl
@@ -640,16 +640,16 @@ validate_gateway_ips([{Idx, InboundIP, ServerIP}|IPs], SIPAuth, ACLs, ResourceId
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec aggregate_resource(kz_json:object()) -> 'ok'.
-aggregate_resource(Resource) ->
+-spec aggregate_resource(kzd_resources:doc()) -> 'ok'.
+aggregate_resource(ResourceJObj) ->
     lager:debug("adding resource to the sip auth aggregate"),
-    Doc = kz_doc:delete_revision(Resource),
+    Doc = kz_doc:delete_revision(ResourceJObj),
     Update = kz_json:to_proplist(kz_json:flatten(Doc)),
     UpdateOptions = [{'update', Update}
                     ,{'create', []}
                     ,{'ensure_saved', 'true'}
                     ],
-    {'ok', _} = kz_datamgr:update_doc(?KZ_SIP_DB, kz_doc:id(Resource), UpdateOptions),
+    {'ok', _} = kz_datamgr:update_doc(?KZ_SIP_DB, kz_doc:id(ResourceJObj), UpdateOptions),
     'ok'.
 
 -spec remove_aggregate(kz_term:ne_binary()) -> boolean().
@@ -689,7 +689,7 @@ get_all_acl_ips() ->
           ,{<<"Node">>, <<"all">>}
           ,{<<"Default">>, kz_json:new()}
           ,{<<"Msg-ID">>, kz_binary:rand_hex(16)}
-           | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+          | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
           ],
     Resp = kz_amqp_worker:call(props:filter_undefined(Req)
                               ,fun kapi_sysconf:publish_get_req/1
@@ -740,37 +740,31 @@ validate_ip(IP, SIPAuth, ACLs, ResourceId) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec maybe_aggregate_resources(kz_json:objects()) -> 'ok'.
+-spec maybe_aggregate_resources(kzd_resources:docs()) -> 'ok'.
 maybe_aggregate_resources([]) -> 'ok';
-maybe_aggregate_resources([Resource|Resources]) ->
+maybe_aggregate_resources([ResourceJObj|ResourceJObjs]) ->
     case lists:any(fun(Gateway) ->
                            kz_json:is_true(<<"register">>, Gateway)
                                andalso (not kz_json:is_false(<<"enabled">>, Gateway))
                    end
-                  ,kz_json:get_list_value(<<"gateways">>, Resource, [])
+                  ,kzd_resources:gateways(ResourceJObj, [])
                   )
     of
         'true' ->
-            aggregate_resource(Resource),
+            aggregate_resource(ResourceJObj),
             _ = kapi_switch:publish_reload_gateways(),
             _ = kapi_switch:publish_reload_acls(),
-            maybe_aggregate_resources(Resources);
+            maybe_aggregate_resources(ResourceJObjs);
         'false' ->
-            _ = maybe_remove_aggregates([Resource]),
-            maybe_aggregate_resources(Resources)
+            _ = maybe_remove_aggregates([ResourceJObj]),
+            maybe_aggregate_resources(ResourceJObjs)
     end.
 %%------------------------------------------------------------------------------
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec maybe_remove_aggregates(kz_json:objects()) -> 'ok'.
+-spec maybe_remove_aggregates(kzd_resources:docs()) -> 'ok'.
 maybe_remove_aggregates([]) -> 'ok';
-maybe_remove_aggregates([Resource|Resources]) ->
-    case kz_datamgr:del_doc(?KZ_SIP_DB, kz_doc:id(Resource)) of
-        {'ok', _JObj} ->
-            _ = kapi_switch:publish_reload_gateways(),
-            _ = kapi_switch:publish_reload_acls(),
-            maybe_remove_aggregates(Resources);
-        {'error', 'not_found'} ->
-            maybe_remove_aggregates(Resources)
-    end.
+maybe_remove_aggregates([ResourceJObj|ResourceJObjs]) ->
+    _ = remove_aggregate(kz_doc:id(ResourceJObj)),
+    maybe_remove_aggregates(ResourceJObjs).

--- a/applications/crossbar/src/modules/cb_resources.erl
+++ b/applications/crossbar/src/modules/cb_resources.erl
@@ -689,7 +689,7 @@ get_all_acl_ips() ->
           ,{<<"Node">>, <<"all">>}
           ,{<<"Default">>, kz_json:new()}
           ,{<<"Msg-ID">>, kz_binary:rand_hex(16)}
-          | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+           | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
           ],
     Resp = kz_amqp_worker:call(props:filter_undefined(Req)
                               ,fun kapi_sysconf:publish_get_req/1

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -537,7 +537,7 @@ refresh([Database|Databases], Pause, Total, Unexpected) ->
             ?STACKTRACE(Error, Reason, StackTrace)
             [io_lib:format("WARNING: Unable to refresh/migrate db ~s! ~s: {~p, ~p}",
                            [Database, Error, Reason, StackTrace])
-             | Unexpected]
+            | Unexpected]
             end,
     refresh(Databases, Pause, Total, NewUnexpected).
 
@@ -1769,7 +1769,7 @@ call_id_status(CallId) ->
 -spec call_id_status(kz_term:ne_binary(), boolean() | kz_term:ne_binary()) -> 'ok'.
 call_id_status(CallId, Verbose) ->
     Req = [{<<"Call-ID">>, kz_term:to_binary(CallId)}
-           | kz_api:default_headers(<<"shell">>, <<"0">>)
+          | kz_api:default_headers(<<"shell">>, <<"0">>)
           ],
     case kz_amqp_worker:call(Req
                             ,fun kapi_call:publish_channel_status_req/1
@@ -1980,7 +1980,7 @@ deprecate_timezone_for_node(Node, AccountsConfig, _Timezone, _Default) ->
 check_system_schemas() ->
     _ = rpc:call(node()
                 ,'crossbar_maintenance'
-                ,'refresh_schemas'
+                ,'update_schemas'
                 ,[]
                 ),
     'ok'.
@@ -2137,7 +2137,7 @@ register_system_dbs_views() ->
             ,kapps_util:get_view_json(?APP, <<"views/pending_notify.json">>)
             ,kapps_util:get_view_json(?APP, <<"views/rates.json">>)
             ,kapps_util:get_view_json(?APP, <<"views/token_auth.json">>)
-             | kapps_util:get_views_json('kazoo_ips', "views")
+            | kapps_util:get_views_json('kazoo_ips', "views")
             ],
     kz_datamgr:register_views(?APP, Views).
 

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -537,7 +537,7 @@ refresh([Database|Databases], Pause, Total, Unexpected) ->
             ?STACKTRACE(Error, Reason, StackTrace)
             [io_lib:format("WARNING: Unable to refresh/migrate db ~s! ~s: {~p, ~p}",
                            [Database, Error, Reason, StackTrace])
-             | Unexpected]
+            | Unexpected]
             end,
     refresh(Databases, Pause, Total, NewUnexpected).
 
@@ -662,7 +662,7 @@ ensure_aggregate_faxbox(Account) ->
     AccountDb = kzs_util:format_account_db(Account),
     case kz_datamgr:get_results(AccountDb, ?FAXBOX_VIEW, ['include_docs']) of
         {'ok', Faxboxes} ->
-            update_or_add_to_faxes_db([kz_json:get_value(<<"doc">>, Faxbox) || Faxbox <- Faxboxes]);
+            update_or_add_to_faxes_db([kz_json:get_json_value(<<"doc">>, Faxbox) || Faxbox <- Faxboxes]);
         {'error', _} -> 'ok'
     end.
 
@@ -1769,7 +1769,7 @@ call_id_status(CallId) ->
 -spec call_id_status(kz_term:ne_binary(), boolean() | kz_term:ne_binary()) -> 'ok'.
 call_id_status(CallId, Verbose) ->
     Req = [{<<"Call-ID">>, kz_term:to_binary(CallId)}
-           | kz_api:default_headers(<<"shell">>, <<"0">>)
+          | kz_api:default_headers(<<"shell">>, <<"0">>)
           ],
     case kz_amqp_worker:call(Req
                             ,fun kapi_call:publish_channel_status_req/1
@@ -1977,6 +1977,14 @@ deprecate_timezone_for_node(Node, AccountsConfig, Timezone, 'undefined') ->
 deprecate_timezone_for_node(Node, AccountsConfig, _Timezone, _Default) ->
     kz_json:delete_key([Node, <<"timezone">>], AccountsConfig).
 
+check_system_schemas() ->
+    _ = rpc:call(node()
+                ,'crossbar_maintenance'
+                ,'refresh_schemas'
+                ,[]
+                ),
+    'ok'.
+
 -spec check_system_configs() -> 'ok'.
 check_system_configs() ->
     io:format("starting system schemas validation~n"),
@@ -2129,7 +2137,7 @@ register_system_dbs_views() ->
             ,kapps_util:get_view_json(?APP, <<"views/pending_notify.json">>)
             ,kapps_util:get_view_json(?APP, <<"views/rates.json">>)
             ,kapps_util:get_view_json(?APP, <<"views/token_auth.json">>)
-             | kapps_util:get_views_json('kazoo_ips', "views")
+            | kapps_util:get_views_json('kazoo_ips', "views")
             ],
     kz_datamgr:register_views(?APP, Views).
 
@@ -2172,6 +2180,7 @@ check_release() ->
     kz_log:put_callid('check_release'),
     Checks = [fun kapps_started/0
              ,fun check_system_configs/0
+             ,fun check_system_schemas/0
              ,fun master_account_created/0
              ,fun migration_4_0_ran/0
              ,fun migration_ran/0
@@ -2193,20 +2202,20 @@ check_release() ->
 
 -spec run_check(fun()) -> 'ok'.
 run_check(CheckFun) ->
-    StartTimeMs = kz_time:now_ms(),
+    StartTime = kz_time:start_time(),
     {Pid, Ref} = kz_process:spawn_monitor(CheckFun, []),
-    wait_for_check(Pid, Ref, StartTimeMs).
+    wait_for_check(Pid, Ref, StartTime).
 
--spec wait_for_check(pid(), reference(), pos_integer()) -> 'ok'.
-wait_for_check(Pid, Ref, StartTimeMs) ->
+-spec wait_for_check(pid(), reference(), kz_time:start_time()) -> 'ok'.
+wait_for_check(Pid, Ref, StartTime) ->
     receive
         {'DOWN', Ref, 'process', Pid, 'normal'} ->
-            lager:info("check finished in ~pms", [kz_time:elapsed_ms(StartTimeMs)]);
+            lager:info("check finished in ~pms", [kz_time:elapsed_ms(StartTime)]);
         {'DOWN', Ref, 'process', Pid, Reason} ->
-            lager:error("check in ~p failed to run after ~pms: ~p", [Pid, kz_time:elapsed_ms(StartTimeMs), Reason]),
+            lager:error("check in ~p failed to run after ~pms: ~p", [Pid, kz_time:elapsed_ms(StartTime), Reason]),
             throw(Reason)
     after 5 * ?MILLISECONDS_IN_MINUTE ->
-            lager:error("check in ~p timed out", [Pid]),
+            lager:error("check in ~p timed out after 5 minutes", [Pid]),
             exit(Pid, 'kill'),
             throw('timeout')
     end.

--- a/core/kazoo_apps/src/kapps_maintenance.erl
+++ b/core/kazoo_apps/src/kapps_maintenance.erl
@@ -537,7 +537,7 @@ refresh([Database|Databases], Pause, Total, Unexpected) ->
             ?STACKTRACE(Error, Reason, StackTrace)
             [io_lib:format("WARNING: Unable to refresh/migrate db ~s! ~s: {~p, ~p}",
                            [Database, Error, Reason, StackTrace])
-            | Unexpected]
+             | Unexpected]
             end,
     refresh(Databases, Pause, Total, NewUnexpected).
 
@@ -1769,7 +1769,7 @@ call_id_status(CallId) ->
 -spec call_id_status(kz_term:ne_binary(), boolean() | kz_term:ne_binary()) -> 'ok'.
 call_id_status(CallId, Verbose) ->
     Req = [{<<"Call-ID">>, kz_term:to_binary(CallId)}
-          | kz_api:default_headers(<<"shell">>, <<"0">>)
+           | kz_api:default_headers(<<"shell">>, <<"0">>)
           ],
     case kz_amqp_worker:call(Req
                             ,fun kapi_call:publish_channel_status_req/1
@@ -2137,7 +2137,7 @@ register_system_dbs_views() ->
             ,kapps_util:get_view_json(?APP, <<"views/pending_notify.json">>)
             ,kapps_util:get_view_json(?APP, <<"views/rates.json">>)
             ,kapps_util:get_view_json(?APP, <<"views/token_auth.json">>)
-            | kapps_util:get_views_json('kazoo_ips', "views")
+             | kapps_util:get_views_json('kazoo_ips', "views")
             ],
     kz_datamgr:register_views(?APP, Views).
 

--- a/core/kazoo_ast/src/kapi_schemas.erl
+++ b/core/kazoo_ast/src/kapi_schemas.erl
@@ -33,8 +33,7 @@
 -type acc() :: #acc{}.
 
 -ifdef(TEST).
--export([base_schema/2
-        ]).
+-export([base_schema/2]).
 -endif.
 
 -spec to_schemas() -> 'ok'.
@@ -585,7 +584,7 @@ ast_to_value(Fun) when is_function(Fun) ->
 ast_to_value(<<Bin/binary>>) -> Bin;
 ast_to_value(Bins) when is_list(Bins) -> Bins;
 ast_to_value(?MOD_FUN_ARGS('kapi_presence', 'presence_states', [])) ->
-    kapi_presence:presence_states();
+    lists:usort(kapi_presence:presence_states());
 ast_to_value(?BINARY(_)=Bin) ->
     kz_ast_util:binary_match_to_binary(Bin);
 ast_to_value(?FA(F, A)) ->

--- a/core/kazoo_directory/src/kz_directory_resource.erl
+++ b/core/kazoo_directory/src/kz_directory_resource.erl
@@ -141,7 +141,7 @@ set_resource_id(Map) -> Map.
 
 -spec maybe_add_t38_settings(resource_context()) -> resource_context().
 maybe_add_t38_settings(#{resource := {'ok', Resource}, ccvs := CCVs} = Map) ->
-    Map#{ccvs => [{<<"Resource-Fax-Option">>, kzd_resources:fax_option(Resource)} | CCVs]};
+    Map#{ccvs => [{<<"Resource-Fax-Option">>, kzd_resources:media_fax_option(Resource)} | CCVs]};
 maybe_add_t38_settings(Map) -> Map.
 
 -spec set_ignore_display_updates(resource_context()) -> resource_context().

--- a/core/kazoo_documents/src/kzd_devices.erl
+++ b/core/kazoo_documents/src/kzd_devices.erl
@@ -62,16 +62,21 @@
 -export([ringtones_internal/1, ringtones_internal/2, set_ringtones_internal/2]).
 -export([sip/1, sip/2, set_sip/2]).
 -export([sip_custom_sip_headers/1, sip_custom_sip_headers/2, set_sip_custom_sip_headers/2]).
+-export([sip_custom_sip_interface/1, sip_custom_sip_interface/2, set_sip_custom_sip_interface/2]).
 -export([sip_expire_seconds/1, sip_expire_seconds/2, set_sip_expire_seconds/2]).
+-export([sip_forward/1, sip_forward/2, set_sip_forward/2]).
 -export([sip_ignore_completed_elsewhere/1, sip_ignore_completed_elsewhere/2, set_sip_ignore_completed_elsewhere/2]).
 -export([sip_invite_format/1, sip_invite_format/2, set_sip_invite_format/2]).
 -export([sip_ip/1, sip_ip/2, set_sip_ip/2]).
 -export([sip_method/1, sip_method/2, set_sip_method/2]).
 -export([sip_number/1, sip_number/2, set_sip_number/2]).
 -export([sip_password/1, sip_password/2, set_sip_password/2]).
+-export([sip_proxy/1, sip_proxy/2, set_sip_proxy/2]).
 -export([sip_realm/1, sip_realm/2, set_sip_realm/2]).
 -export([sip_route/1, sip_route/2, set_sip_route/2]).
+-export([sip_static_invite/1, sip_static_invite/2, set_sip_static_invite/2]).
 -export([sip_static_route/1, sip_static_route/2, set_sip_static_route/2]).
+-export([sip_transport/1, sip_transport/2, set_sip_transport/2]).
 -export([sip_username/1, sip_username/2, set_sip_username/2]).
 -export([suppress_unregister_notifications/1, suppress_unregister_notifications/2, set_suppress_unregister_notifications/2]).
 -export([timezone/1, timezone/2, set_timezone/2]).
@@ -791,6 +796,18 @@ sip_custom_sip_headers(Doc, Default) ->
 set_sip_custom_sip_headers(Doc, SipCustomSipHeaders) ->
     kz_json:set_value([<<"sip">>, <<"custom_sip_headers">>], SipCustomSipHeaders, Doc).
 
+-spec sip_custom_sip_interface(doc()) -> kz_term:api_binary().
+sip_custom_sip_interface(Doc) ->
+    sip_custom_sip_interface(Doc, 'undefined').
+
+-spec sip_custom_sip_interface(doc(), Default) -> binary() | Default.
+sip_custom_sip_interface(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"custom_sip_interface">>], Doc, Default).
+
+-spec set_sip_custom_sip_interface(doc(), binary()) -> doc().
+set_sip_custom_sip_interface(Doc, SipCustomSipInterface) ->
+    kz_json:set_value([<<"sip">>, <<"custom_sip_interface">>], SipCustomSipInterface, Doc).
+
 -spec sip_expire_seconds(doc()) -> integer().
 sip_expire_seconds(Doc) ->
     sip_expire_seconds(Doc, 300).
@@ -802,6 +819,18 @@ sip_expire_seconds(Doc, Default) ->
 -spec set_sip_expire_seconds(doc(), integer()) -> doc().
 set_sip_expire_seconds(Doc, SipExpireSeconds) ->
     kz_json:set_value([<<"sip">>, <<"expire_seconds">>], SipExpireSeconds, Doc).
+
+-spec sip_forward(doc()) -> kz_term:api_binary().
+sip_forward(Doc) ->
+    sip_forward(Doc, 'undefined').
+
+-spec sip_forward(doc(), Default) -> binary() | Default.
+sip_forward(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"forward">>], Doc, Default).
+
+-spec set_sip_forward(doc(), binary()) -> doc().
+set_sip_forward(Doc, SipForward) ->
+    kz_json:set_value([<<"sip">>, <<"forward">>], SipForward, Doc).
 
 -spec sip_ignore_completed_elsewhere(doc()) -> kz_term:api_boolean().
 sip_ignore_completed_elsewhere(Doc) ->
@@ -875,6 +904,18 @@ sip_password(Doc, Default) ->
 set_sip_password(Doc, SipPassword) ->
     kz_json:set_value([<<"sip">>, <<"password">>], SipPassword, Doc).
 
+-spec sip_proxy(doc()) -> kz_term:api_binary().
+sip_proxy(Doc) ->
+    sip_proxy(Doc, 'undefined').
+
+-spec sip_proxy(doc(), Default) -> binary() | Default.
+sip_proxy(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"proxy">>], Doc, Default).
+
+-spec set_sip_proxy(doc(), binary()) -> doc().
+set_sip_proxy(Doc, SipProxy) ->
+    kz_json:set_value([<<"sip">>, <<"proxy">>], SipProxy, Doc).
+
 -spec sip_realm(doc()) -> kz_term:api_ne_binary().
 sip_realm(Doc) ->
     sip_realm(Doc, 'undefined').
@@ -899,6 +940,18 @@ sip_route(Doc, Default) ->
 set_sip_route(Doc, SipRoute) ->
     kz_json:set_value([<<"sip">>, <<"route">>], SipRoute, Doc).
 
+-spec sip_static_invite(doc()) -> kz_term:api_binary().
+sip_static_invite(Doc) ->
+    sip_static_invite(Doc, 'undefined').
+
+-spec sip_static_invite(doc(), Default) -> binary() | Default.
+sip_static_invite(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"static_invite">>], Doc, Default).
+
+-spec set_sip_static_invite(doc(), binary()) -> doc().
+set_sip_static_invite(Doc, SipStaticInvite) ->
+    kz_json:set_value([<<"sip">>, <<"static_invite">>], SipStaticInvite, Doc).
+
 -spec sip_static_route(doc()) -> kz_term:api_binary().
 sip_static_route(Doc) ->
     sip_static_route(Doc, 'undefined').
@@ -910,6 +963,18 @@ sip_static_route(Doc, Default) ->
 -spec set_sip_static_route(doc(), binary()) -> doc().
 set_sip_static_route(Doc, SipStaticRoute) ->
     kz_json:set_value([<<"sip">>, <<"static_route">>], SipStaticRoute, Doc).
+
+-spec sip_transport(doc()) -> kz_term:api_binary().
+sip_transport(Doc) ->
+    sip_transport(Doc, 'undefined').
+
+-spec sip_transport(doc(), Default) -> binary() | Default.
+sip_transport(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"transport">>], Doc, Default).
+
+-spec set_sip_transport(doc(), binary()) -> doc().
+set_sip_transport(Doc, SipTransport) ->
+    kz_json:set_value([<<"sip">>, <<"transport">>], SipTransport, Doc).
 
 -spec sip_username(doc()) -> kz_term:api_ne_binary().
 sip_username(Doc) ->

--- a/core/kazoo_documents/src/kzd_devices.erl.src
+++ b/core/kazoo_documents/src/kzd_devices.erl.src
@@ -60,16 +60,21 @@
 -export([ringtones_internal/1, ringtones_internal/2, set_ringtones_internal/2]).
 -export([sip/1, sip/2, set_sip/2]).
 -export([sip_custom_sip_headers/1, sip_custom_sip_headers/2, set_sip_custom_sip_headers/2]).
+-export([sip_custom_sip_interface/1, sip_custom_sip_interface/2, set_sip_custom_sip_interface/2]).
 -export([sip_expire_seconds/1, sip_expire_seconds/2, set_sip_expire_seconds/2]).
+-export([sip_forward/1, sip_forward/2, set_sip_forward/2]).
 -export([sip_ignore_completed_elsewhere/1, sip_ignore_completed_elsewhere/2, set_sip_ignore_completed_elsewhere/2]).
 -export([sip_invite_format/1, sip_invite_format/2, set_sip_invite_format/2]).
 -export([sip_ip/1, sip_ip/2, set_sip_ip/2]).
 -export([sip_method/1, sip_method/2, set_sip_method/2]).
 -export([sip_number/1, sip_number/2, set_sip_number/2]).
 -export([sip_password/1, sip_password/2, set_sip_password/2]).
+-export([sip_proxy/1, sip_proxy/2, set_sip_proxy/2]).
 -export([sip_realm/1, sip_realm/2, set_sip_realm/2]).
 -export([sip_route/1, sip_route/2, set_sip_route/2]).
+-export([sip_static_invite/1, sip_static_invite/2, set_sip_static_invite/2]).
 -export([sip_static_route/1, sip_static_route/2, set_sip_static_route/2]).
+-export([sip_transport/1, sip_transport/2, set_sip_transport/2]).
 -export([sip_username/1, sip_username/2, set_sip_username/2]).
 -export([suppress_unregister_notifications/1, suppress_unregister_notifications/2, set_suppress_unregister_notifications/2]).
 -export([timezone/1, timezone/2, set_timezone/2]).
@@ -734,6 +739,18 @@ sip_custom_sip_headers(Doc, Default) ->
 set_sip_custom_sip_headers(Doc, SipCustomSipHeaders) ->
     kz_json:set_value([<<"sip">>, <<"custom_sip_headers">>], SipCustomSipHeaders, Doc).
 
+-spec sip_custom_sip_interface(doc()) -> kz_term:api_binary().
+sip_custom_sip_interface(Doc) ->
+    sip_custom_sip_interface(Doc, 'undefined').
+
+-spec sip_custom_sip_interface(doc(), Default) -> binary() | Default.
+sip_custom_sip_interface(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"custom_sip_interface">>], Doc, Default).
+
+-spec set_sip_custom_sip_interface(doc(), binary()) -> doc().
+set_sip_custom_sip_interface(Doc, SipCustomSipInterface) ->
+    kz_json:set_value([<<"sip">>, <<"custom_sip_interface">>], SipCustomSipInterface, Doc).
+
 -spec sip_expire_seconds(doc()) -> integer().
 sip_expire_seconds(Doc) ->
     sip_expire_seconds(Doc, 300).
@@ -745,6 +762,18 @@ sip_expire_seconds(Doc, Default) ->
 -spec set_sip_expire_seconds(doc(), integer()) -> doc().
 set_sip_expire_seconds(Doc, SipExpireSeconds) ->
     kz_json:set_value([<<"sip">>, <<"expire_seconds">>], SipExpireSeconds, Doc).
+
+-spec sip_forward(doc()) -> kz_term:api_binary().
+sip_forward(Doc) ->
+    sip_forward(Doc, 'undefined').
+
+-spec sip_forward(doc(), Default) -> binary() | Default.
+sip_forward(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"forward">>], Doc, Default).
+
+-spec set_sip_forward(doc(), binary()) -> doc().
+set_sip_forward(Doc, SipForward) ->
+    kz_json:set_value([<<"sip">>, <<"forward">>], SipForward, Doc).
 
 -spec sip_ignore_completed_elsewhere(doc()) -> kz_term:api_boolean().
 sip_ignore_completed_elsewhere(Doc) ->
@@ -818,6 +847,18 @@ sip_password(Doc, Default) ->
 set_sip_password(Doc, SipPassword) ->
     kz_json:set_value([<<"sip">>, <<"password">>], SipPassword, Doc).
 
+-spec sip_proxy(doc()) -> kz_term:api_binary().
+sip_proxy(Doc) ->
+    sip_proxy(Doc, 'undefined').
+
+-spec sip_proxy(doc(), Default) -> binary() | Default.
+sip_proxy(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"proxy">>], Doc, Default).
+
+-spec set_sip_proxy(doc(), binary()) -> doc().
+set_sip_proxy(Doc, SipProxy) ->
+    kz_json:set_value([<<"sip">>, <<"proxy">>], SipProxy, Doc).
+
 -spec sip_realm(doc()) -> kz_term:api_ne_binary().
 sip_realm(Doc) ->
     sip_realm(Doc, 'undefined').
@@ -842,6 +883,18 @@ sip_route(Doc, Default) ->
 set_sip_route(Doc, SipRoute) ->
     kz_json:set_value([<<"sip">>, <<"route">>], SipRoute, Doc).
 
+-spec sip_static_invite(doc()) -> kz_term:api_binary().
+sip_static_invite(Doc) ->
+    sip_static_invite(Doc, 'undefined').
+
+-spec sip_static_invite(doc(), Default) -> binary() | Default.
+sip_static_invite(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"static_invite">>], Doc, Default).
+
+-spec set_sip_static_invite(doc(), binary()) -> doc().
+set_sip_static_invite(Doc, SipStaticInvite) ->
+    kz_json:set_value([<<"sip">>, <<"static_invite">>], SipStaticInvite, Doc).
+
 -spec sip_static_route(doc()) -> kz_term:api_binary().
 sip_static_route(Doc) ->
     sip_static_route(Doc, 'undefined').
@@ -853,6 +906,18 @@ sip_static_route(Doc, Default) ->
 -spec set_sip_static_route(doc(), binary()) -> doc().
 set_sip_static_route(Doc, SipStaticRoute) ->
     kz_json:set_value([<<"sip">>, <<"static_route">>], SipStaticRoute, Doc).
+
+-spec sip_transport(doc()) -> kz_term:api_binary().
+sip_transport(Doc) ->
+    sip_transport(Doc, 'undefined').
+
+-spec sip_transport(doc(), Default) -> binary() | Default.
+sip_transport(Doc, Default) ->
+    kz_json:get_binary_value([<<"sip">>, <<"transport">>], Doc, Default).
+
+-spec set_sip_transport(doc(), binary()) -> doc().
+set_sip_transport(Doc, SipTransport) ->
+    kz_json:set_value([<<"sip">>, <<"transport">>], SipTransport, Doc).
 
 -spec sip_username(doc()) -> kz_term:api_ne_binary().
 sip_username(Doc) ->

--- a/core/kazoo_documents/src/kzd_resources.erl
+++ b/core/kazoo_documents/src/kzd_resources.erl
@@ -9,7 +9,19 @@
 %%%-----------------------------------------------------------------------------
 -module(kzd_resources).
 
--export([new/0]).
+-export([new/0
+        ,type/0, type/1
+        ]).
+-export([caller_id_options/1, caller_id_options/2, set_caller_id_options/2]).
+-export([caller_id_options_type/1, caller_id_options_type/2, set_caller_id_options_type/2]).
+-export([cid_rules/1, cid_rules/2, set_cid_rules/2]).
+-export([classifiers/1, classifiers/2, set_classifiers/2]).
+-export([classifiers_emergency/1, classifiers_emergency/2, set_classifiers_emergency/2]).
+-export([classifiers_enabled/1, classifiers_enabled/2, set_classifiers_enabled/2]).
+-export([classifiers_prefix/1, classifiers_prefix/2, set_classifiers_prefix/2]).
+-export([classifiers_regex/1, classifiers_regex/2, set_classifiers_regex/2]).
+-export([classifiers_suffix/1, classifiers_suffix/2, set_classifiers_suffix/2]).
+-export([classifiers_weight_cost/1, classifiers_weight_cost/2, set_classifiers_weight_cost/2]).
 -export([emergency/1, emergency/2, set_emergency/2]).
 -export([enabled/1, enabled/2, set_enabled/2]).
 -export([flags/1, flags/2, set_flags/2]).
@@ -17,6 +29,7 @@
 -export([flat_rate_whitelist/1, flat_rate_whitelist/2, set_flat_rate_whitelist/2]).
 -export([format_from_uri/1, format_from_uri/2, set_format_from_uri/2]).
 -export([formatters/1, formatters/2, set_formatters/2]).
+-export([from_account_realm/1, from_account_realm/2, set_from_account_realm/2]).
 -export([from_uri_realm/1, from_uri_realm/2, set_from_uri_realm/2]).
 -export([gateway_strategy/1, gateway_strategy/2, set_gateway_strategy/2]).
 -export([gateways/1, gateways/2, set_gateways/2]).
@@ -27,19 +40,152 @@
 -export([require_flags/1, require_flags/2, set_require_flags/2]).
 -export([rules/1, rules/2, set_rules/2]).
 -export([weight_cost/1, weight_cost/2, set_weight_cost/2]).
--export([fax_option/1, fax_option/2]).
 
+-export([media_fax_option/1, media_fax_option/2
+        ,media_bypass_media/1, media_bypass_media/2
+        ,media_audio_codecs/1, media_audio_codecs/2
+        ,media_video_codecs/1, media_video_codecs/2
+        ]).
 
 -include("kz_documents.hrl").
 
 -type doc() :: kz_json:object().
--export_type([doc/0]).
+-type docs() :: [doc()].
+-export_type([doc/0, docs/0]).
 
+-define(PVT_TYPE, <<"resource">>).
 -define(SCHEMA, <<"resources">>).
 
 -spec new() -> doc().
 new() ->
-    kz_json_schema:default_object(?SCHEMA).
+    kz_doc:set_type(kz_json_schema:default_object(?SCHEMA), type()).
+
+-spec type() -> kz_term:ne_binary().
+type() -> ?PVT_TYPE.
+
+-spec type(doc()) -> kz_term:ne_binary().
+type(Doc) ->
+    kz_doc:type(Doc, ?PVT_TYPE).
+
+-spec caller_id_options(doc()) -> kz_term:api_object().
+caller_id_options(Doc) ->
+    caller_id_options(Doc, 'undefined').
+
+-spec caller_id_options(doc(), Default) -> kz_json:object() | Default.
+caller_id_options(Doc, Default) ->
+    kz_json:get_json_value([<<"caller_id_options">>], Doc, Default).
+
+-spec set_caller_id_options(doc(), kz_json:object()) -> doc().
+set_caller_id_options(Doc, CallerIdOptions) ->
+    kz_json:set_value([<<"caller_id_options">>], CallerIdOptions, Doc).
+
+-spec caller_id_options_type(doc()) -> kz_term:api_binary().
+caller_id_options_type(Doc) ->
+    caller_id_options_type(Doc, 'undefined').
+
+-spec caller_id_options_type(doc(), Default) -> binary() | Default.
+caller_id_options_type(Doc, Default) ->
+    kz_json:get_binary_value([<<"caller_id_options">>, <<"type">>], Doc, Default).
+
+-spec set_caller_id_options_type(doc(), binary()) -> doc().
+set_caller_id_options_type(Doc, CallerIdOptionsType) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"type">>], CallerIdOptionsType, Doc).
+
+-spec cid_rules(doc()) -> kz_term:api_ne_binaries().
+cid_rules(Doc) ->
+    cid_rules(Doc, 'undefined').
+
+-spec cid_rules(doc(), Default) -> kz_term:ne_binaries() | Default.
+cid_rules(Doc, Default) ->
+    kz_json:get_list_value([<<"cid_rules">>], Doc, Default).
+
+-spec set_cid_rules(doc(), kz_term:ne_binaries()) -> doc().
+set_cid_rules(Doc, CidRules) ->
+    kz_json:set_value([<<"cid_rules">>], CidRules, Doc).
+
+-spec classifiers(doc()) -> kz_term:api_object().
+classifiers(Doc) ->
+    classifiers(Doc, 'undefined').
+
+-spec classifiers(doc(), Default) -> kz_json:object() | Default.
+classifiers(Doc, Default) ->
+    kz_json:get_json_value([<<"classifiers">>], Doc, Default).
+
+-spec set_classifiers(doc(), kz_json:object()) -> doc().
+set_classifiers(Doc, Classifiers) ->
+    kz_json:set_value([<<"classifiers">>], Classifiers, Doc).
+
+-spec classifiers_emergency(doc()) -> boolean().
+classifiers_emergency(Doc) ->
+    classifiers_emergency(Doc, false).
+
+-spec classifiers_emergency(doc(), Default) -> boolean() | Default.
+classifiers_emergency(Doc, Default) ->
+    kz_json:get_boolean_value([<<"classifiers">>, <<"emergency">>], Doc, Default).
+
+-spec set_classifiers_emergency(doc(), boolean()) -> doc().
+set_classifiers_emergency(Doc, ClassifiersEmergency) ->
+    kz_json:set_value([<<"classifiers">>, <<"emergency">>], ClassifiersEmergency, Doc).
+
+-spec classifiers_enabled(doc()) -> boolean().
+classifiers_enabled(Doc) ->
+    classifiers_enabled(Doc, true).
+
+-spec classifiers_enabled(doc(), Default) -> boolean() | Default.
+classifiers_enabled(Doc, Default) ->
+    kz_json:get_boolean_value([<<"classifiers">>, <<"enabled">>], Doc, Default).
+
+-spec set_classifiers_enabled(doc(), boolean()) -> doc().
+set_classifiers_enabled(Doc, ClassifiersEnabled) ->
+    kz_json:set_value([<<"classifiers">>, <<"enabled">>], ClassifiersEnabled, Doc).
+
+-spec classifiers_prefix(doc()) -> kz_term:api_binary().
+classifiers_prefix(Doc) ->
+    classifiers_prefix(Doc, 'undefined').
+
+-spec classifiers_prefix(doc(), Default) -> binary() | Default.
+classifiers_prefix(Doc, Default) ->
+    kz_json:get_binary_value([<<"classifiers">>, <<"prefix">>], Doc, Default).
+
+-spec set_classifiers_prefix(doc(), binary()) -> doc().
+set_classifiers_prefix(Doc, ClassifiersPrefix) ->
+    kz_json:set_value([<<"classifiers">>, <<"prefix">>], ClassifiersPrefix, Doc).
+
+-spec classifiers_regex(doc()) -> kz_term:api_binary().
+classifiers_regex(Doc) ->
+    classifiers_regex(Doc, 'undefined').
+
+-spec classifiers_regex(doc(), Default) -> binary() | Default.
+classifiers_regex(Doc, Default) ->
+    kz_json:get_binary_value([<<"classifiers">>, <<"regex">>], Doc, Default).
+
+-spec set_classifiers_regex(doc(), binary()) -> doc().
+set_classifiers_regex(Doc, ClassifiersRegex) ->
+    kz_json:set_value([<<"classifiers">>, <<"regex">>], ClassifiersRegex, Doc).
+
+-spec classifiers_suffix(doc()) -> kz_term:api_binary().
+classifiers_suffix(Doc) ->
+    classifiers_suffix(Doc, 'undefined').
+
+-spec classifiers_suffix(doc(), Default) -> binary() | Default.
+classifiers_suffix(Doc, Default) ->
+    kz_json:get_binary_value([<<"classifiers">>, <<"suffix">>], Doc, Default).
+
+-spec set_classifiers_suffix(doc(), binary()) -> doc().
+set_classifiers_suffix(Doc, ClassifiersSuffix) ->
+    kz_json:set_value([<<"classifiers">>, <<"suffix">>], ClassifiersSuffix, Doc).
+
+-spec classifiers_weight_cost(doc()) -> integer().
+classifiers_weight_cost(Doc) ->
+    classifiers_weight_cost(Doc, 50).
+
+-spec classifiers_weight_cost(doc(), Default) -> integer() | Default.
+classifiers_weight_cost(Doc, Default) ->
+    kz_json:get_integer_value([<<"classifiers">>, <<"weight_cost">>], Doc, Default).
+
+-spec set_classifiers_weight_cost(doc(), integer()) -> doc().
+set_classifiers_weight_cost(Doc, ClassifiersWeightCost) ->
+    kz_json:set_value([<<"classifiers">>, <<"weight_cost">>], ClassifiersWeightCost, Doc).
 
 -spec emergency(doc()) -> boolean().
 emergency(Doc) ->
@@ -124,6 +270,18 @@ formatters(Doc, Default) ->
 -spec set_formatters(doc(), kz_json:object()) -> doc().
 set_formatters(Doc, Formatters) ->
     kz_json:set_value([<<"formatters">>], Formatters, Doc).
+
+-spec from_account_realm(doc()) -> boolean().
+from_account_realm(Doc) ->
+    from_account_realm(Doc, 'false').
+
+-spec from_account_realm(doc(), Default) -> boolean() | Default.
+from_account_realm(Doc, Default) ->
+    kz_json:get_boolean_value([<<"from_account_realm">>], Doc, Default).
+
+-spec set_from_account_realm(doc(), boolean()) -> doc().
+set_from_account_realm(Doc, FromAccountRealm) ->
+    kz_json:set_value([<<"from_account_realm">>], FromAccountRealm, Doc).
 
 -spec from_uri_realm(doc()) -> kz_term:api_binary().
 from_uri_realm(Doc) ->
@@ -245,10 +403,34 @@ weight_cost(Doc, Default) ->
 set_weight_cost(Doc, WeightCost) ->
     kz_json:set_value([<<"weight_cost">>], WeightCost, Doc).
 
--spec fax_option(doc()) -> kz_term:api_ne_binary().
-fax_option(Doc) ->
-    fax_option(Doc, 'undefined').
+-spec media_fax_option(doc()) -> boolean().
+media_fax_option(Doc) ->
+    media_fax_option(Doc, 'false').
 
--spec fax_option(doc(), Default) -> kz_term:api_ne_binary() | Default.
-fax_option(Doc, Default) ->
-    kz_json:get_ne_binary_value(<<"fax_option">>, media(Doc, kz_json:new()), Default).
+-spec media_fax_option(doc(), Default) -> boolean() | Default.
+media_fax_option(Doc, Default) ->
+    kz_json:is_true([<<"media">>, <<"fax_option">>], Doc, Default).
+
+-spec media_bypass_media(doc()) -> boolean().
+media_bypass_media(Doc) ->
+    media_bypass_media(Doc, 'false').
+
+-spec media_bypass_media(doc(), Default) -> boolean() | Default.
+media_bypass_media(Doc, Default) ->
+    kz_json:is_true([<<"media">>, <<"bypass_media">>], Doc, Default).
+
+-spec media_audio_codecs(doc()) -> kz_term:api_ne_binaries().
+media_audio_codecs(Doc) ->
+    media_audio_codecs(Doc, 'undefined').
+
+-spec media_audio_codecs(doc(), Default) -> kz_term:ne_binaries() | Default.
+media_audio_codecs(Doc, Default) ->
+    kz_json:get_list_value([<<"media">>, <<"audio">>, <<"codecs">>], Doc, Default).
+
+-spec media_video_codecs(doc()) -> kz_term:api_ne_binaries().
+media_video_codecs(Doc) ->
+    media_video_codecs(Doc, 'undefined').
+
+-spec media_video_codecs(doc(), Default) -> kz_term:ne_binaries() | Default.
+media_video_codecs(Doc, Default) ->
+    kz_json:get_list_value([<<"media">>, <<"video">>, <<"codecs">>], Doc, Default).

--- a/core/kazoo_documents/src/kzd_resources.erl.src
+++ b/core/kazoo_documents/src/kzd_resources.erl.src
@@ -6,6 +6,16 @@
 -module(kzd_resources).
 
 -export([new/0]).
+-export([caller_id_options/1, caller_id_options/2, set_caller_id_options/2]).
+-export([caller_id_options_type/1, caller_id_options_type/2, set_caller_id_options_type/2]).
+-export([cid_rules/1, cid_rules/2, set_cid_rules/2]).
+-export([classifiers/1, classifiers/2, set_classifiers/2]).
+-export([classifiers_emergency/1, classifiers_emergency/2, set_classifiers_emergency/2]).
+-export([classifiers_enabled/1, classifiers_enabled/2, set_classifiers_enabled/2]).
+-export([classifiers_prefix/1, classifiers_prefix/2, set_classifiers_prefix/2]).
+-export([classifiers_regex/1, classifiers_regex/2, set_classifiers_regex/2]).
+-export([classifiers_suffix/1, classifiers_suffix/2, set_classifiers_suffix/2]).
+-export([classifiers_weight_cost/1, classifiers_weight_cost/2, set_classifiers_weight_cost/2]).
 -export([emergency/1, emergency/2, set_emergency/2]).
 -export([enabled/1, enabled/2, set_enabled/2]).
 -export([flags/1, flags/2, set_flags/2]).
@@ -13,6 +23,7 @@
 -export([flat_rate_whitelist/1, flat_rate_whitelist/2, set_flat_rate_whitelist/2]).
 -export([format_from_uri/1, format_from_uri/2, set_format_from_uri/2]).
 -export([formatters/1, formatters/2, set_formatters/2]).
+-export([from_account_realm/1, from_account_realm/2, set_from_account_realm/2]).
 -export([from_uri_realm/1, from_uri_realm/2, set_from_uri_realm/2]).
 -export([gateway_strategy/1, gateway_strategy/2, set_gateway_strategy/2]).
 -export([gateways/1, gateways/2, set_gateways/2]).
@@ -35,6 +46,126 @@
 -spec new() -> doc().
 new() ->
     kz_json_schema:default_object(?SCHEMA).
+
+-spec caller_id_options(doc()) -> kz_term:api_object().
+caller_id_options(Doc) ->
+    caller_id_options(Doc, 'undefined').
+
+-spec caller_id_options(doc(), Default) -> kz_json:object() | Default.
+caller_id_options(Doc, Default) ->
+    kz_json:get_json_value([<<"caller_id_options">>], Doc, Default).
+
+-spec set_caller_id_options(doc(), kz_json:object()) -> doc().
+set_caller_id_options(Doc, CallerIdOptions) ->
+    kz_json:set_value([<<"caller_id_options">>], CallerIdOptions, Doc).
+
+-spec caller_id_options_type(doc()) -> kz_term:api_binary().
+caller_id_options_type(Doc) ->
+    caller_id_options_type(Doc, 'undefined').
+
+-spec caller_id_options_type(doc(), Default) -> binary() | Default.
+caller_id_options_type(Doc, Default) ->
+    kz_json:get_binary_value([<<"caller_id_options">>, <<"type">>], Doc, Default).
+
+-spec set_caller_id_options_type(doc(), binary()) -> doc().
+set_caller_id_options_type(Doc, CallerIdOptionsType) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"type">>], CallerIdOptionsType, Doc).
+
+-spec cid_rules(doc()) -> kz_term:api_ne_binaries().
+cid_rules(Doc) ->
+    cid_rules(Doc, 'undefined').
+
+-spec cid_rules(doc(), Default) -> kz_term:ne_binaries() | Default.
+cid_rules(Doc, Default) ->
+    kz_json:get_list_value([<<"cid_rules">>], Doc, Default).
+
+-spec set_cid_rules(doc(), kz_term:ne_binaries()) -> doc().
+set_cid_rules(Doc, CidRules) ->
+    kz_json:set_value([<<"cid_rules">>], CidRules, Doc).
+
+-spec classifiers(doc()) -> kz_term:api_object().
+classifiers(Doc) ->
+    classifiers(Doc, 'undefined').
+
+-spec classifiers(doc(), Default) -> kz_json:object() | Default.
+classifiers(Doc, Default) ->
+    kz_json:get_json_value([<<"classifiers">>], Doc, Default).
+
+-spec set_classifiers(doc(), kz_json:object()) -> doc().
+set_classifiers(Doc, Classifiers) ->
+    kz_json:set_value([<<"classifiers">>], Classifiers, Doc).
+
+-spec classifiers_emergency(doc()) -> boolean().
+classifiers_emergency(Doc) ->
+    classifiers_emergency(Doc, false).
+
+-spec classifiers_emergency(doc(), Default) -> boolean() | Default.
+classifiers_emergency(Doc, Default) ->
+    kz_json:get_boolean_value([<<"classifiers">>, <<"emergency">>], Doc, Default).
+
+-spec set_classifiers_emergency(doc(), boolean()) -> doc().
+set_classifiers_emergency(Doc, ClassifiersEmergency) ->
+    kz_json:set_value([<<"classifiers">>, <<"emergency">>], ClassifiersEmergency, Doc).
+
+-spec classifiers_enabled(doc()) -> boolean().
+classifiers_enabled(Doc) ->
+    classifiers_enabled(Doc, true).
+
+-spec classifiers_enabled(doc(), Default) -> boolean() | Default.
+classifiers_enabled(Doc, Default) ->
+    kz_json:get_boolean_value([<<"classifiers">>, <<"enabled">>], Doc, Default).
+
+-spec set_classifiers_enabled(doc(), boolean()) -> doc().
+set_classifiers_enabled(Doc, ClassifiersEnabled) ->
+    kz_json:set_value([<<"classifiers">>, <<"enabled">>], ClassifiersEnabled, Doc).
+
+-spec classifiers_prefix(doc()) -> kz_term:api_binary().
+classifiers_prefix(Doc) ->
+    classifiers_prefix(Doc, 'undefined').
+
+-spec classifiers_prefix(doc(), Default) -> binary() | Default.
+classifiers_prefix(Doc, Default) ->
+    kz_json:get_binary_value([<<"classifiers">>, <<"prefix">>], Doc, Default).
+
+-spec set_classifiers_prefix(doc(), binary()) -> doc().
+set_classifiers_prefix(Doc, ClassifiersPrefix) ->
+    kz_json:set_value([<<"classifiers">>, <<"prefix">>], ClassifiersPrefix, Doc).
+
+-spec classifiers_regex(doc()) -> kz_term:api_binary().
+classifiers_regex(Doc) ->
+    classifiers_regex(Doc, 'undefined').
+
+-spec classifiers_regex(doc(), Default) -> binary() | Default.
+classifiers_regex(Doc, Default) ->
+    kz_json:get_binary_value([<<"classifiers">>, <<"regex">>], Doc, Default).
+
+-spec set_classifiers_regex(doc(), binary()) -> doc().
+set_classifiers_regex(Doc, ClassifiersRegex) ->
+    kz_json:set_value([<<"classifiers">>, <<"regex">>], ClassifiersRegex, Doc).
+
+-spec classifiers_suffix(doc()) -> kz_term:api_binary().
+classifiers_suffix(Doc) ->
+    classifiers_suffix(Doc, 'undefined').
+
+-spec classifiers_suffix(doc(), Default) -> binary() | Default.
+classifiers_suffix(Doc, Default) ->
+    kz_json:get_binary_value([<<"classifiers">>, <<"suffix">>], Doc, Default).
+
+-spec set_classifiers_suffix(doc(), binary()) -> doc().
+set_classifiers_suffix(Doc, ClassifiersSuffix) ->
+    kz_json:set_value([<<"classifiers">>, <<"suffix">>], ClassifiersSuffix, Doc).
+
+-spec classifiers_weight_cost(doc()) -> integer().
+classifiers_weight_cost(Doc) ->
+    classifiers_weight_cost(Doc, 50).
+
+-spec classifiers_weight_cost(doc(), Default) -> integer() | Default.
+classifiers_weight_cost(Doc, Default) ->
+    kz_json:get_integer_value([<<"classifiers">>, <<"weight_cost">>], Doc, Default).
+
+-spec set_classifiers_weight_cost(doc(), integer()) -> doc().
+set_classifiers_weight_cost(Doc, ClassifiersWeightCost) ->
+    kz_json:set_value([<<"classifiers">>, <<"weight_cost">>], ClassifiersWeightCost, Doc).
 
 -spec emergency(doc()) -> boolean().
 emergency(Doc) ->
@@ -119,6 +250,18 @@ formatters(Doc, Default) ->
 -spec set_formatters(doc(), kz_json:object()) -> doc().
 set_formatters(Doc, Formatters) ->
     kz_json:set_value([<<"formatters">>], Formatters, Doc).
+
+-spec from_account_realm(doc()) -> boolean().
+from_account_realm(Doc) ->
+    from_account_realm(Doc, false).
+
+-spec from_account_realm(doc(), Default) -> boolean() | Default.
+from_account_realm(Doc, Default) ->
+    kz_json:get_boolean_value([<<"from_account_realm">>], Doc, Default).
+
+-spec set_from_account_realm(doc(), boolean()) -> doc().
+set_from_account_realm(Doc, FromAccountRealm) ->
+    kz_json:set_value([<<"from_account_realm">>], FromAccountRealm, Doc).
 
 -spec from_uri_realm(doc()) -> kz_term:api_binary().
 from_uri_realm(Doc) ->

--- a/core/kazoo_endpoint/src/kz_endpoint_v4.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint_v4.erl
@@ -202,7 +202,7 @@ cache_origin(JObj, EndpointId, AccountDb) ->
     Routines = [fun(P) -> [{'db', AccountDb, EndpointId} | P] end
                ,fun(P) ->
                         [{'db', AccountDb, kzs_util:format_account_id(AccountDb)}
-                        | P
+                         | P
                         ]
                 end
                ,fun(P) -> maybe_cached_owner_id(P, JObj, AccountDb) end
@@ -721,11 +721,11 @@ flush(Db, Id) ->
         ,{<<"Database">>, Db}
         ,{<<"Rev">>, Rev}
         ,{<<"Type">>, kzd_devices:type()}
-        | kz_api:default_headers(<<"configuration">>
-                                ,?DOC_EDITED
-                                ,?APP_NAME
-                                ,?APP_VERSION
-                                )
+         | kz_api:default_headers(<<"configuration">>
+                                 ,?DOC_EDITED
+                                 ,?APP_NAME
+                                 ,?APP_VERSION
+                                 )
         ],
     Fun = fun(P) ->
                   kapi_conf:publish_doc_update('edited', Db, kzd_devices:type(), Id, P)
@@ -1011,7 +1011,7 @@ maybe_start_metaflow(Call, Endpoint) ->
                     ,{<<"Binding-Digit">>, kzd_metaflows:binding_digit(Metaflow)}
                     ,{<<"Digit-Timeout">>, kzd_metaflows:digit_timeout(Metaflow)}
                     ,{<<"Listen-On">>, kzd_metaflows:listen_on(Metaflow, <<"self">>)}
-                    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                     ]),
             lager:debug("sending metaflow for endpoint: ~s: ~s"
                        ,[Id, kzd_metaflows:listen_on(Metaflow, <<"self">>)]
@@ -1279,7 +1279,7 @@ create_sip_endpoint(Endpoint, Properties, #clid{}=Clid, Call) ->
                     ,{<<"Failover">>, maybe_build_failover(Endpoint, Call)}
                     ,{<<"Metaflows">>, kzd_devices:metaflows(Endpoint)}
                     ,{<<"Endpoint-Actions">>, endpoint_actions(Endpoint, Call)}
-                    | maybe_get_t38(Endpoint, Call)
+                     | maybe_get_t38(Endpoint, Call)
                     ]),
     maybe_format_endpoint(SIPEndpoint, kzd_devices:formatters(Endpoint)).
 
@@ -1768,7 +1768,7 @@ maybe_set_call_forward({Endpoint, Call, CallFwd, CCVs}) ->
                         ,{<<"Require-Ignore-Early-Media">>, <<"true">>}
                         ,{<<"Loopback-Request-URI">>, LoopBackUri}
                         ,{<<"Ignore-Early-Media">>, <<"true">>}
-                        | bowout_settings('undefined' =:= kapps_call:call_id_direct(Call))
+                         | bowout_settings('undefined' =:= kapps_call:call_id_direct(Call))
                         ]
                        ,CCVs
                        )

--- a/core/kazoo_schemas/src/kz_json_schema.erl
+++ b/core/kazoo_schemas/src/kz_json_schema.erl
@@ -93,10 +93,10 @@ load(Schema) -> fload(Schema).
 -spec load(kz_term:ne_binary() | string()) -> load_return().
 load(<<"./", Schema/binary>>) -> load(Schema);
 load(<<"file://", Schema/binary>>) -> load(Schema);
-load(<<Schema/binary>>) ->
-    case kz_datamgr:open_cache_doc(?KZ_SCHEMA_DB, Schema, [{'cache_failures', ['not_found']}]) of
+load(<<SchemaId/binary>>) ->
+    case kz_datamgr:open_cache_doc(?KZ_SCHEMA_DB, SchemaId, [{'cache_failures', ['not_found']}]) of
         {'error', _E}=E -> E;
-        {'ok', JObj} -> {'ok', kz_json:insert_value(<<"id">>, Schema, JObj)}
+        {'ok', JObj} -> {'ok', kz_json:insert_value(<<"id">>, SchemaId, JObj)}
     end;
 load(Schema) -> load(kz_term:to_binary(Schema)).
 -endif.
@@ -1005,7 +1005,7 @@ flatten_prop(Path, ?JSON_WRAPPER(L) = Value) when is_list(L) ->
 -spec default_object(string() | kz_term:ne_binary() | kz_json:object()) -> kz_json:object().
 default_object([_|_]=SchemaId) ->
     default_object(list_to_binary(SchemaId));
-default_object(?NE_BINARY=SchemaId) ->
+default_object(<<SchemaId/binary>>) ->
     {'ok', Schema} = load(SchemaId),
     default_object(Schema);
 default_object(Schema) ->

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -406,6 +406,8 @@ pages:
   - 'Kazoo IPs':
     - 'core/kazoo_ips/doc/README.md'
     - 'core/kazoo_ips/doc/maintenance.md'
+  - 'Kazoo IM':
+    - 'core/kazoo_im/doc/README.md'
   - 'Kazoo Media':
     - 'core/kazoo_media/doc/README.md'
     - 'core/kazoo_media/doc/maintenance.md'
@@ -425,6 +427,8 @@ pages:
     - 'core/kazoo_apps/doc/kazoo_maintenance.md'
   - 'Kazoo Translator':
     - 'core/kazoo_translator/doc/README.md'
+  - 'Kazoo Telemetry':
+    - 'core/kazoo_telemetry/doc/README.md'
   - 'Kazoo Number Manager':
     - 'core/kazoo_numbers/doc/README.md'
     - 'core/kazoo_numbers/doc/carrier_types.md'


### PR DESCRIPTION
Stepswitch makes use of a number of fields that aren't defined on the
resources schema. Add them and use the accessor module when possible.