### PR TITLE
[4.3] HELP-14771: Add stepswitch.min_shortdial_destination parameter

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -35251,7 +35251,7 @@
                     "type": "boolean"
                 },
                 "fixed_length_shortdial_correction": {
-                    "description": "stepswitch fixed_length_shortdial_correction",
+                    "description": "add {FIXED} digits from caller ID to destination",
                     "minimum": 1,
                     "type": "integer"
                 },
@@ -35262,13 +35262,18 @@
                 },
                 "max_shortdial_correction": {
                     "default": 5,
-                    "description": "stepswitch maximum shortdial correction",
+                    "description": "add up to {MAX} digits from caller ID to destination number",
                     "minimum": 1,
                     "type": "integer"
                 },
                 "min_shortdial_correction": {
                     "default": 2,
-                    "description": "stepswitch minimum shortdial correction",
+                    "description": "add at least {MIN} digits from caller ID to destination number",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "min_shortdial_destination": {
+                    "description": "do short-dial correction if dialed number's length is equal to this value",
                     "minimum": 1,
                     "type": "integer"
                 },

--- a/applications/crossbar/priv/couchdb/schemas/system_config.stepswitch.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.stepswitch.json
@@ -114,7 +114,7 @@
             "type": "boolean"
         },
         "fixed_length_shortdial_correction": {
-            "description": "stepswitch fixed_length_shortdial_correction",
+            "description": "add {FIXED} digits from caller ID to destination",
             "minimum": 1,
             "type": "integer"
         },
@@ -125,13 +125,18 @@
         },
         "max_shortdial_correction": {
             "default": 5,
-            "description": "stepswitch maximum shortdial correction",
+            "description": "add up to {MAX} digits from caller ID to destination number",
             "minimum": 1,
             "type": "integer"
         },
         "min_shortdial_correction": {
             "default": 2,
-            "description": "stepswitch minimum shortdial correction",
+            "description": "add at least {MIN} digits from caller ID to destination number",
+            "minimum": 1,
+            "type": "integer"
+        },
+        "min_shortdial_destination": {
+            "description": "do short-dial correction if dialed number's length is equal to this value",
             "minimum": 1,
             "type": "integer"
         },

--- a/applications/stepswitch/src/stepswitch_util.erl
+++ b/applications/stepswitch/src/stepswitch_util.erl
@@ -16,6 +16,16 @@
 -export([resources_to_endpoints/3]).
 -export([json_to_template_props/1]).
 
+-ifdef(TEST).
+-export([maybe_constrain_shortdial_correction/3
+        ,shortdial_correction_length/3
+        ,maybe_deny_reclassified_number/3
+        ,do_correct_shortdial/3
+        ,should_correct_shortdial/2
+        ,correct_shortdial/4
+        ]).
+-endif.
+
 -include("stepswitch.hrl").
 -include_lib("kazoo_stdlib/include/kazoo_json.hrl").
 -include_lib("kazoo_amqp/include/kapi_offnet_resource.hrl").
@@ -91,6 +101,10 @@ correct_shortdial(<<"+", Number/binary>>, CIDNum, DeniedCallRestrictions) ->
 correct_shortdial(Number, <<"+", CIDNum/binary>>, DeniedCallRestrictions) ->
     correct_shortdial(Number, CIDNum, DeniedCallRestrictions);
 correct_shortdial(Number, CIDNum, DeniedCallRestrictions) when is_binary(CIDNum) ->
+    correct_shortdial(Number, CIDNum, DeniedCallRestrictions, should_correct_shortdial(Number)).
+
+-spec correct_shortdial(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), {boolean(), pos_integer()}) -> kz_term:api_ne_binary().
+correct_shortdial(Number, CIDNum, DeniedCallRestrictions, {'true', _Length}) ->
     case shortdial_correction_length(Number, CIDNum) of
         0 ->
             lager:debug("unable to correct shortdial ~s via CID ~s"
@@ -98,54 +112,89 @@ correct_shortdial(Number, CIDNum, DeniedCallRestrictions) when is_binary(CIDNum)
                        ),
             'undefined';
         Length ->
