### PR TITLE
PISTON-1071: keep many call KVs up to date through cf branches

### DIFF
--- a/applications/callflow/src/cf_route_req.erl
+++ b/applications/callflow/src/cf_route_req.erl
@@ -247,20 +247,12 @@ pre_park_action(Call) ->
 %%------------------------------------------------------------------------------
 -spec update_call(kzd_callflows:doc(), boolean(), kz_term:ne_binary(), kapps_call:call()) ->
           kapps_call:call().
-update_call(Flow, NoMatch, ControllerQ, Call) ->
-    Props = [{'cf_flow_id', kz_doc:id(Flow)}
-            ,{'cf_flow_name', kzd_callflows:name(Flow, kapps_call:request_user(Call))}
-            ,{'cf_flow', kzd_callflows:flow(Flow)}
-            ,{'cf_capture_group', kzd_callflows:capture_group(Flow)}
-            ,{'cf_capture_groups', kzd_callflows:capture_groups(Flow, kz_json:new())}
-            ,{'cf_no_match', NoMatch}
-            ],
-
-    Updaters = [{fun kapps_call:kvs_store_proplist/2, Props}
-               ,{fun kapps_call:set_controller_queue/2, ControllerQ}
+update_call(FlowDoc, NoMatch, ControllerQ, Call) ->
+    Updaters = [{fun kapps_call:set_controller_queue/2, ControllerQ}
                ,{fun kapps_call:set_application_name/2, ?APP_NAME}
                ,{fun kapps_call:set_application_version/2, ?APP_VERSION}
-               ,{fun kapps_call:insert_custom_channel_var/3, <<"CallFlow-ID">>, kz_doc:id(Flow)}
+               ,{fun kapps_call:insert_custom_channel_var/3, <<"CallFlow-ID">>, kz_doc:id(FlowDoc)}
+               ,{fun cf_util:update_call_on_branch/3, FlowDoc, NoMatch}
                ],
     kapps_call:exec(Updaters, Call).
 

--- a/applications/callflow/src/module/cf_branch_bnumber.erl
+++ b/applications/callflow/src/module/cf_branch_bnumber.erl
@@ -83,13 +83,8 @@ maybe_hunt(_Data, Call, CaptureGroup, 'true') ->
     case cf_flow:lookup(CaptureGroup, AccountId) of
         {'ok', Flow, NoMatch} when (not NoMatch)
                                    orelse AllowNoMatch ->
-            Props = [{'cf_capture_group', kz_json:get_ne_value(<<"capture_group">>, Flow)}
-                    ,{'cf_capture_groups', kz_json:get_value(<<"capture_groups">>, Flow, kz_json:new())}
-                    ],
-            UpdatedCall = kapps_call:kvs_store_proplist(Props, Call),
-            cf_exe:set_call(UpdatedCall),
             lager:info("branching to ~s", [kz_doc:id(Flow)]),
-            cf_exe:branch(kzd_callflows:flow(Flow, kz_json:new()), UpdatedCall);
+            cf_exe:branch(Flow, Call);
         _Else ->
             lager:info("hunt failed to find a callflow"),
             cf_exe:continue(Call)

--- a/applications/callflow/src/module/cf_callflow.erl
+++ b/applications/callflow/src/module/cf_callflow.erl
@@ -37,6 +37,5 @@ handle(Data, Call) ->
             cf_exe:continue(Call);
         {'ok', JObj} ->
             lager:info("branching to new callflow ~s", [Id]),
-            Flow = kzd_callflows:flow(JObj, kz_json:new()),
-            cf_exe:branch(Flow, Call)
+            cf_exe:branch(JObj, Call)
     end.

--- a/applications/callflow/src/module/cf_camping_feature.erl
+++ b/applications/callflow/src/module/cf_camping_feature.erl
@@ -197,7 +197,7 @@ no_channels(#state{id = TargetId
     Flow = kz_json:from_list([{<<"module">>, TargetType}
                              ,{<<"data">>, kz_json:from_list([{<<"id">>, TargetId}])}
                              ]),
-    cf_exe:branch(Flow, Call),
+    cf_exe:continue_with_flow(Flow, Call),
     just('connected');
 no_channels(#state{type = <<"offnet">>
                   ,is_no_match = 'true'

--- a/applications/callflow/src/module/cf_directory.erl
+++ b/applications/callflow/src/module/cf_directory.erl
@@ -270,7 +270,7 @@ maybe_confirm_match(Call, User, 'true') ->
 -spec route_to_match(kapps_call:call(), 'fail' | kz_json:object()) -> 'ok'.
 route_to_match(Call, 'fail') -> cf_exe:continue(Call);
 route_to_match(Call, Callflow) ->
-    cf_exe:branch(kz_json:get_value(<<"flow">>, Callflow), Call).
+    cf_exe:branch(Callflow, Call).
 
 %%------------------------------------------------------------------------------
 %% Audio Prompts

--- a/applications/callflow/src/module/cf_disa.erl
+++ b/applications/callflow/src/module/cf_disa.erl
@@ -163,7 +163,7 @@ maybe_restrict_call(Data, Call, Number, Flow) ->
             _ = kapps_call_command:queued_hangup(Call),
             'ok';
         'false' ->
-            cf_exe:branch(kz_json:get_json_value(<<"flow">>, Flow), Call)
+            cf_exe:branch(Flow, Call)
     end.
 
 -spec should_use_account_cid(kz_json:object()) -> boolean().

--- a/applications/callflow/src/module/cf_dynamic_cid.erl
+++ b/applications/callflow/src/module/cf_dynamic_cid.erl
@@ -243,7 +243,7 @@ maybe_restrict_call(Data, Call, Number, Flow) ->
             _ = kapps_call_command:queued_hangup(Call),
             'ok';
         'false' ->
-            cf_exe:branch(kzd_callflows:flow(Flow), Call)
+            cf_exe:branch(Flow, Call)
     end.
 
 %%------------------------------------------------------------------------------

--- a/applications/callflow/src/module/cf_eavesdrop_feature.erl
+++ b/applications/callflow/src/module/cf_eavesdrop_feature.erl
@@ -62,7 +62,7 @@ handle(Data, Call) ->
                                      ,{<<"module">>, <<"eavesdrop">>}
                                      ,{<<"children">>, kz_json:new()}
                                      ]),
-            cf_exe:branch(Flow, Call);
+            cf_exe:continue_with_flow(Flow, Call);
         'false' ->
             _ = cf_eavesdrop:no_permission_to_eavesdrop(Call),
             cf_exe:stop(Call)

--- a/applications/callflow/src/module/cf_intercom.erl
+++ b/applications/callflow/src/module/cf_intercom.erl
@@ -34,7 +34,7 @@ handle(Data, Call) ->
         {'ok', Flow, 'false'} ->
             JObj = suppress_ccv(Data),
             kapps_call_command:set('undefined', JObj, Call),
-            cf_exe:branch(kzd_callflows:flow(Flow, kz_json:new()), Call);
+            cf_exe:branch(Flow, Call);
         _ ->
             cf_exe:continue(Call)
     end.

--- a/applications/callflow/src/module/cf_menu.erl
+++ b/applications/callflow/src/module/cf_menu.erl
@@ -238,12 +238,7 @@ hunt_for_callflow(Digits, Menu, Call) ->
             lager:info("callflow hunt succeeded, branching"),
             _ = kapps_call_command:flush_dtmf(Call),
             _ = play_transferring_prompt(Menu, Call),
-            Props = [{'cf_capture_group', kz_json:get_ne_value(<<"capture_group">>, Flow)}
-                    ,{'cf_capture_groups', kz_json:get_value(<<"capture_groups">>, Flow, kz_json:new())}
-                    ],
-            UpdatedCall = kapps_call:kvs_store_proplist(Props, Call),
-            cf_exe:set_call(UpdatedCall),
-            cf_exe:branch(kzd_callflows:flow(Flow, kz_json:new()), UpdatedCall),
+            cf_exe:branch(Flow, Call),
             'true';
         _ ->
             lager:info("callflow hunt failed"),

--- a/applications/callflow/src/module/cf_privacy.erl
+++ b/applications/callflow/src/module/cf_privacy.erl
@@ -29,7 +29,7 @@ handle(Data, Call, AccountId, Number) ->
     case cf_flow:lookup(Number, AccountId) of
         {'ok', CallFlow, _NoMatch} ->
             UpdatedCall = update_call(Number, Data, Call),
-            cf_exe:branch(kzd_callflows:flow(CallFlow), UpdatedCall);
+            cf_exe:branch(CallFlow, UpdatedCall);
         {'error', _} ->
             cf_exe:stop(Call)
     end.

--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -1035,7 +1035,7 @@ maybe_exist_callflow(Number, Call) ->
                       ,{fun kapps_call:set_to/2, list_to_binary([Number, "@", kapps_call:to_realm(Call)])}
                       ],
             Call1 = cf_exe:update_call(kapps_call:exec(Updates, Call)),
