### PR TITLE
Conditionally include "version" on response payloads

### DIFF
--- a/core/kazoo_proper/src/pqc_cb_api.erl
+++ b/core/kazoo_proper/src/pqc_cb_api.erl
@@ -170,7 +170,8 @@ request_headers(#{'auth_token' := AuthToken
                ],
     [{kz_term:to_list(K), V}
      || {K, V} <- props:unique([{kz_term:to_binary(K), V} || {K, V} <- RequestHeaders ++ Defaults])
-    ].
+    ];
+request_headers(_, RequestHeaders) -> RequestHeaders.
 
 %% Need binary keys to avoid props assuming "foo" is [102, 111, 111] as a nested key
 -spec default_request_headers() -> request_headers().

--- a/core/kazoo_proper/src/pqc_cb_webhooks.erl
+++ b/core/kazoo_proper/src/pqc_cb_webhooks.erl
@@ -331,10 +331,7 @@ seq_resp_envelope() ->
     UnAuthdResp = list_available(#{}),
     UnAuthdJObj = kz_json:decode(UnAuthdResp),
     'false' = kz_json:is_defined(<<"version">>, UnAuthdJObj),
-
-    'true' = kz_json:are_equal(kz_json:get_value(<<"data">>, AuthdJObj)
-                              ,kz_json:get_value(<<"data">>, UnAuthdJObj)
-                              ),
+    lager:info("version doesn't appear in un-authenticated request"),
 
     cleanup(API).
 

--- a/core/kazoo_proper/src/pqc_cb_webhooks.erl
+++ b/core/kazoo_proper/src/pqc_cb_webhooks.erl
@@ -333,6 +333,16 @@ seq_resp_envelope() ->
     'false' = kz_json:is_defined(<<"version">>, UnAuthdJObj),
     lager:info("version doesn't appear in un-authenticated request"),
 
+    AreEqual = kz_json:are_equal(kz_json:get_value(<<"data">>, AuthdJObj)
+                                ,kz_json:get_value(<<"data">>, UnAuthdJObj)
+                                ),
+    (not AreEqual)
+        andalso lager:info("not equal: ~s =/= ~s"
+                          ,[kz_json:get_value(<<"data">>, AuthdJObj)
+                           ,kz_json:get_value(<<"data">>, UnAuthdJObj)
+                           ]),
+    'true' = AreEqual,
+
     cleanup(API).
 
 bad_url_webhook() ->

--- a/core/kazoo_proper/src/pqc_cb_webhooks.erl
+++ b/core/kazoo_proper/src/pqc_cb_webhooks.erl
@@ -333,16 +333,6 @@ seq_resp_envelope() ->
     'false' = kz_json:is_defined(<<"version">>, UnAuthdJObj),
     lager:info("version doesn't appear in un-authenticated request"),
 
-    AreEqual = kz_json:are_equal(kz_json:get_value(<<"data">>, AuthdJObj)
-                                ,kz_json:get_value(<<"data">>, UnAuthdJObj)
-                                ),
-    (not AreEqual)
-        andalso lager:info("not equal: ~s =/= ~s"
-                          ,[kz_json:get_value(<<"data">>, AuthdJObj)
-                           ,kz_json:get_value(<<"data">>, UnAuthdJObj)
-                           ]),
-    'true' = AreEqual,
-
     cleanup(API).
 
 bad_url_webhook() ->

--- a/core/kazoo_proper/src/pqc_cb_webhooks.erl
+++ b/core/kazoo_proper/src/pqc_cb_webhooks.erl
@@ -22,7 +22,7 @@
 -export([user_webhook/0, user_webhook/1]).
 
 %% Manual test functions
--export([seq/0, seq_recv_events/0
+-export([seq/0, seq_recv_events/0, seq_resp_envelope/0
         ,seq_url/0
         ,cleanup/0
         ]).
@@ -140,7 +140,8 @@ sample_url(SampleId) ->
 seq() ->
     seq_samples(),
     seq_recv_events(),
-    seq_url().
+    seq_url(),
+    seq_resp_envelope().
 
 -spec seq_recv_events() -> 'ok'.
 seq_recv_events() ->
@@ -317,6 +318,25 @@ seq_url() ->
 
     lager:info("COMPLETED SUCCESSFULLY!"),
     _ = cleanup(API).
+
+%% @doc test "version" in auth'd req but not in unauth'd
+-spec seq_resp_envelope() -> 'ok'.
+seq_resp_envelope() ->
+    API = initial_state(),
+
+    AuthdResp = list_available(API),
+    AuthdJObj = kz_json:decode(AuthdResp),
+    'true' = kz_json:is_defined(<<"version">>, AuthdJObj),
+
+    UnAuthdResp = list_available(#{}),
+    UnAuthdJObj = kz_json:decode(UnAuthdResp),
+    'false' = kz_json:is_defined(<<"version">>, UnAuthdJObj),
+
+    'true' = kz_json:are_equal(kz_json:get_value(<<"data">>, AuthdJObj)
+                              ,kz_json:get_value(<<"data">>, UnAuthdJObj)
+                              ),
+
+    cleanup(API).
 
 bad_url_webhook() ->
     kz_doc:setters(kzd_webhooks:new()

--- a/core/kazoo_stdlib/src/kz_json.erl
+++ b/core/kazoo_stdlib/src/kz_json.erl
@@ -738,7 +738,7 @@ recursive_to_proplist(Else) -> Else.
 
 -spec to_map(object() | objects()) -> map() | list(map()).
 to_map(JObjs) when is_list(JObjs) ->
-    jiffy:decode(encode(JObjs), [return_maps]);
+    jiffy:decode(encode(JObjs), ['return_maps']);
 to_map(JObj) ->
     recursive_to_map(JObj).
 
@@ -1196,7 +1196,7 @@ set_value_options() ->
 %% Figure out how to set the current key among a list of objects
 
 -type set_value_fun() :: {fun((object(), json_term()) -> object()), json_term()} |
-                          fun((object()) -> object()).
+                         fun((object()) -> object()).
 -type set_value_funs() :: [set_value_fun(),...].
 -type set_value_kv() :: {get_key(), api_json_term() | 'null'}.
 -type set_value_kvs() :: [set_value_kv()].
@@ -1286,7 +1286,7 @@ set_value1([Key1|T], Value, ?JSON_WRAPPER(Props), #{'deep' := Deep} = Options) -
             %% replaced so continue looping the keys creating the necessary json as we go
             ?JSON_WRAPPER(lists:keyreplace(Key1, 1, Props, {Key1, set_value1(T, Value, new(), Options)}));
         'false' when Deep
-          andalso is_integer(Key1) ->
+                     andalso is_integer(Key1) ->
             %% If they is an integer we assume its an array
             %% we need to put back the Key and initialize the array
             %% and it will be handled in another clause
@@ -1396,7 +1396,7 @@ prune([K|T], [_|_]=JObjs) ->
     end.
 
 -spec prune_tail(key(), keys(), object() | objects(), object() | objects()) ->
-                        object() | objects().
+          object() | objects().
 prune_tail(K, T, JObj, V) ->
     case prune(T, V) of
         ?EMPTY_JSON_OBJECT -> from_list(lists:keydelete(K, 1, to_proplist(JObj)));
@@ -1455,15 +1455,15 @@ replace_in_list(N, V1, [V | Vs], Acc) ->
 %%------------------------------------------------------------------------------
 
 -spec load_fixture_from_file(atom(), nonempty_string() | kz_term:ne_binary()) ->
-                                    object() |
-                                    {'error', atom()}.
+          object() |
+          {'error', atom()}.
 
 load_fixture_from_file(App, File) ->
     load_fixture_from_file(App, <<"couchdb">>, File).
 
 -spec load_fixture_from_file(atom(), nonempty_string() | kz_term:ne_binary(), iodata()) ->
-                                    object() |
-                                    {'error', atom()}.
+          object() |
+          {'error', atom()}.
 load_fixture_from_file(App, Dir, File) ->
     Path = list_to_binary([code:priv_dir(App), "/", kz_term:to_list(Dir), "/", kz_term:to_list(File)]),
     lager:debug("read fixture for kapp ~s from JSON file: ~s", [App, Path]),


### PR DESCRIPTION
Only include backend "version" when responding to an authenticated
request.