### PR TITLE
PISTON-1082: Crossbar validation errors with the same top level key will no longer overwrite each other but instead will now merge the keys where possible

### DIFF
--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -1101,7 +1101,7 @@ add_validation_error(Property, Code, Message, Context) ->
                                          )
                                        ),
     ErrorsJObj = validation_errors(Context),
-    Context#cb_context{validation_errors=kz_json:merge_jobjs(ErrorJObj, ErrorsJObj)
+    Context#cb_context{validation_errors=kz_json:merge(ErrorJObj, ErrorsJObj)
                       ,resp_status='error'
                       ,resp_error_code=ErrorCode
                       ,resp_data=kz_json:new()


### PR DESCRIPTION
Kazoo 5pr: https://github.com/2600hz/kazoo-crossbar/pull/140

When CB builds the error response from multiple validation errors it would do a top level merge only resulting in errors regularly overwriting each other in the response.

EG: 
Take the error list below
```
[{<<"numbers">>,<<"type">>,
  {[{<<"message">>,<<"Value did not match type(s): array">>},
    {<<"target">>,<<"array">>},
    {<<"value">>,<<"12345">>}]}},
 {<<"numbers">>,<<"required">>,
  {[{<<"message">>,
     <<"Callflows must be assigned at least one number or pattern">>}]}}]
```
With the current merge CB would return:
```
{[{<<"numbers">>,
   {[{<<"required">>,
      {[{<<"message">>,
         <<"Callflows must be assigned at least one number or pattern">>}]}}]}}]}
```
With this solution, CB will respond with:
```
{[{<<"numbers">>,
   {[{<<"type">>,
      {[{<<"value">>,<<"12345">>},
        {<<"target">>,<<"array">>},
        {<<"message">>,<<"Value did not match type(s): array">>}]}},
     {<<"required">>,
      {[{<<"message">>,
         <<"Callflows must be assigned at least one number or pattern">>}]}}]}}]}
```
This still does not handle the the case where the keys exactly match but the only way to do this would be to change the response type of the error to an array (Breaking change) but maybe its worth considering for a future version.
```
{
    "numbers": {
        "unique": [
            {
                "value": "12345",
                "message": "number is not unique"
            },
            {
                "value": "54321",
                "message": "number is not unique"
            }
        ]
    }
}
```