### PR TITLE
Call Recording Features

### DIFF
--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -3,6 +3,11 @@
 %%% @doc Handles starting/stopping a call recording.
 %%% @author James Aimonetti
 %%% @author Sponsored by Velvetech LLC, Implemented by SIPLABS LLC
+%%%
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(cf_record_call).

--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -3,11 +3,6 @@
 %%% @doc Handles starting/stopping a call recording.
 %%% @author James Aimonetti
 %%% @author Sponsored by Velvetech LLC, Implemented by SIPLABS LLC
-%%%
-%%% This Source Code Form is subject to the terms of the Mozilla Public
-%%% License, v. 2.0. If a copy of the MPL was not distributed with this
-%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
-%%%
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(cf_record_call).
@@ -38,13 +33,19 @@ handle(Data, Call, <<"start">>) ->
     Call1 = kapps_call:kvs_store('recording_follow_transfer', ShouldFollowTransfer, Call),
     lager:info("starting call recording via action (follow transfer: ~s)", [ShouldFollowTransfer]),
     cf_exe:update_call(kapps_call:start_recording(Data, Call1));
-
 handle(_Data, Call, <<"stop">>) ->
-    cf_exe:update_call(kapps_call:stop_recording(Call)).
+    cf_exe:update_call(kapps_call:stop_recording(Call));
+handle(Data, Call, <<"start_on_b_leg">>) ->
+    ShouldFollowTransfer = kz_json:is_true(<<"should_follow_transfer">>, Data, 'true'),
+    Call1 = kapps_call:kvs_store('recording_follow_transfer', ShouldFollowTransfer, Call),
+    Call2 = kapps_call:kvs_store('record_on_b_leg', 'true', Call1),
+    lager:info("starting call recording on b-leg via action (follow transfer: ~s)", [ShouldFollowTransfer]),
+    cf_exe:update_call(Call2).
 
 -spec get_action(kz_json:object()) -> kz_term:ne_binary().
 get_action(Data) ->
     case kz_json:get_ne_binary_value(<<"action">>, Data) of
         <<"stop">> -> <<"stop">>;
-        _ -> <<"start">>
+        <<"start_on_b_leg">> -> <<"start_on_b_leg">>;
+        _  -> <<"start">>
     end.

--- a/applications/crossbar/doc/recordings.md
+++ b/applications/crossbar/doc/recordings.md
@@ -10,11 +10,13 @@ Recordings endpoint provides a way to access call recordings.
 > GET /v2/accounts/{ACCOUNT_ID}/users/{USER_ID}/recordings
 
 Lists the call recording with pagination and filtering.
+soft deleted docs are filtered out by default to include them add `include=soft_delete` to the Query string
+See Patch section below for info on soft_delete
 
 ```shell
 curl -v -X GET \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings?include=soft_delete
 ```
 
 ## Fetch recording media or document
@@ -52,4 +54,89 @@ This will delete the metadata document. If the binary data is stored on the meta
 curl -v -X DELETE \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
