### PR TITLE
SUPP-14: fix losing origination-call-id when faing account to account

### DIFF
--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -399,8 +399,17 @@ handle_info(_Info, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_event(kz_json:object(), kz_term:proplist()) -> gen_listener:handle_event_return().
-handle_event(_JObj, _State) ->
+handle_event(JObj, _State) ->
+    JobId = find_event_job_id(kz_api:event_name(JObj), JObj),
+    kz_util:put_callid(JobId),
     {'reply', []}.
+
+find_event_job_id(<<"CHANNEL_FAX_STATUS">>, JObj) ->
+    kz_json:get_value([<<"Custom-Channel-Vars">>, <<"Authorizing-ID">>], JObj);
+find_event_job_id(<<"offnet_resp">>, JObj) ->
+    kz_api:msg_id(JObj);
+find_event_job_id(_, JObj) ->
+    kz_api:msg_id(JObj).
 
 %%------------------------------------------------------------------------------
 %% @doc This function is called by a `gen_server' when it is about to

--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -53,9 +53,9 @@
 
 -type release_ret() :: {kz_json:object(), kz_json:object()}.
 
--define(ORIGINATE_TIMEOUT, ?MILLISECONDS_IN_MINUTE).
--define(NEGOTIATE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 2).
--define(PAGE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 6).
+-define(ORIGINATE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 3).
+-define(NEGOTIATE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 3).
+-define(PAGE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 12).
 
 -define(BINDINGS(CallId), [{'self', []}
                           ,{'fax', [{'restrict_to', ['query_status']}]}

--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -400,7 +400,7 @@ handle_info(_Info, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_event(kz_json:object(), kz_term:proplist()) -> gen_listener:handle_event_return().
-handle_event(JObj,  #state{job_id = JobId}) ->
+handle_event(_JObj,  #state{job_id = JobId}) ->
     kz_util:put_callid(JobId),
     {'reply', [{'job_id', JobId}]}.
 

--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -137,12 +137,13 @@ server_name(FaxJob) ->
 -spec handle_tx_resp(kz_json:object(), kz_term:proplist()) -> 'ok'.
 handle_tx_resp(JObj, Props) ->
     Srv = props:get_value('server', Props),
-    gen_server:cast(Srv, {'tx_resp', kz_api:msg_id(JObj), JObj}).
+    JobId = props:get_value('job_id', Props),
+    gen_server:cast(Srv, {'tx_resp', JobId, JObj}).
 
 -spec handle_fax_event(kz_json:object(), kz_term:proplist()) -> 'ok'.
 handle_fax_event(JObj, Props) ->
     Srv = props:get_value('server', Props),
-    JobId = kz_call_event:authorizing_id(JObj),
+    JobId = props:get_value('job_id', Props),
     Event = kz_call_event:application_event(JObj),
     gen_server:cast(Srv, {'fax_status', Event, JobId, JObj}).
 
@@ -150,7 +151,7 @@ handle_fax_event(JObj, Props) ->
 handle_job_status_query(JObj, Props) ->
     'true' = kapi_fax:query_status_v(JObj),
     Srv = props:get_value('server', Props),
-    JobId = kapi_fax:job_id(JObj),
+    JobId = props:get_value('job_id', Props),
     Queue = kz_api:server_id(JObj),
     MsgId = kz_api:msg_id(JObj),
     gen_server:cast(Srv, {'query_status', JobId, Queue, MsgId, JObj}).
@@ -399,17 +400,9 @@ handle_info(_Info, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_event(kz_json:object(), kz_term:proplist()) -> gen_listener:handle_event_return().
-handle_event(JObj, _State) ->
-    JobId = find_event_job_id(kz_api:event_name(JObj), JObj),
+handle_event(JObj,  #state{job_id = JobId}) ->
     kz_util:put_callid(JobId),
-    {'reply', []}.
-
-find_event_job_id(<<"CHANNEL_FAX_STATUS">>, JObj) ->
-    kz_json:get_value([<<"Custom-Channel-Vars">>, <<"Authorizing-ID">>], JObj);
-find_event_job_id(<<"offnet_resp">>, JObj) ->
-    kz_api:msg_id(JObj);
-find_event_job_id(_, JObj) ->
-    kz_api:msg_id(JObj).
+    {'reply', [{'job_id', JobId}]}.
 
 %%------------------------------------------------------------------------------
 %% @doc This function is called by a `gen_server' when it is about to

--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -53,9 +53,9 @@
 
 -type release_ret() :: {kz_json:object(), kz_json:object()}.
 
--define(ORIGINATE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 3).
--define(NEGOTIATE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 3).
--define(PAGE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 12).
+-define(ORIGINATE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 2).
+-define(NEGOTIATE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 2).
+-define(PAGE_TIMEOUT, ?MILLISECONDS_IN_MINUTE * 5).
 
 -define(BINDINGS(CallId), [{'self', []}
                           ,{'fax', [{'restrict_to', ['query_status']}]}

--- a/core/kazoo_amqp/src/api/kapi_call.erl
+++ b/core/kazoo_amqp/src/api/kapi_call.erl
@@ -346,7 +346,11 @@ publish_event(Event, ContentType) ->
 
 -spec find_event_call_id(kz_term:proplist()) -> kz_term:api_ne_binary().
 find_event_call_id(Event) ->
-    Keys = case props:is_true(<<"Channel-Is-Loopback">>, Event, 'false') of
+    %% fax needs origination-call-id
+    %% c2c and pivot do not
+    Keys = case kz_api:event_name(Event) =/= <<"CHANNEL_FAX_STATUS">>
+               andalso props:is_true(<<"Channel-Is-Loopback">>, Event, 'false')
+           of
                'true' -> [<<"Call-ID">>, <<"Unique-ID">>];
                'false' -> [<<"Origination-Call-ID">>, <<"Call-ID">>, <<"Unique-ID">>]
            end,


### PR DESCRIPTION
When sending fax, fax_worker sets `Origination-Call-ID` but will be discarded by `kapi_call` on the loopback. This will take care of fax events to honor this field.
Also it puts job_id in fax_worker handle_event as call_id so we can grab logs by job_id for all stages in fax_workers.

Increasing timeouts for fax_worker stages to give it a more relax time if something taking more times to finish like sending the page.