### PR TITLE
[4.3] KSTE-5: look up blacklist number using view

### DIFF
--- a/core/kazoo_apps/priv/couchdb/account/blacklists.json
+++ b/core/kazoo_apps/priv/couchdb/account/blacklists.json
@@ -11,6 +11,18 @@
     "views": {
         "crossbar_listing": {
             "map": "function(doc) { if (doc.pvt_type != 'blacklist' || doc.pvt_deleted) return; emit(doc._id, {'id': doc._id, 'name': doc.name, 'flags': doc.flags || [] }); }"
+        },
+        "listing_by_number": {
+            "map": [
+                "function(doc) {",
+                "  if (doc.pvt_type != 'blacklist' || doc.pvt_deleted) return;",
+                "  for (var i in doc.numbers) {",
+                "    emit(doc.numbers[i], {",
+                "      'should_block_anonymous' : doc.should_block_anonymous",
+                "    });",
+                "  }",
+                "}"
+            ]
         }
     }
 }


### PR DESCRIPTION
To improve blacklist number lookup during route request adding a new view to
fetch the blacklist and check its document id is included in account doc.