### PR TITLE
[4.3] add wav support and remove unnecessary code

### DIFF
--- a/core/kazoo_speech/src/asr/kazoo_asr_ibm.erl
+++ b/core/kazoo_speech/src/asr/kazoo_asr_ibm.erl
@@ -23,8 +23,8 @@
 -define(IBM_ASR_KEY, kapps_config:get_binary(?IBM_CONFIG_CAT, <<"asr_api_key">>)).
 -define(IBM_ASR_PROFANITY_FILTER, kapps_config:get_is_true(?IBM_CONFIG_CAT, <<"asr_profanity_filter">>)).
 -define(IBM_ASR_MODEL, kapps_config:get_binary(?IBM_CONFIG_CAT, <<"asr_model">>, <<"en-US_NarrowbandModel">>)).
--define(IBM_ASR_PREFERRED_CONTENT_TYPE, <<"application/mpeg">>).
--define(IBM_ASR_ACCEPTED_CONTENT_TYPES, [<<"audio/mpeg">>]).
+-define(IBM_ASR_PREFERRED_CONTENT_TYPE, <<"audio/mpeg">>).
+-define(IBM_ASR_ACCEPTED_CONTENT_TYPES, [<<"audio/mpeg">>, <<"audio/wav">>]).
 
 %%%------------------------------------------------------------------------------
 %%% @doc Return true if IBM ASR is configured / available otherwise false.

--- a/core/kazoo_speech/src/kazoo_asr_util.erl
+++ b/core/kazoo_speech/src/kazoo_asr_util.erl
@@ -17,29 +17,15 @@
 %% @end
 %%------------------------------------------------------------------------------
 -spec maybe_convert_content(binary(), kz_term:ne_binary(), kz_term:ne_binaries(), kz_term:ne_binary()) -> conversion_return().
-maybe_convert_content(Content, ContentType, SupportedContentTypes, DefaultContentType) ->
+maybe_convert_content(Content, ContentType, SupportedContentTypes, PreferredContentType) ->
     case lists:member(ContentType, SupportedContentTypes) of
         'true' -> {Content, ContentType};
         'false' ->
-            ConvertTo = default_preferred_content_type(SupportedContentTypes, DefaultContentType),
-            case convert_content(Content, ContentType, ConvertTo) of
-                'error' -> {'error', 'unsupported_content_type'};
-                Converted -> {Converted, ConvertTo}
-            end
-    end.
-
--spec default_preferred_content_type(kz_term:ne_binaries(), kz_term:ne_binary()) -> kz_term:ne_binary().
-default_preferred_content_type(SupportedContentTypes, DefaultContentType) ->
-    PreferredContentType = kazoo_asr:preferred_content_type(),
-    validate_content_type(PreferredContentType, SupportedContentTypes, DefaultContentType).
-
--spec validate_content_type(binary(), kz_term:ne_binaries(), kz_term:ne_binary()) -> kz_term:ne_binary().
-validate_content_type(ContentType, SupportedContentTypes, DefaultContentType) ->
-    case lists:member(ContentType, SupportedContentTypes) of
-        'true' -> ContentType;
-        'false' ->
             lager:debug("content-type ~s is not supported by asr provider", [ContentType]),
-            DefaultContentType
+            case convert_content(Content, ContentType, PreferredContentType) of
+                'error' -> {'error', 'unsupported_content_type'};
+                Converted -> {Converted, PreferredContentType}
+            end
     end.
 
 -spec convert_content(binary(), kz_term:ne_binary(), kz_term:ne_binary()) -> binary() | 'error'.


### PR DESCRIPTION
Added wav supported and removed unnecessary code which was creating confusion, we already have the preferred audio codec not sure why we are looking for it again.
