### PR TITLE
fix hotornot crash when caller_id_numbers is in filter_list

### DIFF
--- a/applications/hotornot/src/hon_util.erl
+++ b/applications/hotornot/src/hon_util.erl
@@ -237,11 +237,11 @@ matching_rate(Rate, <<"routes">>, RateReq) ->
 matching_rate(Rate, <<"caller_id_numbers">>, RateReq) ->
     case kapi_rate:from_did(RateReq) of
         'undefined' -> true;
-    FromDID ->
-        E164 = knm_converters:normalize(FromDID),
-        lists:any(fun(Regex) -> re:run(E164, Regex) =/= 'nomatch' end
-             ,kzd_rates:caller_id_numbers(Rate, [<<".">>])
-             )
+        FromDID ->
+            E164 = knm_converters:normalize(FromDID),
+            lists:any(fun(Regex) -> re:run(E164, Regex) =/= 'nomatch' end
+                     ,kzd_rates:caller_id_numbers(Rate, [<<".">>])
+                     )
     end;
 
 matching_rate(Rate, <<"ratedeck_id">>, RateReq) ->

--- a/applications/hotornot/src/hon_util.erl
+++ b/applications/hotornot/src/hon_util.erl
@@ -235,11 +235,14 @@ matching_rate(Rate, <<"routes">>, RateReq) ->
              );
 
 matching_rate(Rate, <<"caller_id_numbers">>, RateReq) ->
-    FromDID = kapi_rate:from_did(RateReq),
-    E164 = knm_converters:normalize(FromDID),
-    lists:any(fun(Regex) -> re:run(E164, Regex) =/= 'nomatch' end
+    case kapi_rate:from_did(RateReq) of
+        'undefined' -> true;
+    FromDID ->
+        E164 = knm_converters:normalize(FromDID),
+        lists:any(fun(Regex) -> re:run(E164, Regex) =/= 'nomatch' end
              ,kzd_rates:caller_id_numbers(Rate, [<<".">>])
-             );
+             )
+    end;
 
 matching_rate(Rate, <<"ratedeck_id">>, RateReq) ->
     AccountId = kapi_rate:account_id(RateReq),


### PR DESCRIPTION
Fix hotornot crash when caller_id_names is present in system_config/hotornot/filter_list

Before fix:
```
[root@d1k1 ~]# sup hotornot_maintenance rates_for_did 00447800000000 
Candidates:
                                     RATE NAME |   COST | INCREMENT |   MINIMUM | SURCHARGE |    WEIGHT |          PREFIX |   RATEDECK NAME |         VERSION |
                            outbound_GB_447891 | 0.0102 |        60 |        60 |       0.0 |        59 |          447891 |        ratedeck |                 |
                              outbound_GB_4478 | 0.2237 |        60 |        60 |       0.0 |        18 |            4478 |        ratedeck |                 |
                                outbound_GB_44 | 0.0035 |        60 |        60 |       0.0 |        20 |              44 |        ratedeck |                 |
                                 inbound_UK_44 |    0.0 |        60 |        60 |       0.0 |        20 |              44 |        ratedeck |                 |
Command failed: {'EXIT',{function_clause,[{knm_converters,normalize,[undefined],[{file,"src/converters/knm_converters.erl"},{line,101}]},{hon_util,matching_rate,3,[{file,"src/hon_util.erl"},{line,213}]},{lists,'-filter/2-lc$^0/1-0-',2,[{file,"lists.erl"},{line,1286}]},{lists,foldl,3,[{file,"lists.erl"},{line,1263}]},{hotornot_maintenance,rates_for_did,4,[{file,"src/hotornot_maintenance.erl"},{line,83}]},{sup,in_kazoo,4,[{file,"src/sup.erl"},{line,98}]},{rpc,'-handle_call_call/6-fun-0-',5,[{file,"rpc.erl"},{line,197}]}]}}
```


After fix:

```
[root@d1k1 ~]# sup hotornot_maintenance rates_for_did 00447800000000 
Candidates:
                                     RATE NAME |   COST | INCREMENT |   MINIMUM | SURCHARGE |    WEIGHT |          PREFIX |   RATEDECK NAME |         VERSION |
                            outbound_GB_447891 | 0.0102 |        60 |        60 |       0.0 |        59 |          447891 |        ratedeck |                 |
                              outbound_GB_4478 | 0.2237 |        60 |        60 |       0.0 |        18 |            4478 |        ratedeck |                 |
                                outbound_GB_44 | 0.0035 |        60 |        60 |       0.0 |        20 |              44 |        ratedeck |                 |
                                 inbound_UK_44 |    0.0 |        60 |        60 |       0.0 |        20 |              44 |        ratedeck |                 |
Matching:
                                     RATE NAME |   COST | INCREMENT |   MINIMUM | SURCHARGE |    WEIGHT |          PREFIX |   RATEDECK NAME |         VERSION |
                          * outbound_GB_447891 | 0.0102 |        60 |        60 |       0.0 |        59 |          447891 |        ratedeck |                 |
                              outbound_GB_4478 | 0.2237 |        60 |        60 |       0.0 |        18 |            4478 |        ratedeck |                 |
                                 inbound_UK_44 |    0.0 |        60 |        60 |       0.0 |        20 |              44 |        ratedeck |                 |
                                outbound_GB_44 | 0.0035 |        60 |        60 |       0.0 |        20 |              44 |        ratedeck |                 |
ok
```
