### PR TITLE
add deprecated modules - 4.3

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_node_sup.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_node_sup.erl
@@ -32,6 +32,7 @@
 -define(NODE_WORKER, ?NODE_CHILD_TYPE(<<"worker">>)).
 -define(NODE_SUPERVISOR, ?NODE_CHILD_TYPE(<<"supervisor">>)).
 
+-define(DEPRECATED_MODS, [<<"msg">>]).
 %%==============================================================================
 %% API functions
 %%==============================================================================
@@ -113,7 +114,7 @@ init([Node, Options]) ->
 
     NodeB = kz_term:to_binary(Node),
     Args = [Node, Options],
-    M = kazoo_bindings:map(<<"freeswitch.node.modules">>, []),
+    M = kazoo_bindings:map(<<"freeswitch.node.modules">>, []) -- ?DEPRECATED_MODS,
     Modules = lists:foldl(fun(A, B) -> A ++ B end, [], M),
     JObj = maybe_correct_modules(Modules),
     Children = kz_json:foldr(fun(Module, V, Acc) ->


### PR DESCRIPTION
module names are taken from env which may be changed at startup
by changing sys.config.

this makes sure that deprecated modules
are removed from the list in cae a sys.config was changed
or not chagned and still has reference to missing module

a better way would be to ensure that the module exists
but i was out of time :)