### PR TITLE
[4.3] HELP-14818: update stream_attachment options

### DIFF
--- a/core/kazoo_attachments/src/kz_att_azure.erl
+++ b/core/kazoo_attachments/src/kz_att_azure.erl
@@ -35,14 +35,14 @@ put_attachment(Settings, DbName, DocId, AName, Contents, Options) ->
 
     {Container, Name} = resolve_path(Settings, {DbName, DocId, AName}),
     Pid = azure_pid(Settings),
-    AzureOptions = [{content_type, kz_term:to_list(CT)}, return_headers],
+    AzureOptions = [{'content_type', kz_term:to_list(CT)}, 'return_headers'],
     Url = lists:concat([Container, "/", Name]),
     Routines = [{fun kz_att_error:set_req_url/2, Url}
                 | kz_att_error:put_routines(Settings, DbName, DocId, AName, Contents, Options)
                ],
     try
         case erlazure:put_block_blob(Pid, Container, Name, Contents, AzureOptions) of
-            {ok, Headers, _Body} ->
+            {'ok', Headers, _Body} ->
                 props:to_log(Headers, <<"AZURE HEADERS">>),
                 Data = base64:encode(term_to_binary({Settings#{file => Name}, Name})),
                 Metadata = kz_json:from_list(kz_att_util:headers_as_binaries(Headers)),
@@ -61,7 +61,6 @@ put_attachment(Settings, DbName, DocId, AName, Contents, Options) ->
                         [_StackTrace, _FnFailing]),
             handle_erlazure_error_response(ErrorResp, Routines)
     end.
-
 
 -spec fetch_attachment(gen_attachment:handler_props()
                       ,gen_attachment:db_name()

--- a/core/kazoo_data/src/kz_datamgr.erl
+++ b/core/kazoo_data/src/kz_datamgr.erl
@@ -1098,7 +1098,11 @@ stream_attachment(DbName, DocId, AName, Options) ->
 stream_attachment(DbName, {DocType, DocId}, AName, Options, Pid) when ?VALID_DBNAME(DbName) ->
     stream_attachment(DbName, DocId, AName, maybe_add_doc_type(DocType, Options), Pid);
 stream_attachment(DbName, DocId, AName, Options, Pid) when ?VALID_DBNAME(DbName) ->
-    kzs_attachments:stream_attachment(kzs_plan:plan(DbName, Options), DbName, DocId, AName, Pid);
+    case attachment_options(DbName, DocId, Options) of
+        {'error', _E}=Error -> Error;
+        {'ok', NewOpts} ->
+            kzs_attachments:stream_attachment(kzs_plan:plan(DbName, NewOpts), DbName, DocId, AName, Pid)
+    end;
 stream_attachment(DbName, DocId, AName, Options, Pid) ->
     case maybe_convert_dbname(DbName) of
         {'ok', Db} -> stream_attachment(Db, DocId, AName, Options, Pid);

--- a/core/kazoo_media/src/kz_media_url.erl
+++ b/core/kazoo_media/src/kz_media_url.erl
@@ -44,7 +44,7 @@ playback(<<"prompt://", PromptPath/binary>>, Options) ->
             lager:warning("invalid prompt path: ~p", [_Path]),
             {'error', 'invalid_media_name'}
     end;
-playback(<<_/binary>> = Media, JObj) ->
+playback(<<Media/binary>>, JObj) ->
     lager:debug("lookup media url for ~s", [Media]),
     kz_media_file:get_uri(Media, JObj);
 playback(Path, JObj)


### PR DESCRIPTION
fetch_/put_attachment functions updated Options args with the doc's
_rev and doc type, necessary for selecting the proper dataplan before
doing the operation. stream_attachment was not updated and was
selecting the wrong (read: default) plan for the attachment.