### PR TITLE
[4.3] KCRO-24: address pagination issue when querying MODBs

### DIFF
--- a/applications/crossbar/src/crossbar_view.erl
+++ b/applications/crossbar/src/crossbar_view.erl
@@ -892,7 +892,7 @@ handle_query_result(#{is_chunked := 'true'
             ,context => Context1
             ,previous_chunk_length => FilteredLength
             };
-handle_query_result(#{page_size := PageSize
+handle_query_result(#{page_size := _PageSize
                      ,last_key := _OldLastKey
                      }=LoadMap
                    ,[_|RestDbs]
@@ -902,7 +902,7 @@ handle_query_result(#{page_size := PageSize
                    ) ->
     case check_page_size_and_length(LoadMap, FilteredLength, FilteredJObjs, NewLastKey) of
         {'exhausted', LoadMap2} -> LoadMap2;
-        {'next_db', LoadMap2} when PageSize =:= 'infinity', NewLastKey =/= 'undefined' ->
+        {'next_db', LoadMap2} when NewLastKey =/= 'undefined' ->
             lager:debug("updating new last key to ~p from ~p", [NewLastKey, _OldLastKey]),
             get_results(LoadMap2#{last_key => NewLastKey});
         {'next_db', LoadMap2} -> get_results(LoadMap2#{databases => RestDbs})

--- a/core/kazoo_documents/src/kzd_box_message.erl
+++ b/core/kazoo_documents/src/kzd_box_message.erl
@@ -6,7 +6,7 @@
 %%%-----------------------------------------------------------------------------
 -module(kzd_box_message).
 
--export([new/2, build_metadata_object/6
+-export([new/2, build_metadata_object/6, build_metadata_object/7
         ,count_folder/2
         ,create_message_name/3
         ,type/0
@@ -161,9 +161,10 @@ create_message_name(BoxNum, Timezone, UtcSeconds) ->
 -spec message_name(kz_term:ne_binary(), kz_time:datetime(), string()) -> kz_term:ne_binary().
 message_name(BoxNum, {{Y,M,D},{H,I,S}}, TZ) ->
     list_to_binary(["mailbox ", BoxNum, " message "
-                   ,kz_term:to_binary(M), "-"
-                   ,kz_term:to_binary(D), "-"
-                   ,kz_term:to_binary(Y), " "
+                   ,kz_term:to_binary(Y), "-"
+                   ,kz_date:pad_month(M), "-"
+                   ,kz_date:pad_day(D), " "
+
                    ,kz_term:to_binary(H), ":"
                    ,kz_term:to_binary(I), ":"
                    ,kz_term:to_binary(S), TZ
@@ -176,6 +177,11 @@ message_name(BoxNum, {{Y,M,D},{H,I,S}}, TZ) ->
 -spec build_metadata_object(pos_integer(), kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_time:gregorian_seconds()) ->
           doc().
 build_metadata_object(Length, Call, MediaId, CIDNumber, CIDName, Timestamp) ->
+    build_metadata_object(Length, Call, MediaId, CIDNumber, CIDName, Timestamp, ?VM_FOLDER_NEW).
+
+-spec build_metadata_object(pos_integer(), kapps_call:call(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_time:gregorian_seconds(), kz_term:ne_binary()) ->
+          doc().
+build_metadata_object(Length, Call, MediaId, CIDNumber, CIDName, Timestamp, Folder) ->
     kz_json:from_list(
       [{?KEY_MEDIA_ID, MediaId}
       ,{?KEY_META_CALL_ID, kapps_call:call_id(Call)}
@@ -194,7 +200,7 @@ build_metadata_object(Length, Call, MediaId, CIDNumber, CIDName, Timestamp) ->
       ,{?KEY_META_TO_USER, kapps_call:to_user(Call)}
       ,{?KEY_META_TO_REALM, kapps_call:to_realm(Call)}
 
-      ,{?VM_KEY_FOLDER, ?VM_FOLDER_NEW}
+      ,{?VM_KEY_FOLDER, Folder}
       ]).
 
 -spec get_msg_id(kz_json:object()) -> kz_term:api_ne_binary().

--- a/core/kazoo_proper/src/pqc_cb_api.erl
+++ b/core/kazoo_proper/src/pqc_cb_api.erl
@@ -188,7 +188,7 @@ default_request_headers(RequestId) ->
      | default_request_headers()
     ].
 
--spec make_request(expectations() | expectation() | expected_code() | expected_codes(), fun_2(), string(), kz_term:proplist()) ->
+-spec make_request(expectations() | expectation() | expected_code() | expected_codes(), fun_2(), iolist(), kz_term:proplist()) ->
           response().
 make_request(Code, HTTP, URL, RequestHeaders) when is_integer(Code) ->
     make_request([#{'response_codes' => [Code]}], HTTP, URL, RequestHeaders);
@@ -197,11 +197,12 @@ make_request([Code|_]=Codes, HTTP, URL, RequestHeaders) when is_integer(Code) ->
 make_request(#{'response_codes' := _}=Expectation, HTTP, URL, RequestHeaders) ->
     make_request([Expectation], HTTP, URL, RequestHeaders);
 make_request([#{}|_]=Expectations, HTTP, URL, RequestHeaders) ->
-    lager:info("~p(~s, ~p)", [HTTP, URL, RequestHeaders]),
+    lager:info("~p: ~s", [HTTP, URL]),
+    lager:debug("~p", [RequestHeaders]),
 
     handle_response(Expectations, HTTP(URL, RequestHeaders)).
 
--spec make_request(expectations() | expectation() | expected_code() | expected_codes(), fun_3(), string(), kz_term:proplist(), iodata()) ->
+-spec make_request(expectations() | expectation() | expected_code() | expected_codes(), fun_3(), iolist(), kz_term:proplist(), iodata()) ->
           response().
 make_request(Code, HTTP, URL, RequestHeaders, RequestBody) when is_integer(Code) ->
     make_request([#{'response_codes' => [Code]}], HTTP, URL, RequestHeaders, RequestBody);
@@ -211,8 +212,8 @@ make_request(#{'response_codes' := _}=Expectation, HTTP, URL, RequestHeaders, Re
     make_request([Expectation], HTTP, URL, RequestHeaders, RequestBody);
 make_request([#{}|_]=Expectations, HTTP, URL, RequestHeaders, RequestBody) ->
     lager:info("~p: ~s", [HTTP, URL]),
-    ?DEBUG("headers: ~p", [RequestHeaders]),
-    ?DEBUG("body: ~s", [RequestBody]),
+    lager:debug("headers: ~p", [RequestHeaders]),
+    lager:debug("body: ~s", [RequestBody]),
     handle_response(Expectations, HTTP(URL, RequestHeaders, iolist_to_binary(RequestBody))).
 
 -spec create_envelope(kz_json:json_term()) ->

--- a/core/kazoo_proper/src/pqc_cb_vmboxes.erl
+++ b/core/kazoo_proper/src/pqc_cb_vmboxes.erl
@@ -3,13 +3,16 @@
 -export([new_message/5
         ,fetch_message_metadata/4
         ,fetch_message_binary/4
+        ,list_messages/3, list_messages/4
         ,create_box/3
         ,delete_box/3
         ]).
 
--export([seq/0
+-export([seq/0, seq_kcro_24/0
         ,cleanup/0
         ]).
+
+-include_lib("kazoo_stdlib/include/kz_types.hrl").
 
 -define(ACCOUNT_NAMES, [<<?MODULE_STRING>>]).
 
@@ -66,6 +69,20 @@ fetch_message_binary(API, AccountId, BoxId, MessageId) ->
                            ,RequestHeaders
                            ).
 
+-spec list_messages(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
+list_messages(API, AccountId, BoxId) ->
+    list_messages(API, AccountId, BoxId, []).
+
+-spec list_messages(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:proplist()) -> pqc_cb_api:response().
+list_messages(API, AccountId, BoxId, QuerystringParams) ->
+    MessagesURL = messages_url(AccountId, BoxId, QuerystringParams),
+
+    pqc_cb_api:make_request([200]
+                           ,fun kz_http:get/2
+                           ,MessagesURL
+                           ,pqc_cb_api:request_headers(API)
+                           ).
+
 -spec create_box(pqc_cb_api:state(), kz_term:ne_binary(), kz_term:ne_binary()) -> pqc_cb_api:response().
 create_box(API, AccountId, BoxName) ->
     BoxesURL = boxes_url(AccountId),
@@ -101,7 +118,12 @@ box_url(AccountId, BoxId) ->
     string:join([pqc_cb_accounts:account_url(AccountId), "vmboxes", kz_term:to_list(BoxId)], "/").
 
 messages_url(AccountId, BoxId) ->
-    string:join([pqc_cb_accounts:account_url(AccountId), "vmboxes", kz_term:to_list(BoxId), "messages"], "/").
+    messages_url(AccountId, BoxId, []).
+
+messages_url(AccountId, BoxId, QuerystringParams) ->
+    [string:join([pqc_cb_accounts:account_url(AccountId), "vmboxes", kz_term:to_list(BoxId), "messages"], "/")
+    ,"?", kz_http_util:props_to_querystring(QuerystringParams)
+    ].
 
 message_url(AccountId, BoxId, MessageId) ->
     string:join([pqc_cb_accounts:account_url(AccountId), "vmboxes", kz_term:to_list(BoxId), "messages", kz_term:to_list(MessageId)], "/").
@@ -111,10 +133,163 @@ message_bin_url(AccountId, BoxId, MessageId) ->
 
 -spec seq() -> 'ok'.
 seq() ->
-    Fs = [fun seq_kzoo_52/0],
+    Fs = [fun seq_kzoo_52/0
+         ,fun seq_kcro_24/0
+         ],
     lists:foreach(fun run/1, Fs).
 
 run(F) -> F().
+
+-spec seq_kcro_24() -> 'ok'.
+seq_kcro_24() ->
+    Model = initial_state(),
+    API = pqc_kazoo_model:api(Model),
+
+    AccountResp = pqc_cb_accounts:create_account(API, hd(?ACCOUNT_NAMES)),
+    lager:info("created account: ~s", [AccountResp]),
+
+    AccountId = kz_json:get_value([<<"data">>, <<"id">>], kz_json:decode(AccountResp)),
+
+    BoxName = kz_binary:rand_hex(4),
+    CreateResp = create_box(API, AccountId, BoxName),
+    lager:info("created box resp: ~s", [CreateResp]),
+
+    CreatedBox = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
+    BoxId = kz_doc:id(CreatedBox),
+
+    %% create messages
+    {{Year, Month, Day}, _} = calendar:universal_time(),
+    CurrentMonth = {{Year, Month, Day}
+                   ,CurrentMsgs = [{<<"0-new">>, <<"new">>}     %% oldest
+                                  ,{<<"1-saved">>, <<"saved">>}
+                                  ,{<<"2-new">>, <<"new">>}
+                                  ,{<<"3-saved">>, <<"saved">>}
+                                  ,{<<"4-saved">>, <<"saved">>}
+                                  ,{<<"5-new">>, <<"new">>}
+                                  ,{<<"6-saved">>, <<"saved">>}
+                                  ,{<<"7-new">>, <<"new">>}
+                                  ,{<<"8-saved">>, <<"saved">>} %% newest
+                                  ]
+                   },
+    create_messages(API, AccountId, BoxId, CurrentMonth),
+
+    {PrevYear, PrevMonth, PrevDay} = kz_date:normalize({Year, Month-1, Day}),
+
+    LastMonth = {{PrevYear, PrevMonth, PrevDay}
+                ,OlderMsgs = [{<<"10-new">>, <<"new">>}
+                             ,{<<"11-saved">>, <<"saved">>}
+                             ,{<<"12-new">>, <<"new">>}
+                             ,{<<"13-saved">>, <<"saved">>}
+                             ]
+                },
+    create_messages(API, AccountId, BoxId, LastMonth),
+
+    ExpectedCDRs = lists:reverse(CurrentMsgs) ++ lists:reverse(OlderMsgs),
+    ExpectedCDRIds = [CDRId || {CDRId, _} <- ExpectedCDRs],
+    NewCDRIds = [CDRId || {CDRId, <<"new">>} <- ExpectedCDRs],
+
+    lager:info("expected CDR IDs: ~p", [ExpectedCDRIds]),
+
+    %% The main principle to reproduce the issue seems to be to "tune"
+    %% page_size in such a way that it would be less than db size but
+    %% there are requested items in the rest of the db that satisfy
+    %% the filter. These items will be missed in the response.
+
+    %% For example, the current MODB contains 4 new(n) items and 5
+    %% saved(s) messages - "n s n s s n s n s", the order does matter.
+
+    %% If we request new messages with "page_size=5" and filter for
+    %% non-saved messages, we will get only 2 "new" messages from this db,
+    %% as the code takes the next db because the page_size is reached,
+    %% independant on the fact that next_start_key is available and
+    %% the filtered out result less that page_size.
+    %% ------------------------------------------------------------------------
+    ListedResp = list_messages(API, AccountId, BoxId
+                              ,[{<<"page_size">>, 5}
+                               ,{<<"filter_not_folder">>, <<"saved">>}
+                               ]),
+    lager:info("listed messages ~s", [ListedResp]),
+    ListedJObj = kz_json:decode(ListedResp),
+    <<"success">> = kz_json:get_ne_binary_value(<<"status">>, ListedJObj),
+    5 = kz_json:get_integer_value(<<"page_size">>, ListedJObj),
+
+    lager:info("expecting ~p", [NewCDRIds]),
+    Listing = kz_json:get_list_value(<<"data">>, ListedJObj),
+    UpdatedCDRIds = remove_expected_messages(NewCDRIds, Listing),
+
+    NextStartKey = kz_json:get_ne_binary_value(<<"next_start_key">>, ListedJObj),
+
+    SecondPageResp = list_messages(API, AccountId, BoxId
+                                  ,[{<<"page_size">>, 5}
+                                   ,{<<"filter_not_folder">>, <<"saved">>}
+                                   ,{<<"start_key">>, NextStartKey}
+                                   ]
+                                  ),
+    lager:info("second page: ~s", [SecondPageResp]),
+    SecondPage = kz_json:decode(SecondPageResp),
+    <<"success">> = kz_json:get_ne_binary_value(<<"status">>, SecondPage),
+    1 = kz_json:get_integer_value(<<"page_size">>, SecondPage),
+
+    lager:info("expecting second page ~p", [UpdatedCDRIds]),
+    SecondListing = kz_json:get_list_value(<<"data">>, SecondPage),
+    [] = remove_expected_messages(UpdatedCDRIds, SecondListing),
+
+    AllNewOnePageResp = list_messages(API, AccountId, BoxId
+                                     ,[{<<"filter_not_folder">>, <<"saved">>}]
+                                     ),
+    lager:info("all new messages ~s", [AllNewOnePageResp]),
+    AllNewJObj = kz_json:decode(AllNewOnePageResp),
+    <<"success">> = kz_json:get_ne_binary_value(<<"status">>, AllNewJObj),
+    'true' = length(NewCDRIds) =:= kz_json:get_integer_value(<<"page_size">>, AllNewJObj),
+    AllNewListing = kz_json:get_list_value(<<"data">>, AllNewJObj),
+    [] = remove_expected_messages(NewCDRIds, AllNewListing),
+
+    AllMessagesResp = list_messages(API, AccountId, BoxId),
+    lager:info("all messages ~s", [AllMessagesResp]),
+    AllJObj = kz_json:decode(AllMessagesResp),
+    <<"success">> = kz_json:get_ne_binary_value(<<"status">>, AllJObj),
+
+    'true' = length(ExpectedCDRIds) =:= kz_json:get_integer_value(<<"page_size">>, AllJObj),
+    AllListing = kz_json:get_list_value(<<"data">>, AllJObj),
+    [] = remove_expected_messages(ExpectedCDRIds, AllListing),
+
+    %% no pagination enabled
+    NoPagingResp = list_messages(API, AccountId, BoxId, [{<<"paginate">>, 'false'}]),
+    lager:info("no paging messages ~s", [NoPagingResp]),
+    NoPagingJObj = kz_json:decode(NoPagingResp),
+    <<"success">> = kz_json:get_ne_binary_value(<<"status">>, NoPagingJObj),
+
+    NoPagingListing = kz_json:get_list_value(<<"data">>, NoPagingJObj),
+    'true' = length(ExpectedCDRIds) =:= length(NoPagingListing),
+    [] = remove_expected_messages(ExpectedCDRIds, NoPagingListing),
+
+    %% no pagination enabled but with filter
+    NoPagingFilterResp = list_messages(API, AccountId, BoxId, [{<<"paginate">>, 'false'}
+                                                              ,{<<"filter_not_folder">>, <<"saved">>}
+                                                              ]),
+    lager:info("no paging but filtered messages ~s", [NoPagingFilterResp]),
+    NoPagingFilterJObj = kz_json:decode(NoPagingFilterResp),
+    <<"success">> = kz_json:get_ne_binary_value(<<"status">>, NoPagingFilterJObj),
+
+    NoPagingFilterListing = kz_json:get_list_value(<<"data">>, NoPagingFilterJObj),
+    'true' = length(NewCDRIds) =:= length(NoPagingFilterListing),
+    [] = remove_expected_messages(NewCDRIds, NoPagingFilterListing),
+
+
+    DeleteResp = delete_box(API, AccountId, BoxId),
+    lager:info("delete resp: ~s", [DeleteResp]),
+    DeletedBox = kz_json:get_json_value(<<"data">>, kz_json:decode(DeleteResp)),
+    BoxId = kz_doc:id(DeletedBox),
+    BoxName = kzd_vmboxes:name(DeletedBox),
+    'true' = kz_json:is_true([<<"_read_only">>, <<"deleted">>], DeletedBox),
+
+    cleanup(API),
+    lager:info("FINISHED KCRO-24").
+
+remove_expected_messages(CDRIds, []) -> CDRIds;
+remove_expected_messages([CDRId | CDRIds], [Message | Messages]) ->
+    CDRId = kz_json:get_ne_binary_value(<<"call_id">>, Message),
+    remove_expected_messages(CDRIds, Messages).
 
 seq_kzoo_52() ->
     Model = initial_state(),
@@ -127,7 +302,7 @@ seq_kzoo_52() ->
 
     BoxName = kz_binary:rand_hex(4),
     CreateResp = create_box(API, AccountId, BoxName),
-    lager:info("create resp: ~s", [CreateResp]),
+    lager:info("created box resp: ~s", [CreateResp]),
     CreatedBox = kz_json:get_json_value(<<"data">>, kz_json:decode(CreateResp)),
     BoxId = kz_doc:id(CreatedBox),
     BoxName = kzd_vmboxes:name(CreatedBox),
@@ -140,7 +315,7 @@ seq_kzoo_52() ->
     'true' = kz_json:is_true([<<"_read_only">>, <<"deleted">>], DeletedBox),
 
     cleanup(API),
-    lager:info("FINISHED SEQ").
+    lager:info("FINISHED KZOO-52").
 
 -spec initial_state() -> pqc_kazoo_model:model().
 initial_state() ->
@@ -173,3 +348,40 @@ cleanup(API) ->
     cleanup_system().
 
 cleanup_system() -> 'ok'.
+
+create_messages(API, AccountId, BoxId, {{Year, Month, Day}, Folders}) ->
+    MODB = kz_util:format_account_id(AccountId, Year, Month),
+    'true' = kazoo_modb:create(MODB),
+
+    {'ok', MP3} = file:read_file(filename:join([code:priv_dir('kazoo_proper'), "mp3.mp3"])),
+
+    StartTime = calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {0, 0, 0}}),
+
+    {_StartTime, Messages} = lists:foldl(fun create_voicemail/2
+                                        ,{StartTime, []}
+                                        ,Folders
+                                        ),
+    lists:foreach(fun(M) ->
+                          <<_/binary>> = new_message(API, AccountId, BoxId, M, MP3)
+                  end
+                 ,Messages
+                 ).
+
+create_voicemail(Folder, {Timestamp, Messages}) ->
+    Message = create_message(Folder, Timestamp),
+    {Timestamp + ?SECONDS_IN_HOUR, [Message | Messages]}.
+
+create_message({CallId, Folder}, Timestamp) ->
+    kz_json:from_list([{<<"call_id">>, CallId}
+                      ,{<<"timestamp">>, Timestamp}
+                      ,{<<"folder">>, Folder}
+                      ,{<<"metadata">>
+                       ,kz_json:from_list([{<<"call_id">>, CallId}
+                                          ,{<<"caller_id_name">>, <<?MODULE_STRING>>}
+                                          ,{<<"caller_id_number">>, <<?MODULE_STRING>>}
+                                          ,{<<"length">>, 0}
+                                          ,{<<"folder">>, Folder}
+                                          ,{<<"timestamp">>, Timestamp}
+                                          ])
+                       }
+                      ]).

--- a/core/kazoo_web/src/kz_http.erl
+++ b/core/kazoo_web/src/kz_http.erl
@@ -280,22 +280,22 @@ handle_response({'ok', {{_, StatusCode, _}, Headers, Body}})
   when is_integer(StatusCode) ->
     {'ok', StatusCode, Headers, Body};
 handle_response({'error', 'timeout'}=Err) ->
-    lager:debug("connection timeout"),
+    lager:info("connection timeout"),
     Err;
 handle_response({'EXIT', {Error,_Trace}}) ->
-    lager:debug("caught EXIT ~p: ~p", [Error, _Trace]),
+    lager:info("caught EXIT ~p: ~p", [Error, _Trace]),
     {'error', Error};
 handle_response({'error', {'failed_connect',[{_, _Address}, {_, _, 'nxdomain'}]}}) ->
-    lager:debug("non existent domain ~p", [_Address]),
+    lager:info("non existent domain ~p", [_Address]),
     {'error', {'failed_connect', 'nxdomain'}};
 handle_response({'error', {'failed_connect',[{_, _Address}, {_, _, 'econnrefused'}]}}) ->
-    lager:debug("connection refused to ~p", [_Address]),
+    lager:info("connection refused to ~p", [_Address]),
     {'error', {'failed_connect', 'econnrefused'}};
 handle_response({'error', {'malformed_url', _, Url}}) ->
-    lager:debug("failed to parse URL ~p", [Url]),
+    lager:info("failed to parse URL ~p", [Url]),
     {'error', {'malformed_url', Url}};
 handle_response({'error', Error}=Err) ->
-    lager:debug("request failed with ~p", [Error]),
+    lager:info("request failed with ~p", [Error]),
     Err.
 
 %%------------------------------------------------------------------------------
@@ -320,7 +320,9 @@ build_request(Method, Url, Headers, _Body) when Method =:= 'options';
                                                 Method =:= 'get';
                                                 Method =:= 'head';
                                                 Method =:= 'trace' ->
-    {kz_term:to_list(Url), ensure_string_headers(Headers)};
+    {lists:flatten(kz_term:to_list(Url))
+    ,ensure_string_headers(Headers)
+    };
 build_request(Method, Url, Headers, Body) when Method =:= 'post';
                                                Method =:= 'put';
                                                Method =:= 'patch';
@@ -335,7 +337,7 @@ build_request(Method, Url, Headers, Body) when Method =:= 'post';
                                          ,Headers
                                          ,""
                                          ),
-    {kz_term:to_list(Url)
+    {lists:flatten(kz_term:to_list(Url))
     ,ensure_string_headers(Headers)
     ,kz_term:to_list(ContentType)
     ,kz_term:to_binary(Body)


### PR DESCRIPTION
Prior, when page_size and filters are in play with a query, the
next_db clause would not match (since PageSize wasn't
'infinity'). This would lead to results being missed in the intial
query and subsequent queries would skip over to the next group of
results.

Instead, consider if there is a next last key only for whether to
query the current DB again.