### PR TITLE
Prevent Agent in Queue from Logging-out for ever

### DIFF
--- a/applications/acdc/src/acdc_agents_sup.erl
+++ b/applications/acdc/src/acdc_agents_sup.erl
@@ -82,7 +82,7 @@ stop_agent(AcctId, AgentId) ->
     case supervisor:terminate_child(?SERVER, Id) of
         'ok' ->
             lager:info("stopping agent ~s(~s)", [AgentId, AcctId]),
-            supervisor:delete_child(?SERVER, Id);
+            supervisor:restart_child(?SERVER, Id);
         E ->
             lager:info("no supervisor for agent ~s(~s) to stop", [AgentId, AcctId]),
             E


### PR DESCRIPTION
When queue agent doesn't answers to call until the queue goes timeout, ACDC will kicked him out from queue forever.

It seems there is an issue in `restart_agent`.

Scenario:
- Make a call to queue.
- The Agent doesn't answers to call in the current call-queue while call timeout.
- Agent will be logged-out from queue for ever and doesn't back to queue!


Fix:
Use restart_child method instead of delete_child.

Questions:
- Is it a right change in code to fix?
- Is this really an issue or it's normal behavior of ACDC?
