### PR TITLE
[4.3] KZOO-154: make sure e911 email format is email

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -26858,6 +26858,7 @@
                             "default": [],
                             "description": "A list of email addresses to receive notification when this number places an emergency call",
                             "items": {
+                                "format": "email",
                                 "type": "string"
                             },
                             "type": "array"

--- a/applications/crossbar/priv/couchdb/schemas/phone_numbers.json
+++ b/applications/crossbar/priv/couchdb/schemas/phone_numbers.json
@@ -93,6 +93,7 @@
                     "default": [],
                     "description": "A list of email addresses to receive notification when this number places an emergency call",
                     "items": {
+                        "format": "email",
                         "type": "string"
                     },
                     "type": "array"


### PR DESCRIPTION
when invalid email is entered into email section it crashes 911 notifications.
