### PR TITLE
[4.3] acdc - PISTON-1112: fix validation of agent pause timeout/time-limit

### DIFF
--- a/applications/acdc/include/acdc_config.hrl
+++ b/applications/acdc/include/acdc_config.hrl
@@ -2,6 +2,10 @@
 
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
 
+-define(ACDC_CONFIG_CAT, <<"acdc">>).
+
+-define(DEFAULT_AGENT_PAUSE_TIMEOUT, kapps_config:get(?ACDC_CONFIG_CAT, <<"default_agent_pause_timeout">>, 600)).
+
 %% Save data to the DB
 -define(ACDC_ARCHIVE_WINDOW,
         kapps_config:get_integer(<<"acdc">>, <<"archive_window_s">>, ?SECONDS_IN_HOUR)).

--- a/applications/acdc/src/acdc_agent_handler.erl
+++ b/applications/acdc/src/acdc_agent_handler.erl
@@ -24,8 +24,6 @@
 -include("acdc.hrl").
 -include_lib("kazoo_amqp/include/kapi_conf.hrl").
 
--define(DEFAULT_PAUSE, kapps_config:get(?CONFIG_CAT, <<"default_agent_pause_timeout">>, 600)).
-
 -spec handle_status_update(kz_json:object(), kz_term:proplist()) -> 'ok'.
 handle_status_update(JObj, _Props) ->
     _ = kz_util:put_callid(JObj),
@@ -43,7 +41,7 @@ handle_status_update(JObj, _Props) ->
             maybe_stop_agent(AccountId, AgentId, JObj);
         <<"pause">> ->
             'true' = kapi_acdc_agent:pause_v(JObj),
-            Timeout = kz_json:get_value(<<"Time-Limit">>, JObj, ?DEFAULT_PAUSE),
+            Timeout = kz_json:get_value(<<"Time-Limit">>, JObj, ?DEFAULT_AGENT_PAUSE_TIMEOUT),
             Alias = kz_json:get_value(<<"Alias">>, JObj),
             maybe_pause_agent(AccountId, AgentId, Timeout, Alias, JObj);
         <<"resume">> ->

--- a/applications/acdc/src/acdc_maintenance.erl
+++ b/applications/acdc/src/acdc_maintenance.erl
@@ -474,16 +474,15 @@ agent_logout(AcctId, AgentId) ->
 
 -spec agent_pause(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 agent_pause(AcctId, AgentId) ->
-    Timeout = kapps_config:get_integer(?CONFIG_CAT, <<"default_agent_pause_timeout">>, 600),
-    agent_pause(AcctId, AgentId, Timeout).
+    agent_pause(AcctId, AgentId, ?DEFAULT_AGENT_PAUSE_TIMEOUT).
 
--spec agent_pause(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer()) -> 'ok'.
+-spec agent_pause(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer() | kz_term:ne_binary()) -> 'ok'.
 agent_pause(AcctId, AgentId, Timeout) ->
     kz_util:put_callid(?MODULE),
     Update = props:filter_undefined(
                [{<<"Account-ID">>, AcctId}
                ,{<<"Agent-ID">>, AgentId}
-               ,{<<"Timeout">>, kz_term:to_integer(Timeout)}
+               ,{<<"Time-Limit">>, Timeout}
                 | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                ]),
     _ = kz_amqp_worker:cast(Update, fun kapi_acdc_agent:publish_pause/1),

--- a/applications/acdc/src/cf_acdc_agent.erl
+++ b/applications/acdc/src/cf_acdc_agent.erl
@@ -24,6 +24,7 @@
         ,logout_agent/2
         ]).
 
+-include("acdc_config.hrl").
 -include_lib("callflow/src/callflow.hrl").
 
 %%------------------------------------------------------------------------------
@@ -154,11 +155,8 @@ pause_agent(Call, AgentId, Data, Timeout) ->
     _ = play_agent_pause(Call),
     update_agent_status(Call, AgentId, Data, fun kapi_acdc_agent:publish_pause/1, Timeout).
 pause_agent(Call, AgentId, Data) ->
