### PR TITLE
4.3.caller id numbers

### DIFF
--- a/applications/tasks/src/modules/kt_rates.erl
+++ b/applications/tasks/src/modules/kt_rates.erl
@@ -303,7 +303,32 @@ get_ratedeck_db(_ExtraArgs) ->
 -spec to_csv_row(kz_json:object()) -> kz_csv:row().
 to_csv_row(Row) ->
     Doc = kz_json:get_json_value(<<"doc">>, Row),
-    [kz_json:get_binary_value(Key, Doc) || Key <- ?DOC_FIELDS].
+    [to_csv(Key, Doc) || Key <- ?DOC_FIELDS].
+
+-spec to_csv(kz_term:ne_binary(), kz_json:object()) -> kz_term:ne_binary().
+% Convert list of regex's to  a ":" seperated binary string
+% e.g. [<<"^\\+?441.+$">>,<<"^\\+?442.+$">>,<<"^\\+?443.+$">>,<<"^\\+?447.+$">>] -> <<"441:442:443:447">>
+to_csv(<<"caller_id_numbers">>, Doc) ->
+    case kzd_rates:caller_id_numbers(Doc) of
+        'undefined' -> 'undefined';
+    RegexList ->
+        RE = "^\\^\\\\\\+\\?(.*)\\\.\\+\\$",
+        try
+            <<":", ColonList/binary>> = 
+            lists:foldr(fun(X, Acc) -> 
+                           {match, [Y]} = re:run(X, RE, [{capture, all_but_first, binary}]),
+                           <<$:, Y/binary, Acc/binary>> 
+                        end, 
+                        <<>>,
+                        RegexList),
+            ColonList
+        catch
+	   E:R -> lager:warning("caller_id_numbers filters not in expected format ~p:~p", [E, R]),
+           RegexList
+        end
+    end;
+to_csv(Key, Doc) ->
+    kz_json:get_binary_value(Key, Doc).
 
 -spec maybe_override_rate(kz_tasks:args()) -> kzd_rates:doc().
 maybe_override_rate(Args) ->

--- a/core/kazoo_documents/src/kzd_rates.erl
+++ b/core/kazoo_documents/src/kzd_rates.erl
@@ -68,7 +68,7 @@ caller_id_numbers(Doc) ->
 
 -spec caller_id_numbers(doc(), Default) -> binary() | Default.
 caller_id_numbers(Doc, Default) ->
-    kz_json:get_binary_value([<<"caller_id_numbers">>], Doc, Default).
+    kz_json:get_list_value([<<"caller_id_numbers">>], Doc, Default).
 
 -spec set_caller_id_numbers(doc(), binary()) -> doc().
 set_caller_id_numbers(Doc, CallerIdNumbers) ->


### PR DESCRIPTION
Selecting a rate for an inbound call with caller_id_numbers filter was failing here:

https://github.com/2600hz/kazoo/blob/1fbde96c344c63fa0db5f7b63fcdbc3d0b134c65/applications/hotornot/src/hon_util.erl#L258

kzd_rates:caller_id_numbers(Rate, [<<".">>]) should be returning the list of regexes but it was returning a binary instead.

Also fixed up the CSV import/export so now the export CSV has the same format as the import CSV.

When we exported a ratedeck the caller_id_numbers in the CSV were in the internal regex format and so if that file was then imported back the field was corrupted and the filter no longer worked.

The CSV format of the caller_id_numbers should be ':' seperated list of prefixes in both import and export files

