### PR TITLE
[MBRA-1] - Fix formatting issue with voicemail to email HTML template - 4.3

### DIFF
--- a/applications/teletype/priv/templates/voicemail_to_email.html
+++ b/applications/teletype/priv/templates/voicemail_to_email.html
@@ -40,12 +40,15 @@
                         <h3 style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;font-weight:100;">Hi{% if user.first_name %} {{user.first_name}}{% endif %},</h3>
                     </td>
                 </tr>
+                <tr>
                     <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
                         <p style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;">You have a new voicemail from <b>{{caller_id.name_number}}</b> for your voicemail box at <b>{{voicemail.vmbox_name}} ({{voicemail.vmbox_number}})</b>.
+                        <pre style="text-align: left;white-space: pre-line;">
                         {% if voicemail.file_name %}
                             <br><br>Please find the message audio file in the attachment.
                         {% endif %}
-                        </p>
+                        </pre>
+                    </p>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
This PR addresses a small formatting issue with the template where the if block for media file attachment was not wrapping to a new line in the template preview.

- adds a missing <tr> opening tag
- wrap voicemail media file condition in a pre tag to wrap to a new line in branding app template viewer