### PR TITLE
acdc fix pickup and exit by dtmf

### DIFF
--- a/applications/acdc/src/acdc_agent_listener.erl
+++ b/applications/acdc/src/acdc_agent_listener.erl
@@ -647,6 +647,7 @@ handle_cast({'member_connect_accepted', ACallId}, #state{msg_queue_id=AmqpQueue
                                                         ,agent_call_ids=ACallIds
                                                         }=State) ->
     lager:debug("member bridged to agent!"),
+    _ = kapps_call_command:b_flush(Call),
     maybe_start_recording(Call, ShouldRecord, RecordingUrl),
 
     ACallIds1 = filter_agent_calls(ACallIds, ACallId),
@@ -1032,6 +1033,7 @@ maybe_connect_to_agent(MyQ, EPs, Call, Timeout, AgentId, _CdrUrl) ->
                                   ,{<<"Retain-CID">>, <<"true">>}
                                   ,{<<"Agent-ID">>, AgentId}
                                   ,{<<"Member-Call-ID">>, MCallId}
+                                  ,{<<"originate_signal_bond">>, MCallId}
                                   ,{<<"Original-Caller-ID-Name">>, OriginalCIDName}
                                   ,{<<"Original-Caller-ID-Number">>, OriginalCIDNumber}
                                   ]),
@@ -1058,6 +1060,7 @@ maybe_connect_to_agent(MyQ, EPs, Call, Timeout, AgentId, _CdrUrl) ->
                                                  ,<<"Retain-CID">>
                                                  ,<<"Authorizing-ID">>
                                                  ,<<"Authorizing-Type">>
+                                                 ,<<"originate_signal_bond">>
                                                  ]}
              ,{<<"Account-ID">>, AcctId}
              ,{<<"Resource-Type">>, <<"originate">>}

--- a/applications/acdc/src/cf_acdc_member.erl
+++ b/applications/acdc/src/cf_acdc_member.erl
@@ -196,6 +196,7 @@ cancel_member_call(Call, Reason) ->
     kapi_acdc_queue:publish_member_call_cancel(Req).
 
 stop_hold_music(Call) ->
+    _ = kapps_call_command:b_flush(Call),
     Cmd = [{<<"Application-Name">>, <<"play">>}
           ,{<<"Call-ID">>, kapps_call:call_id(Call)}
           ,{<<"Media-Name">>, <<"silence_stream://50">>}

--- a/applications/ecallmgr/src/ecallmgr.hrl
+++ b/applications/ecallmgr/src/ecallmgr.hrl
@@ -325,6 +325,7 @@
                               ,{<<"sip_rh_X-Redirect-Server">>, <<"sip_rh_X-Redirect-Server">>}
                               ,{<<"tts_engine">>, <<"tts_engine">>}
                               ,{<<"tts_voice">>, <<"tts_voice">>}
+                              ,{<<"originate_signal_bond">>, <<"originate_signal_bond">>}
                               ]).
 
 %% [{FreeSWITCH-App-Name, Kazoo-App-Name}] Dialplan-related


### PR DESCRIPTION
1) Add the possibility to make pickup (call replace) to agent's calls.
2) Fix an issue with an exit from the queue by pressing DTMF key.