### PR TITLE
when validating couchdb view, give the function a name

### DIFF
--- a/scripts/validate-js.py
+++ b/scripts/validate-js.py
@@ -43,7 +43,7 @@ def fmap(F, data):
 
 def couchjs(field_js):
     (field, js) = field_js
-    JS = ''.join(js) + '\n'
+    JS = ''.join(js).replace(/function/, 'function arent_you_funny_couch') + '\n'
     if 'Object.keys' in JS:
         print(field, 'contains "Object.keys" which is not available until ECMA2015')
         exit(1)

--- a/scripts/validate-js.py
+++ b/scripts/validate-js.py
@@ -43,7 +43,7 @@ def fmap(F, data):
 
 def couchjs(field_js):
     (field, js) = field_js
-    JS = ''.join(js).replace(/function/, 'function arent_you_funny_couch') + '\n'
+    JS = ''.join(js).replace('function', 'function arent_you_funny_couch') + '\n'
     if 'Object.keys' in JS:
         print(field, 'contains "Object.keys" which is not available until ECMA2015')
         exit(1)


### PR DESCRIPTION
We use CouchDB `couchjs` to validate that view are a valid Javascript code
and has no syntax error. Start with CouchDB 3, `couchjs` is changed now
it really require that we pass it a valid function statement with name.

This adds a name to function before writing it to file for validation.