### PR TITLE
PISTON-1289: create_caller_id_name_if_undefined

### DIFF
--- a/applications/crossbar/doc/ref/users.md
+++ b/applications/crossbar/doc/ref/users.md
@@ -27,6 +27,7 @@ Key | Description | Type | Default | Required | Support Level
 `caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` | `supported`
 `contact_list` | Contact List Parameters | `object()` | `{}` | `false` |  
+`create_caller_id_name_if_undefined` | Create the users caller id name from the first and last name fields if no caller id is defined | `boolean()` |   | `false` | `supported`
 `dial_plan` | A list of rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  
 `directories` | Provides the mappings for what directory the user is a part of (the key), and what callflow (the value) to invoke if the user is selected by the caller. | `object()` |   | `false` |  
 `do_not_disturb.enabled` | Is do-not-disturb enabled for this user? | `boolean()` |   | `false` |  

--- a/applications/crossbar/doc/users.md
+++ b/applications/crossbar/doc/users.md
@@ -29,6 +29,7 @@ Key | Description | Type | Default | Required | Support Level
 `caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `contact_list.exclude` | If set to true the device is excluded from the contact list | `boolean()` |   | `false` | `supported`
 `contact_list` | Contact List Parameters | `object()` | `{}` | `false` |  
+`create_caller_id_name_if_undefined` | Create the users caller id name from the first and last name fields if no caller id is defined | `boolean()` |   | `false` | `supported`
 `dial_plan` | A list of rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  
 `directories` | Provides the mappings for what directory the user is a part of (the key), and what callflow (the value) to invoke if the user is selected by the caller. | `object()` |   | `false` |  
 `do_not_disturb.enabled` | Is do-not-disturb enabled for this user? | `boolean()` |   | `false` |  

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -36765,6 +36765,10 @@
                     },
                     "type": "object"
                 },
+                "create_caller_id_name_if_undefined": {
+                    "description": "Create the users caller id name from the first and last name fields if no caller id is defined",
+                    "type": "boolean"
+                },
                 "dial_plan": {
                     "$ref": "#/definitions/dialplans",
                     "description": "A list of rules used to modify dialed numbers"

--- a/applications/crossbar/priv/couchdb/schemas/users.json
+++ b/applications/crossbar/priv/couchdb/schemas/users.json
@@ -107,6 +107,11 @@
             },
             "type": "object"
         },
+        "create_caller_id_name_if_undefined": {
+            "description": "Create the users caller id name from the first and last name fields if no caller id is defined",
+            "support_level": "supported",
+            "type": "boolean"
+        },
         "dial_plan": {
             "$ref": "dialplans",
             "description": "A list of rules used to modify dialed numbers"

--- a/core/kazoo_documents/src/kzd_users.erl
+++ b/core/kazoo_documents/src/kzd_users.erl
@@ -21,6 +21,7 @@
 -export([caller_id/1, caller_id/2, set_caller_id/2]).
 -export([contact_list/1, contact_list/2, set_contact_list/2]).
 -export([contact_list_exclude/1, contact_list_exclude/2, set_contact_list_exclude/2]).
+-export([create_caller_id_name_if_undefined/1, create_caller_id_name_if_undefined/2, set_create_caller_id_name_if_undefined/2]).
 -export([dial_plan/1, dial_plan/2, set_dial_plan/2]).
 -export([directories/1, directories/2, set_directories/2]).
 -export([do_not_disturb/1, do_not_disturb/2, set_do_not_disturb/2]).
@@ -278,6 +279,18 @@ contact_list_exclude(Doc, Default) ->
 -spec set_contact_list_exclude(doc(), boolean()) -> doc().
 set_contact_list_exclude(Doc, ContactListExclude) ->
     kz_json:set_value([<<"contact_list">>, <<"exclude">>], ContactListExclude, Doc).
+
+-spec create_caller_id_name_if_undefined(doc()) -> kz_term:api_boolean().
+create_caller_id_name_if_undefined(Doc) ->
+    create_caller_id_name_if_undefined(Doc, 'undefined').
+
+-spec create_caller_id_name_if_undefined(doc(), Default) -> boolean() | Default.
+create_caller_id_name_if_undefined(Doc, Default) ->
+    kz_json:get_boolean_value([<<"create_caller_id_name_if_undefined">>], Doc, Default).
+
+-spec set_create_caller_id_name_if_undefined(doc(), boolean()) -> doc().
+set_create_caller_id_name_if_undefined(Doc, CreateCallerIdNameIfUndefined) ->
+    kz_json:set_value([<<"create_caller_id_name_if_undefined">>], CreateCallerIdNameIfUndefined, Doc).
 
 -spec dial_plan(doc()) -> kz_term:api_object().
 dial_plan(Doc) ->

--- a/core/kazoo_documents/src/kzd_users.erl.src
+++ b/core/kazoo_documents/src/kzd_users.erl.src
@@ -23,6 +23,7 @@
 -export([caller_id_options_outbound_privacy/1, caller_id_options_outbound_privacy/2, set_caller_id_options_outbound_privacy/2]).
 -export([contact_list/1, contact_list/2, set_contact_list/2]).
 -export([contact_list_exclude/1, contact_list_exclude/2, set_contact_list_exclude/2]).
+-export([create_caller_id_name_if_undefined/1, create_caller_id_name_if_undefined/2, set_create_caller_id_name_if_undefined/2]).
 -export([dial_plan/1, dial_plan/2, set_dial_plan/2]).
 -export([directories/1, directories/2, set_directories/2]).
 -export([do_not_disturb/1, do_not_disturb/2, set_do_not_disturb/2]).
@@ -278,6 +279,18 @@ contact_list_exclude(Doc, Default) ->
 -spec set_contact_list_exclude(doc(), boolean()) -> doc().
 set_contact_list_exclude(Doc, ContactListExclude) ->
     kz_json:set_value([<<"contact_list">>, <<"exclude">>], ContactListExclude, Doc).
+
+-spec create_caller_id_name_if_undefined(doc()) -> kz_term:api_boolean().
+create_caller_id_name_if_undefined(Doc) ->
+    create_caller_id_name_if_undefined(Doc, 'undefined').
+
+-spec create_caller_id_name_if_undefined(doc(), Default) -> boolean() | Default.
+create_caller_id_name_if_undefined(Doc, Default) ->
+    kz_json:get_boolean_value([<<"create_caller_id_name_if_undefined">>], Doc, Default).
+
+-spec set_create_caller_id_name_if_undefined(doc(), boolean()) -> doc().
+set_create_caller_id_name_if_undefined(Doc, CreateCallerIdNameIfUndefined) ->
+    kz_json:set_value([<<"create_caller_id_name_if_undefined">>], CreateCallerIdNameIfUndefined, Doc).
 
 -spec dial_plan(doc()) -> kz_term:api_object().
 dial_plan(Doc) ->


### PR DESCRIPTION
Added new attribute to the users object 'create_caller_id_name_if_undefined' to allow the creation of the users
caller id name to be optional when no caller id is defined.