### PR TITLE
Piston 1117: Add .vscode directory to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ compile_commands.json
 
 .idea/
 
+.vscode/
+
 core/kazoo_proper/priv/mp3.mp3
 *.md.bak
 *.md.new


### PR DESCRIPTION
Visual Studio Code uses the .vscode directory for workspace settings that should not be under source control.