### PR TITLE
fix missing variable_Call-Control-Queue for kazoo originated calls

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_fs_channel.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_channel.erl
@@ -136,7 +136,8 @@ is_bridged(UUID) ->
                 ],
     case ets:select(?CHANNELS_TBL, MatchSpec) of
         ['undefined'] -> lager:debug("channel is not bridged"), 'false';
-        [Bin] when is_binary(Bin) -> lager:debug("is bridged to: ~s", [Bin]), 'true';
+        [Bin] when is_binary(Bin) 
+                    andalso Bin =/= UUID -> lager:debug("is bridged to: ~s", [Bin]), 'true';
         _E -> lager:debug("not bridged: ~p", [_E]), 'false'
     end.
 

--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -527,7 +527,7 @@ build_originate_args_from_endpoints(Action, Endpoints, JObj, FetchId, CtrlPid) -
 -spec get_channel_vars(kz_json:object(), kz_term:ne_binary()) -> iolist().
 get_channel_vars(JObj, FetchId) ->
     InteractionId = kz_json:get_value([<<"Custom-Channel-Vars">>, <<?CALL_INTERACTION_ID>>], JObj, ?CALL_INTERACTION_DEFAULT),
-    
+
     CCVs = [{<<"Fetch-ID">>, FetchId}
            ,{<<"Ecallmgr-Node">>, kz_term:to_binary(node())}
            ,{<<?CALL_INTERACTION_ID>>, InteractionId}


### PR DESCRIPTION
@lazedo @noahmehl
This is a draft PR to solicit feedback.

There appears to be a problem when Kazoo originates a call to an Endpoint using ecallmgr_originate. The channel variable 'Call-Control-Queue' is not defined in dialstring sent to FS which in turn causes CHANNEL_EXECUTE_COMPLETE events to be blocked due to the filter in CHANNEL_EXECUTE_COMPLETE.xml [https://github.com/2600hz/kazoo/blob/master/applications/ecallmgr/priv/mod_kazoo/events/CHANNEL_EXECUTE_COMPLETE.xml#L4]

With this quick fix, the variable is defined and the events start working.

