### PR TITLE
[4.3] HELP-17551: allow disabling voicemail callback

### DIFF
--- a/applications/callflow/doc/voicemail.md
+++ b/applications/callflow/doc/voicemail.md
@@ -91,3 +91,14 @@ For example, to monitor and check box 3456, the BLF key could be tied to `*98345
 
 !!! note
 If you want to do MWI subscriptions, you must configure the account or system to do so. In the `voicemail` system_config document (or the account's config doc), set `dialog_subscribed_mwi_prefix` to the prefix (in this above case, `*98` would be the value): `sup kapps_config set_default voicemail dialog_subscribed_mwi_prefix '*98'`.
+
+## System configs
+
+### Callback option
+
+When checking voicemails, it is possible for the caller to use the `callback` feature to have the system place a call to the caller ID number on the voicemail. While convenient, a compromised voicemail box can be used to initiate fraudulent calls.
+
+System administrators can toggle two configurations to manage this feature:
+
+1. `voicemail.should_disable_callback`: if set to `true` no callers will be able to use the callback feature
+2. `voicemail.should_disable_offnet_callback`: if set to `true`, the caller *must* be calling from an authorized device (not from outside the account).

--- a/applications/callflow/src/module/cf_park.erl
+++ b/applications/callflow/src/module/cf_park.erl
@@ -24,15 +24,15 @@
 -define(MOD_CONFIG_CAT, <<(?CF_CONFIG_CAT)/binary, ".park">>).
 
 -define(DB_DOC_NAME, kapps_config:get_binary(?MOD_CONFIG_CAT, <<"db_doc_name">>, <<"parked_calls">>)).
--define(DEFAULT_RINGBACK_TM, kapps_config:get_integer(?MOD_CONFIG_CAT, <<"default_ringback_timeout">>, 120000)).
--define(DEFAULT_CALLBACK_TM, kapps_config:get_integer(?MOD_CONFIG_CAT, <<"default_callback_timeout">>, 30000)).
+-define(DEFAULT_RINGBACK_TM, kapps_config:get_integer(?MOD_CONFIG_CAT, <<"default_ringback_timeout">>, 120 * ?MILLISECONDS_IN_SECOND)).
+-define(DEFAULT_CALLBACK_TM, kapps_config:get_integer(?MOD_CONFIG_CAT, <<"default_callback_timeout">>, 30 * ?MILLISECONDS_IN_SECOND)).
 -define(PARKED_CALLS_KEY(Db), {?MODULE, 'parked_calls', Db}).
 -define(DEFAULT_PARKED_TYPE, <<"early">>).
 -define(SYSTEM_PARKED_TYPE, kapps_config:get_ne_binary(?MOD_CONFIG_CAT, <<"parked_presence_type">>, ?DEFAULT_PARKED_TYPE)).
 -define(ACCOUNT_PARKED_TYPE(A), kapps_account_config:get(A, ?MOD_CONFIG_CAT, <<"parked_presence_type">>, ?SYSTEM_PARKED_TYPE)).
 -define(PRESENCE_TYPE_KEY, <<"Presence-Type">>).
 -define(PARK_DELAY_CHECK_TIME_KEY, <<"valet_reservation_cleanup_time_ms">>).
--define(PARK_DELAY_CHECK_TIME, kapps_config:get_integer(?MOD_CONFIG_CAT, ?PARK_DELAY_CHECK_TIME_KEY, ?MILLISECONDS_IN_SECOND * 3)).
+-define(PARK_DELAY_CHECK_TIME, kapps_config:get_integer(?MOD_CONFIG_CAT, ?PARK_DELAY_CHECK_TIME_KEY, 3 * ?MILLISECONDS_IN_SECOND)).
 -define(PARKING_APP_NAME, <<"park">>).
 
 %%------------------------------------------------------------------------------

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -29970,6 +29970,16 @@
                             "minimum": 0,
                             "type": "integer"
                         },
+                        "should_disable_callback": {
+                            "default": false,
+                            "description": "If true, disallows callers to use voicemail callback feature",
+                            "type": "boolean"
+                        },
+                        "should_disable_offnet_callback": {
+                            "default": false,
+                            "description": "If true, requires caller to use an authorized device to use voicemail callback feature",
+                            "type": "boolean"
+                        },
                         "transcribe_default": {
                             "default": false,
                             "description": "callflow voicemail transcribe_default",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
@@ -188,6 +188,16 @@
                     "minimum": 0,
                     "type": "integer"
                 },
+                "should_disable_callback": {
+                    "default": false,
+                    "description": "If true, disallows callers to use voicemail callback feature",
+                    "type": "boolean"
+                },
+                "should_disable_offnet_callback": {
+                    "default": false,
+                    "description": "If true, requires caller to use an authorized device to use voicemail callback feature",
+                    "type": "boolean"
+                },
                 "transcribe_default": {
                     "default": false,
                     "description": "callflow voicemail transcribe_default",


### PR DESCRIPTION
Prior to this change, an malicious caller could leave a voicemail with
a bogus Caller ID number (typically an international number for
fraud) to a compromised voicemail box. Calling back into the voicemail
box, the malicious caller could select the callback option and place a
call to the fraudulent number.

If the account or owner of the voicemail box allowed international
calling, the fraud would progress.

This PR introduces two toggles to give system administrators more
control over callback functionality.

The first global config `should_disable_callback` can toggle whether
to allow the caller to select the callback option in general. If set
to `true`, the callback feature will be disable cluster-wide.

The second global config `should_disable_offnet_callback` requires the
caller to be using an authorized device. If set to `true`, the caller
must place the call from a device known to the account (authorizing_id
must be present).

Presumably, if the malicious caller has compromised SIP credentials,
they can place the fraudulent calls directly without the voicemail
callback. It is recommended to at least toggle
`should_disable_offnet_callback` to `true`.