### PR TITLE
[4.3] PROD-157: Seperate telemetry consensus logic

### DIFF
--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -1232,9 +1232,14 @@ maybe_add_zone(#kz_node{zone=Zone, broker=B}, #state{zones=Zones}=State) ->
 
 -spec node_info() -> kz_json:object().
 node_info() ->
-    kz_json:from_list(pool_states()
-                      ++ amqp_status()
-                     ).
+    AMQP = [{<<"connections">>, kz_json:from_list(amqp_status())}
+           ,{<<"pools">>, kz_json:from_list(pool_states())}
+           ],
+    Info = kazoo_bindings:map(<<"kz_nodes.node.info">>, []),
+    NodeInfo = [{<<"amqp">>, kz_json:from_list(AMQP)}
+                | [{Key, Value} || {Key, Value} <- Info]
+               ],
+    kz_json:from_list(NodeInfo).
 
 -spec amqp_status() -> [{kz_term:ne_binary(), kz_json:object()}].
 amqp_status() ->

--- a/core/kazoo_stdlib/include/kz_records.hrl
+++ b/core/kazoo_stdlib/include/kz_records.hrl
@@ -20,7 +20,7 @@
                  ,conferences = 0 :: non_neg_integer() | '_'
                  ,registrations = 0 :: non_neg_integer() | '_'
                  ,globals = [] :: kz_term:proplist() | '$1' | '_'
-                 ,node_info :: kz_term:api_object() | '_'
+                 ,node_info :: kz_term:api_object() | '$2' | '_'
                  ,roles = [] :: kz_term:proplist() | '$1' | '_'
                  }).
 

--- a/core/kazoo_telemetry/include/kazoo_telemetry.hrl
+++ b/core/kazoo_telemetry/include/kazoo_telemetry.hrl
@@ -10,7 +10,6 @@
 
 -define(TELEMETRY_CAT, <<"telemetry">>).
 -define(TM_LEADER_TICK, 60000).
