### PR TITLE
Fixed failing validate-js test due to the use of the word `function` being detected incorrectly in JSON schema.

### DIFF
--- a/scripts/validate-js.sh
+++ b/scripts/validate-js.sh
@@ -21,10 +21,10 @@ def fmap(F, data):
     elif isinstance(data, tuple):
         (key, value) = data
         if isinstance(value, basestring):
-            if value.startswith('function'):
+            if value.startswith('function('):
                 F(data)
         elif isinstance(value, list) and len(value) > 0 \
-             and isinstance(value[0], basestring) and value[0].startswith('function'):
+             and isinstance(value[0], basestring) and value[0].startswith('function('):
             F(data)
         else:
             fmap(F, value)


### PR DESCRIPTION
validate-js tests were failing on the recently added file `applications/crossbar/priv/couchdb/schemas/system_config.tasks.cleanup.json` due to the word `function` being used in a list. The script was treating it as a view function and calling couchjs on it causing a error.