### PR TITLE
[4.3] HELP-15032: OAuth fixes for FusionAuth

### DIFF
--- a/applications/crossbar/src/modules/cb_auth.erl
+++ b/applications/crossbar/src/modules/cb_auth.erl
@@ -430,7 +430,7 @@ delete(Context, ?PROVIDERS_PATH, _Id) ->
 maybe_authenticate(Context) ->
     case kz_auth:authenticate(cb_context:doc(Context)) of
         {'ok', Claims} ->
-            lager:debug("verified auth: ~p",[Claims]),
+            lager:debug("verified auth claims: ~p", [Claims]),
             Doc = kz_json:set_value(<<"Claims">>, kz_json:from_list(Claims), kz_json:new()),
             Setters = [{fun cb_context:set_resp_status/2, 'success'}
                       ,{fun cb_context:set_doc/2, Doc}

--- a/core/kazoo_auth/doc/example/index.html
+++ b/core/kazoo_auth/doc/example/index.html
@@ -15,38 +15,36 @@
         <script src="//code.jquery.com/jquery-1.9.1.min.js"></script>
         <script src="popup.js"></script>
         <script>
-        function test() {
-        	var params = {
-        		client_id :"YOUR_CLIENT_ID",
-        		response_type : "code",
-        		redirect_uri : "WEB_URL",
-        		scope: ["openid", "profile", "email", "https://www.googleapis.com/auth/drive.file"].join(" "),
-        		include_granted_scopes : true,
-        		access_type : "offline",
-        		authuser : 0
-        	};
-            var url = "https://accounts.google.com/o/oauth2/auth?" + jQuery.param( params );
-            popup(url, params.redirect_uri, function(data) {
-                console.log(data);
-                $("#response")[0].innerText = JSON.stringify(data, null, 2);
-            });
-        }
-        function popup(url, redirect_url, callback) {
-            var pop = new Popup();
-            pop.open(url, "oauth", {}, redirect_url).then(function(oauth) {
-                callback(oauth)
-            }, function(error) {
-                console.log(error);
-            });
-        }
+          function test() {
+              // Adjust params according to your OAuth provider's requirements
+              var params = {
+        	  client_id :"084b9807-c15e-414c-ac49-774a9b156388",
+        	  redirect_uri : "http://localhost:8888",
+                  response_type: "code"
+              };
+              var url = "http://oauth.provider/oauth2/authorize?"  + jQuery.param( params );
 
-        function decode() {
-        	var Token = $('#token')[0].value;
-            var base64Url = Token.split('.')[1];
-            var base64 = base64Url.replace('-', '+').replace('_', '/');
-        	var decoded = JSON.parse(window.atob(base64));
-        	$('#decoded')[0].innerText = JSON.stringify(decoded, null, 2);
-        }
+              popup(url, params.redirect_uri, function(data) {
+                  console.log(data);
+                  $("#response")[0].innerText = JSON.stringify(data, null, 2);
+              });
+          }
+          function popup(url, redirect_url, callback) {
+              var pop = new Popup();
+              pop.open(url, "oauth", {}, redirect_url).then(function(oauth) {
+                  callback(oauth)
+              }, function(error) {
+                  console.log(error);
+              });
+          }
+
+          function decode() {
+              var Token = $('#token')[0].value;
+              var base64Url = Token.split('.')[1];
+              var base64 = base64Url.replace('-', '+').replace('_', '/');
+              var decoded = JSON.parse(window.atob(base64));
+              $('#decoded')[0].innerText = JSON.stringify(decoded, null, 2);
+          }
         </script>
         <div style="margin-top:50px;margin-left:100px">
         <button onclick="test();">AUTHORIZE</button>

--- a/core/kazoo_auth/priv/couchdb/providers/generic.oauth.json
+++ b/core/kazoo_auth/priv/couchdb/providers/generic.oauth.json
@@ -1,0 +1,47 @@
+{
+    "_id": "your_provider",
+    "access_code_url": "https://oauth.server/oauth2/token",
+    "auth_module": "oauth",
+    "auth_url": "https://oauth.server/oauth2/token",
+    "authorization_endpoint": "https://oauth.server/oauth2/auth",
+    "discovery": "https://oauth.server/.well-known/openid-configuration",
+    "enabled": true,
+    "grant_types_supported": [
+        "authorization_code",
+        "password",
+        "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        "refresh_token"
+    ],
+    "id_token_alg_values_supported": "RS256",
+    "issuer_domains": [
+        "oauth.server"
+    ],
+    "name": "Your OAuth Provider",
+    "oauth_url": "https://oauth.server/oauth2/token",
+    "profile_displayName_field": "name",
+    "profile_identity_field": "sub",
+    "profile_url": "https://oauth.server/oauth2/userinfo",
+    "public_key_discovery_field": "jwks_uri",
+    "public_key_jwt_field": "kid",
+    "public_key_jwt_location": "header",
+    "public_key_lookup_field": "kid",
+    "public_key_method": "lookup",
+    "pvt_provider_type": "oauth",
+    "pvt_type": "provider",
+    "response_types_supported": [
+        "code",
+        "token",
+        "id_token"
+    ],
+    "revocation_endpoint": "https://oauth.server/oauth2/revoke",
+    "scopes": [
+        "openid",
+        "email",
+        "profile"
+    ],
+    "subject_types_supported": [
+        "public"
+    ],
+    "token_endpoint": "https://oauth.server/oauth2/token",
+    "userinfo_endpoint": "https://oauth.server/oauth2/userinfo"
+}

--- a/core/kazoo_auth/src/kz_auth_util.erl
+++ b/core/kazoo_auth/src/kz_auth_util.erl
@@ -67,8 +67,10 @@ fetch_access_code(#{auth_app := #{name := ClientId
              ,{"code", AuthorizationCode}
              ],
     Body = string:join(lists:append(lists:map(fun({K,V}) -> [string:join([K, kz_term:to_list(V)], "=") ] end, Fields)),"&"),
+    lager:debug("POST ~s: ~s", [URL, Body]),
     case kz_http:post(kz_term:to_list(URL), Headers, Body, [{'ssl', [{'versions', ['tlsv1.2']}]}]) of
-        {'ok', 200, _RespHeaders, RespXML} -> {'ok', kz_json:decode(RespXML)};
+        {'ok', 200, _RespHeaders, RespJSON} ->
+            {'ok', kz_json:decode(RespJSON)};
         Else ->
             lager:error("~p", [Else]),
             {'error', Else}


### PR DESCRIPTION
Only the path of the provider's profile_url should be searched for
dynamic URL updates. Also provide a convenience function to generate
an auth token for API usage.