### PR TITLE
Add a new action 'start_on_b_leg' to 'record_call' callflow

### DIFF
--- a/applications/callflow/doc/record_call.md
+++ b/applications/callflow/doc/record_call.md
@@ -12,7 +12,7 @@ Validator for the Record Call callflow action
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`action` | Whether to start or stop the recording | `string('start' | 'stop')` | `start` | `true` |  
+`action` | Whether to start or stop the recording | `string('start' | 'stop' | 'start_on_b_leg')` | `start` | `true` |  
 `format` | What format to store the recording on disk | `string('mp3' | 'wav')` |   | `false` |  
 `label` | Label to include in the origin of call recording | `string()` |   | `false` |  
 `media_name` | the name of media | `string()` |   | `false` |  

--- a/applications/callflow/doc/ref/record_call.md
+++ b/applications/callflow/doc/ref/record_call.md
@@ -10,7 +10,7 @@ Validator for the Record Call callflow action
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
-`action` | Whether to start or stop the recording | `string('start' | 'stop')` | `start` | `true` |  
+`action` | Whether to start or stop the recording | `string('start' | 'stop' | 'start_on_b_leg')` | `start` | `true` |  
 `format` | What format to store the recording on disk | `string('mp3' | 'wav')` |   | `false` |  
 `label` | Label to include in the origin of call recording | `string()` |   | `false` |  
 `media_name` | the name of media | `string()` |   | `false` |  

--- a/applications/callflow/src/module/cf_record_call.erl
+++ b/applications/callflow/src/module/cf_record_call.erl
@@ -3,7 +3,6 @@
 %%% @doc Handles starting/stopping a call recording.
 %%% @author James Aimonetti
 %%% @author Sponsored by Velvetech LLC, Implemented by SIPLABS LLC
-%%%
 %%% This Source Code Form is subject to the terms of the Mozilla Public
 %%% License, v. 2.0. If a copy of the MPL was not distributed with this
 %%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -38,13 +37,19 @@ handle(Data, Call, <<"start">>) ->
     Call1 = kapps_call:kvs_store('recording_follow_transfer', ShouldFollowTransfer, Call),
     lager:info("starting call recording via action (follow transfer: ~s)", [ShouldFollowTransfer]),
     cf_exe:update_call(kapps_call:start_recording(Data, Call1));
-
 handle(_Data, Call, <<"stop">>) ->
-    cf_exe:update_call(kapps_call:stop_recording(Call)).
+    cf_exe:update_call(kapps_call:stop_recording(Call));
+handle(Data, Call, <<"start_on_b_leg">>) ->
+    ShouldFollowTransfer = kz_json:is_true(<<"should_follow_transfer">>, Data, 'true'),
+    Call1 = kapps_call:kvs_store('recording_follow_transfer', ShouldFollowTransfer, Call),
+    Call2 = kapps_call:kvs_store('record_on_b_leg', 'true', Call1),
+    lager:info("starting call recording on b-leg via action (follow transfer: ~s)", [ShouldFollowTransfer]),
+    cf_exe:update_call(Call2).
 
 -spec get_action(kz_json:object()) -> kz_term:ne_binary().
 get_action(Data) ->
     case kz_json:get_ne_binary_value(<<"action">>, Data) of
         <<"stop">> -> <<"stop">>;
-        _ -> <<"start">>
+        <<"start_on_b_leg">> -> <<"start_on_b_leg">>;
+        _  -> <<"start">>
     end.

--- a/applications/crossbar/doc/users.md
+++ b/applications/crossbar/doc/users.md
@@ -23,6 +23,7 @@ Key | Description | Type | Default | Required | Support Level
 `call_forward` | The device call forward parameters | `object()` |   | `false` |  
 `call_recording` | endpoint recording settings | [#/definitions/call_recording](#call_recording) |   | `false` |  
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
+`call_waiting` | Parameters for server-side call waiting | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
 `caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
 `caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
@@ -102,6 +103,15 @@ Key | Description | Type | Default | Required | Support Level
 `any` | settings for calls from any network | [#/definitions/call_recording.parameters](#call_recordingparameters) |   | `false` |  
 `offnet` | settings for calls from offnet networks | [#/definitions/call_recording.parameters](#call_recordingparameters) |   | `false` |  
 `onnet` | settings for calls from onnet networks | [#/definitions/call_recording.parameters](#call_recordingparameters) |   | `false` |  
+
+### call_waiting
+
+Parameters for server-side call waiting
+
+
+Key | Description | Type | Default | Required | Support Level
+--- | ----------- | ---- | ------- | -------- | -------------
+`enabled` | Determines if server side call waiting is enabled/disabled | `boolean()` |   | `false` |  
 
 ### caller_id
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -3561,7 +3561,8 @@
                     "description": "Whether to start or stop the recording",
                     "enum": [
                         "start",
-                        "stop"
+                        "stop",
+                        "start_on_b_leg"
                     ],
                     "type": "string"
                 },
@@ -6997,14 +6998,12 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "login"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Presence-ID": {
                     "type": "string"
@@ -7045,14 +7044,12 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "login_queue"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Presence-ID": {
                     "type": "string"
@@ -7087,19 +7084,17 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "login_resp"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Status": {
                     "enum": [
-                        "success",
-                        "failed"
+                        "failed",
+                        "success"
                     ],
                     "type": "string"
                 }
@@ -7121,14 +7116,12 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "logout"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Presence-ID": {
                     "type": "string"
@@ -7169,14 +7162,12 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "logout_queue"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Presence-ID": {
                     "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
+++ b/applications/crossbar/priv/couchdb/schemas/callflows.record_call.json
@@ -8,7 +8,8 @@
             "description": "Whether to start or stop the recording",
             "enum": [
                 "start",
-                "stop"
+                "stop",
+                "start_on_b_leg"
             ],
             "type": "string"
         },

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -2823,6 +2823,7 @@
       'enum':
         - start
         - stop
+        - start_on_b_leg
       'type': string
     'format':
       'description': What format to store the recording on disk

--- a/core/kazoo_endpoint/src/kz_endpoint_recording.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint_recording.erl
@@ -29,7 +29,8 @@ maybe_record_inbound(FromNetwork, Endpoint, Call) ->
           {'true', {kz_json:path(), kz_json:object()}} | 'false'.
 maybe_record_inbound(_FromNetwork, _Endpoint, _Call, 'undefined') -> 'false';
 maybe_record_inbound(FromNetwork, Endpoint, Call, Data) ->
-    case kz_json:is_true(<<"enabled">>, Data) of
+    case kz_json:is_true(<<"enabled">>, Data)
+         orelse kapps_call:kvs_fetch('record_on_b_leg', 'false', Call) of
         'false' -> 'false';
         'true' ->
             Values = [{<<"origin">>, <<"inbound from ", FromNetwork/binary, " to endpoint">>}


### PR DESCRIPTION
This fixes an issue where call recording files for both a-leg and b-leg were being saved
If the agent wanted to stop recording (to get the customers credit card details for example)
and then start recording again afterwards. A total of 3 call recording files were created:

1) recording of complete call on a-leg side started by by 'record_call' callflow 'start' action
2) recording between *7 start_record and *9 stop_record
3) recording after agent *7 start_record to restart recording and end of the call.

Obviously this is a big problem, the reason to stop recording was to NOT record the CC details but the details are still recorded in (1)

A new 'record_call' action 'start_on_b_leg' now starts the call recording on the b-leg rather than the a-leg so in the same scenario only 2 call recording files are
created (2) and (3) in the list above. The CC details are no longer recorded.