### PR TITLE
PISTON-1170: Sets prepend_on_forward media content_type correctly.

### DIFF
--- a/core/kazoo_media/include/kz_media.hrl
+++ b/core/kazoo_media/include/kz_media.hrl
@@ -1,6 +1,7 @@
 -ifndef(KZ_MEDIA_HRL).
 
 -define(CHUNKSIZE, 24576).
+-define(NORMALIZATION_FORMAT, kapps_config:get_ne_binary(<<"crossbar.media">>, <<"normalization_format">>, <<"mp3">>)).
 
 -record(media_file, {stream_url = <<>> :: binary()
                     ,contents = <<>> :: binary()

--- a/core/kazoo_media/src/kz_media_util.erl
+++ b/core/kazoo_media/src/kz_media_util.erl
@@ -45,8 +45,6 @@
 -define(NORMALIZE_SOURCE_ARGS, kapps_config:get_binary(?CONFIG_CAT, <<"normalize_source_args">>, <<>>)).
 -define(NORMALIZE_DEST_ARGS, kapps_config:get_binary(?CONFIG_CAT, <<"normalize_destination_args">>, <<"-r 8000">>)).
 
--define(NORMALIZATION_FORMAT, kapps_config:get_ne_binary(<<"crossbar.media">>, <<"normalization_format">>, <<"mp3">>)).
-
 -define(USE_ACCOUNT_OVERRIDES, kapps_config:get_is_true(?CONFIG_CAT, <<"support_account_overrides">>, 'true')).
 
 -define(DEFAULT_MAX_RECORDING_LIMIT, 3*?SECONDS_IN_HOUR).


### PR DESCRIPTION
The `kzm_message:forward_message/4` function branches, depending on whether the user has recorded an additional message to be prepended to the voicemail message being forwarded. Prepending the additional message requires the two media files to be merged into a temporary file. This is then written to the database as an attachment.

Prior to this fix, the code assumed that the merged media file has an `mp3` format, which is not necessarily true. In addition, it did not pass any content-type option to the `kz_datamgr:put_attachment/5` function which actually writes the attachment. As a result, the attachment metadata in the database always indicated a content-type of `application/octet-stream`.

Calls to `kz_media_util:join_media_files/2` now ensure that the merged output format is specified explicitly, rather than relying on default behaviour. The same format is also mapped to the corresponding MIME type which is passed to `kz_datamgr:put_attachment/5` to ensure the attachment metadata is correct.