-            cf_exe:branch(kz_json:get_json_value(<<"flow">>, Flow), Call1);
+            cf_exe:branch(Flow, Call1);
         _ ->
             lager:info("failed to find a callflow to satisfy ~s", [Number]),
             _ = kapps_call_command:audio_macro([{'prompt', <<"fault-can_not_be_completed_as_dialed">>}], Call),
@@ -2112,7 +2112,7 @@ review_recording(AttachmentName, AllowOperator
         {'ok', Operator} when AllowOperator ->
             lager:info("caller chose to ring the operator"),
             case cf_util:get_operator_callflow(kapps_call:account_id(Call), OpNum) of
-                {'ok', Flow} -> {'branch', Flow};
+                {'ok', FlowDoc} -> {'branch', FlowDoc};
                 {'error',_R} -> review_recording(AttachmentName, AllowOperator, Box, Call, Loop + 1)
             end;
         {'error', 'channel_hungup'} ->


### PR DESCRIPTION
- main benefit: capture groups in callflows that are branched to will actually work, such as when using cf_callflow or dialing the operator in cf_voicemail
- side benefit: tracking KVs stay up to date to understand path thru callflows
- props: cf_flow_id, cf_flow_name, cf_flow, cf_capture_group, cf_capture_groups, cf_no_match

Our current use case example for this is an operator_number on a voicemail box that points to a callflow with a capture group pattern (e.g. `\*9999(\+?[0-9]*)$`). The operator for each VM box is an offnet number specific to the voicemail box. So that number is appended to the prefix *9999 and then a generic callflow can handle the operator for that box.

Another use case could be allowing the user to pick one of a set of caller IDs, using cf_callflow to direct the caller to a callflow with cf_dynamic_cid followed by, for example, a ring group, queue, or destination number. The change also leaves room for more interesting features such as a callflow module that accepts some digits and directs the caller to a capture group pattern callflow, doing something with the entered digits.

I've also included keeping cf_flow* props up to date, as it seems kind of useful for the state to contain which callflow is currently operating for a particular call. Looking for feedback here.

Also if there might be any side-effects of the change, let me know.