### PR TITLE
[4.3] KCAL-60: fix `cf_flush_dtmf`

### DIFF
--- a/applications/callflow/src/module/cf_flush_dtmf.erl
+++ b/applications/callflow/src/module/cf_flush_dtmf.erl
@@ -25,7 +25,9 @@
 -spec handle(kz_json:object(), kapps_call:call()) -> 'ok'.
 handle(Data, Call) ->
     Collection = collection_name(Data),
-    cf_exe:continue(kapps_call:set_dtmf_collection('undefined', Collection, Call)).
+    Call1 = kapps_call:set_dtmf_collection('undefined', Collection, Call),
+    cf_exe:set_call(Call1),
+    cf_exe:continue(Call1).
 
 -spec collection_name(kz_json:object()) -> kz_term:ne_binary().
 collection_name(Data) ->

--- a/applications/callflow/test/cf_flush_dtmf_tests.erl
+++ b/applications/callflow/test/cf_flush_dtmf_tests.erl
@@ -1,0 +1,43 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2023, 2600Hz
+%%% @doc `flush_dtmf' callflow module tests
+%%%
+%%% This Source Code Form is subject to the terms of the Mozilla Public
+%%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%%
+%%% @author Daniel Finke <danielfinke2011@gmail.com>
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(cf_flush_dtmf_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%%=============================================================================
+%%% Eunit Tests
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc Verify the cleared DTMF collection is persisted on the call.
+%% @end
+%%------------------------------------------------------------------------------
+persisted_test_() ->
+    {'setup'
+    ,fun() ->
+             meck:new('cf_exe'),
+             meck:expect('cf_exe', 'set_call', fun(_Call) -> 'ok' end),
+             meck:expect('cf_exe', 'continue', fun(_Call) -> 'ok' end)
+     end
+    ,fun(_) -> meck:unload() end
+    ,[fun() ->
+              Call = kapps_call:set_dtmf_collection(<<"1234">>, kapps_call:new()),
+
+              cf_flush_dtmf:handle(kz_json:new(), Call),
+
+              DTMF = kapps_call:get_dtmf_collection(
+                       meck:capture(1, 'cf_exe', 'set_call', 1, 1)
+                      ),
+              ?assertEqual('undefined', DTMF)
+      end
+     ]
+    }.


### PR DESCRIPTION
Backport of 2600hz/kazoo-callflow#238

Make sure to persist the cleared DTMF collection on the call using `cf_exe:set_call/1`