### PR TITLE
4.3 fax fixes

### DIFF
--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -15,6 +15,7 @@
 -export([handle_tx_resp/2
         ,handle_fax_event/2
         ,handle_job_status_query/2
+        ,maybe_move_doc/1
         ]).
 -export([init/1
         ,handle_call/3
@@ -677,6 +678,12 @@ maybe_notify(JObj, Resp, <<"failed">>) ->
     kapps_notify_publisher:cast(Message, fun kapi_notifications:publish_fax_outbound_error/1);
 maybe_notify(_JObj, _Resp, Status) ->
     lager:debug("notify status ~p not handled", [Status]).
+
+-spec maybe_move_doc(kz_json:object()) ->
+          {'ok', kz_json:object()} |
+          kz_datamgr:data_error().
+maybe_move_doc(JObj) ->
+    maybe_move_doc(JObj, kzd_fax:job_status(JObj)).
 
 -spec maybe_move_doc(kz_json:object(), kz_term:ne_binary()) ->
           {'ok', kz_json:object()} |

--- a/applications/fax/src/fax_worker.erl
+++ b/applications/fax/src/fax_worker.erl
@@ -15,7 +15,6 @@
 -export([handle_tx_resp/2
         ,handle_fax_event/2
         ,handle_job_status_query/2
-        ,maybe_move_doc/1
         ]).
 -export([init/1
         ,handle_call/3
@@ -678,12 +677,6 @@ maybe_notify(JObj, Resp, <<"failed">>) ->
     kapps_notify_publisher:cast(Message, fun kapi_notifications:publish_fax_outbound_error/1);
 maybe_notify(_JObj, _Resp, Status) ->
     lager:debug("notify status ~p not handled", [Status]).
-
--spec maybe_move_doc(kz_json:object()) ->
-          {'ok', kz_json:object()} |
-          kz_datamgr:data_error().
-maybe_move_doc(JObj) ->
-    maybe_move_doc(JObj, kzd_fax:job_status(JObj)).
 
 -spec maybe_move_doc(kz_json:object(), kz_term:ne_binary()) ->
           {'ok', kz_json:object()} |


### PR DESCRIPTION
At the completion of a fax it uses the move_doc (which uses copy_doc) to move the fax document with its attachments to the MODB from the faxes database.  However, bigcouch can return conflict despite being successful when moving attachments.  Since fax documents have so many attachments the move fails frequently causing the faxes db to grow significantly.