### PR TITLE
[4.3] HELP-16882: hangup call if no failover

### DIFF
--- a/applications/trunkstore/src/ts_callflow.erl
+++ b/applications/trunkstore/src/ts_callflow.erl
@@ -93,10 +93,10 @@ send_park(#ts_callflow_state{route_req_jobj=JObj
            ],
     lager:info("trunkstore knows how to route this call, sending park route response"),
     kz_amqp_worker:relay_to(Worker, self()),
-    kz_amqp_worker:cast(Resp
-                       ,fun(API) -> kapi_route:publish_resp(kz_api:server_id(JObj), API) end
-                       ,Worker
-                       ),
+    _ = kz_amqp_worker:cast(Resp
+                           ,fun(API) -> kapi_route:publish_resp(kz_api:server_id(JObj), API) end
+                           ,Worker
+                           ),
     wait_for_win(State, ?WAIT_FOR_WIN_TIMEOUT).
 
 -spec wait_for_win(state(), pos_integer()) -> {'won' | 'lost', state()}.

--- a/applications/trunkstore/src/ts_from_offnet.erl
+++ b/applications/trunkstore/src/ts_from_offnet.erl
@@ -150,22 +150,25 @@ wait_for_bridge(State, Timeout) ->
 
 -spec try_failover(ts_callflow:state()) -> 'ok'.
 try_failover(State) ->
-    case {ts_callflow:get_control_queue(State)
-         ,ts_callflow:get_failover(State)
-         }
-    of
-        {<<>>, _} ->
-            lager:info("no callctl for failover");
-        {_, 'undefined'} ->
-            lager:info("no failover defined");
-        {_, Failover} ->
-            case kz_json:is_empty(Failover) of
-                'true' ->
-                    lager:info("no failover configured");
-                'false' ->
-                    lager:info("trying failover"),
-                    failover(State, Failover)
-            end
+    try_failover(State
+                ,ts_callflow:get_control_queue(State)
+                ,ts_callflow:get_failover(State)
+                ).
+
+-spec try_failover(ts_callflow:state(), binary(), kz_term:api_object()) -> 'ok'.
+try_failover(_State, <<>>, _Failover) ->
+    lager:info("no callctl for failover");
+try_failover(State, _CtlQ, 'undefined') ->
+    lager:info("no failover defined"),
+    ts_callflow:send_hangup(State);
+try_failover(State, _CtlQ, Failover) ->
+    case kz_json:is_empty(Failover) of
+        'true' ->
+            lager:info("no failover configured"),
+            ts_callflow:send_hangup(State);
+        'false' ->
+            lager:info("trying failover"),
+            failover(State, Failover)
     end.
 
 -spec failover(ts_callflow:state(), kz_json:object()) -> 'ok'.
@@ -422,7 +425,7 @@ routing_data(ToDID, AccountId, Settings) ->
 -spec build_ip(kz_term:api_binary(), kz_term:api_binary() | integer()) -> kz_term:api_binary().
 build_ip('undefined', _) -> 'undefined';
 build_ip(IP, 'undefined') -> IP;
-build_ip(IP, <<_/binary>> = PortBin) -> build_ip(IP, kz_term:to_integer(PortBin));
+build_ip(IP, <<PortBin/binary>>) -> build_ip(IP, kz_term:to_integer(PortBin));
 build_ip(IP, 5060) -> IP;
 build_ip(IP, Port) -> list_to_binary([IP, ":", kz_term:to_binary(Port)]).
 

--- a/applications/trunkstore/src/ts_from_onnet.erl
+++ b/applications/trunkstore/src/ts_from_onnet.erl
@@ -228,7 +228,7 @@ wait_for_bridge(State, CtlQ, Timeout) ->
         {'error', #ts_callflow_state{aleg_callid='undefined'}} -> 'ok';
         {'error', #ts_callflow_state{aleg_callid=CallId}=State1} ->
             lager:info("responding to aleg ~s with 686", [CallId]),
-            kz_call_response:send(CallId, CtlQ, <<"686">>),
+            _ = kz_call_response:send(CallId, CtlQ, <<"686">>),
             ts_callflow:send_hangup(State1, <<"686">>)
     end.
 


### PR DESCRIPTION
Prior to this change, if the receiving PBX refused the call and no
failover was configured, Trunkstore would exit and the A-leg would
continue ringing until the caller hungup.

This change sends a hangup to the A-leg before exiting.