### PR TITLE
soft_delete and soft_restore feature

### DIFF
--- a/applications/crossbar/doc/recordings.md
+++ b/applications/crossbar/doc/recordings.md
@@ -10,11 +10,13 @@ Recordings endpoint provides a way to access call recordings.
 > GET /v2/accounts/{ACCOUNT_ID}/users/{USER_ID}/recordings
 
 Lists the call recording with pagination and filtering.
+soft deleted docs are filtered out by default to include them add `include=soft_delete` to the Query string
+See Patch section below for info on soft_delete
 
 ```shell
 curl -v -X GET \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
-    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings?include=soft_delete
 ```
 
 ## Fetch recording media or document
@@ -52,4 +54,89 @@ This will delete the metadata document. If the binary data is stored on the meta
 curl -v -X DELETE \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
+```
+
+## Patch a call recording doc
+
+> PATCH /v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
+
+`"soft_delete"` and `"soft_restore"` objects can be PATCHed so that the call recordings document appear to be deleted to normal users but still actually exist in the DB.
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"data" : {"soft_delete": {"deleted_by": {"account_id": {ACCOUNT_ID}, "user_id": {USER_ID}},
+				                   "deleted_at": "63755032655"}}}' \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
+{
+    "data": {
+        ...data...
+        "soft_delete": {
+            "deleted_by": {
+                "user_id": {USER_ID},
+                "account_id": {ACCOUNT_ID}
+            },
+            "deleted_at": 63755032655
+        },
+        ...data...
+    },
+    "request_id": "{REQUEST_ID}",
+    "revision": "{REVISION}",
+    "timestamp": "2020-05-12T15:36:52Z",
+    "version": {VERSION},
+    "node": {NODE_ID},
+    "status": "success",
+    "auth_token": {AUTH_TOKEN}
+}
+```
+
+## Patch a Collection of call recording docs
+
+> PATCH /v2/accounts/{ACCOUNT_ID}/recordings/collection
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{
+	"data" : {"recordings": [ {RECORDING_ID_1},
+                              {RECORDING_ID_2],
+                "soft_delete": {"deleted_by": {"account_id": {ACCOUNT_ID}, "user_id": {USER_ID}},
+				                "deleted_at": "63755032655"}}}}}}' \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/collection
+{
+    "data": {
+        "success": {
+            {RECORDING_ID_1}: {
+                ...data...
+                "soft_delete": {
+                    "deleted_by": {
+                        "user_id": {USER_ID},
+                        "account_id": {ACCOUNT_ID}
+                    },
+                    "deleted_at": 63755032655
+                },
+                ...data...
+            },
+           {RECORDING_ID_2}: {
+                ...data...
+                "soft_delete": {
+                    "deleted_by": {
+                        "user_id": {USER_ID},
+                        "account_id": {ACCOUNT_ID}
+                    },
+                    "deleted_at": 63755032655
+                },
+                ...data...
+            }
+        }
+    },
+    "timestamp": "2020-05-12T15:49:09Z",
+    "version": {VERSION},
+    "node": {NODE},
+    "request_id": {REQUEST_ID}",
+    "status": "success",
+    "auth_token": {AUTH_TOKEN}
+}
 ```

--- a/applications/crossbar/doc/ref/recordings.md
+++ b/applications/crossbar/doc/ref/recordings.md
@@ -26,6 +26,16 @@ curl -v -X GET \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
 ```
 
+## Patch
+
+> PATCH /v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
+```
+
 ## Remove
 
 > DELETE /v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
@@ -34,5 +44,15 @@ curl -v -X GET \
 curl -v -X DELETE \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}
+```
+
+## Patch
+
+> PATCH /v2/accounts/{ACCOUNT_ID}/recordings/collection
+
+```shell
+curl -v -X PATCH \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/recordings/collection
 ```
 

