### PR TITLE
Add a disclaimer about CCVs used in 2600hz apps

### DIFF
--- a/applications/callflow/doc/resources.md
+++ b/applications/callflow/doc/resources.md
@@ -55,6 +55,8 @@ Adding the value `"zone"` to the `dynamic_flags` array will result in a flag set
 ### Custom Channel Vars
 Adding the value `"custom_channel_vars."` appended with a normalized variable name will add the value (if present) to the flags array.  For example, `"custom_channel_vars.owner_id"`.
 
+PLEASE NOTE: Developers can expect that custom channel variables (CCVs) will be an available field. They can further expect that any variables they have placed there will always be available. However, developers should not assume that all variables offered in CCVs will always be available. Internal KAZOO applications also add CCVs to channels, however they may not always continue to add those variables or add them in a consistent way. Should you need to utilize a CCV added by an internal KAZOO app, we advise completing QA on all KAZOO versions to ensure these values are still present and in the format you are expecting before installing those versions on your or your customers' clusters.
+
 ## Examples
 
 ### Route to the system carriers

--- a/applications/callflow/doc/resources.md
+++ b/applications/callflow/doc/resources.md
@@ -55,7 +55,8 @@ Adding the value `"zone"` to the `dynamic_flags` array will result in a flag set
 ### Custom Channel Vars
 Adding the value `"custom_channel_vars."` appended with a normalized variable name will add the value (if present) to the flags array.  For example, `"custom_channel_vars.owner_id"`.
 
-PLEASE NOTE: Developers can expect that custom channel variables (CCVs) will be an available field. They can further expect that any variables they have placed there will always be available. However, developers should not assume that all variables offered in CCVs will always be available. Internal KAZOO applications also add CCVs to channels, however they may not always continue to add those variables or add them in a consistent way. Should you need to utilize a CCV added by an internal KAZOO app, we advise completing QA on all KAZOO versions to ensure these values are still present and in the format you are expecting before installing those versions on your or your customers' clusters.
+#### PLEASE NOTE
+Developers can expect that custom channel variables (CCVs) will be an available field. They can further expect that any variables they have placed there will always be available. However, developers should not assume that all variables offered in CCVs will always be available. Internal KAZOO applications also add CCVs to channels, however they may not always continue to add those variables or add them in a consistent way. Should you need to utilize a CCV added by an internal KAZOO app, we advise completing QA on all KAZOO versions to ensure these values are still present and in the format you are expecting before installing those versions on your or your customers' clusters.
 
 ## Examples
 


### PR DESCRIPTION
Just to let people know that CCVs that we set and use in our apps may change across versions, and to make sure that if you are using our CCVs as opposed to your own, make sure to test to make sure nothing is broken on an upgrade or downgrade before deploying that KAZOO version to your own production cluster or a customer's cluster, as we don't guarantee consistency of those variables across versions.