### PR TITLE
[4.3] PISTON-1002: use collect_digits for DTMF during vm greeting/instructions

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -460,18 +460,25 @@ play_announcement(Box, Call) ->
     end.
 
 -spec start_composing_voicemail(mailbox(), kapps_call:call()) -> compose_return().
-start_composing_voicemail(#mailbox{media_extension=Ext}=Box, Call) ->
+start_composing_voicemail(#mailbox{interdigit_timeout=Interdigit
+                                  ,media_extension=Ext
+                                  }=Box, Call) ->
     lager:debug("playing mailbox greeting to caller"),
     _ = play_greeting_intro(Box, Call),
     _ = play_greeting(Box, Call),
     _ = play_instructions(Box, Call),
-    _NoopId = kapps_call_command:noop(Call),
-    %% timeout after 5 min for safety, so this process cant hang around forever
-    case kapps_call_command:wait_for_application_or_dtmf(<<"noop">>, 300000) of
-        {'ok', _} ->
+    NoopId = kapps_call_command:noop(Call),
+    case kapps_call_command:collect_digits(?KEY_LENGTH
+                                          ,0
+                                          ,Interdigit
+                                          ,NoopId
+                                          ,Call
+                                          )
+    of
+        {'ok', <<>>} ->
             lager:info("played greeting and instructions to caller, recording new message"),
             record_voicemail(tmp_file(Ext), Box, Call);
-        {'dtmf', Digit} ->
+        {'ok', Digit} ->
             _ = kapps_call_command:b_flush(Call),
             handle_compose_dtmf(Box, Call, Digit);
         {'error', R} ->


### PR DESCRIPTION
Backport of https://github.com/2600hz/kazoo/pull/6249. Going to make a change in master as well as the 8-arity version of kapps_call_command:collect_digits wasn't actually needed.