+```
+
+## Patch a call recording doc
+
+> PATCH /v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
+
+`"soft_delete"` and `"soft_restore"` objects can be PATCHed so that the call recordings document appear to be deleted to normal users but still actually exist in the DB.
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"data" : {"soft_delete": {"deleted_by": {"account_id": {ACCOUNT_ID}, "user_id": {USER_ID}},
+				                   "deleted_at": "63755032655"}}}' \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
+{
+    "data": {
+        ...data...
+        "soft_delete": {
+            "deleted_by": {
+                "user_id": {USER_ID},
+                "account_id": {ACCOUNT_ID}
+            },
+            "deleted_at": 63755032655
+        },
+        ...data...
+    },
+    "request_id": "{REQUEST_ID}",
+    "revision": "{REVISION}",
+    "timestamp": "2020-05-12T15:36:52Z",
+    "version": {VERSION},
+    "node": {NODE_ID},
+    "status": "success",
+    "auth_token": {AUTH_TOKEN}
+}
+```
+
+## Patch a Collection of call recording docs
+
+> PATCH /v2/accounts/{ACCOUNT_ID}/recordings/collection
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{
+	"data" : {"recordings": [ {RECORDING_ID_1},
+                              {RECORDING_ID_2],
+                "soft_delete": {"deleted_by": {"account_id": {ACCOUNT_ID}, "user_id": {USER_ID}},
+				                "deleted_at": "63755032655"}}}}}}' \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/collection
+{
+    "data": {
+        "success": {
+            {RECORDING_ID_1}: {
+                ...data...
+                "soft_delete": {
+                    "deleted_by": {
+                        "user_id": {USER_ID},
+                        "account_id": {ACCOUNT_ID}
+                    },
+                    "deleted_at": 63755032655
+                },
+                ...data...
+            },
+           {RECORDING_ID_2}: {
+                ...data...
+                "soft_delete": {
+                    "deleted_by": {
+                        "user_id": {USER_ID},
+                        "account_id": {ACCOUNT_ID}
+                    },
+                    "deleted_at": 63755032655
+                },
+                ...data...
+            }
+        }
+    },
+    "timestamp": "2020-05-12T15:49:09Z",
+    "version": {VERSION},
+    "node": {NODE},
+    "request_id": {REQUEST_ID}",
+    "status": "success",
+    "auth_token": {AUTH_TOKEN}
+}
 ```

--- a/applications/crossbar/priv/couchdb/schemas/call_recordings.json
+++ b/applications/crossbar/priv/couchdb/schemas/call_recordings.json
@@ -71,6 +71,11 @@
             "name": "from",
             "type": "string"
         },
+        "id": {
+            "description": "id",
+            "name": "id",
+            "type": "string"
+        },
         "interaction_id": {
             "description": "interaction_id",
             "name": "interaction_id",
@@ -106,6 +111,71 @@
             "name": "request",
             "type": "string"
         },
+        "soft_delete": {
+            "additionalProperties": false,
+            "description": "recording has been soft deleted",
+            "name": "soft_delete",
+            "properties": {
+                "deleted_at": {
+                    "description": "Timestamp the soft delete was performed",
+                    "name": "deleted_at",
+                    "type": "integer"
+                },
+                "deleted_by": {
+                    "description": "Entity that performed the soft deleted",
+                    "name": "deleted_by",
+                    "properties": {
+                        "account_id": {
+                            "description": "Account-ID",
+                            "name": "account_id",
+                            "type": "string"
+                        },
+                        "user_id": {
+                            "description": "User-ID",
+                            "name": "user_id",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "soft_restore": {
+            "additionalProperties": false,
+            "description": "recording has been soft restored",
+            "name": "soft_restore",
+            "properties": {
+                "delete_data": {
+                    "description": "The original data from the soft_delete key",
+                    "name": "delete_data",
+                    "type": "object"
+                },
+                "restored_at": {
+                    "description": "Timestamp the soft restore was performed",
+                    "name": "restored_at",
+                    "type": "integer"
+                },
+                "restored_by": {
+                    "description": "Entity that performed the soft restore",
+                    "name": "restored_by",
+                    "properties": {
+                        "account_id": {
+                            "description": "Account-ID",
+                            "name": "account_id",
+                            "type": "string"
+                        },
+                        "user_id": {
+                            "description": "User-ID",
+                            "name": "user_id",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
         "source_type": {
             "description": "source_type",
             "name": "source_type",
@@ -121,11 +191,15 @@
             "name": "to",
             "type": "string"
         },
+        "ui_metadata": {
+            "description": "ui_metadata",
+            "name": "ui_metadata",
+            "type": "object"
+        },
         "url": {
             "description": "url",
             "name": "url",
             "type": "string"
         }
-    },
-    "type": "object"
+    }
 }

--- a/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
@@ -8,7 +8,8 @@
             "description": "Whether to start or stop the recording",
             "enum": [
                 "start",
-                "stop"
+                "stop",
+                "start_on_b_leg"
             ],
             "type": "string"
         },

--- a/applications/crossbar/src/modules/cb_recordings.erl
+++ b/applications/crossbar/src/modules/cb_recordings.erl
@@ -5,11 +5,6 @@
 %%% @author OnNet (Kirill Sysoev [github.com/onnet])
 %%% @author Dinkor (Andrew Korniliv [github.com/dinkor])
 %%% @author Lazedo (Luis Azedo [github.com/2600hz])
-%%%
-%%% This Source Code Form is subject to the terms of the Mozilla Public
-%%% License, v. 2.0. If a copy of the MPL was not distributed with this
-%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
-%%%
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(cb_recordings).
@@ -19,7 +14,9 @@
         ,resource_exists/0, resource_exists/1
         ,content_types_provided/2
         ,validate/1, validate/2
-        ,delete/2
+        ,delete/2, patch/2
+        ,to_json/1
+        ,to_csv/1
         ]).
 
 -include("crossbar.hrl").
@@ -30,6 +27,45 @@
 -define(MEDIA_MIME_TYPES, [{<<"audio">>, <<"mpeg">>}
                           ,{<<"audio">>, <<"mp3">>}
                           ]).
+
+-define(PVT_TYPE, <<"call_recording">>).
+
+-define(COLLECTION, <<"collection">>).
+-define(COLLECTION_RECORDINGS, <<"recordings">>).
+
+-define(COLUMNS
+       ,[{<<"id">>, fun col_id/2}
+        ,{<<"call_id">>, fun col_call_id/2}
+        ,{<<"caller_id_number">>, fun col_caller_id_number/2}
+        ,{<<"caller_id_name">>, fun col_caller_id_name/2}
+        ,{<<"callee_id_number">>, fun col_callee_id_number/2}
+        ,{<<"callee_id_name">>, fun col_callee_id_name/2}
+        ,{<<"cdr_id">>, fun col_cdr_id/2}
+        ,{<<"content_type">>, fun col_content_type/2}
+        ,{<<"custom_channel_vars">>, fun col_custom_channel_vars/2}
+        ,{<<"description">>, fun col_description/2}
+        ,{<<"direction">>, fun col_direction/2}
+        ,{<<"duration">>, fun col_duration/2}
+        ,{<<"duration_ms">>, fun col_duration_ms/2}
+        ,{<<"from">>, fun col_from/2}
+        ,{<<"interaction_id">>, fun col_interaction_id/2}
+        ,{<<"media_source">>, fun col_media_source/2}
+        ,{<<"media_type">>, fun col_media_type/2}
+        ,{<<"name">>, fun col_name/2}
+        ,{<<"origin">>, fun col_origin/2}
+        ,{<<"owner_id">>, fun col_owner_id/2}
+        ,{<<"request">>, fun col_request/2}
+        ,{<<"soft_delete">>, fun col_soft_delete/2}
+        ,{<<"soft_restore">>, fun col_soft_restore/2}
+        ,{<<"source_type">>, fun col_source_type/2}
+        ,{<<"start">>, fun col_start/2}
+        ,{<<"to">>, fun col_to/2}
+        ,{<<"url">>, fun col_url/2}
+        ]).
+
+-define(COLUMNS_RESELLER
+       ,[
+        ]).
 
 %%%=============================================================================
 %%% API
@@ -45,8 +81,11 @@ init() ->
                ,{<<"*.resource_exists.recordings">>, 'resource_exists'}
                ,{<<"*.content_types_provided.recordings">>, 'content_types_provided'}
                ,{<<"*.validate.recordings">>, 'validate'}
+               ,{<<"*.execute.patch.recordings">>, 'patch'}
                ,{<<"*.execute.delete.recordings">>, 'delete'}
                ],
+    _ = crossbar_bindings:bind(<<"*.to_json.get.recordings">>, ?MODULE, 'to_json'),
+    _ = crossbar_bindings:bind(<<"*.to_csv.get.recordings">>, ?MODULE, 'to_json'),
     cb_modules_util:bind(?MODULE, Bindings).
 
 %%------------------------------------------------------------------------------
@@ -59,7 +98,134 @@ init() ->
 allowed_methods() -> [?HTTP_GET].
 
 -spec allowed_methods(path_token()) -> http_methods().
-allowed_methods(_RecordingId) -> [?HTTP_GET, ?HTTP_DELETE].
+allowed_methods(?COLLECTION) ->
+    [?HTTP_PATCH];
+allowed_methods(_RecordingId) -> 
+    [?HTTP_GET, ?HTTP_DELETE, ?HTTP_PATCH].
+
+-spec to_json(cb_cowboy_payload()) -> cb_cowboy_payload().
+to_json({Req, Context}) ->
+    {Req, to_response(Context, <<"json">>, cb_context:req_nouns(Context))}.
+
+-spec to_csv(cb_cowboy_payload()) -> cb_cowboy_payload().
+to_csv({Req, Context}) ->
+    {Req, to_response(Context, <<"csv">>, cb_context:req_nouns(Context))}.
+
+-spec to_response(cb_context:context(), kz_term:ne_binary(), req_nouns()) ->
+          cb_context:context().
+to_response(Context, RespType, [{<<"recordings">>, []}, {?KZ_ACCOUNTS_DB, _}|_]) ->
+    load_chunked_recordings(Context, RespType);
+to_response(Context, _, _) ->
+    Context.
+
+%%------------------------------------------------------------------------------
+%% @doc Loads Call Recordings docs from database and normalized them.
+%% @end
+%%------------------------------------------------------------------------------
+-spec load_chunked_recordings(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
+load_chunked_recordings(Context, RespType) ->
+    load_chunked_recordings(Context, RespType, cb_context:resp_data(Context)).
+
+-spec load_chunked_recordings(cb_context:context(), kz_term:ne_binary(), kz_json:objects()) -> cb_context:context().
+load_chunked_recordings(Context, RespType, RespData) ->
+    AccountId = cb_context:account_id(Context),
+    Fun = fun(JObj, Acc) -> split_to_modbs(AccountId, kz_doc:id(JObj), Acc) end,
+    MapIds = lists:foldl(Fun, #{}, RespData),
+
+    C1 = cb_context:set_resp_data(Context, []),
+    try maps:fold(fun(Db, Ids, C) -> load_chunked_recording_ids(C, RespType, Db, Ids) end, C1, MapIds)
+    catch
+        _T:_E ->
+            cb_context:add_system_error('datastore_fault', Context)
+    end.
+
+%% if request is not chunked, map Ids to MODBs
+-spec split_to_modbs(kz_term:ne_binary(), kz_term:ne_binary(), map()) -> map().
+split_to_modbs(AccountId, ?MATCH_MODB_PREFIX(Year, Month, _)=Id, Map) ->
+    Db = kazoo_modb:get_modb(AccountId, Year, Month),
+    maps:update_with(Db, fun(List) -> List ++ [Id] end, [Id], Map).
+
+-spec load_chunked_recording_ids(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binaries()) -> cb_context:context().
+load_chunked_recording_ids(Context, RespType, Db, Ids) ->
+    load_chunked_recording_ids(Context, RespType, Db, Ids, cb_context:resp_status(Context)).
+
+load_chunked_recording_ids(Context, RespType, Db, Ids, 'success') ->
+    case kz_datamgr:open_docs(Db, Ids, [{'doc_type', kzd_call_recordings:type()}]) of
+        {'ok', Results} ->
+            Resp0 = [normalize_recording(Context, RespType, Result)
+                     || Result <- Results,
+                        %% if there are no filters, include doc
+                        %% otherwise run filters against doc for inclusion
+                        crossbar_filter:by_doc(kz_json:get_json_value(<<"doc">>, Result), Context)
+                    ],
+            RespAcc = cb_context:resp_data(Context),
+            maybe_add_csv_header(Context, RespType, RespAcc ++ Resp0);
+        {'error', Reason} ->
+            lager:debug("failed to load cdrs doc from ~s: ~p", [Db, Reason]),
+            crossbar_doc:handle_datamgr_errors(Reason, <<"load_cdrs">>, Context)
+    end;
+load_chunked_recording_ids(Context, _RespType, _Db, _Ids, _Status) ->
+    Context.
+
+-spec normalize_recording(cb_context:context(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object() | kz_term:binary().
+normalize_recording(Context, <<"json">>, Result) ->
+    JObj = kz_json:get_json_value(<<"doc">>, Result),
+    kz_json:from_list(
+            props:filter_empty(
+                   [{K, F(JObj, Context)} || {K, F} <- csv_rows(Context)]));
+normalize_recording(Context, <<"csv">>, Result) ->
+    JObj = kz_json:get_json_value(<<"doc">>, Result),
+    <<(kz_binary:join([F(JObj, Context) || {_, F} <- csv_rows(Context)], <<",">>))/binary, "\r\n">>.
+
+-spec maybe_add_csv_header(cb_context:context(), kz_term:ne_binary(), kz_json:objects() | kz_term:binaries()) -> cb_context:context().
+maybe_add_csv_header(Context, _, []) ->
+    Context;
+maybe_add_csv_header(Context, <<"json">>, Data) ->
+    cb_context:set_resp_data(Context, Data);
+maybe_add_csv_header(Context, <<"csv">>, [Head | Tail]=Data) ->
+    case cb_context:fetch(Context, 'chunking_started') of
+        'true' ->
+            cb_context:set_resp_data(Context, Data);
+        'false' ->
+            CSVHeader = kz_binary:join([K || {K, _Fun} <- csv_rows(Context)], <<",">>),
+            cb_context:set_resp_data(Context, [<<CSVHeader/binary, "\r\n", Head/binary>> | Tail])
+    end.
+
+%% -spec csv_rows(cb_context:context()) -> [{kz_term:ne_binary(), csv_column_fun()}].
+csv_rows(Context) ->
+    case cb_context:fetch(Context, 'is_reseller', 'false') of
+        'false' -> ?COLUMNS;
+        'true' -> ?COLUMNS ++ ?COLUMNS_RESELLER
+    end.
+
+%% see csv_column_fun() for specs for each function here
+col_id(JObj, _Context) -> kz_doc:id(JObj, <<>>).
+col_call_id(JObj, _Context) -> kzd_cdrs:call_id(JObj, <<>>).
+col_caller_id_number(JObj, _Context) -> kzd_cdrs:caller_id_number(JObj, <<>>).
+col_caller_id_name(JObj, _Context) -> kzd_cdrs:caller_id_name(JObj, <<>>).
+col_callee_id_number(JObj, _Context) -> kzd_cdrs:callee_id_number(JObj, <<>>).
+col_callee_id_name(JObj, _Context) -> kzd_cdrs:callee_id_name(JObj, <<>>).
+col_cdr_id(JObj, _Context) -> kz_json:get_value(<<"cdr_id">>, JObj, <<>>).
+col_content_type(JObj, _Context) -> kz_json:get_value(<<"content_type">>, JObj, <<>>).
+col_custom_channel_vars(JObj, _Context) -> kz_json:get_value(<<"custom_channel_vars">>, JObj, <<>>).
+col_description(JObj, _Context) -> kz_json:get_value(<<"description">>, JObj, <<>>).
+col_direction(JObj, _Context) -> kz_json:get_value(<<"direction">>, JObj, <<>>).
+col_duration(JObj, _Context) -> kz_json:get_value(<<"duration">>, JObj, <<>>).
+col_duration_ms(JObj, _Context) -> kz_json:get_value(<<"duration_ms">>, JObj, <<>>).
+col_from(JObj, _Context) -> kz_json:get_value(<<"from">>, JObj, <<>>).
+col_interaction_id(JObj, _Context) -> kz_json:get_value(<<"interaction_id">>, JObj, <<>>).
+col_media_source(JObj, _Context) -> kz_json:get_value(<<"media_source">>, JObj, <<>>).
+col_media_type(JObj, _Context) -> kz_json:get_value(<<"media_type">>, JObj, <<>>).
+col_name(JObj, _Context) -> kz_json:get_value(<<"name">>, JObj, <<>>).
+col_origin(JObj, _Context) -> kz_json:get_value(<<"origin">>, JObj, <<>>).
+col_owner_id(JObj, _Context) -> kz_json:get_value(<<"owner_id">>, JObj, <<>>).
+col_request(JObj, _Context) -> kz_json:get_value(<<"request">>, JObj, <<>>).
+col_soft_delete(JObj, _Context) -> kz_json:get_value(<<"soft_delete">>, JObj, <<>>).
+col_soft_restore(JObj, _Context) -> kz_json:get_value(<<"soft_restore">>, JObj, <<>>).
+col_source_type(JObj, _Context) -> kz_json:get_value(<<"source_type">>, JObj, <<>>).
+col_start(JObj, _Context) -> kz_json:get_value(<<"start">>, JObj, <<>>).
+col_to(JObj, _Context) -> kz_json:get_value(<<"to">>, JObj, <<>>).
+col_url(JObj, _Context) -> kz_json:get_value(<<"url">>, JObj, <<>>).
 
 %%------------------------------------------------------------------------------
 %% @doc Does the path point to a valid resource.
@@ -99,9 +265,20 @@ content_types_provided_for_download(Context, _Verb) ->
 %%------------------------------------------------------------------------------
 -spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
-    recording_summary(Context).
+    QS = cb_context:query_string(Context),
+    case  kz_json:get_value(<<"include">>, QS) == <<"soft_delete">> of
+        true -> 
+            recording_summary(Context);
+        false ->
+            Values = [{<<"key_missing">>, <<"soft_delete">>}],
+            AdjustedQS = kz_json:set_values(Values, QS),
+            AdjustedContext = cb_context:set_query_string(Context, AdjustedQS),
+            recording_summary(AdjustedContext)
+end.
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
+validate(Context, ?COLLECTION) ->
+    validate_collection_request(Context);
 validate(Context, RecordingId) ->
     validate_recording(Context, RecordingId, cb_context:req_verb(Context)).
 
@@ -112,6 +289,8 @@ validate_recording(Context, RecordingId, ?HTTP_GET) ->
         'download' ->
             load_recording_binary(Context, RecordingId)
     end;
+validate_recording(Context, RecordingId, ?HTTP_PATCH) ->
+    validate_patch(RecordingId, Context);
 validate_recording(Context, RecordingId, ?HTTP_DELETE) ->
     load_recording_doc(Context, RecordingId).
 
@@ -119,6 +298,109 @@ validate_recording(Context, RecordingId, ?HTTP_DELETE) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
+-spec validate_patch(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+validate_patch(RecordingId, Context) ->
+    patch_and_validate(RecordingId, Context, fun validate_request/2).
+    
+-spec patch_and_validate(kz_term:ne_binary(), cb_context:context(), fun()) ->
+          cb_context:context().
+patch_and_validate(Id, Context, ValidateFun) ->
+    Context1 = load_recording_doc(Context, Id),
+    patch_and_validate_doc(Id, Context1, ValidateFun, cb_context:resp_status(Context1)).
+
+-spec patch_and_validate_doc(kz_term:ne_binary(), cb_context:context(), fun(), crossbar_status()) ->
+          cb_context:context().
+patch_and_validate_doc(Id, Context, ValidateFun, 'success') ->
+    PatchedJObj = patch_the_doc(cb_context:req_data(Context), cb_context:doc(Context)),
+    Context1 = cb_context:set_req_data(Context, PatchedJObj),
+    ValidateFun(Id, cb_context:set_doc(Context1, PatchedJObj));
+patch_and_validate_doc(Id, Context, ValidateFun, _RespStatus) ->
+    ValidateFun(Id, Context).
+
+-spec patch_the_doc(kz_json:object(), kz_json:object()) -> kz_json:object().
+patch_the_doc(RequestData, ExistingDoc) ->
+    PubJObj = kz_doc:public_fields(RequestData),
+    kz_json:merge(fun kz_json:merge_left/2, PubJObj, ExistingDoc).
+
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+
+%%-spec validate_request(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+%%validate_request(_RecordingId, Context) ->
+%%    Context.
+-spec validate_request(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+validate_request(RecordingId, Context) ->
+    ValidateFuns = [
+                   fun validate_schema/2
+                   ],
+    lists:foldl(fun(F, C) -> F(RecordingId, C) end
+               ,Context
+               ,ValidateFuns
+               ).
+
+-spec validate_schema(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+validate_schema(RecordingId, Context) ->
+    lager:debug("validating call_recording payload"),
+    OnSuccess = fun(C) ->
+                        lager:debug("account payload is valid"),
+                        on_successful_validation(RecordingId, C)
+                end,
+    cb_context:validate_request_data(<<"call_recordings">>, Context, OnSuccess).
+
+-spec on_successful_validation(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+on_successful_validation(_RecordingId, Context) ->
+    Context.
+
+
+%%------------------------------------------------------------------------------
+%% @doc Validates a collection-type recordings field..
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec validate_collection_request(cb_context:context()) -> cb_context:context().
+validate_collection_request(Context) ->
+    Recordings = kz_json:get_value(?COLLECTION_RECORDINGS, cb_context:req_data(Context)),
+    validate_collection_request(Context, Recordings).
+
+-spec validate_collection_request(cb_context:context(), any()) -> cb_context:context().
+validate_collection_request(Context, 'undefined') ->
+    Msg = kz_json:from_list([{<<"message">>, <<"list of recordings missing">>}
+                            ]),
+    cb_context:add_validation_error(?COLLECTION_RECORDINGS, <<"required">>, Msg, Context);
+validate_collection_request(Context, []) ->
+    Msg = kz_json:from_list([{<<"message">>, <<"minimum 1 recording required">>}
+                            ]),
+    cb_context:add_validation_error(?COLLECTION_RECORDINGS, <<"minimum">>, Msg, Context);
+validate_collection_request(Context, Recordings)
+  when is_list(Recordings) ->
+    UniqNomalised = lists:usort(Recordings),
+    case length(Recordings) =:= length(UniqNomalised) of
+        'true' -> cb_context:set_resp_status(Context, 'success');
+        'false' ->
+            Msg = kz_json:from_list([{<<"message">>, <<"some recordings appear twice">>}
+                                    ]),
+            cb_context:add_validation_error(?COLLECTION_RECORDINGS, <<"uniqueItems">>, Msg, Context)
+    end;
+validate_collection_request(Context, _E) ->
+    Msg = kz_json:from_list([{<<"message">>, <<"recordings must be a list">>}
+                            ]),
+    cb_context:add_validation_error(?COLLECTION_RECORDINGS, <<"type">>, Msg, Context).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec patch(cb_context:context(), path_token()) -> cb_context:context().
+patch(Context, ?COLLECTION) ->
+    Results = collection_process(Context, ?HTTP_PATCH),
+    set_response({ok, Results}, Context);
+patch(Context, _) ->
+    crossbar_doc:save(Context).
+
 -spec delete(cb_context:context(), path_token()) -> cb_context:context().
 delete(Context, _RecordingId) ->
     crossbar_doc:delete(Context).
@@ -127,7 +409,8 @@ delete(Context, _RecordingId) ->
 recording_summary(Context) ->
     UserId = cb_context:user_id(Context),
     ViewName = get_view_name(UserId),
-    Options = [{'mapper', fun summary_doc_fun/2}
+    Options = [{'is_chunked', 'true'}
+              ,{'mapper', fun summary_doc_fun/2}
               ,{'range_start_keymap', [UserId]}
               ,{'range_end_keymap', fun(Ts) -> build_end_key(Ts, UserId) end}
               ,'include_docs'
@@ -162,19 +445,14 @@ get_view_name(_) -> ?CB_LIST_BY_OWNERID.
 
 -spec load_recording_doc(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 load_recording_doc(Context, ?MATCH_MODB_PREFIX(Year, Month, _) = RecordingId) ->
-    Ctx = cb_context:set_db_name(Context
-                                ,kzs_util:format_account_id(cb_context:account_id(Context)
-                                                           ,kz_term:to_integer(Year)
-                                                           ,kz_term:to_integer(Month)
-                                                           )
-                                ),
+    Ctx = cb_context:set_account_modb(Context, kz_term:to_integer(Year), kz_term:to_integer(Month)),
     crossbar_doc:load({<<"call_recording">>, RecordingId}, Ctx, ?TYPE_CHECK_OPTION(<<"call_recording">>));
 load_recording_doc(Context, Id) ->
     crossbar_util:response_bad_identifier(Id, Context).
 
 -spec load_recording_binary(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 load_recording_binary(Context, ?MATCH_MODB_PREFIX(Year, Month, _) = DocId) ->
-    do_load_recording_binary(cb_context:set_db_name(Context, kzs_util:format_account_id(cb_context:account_id(Context), kz_term:to_integer(Year), kz_term:to_integer(Month))), DocId).
+    do_load_recording_binary(cb_context:set_account_modb(Context, kz_term:to_integer(Year), kz_term:to_integer(Month)), DocId).
 
 -spec do_load_recording_binary(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 do_load_recording_binary(Context, DocId) ->
@@ -282,3 +560,70 @@ acceptable_content_types(Context) ->
 -spec is_acceptable_accept(kz_term:proplist(), kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
 is_acceptable_accept(Acceptable, Type, SubType) ->
     lists:member({Type,SubType}, Acceptable).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec collection_process(cb_context:context(), kz_term:ne_binary() | http_method()) -> recordings:ret().
+collection_process(Context, Action) ->
+    ReqData = cb_context:req_data(Context),
+    Recordings = kz_json:get_list_value(<<"recordings">>, ReqData),
+    Context1 = cb_context:set_req_data(Context, kz_json:delete_key(<<"recordings">>, ReqData)),
+    recordings_action(Context1, Action, Recordings).
+
+recordings_action(Context, ?HTTP_PATCH, Recordings) ->
+    Fun = fun(RecordingId, {Success, Failure}) -> 
+            Ctx1 = validate_patch(RecordingId, Context),
+            case cb_context:has_errors(Ctx1) of
+                'true' -> 
+                    {'error', {ErrorCode, ErrorMsg, _ErrorData}} = cb_context:response(Ctx1),
+                    Resp = kz_json:from_list([ {<<"cause">>, RecordingId}
+                                              ,{<<"code">>, ErrorCode}
+                                              ,{<<"message">>, ErrorMsg}]),
+                    {Success, kz_json:set_value(RecordingId, Resp, Failure)};
+                'false' -> 
+                    Ctx2 = crossbar_doc:save(Ctx1),
+                    Doc = cb_context:doc(Ctx2),
+                    {kz_json:set_value(RecordingId, Doc, Success), Failure}
+            end
+            end,
+    {Success, Failure} = lists:foldl(Fun, 
+                            {kz_json:new(), kz_json:new()}, 
+                            Recordings),
+    kz_json:merge(
+                    case kz_json:is_empty(Success) of
+                        true -> kz_json:new();
+                        false -> kz_json:set_value(<<"success">>, Success, kz_json:new())
+                    end,
+                    case kz_json:is_empty(Failure) of
+                        true -> kz_json:new();
+                        false -> kz_json:set_value(<<"failure">>, Failure, kz_json:new())
+                    end
+                  ).
+
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec set_response(result(), cb_context:context()) -> cb_context:context().
+set_response(Result, Context) ->
+    set_response(Result, Context, fun() -> Context end).
+
+-type result() :: {'ok', kz_json:object()} |
+                  recordings:ret() |
+                  {binary(), binary()}.
+-type cb() :: fun(() -> cb_context:context()).
+
+-spec set_response(result(), cb_context:context(), cb()) -> cb_context:context().
+set_response({'ok', Thing}, Context, _) ->
+    crossbar_util:response(Thing, Context);
+
+set_response({Error, Reason}, Context, _) ->
+    lager:error("error ~p: ~p", [Error, Reason]),
+    cb_context:add_system_error(Error, Reason, Context);
+
+set_response(_Else, Context, _) ->
+    lager:warning("unexpected response: ~p", [_Else]),
+    cb_context:add_system_error('unspecified_fault', Context).

--- a/core/kazoo_endpoint/src/kz_endpoint_recording.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint_recording.erl
@@ -29,7 +29,8 @@ maybe_record_inbound(FromNetwork, Endpoint, Call) ->
           {'true', {kz_json:path(), kz_json:object()}} | 'false'.
 maybe_record_inbound(_FromNetwork, _Endpoint, _Call, 'undefined') -> 'false';
 maybe_record_inbound(FromNetwork, Endpoint, Call, Data) ->
-    case kz_json:is_true(<<"enabled">>, Data) of
+    case kz_json:is_true(<<"enabled">>, Data) orelse 
+         kapps_call:kvs_fetch('record_on_b_leg', 'false', Call) of
         'false' -> 'false';
         'true' ->
             Values = [{<<"origin">>, <<"inbound from ", FromNetwork/binary, " to endpoint">>}

--- a/core/kazoo_endpoint/src/kz_endpoint_recording.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint_recording.erl
@@ -29,8 +29,8 @@ maybe_record_inbound(FromNetwork, Endpoint, Call) ->
           {'true', {kz_json:path(), kz_json:object()}} | 'false'.
 maybe_record_inbound(_FromNetwork, _Endpoint, _Call, 'undefined') -> 'false';
 maybe_record_inbound(FromNetwork, Endpoint, Call, Data) ->
-    case kz_json:is_true(<<"enabled">>, Data) orelse 
-         kapps_call:kvs_fetch('record_on_b_leg', 'false', Call) of
+    case kz_json:is_true(<<"enabled">>, Data) 
+        orelse kapps_call:kvs_fetch('record_on_b_leg', 'false', Call) of
         'false' -> 'false';
         'true' ->
             Values = [{<<"origin">>, <<"inbound from ", FromNetwork/binary, " to endpoint">>}


### PR DESCRIPTION
There is 1 fix:

Add a new action 'start_on_b_leg' to 'record_call' callflow

This fixes an issue where call recording files for both a-leg and b-leg were being saved
If the agent wanted to stop recording (to get the customers credit card details for example)
and then start recording again afterwards. A total of 3 call recording files were created:

1) recording of complete call on a-leg side started by by 'record_call' callflow 'start' action
2) recording between *7 start_record and *9 stop_record
3) recording after agent *7 start_record to restart recording and end of the call.

Obviously this is a big problem, the reason to stop recording was to NOT record the CC details but the details are still recorded in (1)

A new 'record_call' action 'start_on_b_leg' now starts the call recording on the b-leg rather than the a-leg so in the same scenario only 2 call recording files are
created (2) and (3) in the list above. The CC details are no longer recorded.


And a new feature:

Our customers want to delete call recordings in the call recording app so we added a soft delete and ability to patch using recordings api to add soft_delete and soft_restore.

soft_delete and soft_restore feature:

      * PATCH a call_recording document
      * Update schema to add soft_delete and soft_restore objects
      * support for 'collections' to PATCH multiple documents
      * enable chunking by default
      * by default hide docs that have soft_delete object present
      * include soft_delete docs if 'include=soft_delete' is in the query string