### PR TITLE
Fixed bug in tasks whereby the results csv was not being generated correctly due to changes to the csv generator to add a new line charter to the end of lines

### DIFF
--- a/applications/tasks/src/kz_tasks_scheduler.erl
+++ b/applications/tasks/src/kz_tasks_scheduler.erl
@@ -213,11 +213,11 @@ maybe_strip_columns(Columns, CSVPath, ColumnsWritten) ->
 strip_columns(FullHeader, Header, CSV, OutputPath) ->
     case kz_csv:take_mapped_row(FullHeader, CSV) of
         'eof' ->
-            'ok' = file:write_file(OutputPath, [kz_csv:row_to_iolist(Header), $\n], ['append']),
+            'ok' = file:write_file(OutputPath, kz_csv:row_to_iolist(Header), ['append']),
             tac(OutputPath);
         {MappedRow, NewCSV} ->
             Stripped = maps:with(Header, MappedRow),
-            Data = [kz_csv:mapped_row_to_iolist(Header, Stripped), $\n],
+            Data = kz_csv:mapped_row_to_iolist(Header, Stripped),
             'ok' = file:write_file(OutputPath, Data, ['append']),
             strip_columns(FullHeader, Header, NewCSV, OutputPath)
     end.

--- a/applications/tasks/src/modules/kt_task_worker.erl
+++ b/applications/tasks/src/modules/kt_task_worker.erl
@@ -276,7 +276,7 @@ write_row(TaskId, Header, MappedRow) ->
 
 -spec write_row(kz_tasks:id(), iodata()) -> 1.
 write_row(TaskId, IOList) ->
-    kz_util:write_file(?OUT(TaskId), [IOList,$\n], ['append']),
+    kz_util:write_file(?OUT(TaskId), IOList, ['append']),
     1.
 
 -spec columns(kz_csv:mapped_row()) -> kz_tasks:columns().
@@ -297,7 +297,7 @@ reason(_) -> <<>>.
 write_output_csv_header(TaskId, {'replace', Header}) ->
     write_output_csv_header(TaskId, Header);
 write_output_csv_header(TaskId, Header) ->
-    Data = [kz_csv:row_to_iolist(Header), $\n],
+    Data = kz_csv:row_to_iolist(Header),
     file:write_file(?OUT(TaskId), Data).
 
 -spec output_csv_header(kz_json:object(), kz_csv:row()) -> kz_tasks:output_header().


### PR DESCRIPTION
As the csv module is now adding \n to the end of lines there is no need to add one in the tasks code