### PR TITLE
[4.3] KZOO-173: Strict check ipv4 addresses

### DIFF
--- a/core/kazoo_stdlib/src/kz_network_utils.erl
+++ b/core/kazoo_stdlib/src/kz_network_utils.erl
@@ -212,7 +212,7 @@ detect_ip_family(IP) ->
         case inet:parse_ipv6strict_address(IP) of
             {'ok', IPv6} -> {'inet6', IPv6};
             {'error', 'einval'} ->
-                case inet:parse_ipv4_address(IP) of
+                case inet:parse_ipv4strict_address(IP) of
                     {'ok', IPv4} -> {'inet', IPv4};
                     {'error', 'einval'}=Error -> Error
                 end


### PR DESCRIPTION
when a number is passed through ip check it results in saying valid ip when its just a number, strict checking of ipv4 will make sure when an ip is properly formatted with dots is accepted as a valid IP.
