### PR TITLE
[4.3] Upstream 4.3 telnyx carrier api issues

### DIFF
--- a/core/kazoo_number_manager/include/knm_telnyx.hrl
+++ b/core/kazoo_number_manager/include/knm_telnyx.hrl
@@ -1,0 +1,8 @@
+-ifndef(KNM_TELNYX_HRL).
+
+-define(SEARCH_TYPE_NPA, 1).
+-define(SEARCH_TYPE_INTERNATIONAL, 2).
+-define(SEARCH_TYPE_TOLEFREE, 3).
+
+-define(KNM_TELNYX_HRL, 'true').
+-endif.

--- a/core/kazoo_number_manager/src/carriers/knm_telnyx.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_telnyx.erl
@@ -17,6 +17,7 @@
 -export([check_numbers/1]).
 
 -include("knm.hrl").
+-include("knm_telnyx.hrl").
 
 -define(MOD_CONFIG_CAT, <<(?KNM_CONFIG_CAT)/binary, ".telnyx">>).
 
@@ -183,9 +184,9 @@ ugly_hack(Dialcode, Num) ->
     kz_binary:pad(<<Dialcode/binary, Num/binary>>, 9, <<"0">>).
 
 -spec search_kind(kind()) -> integer().
-search_kind('npa') -> 1;
-search_kind('region') -> 2;
-search_kind('tollfree') -> 3.
+search_kind('npa') -> ?SEARCH_TYPE_NPA;
+search_kind('region') -> ?SEARCH_TYPE_INTERNATIONAL;
+search_kind('tollfree') -> ?SEARCH_TYPE_TOLEFREE.
 
 -spec search_prefix(kind(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> kz_json:json_proplist().
 search_prefix('tollfree', NPA, 'undefined') ->

--- a/core/kazoo_number_manager/src/carriers/knm_telnyx.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_telnyx.erl
@@ -87,12 +87,9 @@ find_numbers(<<"+",_/binary>>=_InternationalNum, Quantity, Options) ->
 %% Return `undefined' if the NXX value can not be parsed.
 %% @end
 %%------------------------------------------------------------------------------
--spec get_nxx(kz_term:ne_binary()) -> kz_term:ne_binary() | 'undefined'.
-get_nxx(Num) ->
-    case byte_size(Num) >= 2+3+3 of
-        'true' -> binary:part(Num, 2+3, 3);
-        'false' -> 'undefined'
-    end.
+-spec get_nxx(kz_term:ne_binary()) -> kz_term:api_ne_binary().
+get_nxx(<<_PlusOneAreaCode:5/binary, NXX:3/binary, _/binary>>) -> NXX;
+get_nxx(_) -> 'undefined'.
 
 %%------------------------------------------------------------------------------
 %% @doc Acquire a given number from the carrier

--- a/core/kazoo_number_manager/src/carriers/knm_telnyx.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_telnyx.erl
@@ -26,6 +26,9 @@
 -define(IS_PROVISIONING_ENABLED
        ,kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"enable_provisioning">>, 'true')
        ).
+-define(SHOULD_KEEP_BEST_EFFORT
+       ,kapps_config:get_is_true(?MOD_CONFIG_CAT, <<"should_keep_best_effort">>, 'false')
+       ).
 
 %%% API
 
@@ -182,23 +185,35 @@ international_numbers(JObjs, Options) ->
 ugly_hack(Dialcode, Num) ->
     kz_binary:pad(<<Dialcode/binary, Num/binary>>, 9, <<"0">>).
 
+-spec search_kind(kind()) -> integer().
 search_kind('npa') -> 1;
 search_kind('region') -> 2;
 search_kind('tollfree') -> 3.
 
+-spec search_prefix(kind(), kz_term:ne_binary(), kz_term:api_ne_binary()) -> kz_json:json_proplist().
 search_prefix('tollfree', NPA, 'undefined') ->
-    [{<<"npa">>, NPA}];
+    [{<<"npa">>, NPA}
+    ,should_keep_best_effort()
+    ];
 search_prefix('tollfree', NPA, NXX) ->
     [{<<"nxx">>, NXX}
+    ,should_keep_best_effort()
      |search_prefix('tollfree', NPA, 'undefined')
     ];
 search_prefix('region', Country, _) ->
-    [{<<"country_iso">>, Country}];
+    [{<<"country_iso">>, Country}
+    ,should_keep_best_effort()
+    ];
 search_prefix('npa', NPA, 'undefined') ->
-    [{<<"npa">>, NPA}];
+    [{<<"npa">>, NPA}
+    ,should_keep_best_effort()
+    ];
 search_prefix('npa', NPA, NXX) ->
     [{<<"nxx">>, NXX}
+    ,should_keep_best_effort()
      |search_prefix('npa', NPA, 'undefined')
     ].
 
+-spec should_keep_best_effort() -> {kz_term:ne_binary(), boolean()}.
+should_keep_best_effort() -> {<<"best_effort">>, ?SHOULD_KEEP_BEST_EFFORT}.
 %%% End of Module

--- a/core/kazoo_number_manager/src/knm_search.erl
+++ b/core/kazoo_number_manager/src/knm_search.erl
@@ -235,11 +235,13 @@ first(Options) ->
     QID = query_id(Options),
     gen_listener:cast(?MODULE, {'reset_search', QID}),
     Self = self(),
-    Opts = [{'quantity', ?MAX_SEARCH}
-           ,{'offset', 0}
-           ,{'normalized_prefix', normalized_prefix(Options)}
-            | Options
-           ],
+    Setters = [{'quantity', ?MAX_SEARCH}
+              ,{'offset', 0}
+              ,{'normalized_prefix', normalized_prefix(Options)}
+              ],
+    Opts = lists:foldl(fun({Key, Value}, OptAcc) -> props:insert_value(Key, Value, OptAcc) end
+                      ,Options
+                      ,Setters),
     lists:foreach(fun(Carrier) -> search_spawn(Self, Carrier, Opts) end, Carriers),
     wait_for_search(length(Carriers)),
     gen_listener:call(?MODULE, {'first', Options}).

--- a/core/kazoo_number_manager/src/knm_search.erl
+++ b/core/kazoo_number_manager/src/knm_search.erl
@@ -239,9 +239,7 @@ first(Options) ->
               ,{'offset', 0}
               ,{'normalized_prefix', normalized_prefix(Options)}
               ],
-    Opts = lists:foldl(fun({Key, Value}, OptAcc) -> props:insert_value(Key, Value, OptAcc) end
-                      ,Options
-                      ,Setters),
+    Opts = lists:foldl(fun props:insert_value/2, Options, Setters),
     lists:foreach(fun(Carrier) -> search_spawn(Self, Carrier, Opts) end, Carriers),
     wait_for_search(length(Carriers)),
     gen_listener:call(?MODULE, {'first', Options}).

--- a/core/kazoo_number_manager/src/knm_search.erl
+++ b/core/kazoo_number_manager/src/knm_search.erl
@@ -235,11 +235,11 @@ first(Options) ->
     QID = query_id(Options),
     gen_listener:cast(?MODULE, {'reset_search', QID}),
     Self = self(),
-    Setters = [{'quantity', ?MAX_SEARCH}
-              ,{'offset', 0}
-              ,{'normalized_prefix', normalized_prefix(Options)}
-              ],
-    Opts = lists:foldl(fun props:insert_value/2, Options, Setters),
+    Defaults = [{'quantity', ?MAX_SEARCH}
+               ,{'offset', 0}
+               ,{'normalized_prefix', normalized_prefix(Options)}
+               ],
+    Opts = props:insert_values(Defaults, Options),
     lists:foreach(fun(Carrier) -> search_spawn(Self, Carrier, Opts) end, Carriers),
     wait_for_search(length(Carriers)),
     gen_listener:call(?MODULE, {'first', Options}).

--- a/core/kazoo_number_manager/src/knm_telnyx_util.erl
+++ b/core/kazoo_number_manager/src/knm_telnyx_util.erl
@@ -10,6 +10,7 @@
 -export([req/2, req/3]).
 
 -include("knm.hrl").
+-include("knm_telnyx.hrl").
 
 -define(MOD_CONFIG_CAT, <<(?KNM_CONFIG_CAT)/binary, ".telnyx">>).
 
@@ -41,10 +42,6 @@
 
 -define(DOMAIN, "api.telnyx.com").
 -define(URL(Path), "https://" ?DOMAIN "/origination/" ++ filename:join(Path)).
-
--define(SEARCH_TYPE_NPA, 1).
--define(SEARCH_TYPE_INTERNATIONAL, 2).
--define(SEARCH_TYPE_TOLEFREE, 3).
 
 %%------------------------------------------------------------------------------
 %% @doc Turns +13129677542 into %2B13129677542.

--- a/core/kazoo_number_manager/src/knm_telnyx_util.erl
+++ b/core/kazoo_number_manager/src/knm_telnyx_util.erl
@@ -62,13 +62,10 @@ req(Method, Path) ->
 
 -spec req(atom(), [nonempty_string()], kz_json:object()) -> kz_json:object().
 req('post', ["number_searches"], JObj) ->
-    case kz_json:get_value([<<"search_descriptor">>, <<"prefix">>], JObj) of
-        <<"800">> -> rep_fixture("telnyx_tollfree_search.json");
-        'undefined' ->
-            case kz_json:get_value([<<"search_descriptor">>, <<"country_iso">>], JObj) of
-                <<"GB">> -> rep_fixture("telnyx_international_search.json");
-                'undefined' -> rep_fixture("telnyx_npa_search.json")
-            end
+    case kz_json:get_integer_value([<<"search_type">>], JObj) of
+        1 -> rep_fixture("telnyx_npa_search.json");
+        2 -> rep_fixture("telnyx_international_search.json");
+        3 -> rep_fixture("telnyx_tollfree_search.json")
     end;
 req('post', ["e911_addresses"], Body) ->
     <<"301 MARINA BLVD">> = kz_json:get_value(<<"line_1">>, Body),


### PR DESCRIPTION
Fixes to the Telnyx carrier module

The best effort configuration setting did not work, My guess is that this was written and then telnyx changed the api response and the response to no longer included the flag “any_best_effort” so the old code would never filter the best effort out. This improvement will now pass the best effort flag to telnyx and remove the need to filter the response.

Requests for TF numbers was failing as the request built and passed to Telnyx was incorrect. It passed the TF NAP as `prefix` in the body and it should be `nap` as there api doc states. I have also added the option to filer TF numbers by NXX.

Also found that the crossbar quantity option was always overwritten to 500 so every time you requested 15 numbers through CB it requested 500 from telnyx resulting in longer query times. The fix was to only set the default values if they were not set.

Kazoo5 PR https://github.com/2600hz/kazoo-core/pull/48