### PR TITLE
[4.3] PISTON-1144: add missing entries for kapi_notifications for voicemail_deleted

### DIFF
--- a/applications/crossbar/src/modules/cb_notifications.erl
+++ b/applications/crossbar/src/modules/cb_notifications.erl
@@ -593,6 +593,8 @@ publish_fun(<<"transaction">>) ->
     fun kapi_notifications:publish_transaction/1;
 publish_fun(<<"transaction_failed">>) ->
     fun kapi_notifications:publish_transaction/1;
+publish_fun(<<"voicemail_deleted">>) ->
+    fun kapi_notifications:publish_voicemail_deleted/1;
 publish_fun(<<"voicemail_full">>) ->
     fun kapi_notifications:publish_voicemail_full/1;
 publish_fun(<<"voicemail_to_email">>) ->

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -1413,6 +1413,8 @@ api_definition(<<"new_user">>) ->
     new_user_definition();
 api_definition(<<"password_recovery">>) ->
     password_recovery_definition();
+api_definition(<<"voicemail_deleted">>) ->
+    voicemail_deleted_definition();
 api_definition(<<"voicemail_full">>) ->
     voicemail_full_definition();
 api_definition(<<"voicemail_new">>) ->


### PR DESCRIPTION
- Causes crashes without these if Preview mode is used for the template via cb_notifications