### PR TITLE
PISTON-1191 Add Queue name and options to tasks_listener

### DIFF
--- a/applications/tasks/src/tasks_listener.erl
+++ b/applications/tasks/src/tasks_listener.erl
@@ -28,6 +28,9 @@
 
 -record(state, {}).
 -type state() :: #state{}.
+-define(QUEUE_NAME, <<"tasks_listener">>).
+-define(QUEUE_OPTIONS, [{'exclusive', 'false'}]).
+-define(CONSUME_OPTIONS, [{'exclusive', 'false'}]).
 
 -define(BINDINGS, [{'self', []}
                   ,{'tasks', []}
@@ -60,6 +63,9 @@ start_link() ->
     gen_listener:start_link(?SERVER
                            ,[{'bindings', ?BINDINGS}
                             ,{'responders', ?RESPONDERS}
+                            ,{'queue_name', ?QUEUE_NAME}
+                            ,{'queue_options', ?QUEUE_OPTIONS}
+                            ,{'consume_options', ?CONSUME_OPTIONS}
                             ]
                            ,[]
                            ).


### PR DESCRIPTION
After the removal of kz_globals from the tasks app the tasks app was creating N number of copies of an object where N was the number of tasks applications in the cluster.

Kazoo 5.x PR https://github.com/2600hz/kazoo-tasks/pull/13