### PR TITLE
Added "ring_all" strategy for acdc queue manager schema

### DIFF
--- a/applications/crossbar/priv/couchdb/schemas/queues.json
+++ b/applications/crossbar/priv/couchdb/schemas/queues.json
@@ -144,7 +144,8 @@
             "description": "The queue strategy for connecting agents to callers",
             "enum": [
                 "round_robin",
-                "most_idle"
+                "most_idle",
+                "ring_all"
             ],
             "type": "string"
         }


### PR DESCRIPTION
ACDC supports ring_all strategy, but it doesn't appear in the schema

[Here the strategy](https://github.com/2600hz/kazoo/blob/master/applications/acdc/src/acdc_queue_manager.erl#L873)