### PR TITLE
PISTON-1123: Fixes voicemail forward confirmation.

### DIFF
--- a/applications/callflow/src/module/cf_voicemail.erl
+++ b/applications/callflow/src/module/cf_voicemail.erl
@@ -1220,7 +1220,7 @@ maybe_forward(AttachmentName, Message, SourceBoxId, DestinationBox, Call, Msg, {
     forward_message(AttachmentName, Length, Message, SourceBoxId, DestinationBox, Call).
 
 %%------------------------------------------------------------------------------
-%% @doc Starts a task to asynchronously forward a message to another vmbox and 
+%% @doc Starts a task to asynchronously forward a message to another vmbox and
 %% plays a confirmation of the operation.
 %% @end
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
The `cf_voicemail:forward_message/6` function has been refactored to consistently execute the forwarding operation as an asynchronous task and to play the confirmation of the operation synchronously. The previous flow of control was inconsistent, depending on configuration. In some circumstances, the forwarding operation was performed asynchronously, but this resulted in no audible confirmation. In other circumstances, forwarding was performed synchronously.