### PR TITLE
HELP-13212: Improve check to include attachment referral information

### DIFF
--- a/applications/teletype/priv/templates/voicemail_to_email.html
+++ b/applications/teletype/priv/templates/voicemail_to_email.html
@@ -44,7 +44,7 @@
                     <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
                         <p style="margin:0;padding:0;font-family:'Open Sans',sans-serif;color:#555555;">You have a new voicemail from <b>{{caller_id.name_number}}</b> for your voicemail box at <b>{{voicemail.vmbox_name}} ({{voicemail.vmbox_number}})</b>.
                         <pre style="text-align: left;white-space: pre-line;">
-                        {% if voicemail.file_name %}
+                        {% if voicemail.vmbox_include_message_on_notify %}
                             <br><br>Please find the message audio file in the attachment.
                         {% endif %}
                         </pre>

--- a/applications/teletype/priv/templates/voicemail_to_email.text
+++ b/applications/teletype/priv/templates/voicemail_to_email.text
@@ -5,7 +5,7 @@ Hi{% if user.first_name %} {{user.first_name}}{% endif %},
 
 You have a new voicemail from {{caller_id.name_number}} for
 your voicemail box at {{voicemail.vmbox_name}} (number: {{voicemail.vmbox_number}}).
-{% if voicemail.file_name %}
+{% if voicemail.vmbox_include_message_on_notify %}
 Please find the message audio file in the attachment.
 {% endif %}
 {% if voicemail.transcription %}

--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -279,6 +279,9 @@ build_voicemail_data(DataJObj) ->
       ,{<<"box">>, kz_json:get_value(<<"voicemail_box">>, DataJObj)} %% backward compatibility
       ,{<<"vmbox_name">>, kz_json:get_value([<<"vmbox_doc">>, <<"name">>], DataJObj)}
       ,{<<"vmbox_number">>, kz_json:get_value([<<"vmbox_doc">>, <<"mailbox">>], DataJObj)}
+      ,{<<"vmbox_include_message_on_notify">>
+       ,kz_json:get_value([<<"vmbox_doc">>, <<"include_message_on_notify">>], DataJObj, 'true')
+       }
       ,{<<"msg_id">>, kz_json:get_value(<<"voicemail_id">>, DataJObj)}
       ,{<<"name">>, kz_json:get_value(<<"voicemail_id">>, DataJObj)} %% backward compatibility
       ,{<<"transcription">>, maybe_get_transcription(DataJObj)}

--- a/applications/teletype/src/templates/teletype_voicemail_to_email.erl
+++ b/applications/teletype/src/templates/teletype_voicemail_to_email.erl
@@ -280,7 +280,7 @@ build_voicemail_data(DataJObj) ->
       ,{<<"vmbox_name">>, kz_json:get_value([<<"vmbox_doc">>, <<"name">>], DataJObj)}
       ,{<<"vmbox_number">>, kz_json:get_value([<<"vmbox_doc">>, <<"mailbox">>], DataJObj)}
       ,{<<"vmbox_include_message_on_notify">>
-       ,kz_json:get_value([<<"vmbox_doc">>, <<"include_message_on_notify">>], DataJObj, 'true')
+       ,kz_json:is_true([<<"vmbox_doc">>, <<"include_message_on_notify">>], DataJObj, 'true')
        }
       ,{<<"msg_id">>, kz_json:get_value(<<"voicemail_id">>, DataJObj)}
       ,{<<"name">>, kz_json:get_value(<<"voicemail_id">>, DataJObj)} %% backward compatibility


### PR DESCRIPTION
It seems `voicemail.file_name` is also set when `transcribe` is enabled so I added a new parameter to the template data object to take an accurate decision on whether or not to include the attachment's referral information.

[4.3 PR](https://github.com/2600hz/kazoo/pull/6476)