### PR TITLE
Fix tickets URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ See the [installation](./doc/installation.md) page to build.
     * [KAZOO developer documentation](https://docs.2600hz.com/dev/)
     * [UI developer documentation](https://docs.2600hz.com/ui/)
     * [System administrator documentation](https://docs.2600hz.com/sysadmin/)
-* Bugs and feature requests can be found [here](http://tickets.2600hz.org)
+* Bugs and feature requests can be found [here](https://tickets.2600hz.com)
 * [Learn you some Erlang!](http://learnyousomeerlang.com/)
 * Check out the [FreeSWITCH documentation](https://freeswitch.org/confluence/display/FREESWITCH/FreeSWITCH+Explained)
 * Take a look at the [Kamailio documentation](https://www.kamailio.org/w/documentation/)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ See the [installation](./doc/installation.md) page to build.
     * [KAZOO developer documentation](https://docs.2600hz.com/dev/)
     * [UI developer documentation](https://docs.2600hz.com/ui/)
     * [System administrator documentation](https://docs.2600hz.com/sysadmin/)
-* Bugs and feature requests can be found [here](https://tickets.2600hz.com)
+* Bugs and feature requests can be found [here](https://tickets.2600hz.org)
 * [Learn you some Erlang!](http://learnyousomeerlang.com/)
 * Check out the [FreeSWITCH documentation](https://freeswitch.org/confluence/display/FREESWITCH/FreeSWITCH+Explained)
 * Take a look at the [Kamailio documentation](https://www.kamailio.org/w/documentation/)


### PR DESCRIPTION
Tickets URL was pointing to **.org** domain and wasn't redirecting to Jira page.