### PR TITLE
[4.3] fix `make validate-js`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ validate-swagger:
 	@$(ROOT)/scripts/validate-swagger.sh
 
 validate-js:
-	@./scripts/validate-js.sh $(find {core,applications}/*/priv/**/* -name *.json)
+	@$(ROOT)/scripts/validate-js.sh $(shell find $(ROOT)/{core,applications}/*/priv/**/* -name *.json)
 
 sdks:
 	@$(ROOT)/scripts/make-swag.sh


### PR DESCRIPTION
`make validate-js` was always failing with
```
Usage: ./scripts/validate-js.sh file.json+
```