### PR TITLE
HELP-15121: Fix moh-sound conference setting to work with media-id

### DIFF
--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -516,9 +516,10 @@ get_prompt(PromptId, Lang, _AccountId, 'false') ->
             kz_binary:join([<<"prompt:/">>, ?KZ_MEDIA_DB, PromptId, Lang], <<"/">>)
     end.
 
--spec maybe_prompt_path(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), {'ok', kz_json:object()} | {'error', 'not_found'}) ->
+-spec maybe_prompt_path(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), {'ok', kz_json:object()} | kz_datamgr:data_error()) ->
           kz_term:api_ne_binary().
-maybe_prompt_path(PromptId, Lang, AccountId, {'error', 'not_found'}) ->
+maybe_prompt_path(PromptId, Lang, AccountId, {'error', _}=Err) ->
+    lager:debug("building default prompt path. Error looking up for prompt ~s: ~p", [PromptId, Err]),
     kz_binary:join([<<"prompt:/">>, AccountId, PromptId, Lang], <<"/">>);
 maybe_prompt_path(PromptId, _Lang, AccountId, {'ok', _}) ->
     prompt_path(AccountId, PromptId).

--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -500,7 +500,11 @@ get_prompt(PromptId, Lang, AccountId, 'true') ->
             PromptId;
         'false' ->
             lager:debug("using account override for ~s in account ~s", [PromptId, AccountId]),
-            kz_binary:join([<<"prompt:/">>, AccountId, PromptId, Lang], <<"/">>)
+            maybe_prompt_path(PromptId
+                             ,Lang
+                             ,AccountId
+                             ,lookup_prompt(kz_util:format_account_db(AccountId), PromptId)
+                             )
     end;
 get_prompt(PromptId, Lang, _AccountId, 'false') ->
     case is_not_prompt(PromptId) of
@@ -511,6 +515,11 @@ get_prompt(PromptId, Lang, _AccountId, 'false') ->
             lager:debug("account overrides not enabled; ignoring account prompt for ~s", [PromptId]),
             kz_binary:join([<<"prompt:/">>, ?KZ_MEDIA_DB, PromptId, Lang], <<"/">>)
     end.
+
+maybe_prompt_path(PromptId, Lang, AccountId, {'error', 'not_found'}) ->
+    kz_binary:join([<<"prompt:/">>, AccountId, PromptId, Lang], <<"/">>);
+maybe_prompt_path(PromptId, _Lang, AccountId, {'ok', _}) ->
+    prompt_path(AccountId, PromptId).
 
 -spec is_not_prompt(kz_term:api_binary()) -> boolean().
 is_not_prompt('undefined') -> 'true';

--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -516,6 +516,8 @@ get_prompt(PromptId, Lang, _AccountId, 'false') ->
             kz_binary:join([<<"prompt:/">>, ?KZ_MEDIA_DB, PromptId, Lang], <<"/">>)
     end.
 
+-spec maybe_prompt_path(kz_term:ne_binary(), kz_term:api_ne_binary(), kz_term:api_ne_binary(), {'ok', kz_json:object()} | {'error', 'not_found'}) ->
+          kz_term:api_ne_binary().
 maybe_prompt_path(PromptId, Lang, AccountId, {'error', 'not_found'}) ->
     kz_binary:join([<<"prompt:/">>, AccountId, PromptId, Lang], <<"/">>);
 maybe_prompt_path(PromptId, _Lang, AccountId, {'ok', _}) ->

--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -617,7 +617,7 @@ get_account_prompt(Name, Lang, AccountId, OriginalLang) ->
 
 -spec lookup_prompt(kz_term:ne_binary(), kz_term:ne_binary()) ->
           {'ok', kz_json:object()} |
-          {'error', 'not_found'}.
+          kz_datamgr:data_error().
 lookup_prompt(Db, Id) ->
     case kz_datamgr:open_cache_doc(Db, Id) of
         {'ok', Doc} ->


### PR DESCRIPTION
Before this change if you set `conference.profile.moh-sound=media-id` you get dead air when you join the conference.

Master: https://github.com/2600hz/kazoo-core/pull/41