### PR TITLE
KSTE-1: Include additional parameters on local ext bridge request

### DIFF
--- a/applications/stepswitch/src/stepswitch_bridge.erl
+++ b/applications/stepswitch/src/stepswitch_bridge.erl
@@ -16,6 +16,7 @@
         ,bridge_outbound_cid_number/1
         ,bridge_emergency_cid_name/1
         ,bridge_outbound_cid_name/1
+        ,maybe_override_asserted_identity/2
         ]).
 
 -export([init/1
@@ -28,9 +29,9 @@
         ]).
 
 -ifdef(TEST).
--export[avoid_privacy_if_emergency_call/2
-       ,contains_emergency_endpoints/1
-       ].
+-export([avoid_privacy_if_emergency_call/2
+        ,contains_emergency_endpoints/1
+        ]).
 -endif.
 
 -include("stepswitch.hrl").
@@ -424,8 +425,8 @@ build_bridge(#state{endpoints=Endpoints
                                      ,{<<"Reseller-ID">>, kz_services_reseller:get_id(AccountId)}
                                      ,{<<"Outbound-Flags">>, outbound_flags(OffnetReq)}
                                      ]),
-    RemoveCCVs = [{<<"Require-Ignore-Early-Media">>, null}
-                 ,{<<"Require-Fail-On-Single-Reject">>, null}
+    RemoveCCVs = [{<<"Require-Ignore-Early-Media">>, 'null'}
+                 ,{<<"Require-Fail-On-Single-Reject">>, 'null'}
                  ],
 
     NewEndpoints = avoid_privacy_if_emergency_call(IsEmergency, Endpoints),
@@ -438,31 +439,31 @@ build_bridge(#state{endpoints=Endpoints
 
     props:filter_undefined(
       [{<<"Application-Name">>, <<"bridge">>}
-      ,{<<"Dial-Endpoint-Method">>, <<"single">>}
-      ,{?KEY_OUTBOUND_CALLER_ID_NUMBER, Number}
-      ,{?KEY_OUTBOUND_CALLER_ID_NAME, Name}
-      ,{<<"Caller-ID-Number">>, Number}
-      ,{<<"Caller-ID-Name">>, Name}
-      ,{<<"Custom-Channel-Vars">>, CCVs}
-      ,{<<"Custom-Application-Vars">>, kapi_offnet_resource:custom_application_vars(OffnetReq)}
-      ,{<<"Timeout">>, kapi_offnet_resource:timeout(OffnetReq)}
-      ,{<<"Ignore-Early-Media">>, IgnoreEarlyMedia}
-      ,{<<"Fail-On-Single-Reject">>, FailOnSingleReject}
-      ,{<<"Media">>, kapi_offnet_resource:media(OffnetReq)}
-      ,{<<"Hold-Media">>, kapi_offnet_resource:hold_media(OffnetReq)}
-      ,{<<"Presence-ID">>, kapi_offnet_resource:presence_id(OffnetReq)}
-      ,{<<"Ringback">>, kapi_offnet_resource:ringback(OffnetReq)}
-      ,{<<"Call-ID">>, kapi_offnet_resource:call_id(OffnetReq)}
-      ,{<<"Fax-Identity-Number">>, kapi_offnet_resource:fax_identity_number(OffnetReq, Number)}
-      ,{<<"Fax-Identity-Name">>, kapi_offnet_resource:fax_identity_name(OffnetReq, Name)}
-      ,{<<"Outbound-Callee-ID-Number">>, kapi_offnet_resource:outbound_callee_id_number(OffnetReq)}
-      ,{<<"Outbound-Callee-ID-Name">>, kapi_offnet_resource:outbound_callee_id_name(OffnetReq)}
-      ,{<<"Asserted-Identity-Number">>, AssertedNumber}
       ,{<<"Asserted-Identity-Name">>, AssertedName}
+      ,{<<"Asserted-Identity-Number">>, AssertedNumber}
       ,{<<"Asserted-Identity-Realm">>, kapi_offnet_resource:asserted_identity_realm(OffnetReq, Realm)}
       ,{<<"B-Leg-Events">>, kapi_offnet_resource:b_leg_events(OffnetReq, [])}
-      ,{<<"Endpoints">>, FmtEndpoints}
       ,{<<"Bridge-Actions">>, kapi_offnet_resource:outbound_actions(OffnetReq)}
+      ,{<<"Call-ID">>, kapi_offnet_resource:call_id(OffnetReq)}
+      ,{<<"Caller-ID-Name">>, Name}
+      ,{<<"Caller-ID-Number">>, Number}
+      ,{<<"Custom-Application-Vars">>, kapi_offnet_resource:custom_application_vars(OffnetReq)}
+      ,{<<"Custom-Channel-Vars">>, CCVs}
+      ,{<<"Dial-Endpoint-Method">>, <<"single">>}
+      ,{<<"Endpoints">>, FmtEndpoints}
+      ,{<<"Fail-On-Single-Reject">>, FailOnSingleReject}
+      ,{<<"Fax-Identity-Name">>, kapi_offnet_resource:fax_identity_name(OffnetReq, Name)}
+      ,{<<"Fax-Identity-Number">>, kapi_offnet_resource:fax_identity_number(OffnetReq, Number)}
+      ,{<<"Hold-Media">>, kapi_offnet_resource:hold_media(OffnetReq)}
+      ,{<<"Ignore-Early-Media">>, IgnoreEarlyMedia}
+      ,{<<"Media">>, kapi_offnet_resource:media(OffnetReq)}
+      ,{<<"Outbound-Callee-ID-Name">>, kapi_offnet_resource:outbound_callee_id_name(OffnetReq)}
+      ,{<<"Outbound-Callee-ID-Number">>, kapi_offnet_resource:outbound_callee_id_number(OffnetReq)}
+      ,{<<"Presence-ID">>, kapi_offnet_resource:presence_id(OffnetReq)}
+      ,{<<"Ringback">>, kapi_offnet_resource:ringback(OffnetReq)}
+      ,{<<"Timeout">>, kapi_offnet_resource:timeout(OffnetReq)}
+      ,{?KEY_OUTBOUND_CALLER_ID_NAME, Name}
+      ,{?KEY_OUTBOUND_CALLER_ID_NUMBER, Number}
        | kz_api:default_headers(Q, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
       ]).
 

--- a/applications/stepswitch/src/stepswitch_local_extension.erl
+++ b/applications/stepswitch/src/stepswitch_local_extension.erl
@@ -158,9 +158,9 @@ handle_cast(_Msg, State) ->
 handle_info('local_extension_timeout', #state{timeout='undefined'}=State) ->
     {'noreply', State};
 handle_info('local_extension_timeout', #state{response_queue=ResponseQ
-                                             ,resource_req=OffnetJObj
+                                             ,resource_req=OffnetReq
                                              }=State) ->
-    kapi_offnet_resource:publish_resp(ResponseQ, local_extension_timeout(OffnetJObj)),
+    kapi_offnet_resource:publish_resp(ResponseQ, local_extension_timeout(OffnetReq)),
     {'stop', 'normal', State#state{timeout='undefined'}};
 handle_info(_Info, State) ->
     lager:debug("unhandled info: ~p", [_Info]),
@@ -286,93 +286,116 @@ code_change(_OldVsn, State, _Extra) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec outbound_flags(kapi_offnet_resource:req()) -> kz_term:api_binary().
-outbound_flags(OffnetJObj) ->
-    case kapi_offnet_resource:flags(OffnetJObj) of
+outbound_flags(OffnetReq) ->
+    case kapi_offnet_resource:flags(OffnetReq) of
         [] -> 'undefined';
         Flags -> kz_binary:join(Flags, <<"|">>)
     end.
 
 -spec build_local_extension(state()) -> kz_term:proplist().
 build_local_extension(#state{number_props=Props
-                            ,resource_req=OffnetJObj
+                            ,resource_req=OffnetReq
                             ,queue=Q
                             }) ->
-    {CIDName, CIDNum} = local_extension_caller_id(OffnetJObj),
+    {CIDName, CIDNum} = local_extension_caller_id(OffnetReq),
     lager:debug("set outbound caller id to ~s '~s'", [CIDNum, CIDName]),
     Number = knm_options:number(Props),
     AccountId = knm_options:account_id(Props),
     ResellerId = kz_services_reseller:get_id(AccountId),
-    OriginalAccountId = kapi_offnet_resource:account_id(OffnetJObj),
+    OriginalAccountId = kapi_offnet_resource:account_id(OffnetReq),
     OriginalResellerId = kz_services_reseller:get_id(OriginalAccountId),
-    {CEDNum, CEDName} = local_extension_callee_id(OffnetJObj, Number),
+    {CEDNum, CEDName} = local_extension_callee_id(OffnetReq, Number),
     Realm = get_account_realm(AccountId),
     FromRealm = get_account_realm(OriginalAccountId),
-    CCVsOrig = kapi_offnet_resource:custom_channel_vars(OffnetJObj, kz_json:new()),
-    CAVs = kapi_offnet_resource:custom_application_vars(OffnetJObj),
+    CCVsOrig = kapi_offnet_resource:custom_channel_vars(OffnetReq, kz_json:new()),
+    CAVs = kapi_offnet_resource:custom_application_vars(OffnetReq),
 
-    CCVs = kz_json:set_values([{<<"Ignore-Display-Updates">>, <<"true">>}
-                              ,{<<"Account-ID">>, OriginalAccountId}
-                              ,{<<"Reseller-ID">>, OriginalResellerId}
+    CCVs = kz_json:set_values([{<<"Account-ID">>, OriginalAccountId}
+                              ,{<<"From-URI">>, <<CIDNum/binary, "@", FromRealm/binary>>}
+                              ,{<<"Ignore-Display-Updates">>, <<"true">>}
+                              ,{<<"Outbound-Flags">>, outbound_flags(OffnetReq)}
                               ,{<<"Realm">>, FromRealm}
-                              ,{<<"Outbound-Flags">>, outbound_flags(OffnetJObj)}
+                              ,{<<"Request-URI">>, <<Number/binary, "@", FromRealm/binary>>}
+                              ,{<<"Reseller-ID">>, OriginalResellerId}
                               ,{<<"Resource-ID">>, AccountId}
                               ,{<<"Resource-Type">>, <<"onnet-termination">>}
-                              ,{<<"From-URI">>, <<CIDNum/binary, "@", FromRealm/binary>>}
-                              ,{<<"Request-URI">>, <<Number/binary, "@", FromRealm/binary>>}
                               ,{<<"To-URI">>, <<Number/binary, "@", FromRealm/binary>>}
                               ]
                              ,CCVsOrig
                              ),
 
+    {AssertedNumber, AssertedName} = stepswitch_bridge:maybe_override_asserted_identity(OffnetReq
+                                                                                       ,{'false'
+                                                                                        ,stepswitch_bridge:bridge_outbound_cid_number(OffnetReq)
+                                                                                        ,stepswitch_bridge:bridge_outbound_cid_name(OffnetReq)
+                                                                                        }),
+
     CCVUpdates = kz_json:from_list(
-                   [{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Inception">>, <<Number/binary, "@", Realm/binary>>}
-                   ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Account-ID">>, AccountId}
-                   ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Reseller-ID">>, ResellerId}
+                   [{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Account-ID">>, AccountId}
+                   ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Inception">>, <<Number/binary, "@", Realm/binary>>}
+                   ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Inception-Account-ID">>, OriginalAccountId}
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Realm">>, Realm}
+                   ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Reseller-ID">>, ResellerId}
+                   ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Resource-Type">>, <<"onnet-origination">>}
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "SIP-Invite-Domain">>, Realm}
 
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "From-URI">>, <<CIDNum/binary, "@", Realm/binary>>}
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Request-URI">>, <<Number/binary, "@", Realm/binary>>}
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "To-URI">>, <<Number/binary, "@", Realm/binary>>}
-
-                   ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Inception-Account-ID">>, OriginalAccountId}
-                   ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Resource-Type">>, <<"onnet-origination">>}
                    ]),
 
     Endpoint = kz_json:from_list(
-                 [{<<"Invite-Format">>, <<"loopback">>}
+                 [{<<"Caller-ID-Name">>, CIDName}
+                 ,{<<"Caller-ID-Number">>, CIDNum}
+                 ,{<<"Custom-Channel-Vars">>, CCVUpdates}
+                 ,{<<"Enable-T38-Fax">>, 'false'}
+                 ,{<<"Enable-T38-Fax-Request">>, 'false'}
+                 ,{<<"Ignore-Early-Media">>, 'true'}
+                 ,{<<"Invite-Format">>, <<"loopback">>}
+                 ,{<<"Outbound-Callee-ID-Name">>, CEDName}
+                 ,{<<"Outbound-Callee-ID-Number">>, CEDNum}
+                 ,{<<"Outbound-Caller-ID-Name">>, CIDName}
+                 ,{<<"Outbound-Caller-ID-Number">>, CIDNum}
                  ,{<<"Route">>, Number}
                  ,{<<"To-DID">>, Number}
                  ,{<<"To-Realm">>, FromRealm}
-                 ,{<<"Custom-Channel-Vars">>, CCVUpdates}
-                 ,{<<"Outbound-Caller-ID-Name">>, CIDName}
-                 ,{<<"Outbound-Caller-ID-Number">>, CIDNum}
-                 ,{<<"Outbound-Callee-ID-Name">>, CEDName}
-                 ,{<<"Outbound-Callee-ID-Number">>, CEDNum}
-                 ,{<<"Caller-ID-Name">>, CIDName}
-                 ,{<<"Caller-ID-Number">>, CIDNum}
-                 ,{<<"Ignore-Early-Media">>, 'true'}
-                 ,{<<"Enable-T38-Fax">>, 'false'}
-                 ,{<<"Enable-T38-Fax-Request">>, 'false'}
                  ]),
 
     props:filter_undefined(
       [{<<"Application-Name">>, <<"bridge">>}
-      ,{<<"Call-ID">>, kapi_offnet_resource:call_id(OffnetJObj)}
+
+      ,{<<"Asserted-Identity-Name">>, AssertedName}
+      ,{<<"Asserted-Identity-Number">>, AssertedNumber}
+      ,{<<"Asserted-Identity-Realm">>, kapi_offnet_resource:asserted_identity_realm(OffnetReq, Realm)}
+
+      ,{<<"B-Leg-Events">>, kapi_offnet_resource:b_leg_events(OffnetReq, [])}
+      ,{<<"Bridge-Actions">>, kapi_offnet_resource:outbound_actions(OffnetReq)}
+
+      ,{<<"Call-ID">>, kapi_offnet_resource:call_id(OffnetReq)}
       ,{<<"Caller-ID-Name">>, CIDName}
       ,{<<"Caller-ID-Number">>, CIDNum}
       ,{<<"Custom-Application-Vars">>, CAVs}
       ,{<<"Custom-Channel-Vars">>, CCVs}
       ,{<<"Dial-Endpoint-Method">>, <<"single">>}
       ,{<<"Endpoints">>, [Endpoint]}
+
+      ,{<<"Fax-Identity-Name">>, kapi_offnet_resource:fax_identity_name(OffnetReq, CIDName)}
+      ,{<<"Fax-Identity-Number">>, kapi_offnet_resource:fax_identity_number(OffnetReq, CIDNum)}
+
+      ,{<<"Hold-Media">>, kapi_offnet_resource:hold_media(OffnetReq)}
+
       ,{<<"Loopback-Bowout">>, <<"false">>}
       ,{<<"Media">>, <<"process">>}
       ,{<<"Outbound-Callee-ID-Name">>, CEDName}
       ,{<<"Outbound-Callee-ID-Number">>, CEDNum}
       ,{<<"Outbound-Caller-ID-Name">>, CIDName}
       ,{<<"Outbound-Caller-ID-Number">>, CIDNum}
+      ,{<<"Presence-ID">>, kapi_offnet_resource:presence_id(OffnetReq)}
+      ,{<<"Ringback">>, kapi_offnet_resource:ringback(OffnetReq)}
+      ,{<<"Timeout">>, kapi_offnet_resource:timeout(OffnetReq)}
+
       ,{<<"Simplify-Loopback">>, <<"false">>}
-       | kz_api:default_headers(Q, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
+      | kz_api:default_headers(Q, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
       ]).
 
 -spec get_account_realm(kz_term:ne_binary()) -> kz_term:ne_binary().
@@ -412,7 +435,7 @@ local_extension_timeout(OffnetReq) ->
     ,{<<"Response-Code">>, <<"sip:500">>}
     ,{<<"Error-Message">>, <<"local extension request timed out">>}
     ,{<<"To-DID">>, kapi_offnet_resource:to_did(OffnetReq)}
-     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 
 -spec local_extension_error(kz_call_event:doc(), kapi_offnet_resource:req()) -> kz_term:proplist().
@@ -424,7 +447,7 @@ local_extension_error(CallEvt, OffnetReq) ->
     ,{<<"Response-Code">>, <<"sip:500">>}
     ,{<<"Error-Message">>, kz_call_event:error_message(CallEvt, <<"failed to process request">>)}
     ,{<<"To-DID">>, kapi_offnet_resource:to_did(OffnetReq)}
-     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 
 -spec local_extension_success(kapi_offnet_resource:req()) -> kz_term:proplist().
@@ -435,7 +458,7 @@ local_extension_success(OffnetReq) ->
     ,{<<"Response-Message">>, <<"SUCCESS">>}
     ,{<<"Response-Code">>, <<"sip:200">>}
     ,{<<"Resource-Response">>, kz_json:new()}
-     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 
 -spec local_extension_failure(kz_call_event:doc(), kapi_offnet_resource:req()) -> kz_term:proplist().
@@ -448,7 +471,7 @@ local_extension_failure(CallEvt, OffnetReq) ->
     ,{<<"Response-Message">>, response_message(CallEvt)}
     ,{<<"Response-Code">>, kz_call_event:hangup_code(CallEvt)}
     ,{<<"Resource-Response">>, CallEvt}
-     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 
 -spec response_message(kz_call_event:doc()) -> kz_term:api_ne_binary().

--- a/applications/stepswitch/src/stepswitch_local_extension.erl
+++ b/applications/stepswitch/src/stepswitch_local_extension.erl
@@ -395,7 +395,7 @@ build_local_extension(#state{number_props=Props
       ,{<<"Timeout">>, kapi_offnet_resource:timeout(OffnetReq)}
 
       ,{<<"Simplify-Loopback">>, <<"false">>}
-      | kz_api:default_headers(Q, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
+       | kz_api:default_headers(Q, <<"call">>, <<"command">>, ?APP_NAME, ?APP_VERSION)
       ]).
 
 -spec get_account_realm(kz_term:ne_binary()) -> kz_term:ne_binary().
@@ -435,7 +435,7 @@ local_extension_timeout(OffnetReq) ->
     ,{<<"Response-Code">>, <<"sip:500">>}
     ,{<<"Error-Message">>, <<"local extension request timed out">>}
     ,{<<"To-DID">>, kapi_offnet_resource:to_did(OffnetReq)}
-    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 
 -spec local_extension_error(kz_call_event:doc(), kapi_offnet_resource:req()) -> kz_term:proplist().
@@ -447,7 +447,7 @@ local_extension_error(CallEvt, OffnetReq) ->
     ,{<<"Response-Code">>, <<"sip:500">>}
     ,{<<"Error-Message">>, kz_call_event:error_message(CallEvt, <<"failed to process request">>)}
     ,{<<"To-DID">>, kapi_offnet_resource:to_did(OffnetReq)}
-    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 
 -spec local_extension_success(kapi_offnet_resource:req()) -> kz_term:proplist().
@@ -458,7 +458,7 @@ local_extension_success(OffnetReq) ->
     ,{<<"Response-Message">>, <<"SUCCESS">>}
     ,{<<"Response-Code">>, <<"sip:200">>}
     ,{<<"Resource-Response">>, kz_json:new()}
-    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 
 -spec local_extension_failure(kz_call_event:doc(), kapi_offnet_resource:req()) -> kz_term:proplist().
@@ -471,7 +471,7 @@ local_extension_failure(CallEvt, OffnetReq) ->
     ,{<<"Response-Message">>, response_message(CallEvt)}
     ,{<<"Response-Code">>, kz_call_event:hangup_code(CallEvt)}
     ,{<<"Resource-Response">>, CallEvt}
-    | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+     | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
     ].
 
 -spec response_message(kz_call_event:doc()) -> kz_term:api_ne_binary().

--- a/core/kazoo/src/kz_util.erl
+++ b/core/kazoo/src/kz_util.erl
@@ -239,7 +239,7 @@ calling_process() ->
               {'ok', KApp} -> KApp;
               'undefined' -> Module
           end,
-    {NewApp, {Mod, Function, Arity, [{file, Filename}, {line, Line}]}} =
+    {NewApp, {Mod, Function, Arity, [{'file', Filename}, {'line', Line}]}} =
         case process_fold(Start, App) of
             App -> {App, M};
             {Parent, MFA } -> {Parent, MFA}
@@ -253,7 +253,7 @@ calling_process() ->
      }.
 
 -spec get_app(atom() | kz_term:ne_binary()) -> {atom(), string(), string()} | 'undefined'.
-get_app(<<_/binary>> = AppName) ->
+get_app(<<AppName/binary>>) ->
     get_app(kz_term:to_atom(AppName));
 get_app(AppName) ->
     case [App || {Name, _, _}=App <- application:loaded_applications(), Name =:= AppName] of

--- a/core/kazoo_amqp/include/kz_api.hrl
+++ b/core/kazoo_amqp/include/kz_api.hrl
@@ -2,7 +2,7 @@
 
 -include_lib("kazoo_amqp/include/kz_api_literals.hrl").
 
--type api_formatter_return() :: {'ok', iolist()} | {'error', string()}.
+-type api_formatter_return() :: {'ok', iodata()} | {'error', string()}.
 -type api_headers() :: kz_term:ne_binaries() | [kz_term:ne_binary() | kz_term:ne_binaries()].
 
 -type api_types() :: [{kz_term:ne_binary(), fun()}].

--- a/core/kazoo_numbers/src/knm_options.erl
+++ b/core/kazoo_numbers/src/knm_options.erl
@@ -50,7 +50,9 @@
                            {'reseller_id', kz_term:api_ne_binary()}.
 -type crossbar_options() :: [crossbar_option()].
 
--type option() :: {'assign_to', kz_term:api_ne_binary()} |
+-type assign_to() :: kz_term:api_ne_binary().
+
+-type option() :: {'assign_to', assign_to()} |
                   {'auth_by', kz_term:api_ne_binary()} |
                   {'batch_run', boolean()} |
                   {'crossbar', crossbar_options()} |
@@ -164,16 +166,16 @@ mdn_run(Options) ->
         andalso lager:debug("mdn_run-ing btw"),
     R.
 
--spec assign_to(options()) -> kz_term:api_binary().
+-spec assign_to(options()) -> assign_to().
 assign_to(Options) ->
     assign_to(Options, 'undefined').
 
--spec assign_to(options(), Default) -> kz_term:ne_binary() | Default.
+-spec assign_to(options(), Default) -> assign_to() | Default.
 assign_to(Options, Default) ->
     props:get_binary_value('assign_to', Options, Default).
 
--spec set_assign_to(options(), kz_term:ne_binary()) -> options().
-set_assign_to(Options, AssignTo) ->
+-spec set_assign_to(options(), assign_to()) -> options().
+set_assign_to(Options, ?MATCH_ACCOUNT_RAW(AssignTo)) ->
     props:set_value('assign_to', AssignTo, Options).
 
 -spec auth_by(options()) -> kz_term:api_ne_binary().


### PR DESCRIPTION
When using local_extension (when hairpinning calls to stay on-net) in
stepswitch, the local_extension bridge command was missing some key
values - specifically setting `Bridge-Actions` with the offnet
request's `Outbound-Actions` (which sets up recording on answer for
instance).