### PR TITLE
[4.3] kz json schema filter add additional properties support JObjs with the schema's additionalProperties field.

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -74,6 +74,7 @@
                         "default": {
                             "description": "conferences controls default",
                             "items": {
+                                "additionalProperties": false,
                                 "properties": {
                                     "action": {
                                         "description": "what action to assign to the star-code",
@@ -91,6 +92,7 @@
                         "page": {
                             "description": "conferences controls page",
                             "items": {
+                                "additionalProperties": false,
                                 "properties": {
                                     "action": {
                                         "description": "what action to assign to the star-code",

--- a/applications/crossbar/priv/couchdb/schemas/account_config.call_command.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.call_command.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.call_command",
+    "additionalProperties": false,
     "description": "Schema for call_command account_config",
     "properties": {
         "unknown_cid_name": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.callflow.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.callflow",
+    "additionalProperties": false,
     "description": "Schema for callflow account_config",
     "properties": {
         "dialog_subscribed_mwi_prefix": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.cdr.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.cdr.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.cdr",
+    "additionalProperties": false,
     "description": "Schema for cdr account_config",
     "properties": {
         "ignore_loopback_bowout": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.conferences.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.conferences.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.conferences",
+    "additionalProperties": false,
     "description": "Schema for conferences account_config",
     "properties": {
         "controls": {
@@ -8,6 +9,7 @@
                 "default": {
                     "description": "conferences controls default",
                     "items": {
+                        "additionalProperties": false,
                         "properties": {
                             "action": {
                                 "description": "what action to assign to the star-code",
@@ -25,6 +27,7 @@
                 "page": {
                     "description": "conferences controls page",
                     "items": {
+                        "additionalProperties": false,
                         "properties": {
                             "action": {
                                 "description": "what action to assign to the star-code",

--- a/applications/crossbar/priv/couchdb/schemas/account_config.crossbar.auth.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.crossbar.auth.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.crossbar.auth",
+    "additionalProperties": false,
     "description": "Schema for crossbar.auth account_config",
     "properties": {
         "auth_modules": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.crossbar.sms.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.crossbar.sms.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.crossbar.sms",
+    "additionalProperties": false,
     "description": "Schema for crossbar.sms account_config",
     "properties": {
         "api_e164_convert_from": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.doodle.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.doodle.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.doodle",
+    "additionalProperties": false,
     "description": "Schema for doodle account_config",
     "properties": {
         "api_preserve_caller_id": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.fax.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.fax.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.fax",
+    "additionalProperties": false,
     "description": "Schema for fax account_config",
     "properties": {
         "default_smtp_domain": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.kazoo_endpoint.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.kazoo_endpoint.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.kazoo_endpoint",
+    "additionalProperties": false,
     "description": "Schema for kazoo_endpoint account_config",
     "properties": {
         "default_can_text_self": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.keys.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.keys.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.keys",
+    "additionalProperties": false,
     "description": "Schema for DTMF keys account_config",
     "properties": {
         "voicemail": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.ledgers.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.ledgers.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.ledgers",
+    "additionalProperties": false,
     "description": "Schema for ledgers account_config",
     "properties": {
         "registered_ledgers": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.media.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.media.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.media",
+    "additionalProperties": false,
     "description": "Schema for media account_config",
     "properties": {
         "call_recording": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.notify.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.notify.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.notify",
+    "additionalProperties": false,
     "description": "Schema for notify account_config",
     "properties": {
         "notify_persist_exceptions": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.number_manager.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.number_manager.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.number_manager",
+    "additionalProperties": false,
     "description": "Schema for number_manager account_config",
     "properties": {
         "unauthorized_numbers_lookup": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.omnipresence.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.omnipresence.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.omnipresence",
+    "additionalProperties": false,
     "description": "Schema for omnipresence account_config",
     "properties": {
         "dialog_subscribed_mwi_prefix": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.privacy.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.privacy.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.privacy",
+    "additionalProperties": false,
     "description": "Schema for privacy account_config",
     "properties": {
         "block_anonymous_caller_id": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.tasks.bill_early.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.tasks.bill_early.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.tasks.bill_early",
+    "additionalProperties": false,
     "description": "Schema for tasks.bill_early account_config",
     "properties": {
         "bill_early_enabled": {

--- a/applications/crossbar/priv/couchdb/schemas/account_config.webhooks.json
+++ b/applications/crossbar/priv/couchdb/schemas/account_config.webhooks.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "_id": "account_config.webhooks",
+    "additionalProperties": false,
     "description": "Schema for webhooks account_config",
     "properties": {
         "attempt_failure_count": {


### PR DESCRIPTION
kz_json_schema:filter/2 was not respecting the schemas “additionalProperties” field when filtering JObjs. As a result if a schema defined an object with “additionalProperties” set to an object then kz_json_schema:filter/2 would all ways filter out the objects.

Eg, if you defined a property of a schema as below and called filter/2 it would all ways be filtered out.

  ``` 
     "new_property": {
        "additionalProperties": {
            "properties": {
                "additional_property_1": {
                    "description": "Example additional property",
                    "type": "string"
                }
            },
            "additionalProperties": false,
            "type": "object"
        },
        "description": "Example new property with additional properties",
        "type": "object"
    }
```


With the new implementation, for it filter out additional properties from a JObj that are not defined in the schemas properties, you must define "additionalProperties": false. This is because by default "additionalProperties" is assumed to be true allowing additional properties to be defined without breaking the schema.

Kazoo5 PRs:
https://github.com/2600hz/kazoo-core/pull/77
https://github.com/2600hz/kazoo-crossbar/pull/47