### PR TITLE
[4.3] HELP-15749: start kazoo_number_manager before kazoo_events

### DIFF
--- a/applications/blackhole/src/blackhole_data_emitter.erl
+++ b/applications/blackhole/src/blackhole_data_emitter.erl
@@ -13,11 +13,12 @@
 -define(MAX_QUEUED_MESSAGES, kapps_config:get_integer(?CONFIG_CAT, <<"max_queued_messages">>, 50)).
 
 -spec event(map(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
-event(Binding, RK, Name, Data) ->
-    #{subscribed_key := SubscribedKey
-     ,subscription_key := SubscriptionKey
-     ,session_pid := SessionPid
-     } = Binding,
+event(#{subscribed_key := SubscribedKey
+       ,subscription_key := SubscriptionKey
+       ,session_pid := SessionPid
+       }
+     ,RK, Name, Data
+     ) ->
     Msg = [{<<"action">>, <<"event">>}
           ,{<<"subscribed_key">>, SubscribedKey}
           ,{<<"subscription_key">>, SubscriptionKey}
@@ -25,6 +26,7 @@ event(Binding, RK, Name, Data) ->
           ,{<<"routing_key">>, RK}
           ,{<<"data">>, Data}
           ],
+    lager:debug("sending event with routing key ~s to session PID ~p", [RK, SessionPid]),
     maybe_send(SessionPid, kz_json:from_list(Msg)).
 
 -spec reply(pid(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> 'ok'.
@@ -47,7 +49,6 @@ maybe_send(_SessionPid, _Data, 'undefined') ->
 
 maybe_send(SessionPid, _Data, QueueLen, MaxLen) when QueueLen > MaxLen ->
     lager:error("~p queue length ~p (max: ~p), dropping event", [SessionPid, QueueLen, MaxLen]);
-maybe_send(SessionPid, Data, QueueLen, _MaxLen) ->
-    lager:info("~p queue length ~p (max: ~p)", [SessionPid, QueueLen, _MaxLen]),
+maybe_send(SessionPid, Data, _QueueLen, _MaxLen) ->
     SessionPid ! {'send_data', Data},
     'ok'.

--- a/applications/blackhole/src/blackhole_maintenance.erl
+++ b/applications/blackhole/src/blackhole_maintenance.erl
@@ -112,15 +112,17 @@ active_sessions_by_account(<<AccountId/binary>>) ->
 
 -spec print_sessions([bh_context:context()]) -> 'ok'.
 print_sessions([]) -> io:format("no active sessions~n");
+print_sessions({'error', 'not_found'}) -> io:format("no active sessions~n");
 print_sessions(Sessions) ->
     io:format("Active websocket connections:~n"),
-    io:format("~22s | ~10s | ~12s | ~32s~n", [<<"Peer">>, <<"Uptime">>, <<"PID">>, <<"Account-ID">>]),
+    io:format("~22s | ~10s | ~12s | ~32s | ~s~n", [<<"Peer">>, <<"Uptime">>, <<"PID">>, <<"Account-ID">>, <<"Bindings">>]),
     lists:foreach(fun print_session/1, Sessions).
 
 print_session(Context) ->
-    io:format("~22s | ~10s | ~12s | ~32s~n"
+    io:format("~22s | ~10s | ~12s | ~32s | ~s~n"
              ,[bh_context:websocket_session_id(Context)
               ,kz_time:pretty_print_elapsed_s(kz_time:elapsed_s(bh_context:timestamp(Context)))
               ,kz_term:to_binary(bh_context:websocket_pid(Context))
               ,bh_context:auth_account_id(Context)
+              ,bh_context:client_bindings(Context)
               ]).

--- a/core/kazoo_events/include/kz_hooks.hrl
+++ b/core/kazoo_events/include/kz_hooks.hrl
@@ -2,8 +2,9 @@
 
 -define(HOOKS_CACHE_NAME, 'kz_hooks_cache').
 
--define(HOOK_EVT(AccountId, EventType, JObj),
-        {'kz_hook', AccountId, EventType, JObj}).
+-define(HOOK_EVT(AccountId, EventType, JObj)
+       ,{'kz_hook', AccountId, EventType, JObj}
+       ).
 
 -define(KZ_HOOKS_HRL, 'true').
 -endif.

--- a/core/kazoo_events/src/kazoo_events.app.src
+++ b/core/kazoo_events/src/kazoo_events.app.src
@@ -1,20 +1,11 @@
-{application, kazoo_events,
- [
-  {description, "Kazoo shared events for Applications"}
- ,{id, "9fd3b140-8727-11e0-9d78-0800200c9a66"}
- ,{vsn, "4.0.0"}
- ,{modules, []}
- ,{registered, [kazoo_events_sup, kz_hooks_cache, kz_hooks_listener, kz_hooks_shared_listener]}
- ,{applications, [ kernel
-                 , stdlib
-
-                 , kazoo_amqp
-
-                 , syslog
-                 , lager
-                 , lager_syslog
-                 , gproc
-                 , eflame
-                 ]}
- ,{mod, {kazoo_events_app, []}}
- ]}.
+{application,kazoo_events,
+             [{applications,[gproc,kazoo,kazoo_amqp,kazoo_apps,kazoo_caches,
+                             kazoo_documents,kazoo_number_manager,
+                             kazoo_stdlib,kernel,lager,stdlib]},
+              {description,"Kazoo shared events for Applications"},
+              {id,"9fd3b140-8727-11e0-9d78-0800200c9a66"},
+              {vsn,"4.0.0"},
+              {modules,[]},
+              {registered,[kazoo_events_sup,kz_hooks_cache,kz_hooks_listener,
+                           kz_hooks_shared_listener]},
+              {mod,{kazoo_events_app,[]}}]}.

--- a/core/kazoo_proper/src/pqc_blackhole.erl
+++ b/core/kazoo_proper/src/pqc_blackhole.erl
@@ -124,6 +124,9 @@ seq_api() ->
     %% test receiving events over the ws
     _ = test_crud_user_events(WSConn, API, AccountId),
 
+    %% test receiving call events over the ws
+    _ = test_channel_create(WSConn, API, AccountId),
+
     %% test unbinding for events
     _ = test_ws_unbind(API, WSConn, AccountId, SocketId, BindReq, Binding),
 
@@ -247,7 +250,6 @@ test_crud_user_events(WSConn, API, AccountId) ->
     UserId = kz_json:get_ne_binary_value(<<"id">>, DeleteJObj).
 
 test_ws_unbind(API, WSConn, AccountId, SocketId, BindReq, Binding) ->
-
     UnbindReqId = kz_binary:rand_hex(4),
     UnbindReq = kz_json:set_values([{<<"action">>, <<"unsubscribe">>}
                                    ,{<<"request_id">>, UnbindReqId}
@@ -274,3 +276,54 @@ test_empty_active_connections(API, AccountId) ->
     EmptySockets = pqc_cb_websockets:summary(API, AccountId),
     lager:info("empty: ~s", [EmptySockets]),
     [] = kz_json:get_list_value(<<"data">>, kz_json:decode(EmptySockets)).
+
+test_channel_create(WSConn, #{auth_token := AuthToken}, AccountId) ->
+    BindReqId = kz_binary:rand_hex(4),
+    BindReq = kz_json:from_list([{<<"action">>, <<"subscribe">>}
+                                ,{<<"auth_token">>, AuthToken}
+                                ,{<<"request_id">>, BindReqId}
+                                ,{<<"data">>
+                                 ,kz_json:from_list([{<<"account_id">>, AccountId}
+                                                    ,{<<"binding">>, (Binding = <<"call.CHANNEL_CREATE.*">>)}
+                                                    ])
+                                 }
+                                ]),
+    _Send = pqc_ws_client:send(WSConn, kz_json:encode(BindReq)),
+    {'json', BindReplyJObj} = pqc_ws_client:recv(WSConn, 1000),
+    lager:info("bind reply: ~p", [BindReplyJObj]),
+    <<"reply">> = kz_json:get_ne_binary_value(<<"action">>, BindReplyJObj),
+    BindReqId = kz_json:get_ne_binary_value(<<"request_id">>, BindReplyJObj),
+    <<"success">> = kz_json:get_ne_binary_value(<<"status">>, BindReplyJObj),
+    Bindings = kz_json:get_list_value([<<"data">>, <<"subscribed">>], BindReplyJObj),
+    'true' = lists:member(Binding, Bindings),
+
+    CallId = kz_binary:rand_hex(4),
+    CallProps = [{<<"Event-Name">>, <<"CHANNEL_CREATE">>}
+                ,{<<"Call-ID">>, CallId}
+                ,{<<"variable_sip_req_uri">>, <<"request@domain.com">>}
+                ,{<<"variable_sip_to_uri">>, <<"to@domain.com">>}
+                ,{<<"variable_sip_from_uri">>, <<"from@domain.com">>}
+                ,{<<"Call-Direction">>, <<"inbound">>}
+                ,{<<"Custom-Channel-Vars">>, kz_json:from_list([{<<"Account-ID">>, AccountId}])}
+                 | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                ],
+    lager:info("publishing call event ~s", [CallId]),
+    ecallmgr_call_events:publish_event(CallProps),
+    {'json', CallEvent} = pqc_ws_client:recv(WSConn, 1000),
+    lager:info("call event: ~p", [CallEvent]),
+
+    UnbindReqId = kz_binary:rand_hex(4),
+    UnbindReq = kz_json:set_values([{<<"action">>, <<"unsubscribe">>}
+                                   ,{<<"request_id">>, UnbindReqId}
+                                   ]
+                                  ,BindReq
+                                  ),
+    _Send = pqc_ws_client:send(WSConn, kz_json:encode(UnbindReq)),
+
+    {'json', UnbindReplyJObj} = pqc_ws_client:recv(WSConn, 1000),
+    lager:info("unbind reply: ~p", [UnbindReplyJObj]),
+    <<"reply">> = kz_json:get_ne_binary_value(<<"action">>, UnbindReplyJObj),
+    UnbindReqId = kz_json:get_ne_binary_value(<<"request_id">>, UnbindReplyJObj),
+    <<"success">> = kz_json:get_ne_binary_value(<<"status">>, UnbindReplyJObj),
+    [Binding] = kz_json:get_list_value([<<"data">>, <<"unsubscribed">>], UnbindReplyJObj),
+    [_] = kz_json:get_list_value([<<"data">>, <<"subscribed">>], UnbindReplyJObj).


### PR DESCRIPTION
When blackhole runs stand-alone, it relies on kazoo_events for the
kz_hooks when subscriptions for channel events are made. When the
event is a CHANNEL_CREATE from offnet, and no account ID is
associated, kz_hooks_util uses knm_number to lookup the account
associated with the destination.

kazoo_events.app did not list kazoo_number_manager as a dependency;
thus knm was not started and number lookups failed since the knm cache
wasn't started.

Updating kazoo_events.app to its proper dependencies resolves the issue.