### PR TITLE
Updates to account for changes in the breakening

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -1,3 +1,0 @@
-* Breakening TODOs
-** TODO remove kazoo_proper from kazoo-core repo
-** TODO remove kazoo_ast from kazoo-core repo

--- a/rel/ci.relx.config.script
+++ b/rel/ci.relx.config.script
@@ -14,6 +14,7 @@ ToFilterOut = [rabbitmq_codegen
               ,'ci.erlang.mk'
               ,'.settings'
               ,'.git'
+              ,'.circleci'
               ,skel
               ,parse_trans
               ,meck

--- a/rel/dev.relx.config.script
+++ b/rel/dev.relx.config.script
@@ -15,6 +15,7 @@ ToFilterOut = [rabbitmq_codegen
               ,'ci.erlang.mk'
               ,'.settings'
               ,'.git'
+              ,'.circleci'
               ,skel
               ,parse_trans
               ,meck

--- a/rel/relx.config.script
+++ b/rel/relx.config.script
@@ -15,6 +15,7 @@ ToFilterOut = [rabbitmq_codegen
               ,'ci.erlang.mk'
               ,'.settings'
               ,'.git'
+              ,'.circleci'
               ,skel
               ,parse_trans
               ,meck


### PR DESCRIPTION
- Put a safety check on `make sparkly-clean` to avoid losing work
- Update file references to match make targets
- Filter out .circleci directories