### PR TITLE
[4.3] KZOO-212: change bandwidth api url

### DIFF
--- a/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_bandwidth2.erl
@@ -47,7 +47,7 @@
        ).
 -endif.
 
--define(BW2_BASE_URL, "https://api.inetwork.com/v1.0").
+-define(BW2_BASE_URL, "https://dashboard.bandwidth.com/api").
 
 -ifdef(TEST).
 -define(BW2_ACCOUNT_ID, "eunit_testing_account").
@@ -289,7 +289,7 @@ process_site(Site) ->
 
 -spec peers(binary()) -> 'ok'.
 peers(SiteId) ->
-    {'ok', Xml} = api_get(url(["sippeers"])),
+    {'ok', Xml} = api_get(url(["sites/", ?BW2_SITE_ID, "/sippeers"])),
     io:format("listing all peers for account ~p, site ~p~n", [?BW2_ACCOUNT_ID, SiteId]),
     Peers = xmerl_xpath:string("SipPeers/SipPeer", Xml),
     lists:foreach(fun process_peer/1, Peers),
@@ -332,13 +332,13 @@ api_get(Url) ->
     Response = kz_http:get(Url, [], HTTPOptions),
     handle_response(Response).
 -else.
-api_get("https://api.inetwork.com/v1.0/accounts/eunit_testing_account/availableNumbers?areaCode="++_) ->
+api_get("https://dashboard.bandwidth.com/api/accounts/eunit_testing_account/availableNumbers?areaCode="++_) ->
     Resp = knm_util:fixture("bandwidth2_find_by_npa_no_detail.xml"),
     handle_response({'ok', 200, [], Resp});
-api_get("https://api.inetwork.com/v1.0/accounts/eunit_testing_account/availableNumbers?tollFreeWildCardPattern="++_) ->
+api_get("https://dashboard.bandwidth.com/api/accounts/eunit_testing_account/availableNumbers?tollFreeWildCardPattern="++_) ->
     Resp = knm_util:fixture("bandwidth2_find_tollfree.xml"),
     handle_response({'ok', 200, [], Resp});
-api_get("https://api.inetwork.com/v1.0/accounts/eunit_testing_account/orders/" ++ _) ->
+api_get("https://dashboard.bandwidth.com/api/accounts/eunit_testing_account/orders/" ++ _) ->
     Resp = knm_util:fixture("bandwidth2_check_order.xml"),
     handle_response({'ok', 200, [], Resp}).
 -endif.
@@ -362,7 +362,7 @@ api_post(Url, Body) ->
     Response = kz_http:post(Url, Headers, UnicodeBody, HTTPOptions),
     handle_response(Response).
 -else.
-api_post("https://api.inetwork.com/v1.0/accounts/eunit_testing_account/orders", Body) ->
+api_post("https://dashboard.bandwidth.com/api/accounts/eunit_testing_account/orders", Body) ->
     _UnicodeBody = unicode:characters_to_binary(Body),
     Resp = knm_util:fixture("bandwidth2_buy_a_number.xml"),
     handle_response({'ok', 200, [], Resp}).


### PR DESCRIPTION
Old bandwidth API URL is shutting down. Using the new URL.