### PR TITLE
[4.3] PISTON-1177: new approach to determine initial availability for agents of queue

### DIFF
--- a/applications/acdc/src/acdc_agent_handler.erl
+++ b/applications/acdc/src/acdc_agent_handler.erl
@@ -19,6 +19,7 @@
         ,handle_agent_message/2
         ,handle_config_change/2
         ,handle_presence_probe/2
+        ,handle_queue_started_notif/2
         ]).
 
 -include("acdc.hrl").
@@ -490,3 +491,16 @@ maybe_update_presence(Sup, JObj, PresenceState) ->
     APid = acdc_agent_sup:listener(Sup),
     acdc_agent_listener:maybe_update_presence_id(APid, presence_id(JObj)),
     acdc_agent_listener:presence_update(APid, presence_state(JObj, PresenceState)).
+
+%%------------------------------------------------------------------------------
+%% @doc When a queue this agent is bound to (a member of) is started, handle the
+%% notif by sending an availability update to the queue so it knows the
+%% availability state of this agent for taking calls.
+%% @end
+%%------------------------------------------------------------------------------
+-spec handle_queue_started_notif(kz_json:object(), kz_term:proplist()) -> 'ok'.
+handle_queue_started_notif(JObj, Props) ->
+    'true' = kapi_acdc_queue:started_notif_v(JObj),
+    FSM = props:get_value('fsm_pid', Props),
+    QueueId = kz_json:get_ne_binary_value(<<"Queue-ID">>, JObj),
+    acdc_agent_fsm:send_availability_update(FSM, QueueId).

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -7751,6 +7751,36 @@
             ],
             "type": "object"
         },
+        "kapi.acdc_queue.started_notif": {
+            "description": "AMQP API for acdc_queue.started_notif",
+            "properties": {
+                "Account-ID": {
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "Event-Category": {
+                    "enum": [
+                        "queue"
+                    ],
+                    "type": "string"
+                },
+                "Event-Name": {
+                    "enum": [
+                        "started_notif"
+                    ],
+                    "type": "string"
+                },
+                "Queue-ID": {
+                    "minLength": 1,
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Account-ID",
+                "Queue-ID"
+            ],
+            "type": "object"
+        },
         "kapi.acdc_queue.sync_req": {
             "description": "AMQP API for acdc_queue.sync_req",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.started_notif.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.acdc_queue.started_notif.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.acdc_queue.started_notif",
+    "description": "AMQP API for acdc_queue.started_notif",
+    "properties": {
+        "Account-ID": {
+            "minLength": 1,
+            "type": "string"
+        },
+        "Event-Category": {
+            "enum": [
+                "queue"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "started_notif"
+            ],
+            "type": "string"
+        },
+        "Queue-ID": {
+            "minLength": 1,
+            "type": "string"
+        }
+    },
+    "required": [
+        "Account-ID",
+        "Queue-ID"
+    ],
+    "type": "object"
+}


### PR DESCRIPTION
- when acdc_queue_manager boots, do not immediately assume all member agents are available
- when manager proc is ready, pub msg so that agents send an availability update
- any subsequent agent starts/availability changes will already be picked up by existing bindings