### PR TITLE
[4.3] KSTE-1: Include additional parameters on local ext bridge request

### DIFF
--- a/applications/stepswitch/src/stepswitch_bridge.erl
+++ b/applications/stepswitch/src/stepswitch_bridge.erl
@@ -12,6 +12,7 @@
         ,bridge_outbound_cid_number/1
         ,bridge_emergency_cid_name/1
         ,bridge_outbound_cid_name/1
+        ,maybe_override_asserted_identity/2
         ]).
 
 -export([init/1
@@ -24,9 +25,9 @@
         ]).
 
 -ifdef(TEST).
--export[avoid_privacy_if_emergency_call/2
-       ,contains_emergency_endpoints/1
-       ].
+-export([avoid_privacy_if_emergency_call/2
+        ,contains_emergency_endpoints/1
+        ]).
 -endif.
 
 -include("stepswitch.hrl").
@@ -409,8 +410,8 @@ build_bridge(#state{endpoints=Endpoints
                                      ,{<<"Reseller-ID">>, kz_services_reseller:get_id(AccountId)}
                                      ,{<<"Outbound-Flags">>, outbound_flags(OffnetReq)}
                                      ]),
-    RemoveCCVs = [{<<"Require-Ignore-Early-Media">>, null}
-                 ,{<<"Require-Fail-On-Single-Reject">>, null}
+    RemoveCCVs = [{<<"Require-Ignore-Early-Media">>, 'null'}
+                 ,{<<"Require-Fail-On-Single-Reject">>, 'null'}
                  ],
 
     NewEndpoints = avoid_privacy_if_emergency_call(IsEmergency, Endpoints),
@@ -423,31 +424,31 @@ build_bridge(#state{endpoints=Endpoints
 
     props:filter_undefined(
       [{<<"Application-Name">>, <<"bridge">>}
-      ,{<<"Dial-Endpoint-Method">>, <<"single">>}
-      ,{?KEY_OUTBOUND_CALLER_ID_NUMBER, Number}
-      ,{?KEY_OUTBOUND_CALLER_ID_NAME, Name}
-      ,{<<"Caller-ID-Number">>, Number}
-      ,{<<"Caller-ID-Name">>, Name}
-      ,{<<"Custom-Channel-Vars">>, CCVs}
-      ,{<<"Custom-Application-Vars">>, kapi_offnet_resource:custom_application_vars(OffnetReq)}
-      ,{<<"Timeout">>, kapi_offnet_resource:timeout(OffnetReq)}
-      ,{<<"Ignore-Early-Media">>, IgnoreEarlyMedia}
-      ,{<<"Fail-On-Single-Reject">>, FailOnSingleReject}
-      ,{<<"Media">>, kapi_offnet_resource:media(OffnetReq)}
-      ,{<<"Hold-Media">>, kapi_offnet_resource:hold_media(OffnetReq)}
-      ,{<<"Presence-ID">>, kapi_offnet_resource:presence_id(OffnetReq)}
-      ,{<<"Ringback">>, kapi_offnet_resource:ringback(OffnetReq)}
-      ,{<<"Call-ID">>, kapi_offnet_resource:call_id(OffnetReq)}
-      ,{<<"Fax-Identity-Number">>, kapi_offnet_resource:fax_identity_number(OffnetReq, Number)}
-      ,{<<"Fax-Identity-Name">>, kapi_offnet_resource:fax_identity_name(OffnetReq, Name)}
-      ,{<<"Outbound-Callee-ID-Number">>, kapi_offnet_resource:outbound_callee_id_number(OffnetReq)}
-      ,{<<"Outbound-Callee-ID-Name">>, kapi_offnet_resource:outbound_callee_id_name(OffnetReq)}
-      ,{<<"Asserted-Identity-Number">>, AssertedNumber}
       ,{<<"Asserted-Identity-Name">>, AssertedName}
+      ,{<<"Asserted-Identity-Number">>, AssertedNumber}
       ,{<<"Asserted-Identity-Realm">>, kapi_offnet_resource:asserted_identity_realm(OffnetReq, Realm)}
       ,{<<"B-Leg-Events">>, kapi_offnet_resource:b_leg_events(OffnetReq, [])}
-      ,{<<"Endpoints">>, FmtEndpoints}
       ,{<<"Bridge-Actions">>, kapi_offnet_resource:outbound_actions(OffnetReq)}
+      ,{<<"Call-ID">>, kapi_offnet_resource:call_id(OffnetReq)}
+      ,{<<"Caller-ID-Name">>, Name}
+      ,{<<"Caller-ID-Number">>, Number}
+      ,{<<"Custom-Application-Vars">>, kapi_offnet_resource:custom_application_vars(OffnetReq)}
+      ,{<<"Custom-Channel-Vars">>, CCVs}
+      ,{<<"Dial-Endpoint-Method">>, <<"single">>}
+      ,{<<"Endpoints">>, FmtEndpoints}
+      ,{<<"Fail-On-Single-Reject">>, FailOnSingleReject}
+      ,{<<"Fax-Identity-Name">>, kapi_offnet_resource:fax_identity_name(OffnetReq, Name)}
+      ,{<<"Fax-Identity-Number">>, kapi_offnet_resource:fax_identity_number(OffnetReq, Number)}
+      ,{<<"Hold-Media">>, kapi_offnet_resource:hold_media(OffnetReq)}
+      ,{<<"Ignore-Early-Media">>, IgnoreEarlyMedia}
+      ,{<<"Media">>, kapi_offnet_resource:media(OffnetReq)}
+      ,{<<"Outbound-Callee-ID-Name">>, kapi_offnet_resource:outbound_callee_id_name(OffnetReq)}
+      ,{<<"Outbound-Callee-ID-Number">>, kapi_offnet_resource:outbound_callee_id_number(OffnetReq)}
+      ,{<<"Presence-ID">>, kapi_offnet_resource:presence_id(OffnetReq)}
+      ,{<<"Ringback">>, kapi_offnet_resource:ringback(OffnetReq)}
+      ,{<<"Timeout">>, kapi_offnet_resource:timeout(OffnetReq)}
+      ,{?KEY_OUTBOUND_CALLER_ID_NAME, Name}
+      ,{?KEY_OUTBOUND_CALLER_ID_NUMBER, Number}
        | kz_api:default_headers(Q, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
       ]).
 

--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -680,7 +680,7 @@ process_fold(App, _, M, _) -> {App, M}.
 %%------------------------------------------------------------------------------
 -spec calling_app() -> kz_term:ne_binary().
 calling_app() ->
-    Modules = erlang:process_info(self(),current_stacktrace),
+    Modules = erlang:process_info(self(), 'current_stacktrace'),
     {'current_stacktrace', [_Me, {Module, _, _, _} | Start]} = Modules,
     {'ok', App} = application:get_application(Module),
     case process_fold(Start, App) of
@@ -690,7 +690,7 @@ calling_app() ->
 
 -spec calling_app_version() -> {kz_term:ne_binary(), kz_term:ne_binary()}.
 calling_app_version() ->
-    Modules = erlang:process_info(self(),current_stacktrace),
+    Modules = erlang:process_info(self(), 'current_stacktrace'),
     {'current_stacktrace', [_Me, {Module, _, _, _} | Start]} = Modules,
     {'ok', App} = application:get_application(Module),
     NewApp = case process_fold(Start, App) of
@@ -702,13 +702,13 @@ calling_app_version() ->
 
 -spec calling_process() -> map().
 calling_process() ->
-    Modules = erlang:process_info(self(),current_stacktrace),
+    Modules = erlang:process_info(self(), 'current_stacktrace'),
     {'current_stacktrace', [_Me, {Module, _, _, _}=M | Start]} = Modules,
     App = case application:get_application(Module) of
               {'ok', KApp} -> KApp;
               'undefined' -> Module
           end,
-    {NewApp, {Mod, Function, Arity, [{file, Filename}, {line, Line}]}} =
+    {NewApp, {Mod, Function, Arity, [{'file', Filename}, {'line', Line}]}} =
         case process_fold(Start, App) of
             App -> {App, M};
             {Parent, MFA } -> {Parent, MFA}
@@ -722,7 +722,7 @@ calling_process() ->
      }.
 
 -spec get_app(atom() | kz_term:ne_binary()) -> {atom(), string(), string()} | 'undefined'.
-get_app(<<_/binary>> = AppName) ->
+get_app(<<AppName/binary>>) ->
     get_app(kz_term:to_atom(AppName));
 get_app(AppName) ->
     case [App || {Name, _, _}=App <- application:loaded_applications(), Name =:= AppName] of
@@ -743,13 +743,13 @@ application_version(Application) ->
 %% Time: `O(nlog(n))'
 %% @end
 %%------------------------------------------------------------------------------
--spec uniq([kz_term:proplist()]) -> kz_term:proplist().
+-spec uniq(kz_term:proplist()) -> kz_term:proplist().
 uniq(KVs) when is_list(KVs) -> uniq(KVs, sets:new(), []).
 uniq([], _, L) -> lists:reverse(L);
 uniq([{K,_}=KV|Rest], S, L) ->
     case sets:is_element(K, S) of
-        true -> uniq(Rest, S, L);
-        false ->
+        'true' -> uniq(Rest, S, L);
+        'false' ->
             NewS = sets:add_element(K, S),
             uniq(Rest, NewS, [KV|L])
     end.

--- a/core/kazoo_number_manager/src/knm_number_options.erl
+++ b/core/kazoo_number_manager/src/knm_number_options.erl
@@ -46,7 +46,9 @@
                            {'reseller_id', kz_term:api_ne_binary()}.
 -type crossbar_options() :: [crossbar_option()].
 
--type option() :: {'assign_to', kz_term:api_ne_binary()} |
+-type assign_to() :: kz_term:api_ne_binary().
+
+-type option() :: {'assign_to', assign_to()} |
                   {'auth_by', kz_term:api_ne_binary()} |
                   {'batch_run', boolean()} |
                   {'crossbar', crossbar_options()} |
@@ -130,19 +132,19 @@ mdn_run(Options) ->
         andalso lager:debug("mdn_run-ing btw"),
     R.
 
--spec assign_to(options()) -> kz_term:api_binary().
+-spec assign_to(options()) -> assign_to().
 assign_to(Options) ->
     assign_to(Options, 'undefined').
 
--spec assign_to(options(), Default) -> kz_term:ne_binary() | Default.
+-spec assign_to(options(), Default) -> assign_to() | Default.
 assign_to(Options, Default) ->
     props:get_binary_value('assign_to', Options, Default).
 
--spec set_assign_to(options(), kz_term:ne_binary()) -> options().
-set_assign_to(Options, AssignTo) ->
+-spec set_assign_to(options(), assign_to()) -> options().
+set_assign_to(Options, ?MATCH_ACCOUNT_RAW(AssignTo)) ->
     props:set_value('assign_to', AssignTo, Options).
 
--spec auth_by(options()) -> kz_term:api_binary().
+-spec auth_by(options()) -> kz_term:api_ne_binary().
 auth_by(Options) ->
     auth_by(Options, 'undefined').
 


### PR DESCRIPTION
When using local_extension (when hairpinning calls to stay on-net) in
stepswitch, the local_extension bridge command was missing some key
values - specifically setting `Bridge-Actions` with the offnet
request's `Outbound-Actions` (which sets up recording on answer for
instance).