### PR TITLE
Sup UUID 43

### DIFF
--- a/applications/crossbar/src/crossbar_maintenance.erl
+++ b/applications/crossbar/src/crossbar_maintenance.erl
@@ -19,6 +19,7 @@
         ,register_views/0
         ,flush/0
         ]).
+
 -export([find_account_by_number/1]).
 -export([find_account_by_name/1]).
 -export([find_account_by_realm/1]).
@@ -26,7 +27,7 @@
 -export([enable_account/1, disable_account/1]).
 -export([promote_account/1, demote_account/1]).
 -export([allow_account_number_additions/1, disallow_account_number_additions/1]).
--export([create_account/4]).
+-export([create_account/4, create_account/5, create_account/6]).
 -export([create_account/1]).
 -export([move_account/2]).
 -export([descendants_count/0, descendants_count/1]).
@@ -382,19 +383,29 @@ demote_account(AccountId) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec create_account(input_term(), input_term(), input_term(), input_term()) -> 'ok' | 'failed'.
-create_account(AccountName, Realm, Username, Password)
+create_account(AccountName, Realm, Username, Password) ->
+    create_account(AccountName, Realm, Username, Password, kz_datamgr:get_uuid()).
+
+-spec create_account(input_term(), input_term(), input_term(), input_term(), input_term()) -> 'ok' | 'failed'.
+create_account(AccountName, Realm, Username, Password, AccountId) ->
+    create_account(AccountName, Realm, Username, Password, AccountId, kz_datamgr:get_uuid()).
+
+-spec create_account(input_term(), input_term(), input_term(), input_term(), input_term(), input_term()) -> 'ok' | 'failed'.
+create_account(AccountName, Realm, Username, Password, AccountId, UserId)
   when is_binary(AccountName),
        is_binary(Realm),
        is_binary(Username),
-       is_binary(Password) ->
-    Account = kz_json:set_values([{<<"_id">>, kz_datamgr:get_uuid()}
+       is_binary(Password),
+       is_binary(AccountId),
+       is_binary(UserId) ->
+    Account = kz_json:set_values([{<<"_id">>, AccountId}
                                  ,{<<"name">>, AccountName}
                                  ,{<<"realm">>, Realm}
                                  ]
                                 ,kzd_accounts:new()
                                 ),
 
-    User = kz_json:set_values([{<<"_id">>, kz_datamgr:get_uuid()}
+    User = kz_json:set_values([{<<"_id">>, UserId}
                               ,{<<"username">>, Username}
                               ,{<<"password">>, Password}
                               ,{<<"first_name">>, <<"Account">>}
@@ -419,11 +430,13 @@ create_account(AccountName, Realm, Username, Password)
             io:format("failed to create '~s': ~p~n", [AccountName, _R]),
             'failed'
     end;
-create_account(AccountName, Realm, Username, Password) ->
+create_account(AccountName, Realm, Username, Password, AccountId, UserId) ->
     create_account(kz_term:to_binary(AccountName)
                   ,kz_term:to_binary(Realm)
                   ,kz_term:to_binary(Username)
                   ,kz_term:to_binary(Password)
+                  ,kz_term:to_binary(AccountId)
+                  ,kz_term:to_binary(UserId)
                   ).
 
 -spec maybe_promote_account(cb_context:context()) -> {'ok', cb_context:context()}.


### PR DESCRIPTION
Corresponding back port PR for: https://github.com/2600hz/kazoo/pull/6495

This is an extension of the SUP command to create the initial master account. We wanted to be able to add optional parameters for the uuid's of the account and user. This is so we can set the UUIDs ahead of time for functional testing.