### PR TITLE
[4.3] HELP-14436: update gen_smtp to fix multiple to header lines

### DIFF
--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -72,6 +72,7 @@ send_email(Emails0, Subject, RenderedTemplates, Attachments) ->
             ,email_parameters([{<<"To">>, To}
                               ,{<<"Cc">>, props:get_value(<<"cc">>, Emails)}
                               ,{<<"Bcc">>, props:get_value(<<"bcc">>, Emails)}
+                              ,{<<"X-Teletype-Log-ID">>, kz_util:get_callid()}
                               ]
                              ,[{<<"From">>, From}
                               ,{<<"Reply-To">>, props:get_value(<<"reply_to">>, Emails)}
@@ -154,8 +155,6 @@ email_parameters([], Params) ->
     lists:reverse(props:filter_empty(Params));
 email_parameters([{_Key, 'undefined'}|T], Params) ->
     email_parameters(T, Params);
-email_parameters([{Key, Vs}|T], Params) when is_list(Vs) ->
-    email_parameters(T, [{Key, V} || V <- Vs] ++ Params);
 email_parameters([{Key, V}|T], Params) ->
     email_parameters(T, [{Key, V} | Params]).
 

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -108,6 +108,7 @@ dep_syslog = git https://github.com/2600hz/erlang-syslog bbad537a1cb5e4f37e672d2
 
 dep_fcm = git https://github.com/softwarejoint/fcm-erlang.git b2f68a4c6f0f59475597a35e2dc9be13d9ba2910
 
-dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 973d3ea1867a6bb3565f67afb78b449253c3b76e
+dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 3f80bfcd4fd8704739d264eb4d5005d4392f2a35
 ## pinning gen_smtp because upstream made some breaking changes (using maps in some options)
 ## adding check to not convert if the From/To encodings match
+## latest commit to origin/2600Hz: Fixes for encoding email address in a single comma separated header line


### PR DESCRIPTION
This is updating gen_smtp to have a our fix to the multiple occuring `to`
headers by properly encoding addresses in a comma separared fashion.

Also adding X-Teletype-Log-ID headers to identify and debug tickets about email easy.

master: https://github.com/2600hz/kazoo/pull/6527