### PR TITLE
argument expansion in sup - 4.3

### DIFF
--- a/core/sup/priv/sup
+++ b/core/sup/priv/sup
@@ -32,5 +32,5 @@ shift $(($OPTIND - 1))
 KAZOO_NODE=${SUP_NODE_ARG:-${KAZOO_NODE:-kazoo_apps}}
 KAZOO_COOKIE=${SUP_COOKIE_ARG:-${KAZOO_COOKIE:-change_me}}
 
-${DEFAULT_ROOT}/bin/kazoo escript lib/sup-*/priv/sup.escript -n ${KAZOO_NODE} -c ${KAZOO_COOKIE} $*
+${DEFAULT_ROOT}/bin/kazoo escript lib/sup-*/priv/sup.escript -n ${KAZOO_NODE} -c ${KAZOO_COOKIE} "$@"
 exit $?

--- a/rel/kazoo
+++ b/rel/kazoo
@@ -40,6 +40,7 @@ ERL_OPTS="{{ erl_opts }}"
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-/tmp/log}"
 VM_NODE_FILES_DIR="${VM_NODE_FILES_DIR:-/tmp}"
 NAME_TYPE="${NODE_NAME_TYPE:--name}"
+NODE_STARTUP_FILE_PATH=${NODE_STARTUP_FILE_PATH:-/etc/kazoo/core}
 
 
 # start/stop/install/upgrade pre/post hooks
@@ -177,10 +178,9 @@ relx_nodetool() {
 
 # Run an escript in the node's environment
 relx_escript() {
-    shift; scriptpath="$1"; shift
+    shift; scriptpath="$ROOTDIR/$1"; shift
     export RELEASE_ROOT_DIR
-
-    "$ERTS_DIR/bin/escript" "$ROOTDIR/$scriptpath" $@
+    "$ERTS_DIR/bin/escript" $scriptpath "$@"
 }
 
 # Output a start command for the last argument of run_erl
@@ -333,6 +333,18 @@ else
     fi
 fi
 
+if [ -f "${NODE_STARTUP_FILE_PATH}/${KAZOO_NODE}.vm.args" ]; then
+    VM_ARGS_FILE="${NODE_STARTUP_FILE_PATH}/${KAZOO_NODE}.vm.args"
+else
+    VM_ARGS_FILE="$VMARGS_PATH"
+fi
+
+if [ -f "${NODE_STARTUP_FILE_PATH}/${KAZOO_NODE}.sys.config" ]; then
+    SYS_CONFIG_FILE="${NODE_STARTUP_FILE_PATH}/${KAZOO_NODE}.sys.config"
+else
+    SYS_CONFIG_FILE="$RELX_CONFIG_PATH"
+fi
+
 cd "$ROOTDIR"
 
 # Check the first argument for instructions
@@ -421,7 +433,7 @@ case "$1" in
 
     escript)
         ## Run an escript under the node's environment
-        if ! relx_escript $@; then
+        if ! relx_escript "$@"; then
             exit 1
         fi
         ;;
@@ -535,11 +547,10 @@ case "$1" in
             +pc unicode \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
-            -config "$RELX_CONFIG_PATH" \
+            -config "$SYS_CONFIG_FILE" \
             $NAME_ARG \
             -setcookie $COOKIE \
-            -args_file "$VMARGS_PATH" \
-            -pa ${__code_paths}
+            -args_file "$VM_ARGS_FILE" 
 
         # Dump environment info for logging purposes
         echo "Exec: $@" -- ${1+$ARGS}


### PR DESCRIPTION
ensures proper expansion of arguments

example:

sup kapps_config set_json cat a.b.c '{"fsxxx.fqdn": {"foo" : "bar"}}'