### PR TITLE
[4.3] PROD-167: capture the subject line in inbound email to fax for use in notifications

### DIFF
--- a/applications/crossbar/doc/faxes.md
+++ b/applications/crossbar/doc/faxes.md
@@ -37,6 +37,7 @@ Key | Description | Type | Default | Required | Support Level
 `notifications.sms` | SMS notifications | `object()` |   | `false` |  
 `notifications` | Status notifications | `object()` |   | `false` |  
 `retries` | The number of times to retry | `integer()` | `1` | `false` |  
+`subject` | The subject header in an email to fax message | `string()` |   | `false` |  
 `to_name` | The recipient name for the fax | `string()` |   | `false` |  
 `to_number` | The recipient number for the fax | `string()` |   | `true` |  
 `tx_result.error_message` | A description of any error that occurred | `string()` | "" | `false` |  

--- a/applications/crossbar/doc/ref/faxes.md
+++ b/applications/crossbar/doc/ref/faxes.md
@@ -28,6 +28,7 @@ Key | Description | Type | Default | Required | Support Level
 `notifications.sms` | SMS notifications | `object()` |   | `false` |  
 `notifications` | Status notifications | `object()` |   | `false` |  
 `retries` | The number of times to retry | `integer()` | `1` | `false` |  
+`subject` | The subject header in an email to fax message | `string()` |   | `false` |  
 `to_name` | The recipient name for the fax | `string()` |   | `false` |  
 `to_number` | The recipient number for the fax | `string()` |   | `true` |  
 `tx_result.error_message` | A description of any error that occurred | `string()` | "" | `false` |  

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -6416,6 +6416,10 @@
                     "minimum": 0,
                     "type": "integer"
                 },
+                "subject": {
+                    "description": "The subject header in an email to fax message",
+                    "type": "string"
+                },
                 "to_name": {
                     "description": "The recipient name for the fax",
                     "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/faxes.json
+++ b/applications/crossbar/priv/couchdb/schemas/faxes.json
@@ -105,6 +105,10 @@
             "minimum": 0,
             "type": "integer"
         },
+        "subject": {
+            "description": "The subject header in an email to fax message",
+            "type": "string"
+        },
         "to_name": {
             "description": "The recipient name for the fax",
             "type": "string"

--- a/applications/teletype/priv/templates/fax_outbound_error_to_email.html
+++ b/applications/teletype/priv/templates/fax_outbound_error_to_email.html
@@ -53,6 +53,7 @@
                 <tr>
                     <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
                         <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Sender:</b>&nbsp;{% if callee_id.name_number or fax.remote_station_id %}{% firstof callee_id.name_number fax.remote_station_id %}{% endif %}</p>
+                        <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Subject:</b>&nbsp;{{fax.subject}}</p>
                         <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Callee:</b>&nbsp;{{to.user}} (originally dialed number)</p>
                         <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Sent Date:</b>&nbsp;{{date_called.local|date:"l, F j, Y \\a\\t H:i"}}</p>
                         <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Fax ID:</b>&nbsp;{{fax.id}}</p>

--- a/applications/teletype/priv/templates/fax_outbound_error_to_email.text
+++ b/applications/teletype/priv/templates/fax_outbound_error_to_email.text
@@ -10,6 +10,7 @@ Here are some more details on what went wrong during transmission.
 === Sending Fax Failure Details ===
 
     Sender: {% if caller_id.name_number or fax.remote_station_id %}{% firstof caller_id.name_number fax.remote_station_id %}{% endif %}
+    Subject: {{fax.subject}}
     Callee: {{to.user}} (originally dialed number)
     Sent Date: {{date_called.local|date:"l, F j, Y \\a\\t H:i"}}
     Fax ID: {{fax.id}}

--- a/applications/teletype/priv/templates/fax_outbound_smtp_error_to_email.html
+++ b/applications/teletype/priv/templates/fax_outbound_smtp_error_to_email.html
@@ -53,6 +53,7 @@
                 <tr>
                     <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
                         <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Sender:</b>&nbsp;{{fax.from}}</p>
+                        <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Subject:</b>&nbsp;{{fax.subject}}</p>
                         <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Destination Email Address:</b>&nbsp;{{fax.to}}</p>
                         <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Original Destination Fax Number:</b>&nbsp;{% firstof fax.original_number "Unknown" %} (originally dialed number)</p>
                         <p style="margin:0 25px 10px;padding:0;font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;"><b>Destination Fax Number:</b>&nbsp;{% firstof fax.number "Unknown" %}</p>

--- a/applications/teletype/priv/templates/fax_outbound_smtp_error_to_email.txt
+++ b/applications/teletype/priv/templates/fax_outbound_smtp_error_to_email.txt
@@ -10,6 +10,7 @@ Here are some more details on what went wrong during transmission.
 === Email to Fax Failure Details ===
 
     Sender: {{fax.from}}
+    Subject: {{fax.subject}}
     Destination Email Address: {{fax.to}}
     Original Destination Fax Number: {% firstof {{fax.original_number}} "Unknown" %} (originally dialed number)
     Destination Fax Number: {% firstof {{fax.number}} "Unknown" %}

--- a/applications/teletype/priv/templates/fax_outbound_to_email.html
+++ b/applications/teletype/priv/templates/fax_outbound_to_email.html
@@ -53,6 +53,7 @@
                 <tr>
                     <td bgcolor="#ffffff" style="padding:20px;font-family:'Open Sans',sans-serif;color:#555555;">
                         <p style="font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;margin:0 25px 10px;padding:0;"><b>Sender:</b>&nbsp;{{caller_id.name_number}}</p>
+                        <p style="font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;margin:0 25px 10px;padding:0;"><b>Subject:</b>&nbsp;{{fax.subject}}</p>
                         <p style="font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;margin:10px 25px;padding:0;"><b>Callee:</b>&nbsp;{{to.user}} (originally dialed number)</p>
                         <p style="font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;margin:10px 25px;padding:0;"><b>Sent:</b>&nbsp;{{date_called.local|date:"l, F j, Y \\a\\t H:i"}}</p>{% if fax.total_pages %}
                         <p style="font-family:'Open Sans', sans-serif;color:#555555;line-height:20px;margin:10px 25px;padding:0;"><b>Total Pages:</b>&nbsp;{{fax.total_pages}}</p>{% endif %}{% if fax.media %}

--- a/applications/teletype/priv/templates/fax_outbound_to_email.text
+++ b/applications/teletype/priv/templates/fax_outbound_to_email.text
@@ -8,6 +8,7 @@ You sent a new fax document to {{callee_id.name_number}}{% if fax.box_name %} fr
 === Fax Details ===
 
 	Sender: {{caller_id.name_number}}
+	Subject: {{fax.subject}}
 	Callee: {{to.user}} (originally dialed number)
 	Received: {{date_called.local|date:"l, F j, Y \\a\\t H:i"}}{% if fax.total_pages %}
 	Total Pages: {{fax.total_pages}}{% endif %}{% if fax.media %}

--- a/applications/teletype/src/teletype.hrl
+++ b/applications/teletype/src/teletype.hrl
@@ -207,6 +207,10 @@
         ,?MACRO_VALUE(<<"fax.remote_station_id">>, <<"fax_remote_station_id">>, <<"Fax Remote Station ID">>, <<"Fax Remote Station ID">>)
         ]).
 
