### PR TITLE
PISTON-1137: Fixes inaccurate stack trace.

### DIFF
--- a/core/kazoo_voicemail/src/kvm_message.erl
+++ b/core/kazoo_voicemail/src/kvm_message.erl
@@ -755,8 +755,8 @@ prepend_and_notify(Call, ForwardId, Metadata, SrcBoxId, Props) ->
             forward_to_vmbox(Call, Metadata, SrcBoxId, Props, UpdateFuns)
     catch
         _T:_E ->
-            remove_malform_vm(Call, ForwardId),
             ST = erlang:get_stacktrace(),
+            remove_malform_vm(Call, ForwardId),
             ErrorMessage = kz_term:to_binary(io_lib:format("exception occurred during prepend and joining audio files: ~p:~p", [_T, _E])),
             lager:error(ErrorMessage),
             kz_util:log_stacktrace(ST),


### PR DESCRIPTION
If an exception is caught within the `kvm_message:prepend_and_notify/5` function, the correct stack trace was potentially overwritten by an exception occuring within the `kvm_message:remove_malform_vm/2` function. The stack trace is now captured before calling that function.