### PR TITLE
Add restrict_presence_event_publisher ecallmgr system_config option

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -295,6 +295,7 @@
     "ecallmgr.recording_software_name": "ecallmgr recording software name",
     "ecallmgr.redirect_via_proxy": "ecallmgr redirect via proxy",
     "ecallmgr.restrict_channel_state_publisher": "ecallmgr restrict channel state publisher",
+    "ecallmgr.restrict_presence_event_publisher": "ecallmgr restrict presence event publisher",
     "ecallmgr.should_detect_inband_dtmf": "ecallmgr should detect inband dtmf",
     "ecallmgr.sofia_conf": "ecallmgr sofia conf",
     "ecallmgr.tcp_packet_type": "ecallmgr tcp packet type",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -31889,6 +31889,11 @@
                     "description": "ecallmgr restrict channel state publisher",
                     "type": "boolean"
                 },
+                "restrict_presence_event_publisher": {
+                    "default": false,
+                    "description": "ecallmgr restrict presence event publisher",
+                    "type": "boolean"
+                },
                 "sanitize_fs_value_regex": {
                     "default": "[^0-9\\w\\s-]",
                     "description": "ecallmgr sanitize_fs_value_regex",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
@@ -377,6 +377,11 @@
             "description": "ecallmgr restrict channel state publisher",
             "type": "boolean"
         },
+        "restrict_presence_event_publisher": {
+            "default": false,
+            "description": "ecallmgr restrict presence event publisher",
+            "type": "boolean"
+        },
         "sanitize_fs_value_regex": {
             "default": "[^0-9\\w\\s-]",
             "description": "ecallmgr sanitize_fs_value_regex",

--- a/applications/ecallmgr/doc/config.md
+++ b/applications/ecallmgr/doc/config.md
@@ -62,6 +62,7 @@ Key | Description | Type | Default | Required | Support Level
 `recording_software_name` | ecallmgr recording software name | `string()` | `2600Hz, Inc.'s Kazoo` | `false` |
 `redirect_via_proxy` | ecallmgr redirect via proxy | `boolean()` | `true` | `false` |
 `restrict_channel_state_publisher` | ecallmgr restrict channel state publisher | `boolean()` | `false` | `false` |
+`restrict_presence_event_publisher` | ecallmgr restrict presence event publisher | `boolean()` | `false` | `false` |
 `sanitize_fs_value_regex` | ecallmgr sanitize_fs_value_regex | `string()` | `[^0-9\w\s-]` | `false` |
 `should_detect_inband_dtmf` | ecallmgr should detect inband dtmf | `boolean()` | `false` | `false` |
 `sofia_conf` | ecallmgr sofia conf | `boolean()` |   | `false` |


### PR DESCRIPTION
When enabled it prevents all but the ecallmgr node handling a call from sending presence updates. This stops duplicate notifies being sent to devices which can result in them returning 500 errors, removing their subscriptions and subsequently breaking BLFs.

A caveat to this is that the initial state change will not be forwarded to subscribers when a device is dialling, as no ecallmgr node will be defined at this stage. This is usually for a very short period as the following state changes will be at the point where the call is being handled by an ecallmgr node.