### PR TITLE
KTEL-10: Replace colons by dashes on fax attachments names

### DIFF
--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -242,4 +242,5 @@ get_file_name(Macros, Ext) ->
         end,
     LocalDateTime = props:get_value([<<"date_called">>, <<"local">>], Macros, <<"0000-00-00_00-00-00">>),
     FName = list_to_binary([CallerID, "_", kz_time:pretty_print_datetime(LocalDateTime), ".", Ext]),
-    re:replace(kz_term:to_lower_binary(FName), <<"\\s+">>, <<"_">>, [{'return', 'binary'}, 'global']).
+    ReOpts = [{'return', 'binary'}, 'global'],
+    re:replace(re:replace(kz_term:to_lower_binary(FName), <<"\\s+">>, <<"_">>, ReOpts), <<":">>, <<"-">>, ReOpts).

--- a/applications/teletype/src/teletype_fax_util.erl
+++ b/applications/teletype/src/teletype_fax_util.erl
@@ -243,4 +243,5 @@ get_file_name(Macros, Ext) ->
     LocalDateTime = props:get_value([<<"date_called">>, <<"local">>], Macros, <<"0000-00-00_00-00-00">>),
     FName = list_to_binary([CallerID, "_", kz_time:pretty_print_datetime(LocalDateTime), ".", Ext]),
     ReOpts = [{'return', 'binary'}, 'global'],
-    re:replace(re:replace(kz_term:to_lower_binary(FName), <<"\\s+">>, <<"_">>, ReOpts), <<":">>, <<"-">>, ReOpts).
+    NoSpaces = re:replace(kz_term:to_lower_binary(FName), <<"\\s+">>, <<"_">>, ReOpts),
+    re:replace(NoSpaces, <<":">>, <<"-">>, ReOpts).


### PR DESCRIPTION
5.x: https://github.com/2600hz/kazoo-teletype/pull/22

When teletype sends a fax attachment, its name includes a time format that includes colons. Colons are not allowed characters for filenames in Windows and so many SMTP relays and mail servers will auto-correct the colon to a dash or underscore character. However, if the end user's server does not correct this, the resulting attachment is unopenable on Windows.