--- a/applications/crossbar/doc/users.md
+++ b/applications/crossbar/doc/users.md
@@ -23,6 +23,7 @@ Key | Description | Type | Default | Required | Support Level
 `call_forward` | The device call forward parameters | `object()` |   | `false` |  
 `call_recording` | endpoint recording settings | [#/definitions/call_recording](#call_recording) |   | `false` |  
 `call_restriction` | Device level call restrictions for each available number classification | `object()` | `{}` | `false` |  
+`call_waiting` | Parameters for server-side call waiting | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The device caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
 `caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
 `caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
@@ -102,6 +103,15 @@ Key | Description | Type | Default | Required | Support Level
 `any` | settings for calls from any network | [#/definitions/call_recording.parameters](#call_recordingparameters) |   | `false` |  
 `offnet` | settings for calls from offnet networks | [#/definitions/call_recording.parameters](#call_recordingparameters) |   | `false` |  
 `onnet` | settings for calls from onnet networks | [#/definitions/call_recording.parameters](#call_recordingparameters) |   | `false` |  
+
+### call_waiting
+
+Parameters for server-side call waiting
+
+
+Key | Description | Type | Default | Required | Support Level
+--- | ----------- | ---- | ------- | -------- | -------------
+`enabled` | Determines if server side call waiting is enabled/disabled | `boolean()` |   | `false` |  
 
 ### caller_id
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6997,14 +6997,12 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "login"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Presence-ID": {
                     "type": "string"
@@ -7045,14 +7043,12 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "login_queue"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Presence-ID": {
                     "type": "string"
@@ -7087,19 +7083,17 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "login_resp"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Status": {
                     "enum": [
-                        "success",
-                        "failed"
+                        "failed",
+                        "success"
                     ],
                     "type": "string"
                 }
@@ -7121,14 +7115,12 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "logout"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Presence-ID": {
                     "type": "string"
@@ -7169,14 +7161,12 @@
                 "Event-Category": {
                     "enum": [
                         "agent"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Event-Name": {
                     "enum": [
                         "logout_queue"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "Presence-ID": {
                     "type": "string"
@@ -49127,6 +49117,23 @@
                 }
             }
         },
+        "/accounts/{ACCOUNT_ID}/recordings/collection": {
+            "patch": {
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/auth_token_header"
+                    },
+                    {
+                        "$ref": "#/parameters/ACCOUNT_ID"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "request succeeded"
+                    }
+                }
+            }
+        },
         "/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}": {
             "delete": {
                 "parameters": [
@@ -49147,6 +49154,24 @@
                 }
             },
             "get": {
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/auth_token_header"
+                    },
+                    {
+                        "$ref": "#/parameters/ACCOUNT_ID"
+                    },
+                    {
+                        "$ref": "#/parameters/RECORDING_ID"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "request succeeded"
+                    }
+                }
+            },
+            "patch": {
                 "parameters": [
                     {
                         "$ref": "#/parameters/auth_token_header"

--- a/applications/crossbar/priv/couchdb/schemas/call_recordings.json
+++ b/applications/crossbar/priv/couchdb/schemas/call_recordings.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "call_recordings",
-    "additionalProperties": false,
+    "additionalProperties": true,
     "description": "endpoint recording settings",
     "properties": {
         "call_id": {

--- a/applications/crossbar/priv/oas3/oas3-schemas.yml
+++ b/applications/crossbar/priv/oas3/oas3-schemas.yml
@@ -916,7 +916,7 @@
       'description': settings for calls from onnet networks
   'type': object
 'call_recordings':
-  'additionalProperties': false
+  'additionalProperties': true
   'description': endpoint recording settings
   'properties':
     'call_id':

--- a/applications/crossbar/priv/oas3/openapi.yml
+++ b/applications/crossbar/priv/oas3/openapi.yml
@@ -430,6 +430,9 @@
     '$ref': 'paths/rate_limits.yml#/paths/~1accounts~1{ACCOUNT_ID}~1rate_limits'
   '/accounts/{ACCOUNT_ID}/recordings':
     '$ref': 'paths/recordings.yml#/paths/~1accounts~1{ACCOUNT_ID}~1recordings'
+  '/accounts/{ACCOUNT_ID}/recordings/collection':
+    '$ref': >-
+      paths/recordings.yml#/paths/~1accounts~1{ACCOUNT_ID}~1recordings~1collection
   '/accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}':
     '$ref': >-
       paths/recordings.yml#/paths/~1accounts~1{ACCOUNT_ID}~1recordings~1{RECORDING_ID}

--- a/applications/crossbar/priv/oas3/paths/recordings.yml
+++ b/applications/crossbar/priv/oas3/paths/recordings.yml
@@ -11,6 +11,18 @@ paths:
       summary: Get all recordings
       tags:
         - recordings
+  /accounts/{ACCOUNT_ID}/recordings/collection:
+    patch:
+      operationId: PatchAccountsAccountIdRecordingsCollection
+      parameters:
+        - $ref: '../oas3-parameters.yml#/auth_token_header'
+        - $ref: '../oas3-parameters.yml#/ACCOUNT_ID'
+      responses:
+        200:
+          description: Successful operation
+      summary: Patch specific fields of recordings
+      tags:
+        - recordings
   /accounts/{ACCOUNT_ID}/recordings/{RECORDING_ID}:
     delete:
       operationId: DeleteAccountsAccountIdRecordingsRecordingId
@@ -34,5 +46,17 @@ paths:
         200:
           description: Successful operation
       summary: Get a recordings by ID
+      tags:
+        - recordings
+    patch:
+      operationId: PatchAccountsAccountIdRecordingsRecordingId
+      parameters:
+        - $ref: '../oas3-parameters.yml#/auth_token_header'
+        - $ref: '../oas3-parameters.yml#/ACCOUNT_ID'
+        - $ref: '../oas3-parameters.yml#/RECORDING_ID'
+      responses:
+        200:
+          description: Successful operation
+      summary: Patch specific fields of recordings
       tags:
         - recordings

--- a/applications/crossbar/src/modules/cb_recordings.erl
+++ b/applications/crossbar/src/modules/cb_recordings.erl
@@ -5,7 +5,6 @@
 %%% @author OnNet (Kirill Sysoev [github.com/onnet])
 %%% @author Dinkor (Andrew Korniliv [github.com/dinkor])
 %%% @author Lazedo (Luis Azedo [github.com/2600hz])
-%%%
 %%% This Source Code Form is subject to the terms of the Mozilla Public
 %%% License, v. 2.0. If a copy of the MPL was not distributed with this
 %%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -19,7 +18,9 @@
         ,resource_exists/0, resource_exists/1
         ,content_types_provided/2
         ,validate/1, validate/2
-        ,delete/2
+        ,delete/2, patch/2
+        ,to_json/1
+        ,to_csv/1
         ]).
 
 -include("crossbar.hrl").
@@ -30,6 +31,45 @@
 -define(MEDIA_MIME_TYPES, [{<<"audio">>, <<"mpeg">>}
                           ,{<<"audio">>, <<"mp3">>}
                           ]).
+
+-define(PVT_TYPE, <<"call_recording">>).
+
+-define(COLLECTION, <<"collection">>).
+-define(COLLECTION_RECORDINGS, <<"recordings">>).
+
+-define(COLUMNS
+       ,[{<<"id">>, fun col_id/2}
+        ,{<<"call_id">>, fun col_call_id/2}
+        ,{<<"caller_id_number">>, fun col_caller_id_number/2}
+        ,{<<"caller_id_name">>, fun col_caller_id_name/2}
+        ,{<<"callee_id_number">>, fun col_callee_id_number/2}
+        ,{<<"callee_id_name">>, fun col_callee_id_name/2}
+        ,{<<"cdr_id">>, fun col_cdr_id/2}
+        ,{<<"content_type">>, fun col_content_type/2}
+        ,{<<"custom_channel_vars">>, fun col_custom_channel_vars/2}
+        ,{<<"description">>, fun col_description/2}
+        ,{<<"direction">>, fun col_direction/2}
+        ,{<<"duration">>, fun col_duration/2}
+        ,{<<"duration_ms">>, fun col_duration_ms/2}
+        ,{<<"from">>, fun col_from/2}
+        ,{<<"interaction_id">>, fun col_interaction_id/2}
+        ,{<<"media_source">>, fun col_media_source/2}
+        ,{<<"media_type">>, fun col_media_type/2}
+        ,{<<"name">>, fun col_name/2}
+        ,{<<"origin">>, fun col_origin/2}
+        ,{<<"owner_id">>, fun col_owner_id/2}
+        ,{<<"request">>, fun col_request/2}
+        ,{<<"soft_delete">>, fun col_soft_delete/2}
+        ,{<<"soft_restore">>, fun col_soft_restore/2}
+        ,{<<"source_type">>, fun col_source_type/2}
+        ,{<<"start">>, fun col_start/2}
+        ,{<<"to">>, fun col_to/2}
+        ,{<<"url">>, fun col_url/2}
+        ]).
+
+-define(COLUMNS_RESELLER
+       ,[
+        ]).
 
 %%%=============================================================================
 %%% API
@@ -45,8 +85,11 @@ init() ->
                ,{<<"*.resource_exists.recordings">>, 'resource_exists'}
                ,{<<"*.content_types_provided.recordings">>, 'content_types_provided'}
                ,{<<"*.validate.recordings">>, 'validate'}
+               ,{<<"*.execute.patch.recordings">>, 'patch'}
                ,{<<"*.execute.delete.recordings">>, 'delete'}
                ],
+    _ = crossbar_bindings:bind(<<"*.to_json.get.recordings">>, ?MODULE, 'to_json'),
+    _ = crossbar_bindings:bind(<<"*.to_csv.get.recordings">>, ?MODULE, 'to_json'),
     cb_modules_util:bind(?MODULE, Bindings).
 
 %%------------------------------------------------------------------------------
@@ -59,7 +102,134 @@ init() ->
 allowed_methods() -> [?HTTP_GET].
 
 -spec allowed_methods(path_token()) -> http_methods().
-allowed_methods(_RecordingId) -> [?HTTP_GET, ?HTTP_DELETE].
+allowed_methods(?COLLECTION) ->
+    [?HTTP_PATCH];
+allowed_methods(_RecordingId) ->
+    [?HTTP_GET, ?HTTP_DELETE, ?HTTP_PATCH].
+
+-spec to_json(cb_cowboy_payload()) -> cb_cowboy_payload().
+to_json({Req, Context}) ->
+    {Req, to_response(Context, <<"json">>, cb_context:req_nouns(Context))}.
+
+-spec to_csv(cb_cowboy_payload()) -> cb_cowboy_payload().
+to_csv({Req, Context}) ->
+    {Req, to_response(Context, <<"csv">>, cb_context:req_nouns(Context))}.
+
+-spec to_response(cb_context:context(), kz_term:ne_binary(), req_nouns()) ->
+          cb_context:context().
+to_response(Context, RespType, [{<<"recordings">>, []}, {?KZ_ACCOUNTS_DB, _}|_]) ->
+    load_chunked_recordings(Context, RespType);
+to_response(Context, _, _) ->
+    Context.
+
+%%------------------------------------------------------------------------------
+%% @doc Loads Call Recordings docs from database and normalized them.
+%% @end
+%%------------------------------------------------------------------------------
+-spec load_chunked_recordings(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
+load_chunked_recordings(Context, RespType) ->
+    load_chunked_recordings(Context, RespType, cb_context:resp_data(Context)).
+
+-spec load_chunked_recordings(cb_context:context(), kz_term:ne_binary(), kz_json:objects()) -> cb_context:context().
+load_chunked_recordings(Context, RespType, RespData) ->
+    AccountId = cb_context:account_id(Context),
+    Fun = fun(JObj, Acc) -> split_to_modbs(AccountId, kz_doc:id(JObj), Acc) end,
+    MapIds = lists:foldl(Fun, #{}, RespData),
+
+    C1 = cb_context:set_resp_data(Context, []),
+    try maps:fold(fun(Db, Ids, C) -> load_chunked_recording_ids(C, RespType, Db, Ids) end, C1, MapIds)
+    catch
+        _T:_E ->
+            cb_context:add_system_error('datastore_fault', Context)
+    end.
+
+%% if request is not chunked, map Ids to MODBs
+-spec split_to_modbs(kz_term:ne_binary(), kz_term:ne_binary(), map()) -> map().
+split_to_modbs(AccountId, ?MATCH_MODB_PREFIX(Year, Month, _)=Id, Map) ->
+    Db = kazoo_modb:get_modb(AccountId, Year, Month),
+    maps:update_with(Db, fun(List) -> List ++ [Id] end, [Id], Map).
+
+-spec load_chunked_recording_ids(cb_context:context(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binaries()) -> cb_context:context().
+load_chunked_recording_ids(Context, RespType, Db, Ids) ->
+    load_chunked_recording_ids(Context, RespType, Db, Ids, cb_context:resp_status(Context)).
+
+load_chunked_recording_ids(Context, RespType, Db, Ids, 'success') ->
+    case kz_datamgr:open_docs(Db, Ids, [{'doc_type', kzd_call_recordings:type()}]) of
+        {'ok', Results} ->
+            Resp0 = [normalize_recording(Context, RespType, Result)
+                     || Result <- Results,
+                        %% if there are no filters, include doc
+                        %% otherwise run filters against doc for inclusion
+                        crossbar_filter:by_doc(kz_json:get_json_value(<<"doc">>, Result), Context)
+                    ],
+            RespAcc = cb_context:resp_data(Context),
+            maybe_add_csv_header(Context, RespType, RespAcc ++ Resp0);
+        {'error', Reason} ->
+            lager:debug("failed to load cdrs doc from ~s: ~p", [Db, Reason]),
+            crossbar_doc:handle_datamgr_errors(Reason, <<"load_cdrs">>, Context)
+    end;
+load_chunked_recording_ids(Context, _RespType, _Db, _Ids, _Status) ->
+    Context.
+
+-spec normalize_recording(cb_context:context(), kz_term:ne_binary(), kz_json:object()) -> kz_json:object() | kz_term:binary().
+normalize_recording(Context, <<"json">>, Result) ->
+    JObj = kz_json:get_json_value(<<"doc">>, Result),
+    kz_json:from_list(
+            props:filter_empty(
+                   [{K, F(JObj, Context)} || {K, F} <- csv_rows(Context)]));
+normalize_recording(Context, <<"csv">>, Result) ->
+    JObj = kz_json:get_json_value(<<"doc">>, Result),
+    <<(kz_binary:join([F(JObj, Context) || {_, F} <- csv_rows(Context)], <<",">>))/binary, "\r\n">>.
+
+-spec maybe_add_csv_header(cb_context:context(), kz_term:ne_binary(), kz_json:objects() | kz_term:binaries()) -> cb_context:context().
+maybe_add_csv_header(Context, _, []) ->
+    Context;
+maybe_add_csv_header(Context, <<"json">>, Data) ->
+    cb_context:set_resp_data(Context, Data);
+maybe_add_csv_header(Context, <<"csv">>, [Head | Tail]=Data) ->
+    case cb_context:fetch(Context, 'chunking_started') of
+        'true' ->
+            cb_context:set_resp_data(Context, Data);
+        'false' ->
+            CSVHeader = kz_binary:join([K || {K, _Fun} <- csv_rows(Context)], <<",">>),
+            cb_context:set_resp_data(Context, [<<CSVHeader/binary, "\r\n", Head/binary>> | Tail])
+    end.
+
+%% -spec csv_rows(cb_context:context()) -> [{kz_term:ne_binary(), csv_column_fun()}].
+csv_rows(Context) ->
+    case cb_context:fetch(Context, 'is_reseller', 'false') of
+        'false' -> ?COLUMNS;
+        'true' -> ?COLUMNS ++ ?COLUMNS_RESELLER
+    end.
+
+%% see csv_column_fun() for specs for each function here
+col_id(JObj, _Context) -> kz_doc:id(JObj, <<>>).
+col_call_id(JObj, _Context) -> kzd_cdrs:call_id(JObj, <<>>).
+col_caller_id_number(JObj, _Context) -> kzd_cdrs:caller_id_number(JObj, <<>>).
+col_caller_id_name(JObj, _Context) -> kzd_cdrs:caller_id_name(JObj, <<>>).
+col_callee_id_number(JObj, _Context) -> kzd_cdrs:callee_id_number(JObj, <<>>).
+col_callee_id_name(JObj, _Context) -> kzd_cdrs:callee_id_name(JObj, <<>>).
+col_cdr_id(JObj, _Context) -> kz_json:get_value(<<"cdr_id">>, JObj, <<>>).
+col_content_type(JObj, _Context) -> kz_json:get_value(<<"content_type">>, JObj, <<>>).
+col_custom_channel_vars(JObj, _Context) -> kz_json:get_value(<<"custom_channel_vars">>, JObj, <<>>).
+col_description(JObj, _Context) -> kz_json:get_value(<<"description">>, JObj, <<>>).
+col_direction(JObj, _Context) -> kz_json:get_value(<<"direction">>, JObj, <<>>).
+col_duration(JObj, _Context) -> kz_json:get_value(<<"duration">>, JObj, <<>>).
+col_duration_ms(JObj, _Context) -> kz_json:get_value(<<"duration_ms">>, JObj, <<>>).
+col_from(JObj, _Context) -> kz_json:get_value(<<"from">>, JObj, <<>>).
+col_interaction_id(JObj, _Context) -> kz_json:get_value(<<"interaction_id">>, JObj, <<>>).
+col_media_source(JObj, _Context) -> kz_json:get_value(<<"media_source">>, JObj, <<>>).
+col_media_type(JObj, _Context) -> kz_json:get_value(<<"media_type">>, JObj, <<>>).
+col_name(JObj, _Context) -> kz_json:get_value(<<"name">>, JObj, <<>>).
+col_origin(JObj, _Context) -> kz_json:get_value(<<"origin">>, JObj, <<>>).
+col_owner_id(JObj, _Context) -> kz_json:get_value(<<"owner_id">>, JObj, <<>>).
+col_request(JObj, _Context) -> kz_json:get_value(<<"request">>, JObj, <<>>).
+col_soft_delete(JObj, _Context) -> kz_json:get_value(<<"soft_delete">>, JObj, <<>>).
+col_soft_restore(JObj, _Context) -> kz_json:get_value(<<"soft_restore">>, JObj, <<>>).
+col_source_type(JObj, _Context) -> kz_json:get_value(<<"source_type">>, JObj, <<>>).
+col_start(JObj, _Context) -> kz_json:get_value(<<"start">>, JObj, <<>>).
+col_to(JObj, _Context) -> kz_json:get_value(<<"to">>, JObj, <<>>).
+col_url(JObj, _Context) -> kz_json:get_value(<<"url">>, JObj, <<>>).
 
 %%------------------------------------------------------------------------------
 %% @doc Does the path point to a valid resource.
@@ -99,9 +269,20 @@ content_types_provided_for_download(Context, _Verb) ->
 %%------------------------------------------------------------------------------
 -spec validate(cb_context:context()) -> cb_context:context().
 validate(Context) ->
-    recording_summary(Context).
+    QS = cb_context:query_string(Context),
+    case  kz_json:get_value(<<"include">>, QS) == <<"soft_delete">> of
+        true ->
+            recording_summary(Context);
+        false ->
+            Values = [{<<"key_missing">>, <<"soft_delete">>}],
+            AdjustedQS = kz_json:set_values(Values, QS),
+            AdjustedContext = cb_context:set_query_string(Context, AdjustedQS),
+            recording_summary(AdjustedContext)
+end.
 
 -spec validate(cb_context:context(), path_token()) -> cb_context:context().
+validate(Context, ?COLLECTION) ->
+    validate_collection_request(Context);
 validate(Context, RecordingId) ->
     validate_recording(Context, RecordingId, cb_context:req_verb(Context)).
 
@@ -112,6 +293,8 @@ validate_recording(Context, RecordingId, ?HTTP_GET) ->
         'download' ->
             load_recording_binary(Context, RecordingId)
     end;
+validate_recording(Context, RecordingId, ?HTTP_PATCH) ->
+    validate_patch(RecordingId, Context);
 validate_recording(Context, RecordingId, ?HTTP_DELETE) ->
     load_recording_doc(Context, RecordingId).
 
@@ -119,6 +302,109 @@ validate_recording(Context, RecordingId, ?HTTP_DELETE) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
+-spec validate_patch(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+validate_patch(RecordingId, Context) ->
+    patch_and_validate(RecordingId, Context, fun validate_request/2).
+
+-spec patch_and_validate(kz_term:ne_binary(), cb_context:context(), fun()) ->
+          cb_context:context().
+patch_and_validate(Id, Context, ValidateFun) ->
+    Context1 = load_recording_doc(Context, Id),
+    patch_and_validate_doc(Id, Context1, ValidateFun, cb_context:resp_status(Context1)).
+
+-spec patch_and_validate_doc(kz_term:ne_binary(), cb_context:context(), fun(), crossbar_status()) ->
+          cb_context:context().
+patch_and_validate_doc(Id, Context, ValidateFun, 'success') ->
+    PatchedJObj = patch_the_doc(cb_context:req_data(Context), cb_context:doc(Context)),
+    Context1 = cb_context:set_req_data(Context, PatchedJObj),
+    ValidateFun(Id, cb_context:set_doc(Context1, PatchedJObj));
+patch_and_validate_doc(Id, Context, ValidateFun, _RespStatus) ->
+    ValidateFun(Id, Context).
+
+-spec patch_the_doc(kz_json:object(), kz_json:object()) -> kz_json:object().
+patch_the_doc(RequestData, ExistingDoc) ->
+    PubJObj = kz_doc:public_fields(RequestData),
+    kz_json:merge(fun kz_json:merge_left/2, PubJObj, ExistingDoc).
+
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+
+%%-spec validate_request(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+%%validate_request(_RecordingId, Context) ->
+%%    Context.
+-spec validate_request(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+validate_request(RecordingId, Context) ->
+    ValidateFuns = [
+                   fun validate_schema/2
+                   ],
+    lists:foldl(fun(F, C) -> F(RecordingId, C) end
+               ,Context
+               ,ValidateFuns
+               ).
+
+-spec validate_schema(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+validate_schema(RecordingId, Context) ->
+    lager:debug("validating call_recording payload"),
+    OnSuccess = fun(C) ->
+                        lager:debug("account payload is valid"),
+                        on_successful_validation(RecordingId, C)
+                end,
+    cb_context:validate_request_data(<<"call_recordings">>, Context, OnSuccess).
+
+-spec on_successful_validation(kz_term:api_binary(), cb_context:context()) -> cb_context:context().
+on_successful_validation(_RecordingId, Context) ->
+    Context.
+
+
+%%------------------------------------------------------------------------------
+%% @doc Validates a collection-type recordings field..
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec validate_collection_request(cb_context:context()) -> cb_context:context().
+validate_collection_request(Context) ->
+    Recordings = kz_json:get_value(?COLLECTION_RECORDINGS, cb_context:req_data(Context)),
+    validate_collection_request(Context, Recordings).
+
+-spec validate_collection_request(cb_context:context(), any()) -> cb_context:context().
+validate_collection_request(Context, 'undefined') ->
+    Msg = kz_json:from_list([{<<"message">>, <<"list of recordings missing">>}
+                            ]),
+    cb_context:add_validation_error(?COLLECTION_RECORDINGS, <<"required">>, Msg, Context);
+validate_collection_request(Context, []) ->
+    Msg = kz_json:from_list([{<<"message">>, <<"minimum 1 recording required">>}
+                            ]),
+    cb_context:add_validation_error(?COLLECTION_RECORDINGS, <<"minimum">>, Msg, Context);
+validate_collection_request(Context, Recordings)
+  when is_list(Recordings) ->
+    UniqNomalised = lists:usort(Recordings),
+    case length(Recordings) =:= length(UniqNomalised) of
+        'true' -> cb_context:set_resp_status(Context, 'success');
+        'false' ->
+            Msg = kz_json:from_list([{<<"message">>, <<"some recordings appear twice">>}
+                                    ]),
+            cb_context:add_validation_error(?COLLECTION_RECORDINGS, <<"uniqueItems">>, Msg, Context)
+    end;
+validate_collection_request(Context, _E) ->
+    Msg = kz_json:from_list([{<<"message">>, <<"recordings must be a list">>}
+                            ]),
+    cb_context:add_validation_error(?COLLECTION_RECORDINGS, <<"type">>, Msg, Context).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec patch(cb_context:context(), path_token()) -> cb_context:context().
+patch(Context, ?COLLECTION) ->
+    Results = collection_process(Context, ?HTTP_PATCH),
+    crossbar_util:response(Results, Context);
+patch(Context, _) ->
+    crossbar_doc:save(Context).
+
 -spec delete(cb_context:context(), path_token()) -> cb_context:context().
 delete(Context, _RecordingId) ->
     crossbar_doc:delete(Context).
@@ -127,7 +413,8 @@ delete(Context, _RecordingId) ->
 recording_summary(Context) ->
     UserId = cb_context:user_id(Context),
     ViewName = get_view_name(UserId),
-    Options = [{'mapper', fun summary_doc_fun/2}
+    Options = [{'is_chunked', 'true'}
+              ,{'mapper', fun summary_doc_fun/2}
               ,{'range_start_keymap', [UserId]}
               ,{'range_end_keymap', fun(Ts) -> build_end_key(Ts, UserId) end}
               ,'include_docs'
@@ -162,19 +449,14 @@ get_view_name(_) -> ?CB_LIST_BY_OWNERID.
 
 -spec load_recording_doc(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 load_recording_doc(Context, ?MATCH_MODB_PREFIX(Year, Month, _) = RecordingId) ->
-    Ctx = cb_context:set_db_name(Context
-                                ,kzs_util:format_account_id(cb_context:account_id(Context)
-                                                           ,kz_term:to_integer(Year)
-                                                           ,kz_term:to_integer(Month)
-                                                           )
-                                ),
+    Ctx = cb_context:set_account_modb(Context, kz_term:to_integer(Year), kz_term:to_integer(Month)),
     crossbar_doc:load({<<"call_recording">>, RecordingId}, Ctx, ?TYPE_CHECK_OPTION(<<"call_recording">>));
 load_recording_doc(Context, Id) ->
     crossbar_util:response_bad_identifier(Id, Context).
 
 -spec load_recording_binary(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 load_recording_binary(Context, ?MATCH_MODB_PREFIX(Year, Month, _) = DocId) ->
-    do_load_recording_binary(cb_context:set_db_name(Context, kzs_util:format_account_id(cb_context:account_id(Context), kz_term:to_integer(Year), kz_term:to_integer(Month))), DocId).
+    do_load_recording_binary(cb_context:set_account_modb(Context, kz_term:to_integer(Year), kz_term:to_integer(Month)), DocId).
 
 -spec do_load_recording_binary(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 do_load_recording_binary(Context, DocId) ->
@@ -282,3 +564,45 @@ acceptable_content_types(Context) ->
 -spec is_acceptable_accept(kz_term:proplist(), kz_term:ne_binary(), kz_term:ne_binary()) -> boolean().
 is_acceptable_accept(Acceptable, Type, SubType) ->
     lists:member({Type,SubType}, Acceptable).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec collection_process(cb_context:context(), kz_term:ne_binary() | http_method()) -> recordings:ret().
+collection_process(Context, Action) ->
+    ReqData = cb_context:req_data(Context),
+    Recordings = kz_json:get_list_value(<<"recordings">>, ReqData),
+    Context1 = cb_context:set_req_data(Context, kz_json:delete_key(<<"recordings">>, ReqData)),
+    recordings_action(Context1, Action, Recordings).
+
+recordings_action(Context, ?HTTP_PATCH, Recordings) ->
+    Fun = fun(RecordingId, {Success, Failure}) ->
+            Ctx1 = validate_patch(RecordingId, Context),
+            case cb_context:has_errors(Ctx1) of
+                'true' ->
+                    {'error', {ErrorCode, ErrorMsg, _ErrorData}} = cb_context:response(Ctx1),
+                    Resp = kz_json:from_list([ {<<"cause">>, RecordingId}
+                                              ,{<<"code">>, ErrorCode}
+                                              ,{<<"message">>, ErrorMsg}]),
+                    {Success, kz_json:set_value(RecordingId, Resp, Failure)};
+                'false' ->
+                    Ctx2 = crossbar_doc:save(Ctx1),
+                    Doc = cb_context:doc(Ctx2),
+                    {kz_json:set_value(RecordingId, Doc, Success), Failure}
+            end
+            end,
+    {Success, Failure} = lists:foldl(Fun,
+                            {kz_json:new(), kz_json:new()},
+                            Recordings),
+    kz_json:merge(
+                    case kz_json:is_empty(Success) of
+                        true -> kz_json:new();
+                        false -> kz_json:set_value(<<"success">>, Success, kz_json:new())
+                    end,
+                    case kz_json:is_empty(Failure) of
+                        true -> kz_json:new();
+                        false -> kz_json:set_value(<<"failure">>, Failure, kz_json:new())
+                    end
+                  ).
+


### PR DESCRIPTION
      * PATCH a call_recording document
      * Update schema to add soft_delete and soft_restore objects
      * support for 'collections' to PATCH multiple documents
      * enable chunking by default
      * by default hide docs that have soft_delete object present
      * include soft_delete docs if 'include=soft_delete' is in the query string