### PR TITLE
Fix the HTTP storage validation URL

### DIFF
--- a/core/kazoo_attachments/src/kz_att_http.erl
+++ b/core/kazoo_attachments/src/kz_att_http.erl
@@ -115,10 +115,9 @@ fields(_Settings) -> kz_att_util:default_format_url_fields().
                     ,gen_attachment:att_name()
                     ) -> kz_term:ne_binary().
 attachment_url(HandlerProps, DbName, DocId, AName) ->
-    BaseUrlParam = kz_json:get_ne_binary_value(<<"url">>, HandlerProps),
     HProps = handler_props_map(HandlerProps),
+    BaseUrl = maps:get('url', HProps),
 
-    BaseUrl = kz_binary:strip_right(BaseUrlParam, $/),
     ClientSegment = kz_att_util:format_url(HProps, {DbName, DocId, AName}, fields(HProps)),
     Separator = base_separator(BaseUrl),
 


### PR DESCRIPTION
Currently, the HTTP storage validation sending this URL 
http://example.com/system_data/1b34fd65880aba98449c4b086d5125a1/d589258d403a6ed9e1559a992a9c975c_test_credentials_file.txt/system_data/1b34fd65880aba98449c4b086d5125a1/d589258d403a6ed9e1559a992a9c975c_test_credentials_file.txt?att_uuid=2876bab103524ba08e2b31c95dc6c31c&content=some+random+content%3A+d589258d403a6ed9e1559a992a9c975c&request_id=466a2643c4bf8d6c27c639c48e391d24&id=1b34fd65880aba98449c4b086d5125a1
Instead of 
http://example.com/system_data/1b34fd65880aba98449c4b086d5125a1/d589258d403a6ed9e1559a992a9c975c_test_credentials_file.txt?att_uuid=2876bab103524ba08e2b31c95dc6c31c&content=some+random+content%3A+d589258d403a6ed9e1559a992a9c975c&request_id=466a2643c4bf8d6c27c639c48e391d24&id=1b34fd65880aba98449c4b086d5125a1

It looks like this bug starts from this commit: d723e900c63242b9df7d58528d962280b26e5068