### PR TITLE
[4.3] KZOO-185: increase stop recording expiration timer

### DIFF
--- a/core/kazoo_call/src/kzc_recording.erl
+++ b/core/kazoo_call/src/kzc_recording.erl
@@ -45,6 +45,7 @@
 -define(SERVER, ?MODULE).
 -define(RECORDING_TIMER_EXPIRED, 'recording_timer_expired').
 -define(RECORDING_STOP_TIMER_EXPIRED, 'recording_stop_timer_expired').
+-define(RECORDING_STOP_TIMER_EXPIRED_MS, 30 * ?MILLISECONDS_IN_SECOND).
 
 -type media_directory() :: file:filename_all().
 -type media_name() :: file:filename_all().
@@ -733,7 +734,7 @@ start_recording_timer(TimeLimit) ->
 -spec start_recording_stop_timer() -> reference().
 start_recording_stop_timer() ->
     lager:debug("starting timer while waiting for RECORD_STOP"),
-    erlang:start_timer(5 * ?MILLISECONDS_IN_SECOND
+    erlang:start_timer(?RECORDING_STOP_TIMER_EXPIRED_MS
                       ,self()
                       ,?RECORDING_STOP_TIMER_EXPIRED
                       ).


### PR DESCRIPTION
It has been observed the timer for expiration timer while waiting to receive
`RECORD_STOP` event could timed out sooner than receiving that event. Increasing
this timer to allow more time for the event to arrive so the recording can
properly stored.