-    Timeout = kz_json:get_value(<<"timeout">>
-                               ,Data
-                               ,kapps_config:get(<<"acdc">>, <<"default_agent_pause_timeout">>, 600)
-                               ),
-    lager:info("agent ~s is pausing work for ~b s", [AgentId, Timeout]),
+    Timeout = kz_json:get_value(<<"timeout">>, Data, ?DEFAULT_AGENT_PAUSE_TIMEOUT),
+    lager:info("agent ~s is pausing work for ~p s", [AgentId, Timeout]),
     pause_agent(Call, AgentId, Data, Timeout).
 
 resume_agent(Call, AgentId, Data) ->

--- a/applications/acdc/src/kapi_acdc_agent.erl
+++ b/applications/acdc/src/kapi_acdc_agent.erl
@@ -224,7 +224,7 @@ stats_resp_v(JObj) ->
 -define(AGENT_KEY, "acdc.agent.action."). % append queue ID
 
 -define(AGENT_HEADERS, [<<"Account-ID">>, <<"Agent-ID">>]).
--define(OPTIONAL_AGENT_HEADERS, [<<"Time-Limit">>, <<"Queue-ID">>
+-define(OPTIONAL_AGENT_HEADERS, [<<"Queue-ID">>
                                 ,<<"Presence-ID">>, <<"Presence-State">>
                                 ]).
 -define(AGENT_VALUES, [{<<"Event-Category">>, <<"agent">>}
@@ -232,7 +232,8 @@ stats_resp_v(JObj) ->
                       ]).
 -define(AGENT_TYPES, []).
 
--define(OPTIONAL_PAUSE_HEADERS, [<<"Alias">>]).
+-define(PAUSE_HEADERS, [<<"Time-Limit">> | ?AGENT_HEADERS]).
+-define(OPTIONAL_PAUSE_HEADERS, [<<"Alias">> | ?OPTIONAL_AGENT_HEADERS]).
 
 -define(LOGIN_VALUES, [{<<"Event-Name">>, <<"login">>} | ?AGENT_VALUES]).
 -define(LOGOUT_VALUES, [{<<"Event-Name">>, <<"logout">>} | ?AGENT_VALUES]).
@@ -242,6 +243,14 @@ stats_resp_v(JObj) ->
 -define(LOGIN_QUEUE_VALUES, [{<<"Event-Name">>, <<"login_queue">>} | ?AGENT_VALUES]).
 -define(LOGOUT_QUEUE_VALUES, [{<<"Event-Name">>, <<"logout_queue">>} | ?AGENT_VALUES]).
 -define(RESTART_VALUES, [{<<"Event-Name">>, <<"restart">>} | ?AGENT_VALUES]).
+
+-define(PAUSE_TYPES, [{<<"Time-Limit">>, fun(<<"infinity">>) -> 'true';
+                                            (TimeLimit) when is_integer(TimeLimit) -> TimeLimit >= 0;
+                                            (_) -> 'false'
+                                         end
+                      }
+                      | ?AGENT_TYPES
+                     ]).
 
 -spec login(kz_term:api_terms()) ->
           {'ok', iolist()} |
@@ -317,7 +326,7 @@ logout_queue_v(JObj) ->
           {'error', string()}.
 pause(Props) when is_list(Props) ->
     case pause_v(Props) of
-        'true' -> kz_api:build_message(Props, ?AGENT_HEADERS, ?OPTIONAL_AGENT_HEADERS ++ ?OPTIONAL_PAUSE_HEADERS);
+        'true' -> kz_api:build_message(Props, ?PAUSE_HEADERS, ?OPTIONAL_PAUSE_HEADERS);
         'false' -> {'error', "Proplist failed validation for agent_pause"}
     end;
 pause(JObj) ->
@@ -325,7 +334,7 @@ pause(JObj) ->
 
 -spec pause_v(kz_term:api_terms()) -> boolean().
 pause_v(Prop) when is_list(Prop) ->
-    kz_api:validate(Prop, ?AGENT_HEADERS, ?PAUSE_VALUES, ?AGENT_TYPES);
+    kz_api:validate(Prop, ?PAUSE_HEADERS, ?PAUSE_VALUES, ?PAUSE_TYPES);
 pause_v(JObj) ->
     pause_v(kz_json:to_proplist(JObj)).
 

--- a/applications/acdc/src/kapi_acdc_agent.erl
+++ b/applications/acdc/src/kapi_acdc_agent.erl
@@ -232,8 +232,7 @@ stats_resp_v(JObj) ->
                       ]).
 -define(AGENT_TYPES, []).
 
