### PR TITLE
PISTON-1267 add a handler for action 'move' to channel's crossbar API

### DIFF
--- a/applications/crossbar/doc/channels.md
+++ b/applications/crossbar/doc/channels.md
@@ -107,6 +107,24 @@ curl -v -X POST \
 
 Available `action` values are `transfer`, `hangup`, `break`, `callflow`, `move` and `intercept`.
 
+### Move
+
+```shell
+curl -v -x POST \
+    -H "Content-Type: application/json" \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -d '{"data": {"action": "move", "owner_id": "2e04e3205b36b6291f854995e80985b0", "device_id": "c27b0a86c5e7b0f2a5999967fd8bbf09", "auto_answer": true, "can_call_self": true, "dial_strategy": "simultaneous"}}' \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/channels/{UUID}
+```
+
+Key | Description | Type | Default | Required
+--- | ----------- | ---- | ------- | --------
+`auto_answer` | Whether to auto-answer the new leg | `boolean()` | `false` | `false`
+`can_call_self` | Can intercept devices of the same targeted user | `boolean()` | `true` | `false`
+`device_id` | Move the call to a specific device | `string()` |   | `false`
+`dial_strategy` | How to ring the endpoints, if multiple | `string()` | `simultaneous` | `false`
+`owner_id` | User ID to use for finding endpoints | `string()` |   | `false`
+
 ### Transfer
 
 ```shell

--- a/applications/crossbar/doc/channels.md
+++ b/applications/crossbar/doc/channels.md
@@ -105,7 +105,7 @@ curl -v -X POST \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/channels/{UUID}
 ```
 
-Available `action` values are `transfer`, `hangup`, `break`, `callflow`, and `intercept`.
+Available `action` values are `transfer`, `hangup`, `break`, `callflow`, `move` and `intercept`.
 
 ### Transfer
 

--- a/applications/crossbar/src/modules/cb_channels.erl
+++ b/applications/crossbar/src/modules/cb_channels.erl
@@ -545,11 +545,23 @@ maybe_intercept(Context, CallId, TargetType, TargetId) ->
     kz_amqp_worker:cast(API, fun kapi_metaflow:publish_action/1),
     crossbar_util:response_202(<<"intercept initiated">>, Context).
 
+%%------------------------------------------------------------------------------
+%% @doc API action for moving a channel.
+%% Kazoo dials `device_id'(or all devices for `owner_id') and if a device answers the call
+%% it will be bridged with a remote channel instead of the original.
+%% All params are optional.
+%% @end
+%%------------------------------------------------------------------------------
 -spec maybe_move(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
 maybe_move(Context, CallId) ->
     API = [{<<"Call-ID">>, CallId}
           ,{<<"Action">>, <<"move">>}
-          ,{<<"Data">>, kz_json:new()}
+          ,{<<"Data">>, kz_json:from_list([{<<"auto_answer">>, cb_context:req_value(Context, <<"auto_answer">>, 'false')}
+                                          ,{<<"can_call_self">>, cb_context:req_value(Context, <<"can_call_self">>, 'true')}
+                                          ,{<<"device_id">>, cb_context:req_value(Context, <<"device_id">>)}
+                                          ,{<<"dial_strategy">>, cb_context:req_value(Context, <<"dial_strategy">>, <<"simultaneous">>)}
+                                          ,{<<"owner_id">>, cb_context:req_value(Context, <<"owner_id">>)}
+                                          ])}
            | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
           ],
     lager:debug("attempting to move ~s", [CallId]),

--- a/applications/crossbar/src/modules/cb_channels.erl
+++ b/applications/crossbar/src/modules/cb_channels.erl
@@ -219,6 +219,8 @@ maybe_execute_command(Context, CallId, <<"callflow">>) ->
     maybe_callflow(Context, CallId);
 maybe_execute_command(Context, CallId, <<"intercept">>) ->
     maybe_intercept(Context, CallId);
+maybe_execute_command(Context, CallId, <<"move">>) ->
+    maybe_move(Context, CallId);
 maybe_execute_command(Context, _CallId, _Command) ->
     lager:debug("unknown command: ~s", [_Command]),
     crossbar_util:response_invalid_data(cb_context:doc(Context), Context).
@@ -542,6 +544,17 @@ maybe_intercept(Context, CallId, TargetType, TargetId) ->
     lager:debug("attempting to move ~s to ~s(~s)", [CallId, TargetId, TargetType]),
     kz_amqp_worker:cast(API, fun kapi_metaflow:publish_action/1),
     crossbar_util:response_202(<<"intercept initiated">>, Context).
+
+-spec maybe_move(cb_context:context(), kz_term:ne_binary()) -> cb_context:context().
+maybe_move(Context, CallId) ->
+    API = [{<<"Call-ID">>, CallId}
+          ,{<<"Action">>, <<"move">>}
+          ,{<<"Data">>, kz_json:new()}
+           | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+          ],
+    lager:debug("attempting to move ~s", [CallId]),
+    _ = kz_amqp_worker:cast(API, fun kapi_metaflow:publish_action/1),
+    crossbar_util:response_202(<<"move initiated">>, Context).
 
 -spec get_account_id(cb_context:context()) -> kz_term:ne_binary().
 get_account_id(Context) ->


### PR DESCRIPTION
Add ability to move a call(call-flipping) via crossbar API
kazoo5 PR: https://github.com/2600hz/kazoo-crossbar/pull/203