+-define(FAX_OUTBOUND_MACROS
+       ,[?MACRO_VALUE(<<"fax.subject">>, <<"subject">>, <<"Fax Subject">>, <<"Fax Subject">>)
+        ]).
+
 -define(FAX_ERROR_MACROS
        ,[?MACRO_VALUE(<<"fax.info">>, <<"fax_info">>, <<"Fax Info">>, <<"Fax Info">>)
         ,?MACRO_VALUE(<<"error.call_info">>, <<"error_call_info">>, <<"Fax Call Error">>, <<"Fax Call Error">>)

--- a/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_error_to_email.erl
@@ -18,6 +18,7 @@
        ,kz_json:from_list(
           ?FAX_ERROR_MACROS
           ++ ?FAX_MACROS
+          ++ ?FAX_OUTBOUND_MACROS
           ++ ?DEFAULT_CALL_MACROS
           ++ ?USER_MACROS
           ++ ?COMMON_TEMPLATE_MACROS
@@ -124,6 +125,7 @@ build_fax_template_data(DataJObj) ->
       [{<<"info">>, kz_json:to_proplist(<<"fax_info">>, DataJObj)}
       ,{<<"remote_station_id">>, kz_json:get_value(<<"fax_remote_station_id">>, DataJObj)}
       ,{<<"id">>, kz_json:get_value(<<"fax_id">>, DataJObj)}
+      ,{<<"subject">>, kz_json:get_value(<<"subject">>, FaxJObj)}
       ,{<<"box_id">>, kz_json:get_value(<<"faxbox_id">>, DataJObj, kz_doc:id(FaxBoxJObj))}
       ,{<<"box_name">>, kz_json:get_value(<<"name">>, FaxBoxJObj)}
       ,{<<"timestamp">>, kz_json:get_value(<<"fax_timestamp">>, DataJObj, kz_time:now_s())}

--- a/applications/teletype/src/templates/teletype_fax_outbound_smtp_error_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_smtp_error_to_email.erl
@@ -29,6 +29,7 @@
           ,?MACRO_VALUE(<<"faxbox.id">>, <<"faxbox_id">>, <<"FaxBox ID">>, <<"FaxBox ID">>)
           ,?MACRO_VALUE(<<"faxbox.name">>, <<"faxbox_name">>, <<"FaxBox Name">>, <<"FaxBox Name">>)
           ]
+          ++ ?FAX_OUTBOUND_MACROS
           ++ ?USER_MACROS
           ++ ?COMMON_TEMPLATE_MACROS
          )

--- a/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
+++ b/applications/teletype/src/templates/teletype_fax_outbound_to_email.erl
@@ -17,6 +17,7 @@
 -define(TEMPLATE_MACROS
        ,kz_json:from_list(
           ?FAX_MACROS
+          ++ ?FAX_OUTBOUND_MACROS
           ++ ?DEFAULT_CALL_MACROS
           ++ ?USER_MACROS
           ++ ?COMMON_TEMPLATE_MACROS
@@ -117,6 +118,7 @@ build_fax_template_data(DataJObj) ->
     FaxBoxJObj = kz_json:get_value(<<"faxbox">>, DataJObj),
     props:filter_undefined(
       [{<<"id">>, kz_json:get_value(<<"fax_id">>, DataJObj)}
+      ,{<<"subject">>, kz_json:get_value(<<"subject">>, FaxJObj)}
       ,{<<"box_id">>, kz_json:get_value(<<"faxbox_id">>, DataJObj, kz_doc:id(FaxBoxJObj))}
       ,{<<"box_name">>, kz_json:get_value(<<"name">>, FaxBoxJObj)}
       ,{<<"timestamp">>, kz_json:get_value(<<"fax_timestamp">>, DataJObj, kz_time:now_s())}

--- a/core/kazoo_documents/src/kzd_fax.erl
+++ b/core/kazoo_documents/src/kzd_fax.erl
@@ -19,6 +19,7 @@
         ,to_name/1, to_name/2
         ,identity_number/1, identity_number/2
         ,identity_name/1, identity_name/2
+        ,subject/1, subject/2
         ,folder/1, folder/2
         ,document/1, document/2
         ,document_url/1
@@ -50,6 +51,7 @@
 -define(KEY_TX_RESULT, <<"tx_result">>).
 -define(KEY_PAGES, <<"pvt_pages">>).
 -define(KEY_SIZE, <<"pvt_size">>).
+-define(KEY_SUBJECT, <<"subject">>).
 -define(KEY_FROM_NAME, <<"from_name">>).
 -define(KEY_FROM_NUMBER, <<"from_number">>).
 -define(KEY_TO_NAME, <<"to_name">>).
@@ -217,6 +219,14 @@ size(FaxDoc) ->
 -spec size(doc(), Default) -> integer() | Default.
 size(FaxDoc, Default) ->
     kz_json:get_integer_value(?KEY_SIZE, FaxDoc, Default).
+
+-spec subject(doc()) -> kz_term:api_binary().
+subject(FaxDoc) ->
+    subject(FaxDoc, 'undefined').
+
+-spec subject(doc(), Default) -> kz_term:api_binary() | Default.
+subject(FaxDoc, Default) ->
+    kz_json:get_value(?KEY_SUBJECT, FaxDoc, Default).
 
 -spec pages(doc()) -> kz_term:api_integer().
 pages(FaxDoc) ->

--- a/core/kazoo_documents/src/kzd_faxes.erl.src
+++ b/core/kazoo_documents/src/kzd_faxes.erl.src
@@ -22,6 +22,7 @@
 -export([notifications_sms/1, notifications_sms/2, set_notifications_sms/2]).
 -export([notifications_sms_send_to/1, notifications_sms_send_to/2, set_notifications_sms_send_to/2]).
 -export([retries/1, retries/2, set_retries/2]).
+-export([subject/1, subject/2, set_subject/2]).
 -export([to_name/1, to_name/2, set_to_name/2]).
 -export([to_number/1, to_number/2, set_to_number/2]).
 -export([tx_result/1, tx_result/2, set_tx_result/2]).
@@ -237,6 +238,18 @@ retries(Doc, Default) ->
 -spec set_retries(doc(), integer()) -> doc().
 set_retries(Doc, Retries) ->
     kz_json:set_value([<<"retries">>], Retries, Doc).
+
+-spec subject(doc()) -> kz_term:api_binary().
+subject(Doc) ->
+    subject(Doc, 'undefined').
+
+-spec subject(doc(), Default) -> binary() | Default.
+subject(Doc, Default) ->
+    kz_json:get_binary_value([<<"subject">>], Doc, Default).
+
+-spec set_subject(doc(), binary()) -> doc().
+set_subject(Doc, Subject) ->
+    kz_json:set_value([<<"subject">>], Subject, Doc).
 
 -spec to_name(doc()) -> kz_term:api_binary().
 to_name(Doc) ->


### PR DESCRIPTION
After an upgrade to a release containing this enhancement,  from one server running the `teletype` app by running the command:

`sup teletype_maintenance restore_system_templates` 

 This command will add the {{ subject }} macro used in templates and update the default templates in the database.

 