### PR TITLE
Fixed crushes when used AWS ALB instead of haproxy

### DIFF
--- a/applications/pusher/deps.mk
+++ b/applications/pusher/deps.mk
@@ -1,6 +1,6 @@
 DEPS = apns fcm lager
 
-dep_apns = git https://github.com/2600hz/erlang-apns4erl.git aba1fa96a4abbbb2c1628ad5d604f482aad4d12f # latest commit SHA to 2600hz branch
+dep_apns = git https://github.com/2600hz/erlang-apns4erl.git 20668a1f5fde5a7afd195d03a5cd30825786f2c5 # latest commit SHA to 2600hz branch
 
 dep_fcm = git https://github.com/2600hz/erlang-fcm.git b2f68a4c6f0f59475597a35e2dc9be13d9ba2910
 # Firebase cloud messaging

--- a/applications/stats/src/stats_handler.erl
+++ b/applications/stats/src/stats_handler.erl
@@ -160,6 +160,7 @@ table_def() ->
       ,{<<"memory-ets">>, 0}
       ,{<<"amqp-error">>, 0}
       ,{<<"amqp-request">>, 0}
+      ,{<<"bigcouch-502-error">>, 0}
       ,{<<"bigcouch-504-error">>, 0}
       ,{<<"bigcouch-other-error">>, 0}
       ,{<<"bigcouch-request">>, 0}

--- a/core/kazoo_couch/src/kz_couch_util.erl
+++ b/core/kazoo_couch/src/kz_couch_util.erl
@@ -72,6 +72,10 @@ retry504s(Fun, Cnt) ->
             {'ok', kz_json:decode(Body)};
         {'error', {'bad_response',{204, _Headers, _Body}}} ->
             {'ok', kz_json:new()};
+        {'error', {'bad_response',{502, _Headers, _Body}}} ->
+            kazoo_stats:increment_counter(<<"bigcouch-502-error">>),
+            timer:sleep(100 * (Cnt+1)),
+            retry504s(Fun, Cnt+1);
         {'error', {'bad_response',{_Code, _Headers, _Body}}=Response} ->
             kazoo_stats:increment_counter(<<"bigcouch-other-error">>),
             lager:critical("response code ~b not expected : ~p", [_Code, _Body]),


### PR DESCRIPTION
When CouchDB server not available AWS load balancer returns 502 error code.
Added handles for this error code.