--define(PAUSE_HEADERS, [<<"Time-Limit">> | ?AGENT_HEADERS]).
--define(OPTIONAL_PAUSE_HEADERS, [<<"Alias">> | ?OPTIONAL_AGENT_HEADERS]).
+-define(OPTIONAL_PAUSE_HEADERS, [<<"Alias">>, <<"Time-Limit">> | ?OPTIONAL_AGENT_HEADERS]).
 
 -define(LOGIN_VALUES, [{<<"Event-Name">>, <<"login">>} | ?AGENT_VALUES]).
 -define(LOGOUT_VALUES, [{<<"Event-Name">>, <<"logout">>} | ?AGENT_VALUES]).
@@ -326,7 +325,7 @@ logout_queue_v(JObj) ->
           {'error', string()}.
 pause(Props) when is_list(Props) ->
     case pause_v(Props) of
-        'true' -> kz_api:build_message(Props, ?PAUSE_HEADERS, ?OPTIONAL_PAUSE_HEADERS);
+        'true' -> kz_api:build_message(Props, ?AGENT_HEADERS, ?OPTIONAL_PAUSE_HEADERS);
         'false' -> {'error', "Proplist failed validation for agent_pause"}
     end;
 pause(JObj) ->
@@ -334,7 +333,7 @@ pause(JObj) ->
 
 -spec pause_v(kz_term:api_terms()) -> boolean().
 pause_v(Prop) when is_list(Prop) ->
