### PR TITLE
Corrected HTTP method in curl example for device SIP NOTIFY

### DIFF
--- a/applications/crossbar/doc/devices.md
+++ b/applications/crossbar/doc/devices.md
@@ -603,7 +603,7 @@ Key | Type | Description
 > PUT /v2/accounts/{ACCOUNT_ID}/devices/{DEVICE_ID}
 
 ```shell
-curl -v -X POST \
+curl -v -X PUT \
     -H "X-Auth-Token: {AUTH_TOKEN}" \
     -H "Content-Type: application/json" \
     -d '{"action": "notify",


### PR DESCRIPTION
Corrected curl request example using POST instead of PUT