### PR TITLE
PISTON-1090: backport stepswitch loopback fields to fix fax doc "from"

### DIFF
--- a/applications/stepswitch/src/stepswitch_local_extension.erl
+++ b/applications/stepswitch/src/stepswitch_local_extension.erl
@@ -312,6 +312,7 @@ build_local_extension(#state{number_props=Props
                    [{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Inception">>, <<Number/binary, "@", Realm/binary>>}
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Account-ID">>, AccountId}
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Retain-CID">>, kz_json:get_value(<<"Retain-CID">>, CCVsOrig)}
+                   ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "SIP-Invite-Domain">>, Realm}
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "From-URI">>, FromURI}
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Inception-Account-ID">>, OriginalAccountId}
                    ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Resource-Type">>, <<"onnet-origination">>}

--- a/applications/stepswitch/src/stepswitch_outbound.erl
+++ b/applications/stepswitch/src/stepswitch_outbound.erl
@@ -175,16 +175,31 @@ create_loopback_endpoint(Props, OffnetReq) ->
     {CIDNum, CIDName} = local_originate_caller_id(OffnetReq),
     lager:debug("set outbound caller id to ~s '~s'", [CIDNum, CIDName]),
     Number = knm_number_options:number(Props),
-    AccountId = knm_number_options:account_id(Props),
-    Realm = get_account_realm(AccountId),
+    TargetAccountId = knm_number_options:account_id(Props),
+    TargetResellerId = kz_services_reseller:get_id(TargetAccountId),
+    TargetRealm = get_account_realm(TargetAccountId),
+    OriginalAccountId = kapi_offnet_resource:account_id(OffnetReq),
+    OriginalResellerId = kz_services_reseller:get_id(OriginalAccountId),
+    FromRealm = get_account_realm(OriginalAccountId),
     CCVs = kz_json:from_list(
-             [{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Inception">>, <<Number/binary, "@", Realm/binary>>}
-             ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Account-ID">>, AccountId}
+             [{<<"Account-ID">>, OriginalAccountId}
+             ,{<<"Reseller-ID">>, OriginalResellerId}
+             ,{<<"Realm">>, FromRealm}
+             ,{<<"Resource-ID">>, TargetAccountId}
+             ,{<<"Resource-Type">>, <<"onnet-termination">>}
+             ,{<<"From-URI">>, <<CIDNum/binary, "@", FromRealm/binary>>}
+             ,{<<"Request-URI">>, <<Number/binary, "@", FromRealm/binary>>}
+             ,{<<"To-URI">>, <<Number/binary, "@", FromRealm/binary>>}
+
+             ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Inception">>, <<Number/binary, "@", TargetRealm/binary>>}
+             ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Account-ID">>, TargetAccountId}
+             ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Reseller-ID">>, TargetResellerId}
              ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Retain-CID">>, "true"}
              ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Resource-Type">>, <<"onnet-origination">>}
-             ,{<<"Resource-ID">>, AccountId}
-             ,{<<"Loopback-Request-URI">>, <<Number/binary, "@", Realm/binary>>}
-             ,{<<"Resource-Type">>, <<"onnet-termination">>}
+             ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "From-URI">>, <<CIDNum/binary, "@", TargetRealm/binary>>}
+             ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "Request-URI">>, <<Number/binary, "@", TargetRealm/binary>>}
+             ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "To-URI">>, <<Number/binary, "@", TargetRealm/binary>>}
+             ,{<<?CHANNEL_LOOPBACK_HEADER_PREFIX, "SIP-Invite-Domain">>, TargetRealm}
              ]),
     CAVs = kapi_offnet_resource:custom_application_vars(OffnetReq),
     kz_json:from_list(
@@ -201,7 +216,7 @@ create_loopback_endpoint(Props, OffnetReq) ->
       ,{<<"Outbound-Caller-ID-Number">>, CIDNum}
       ,{<<"Route">>, Number}
       ,{<<"To-DID">>, Number}
-      ,{<<"To-Realm">>, Realm}
+      ,{<<"To-Realm">>, TargetRealm}
       ]).
 %%------------------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
Based on discussion in IRC on 12 June 2020. Fixes the "from_uri" (& other variables) of a loopback channel, so that the CDRs and fax recipient doc contain the expected values.

- backport of https://github.com/2600hz/kazoo-stepswitch/commit/23b4030b86cdeec92739c170e8a99e9dc6e4d8f9