-            try_to_correct(Number, CIDNum, DeniedCallRestrictions, Length)
-    end.
+            maybe_deny_reclassified_number(do_correct_shortdial(Number, CIDNum, Length)
+                                          ,CIDNum
+                                          ,DeniedCallRestrictions
+                                          )
+    end;
+correct_shortdial(Number, _CIDNum, _DeniedCallRestrictions, {'false', Length}) ->
+    lager:debug("~s's lenght (~p) doesn't match min_shortdial_destination param's value (~p), skipping"
+               ,[Number, byte_size(Number), Length]
+               ),
+    'undefined'.
 
--spec try_to_correct(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object(), non_neg_integer()) -> kz_term:api_ne_binary().
-try_to_correct(Number, CIDNum, DeniedCallRestrictions, Length) ->
+-spec should_correct_shortdial(kz_term:ne_binary()) -> {boolean(), pos_integer()}.
+should_correct_shortdial(Number) ->
+    should_correct_shortdial(Number
+                            ,kapps_config:get_integer(?SS_CONFIG_CAT
+                                                     ,<<"min_shortdial_destination">>
+                                                     )
+                            ).
+
+-spec should_correct_shortdial(kz_term:ne_binary(), pos_integer()) -> {boolean(), pos_integer()}.
+should_correct_shortdial(_Number, 'undefined') ->
+    {'true', 0};
+should_correct_shortdial(Number, Length) ->
+    %% The length is also included on the response just to avoid having to read this configuration
+    %% parameter again when printing the debug line. So it is only useful for the `{false, N}' branch.
+    {byte_size(Number) =:= Length, Length}.
+
+-spec do_correct_shortdial(kz_term:ne_binary(), kz_term:ne_binary(), non_neg_integer()) -> kz_term:api_ne_binary().
+do_correct_shortdial(Number, CIDNum, Length) ->
     Correction = kz_binary:truncate_right(CIDNum, Length),
     CorrectedNumber = knm_converters:normalize(<<Correction/binary, Number/binary>>),
-    lager:debug("corrected shortdial ~s via CID ~s to ~s"
-               ,[Number, CIDNum, CorrectedNumber]
-               ),
-    case should_deny_reclassified_number(CorrectedNumber, DeniedCallRestrictions) of
-        'true' ->
-            lager:info("unable to correct shortdial ~s via CID ~s due to a call restriction"
-                      ,[Number, CIDNum]
-                      ),
-            'undefined';
-        'false' ->
-            CorrectedNumber
-    end.
+    lager:debug("corrected shortdial ~s via CID ~s to ~s", [Number, CIDNum, CorrectedNumber]),
+    CorrectedNumber.
 
--spec should_deny_reclassified_number(kz_term:ne_binary(), kz_json:object()) -> boolean().
-should_deny_reclassified_number(CorrectedNumber, DeniedCallRestrictions) ->
+-spec maybe_deny_reclassified_number(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> kz_term:api_ne_binary().
+maybe_deny_reclassified_number(CorrectedNumber, CIDNum, DeniedCallRestrictions) ->
     Classification = knm_converters:classify(CorrectedNumber),
     lager:debug("re-classified corrected number ~s as ~s, testing for call restrictions"
                ,[CorrectedNumber, Classification]
                ),
-    kz_json:get_ne_binary_value([Classification, <<"action">>], DeniedCallRestrictions)
-        =:= <<"deny">>.
+    case kz_json:get_ne_binary_value([Classification, <<"action">>], DeniedCallRestrictions) of
+        <<"deny">> ->
+            lager:info("unable to correct shortdial via CID ~s due to a call restriction", [CIDNum]),
+            'undefined';
+        _ ->
+            CorrectedNumber
+    end.
 
 -spec shortdial_correction_length(kz_term:ne_binary(), kz_term:ne_binary()) -> integer().
 shortdial_correction_length(Number, CIDNum) ->
-    case kapps_config:get_integer(?SS_CONFIG_CAT, <<"fixed_length_shortdial_correction">>) of
-        'undefined' ->
-            Length = byte_size(CIDNum) - byte_size(Number),
-            maybe_constrain_shortdial_correction(Length);
-        FixedLength -> FixedLength
-    end.
+    shortdial_correction_length(Number
+                               ,CIDNum
+                               ,kapps_config:get_integer(?SS_CONFIG_CAT
+                                                        ,<<"fixed_length_shortdial_correction">>
+                                                        )
+                               ).
+
+-spec shortdial_correction_length(kz_term:ne_binary(), kz_term:ne_binary(), integer()) -> integer().
+shortdial_correction_length(Number, CIDNum, 'undefined') ->
+    Length = byte_size(CIDNum) - byte_size(Number),
+    maybe_constrain_shortdial_correction(Length);
+shortdial_correction_length(_Number, _CIDNum, FixedLength) ->
+    FixedLength.
 
 -spec maybe_constrain_shortdial_correction(integer()) -> integer().
 maybe_constrain_shortdial_correction(Length) ->
-    MaxCorrection = kapps_config:get_integer(?SS_CONFIG_CAT, <<"max_shortdial_correction">>, 5),
-    MinCorrection = kapps_config:get_integer(?SS_CONFIG_CAT, <<"min_shortdial_correction">>, 2),
-    case Length =< MaxCorrection
-        andalso Length >= MinCorrection
-    of
-        'true' -> Length;
-        'false' -> 0
-    end.
+    maybe_constrain_shortdial_correction(Length
+                                        ,kapps_config:get_integer(?SS_CONFIG_CAT
+                                                                 ,<<"min_shortdial_correction">>
+                                                                 ,2
+                                                                 )
+                                        ,kapps_config:get_integer(?SS_CONFIG_CAT
+                                                                 ,<<"max_shortdial_correction">>
+                                                                 ,5
+                                                                 )
+                                        ).
+
+-spec maybe_constrain_shortdial_correction(integer(), integer(), integer()) -> integer().
+maybe_constrain_shortdial_correction(Length, Min, Max) when Length >= Min
+                                                            andalso Length =< Max ->
+    Length;
+maybe_constrain_shortdial_correction(_Length, _Min, _Max) ->
+    0.
 
 -spec get_sip_headers(kapi_offnet_resource:req()) -> kz_json:object().
 get_sip_headers(OffnetReq) ->
@@ -164,7 +213,6 @@ get_sip_headers(OffnetReq) ->
 -spec maybe_remove_diversions(kz_json:object()) -> kz_json:object().
 maybe_remove_diversions(JObj) ->
     kz_json:delete_key(<<"Diversions">>, JObj).
-
 
 -spec get_diversions(kz_json:object()) ->
           'undefined' |

--- a/applications/stepswitch/test/stepswitch_util_tests.erl
+++ b/applications/stepswitch/test/stepswitch_util_tests.erl
@@ -1,0 +1,186 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2011-2020, 2600Hz
+%%% @doc This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(stepswitch_util_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("stepswitch.hrl").
+
+maybe_constrain_shortdial_correction_test_() ->
+    Test = fun(Length) -> stepswitch_util:maybe_constrain_shortdial_correction(Length, 2, 4) end,
+
+    [{"If calculated length is within bounds , return length"
+     ,[?_assertEqual(4, Test(4))
+      ,?_assertEqual(3, Test(3))
+      ,?_assertEqual(2, Test(2))
+      ]
+     }
+    ,{"If calculated length is out of bounds, return 0"
+     ,[?_assertEqual(0, Test(10))
+      ,?_assertEqual(0, Test(5))
+      ,?_assertEqual(0, Test(1))
+      ]
+     }
+    ].
+
+shortdial_correction_length_test_() ->
+    Test = fun stepswitch_util:shortdial_correction_length/3,
+    FixedLength = 5,
+    Fixed = fun(CalleeNum, CallerNum) -> Test(CalleeNum, CallerNum, FixedLength) end,
+    Undefined = fun(CalleeNum, CallerNum) -> Test(CalleeNum, CallerNum, 'undefined') end,
+
+    %% By default min=2, max=5
+    [{"If fixed is undefined, return calculated length if it is within bounds, 0 otherwise"
+     ,[?_assertEqual(2, Undefined(<<"12345">>, <<"1234567">>))
+      ,?_assertEqual(4, Undefined(<<"123">>, <<"1234567">>))
+      ,?_assertEqual(0, Undefined(<<"123">>, <<"123456789">>)) %% Difference = 6
+      ,?_assertEqual(0, Undefined(<<"123">>, <<"1234">>)) %% Difference = 1
+      ]
+     }
+    ,{"If fixed is set, return its value"
+     ,[?_assertEqual(FixedLength, Fixed(<<"12345">>, <<"1234567">>))
+      ,?_assertEqual(FixedLength, Fixed(<<"123">>, <<"1234567">>))
+      ]
+     }
+    ].
+
+maybe_deny_reclassified_number_test_() ->
+    Test = fun stepswitch_util:maybe_deny_reclassified_number/3,
+    CorrectedNumber = <<"1234567">>,
+    CallRestrictions = kz_json:from_list_recursive([{<<"unknown">>, [{<<"action">>, <<"deny">>}]}]),
+
+    meck:new('knm_converters', ['passthrough']),
+    meck:expect('knm_converters', 'classify', fun(_) -> <<"unknown">> end), %% Just to be sure ;)
+    Resp1 = Test(CorrectedNumber, <<"1234">>, CallRestrictions),
+    Resp2 = Test(CorrectedNumber, <<"7654321">>, CallRestrictions),
+    meck:unload('knm_converters'),
+
+    [{"If not Call Restrictions, return the corrected number"
+     ,[?_assertEqual(CorrectedNumber, Test(CorrectedNumber, <<"1234">>, kz_json:new()))
+      ,?_assertEqual(CorrectedNumber, Test(CorrectedNumber, <<"7654321">>, kz_json:new()))
+      ]
+     }
+    ,{"If Call Restrictions apply, return undefined"
+     ,[?_assertEqual('undefined', Resp1)
+      ,?_assertEqual('undefined', Resp2)
+      ]
+     }
+    ].
+
+do_correct_shortdial_test_() ->
+    Test = fun stepswitch_util:do_correct_shortdial/3,
+    CallerNumber = <<"12223334444">>,
+    CalleeNumber = <<"3335555">>,
+
+    [{"Take up to Length digits from CallerNumber and prefix CalleeNumber with those digits"
+     ,[?_assertEqual(<<"3335555">>, Test(CalleeNumber, CallerNumber, 0))
+      ,?_assertEqual(<<"123335555">>, Test(CalleeNumber, CallerNumber, 2))
+      ,?_assertEqual(<<"+12223335555">>, Test(CalleeNumber, CallerNumber, 4))
+      ,?_assertEqual(<<CallerNumber/binary, CalleeNumber/binary>>
+                    ,Test(CalleeNumber, CallerNumber, byte_size(CallerNumber) + 1)
+                    )
+      ]
+     }
+    ].
+
+should_correct_shortdial_test_() ->
+    Test = fun stepswitch_util:should_correct_shortdial/2,
+    Number = <<"3335555">>,
+    Length1 = byte_size(Number) + 1,
+    Length2 = byte_size(Number),
+
+    [{"If min_shortdial_destination is disabled, return {true, 0}"
+     ,?_assertEqual({'true', 0}, Test(Number, 'undefined'))
+     }
+    ,{"If min_shortdial_destination is set and doesn't match dialed number's length, return {false, Length}"
+     ,[?_assertEqual({'false', Length1}, Test(Number, Length1))
+      ,?_assertEqual({'false', Length1}, Test(kz_binary:truncate(Number, 5), Length1))
+      ]
+     }
+    ,{"If min_shortdial_destination is set and matches dialed number's length, return {true, Length}"
+     ,?_assertEqual({'true', Length2}, Test(Number, Length2))
+     }
+    ].
+
+correct_shortdial_test_() ->
+    Test = fun stepswitch_util:correct_shortdial/4,
+    %% automatically-calculated = length(CallerNumber) - length(CalleeNumber) = 4
+    CallerNumber = <<"12223334444">>,
+    CalleeNumber = <<"3335555">>,
+    CallRestrictions = kz_json:from_list_recursive([{<<"unknown">>, [{<<"action">>, <<"deny">>}]}]),
+
+    meck:new('kapps_config', ['unstick', 'passthrough']),
+    meck:new('knm_converters', ['passthrough']),
+
+    Fixed = fun(L) -> fun(?SS_CONFIG_CAT, <<"fixed_length_shortdial_correction">>) -> L end end,
+
+    %% By default min=2, max=5, fixed=undefined
+    %% fixed=undefined, length=automatically-calculated
+    Resp1 = Test(CalleeNumber, CallerNumber, kz_json:new(), {'true', 0}),
+
+    meck:expect('kapps_config', 'get_integer', Fixed(6)),
+    %% fixed=6, length=fixed
+    Resp2 = Test(CalleeNumber, CallerNumber, kz_json:new(), {'true', 0}),
+
+    meck:expect('kapps_config', 'get_integer', Fixed(3)),
+    %% fixed=3, length=fixed
+    Resp3 = Test(CalleeNumber, CallerNumber, kz_json:new(), {'true', 0}),
+
+    meck:expect('kapps_config', 'get_integer', Fixed('undefined')),
+    %% fixed=undefined length=automatically-calculated+2 = 6
+    Resp4 = Test(CalleeNumber, <<CallerNumber/binary, "12">>, kz_json:new(), {'true', 0}),
+
+    %% fixed=undefined, length=automatically-calculated-3 = 1
+    Resp5 = Test(<<CalleeNumber/binary, "123">>, CallerNumber, kz_json:new(), {'true', 0}),
+
+    meck:expect('knm_converters', 'classify', fun(_) -> <<"unknown">> end), %% Just to be sure ;)
+    %% fixed=undefined, length=automatically-calculated
+    Resp6 = Test(CalleeNumber, CallerNumber, CallRestrictions, {'true', 0}),
+
+    meck:expect('kapps_config', 'get_integer', Fixed(1)),
+    %% fixed=1, length=fixed
+    Resp7 = Test(CalleeNumber, CallerNumber, CallRestrictions, {'true', 0}),
+
+    meck:expect('kapps_config', 'get_integer', Fixed(0)),
+    %% fixed=0, length=fixed
+    Resp8 = Test(CalleeNumber, CallerNumber, kz_json:new(), {'true', 0}),
+
+    Tests =
+        [{"If min_shortdial_destination is 'disabled', no call restrictions, and calculated length is between bounds or fixed is defined, return corrected number"
+         ,[?_assertEqual(<<"+12223335555">>, Resp1)
+          ,?_assertEqual(<<"1222333335555">>, Resp2)
+          ,?_assertEqual(<<"1223335555">>, Resp3)
+          ]
+         }
+        ,{"If fixed and min_shortdial_destination are 'disabled', no call restrictions, and calculated length is outside bounds, return undefined"
+         ,[?_assertEqual('undefined', Resp4)
+          ,?_assertEqual('undefined', Resp5)
+          ]
+         }
+        ,{"If min_shortdial_destination is disabled, calculated length is between bounds or fixed is defined, but call restrictions apply, return undefined"
+         ,[?_assertEqual('undefined', Resp6)
+          ,?_assertEqual('undefined', Resp7)
+          ]
+         }
+        ,{"If min_shortdial_destination is disabled, no call restrictions, and fixed value is 0 (zero), return undefined"
+         ,?_assertEqual('undefined', Resp8)
+         }
+        ,{"If min_shortdial_destination is defined and CalleeNumber's length doesn't match it, return undefined"
+         ,[?_assertEqual('undefined'
+                        ,Test(CalleeNumber, CallerNumber, kz_json:new(), {'false', byte_size(CalleeNumber) + 1})
+                        )
+          ,?_assertEqual('undefined'
+                        ,Test(CalleeNumber, CallerNumber, kz_json:new(), {'false', byte_size(CalleeNumber) - 1})
+                        )
+          ]
+         }
+        ],
+
+    meck:unload('knm_converters'),
+    meck:unload('kapps_config'),
+    Tests.


### PR DESCRIPTION
And also refactor short-dial correction code in order to be able to add
unit tests for that functionality per @jamesaimonetti request.

Master PRs:
- https://github.com/2600hz/kazoo-stepswitch/pull/4
- https://github.com/2600hz/kazoo-crossbar/pull/21