### PR TITLE
[4.3] CAV doesn't work in quickcall after answer

### DIFF
--- a/applications/crossbar/src/modules/cb_quickcall.erl
+++ b/applications/crossbar/src/modules/cb_quickcall.erl
@@ -247,6 +247,7 @@ originate_quickcall(Endpoints, Call, Context) ->
           ,{<<"Continue-On-Fail">>, 'false'}
           ,{<<"Custom-Application-Vars">>, kz_json:from_list(CAVs)}
           ,{<<"Custom-Channel-Vars">>, kz_json:from_list(CCVs)}
+          ,{<<"Export-Custom-Application-Vars">>, kz_json:get_keys(kz_json:from_list(CAVs))}        
           ,{<<"Dial-Endpoint-Method">>, <<"simultaneous">>}
           ,{<<"Endpoints">>, update_quickcall_endpoints(AutoAnswer, Endpoints)}
           ,{<<"Existing-Call-ID">>, cb_context:req_value(Context, <<"target_call_id">>)}

--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -623,9 +623,18 @@ get_unset_vars(JObj) ->
     Export = [K || KV <- FSVars,
                    ([K, _] = string:tokens(binary_to_list(KV), "=")) =/= 'undefined'
              ],
+    ExportCAVProps = [{K, <<>>} || K <- kz_json:get_value(<<"Export-Custom-Application-Vars">>, JObj, [])],
+    FSCAVVars = lists:foldr(fun ecallmgr_fs_xml:kazoo_var_to_fs_var/2
+                        ,[]
+                        ,[{<<"Custom-Application-Vars">>, kz_json:from_list(ExportCAVProps)}]
+                        ),
+    ExportCAV = [K || KV <- FSCAVVars,
+                   ([K, _] = string:tokens(binary_to_list(KV), "=")) =/= 'undefined'
+             ],
     case ["unset:" ++ K
           || KV <- lists:foldr(fun ecallmgr_fs_xml:kazoo_var_to_fs_var/2, [], kz_json:to_proplist(JObj)),
-             not lists:member(begin [K, _] = string:tokens(binary_to_list(KV), "="), K end, Export)
+             not lists:member(begin [K, _] = string:tokens(binary_to_list(KV), "="), K end, Export),
+             not lists:member(begin [K, _] = string:tokens(binary_to_list(KV), "="), K end, ExportCAV) 
          ]
     of
         [] -> "";

--- a/core/kazoo_amqp/src/api/kapi_resource.erl
+++ b/core/kazoo_amqp/src/api/kapi_resource.erl
@@ -68,6 +68,7 @@
 -define(ORIGINATE_REQ_HEADERS, [<<"Endpoints">>, <<"Application-Name">>]).
 -define(OPTIONAL_ORIGINATE_REQ_HEADERS, [<<"Application-Data">>
                                         ,<<"Custom-Application-Vars">>
+                                        ,<<"Export-Custom-Application-Vars">>
                                         ,<<"Custom-Channel-Vars">>
                                         ,<<"Existing-Call-ID">> % If set, use this node, otherwise ignore
                                         ,<<"Export-Custom-Channel-Vars">>


### PR DESCRIPTION
Custome application vars don't work in quickcall after answer in CDR and CHANNEL_DESTROYED event