### PR TITLE
adding CouchDB 3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,9 @@ jobs:
     docker:
       - image: offical2600hz/circleci:21.3.8.12
       - image: couchdb:3.0
+        environment:
+          COUCHDB_USER: admin
+          COUCHDB_PASSWORD: admin
       - image: 2600hz/rabbitmq
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ workflows:
       - release:
           requires:
             - build
-    
+
 defaults: &defaults
   docker:
     - image: offical2600hz/circleci:21.3.8.12
@@ -194,7 +194,7 @@ jobs:
     <<: *defaults
     docker:
       - image: offical2600hz/circleci:21.3.8.12
-      - image: couchdb:2.3.1
+      - image: couchdb:3.0
       - image: 2600hz/rabbitmq
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
@@ -246,6 +246,6 @@ jobs:
       BUILD_RPMS: "/home/circleci/2600hz/packager/RPMS"
       APP_DIR: "/home/circleci/2600hz/kazoo"
     steps:
-      - run: 
+      - run:
           name: dummy step
-          command: echo ok 
+          command: echo ok

--- a/applications/tasks/src/modules/kt_compactor.erl
+++ b/applications/tasks/src/modules/kt_compactor.erl
@@ -71,6 +71,12 @@
 %%------------------------------------------------------------------------------
 -spec init() -> 'ok'.
 init() ->
+    init(kazoo_couch:server_version()).
+
+-spec init(kazoo_couch:server_version()) -> 'ok'.
+init('couchdb_3') ->
+    lager:debug("CouchDB 3 doesn't need me :(");
+init(_) ->
     AdminNodes = kazoo_couch:get_admin_nodes(),
     %% Refresh `nodes | _nodes' db
     _ = kapps_maintenance:refresh(AdminNodes),

--- a/applications/tasks/src/modules/kt_compactor.erl
+++ b/applications/tasks/src/modules/kt_compactor.erl
@@ -75,7 +75,7 @@ init() ->
 
 -spec init(kazoo_couch:server_version()) -> 'ok'.
 init('couchdb_3') ->
-    lager:debug("CouchDB 3 doesn't need me :(");
+    lager:debug("couchdb 3 does not need compactor, not binding");
 init(_) ->
     AdminNodes = kazoo_couch:get_admin_nodes(),
     %% Refresh `nodes | _nodes' db

--- a/core/kazoo_couch/src/kazoo_couch.erl
+++ b/core/kazoo_couch/src/kazoo_couch.erl
@@ -18,7 +18,7 @@
 %% Server callbacks
 -export([server_info/1
         ,server_url/1
-        ,server_version/1
+        ,server_version/0, server_version/1
         ,get_db/2
         ,get_admin_dbs/0, get_admin_dbs/1
         ,get_admin_nodes/0, get_admin_nodes/1
@@ -169,6 +169,8 @@ db_list(Server, Options) ->
 %%
 %% db specific
 %%
+db_list('couchdb_3', Server, Options) ->
+    kz_couch_db:db_list(Server, Options);
 db_list('couchdb_2', Server, Options) ->
     kz_couch_db:db_list(Server, Options);
 db_list('bigcouch', Server, Options) ->
@@ -300,6 +302,11 @@ show(Server, DbName, DesignDoc, DocId, Options) ->
           couchbeam_error().
 all_docs(Server, DbName, Options) ->
     kz_couch_view:all_docs(Server, DbName, Options).
+
+-spec server_version() -> couch_version().
+server_version() ->
+    #{server := {_App, #server{}=Conn}} = kzs_plan:plan(),
+    server_version(Conn).
 
 -spec server_version(server()) -> couch_version().
 server_version(#server{options=Options}) ->

--- a/core/kazoo_couch/src/kz_couch.hrl
+++ b/core/kazoo_couch/src/kz_couch.hrl
@@ -77,7 +77,7 @@
 -define(NO_OPTIONS, ['cookie', 'admin_port', 'compact_automatically']).
 -define(ATOM_OPTIONS, ['pool', 'pool_name']).
 
--type couch_version() :: 'couchdb_1_6' | 'couchdb_2' | 'bigcouch'.
+-type couch_version() :: 'couchdb_1_6' | 'couchdb_2' | 'couchdb_3' | 'bigcouch'.
 
 -define(KZ_COUCH_HRL, 'true').
 -endif.

--- a/rel/ci.config.ini
+++ b/rel/ci.config.ini
@@ -10,3 +10,12 @@ cookie = change_me
 [log]
 console=info
 error=error
+
+[data]
+config = couchdb3
+
+[couchdb3]
+; ip = "127.0.0.1"
+; port = 5984
+username = admin
+password = admin


### PR DESCRIPTION
* Adding support for CouchDB version 3
* Not starting `kt_compactor` if couchdb version is 3

Note: this PR doesn't address deprecation of `list` and `show` functions.