-    kz_api:validate(Prop, ?PAUSE_HEADERS, ?PAUSE_VALUES, ?PAUSE_TYPES);
+    kz_api:validate(Prop, ?AGENT_HEADERS, ?PAUSE_VALUES, ?PAUSE_TYPES);
 pause_v(JObj) ->
     pause_v(kz_json:to_proplist(JObj)).
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6677,9 +6677,6 @@
                 },
                 "Queue-ID": {
                     "type": "string"
-                },
-                "Time-Limit": {
-                    "type": "integer"
                 }
             },
             "required": [
@@ -6725,9 +6722,6 @@
                 },
                 "Queue-ID": {
                     "type": "string"
-                },
-                "Time-Limit": {
-                    "type": "integer"
                 }
             },
             "required": [
@@ -6773,9 +6767,6 @@
                 },
                 "Queue-ID": {
                     "type": "string"
-                },
-                "Time-Limit": {
-                    "type": "integer"
                 }
             },
             "required": [
@@ -6849,9 +6840,6 @@
                 },
                 "Queue-ID": {
                     "type": "string"
-                },
-                "Time-Limit": {
-                    "type": "integer"
                 }
             },
             "required": [
@@ -6897,9 +6885,6 @@
                 },
                 "Queue-ID": {
                     "type": "string"
-                },
-                "Time-Limit": {
-                    "type": "integer"
                 }
             },
             "required": [
@@ -7053,9 +7038,6 @@
                 },
                 "Queue-ID": {
                     "type": "string"
-                },
-                "Time-Limit": {
-                    "type": "integer"
                 }
             },
             "required": [
@@ -7101,9 +7083,6 @@
                 },
                 "Queue-ID": {
                     "type": "string"
-                },
-                "Time-Limit": {
-                    "type": "integer"
                 }
             },
             "required": [
@@ -29442,7 +29421,12 @@
                 "default_agent_pause_timeout": {
                     "default": 600,
                     "description": "acdc default agent pause timeout",
-                    "type": "integer"
+                    "minimum": 0,
+                    "pattern": "infinity",
+                    "type": [
+                        "integer",
+                        "string"
+                    ]
                 },
                 "max_connect_failures": {
                     "default": 3,

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.end_wrapup.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.end_wrapup.json
@@ -37,9 +37,6 @@
         },
         "Queue-ID": {
             "type": "string"
-        },
-        "Time-Limit": {
-            "type": "integer"
         }
     },
     "required": [

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.login.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.login.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.acdc_agent.login",
+    "description": "AMQP API for acdc_agent.login",
+    "properties": {
+        "Account-ID": {
+            "type": "string"
+        },
+        "Agent-ID": {
+            "type": "string"
+        },
+        "Event-Category": {
+            "enum": [
+                "agent"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "login"
+            ],
+            "type": "string"
+        },
+        "Presence-ID": {
+            "type": "string"
+        },
+        "Presence-State": {
+            "enum": [
+                "trying",
+                "online",
+                "offline",
+                "early",
+                "confirmed",
+                "terminated"
+            ],
+            "type": "string"
+        },
+        "Queue-ID": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Account-ID",
+        "Agent-ID"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.login_queue.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.login_queue.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.acdc_agent.login_queue",
+    "description": "AMQP API for acdc_agent.login_queue",
+    "properties": {
+        "Account-ID": {
+            "type": "string"
+        },
+        "Agent-ID": {
+            "type": "string"
+        },
+        "Event-Category": {
+            "enum": [
+                "agent"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "login_queue"
+            ],
+            "type": "string"
+        },
+        "Presence-ID": {
+            "type": "string"
+        },
+        "Presence-State": {
+            "enum": [
+                "trying",
+                "online",
+                "offline",
+                "early",
+                "confirmed",
+                "terminated"
+            ],
+            "type": "string"
+        },
+        "Queue-ID": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Account-ID",
+        "Agent-ID"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.login_resp.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.login_resp.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.acdc_agent.login_resp",
+    "description": "AMQP API for acdc_agent.login_resp",
+    "properties": {
+        "Event-Category": {
+            "enum": [
+                "agent"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "login_resp"
+            ],
+            "type": "string"
+        },
+        "Status": {
+            "enum": [
+                "success",
+                "failed"
+            ],
+            "type": "string"
+        }
+    },
+    "required": [
+        "Status"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.logout.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.logout.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.acdc_agent.logout",
+    "description": "AMQP API for acdc_agent.logout",
+    "properties": {
+        "Account-ID": {
+            "type": "string"
+        },
+        "Agent-ID": {
+            "type": "string"
+        },
+        "Event-Category": {
+            "enum": [
+                "agent"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "logout"
+            ],
+            "type": "string"
+        },
+        "Presence-ID": {
+            "type": "string"
+        },
+        "Presence-State": {
+            "enum": [
+                "trying",
+                "online",
+                "offline",
+                "early",
+                "confirmed",
+                "terminated"
+            ],
+            "type": "string"
+        },
+        "Queue-ID": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Account-ID",
+        "Agent-ID"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.logout_queue.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.logout_queue.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.acdc_agent.logout_queue",
+    "description": "AMQP API for acdc_agent.logout_queue",
+    "properties": {
+        "Account-ID": {
+            "type": "string"
+        },
+        "Agent-ID": {
+            "type": "string"
+        },
+        "Event-Category": {
+            "enum": [
+                "agent"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "logout_queue"
+            ],
+            "type": "string"
+        },
+        "Presence-ID": {
+            "type": "string"
+        },
+        "Presence-State": {
+            "enum": [
+                "trying",
+                "online",
+                "offline",
+                "early",
+                "confirmed",
+                "terminated"
+            ],
+            "type": "string"
+        },
+        "Queue-ID": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Account-ID",
+        "Agent-ID"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.restart.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.restart.json
@@ -37,9 +37,6 @@
         },
         "Queue-ID": {
             "type": "string"
-        },
-        "Time-Limit": {
-            "type": "integer"
         }
     },
     "required": [

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.resume.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_agent.resume.json
@@ -37,9 +37,6 @@
         },
         "Queue-ID": {
             "type": "string"
-        },
-        "Time-Limit": {
-            "type": "integer"
         }
     },
     "required": [

--- a/applications/crossbar/priv/couchdb/schemas/system_config.acdc.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.acdc.json
@@ -39,7 +39,12 @@
         "default_agent_pause_timeout": {
             "default": 600,
             "description": "acdc default agent pause timeout",
-            "type": "integer"
+            "minimum": 0,
+            "pattern": "infinity",
+            "type": [
+                "integer",
+                "string"
+            ]
         },
         "max_connect_failures": {
             "default": 3,


### PR DESCRIPTION
- schema validates system_config.acdc default_agent_pause_timeout for non-negative integers or the "infinity" special string
- refactored out ?DEFAULT_AGENT_PAUSE_TIMEOUT into shared header
- fixed acdc_maintenance expecting integer, despite possibility of <<"infinity">> value
- moved Time-Limit validation in kapi_acdc_agent into PAUSE_* macros rather than AGENT_*