--define(TM_LEADER_APP, <<"kazoo_telemetry">>).
 -define(TM_RESPONDERS, [<<"waveguide_responder">>]).
 
 -define(ANONYMIZE_CLUSTER

--- a/core/kazoo_telemetry/src/extractors/kztm_nodes_extractor.erl
+++ b/core/kazoo_telemetry/src/extractors/kztm_nodes_extractor.erl
@@ -127,5 +127,11 @@ media_servers_foldl({Server, Meta}, Acc) ->
 %%------------------------------------------------------------------------------
 -spec maybe_extract_kamailio_metadata(kz_types:kz_node(), kz_json:objects()) -> kz_json:objects().
 maybe_extract_kamailio_metadata(#kz_node{roles=[]}, Acc) -> Acc;
-maybe_extract_kamailio_metadata(#kz_node{roles=_Roles, registrations=Registrations}, Acc) ->
-    kz_json:set_value(<<"registrations">>, Registrations, Acc).
+maybe_extract_kamailio_metadata(#kz_node{roles=Roles}, Acc) ->
+    case props:get_value(<<"Registrar">>, Roles) of
+        'undefined' -> Acc;
+        Registrar ->
+            Registrations = kz_json:get_integer_value(<<"Registrations">>, Registrar, 0),
+            lager:notice("Registrations: ~p", [Registrations]),
+            kz_json:set_value(<<"registrations">>, Registrations, Acc)
+    end.

--- a/core/kazoo_telemetry/src/kazoo_telemetry_app.erl
+++ b/core/kazoo_telemetry/src/kazoo_telemetry_app.erl
@@ -12,7 +12,6 @@
 
 -export([start/2
         ,stop/1
-        ,request/1
         ]).
 
 %%------------------------------------------------------------------------------
@@ -21,8 +20,6 @@
 %%------------------------------------------------------------------------------
 -spec start(application:start_type(), any()) -> kz_types:startapp_ret().
 start(_Type, _Args) ->
-    _ = kz_util:set_startup(),
-    _ = kz_nodes_bindings:bind('kazoo_telemetry'),
     kazoo_telemetry_sup:start_link().
 
 %%------------------------------------------------------------------------------
@@ -31,8 +28,4 @@ start(_Type, _Args) ->
 %%------------------------------------------------------------------------------
 -spec stop(any()) -> any().
 stop(_State) ->
-    _ = kz_nodes_bindings:unbind('kazoo_telemetry'),
     'ok'.
-
--spec request(kz_nodes:request_acc()) -> kz_nodes:request_acc().
-request(Acc) -> Acc.

--- a/core/kazoo_telemetry/src/kazoo_telemetry_leader.erl
+++ b/core/kazoo_telemetry/src/kazoo_telemetry_leader.erl
@@ -12,6 +12,7 @@
 
 -export([start_link/0
         ,leader/0
+        ,node_info/0
         ]).
 -export([init/1
         ,handle_call/3
@@ -28,9 +29,19 @@
 -record(state, {leader = 'undefined' :: node() | 'undefined'
                ,leader_poll_tref :: reference()
                ,responders = [] :: kz_term:ne_binaries()
+               ,startup = 0 :: non_neg_integer()
                }).
 
 -type state() :: #state{}.
+
+-include_lib("kazoo_stdlib/include/kz_types.hrl").
+
+-type oldest_kztm_node() :: 'undefined' |
+                            {node(), kz_time:gregorian_seconds()}.
+
+-define(NODE_INFO_BINDING, <<"kz_nodes.node.info">>).
+-define(NODE_KEY, <<"telemetry">>).
+
 
 %%%=============================================================================
 %%% API
@@ -42,7 +53,49 @@
 %%------------------------------------------------------------------------------
 -spec leader() -> node().
 leader() ->
-    kz_nodes:whapp_oldest_node(?TM_LEADER_APP).
+    case kztm_oldest_node() of
+        'undefined' -> node();
+        {Node, _} -> Node
+    end.
+
+-spec kztm_oldest_node() -> oldest_kztm_node().
+kztm_oldest_node() ->
+    MatchSpec = [{#kz_node{node='$1'
+                          ,node_info='$2'
+                          ,_ = '_'
+                          }
+                 ,[]
+                 ,[{{'$1','$2'}}]
+                 }],
+    determine_kztm_oldest_node(MatchSpec).
+
+-spec determine_kztm_oldest_node(ets:match_spec()) -> oldest_kztm_node().
+determine_kztm_oldest_node(MatchSpec) ->
+    Results = ets:select('kz_nodes', MatchSpec),
+    lists:foldl(fun determine_kztm_oldest_node_fold/2, 'undefined', Results).
+
+-spec determine_kztm_oldest_node_fold({node(), kz_term:api_object()}, oldest_kztm_node()) -> oldest_kztm_node().
+determine_kztm_oldest_node_fold({_Node, 'undefined'}, Acc) ->
+    Acc;
+determine_kztm_oldest_node_fold({Node, Info}, Acc) ->
+    NodeTs = kz_json:get_integer_value([?NODE_KEY, <<"Startup">>], Info, 'undefined'),
+    case Acc of
+        'undefined' when NodeTs =:= 'undefined' -> Acc;
+        'undefined' -> {Node, NodeTs};
+        {_, Startup} when NodeTs < Startup -> {Node, NodeTs};
+        _ -> Acc
+    end.
+
+-spec node_info() -> {kz_term:ne_binary(), kz_json:object()}.
+node_info() ->
+    Info = [{<<"Startup">>, startup()}
+           ,{<<"leader">>, leader()}
+           ],
+    {?NODE_KEY, kz_json:from_list(Info)}.
+
+-spec startup() -> non_neg_integer().
+startup() ->
+    gen_server:call(?SERVER, 'startup').
 
 %%------------------------------------------------------------------------------
 %% @doc Starts the server
@@ -62,10 +115,15 @@ start_link() ->
 %%------------------------------------------------------------------------------
 -spec init([]) -> {'ok', state()}.
 init([]) ->
+    _ = kz_util:set_startup(),
+    _ = kazoo_bindings:bind(?NODE_INFO_BINDING
+                           ,'kazoo_telemetry_leader'
+                           ,'node_info'),
     lager:notice("starting kazoo_telemetry leader"),
     LeaderCheck = erlang:start_timer(?TM_LEADER_TICK, self(), 'leader_poll'),
     {'ok', #state{responders=?TM_RESPONDERS
                  ,leader_poll_tref = LeaderCheck
+                 ,startup = get('$startup')
                  }}.
 
 %%------------------------------------------------------------------------------
@@ -73,6 +131,8 @@ init([]) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_call(any(), kz_term:pid_ref(), state()) -> kz_types:handle_call_ret_state(state()).
+handle_call('startup', _From, #state{startup=Startup}=State) ->
+    {'reply', Startup, State};
 handle_call(_Request, _From, State) ->
     {'reply', 'ok', State}.
 
@@ -90,11 +150,20 @@ handle_cast('leader_change', #state{leader=OldLeader}=State) ->
             {'noreply', NewState};
         'true' ->
             lager:debug("elected telemetry leader starting responders"),
-            _Pids = lists:foldl(fun(App, Acc) -> {'ok', Pid} = (kz_term:to_atom(App)):start_link(), [{App, Pid} | Acc] end,[], State#state.responders),
+            _ = lists:foreach(fun responder_start_fold/1, State#state.responders),
             {'noreply', NewState}
     end;
 handle_cast(_Msg, State) ->
     {'noreply', State}.
+
+-spec responder_start_fold(kz_term:ne_binary()) -> 'ok'.
+responder_start_fold(App) ->
+    case (kz_term:to_atom(App)):start_link() of
+        {'error', _R} ->
+            lager:debug("issue starting telemetry responder: ~p", [_R]),
+            'ok';
+        _ -> 'ok'
+    end.
 
 %%------------------------------------------------------------------------------
 %% @doc Handling all non call/cast messages
@@ -150,3 +219,4 @@ maybe_stop_responders(_State, 'false') -> 'ok';
 maybe_stop_responders(#state{responders=Responders}, _) ->
     lists:foldl(fun(R, _) -> (kz_term:to_atom(R)):stop() end, [], Responders),
     'ok'.
+

--- a/core/kazoo_telemetry/src/kazoo_telemetry_sup.erl
+++ b/core/kazoo_telemetry/src/kazoo_telemetry_sup.erl
@@ -44,7 +44,6 @@ start_link() ->
 %%------------------------------------------------------------------------------
 -spec init(any()) -> kz_types:sup_init_ret().
 init([]) ->
-    _ = kz_util:set_startup(),
     RestartStrategy = 'one_for_one',
     MaxRestarts = 5,
     MaxSecondsBetweenRestarts = 10,


### PR DESCRIPTION
This PR modifies how kazoo_telemetry determines its leader and removes functionality from `kz_nodes`.

### Changes:
- backports change to `kz_nodes` to use node_info binding to retrieve metadata for node_info status
- consensus logic moved to `kazoo_telemetry_leader`
- `kazoo_telemetry_leader` now uses node_info binding to publish leader data
- fixes bug where registration metadata wasn't being from registrar role in #kz_node{} record


